### PR TITLE
Disabled merge.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,3 +20,9 @@ notifications:
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org
   jira_options: link label worklog
+
+github:
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true


### PR DESCRIPTION
Let's try a PR about processes and see how this works.

Proposal: keep the main branch with a linear history by deactivating the "merge" option of PRs, like apache/arrow has.
