### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,9 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem or challenge? Please describe what you are trying to do.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] 
+(This section helps Arrow developers understand the context and *why* for this feature, in addition to  the *what*)
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Which issue does this PR close?
+
+We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
+
+Closes #.
+
+# What changes are included in this PR?
+
+There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
+
+# Are there any user-facing changes?
+
+If there are user-facing changes then we may require documentation to be updated before approving the PR.
+
+If there are any breaking changes to public APIs, please add the `breaking change` label.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@ We generally require a GitHub issue to be filed for all bug fixes and enhancemen
 
 Closes #.
 
+ # Rationale for this change
+ Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
+ Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
+
 # What changes are included in this PR?
 
 There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
@@ -13,4 +17,3 @@ There is no need to duplicate the description in the issue here but it is someti
 If there are user-facing changes then we may require documentation to be updated before approving the PR.
 
 If there are any breaking changes to public APIs, please add the `breaking change` label.
-

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -7,7 +7,8 @@
 *.csv
 *.json
 *.snap
-.github/ISSUE_TEMPLATE/question.md
+.github/ISSUE_TEMPLATE/*.md
+.github/pull_request_template.md
 ci/etc/rprofile
 ci/etc/*.patch
 ci/vcpkg/*.patch


### PR DESCRIPTION
Here are suggested issue templates for bugs and features, as well as a PR template that will prompt users to enter the issue that the PR is closing.