### PR TITLE
ARROW-12504: Buffer::from_slice_ref set correct capacity

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -55,8 +55,8 @@ impl Buffer {
     /// Initializes a [Buffer] from a slice of items.
     pub fn from_slice_ref<U: ArrowNativeType, T: AsRef<[U]>>(items: &T) -> Self {
         let slice = items.as_ref();
-        let len = slice.len();
-        let mut buffer = MutableBuffer::with_capacity(len);
+        let capacity = slice.len() * std::mem::size_of::<U>();
+        let mut buffer = MutableBuffer::with_capacity(capacity);
         buffer.extend_from_slice(slice);
         buffer.into()
     }


### PR DESCRIPTION
A minor change, that quite possibly makes no performance difference in practice, as the subsequent call to extend_from_slice calls reserve with the correct data size, but thought it couldn't hurt to fix