### PR TITLE
support LargeUtf8 in sort kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ target
 rusty-tags.vi
 .history
 .flatbuffers/
-
+.idea/
 .vscode
 venv/*


### PR DESCRIPTION
This PR adds `LargeUtf8` support for the sort kernels. Closes #25 
