### PR TITLE
Fix code examples for RecordBatch::try_from_iter

### DIFF
--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -268,7 +268,7 @@ impl RecordBatch {
     ///   ("a", a),
     ///   ("b", b),
     /// ]);
-    ///
+    /// ```
     pub fn try_from_iter<I, F>(value: I) -> Result<Self>
     where
         I: IntoIterator<Item = (F, ArrayRef)>,
@@ -307,6 +307,7 @@ impl RecordBatch {
     ///   ("a", a, false),
     ///   ("b", b, true),
     /// ]);
+    /// ```
     pub fn try_from_iter_with_nullable<I, F>(value: I) -> Result<Self>
     where
         I: IntoIterator<Item = (F, ArrayRef, bool)>,


### PR DESCRIPTION
I noticed this after merging https://github.com/apache/arrow-rs/pull/7

Namely the ending tick marks were not present. I checked and rust-doc seems to properly create the examples anyways, but I wanted to fix it for real.
