### PR TITLE
Read list field correctly

### DIFF
--- a/parquet/src/arrow/arrow_writer.rs
+++ b/parquet/src/arrow/arrow_writer.rs
@@ -92,6 +92,8 @@ impl<W: 'static + ParquetWriter> ArrowWriter<W> {
         let mut row_group_writer = self.writer.next_row_group()?;
         for (array, field) in batch.columns().iter().zip(batch.schema().fields()) {
             let mut levels = batch_level.calculate_array_levels(array, field);
+            // Reverse levels as we pop() them when writing arrays
+            levels.reverse();
             write_leaves(&mut row_group_writer, array, &mut levels)?;
         }
 
@@ -741,7 +743,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "See ARROW-11294, data is correct but list field name is incorrect"]
     fn arrow_writer_complex() {
         // define schema
         let struct_field_d = Field::new("d", DataType::Float64, true);
@@ -934,7 +935,6 @@ mod tests {
             let actual_data = actual_batch.column(i).data();
 
             assert_eq!(expected_data, actual_data);
-            // assert_eq!(expected_data, actual_data, "L: {:#?}\nR: {:#?}", expected_data, actual_data);
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #167 .

 # Rationale for this change

We have been creating incorrect list types when reading Parquet lists to Arrow. If we have a list with field type:

```rust
let list_field = Field::new("a", DataType::List(Box::new(Field::new("item", DataType::_, true))), true);
```

We would instead read this list in as

```rust
let list_field = Field::new("a", DataType::List(Box::new(Field::new("a", DataType::_, true))), true);
```

With the list child taking the list's name of `"a"`.

# What changes are included in this PR?

This PR fixes the above issue.
it also fixes the order of the `LevelInfo` that's generated, as I identified this issue while fixing the test case for the above issue.

# Are there any user-facing changes?

No user changes
