### PR TITLE
sort_primitive result is capped to the min of limit or values.len

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -495,12 +495,11 @@ where
     }
 
     // collect results directly into a buffer instead of a vec to avoid another aligned allocation
-    let mut result = MutableBuffer::new(values.len() * std::mem::size_of::<u32>());
+    let result_capacity = len * std::mem::size_of::<u32>();
+    let mut result = MutableBuffer::new(result_capacity);
     // sets len to capacity so we can access the whole buffer as a typed slice
-    result.resize(values.len() * std::mem::size_of::<u32>(), 0);
+    result.resize(result_capacity, 0);
     let result_slice: &mut [u32] = result.typed_data_mut();
-
-    debug_assert_eq!(result_slice.len(), nulls_len + valids_len);
 
     if options.nulls_first {
         let size = nulls_len.min(len);
@@ -1555,6 +1554,17 @@ mod tests {
             }),
             Some(3),
             vec![Some(1.0), Some(2.0), Some(3.0)],
+        );
+
+        // limit that includes some extra nulls
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(2.0), None, None, Some(1.0)],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: false,
+            }),
+            Some(3),
+            vec![Some(1.0), Some(2.0), None],
         );
     }
 

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -1560,7 +1560,7 @@ mod tests {
             vec![Some(1.0), Some(2.0), Some(3.0)],
         );
 
-        // limit that includes some extra nulls
+        // valid values less than limit with extra nulls
         test_sort_primitive_arrays::<Float64Type>(
             vec![Some(2.0), None, None, Some(1.0)],
             Some(SortOptions {
@@ -1571,7 +1571,17 @@ mod tests {
             vec![Some(1.0), Some(2.0), None],
         );
 
-        // too many nulls
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(2.0), None, None, Some(1.0)],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+            Some(3),
+            vec![None, None, Some(1.0)],
+        );
+
+        // more nulls than limit
         test_sort_primitive_arrays::<Float64Type>(
             vec![Some(2.0), None, None, None],
             Some(SortOptions {
@@ -1580,6 +1590,16 @@ mod tests {
             }),
             Some(2),
             vec![None, None],
+        );
+
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(2.0), None, None, None],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: false,
+            }),
+            Some(2),
+            vec![Some(2.0), None],
         );
     }
 


### PR DESCRIPTION
Closes #235

# What changes are included in this PR?

The result slice in `sort_primitive` is the size of all the values being sorted even when a limit is provided. Change the size to be the maximum possible result (thus avoiding the panic in #235)

There are other slice size errors as well (such as when the number of nulls exceeds the limit) that are included.

# Are there any user-facing changes?

No

###  Notes

I've provided a reproducing test, but skipped other variants of limits /w nulls. Those should be easy so let me know if they're of interest. Additionally it is possible that `result` is intentionally over-large in which case I can try alternative fixes.