### PR TITLE
fix parquet max_definition for non-null structs

### DIFF
--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -99,7 +99,7 @@ impl LevelInfo {
     /// Returns a list of `LevelInfo`, where each level is for nested primitive arrays.
     ///
     /// The parent struct's nullness is tracked, as it determines whether the child
-    /// max_deginition should be incremented.
+    /// max_definition should be incremented.
     /// The 'is_parent_struct' variable asks "is this field's parent a struct?".
     /// * If we are starting at a [RecordBatch], this is `false`.
     /// * If we are calculating a list's child, this is `false`.

--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -1510,7 +1510,7 @@ mod tests {
         );
 
         // The 2 levels should not be the same
-        if &struct_non_null_level == &struct_null_level {
+        if struct_non_null_level == struct_null_level {
             panic!("Levels should not be equal, to reflect the difference in struct nullness");
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #244 .

 # Rationale for this change

This fixes a bug

# What changes are included in this PR?

* The calculation of levels for non-null structs has been fixed.
* I also refer to #245 where more investigations about parquet & arrow struct compatibility are needed.
* I added a test, and ignored one that was failing before this PR

# Are there any user-facing changes?

No, changes made to crate-level structs, that are not publicly exposed
