### PR TITLE
Fix empty Schema::metadata deserialization error

### DIFF
--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -35,6 +35,7 @@ pub struct Schema {
     pub(crate) fields: Vec<Field>,
     /// A map of key-value pairs containing additional meta data.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
     pub(crate) metadata: HashMap<String, String>,
 }
 
@@ -334,4 +335,36 @@ impl fmt::Display for Schema {
 struct MetadataKeyValue {
     key: String,
     value: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::datatypes::DataType;
+
+    use super::*;
+
+    #[test]
+    fn test_empty_metadata() {
+        // ser/de with empty metadata
+        let mut schema = Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("address", DataType::Utf8, false),
+            Field::new("priority", DataType::UInt8, false),
+        ]);
+
+        let json = serde_json::to_string(&schema).unwrap();
+        let de_schema = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(schema, de_schema);
+
+        // ser/de with non-empty metadata
+        schema.metadata = [("key".to_owned(), "val".to_owned())]
+            .iter()
+            .cloned()
+            .collect();
+        let json = serde_json::to_string(&schema).unwrap();
+        let de_schema = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(schema, de_schema);
+    }
 }

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -344,7 +344,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_empty_metadata() {
+    fn test_ser_de_metadata() {
         // ser/de with empty metadata
         let mut schema = Schema::new(vec![
             Field::new("name", DataType::Utf8, false),


### PR DESCRIPTION
Hope this fixes issue #241

# Which issue does this PR close?
Closes #241 

# Rationale for this change

De-serializing schema with empty metadata gives us a "missing field metadata..." error,  as stated in #241. returns an empty HashMap may be a better choice. 

# What changes are included in this PR?

Annotates field `Schema::metadata` with `#[serde(default)]`, which will give us a empty HashMap if metadata is empty.

# Are there any user-facing changes?

none.