### PR TITLE
re-export parquet-format

### DIFF
--- a/parquet/src/arrow/arrow_reader.rs
+++ b/parquet/src/arrow/arrow_reader.rs
@@ -578,7 +578,7 @@ mod tests {
         values: &[Vec<T::T>],
         path: &Path,
         schema: TypePtr,
-    ) -> Result<parquet_format::FileMetaData> {
+    ) -> Result<crate::format::FileMetaData> {
         let file = File::create(path)?;
         let writer_props = Arc::new(WriterProperties::builder().build());
 

--- a/parquet/src/arrow/arrow_writer.rs
+++ b/parquet/src/arrow/arrow_writer.rs
@@ -101,7 +101,7 @@ impl<W: 'static + ParquetWriter> ArrowWriter<W> {
     }
 
     /// Close and finalize the underlying Parquet writer
-    pub fn close(&mut self) -> Result<parquet_format::FileMetaData> {
+    pub fn close(&mut self) -> Result<crate::format::FileMetaData> {
         self.writer.close()
     }
 }

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -20,12 +20,12 @@
 
 use std::{convert, fmt, result, str};
 
-use parquet_format as parquet;
+use crate::format as parquet;
 
 use crate::errors::ParquetError;
 
-// Re-export parquet_format types used in this module
-pub use parquet_format::{
+// Re-export parquet::format types used in this module, for convenience
+pub use crate::format::{
     BsonType, DateType, DecimalType, EnumType, IntType, JsonType, ListType, MapType,
     NullType, StringType, TimeType, TimeUnit, TimestampType, UUIDType,
 };

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -22,17 +22,15 @@ use std::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use parquet_format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
 use thrift::protocol::TCompactInputProtocol;
 
 use crate::basic::ColumnOrder;
-
 use crate::errors::{ParquetError, Result};
 use crate::file::{
     metadata::*, reader::ChunkReader, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE,
     PARQUET_MAGIC,
 };
-
+use crate::format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
 use crate::schema::types::{self, SchemaDescriptor};
 
 /// Layout of Parquet file
@@ -159,9 +157,9 @@ mod tests {
 
     use crate::basic::SortOrder;
     use crate::basic::Type;
+    use crate::format::TypeDefinedOrder;
     use crate::schema::types::Type as SchemaType;
     use crate::util::test_common::get_temp_file;
-    use parquet_format::TypeDefinedOrder;
 
     #[test]
     fn test_parse_metadata_size_smaller_than_footer() {

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -35,11 +35,10 @@
 
 use std::sync::Arc;
 
-use parquet_format::{ColumnChunk, ColumnMetaData, RowGroup};
-
 use crate::basic::{ColumnOrder, Compression, Encoding, Type};
 use crate::errors::{ParquetError, Result};
 use crate::file::statistics::{self, Statistics};
+use crate::format::{ColumnChunk, ColumnMetaData, RowGroup};
 use crate::schema::types::{
     ColumnDescPtr, ColumnDescriptor, ColumnPath, SchemaDescPtr, SchemaDescriptor,
     Type as SchemaType,
@@ -84,7 +83,7 @@ impl ParquetMetaData {
     }
 }
 
-pub type KeyValue = parquet_format::KeyValue;
+pub type KeyValue = crate::format::KeyValue;
 
 /// Reference counted pointer for [`FileMetaData`].
 pub type FileMetaDataPtr = Arc<FileMetaData>;

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -20,7 +20,6 @@
 
 use std::{convert::TryFrom, fs::File, io::Read, path::Path, sync::Arc};
 
-use parquet_format::{PageHeader, PageType};
 use thrift::protocol::TCompactInputProtocol;
 
 use crate::basic::{Compression, Encoding, Type};
@@ -28,6 +27,7 @@ use crate::column::page::{Page, PageReader};
 use crate::compression::{create_codec, Codec};
 use crate::errors::{ParquetError, Result};
 use crate::file::{footer, metadata::*, reader::*, statistics};
+use crate::format::{PageHeader, PageType};
 use crate::record::reader::RowIter;
 use crate::record::Row;
 use crate::schema::types::Type as SchemaType;

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -40,10 +40,10 @@
 use std::{cmp, fmt};
 
 use byteorder::{ByteOrder, LittleEndian};
-use parquet_format::Statistics as TStatistics;
 
 use crate::basic::Type;
 use crate::data_type::*;
+use crate::format::Statistics as TStatistics;
 use crate::util::bit_util::from_ne_slice;
 
 // Macro to generate methods create Statistics.

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -24,7 +24,6 @@ use std::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use parquet_format as parquet;
 use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol};
 
 use crate::basic::PageType;
@@ -37,6 +36,7 @@ use crate::file::{
     metadata::*, properties::WriterPropertiesPtr,
     statistics::to_thrift as statistics_to_thrift, FOOTER_SIZE, PARQUET_MAGIC,
 };
+use crate::format as parquet;
 use crate::schema::types::{self, SchemaDescPtr, SchemaDescriptor, TypePtr};
 use crate::util::io::{FileSink, Position};
 

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -45,6 +45,11 @@ pub mod data_type;
 pub use self::encodings::{decoding, encoding};
 pub use self::util::memory;
 
+/// Re-export parquet_format as `parquet::format`.
+///
+/// Users are encouraged to use this, to avoid format mismatches.
+pub use parquet_format as format;
+
 #[macro_use]
 mod util;
 #[cfg(any(feature = "arrow", test))]

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -19,12 +19,11 @@
 
 use std::{collections::HashMap, convert::From, fmt, sync::Arc};
 
-use parquet_format::SchemaElement;
-
 use crate::basic::{
     ConvertedType, LogicalType, Repetition, TimeType, TimeUnit, Type as PhysicalType,
 };
 use crate::errors::{ParquetError, Result};
+use crate::format::SchemaElement;
 
 // ----------------------------------------------------------------------
 // Parquet Type definitions


### PR DESCRIPTION
# Which issue does this PR close?

Closes #237 .

 # Rationale for this change

We might need to expose more `parquet-format` internals in future, as we already expose the `FileMetadata` struct. Users who wish to use these structs sometimes need to also use the `parquet-format` crate.
There is a risk that users might end up importing incompatible versions.

Re-exporting this crate would make things simpler for users. 

# What changes are included in this PR?

* Exporting `parquet_format` as `parquet::format`
* Reusing `parquet::format` wherever we internally use `parquet_format`

# Are there any user-facing changes?

We are exposing a new submodule, `parquet::format`. This is not a breaking change.
