### PR TITLE
Update PR template by commenting out instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,31 @@
 # Which issue does this PR close?
 
+<!---
 We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
+-->
 
 Closes #.
 
  # Rationale for this change
+ 
+ <!---
  Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
- Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
+ Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
+-->
 
 # What changes are included in this PR?
 
+<!---
 There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
+-->
 
 # Are there any user-facing changes?
 
-If there are user-facing changes then we may require documentation to be updated before approving the PR.
 
+<!---
+If there are user-facing changes then we may require documentation to be updated before approving the PR.
+-->
+
+<!---
 If there are any breaking changes to public APIs, please add the `breaking change` label.
+-->


### PR DESCRIPTION
# Which issue does this PR close?

Closes #277.

 # Rationale for this change

Some contributors don't remove the guidelines when creating PRs, so it might be more convenient if we hide them behind comments.
The comments are still visible when editing, but are not displayed when the markdown is rendered

# What changes are included in this PR?

Comments out the text, but not the headings of this PR template.

# Are there any user-facing changes?

No
