### PR TITLE
Speed up bound checking in `take`

### DIFF
--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -23,7 +23,7 @@ use rand::Rng;
 
 extern crate arrow;
 
-use arrow::compute::{TakeOptions, take};
+use arrow::compute::{take, TakeOptions};
 use arrow::datatypes::*;
 use arrow::util::test_util::seedable_rng;
 use arrow::{array::*, util::bench_util::*};
@@ -47,7 +47,9 @@ fn bench_take(values: &dyn Array, indices: &UInt32Array) {
 }
 
 fn bench_take_bounds_check(values: &dyn Array, indices: &UInt32Array) {
-    criterion::black_box(take(values, &indices, Some(TakeOptions{check_bounds: true})).unwrap());
+    criterion::black_box(
+        take(values, &indices, Some(TakeOptions { check_bounds: true })).unwrap(),
+    );
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -62,13 +64,14 @@ fn add_benchmark(c: &mut Criterion) {
 
     let values = create_primitive_array::<Int32Type>(512, 0.0);
     let indices = create_random_index(512, 0.0);
-    c.bench_function("take check bounds i32 512", |b| b.iter(|| bench_take_bounds_check(&values, &indices)));
+    c.bench_function("take check bounds i32 512", |b| {
+        b.iter(|| bench_take_bounds_check(&values, &indices))
+    });
     let values = create_primitive_array::<Int32Type>(1024, 0.0);
     let indices = create_random_index(1024, 0.0);
     c.bench_function("take check bounds i32 1024", |b| {
         b.iter(|| bench_take_bounds_check(&values, &indices))
     });
-
 
     let indices = create_random_index(512, 0.5);
     c.bench_function("take i32 nulls 512", |b| {

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -102,27 +102,25 @@ where
         let len = values.len();
         if indices.null_count() > 0 {
             indices.iter().flatten().try_for_each(|index| {
-                let ix =
-                ToPrimitive::to_usize(&index).ok_or_else(|| {
+                let ix = ToPrimitive::to_usize(&index).ok_or_else(|| {
                     ArrowError::ComputeError("Cast to usize failed".to_string())
                 })?;
                 if ix >= len {
                     return Err(ArrowError::ComputeError(
-                format!("Array index out of bounds, cannot get item at index {} from {} entries", ix, len))
-                );
+                        format!("Array index out of bounds, cannot get item at index {} from {} entries", ix, len))
+                    );
                 }
                 Ok(())
             })?;
         } else {
             indices.values().iter().try_for_each(|index| {
-                let ix =
-                ToPrimitive::to_usize(index).ok_or_else(|| {
+                let ix = ToPrimitive::to_usize(index).ok_or_else(|| {
                     ArrowError::ComputeError("Cast to usize failed".to_string())
                 })?;
                 if ix >= len {
                     return Err(ArrowError::ComputeError(
-                format!("Array index out of bounds, cannot get item at index {} from {} entries", ix, len))
-                );
+                        format!("Array index out of bounds, cannot get item at index {} from {} entries", ix, len))
+                    );
                 }
                 Ok(())
             })?


### PR DESCRIPTION
# Which issue does this PR close?

Closes #280 

 # Rationale for this change 
\>2x speed up for common case (non-null indices) when using `TakeOptions {check_bounds: true}`

```
take check bounds i32 512                        
                        time:   [618.35 ns 619.16 ns 620.08 ns]
                        change: [-55.905% -55.474% -55.115%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

Benchmarking take check bounds i32 1024: Collecting 100 samples in estimated 5.0026 s (4.7M iteratio                                                                                                    take check bounds i32 1024                        
                        time:   [1.0389 us 1.0409 us 1.0430 us]
                        change: [-57.474% -57.278% -57.093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

# What changes are included in this PR?

Speed up kernel with bound checking option on. 

# Are there any user-facing changes?

No