### PR TITLE
return reference from DictionaryArray::values() (#313)

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -101,9 +101,9 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
             .flatten()
     }
 
-    /// Returns an `ArrayRef` to the dictionary values.
-    pub fn values(&self) -> ArrayRef {
-        self.values.clone()
+    /// Returns a reference to the dictionary values array
+    pub fn values(&self) -> &ArrayRef {
+        &self.values
     }
 
     /// Returns a clone of the value type of this list.

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1371,10 +1371,10 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
                 })?;
 
             let keys_array: ArrayRef = Arc::new(dict_array.keys_array());
-            let values_array: ArrayRef = dict_array.values();
+            let values_array = dict_array.values();
             let cast_keys = cast_with_options(&keys_array, to_index_type, &cast_options)?;
             let cast_values =
-                cast_with_options(&values_array, to_value_type, &cast_options)?;
+                cast_with_options(values_array, to_value_type, &cast_options)?;
 
             // Failure to cast keys (because they don't fit in the
             // target type) results in NULL values;

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -1007,7 +1007,7 @@ mod tests {
         expected_data: Vec<Option<&str>>,
     ) {
         let array = DictionaryArray::<T>::from_iter(data.into_iter());
-        let array_values = array.values();
+        let array_values = array.values().clone();
         let dict = array_values
             .as_any()
             .downcast_ref::<StringArray>()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #313.

 # Rationale for this change
 
See ticket, but in short it allows borrow lifetimes to correctly propagate without creating issues around stack-local temporaries

# Are there any user-facing changes?

As currently formulated this is a breaking change, but it could easily be reworked to not be if preferred.

EDIT: I don't seem to have permission to add the breaking change label as instructed by the placeholder text