### PR TITLE
Mutablebuffer::shrink_to_fit

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -191,9 +191,6 @@ impl MutableBuffer {
     /// buffer.shrink_to_fit();
     /// assert!(buffer.capacity() >= 64 && buffer.capacity() < 128);
     /// ```
-    // For performance reasons, this must be inlined so that the `if` is executed inside the caller, and not as an extra call that just
-    // exits.
-    #[inline(always)]
     pub fn shrink_to_fit(&mut self) {
         let new_capacity = bit_util::round_upto_multiple_of_64(self.len);
         if new_capacity < self.capacity {
@@ -779,5 +776,16 @@ mod tests {
 
         buf2.reserve(65);
         assert!(buf != buf2);
+    }
+
+    #[test]
+    fn test_mutable_shrink_to_fit() {
+        let mut buffer = MutableBuffer::new(128);
+        assert_eq!(buffer.capacity(), 128);
+        buffer.push(1);
+        buffer.push(2);
+
+        buffer.shrink_to_fit();
+        assert!(buffer.capacity() >= 64 && buffer.capacity() < 128);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

This PR add `shrink_to_fit` to the public API of  `MutableBuffer`. This closes  #297. 

In line of this, I'd like the option to shrink existing `array` data, where would such logic be a best fit. I was thinking membership of `dyn Array` trait.