### PR TITLE
Fix undefined behavior in FFI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -259,8 +259,9 @@ jobs:
           export MIRIFLAGS="-Zmiri-disable-isolation"
           cargo miri setup
           cargo clean
-          # Ignore MIRI errors until we can get a clean run
-          cargo miri test || true
+          # Currently only the arrow crate is tested with miri 
+          # IO related tests and some unsupported tests are skipped
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json
 
   lint:
     name: Lint

--- a/arrow/src/array/raw_pointer.rs
+++ b/arrow/src/array/raw_pointer.rs
@@ -57,6 +57,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "memory is not aligned")]
+    #[cfg_attr(miri, ignore)] // sometimes does not panic as expected
     fn test_primitive_array_alignment() {
         let bytes = vec![0u8, 1u8];
         unsafe { RawPtrBox::<u64>::new(bytes.as_ptr().offset(1)) };

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -3521,6 +3521,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // running forever
     fn test_can_cast_types() {
         // this function attempts to ensure that can_cast_types stays
         // in sync with cast.  It simply tries all combinations of

--- a/arrow/src/compute/kernels/cast_utils.rs
+++ b/arrow/src/compute/kernels/cast_utils.rs
@@ -220,6 +220,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function: mktime
     fn string_to_timestamp_no_timezone() -> Result<()> {
         // This test is designed to succeed in regardless of the local
         // timezone the test machine is running. Thus it is still

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -154,6 +154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // running forever
     fn length_test_string() -> Result<()> {
         length_cases()
             .into_iter()
@@ -170,6 +171,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // running forever
     fn length_test_large_string() -> Result<()> {
         length_cases()
             .into_iter()

--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -184,6 +184,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
     fn test_iter_unaligned() {
         let input: &[u8] = &[
             0b00000000, 0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000,
@@ -205,6 +206,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
     fn test_iter_unaligned_remainder_1_byte() {
         let input: &[u8] = &[
             0b00000000, 0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000,
@@ -226,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
     fn test_iter_unaligned_remainder_bits_across_bytes() {
         let input: &[u8] = &[0b00111111, 0b11111100];
         let buffer: Buffer = Buffer::from(input);
@@ -239,6 +242,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: Undefined Behavior: using uninitialized data, but this operation requires initialized memory
     fn test_iter_unaligned_remainder_bits_large() {
         let input: &[u8] = &[
             0b11111111, 0b00000000, 0b11111111, 0b00000000, 0b11111111, 0b00000000,

--- a/arrow/src/util/integration_util.rs
+++ b/arrow/src/util/integration_util.rs
@@ -722,6 +722,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // running forever
     fn test_arrow_data_equality() {
         let secs_tz = Some("Europe/Budapest".to_string());
         let millis_tz = Some("America/New_York".to_string());


### PR DESCRIPTION
Fix UB in FFI due to violation of aliasing rules

# Which issue does this PR close?

Closes #322.
 
# What changes are included in this PR?

- Fix the issue by using raw pointers derived from the Box objects in private data rather than from moved boxes
- Enable MIRI in CI for most tests in arrow crate 
    `test result: ok. 584 passed; 0 failed; 10 ignored; 0 measured; 102 filtered out`

Specifically, the CI is changed to run miri test against the arrow crate (only) while skipping some tests:
1. Individual tests that are either unsupported, fail, or get stuck are ignored using `#[cfg_attr(miri, ignore)]` with a code comment that indicates why it's disabled
2. IO tests (csv, json, ipc) are skipped in CI due to slowness and/or failures.

The above was required because otherwise the CI would be stuck forever (e.g., in the `test_can_cast_types` test). This wasn't the case so far because the FFI issue failed the run. I suggest to track enabling more tests in #227.

# Are there any user-facing changes?

No
