### PR TITLE
feature gate ipc reader/writer

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -47,16 +47,17 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
-flatbuffers = "=0.8.4"
+flatbuffers = { version = "=0.8.4", optional = true }
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
 multiversion = "0.6.1"
 
 [features]
-default = ["csv"]
+default = ["csv", "ipc"]
 avx512 = []
 csv = ["csv_crate"]
+ipc = ["flatbuffers"]
 simd = ["packed_simd"]
 prettyprint = ["prettytable-rs"]
 # this is only intended to be used in single-threaded programs: it verifies that

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -154,6 +154,7 @@ pub mod csv;
 pub mod datatypes;
 pub mod error;
 pub mod ffi;
+#[cfg(feature = "ipc")]
 pub mod ipc;
 pub mod json;
 pub mod record_batch;


### PR DESCRIPTION
# Which issue does this PR close?

This closes #310. This was as easy as bumping `#[cfg(feature = "ipc")]` on the module. This make `flatbuffers` an optional dependency. To reduce migration friction, the feature `ipc` was added to the default features.