### PR TITLE
Fix filter UB and add fast path

### DIFF
--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -412,7 +412,7 @@ impl ArrayData {
     }
 
     /// Returns a new empty [ArrayData] valid for `data_type`.
-    pub(super) fn new_empty(data_type: &DataType) -> Self {
+    pub fn new_empty(data_type: &DataType) -> Self {
         let buffers = new_buffers(data_type, 0);
         let [buffer1, buffer2] = buffers;
         let buffers = into_buffers(data_type, buffer1, buffer2);

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -257,8 +257,7 @@ pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
     match iter.filter_count {
         0 => {
             // return empty
-            let data = ArrayData::new_empty(array.data_type());
-            Ok(make_array(data))
+            Ok(new_empty_array(array.data_type()))
         }
         len if len == array.len() => {
             // return all


### PR DESCRIPTION
This also fixes UB for filter on `RecordBatches`. Still issue #295.

Besides this, I also added a fast path. We already do a `popcount` in the `filter` operation, it seems to me a missed opportunity to not just `Arc` clone the data when all values are `true`. 

EDIT:

I also made `ArrayData::new_empty` public. If there is any objection to that I can make it private. IMO this should be public, as I think it should be easy to make an empty container of data structures.