### PR TITLE
Ignore array::array_primitive::tests::test_time32second_invalid_neg during MIRI run

### DIFF
--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -865,6 +865,9 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "invalid time")]
+    // don't run on MIRI as it was causing MIRI to fail (even when the panic was expected)
+    // https://github.com/apache/arrow-rs/issues/345
+    #[cfg_attr(miri, ignore)]
     fn test_time32second_invalid_neg() {
         // The panic should come from chrono, not from arrow
         let arr: PrimitiveArray<Time32SecondType> = vec![-7201, -60054].into();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #345 (maybe)

 # Rationale for this change
 
It isn't entirely clear to me, but part of the stacktrace that is dumped on MIRI failure contains this test.  I am testing what happens if we just disable running this test during the MIRI run

# What changes are included in this PR?

Disable a suspicious test when running under MIRI

# Are there any user-facing changes?

No
