### PR TITLE
Disable MIRI check until it runs cleanly on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,40 +230,43 @@ jobs:
           export CARGO_TARGET_DIR="/github/home/target"
           cargo clippy --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
 
-  miri-checks:
-    name: MIRI
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [nightly-2021-03-24]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
-      - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt clippy miri
-      - name: Run Miri Checks
-        env:
-          RUST_BACKTRACE: full
-          RUST_LOG: 'trace'
-        run: |
-          export MIRIFLAGS="-Zmiri-disable-isolation"
-          cargo miri setup
-          cargo clean
-          # Currently only the arrow crate is tested with miri 
-          # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+  # MIRI checks are disabled until they runs cleanly:
+  # https://github.com/apache/arrow-rs/issues/345
+  #
+  # miri-checks:
+  #   name: MIRI
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       arch: [amd64]
+  #       rust: [nightly-2021-03-24]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry
+  #           ~/.cargo/git
+  #           target
+  #         key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+  #     - name: Setup Rust toolchain
+  #       run: |
+  #         rustup toolchain install ${{ matrix.rust }}
+  #         rustup default ${{ matrix.rust }}
+  #         rustup component add rustfmt clippy miri
+  #     - name: Run Miri Checks
+  #       env:
+  #         RUST_BACKTRACE: full
+  #         RUST_LOG: 'trace'
+  #       run: |
+  #         export MIRIFLAGS="-Zmiri-disable-isolation"
+  #         cargo miri setup
+  #         cargo clean
+  #         # Currently only the arrow crate is tested with miri
+  #         # IO related tests and some unsupported tests are skipped
+  #         cargo miri test -p arrow -- --skip csv --skip ipc --skip json || true
 
   lint:
     name: Lint


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/345 (but doesn't fix the underlying issue)

# Rationale for this change
The MIRI checks enabled in https://github.com/apache/arrow-rs/pull/323 have been failing frequently with false positives on PRs and master. Until they run cleanly and only fail when there are actual problems, running these CI checks on all PRs is slowing everyone down and causing confusion, 
 

# What changes are included in this PR?
1. Disable MIRI check on CI

I disabled the whole thing this time, whereas prior to https://github.com/apache/arrow-rs/pull/323 they "ran" but the results were not checked. That seems like a waste of CPU time / github actions credits to me. 


# Are there any user-facing changes?

Hopefully contributors' PRs will stop getting failing checks