### PR TITLE
allow `SliceableCursor` to be constructed from an `Arc` directly

### DIFF
--- a/parquet/src/util/cursor.rs
+++ b/parquet/src/util/cursor.rs
@@ -46,10 +46,11 @@ impl fmt::Debug for SliceableCursor {
 }
 
 impl SliceableCursor {
-    pub fn new(content: Vec<u8>) -> Self {
-        let size = content.len();
+    pub fn new(content: impl Into<Arc<Vec<u8>>>) -> Self {
+        let inner = content.into();
+        let size = inner.len();
         SliceableCursor {
-            inner: Arc::new(content),
+            inner,
             start: 0,
             pos: 0,
             length: size,


### PR DESCRIPTION
This is backwards-compatible since we change the argument from `Vec<u8>`
to `impl Into<Arc<Vec<u8>>>` and the following implementations exists in
std:

- `impl<T, U> Into<U> for T where U: From<T>` (reverse direction)
- `impl<T> From<T> for Arc<T>` (create `Arc` from any type)

Furthermore `Arc<Vec<u8>>` can be passed directly now because the following
implementations exists:

- `impl<T> From<T> for T` (identity)

Closes #368.