### PR TITLE
Cherry pick Only register Flight.proto with cargo if it exists to active_release

### DIFF
--- a/arrow-flight/build.rs
+++ b/arrow-flight/build.rs
@@ -23,9 +23,6 @@ use std::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // avoid rerunning build if the file has not changed
-    println!("cargo:rerun-if-changed=../format/Flight.proto");
-
     // override the build location, in order to check in the changes to proto files
     env::set_var("OUT_DIR", "src");
 
@@ -33,6 +30,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // built or released so we build an absolute path to the proto file
     let path = Path::new("../format/Flight.proto");
     if path.exists() {
+        // avoid rerunning build if the file has not changed
+        println!("cargo:rerun-if-changed=../format/Flight.proto");
+
         tonic_build::compile_protos("../format/Flight.proto")?;
         // read file contents to string
         let mut file = OpenOptions::new()


### PR DESCRIPTION
Automatic cherry-pick of 7753f416a620b4ea5b6242366f68acbbcf35bc06
* Originally appeared in https://github.com/apache/arrow-rs/pull/351: Only register Flight.proto with cargo if it exists
