### PR TITLE
Fix typo in release script, update release location

### DIFF
--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -73,7 +73,7 @@ echo ""
 echo "---------------------------------------------------------"
 cat <<MAIL
 To: dev@arrow.apache.org
-Subject: [VOTE][RUST] Release Apache Arrow Rust ${version}
+Subject: [VOTE][RUST] Release Apache Arrow Rust ${tag}
 
 Hi,
 

--- a/dev/release/release-tarball.sh
+++ b/dev/release/release-tarball.sh
@@ -57,7 +57,7 @@ echo "Clone release dist repository"
 svn co https://dist.apache.org/repos/dist/release/arrow ${tmp_dir}/release
 
 echo "Copy ${version}-rc${rc} to release working copy"
-release_version=arrow-${version}
+release_version=arrow-rs-${version}
 mkdir -p ${tmp_dir}/release/${release_version}
 cp -r ${tmp_dir}/dev/* ${tmp_dir}/release/${release_version}/
 svn add ${tmp_dir}/release/${release_version}


### PR DESCRIPTION
I want the version number in the proposed vote email

Also, implement @kou 's suggestion from the [mailing list](https://lists.apache.org/thread.html/re500902ac555def8acc53bd4eeef3bf16b6e7cd5e355e18544b2656f%40%3Cdev.arrow.apache.org%3E) to put the rust releases in a directory `arrow-rs-{version}` rather than `arrow-{version}`