### PR TITLE
make sure that only concat preallocates buffers

### DIFF
--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -256,7 +256,7 @@ pub type DurationMillisecondBuilder = PrimitiveBuilder<DurationMillisecondType>;
 pub type DurationMicrosecondBuilder = PrimitiveBuilder<DurationMicrosecondType>;
 pub type DurationNanosecondBuilder = PrimitiveBuilder<DurationNanosecondType>;
 
-pub use self::transform::MutableArrayData;
+pub use self::transform::{Capacities, MutableArrayData};
 
 // --------------------- Array Iterator ---------------------
 

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -520,6 +520,9 @@ impl<'a> MutableArrayData<'a> {
                 0 => unreachable!(),
                 1 => Some(arrays[0].child_data()[0].clone()),
                 _ => {
+                    if let Capacities::Dictionary(_, _) = capacities {
+                        panic!("dictionary capacity not yet supported")
+                    }
                     // Concat dictionaries together
                     let dictionaries: Vec<_> =
                         arrays.iter().map(|array| &array.child_data()[0]).collect();

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -405,21 +405,11 @@ impl<'a> MutableArrayData<'a> {
         // We can prevent reallocation by precomputing the needed size.
         // This is faster and more memory efficient.
         let ([buffer1, buffer2], capacity) = match (data_type, &capacities) {
-            (DataType::LargeUtf8, Capacities::Binary(cap, value_cap))
-                if value_cap.is_some() =>
-            {
-                (
-                    preallocate_str_buffer::<i64>(*cap, value_cap.unwrap()),
-                    *cap,
-                )
+            (DataType::LargeUtf8, Capacities::Binary(cap, Some(value_cap))) => {
+                (preallocate_str_buffer::<i64>(*cap, *value_cap), *cap)
             }
-            (DataType::Utf8, Capacities::Binary(cap, value_cap))
-                if value_cap.is_some() =>
-            {
-                (
-                    preallocate_str_buffer::<i32>(*cap, value_cap.unwrap()),
-                    *cap,
-                )
+            (DataType::Utf8, Capacities::Binary(cap, Some(value_cap))) => {
+                (preallocate_str_buffer::<i32>(*cap, *value_cap), *cap)
             }
             (_, Capacities::Array(capacity)) => {
                 (new_buffers(data_type, *capacity), *capacity)


### PR DESCRIPTION
# Which issue does this PR close?

Partial fix for #347. In #348  @jorgecarleitao pointed out that the memory savings don't work for the `filter` and the `zip` kernel. 
This PR restores the implementation for those two kernels, and keeps the new `preallocation` for the `concat` kernel. 

This is achieved by create a builder pattern for `MutableArrayData`. This way we don't break the API, and we may choose to `preallocate` buffers.

Could you take a look at this @jorgecarleitao ?

# Are there any user-facing changes?

There is an builder pattern struct for `MutableArrayData`.

# If there are any breaking changes to public APIs, please add the `breaking change` label.

No
