### PR TITLE
Add set_bit to BooleanBufferBuilder to allow mutating bit in index

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -304,7 +304,7 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn set_bit(&mut self, index: usize, v: bool) {
-        if bit {
+        if v {
             bit_util::set_bit(self.buffer.as_mut(), index);
         } else {
             bit_util::unset_bit(self.buffer.as_mut(), index);

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2303,7 +2303,7 @@ mod tests {
         buffer.append(true);
         buffer.set_bit(0, false);
         assert_eq!(buffer.len(), 4);
-        assert_eq!(buffer.finish().as_slice(), &[0b1010 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b1010_u8]);
     }
 
     #[test]
@@ -2315,7 +2315,7 @@ mod tests {
         buffer.append(true);
         buffer.set_bit(3, false);
         assert_eq!(buffer.len(), 4);
-        assert_eq!(buffer.finish().as_slice(), &[0b0011 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b0011_u8]);
     }
 
     #[test]
@@ -2327,7 +2327,7 @@ mod tests {
         buffer.append(true);
         buffer.set_bit(1, false);
         assert_eq!(buffer.len(), 4);
-        assert_eq!(buffer.finish().as_slice(), &[0b1001 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b1001_u8]);
     }
 
     #[test]
@@ -2341,7 +2341,7 @@ mod tests {
         buffer.set_bit(1, false);
         buffer.set_bit(2, false);
         assert_eq!(buffer.len(), 5);
-        assert_eq!(buffer.finish().as_slice(), &[0b10001 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b10001_u8]);
     }
 
     #[test]
@@ -2352,7 +2352,7 @@ mod tests {
         buffer.set_bit(3, false);
         buffer.set_bit(9, false);
         assert_eq!(buffer.len(), 10);
-        assert_eq!(buffer.finish().as_slice(), &[0b11110110, 0b01]);
+        assert_eq!(buffer.finish().as_slice(), &[0b11110110_u8, 0b01_u8]);
     }
 
     #[test]
@@ -2368,7 +2368,7 @@ mod tests {
         buffer.set_bit(14, true);
         buffer.set_bit(13, false);
         assert_eq!(buffer.len(), 15);
-        assert_eq!(buffer.finish().as_slice(), &[0b01010110, 0b1011100]);
+        assert_eq!(buffer.finish().as_slice(), &[0b01010110_u8, 0b1011100_u8]);
     }
 
     #[test]

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2295,7 +2295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_buffer_builder_flip_first_bit() {
+    fn test_boolean_buffer_builder_unset_first_bit() {
         let mut buffer = BooleanBufferBuilder::new(4);
         buffer.append(true);
         buffer.append(true);
@@ -2303,11 +2303,11 @@ mod tests {
         buffer.append(true);
         buffer.set_bit(0, false);
         assert_eq!(buffer.len(), 4);
-        assert_eq!(buffer.finish().as_slice(), &[0b0101 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b1010 as u8]);
     }
 
     #[test]
-    fn test_boolean_buffer_builder_flip_last_bit() {
+    fn test_boolean_buffer_builder_unset_last_bit() {
         let mut buffer = BooleanBufferBuilder::new(4);
         buffer.append(true);
         buffer.append(true);
@@ -2315,11 +2315,11 @@ mod tests {
         buffer.append(true);
         buffer.set_bit(3, false);
         assert_eq!(buffer.len(), 4);
-        assert_eq!(buffer.finish().as_slice(), &[0b1100 as u8]);
+        assert_eq!(buffer.finish().as_slice(), &[0b0011 as u8]);
     }
 
     #[test]
-    fn test_boolean_buffer_builder_flip_an_inner_bit() {
+    fn test_boolean_buffer_builder_unset_an_inner_bit() {
         let mut buffer = BooleanBufferBuilder::new(5);
         buffer.append(true);
         buffer.append(true);
@@ -2331,7 +2331,7 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_buffer_builder_flip_several_bits() {
+    fn test_boolean_buffer_builder_unset_several_bits() {
         let mut buffer = BooleanBufferBuilder::new(5);
         buffer.append(true);
         buffer.append(true);
@@ -2345,14 +2345,30 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_buffer_builder_flip_several_bits_bigger_than_one_byte() {
+    fn test_boolean_buffer_builder_unset_several_bits_bigger_than_one_byte() {
         let mut buffer = BooleanBufferBuilder::new(16);
         buffer.append_n(10, true);
         buffer.set_bit(0, false);
         buffer.set_bit(3, false);
         buffer.set_bit(9, false);
         assert_eq!(buffer.len(), 10);
-        assert_eq!(buffer.finish().as_slice(), &[0b10111110, 0b01]);
+        assert_eq!(buffer.finish().as_slice(), &[0b11110110, 0b01]);
+    }
+
+    #[test]
+    fn test_boolean_buffer_builder_flip_several_bits_bigger_than_one_byte() {
+        let mut buffer = BooleanBufferBuilder::new(16);
+        buffer.append_n(5, true);
+        buffer.append_n(5, false);
+        buffer.append_n(5, true);
+        buffer.set_bit(0, false);
+        buffer.set_bit(3, false);
+        buffer.set_bit(9, false);
+        buffer.set_bit(6, true);
+        buffer.set_bit(14, true);
+        buffer.set_bit(13, false);
+        assert_eq!(buffer.len(), 15);
+        assert_eq!(buffer.finish().as_slice(), &[0b01010110, 0b1011100]);
     }
 
     #[test]

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -303,7 +303,7 @@ impl BooleanBufferBuilder {
     }
 
     #[inline]
-    pub fn set_bit(&mut self, index: usize, bit: bool) {
+    pub fn set_bit(&mut self, index: usize, v: bool) {
         if bit {
             bit_util::set_bit(self.buffer.as_mut(), index);
         } else {

--- a/arrow/src/util/bit_util.rs
+++ b/arrow/src/util/bit_util.rs
@@ -62,7 +62,7 @@ pub unsafe fn get_bit_raw(data: *const u8, i: usize) -> bool {
     (*data.add(i >> 3) & BIT_MASK[i & 7]) != 0
 }
 
-/// Sets bit at position `i` for `data`
+/// Sets bit at position `i` for `data` to 1
 #[inline]
 pub fn set_bit(data: &mut [u8], i: usize) {
     data[i >> 3] |= BIT_MASK[i & 7];


### PR DESCRIPTION
# Which issue does this PR close?
<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to https://github.com/apache/arrow-datafusion/issues/240 & https://github.com/apache/arrow-datafusion/pull/342

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`BooleanBufferBuilder` behaves as a bitmap. My intention is to extend its API to allow mutating bits already set, to make it's API closer to the `bitvec` crate and useable for my use-case in `arrow-datafusion`.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR includes the implementation and some tests that currently **does not** pass. I'm making the PR public to get help from the community, as I'm stuck.

# Are there any user-facing changes?

There is a new public method `set_bit` added to `BooleanBufferBuilder`.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
