### PR TITLE
make slice work for nested types

### DIFF
--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -84,12 +84,7 @@ impl From<ArrayData> for StructArray {
     fn from(data: ArrayData) -> Self {
         let mut boxed_fields = vec![];
         for cd in data.child_data() {
-            let child_data = if data.offset() != 0 || data.len() != cd.len() {
-                cd.slice(data.offset(), data.len())
-            } else {
-                cd.clone()
-            };
-            boxed_fields.push(make_array(child_data));
+            boxed_fields.push(make_array(cd.clone()));
         }
         Self { data, boxed_fields }
     }

--- a/arrow/src/array/transform/structure.rs
+++ b/arrow/src/array/transform/structure.rs
@@ -26,13 +26,10 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                   index: usize,
                   start: usize,
                   len: usize| {
-                mutable.child_data.iter_mut().for_each(|child| {
-                    child.extend(
-                        index,
-                        array.offset() + start,
-                        array.offset() + start + len,
-                    )
-                })
+                mutable
+                    .child_data
+                    .iter_mut()
+                    .for_each(|child| child.extend(index, start, start + len))
             },
         )
     } else {
@@ -41,7 +38,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                   index: usize,
                   start: usize,
                   len: usize| {
-                (array.offset() + start..array.offset() + start + len).for_each(|i| {
+                (start..start + len).for_each(|i| {
                     if array.is_valid(i) {
                         mutable
                             .child_data


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/554

# Rationale for this change
 
`ArrayData::slice()` does not work for nested types, because only the `ArrayData::buffers` are updated with the new offset and length. This has caused a lot of issues in the past.

This blocks us from being able to implement `RecordBatch::slice()`, and has led to creating #381 to sidestep this issue.

# What changes are included in this PR?

I propose a manual slice where we check if `ArrayData::child_data` is not empty, and then propagate the offset and length down to them. The only trick is with list and largelist, where we have to inspect the offset buffers to determine what the new offset and length should be.

# Are there any user-facing changes?

No UFC