### PR TITLE
Add Decimal to CsvWriter and improve debug display

### DIFF
--- a/arrow/benches/csv_writer.rs
+++ b/arrow/benches/csv_writer.rs
@@ -28,14 +28,14 @@ use arrow::record_batch::RecordBatch;
 use std::fs::File;
 use std::sync::Arc;
 
-fn record_batches_to_csv() {
+fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(feature = "csv")]
     {
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Utf8, false),
             Field::new("c2", DataType::Float64, true),
             Field::new("c3", DataType::UInt32, false),
-            Field::new("c3", DataType::Boolean, true),
+            Field::new("c4", DataType::Boolean, true),
         ]);
 
         let c1 = StringArray::from(vec![
@@ -59,15 +59,16 @@ fn record_batches_to_csv() {
         let file = File::create("target/bench_write_csv.csv").unwrap();
         let mut writer = csv::Writer::new(file);
         let batches = vec![&b, &b, &b, &b, &b, &b, &b, &b, &b, &b, &b];
-        #[allow(clippy::unit_arg)]
-        criterion::black_box(for batch in batches {
-            writer.write(batch).unwrap()
+
+        c.bench_function("record_batches_to_csv", |b| {
+            b.iter(|| {
+                #[allow(clippy::unit_arg)]
+                criterion::black_box(for batch in &batches {
+                    writer.write(batch).unwrap()
+                });
+            });
         });
     }
-}
-
-fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("record_batches_to_csv", |b| b.iter(record_batches_to_csv));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -65,7 +65,10 @@
 //! }
 //! ```
 
+use std::convert::TryInto;
 use std::io::Write;
+
+use num::integer::div_rem;
 
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
@@ -241,6 +244,14 @@ impl<W: Write> Writer<W> {
                             .unwrap(),
                     };
                     format!("{}", datetime.format(&self.timestamp_format))
+                }
+                DataType::Decimal(_precision, scale) => {
+                    let c = col.as_any().downcast_ref::<DecimalArray>().unwrap();
+                    let value = c.value(row_index);
+                    let (prefix, suffix) =
+                        div_rem(value, 10_i128.pow((*scale).try_into().unwrap()));
+
+                    format!("{}.{}", prefix, suffix.abs())
                 }
                 t => {
                     // List and Struct arrays not supported by the writer, any
@@ -566,6 +577,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
             Field::new("c4", DataType::Boolean, true),
             Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond, None), true),
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
+            Field::new("c7", DataType::Decimal(6, 2), false),
         ]);
 
         let c1 = StringArray::from(vec![
@@ -585,6 +597,11 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
             None,
         );
         let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
+        let mut c7_builder = DecimalBuilder::new(5, 6, 2);
+        c7_builder.append_value(12345_i128).unwrap();
+        c7_builder.append_value(-12345_i128).unwrap();
+        c7_builder.append_null().unwrap();
+        let c7 = c7_builder.finish();
 
         let batch = RecordBatch::try_new(
             Arc::new(schema),
@@ -595,6 +612,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
                 Arc::new(c4),
                 Arc::new(c5),
                 Arc::new(c6),
+                Arc::new(c7),
             ],
         )
         .unwrap();
@@ -606,13 +624,13 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
             writer.write(batch).unwrap();
         }
 
-        let left = "c1,c2,c3,c4,c5,c6
-Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34
-consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20
-sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
-Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34
-consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20
-sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03\n";
+        let left = "c1,c2,c3,c4,c5,c6,c7
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34,123.45
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20,-123.45
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34,123.45
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20,-123.45
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,\n";
         let right = writer.writer.into_inner().map(|s| s.to_string());
         assert_eq!(Some(left.to_string()), right.ok());
     }

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -19,6 +19,8 @@
 //! purposes. See the `pretty` crate for additional functions for
 //! record batch pretty printing.
 
+use std::sync::Arc;
+
 use crate::array::Array;
 use crate::datatypes::{
     ArrowNativeType, ArrowPrimitiveType, DataType, Int16Type, Int32Type, Int64Type,
@@ -192,18 +194,15 @@ macro_rules! make_string_from_list {
     }};
 }
 
-macro_rules! make_string_from_decimal {
-    ($array_type: ty, $column: ident, $row: ident, $scale: ident) => {{
-        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
-        let decimal_string = array.value($row).to_string();
-        let formatted_decimal = if *$scale == 0 {
-            decimal_string
-        } else {
-            let splits = decimal_string.split_at(decimal_string.len() - *$scale);
-            format!("{}.{}", splits.0, splits.1)
-        };
-        Ok(formatted_decimal)
-    }};
+#[inline(always)]
+pub fn make_string_from_decimal(column: &Arc<dyn Array>, row: usize) -> Result<String> {
+    let array = column
+        .as_any()
+        .downcast_ref::<array::DecimalArray>()
+        .unwrap();
+
+    let formatted_decimal = array.value_as_string(row);
+    Ok(formatted_decimal)
 }
 
 /// Get the value at the given row in an array as a String.
@@ -231,9 +230,7 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::Float16 => make_string!(array::Float32Array, column, row),
         DataType::Float32 => make_string!(array::Float32Array, column, row),
         DataType::Float64 => make_string!(array::Float64Array, column, row),
-        DataType::Decimal(_, scale) => {
-            make_string_from_decimal!(array::DecimalArray, column, row, scale)
-        }
+        DataType::Decimal(..) => make_string_from_decimal(column, row),
         DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
             make_string_datetime!(array::TimestampSecondArray, column, row)
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #405.

# Rationale for this change
A simple CSV serializer for Decimals and matching debug format improvement.

# What changes are included in this PR?
Decimal -> string conversion.

# Are there any user-facing changes?
The debug display of DecimalArray(precision:10, scale:2) is changed from:
```
12345
```
to
```
123.45
```

# Two things to consider for any reviewer:

1. I might be wrong with `try_into()` and ` as i32` and other cast. I'm new to Rust and I don't know the exact implications of my introduced changes.
2. For integer-like decimals I still write `1.0` instead of `1`. This was a subjective decision, I don't have strong feelings about it. Padding was/is missing as well. 