### PR TITLE
Add labels to cherry pick scripts + writeup

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -262,6 +262,7 @@ There are two tags that help keep track of backporting:
 1. [`cherry-picked`](https://github.com/apache/arrow-rs/labels/cherry-picked) for PRs that have been cherry-picked/backported to `active_release`
 2. [`release-cherry-pick`](https://github.com/apache/arrow-rs/labels/release-cherry-pick) for the PRs that are the cherry pick
 
+You can find candidates to cherry pick using this filter: https://github.com/apache/arrow-rs/pulls?page=2&q=is%3Apr+is%3Aclosed+-label%3Arelease-cherry-pick+-label%3Acherry-picked
 
 ## Rationale for creating PRs:
 1. PRs are a natural place to run the CI tests to make sure there are no logical conflicts

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -250,6 +250,7 @@ ARROW_GITHUB_API_TOKEN=$ARROW_GITHUB_API_TOKEN CHECKOUT_ROOT=/tmp/arrow-rs CHERR
 ```
 
 ## Tags
+
 There are two tags that help keep track of backporting:
 
 1. [`cherry-picked`](https://github.com/apache/arrow-rs/labels/cherry-picked) for PRs that have been cherry-picked/backported to `active_release`

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -248,7 +248,6 @@ Step 3a: If CI passes, merge cherry-pick PR
 Step 3b: If CI doesn't pass or some other changes are needed, the PR should be reviewed / approved as normal prior to merge
 
 
-
 For example, to backport `b2de5446cc1e45a0559fb39039d0545df1ac0d26` to active_release use the folliwing
 
 ```shell
@@ -256,6 +255,13 @@ git clone git@github.com:apache/arrow-rs.git /tmp/arrow-rs
 
 ARROW_GITHUB_API_TOKEN=$ARROW_GITHUB_API_TOKEN CHECKOUT_ROOT=/tmp/arrow-rs CHERRY_PICK_SHA=b2de5446cc1e45a0559fb39039d0545df1ac0d26 python3 dev/release/cherry-pick-pr.py
 ```
+
+## Tags
+There are two tags that help keep track of backporting:
+
+1. [`cherry-picked`](https://github.com/apache/arrow-rs/labels/cherry-picked) for PRs that have been cherry-picked/backported to `active_release`
+2. [`release-cherry-pick`](https://github.com/apache/arrow-rs/labels/release-cherry-pick) for the PRs that are the cherry pick
+
 
 ## Rationale for creating PRs:
 1. PRs are a natural place to run the CI tests to make sure there are no logical conflicts

--- a/dev/release/cherry-pick-pr.py
+++ b/dev/release/cherry-pick-pr.py
@@ -142,9 +142,10 @@ def make_cherry_pick_pr():
                           body=new_commit_message,
                           base='refs/heads/active_release',
                           head='refs/heads/{}'.format(new_branch),
-                          maintainer_can_modify=True
-                          labels=[release_cherry_pick_label]
+                          maintainer_can_modify=True,
                           )
+
+    pr.add_to_labels(release_cherry_pick_label)
 
     print('Created PR {}'.format(pr.html_url))
 

--- a/dev/release/cherry-pick-pr.py
+++ b/dev/release/cherry-pick-pr.py
@@ -117,10 +117,14 @@ def make_cherry_pick():
     run_cmd(['git', 'push', '-u', 'origin', new_branch])
 
 
+
 def make_cherry_pick_pr():
     from github import Github
     g = Github(token)
     repo = g.get_repo(TARGET_REPO)
+
+    release_cherry_pick_label = repo.get_label('release-cherry-pick')
+    cherry_picked_label = repo.get_label('cherry-picked')
 
     # Default titles
     new_title = 'Cherry pick {} to active_release'.format(new_sha)
@@ -132,12 +136,14 @@ def make_cherry_pick_pr():
         new_commit_message += '* Originally appeared in {}: {}\n'.format(
             orig_pull.html_url, orig_pull.title)
         new_title = 'Cherry pick {} to active_release'.format(orig_pull.title)
+        orig_pull.add_to_labels(cherry_picked_label)
 
     pr = repo.create_pull(title=new_title,
                           body=new_commit_message,
                           base='refs/heads/active_release',
                           head='refs/heads/{}'.format(new_branch),
                           maintainer_can_modify=True
+                          labels=[release_cherry_pick_label]
                           )
 
     print('Created PR {}'.format(pr.html_url))


### PR DESCRIPTION
re https://github.com/apache/arrow-rs/issues/292

# Rationale for this change
I am trying to use labels to make it clear which PRs has been backported and what has not been backported. 

This PR is a step towards my final goal of https://github.com/apache/arrow-rs/issues/292, which will be to automate the invocation of backporting in a github action.

# What changes are included in this PR?
1. The cherry-pick script adds labels now
2. Adds documentation about how this works

# Are there any user-facing changes?
No

