### PR TITLE
Fix bug with null buffer offset in boolean not kernel

### DIFF
--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -376,7 +376,7 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray> {
     let null_bit_buffer = data
         .null_bitmap()
         .as_ref()
-        .map(|b| b.bits.slice(left_offset));
+        .map(|b| b.bits.bit_slice(left_offset, len));
 
     let values = buffer_unary_not(&data.buffers()[0], left_offset, len);
 
@@ -809,6 +809,19 @@ mod tests {
         let c = not(&a).unwrap();
 
         let expected = BooleanArray::from(vec![true, false]);
+
+        assert_eq!(c, expected);
+    }
+
+    #[test]
+    fn test_bool_array_not_sliced() {
+        let a = BooleanArray::from(vec![None, Some(true), Some(false), None, Some(true)]);
+        let a = a.slice(1, 4);
+        let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let c = not(&a).unwrap();
+
+        let expected =
+            BooleanArray::from(vec![Some(false), Some(true), None, Some(false)]);
 
         assert_eq!(c, expected);
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #417.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
