### PR TITLE
Remove DictionaryArray::keys_array method

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -70,24 +70,9 @@ pub struct DictionaryArray<K: ArrowPrimitiveType> {
 }
 
 impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
-    /// Return an iterator to the keys of this dictionary.
+    /// Return an array view of the keys of this dictionary as a PrimitiveArray.
     pub fn keys(&self) -> &PrimitiveArray<K> {
         &self.keys
-    }
-
-    /// Returns an array view of the keys of this dictionary
-    pub fn keys_array(&self) -> PrimitiveArray<K> {
-        let data = self.data_ref();
-        let keys_data = ArrayData::new(
-            K::DATA_TYPE,
-            data.len(),
-            Some(data.null_count()),
-            data.null_buffer().cloned(),
-            data.offset(),
-            data.buffers().to_vec(),
-            vec![],
-        );
-        PrimitiveArray::<K>::from(keys_data)
     }
 
     /// Returns the lookup key by doing reverse dictionary lookup
@@ -379,7 +364,7 @@ mod tests {
         let test = vec!["a", "b", "c", "a"];
         let array: DictionaryArray<Int8Type> = test.into_iter().collect();
 
-        let keys = array.keys_array();
+        let keys = array.keys();
         assert_eq!(&DataType::Int8, keys.data_type());
         assert_eq!(0, keys.null_count());
         assert_eq!(&[0, 1, 2, 0], keys.values());
@@ -390,7 +375,7 @@ mod tests {
         let test = vec![Some("a"), None, Some("b"), None, None, Some("a")];
         let array: DictionaryArray<Int32Type> = test.into_iter().collect();
 
-        let keys = array.keys_array();
+        let keys = array.keys();
         assert_eq!(&DataType::Int32, keys.data_type());
         assert_eq!(3, keys.null_count());
 

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -3196,7 +3196,7 @@ mod tests {
         assert_eq!(array.is_null(1), true);
         assert_eq!(array.is_valid(1), false);
 
-        let keys = array.keys_array();
+        let keys = array.keys();
 
         assert_eq!(keys.value(0), 1);
         assert_eq!(keys.is_null(1), true);

--- a/arrow/src/array/ord.rs
+++ b/arrow/src/array/ord.rs
@@ -90,8 +90,8 @@ where
 {
     let left = left.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
     let right = right.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
-    let left_keys = left.keys_array();
-    let right_keys = right.keys_array();
+    let left_keys = left.keys();
+    let right_keys = right.keys();
 
     let left_values = StringArray::from(left.values().data().clone());
     let right_values = StringArray::from(right.values().data().clone());

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1370,7 +1370,8 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
                     )
                 })?;
 
-            let keys_array: ArrayRef = Arc::new(dict_array.keys_array());
+            let keys_array: ArrayRef =
+                Arc::new(PrimitiveArray::<K>::from(dict_array.keys().data().clone()));
             let values_array = dict_array.values();
             let cast_keys = cast_with_options(&keys_array, to_index_type, &cast_options)?;
             let cast_values =
@@ -1450,7 +1451,8 @@ where
         cast_with_options(&dict_array.values(), to_type, cast_options)?;
 
     // Note take requires first casting the indices to u32
-    let keys_array: ArrayRef = Arc::new(dict_array.keys_array());
+    let keys_array: ArrayRef =
+        Arc::new(PrimitiveArray::<K>::from(dict_array.keys().data().clone()));
     let indicies = cast_with_options(&keys_array, &DataType::UInt32, cast_options)?;
     let u32_indicies =
         indicies

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -584,7 +584,7 @@ fn sort_string_dictionary<T: ArrowDictionaryKeyType>(
 ) -> Result<UInt32Array> {
     let values: &DictionaryArray<T> = as_dictionary_array::<T>(values);
 
-    let keys: &PrimitiveArray<T> = &values.keys_array();
+    let keys: &PrimitiveArray<T> = values.keys();
 
     let dict = values.values();
     let dict: &StringArray = as_string_array(&dict);
@@ -1028,7 +1028,7 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("Unable to get dictionary values");
-        let sorted_keys = sorted.keys_array();
+        let sorted_keys = sorted.keys();
 
         assert_eq!(sorted_dict, dict);
 

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -755,7 +755,7 @@ where
     I: ArrowNumericType,
     I::Native: ToPrimitive,
 {
-    let new_keys = take_primitive::<T, I>(&values.keys_array(), indices)?;
+    let new_keys = take_primitive::<T, I>(values.keys(), indices)?;
     let new_keys_data = new_keys.data_ref();
 
     let data = ArrayData::new(

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -297,7 +297,7 @@ fn dict_array_value_to_string<K: ArrowPrimitiveType>(
 ) -> Result<String> {
     let dict_array = colum.as_any().downcast_ref::<DictionaryArray<K>>().unwrap();
 
-    let keys_array = dict_array.keys_array();
+    let keys_array = dict_array.keys();
 
     if keys_array.is_null(row) {
         return Ok(String::from(""));


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #391.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The `keys_array` can be a performance problem if used in inner loops and most usages can be directly replaced by the `keys` method which returns a reference without any cloning or allocations.

# What changes are included in this PR?

Removed the method and replaced it's usages with the `keys` method.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, this is a breaking change.

This is currently a draft because there were actually two usages in the `cast` kernels that could not be directly replaced. We do not seem to have an obvious way to get from `&PrimitiveArray<T>` to `ArrayRef`. This transformation would be much easier if the `PrimitiveArray` itself was cloneable.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
