### PR TITLE
Reenable MIRI check on PRs

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Rust
+
+on:
+  # always trigger
+  push:
+  pull_request:
+
+jobs:
+
+  miri-checks:
+    name: MIRI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [nightly-2021-03-24]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt clippy miri
+      - name: Run Miri Checks
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: 'trace'
+        run: |
+          export MIRIFLAGS="-Zmiri-disable-isolation"
+          cargo miri setup
+          cargo clean
+          # Currently only the arrow crate is tested with miri
+          # IO related tests and some unsupported tests are skipped
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json || true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,44 +230,6 @@ jobs:
           export CARGO_TARGET_DIR="/github/home/target"
           cargo clippy --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
 
-  # MIRI checks are disabled until they runs cleanly:
-  # https://github.com/apache/arrow-rs/issues/345
-  #
-  # miri-checks:
-  #   name: MIRI
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       arch: [amd64]
-  #       rust: [nightly-2021-03-24]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         submodules: true
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           ~/.cargo/registry
-  #           ~/.cargo/git
-  #           target
-  #         key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
-  #     - name: Setup Rust toolchain
-  #       run: |
-  #         rustup toolchain install ${{ matrix.rust }}
-  #         rustup default ${{ matrix.rust }}
-  #         rustup component add rustfmt clippy miri
-  #     - name: Run Miri Checks
-  #       env:
-  #         RUST_BACKTRACE: full
-  #         RUST_LOG: 'trace'
-  #       run: |
-  #         export MIRIFLAGS="-Zmiri-disable-isolation"
-  #         cargo miri setup
-  #         cargo clean
-  #         # Currently only the arrow crate is tested with miri
-  #         # IO related tests and some unsupported tests are skipped
-  #         cargo miri test -p arrow -- --skip csv --skip ipc --skip json || true
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -281,6 +281,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: this test uses too much memory to run on CI
     fn bit_length_test_string() -> Result<()> {
         bit_length_cases()
             .into_iter()
@@ -297,6 +298,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // error: this test uses too much memory to run on CI
     fn bit_length_test_large_string() -> Result<()> {
         bit_length_cases()
             .into_iter()


### PR DESCRIPTION
# Which issue does this PR close?
Fixes: https://github.com/apache/arrow-rs/issues/345

# Rationale:
We disabled this check in https://github.com/apache/arrow-rs/pull/360 as it was failing intermittently. However, @roee88  diagnosed the problem with a few tests that consumed a lot of memory, and @jhorstmann has been fixing some other MIR related issues in https://github.com/apache/arrow-rs/pull/416

# Changes:
1. Reenable MIRI tests
2. Mark `bit_length_test_string` and `bit_length_test_large_string` to not run under MIRI
2. Put them in their own github actions workflow (so that if they fail we don't have to rerun the entire workflow again)
