### PR TITLE
disable lexsort bound check

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -20,6 +20,7 @@
 use crate::array::*;
 use crate::buffer::MutableBuffer;
 use crate::compute::take;
+use crate::compute::TakeOptions;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use std::cmp::Ordering;

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -805,7 +805,17 @@ pub fn lexsort(columns: &[SortColumn], limit: Option<usize>) -> Result<Vec<Array
     let indices = lexsort_to_indices(columns, limit)?;
     columns
         .iter()
-        .map(|c| take(c.values.as_ref(), &indices, None))
+        .map(|c| {
+            take(
+                c.values.as_ref(),
+                &indices,
+                // disable bound check overhead since indices are already generated from
+                // the same record batch
+                Some(TakeOptions {
+                    check_bounds: false,
+                }),
+            )
+        })
         .collect()
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Re https://github.com/apache/arrow-rs/issues/428

# Rationale for this change

disable bound check in sort to reduce overhead since indices are already generated from the same record batch

# What changes are included in this PR?



# Are there any user-facing changes?


