### PR TITLE
Derive Eq and PartialEq for SortOptions

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -361,7 +361,7 @@ pub fn sort_to_indices(
 }
 
 /// Options that define how sort kernels should behave
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,


### PR DESCRIPTION
Being able to compare SortOptions settings is very useful, especially when writing tests

Resolves https://github.com/apache/arrow-rs/issues/426