### PR TITLE
Cherry pick Derive Eq and PartialEq for SortOptions to active_release

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -361,7 +361,7 @@ pub fn sort_to_indices(
 }
 
 /// Options that define how sort kernels should behave
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,


### PR DESCRIPTION
Automatic cherry-pick of 5adfd3d
* Originally appeared in https://github.com/apache/arrow-rs/pull/425: Derive Eq and PartialEq for SortOptions
