### PR TITLE
use iterator for partition kernel instead of generating vec

### DIFF
--- a/arrow/benches/partition_kernels.rs
+++ b/arrow/benches/partition_kernels.rs
@@ -48,7 +48,11 @@ fn bench_partition(sorted_columns: &[ArrayRef]) {
         })
         .collect::<Vec<_>>();
 
-    criterion::black_box(lexicographical_partition_ranges(&columns).unwrap());
+    criterion::black_box(
+        lexicographical_partition_ranges(&columns)
+            .unwrap()
+            .collect::<Vec<_>>(),
+    );
 }
 
 fn create_sorted_low_cardinality_data(length: usize) -> Vec<ArrayRef> {


### PR DESCRIPTION
# Which issue does this PR close?

based on #424
Closes #437 

# Rationale for this change

use iterator for partition kernel instead of generating vec

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
