### PR TITLE
Implement the Iterator trait for the json Reader.

### DIFF
--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1573,11 +1573,7 @@ impl<R: Read> Iterator for Reader<R> {
     type Item = Result<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.next() {
-            Ok(None) => None,
-            Ok(Some(some)) => Some(Ok(some)),
-            Err(e) => Some(Err(e)),
-        }
+        self.next().transpose()
     }
 }
 

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1569,6 +1569,18 @@ impl ReaderBuilder {
     }
 }
 
+impl<R: Read> Iterator for Reader<R> {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next() {
+            Ok(None) => None,
+            Ok(Some(some)) => Some(Ok(some)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -2945,5 +2957,36 @@ mod tests {
 
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.num_rows(), 3);
+    }
+
+    #[test]
+    fn test_json_iterator() {
+        let builder = ReaderBuilder::new().infer_schema(None).with_batch_size(5);
+        let reader: Reader<File> = builder
+            .build::<File>(File::open("test/data/basic.json").unwrap())
+            .unwrap();
+        let schema = reader.schema();
+        let (col_a_index, _) = schema.column_with_name("a").unwrap();
+
+        let mut sum_num_rows = 0;
+        let mut num_batches = 0;
+        let mut sum_a = 0;
+        for batch in reader {
+            let batch = batch.unwrap();
+            assert_eq!(4, batch.num_columns());
+            sum_num_rows += batch.num_rows();
+            num_batches += 1;
+            let batch_schema = batch.schema();
+            assert_eq!(schema, batch_schema);
+            let a_array = batch
+                .column(col_a_index)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            sum_a += (0..a_array.len()).map(|i| a_array.value(i)).sum::<i64>();
+        }
+        assert_eq!(12, sum_num_rows);
+        assert_eq!(3, num_batches);
+        assert_eq!(100000000000011, sum_a);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #193 (JSON reader does not implement iterator). 

# Rationale for this change

Fairly straightforward change that makes it easy to iterate over `RecordBatch` when reading a json file.

# What changes are included in this PR?

- Implement the `Iterator` trait directly on `json::Reader`.
- Add test reading some json file through a for loop using this iterator.

# Are there any user-facing changes?

None expected, this adds a `next` function as part of the trait, there is already a public `next` function defined on `json::Reader` and this doesn't seem to be an issue.