### PR TITLE
Fix clippy lints introduced in rust 1.53

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1009,11 +1009,11 @@ mod tests {
         assert_eq!(array.value(1), b"two");
         assert_eq!(array.value(3), b"");
         assert_eq!(array.value(4), b"three");
-        assert_eq!(array.is_null(0), false);
-        assert_eq!(array.is_null(1), false);
-        assert_eq!(array.is_null(2), true);
-        assert_eq!(array.is_null(3), false);
-        assert_eq!(array.is_null(4), false);
+        assert!(!array.is_null(0));
+        assert!(!array.is_null(1));
+        assert!(array.is_null(2));
+        assert!(!array.is_null(3));
+        assert!(!array.is_null(4));
     }
 
     #[test]

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -147,7 +147,7 @@ impl From<Vec<bool>> for BooleanArray {
 
 impl From<Vec<Option<bool>>> for BooleanArray {
     fn from(data: Vec<Option<bool>>) -> Self {
-        BooleanArray::from_iter(data.iter())
+        data.iter().collect()
     }
 }
 

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -379,12 +379,12 @@ mod tests {
         assert_eq!(&DataType::Int32, keys.data_type());
         assert_eq!(3, keys.null_count());
 
-        assert_eq!(true, keys.is_valid(0));
-        assert_eq!(false, keys.is_valid(1));
-        assert_eq!(true, keys.is_valid(2));
-        assert_eq!(false, keys.is_valid(3));
-        assert_eq!(false, keys.is_valid(4));
-        assert_eq!(true, keys.is_valid(5));
+        assert!(keys.is_valid(0));
+        assert!(!keys.is_valid(1));
+        assert!(keys.is_valid(2));
+        assert!(!keys.is_valid(3));
+        assert!(!keys.is_valid(4));
+        assert!(keys.is_valid(5));
 
         assert_eq!(0, keys.value(0));
         assert_eq!(1, keys.value(2));

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -777,19 +777,19 @@ mod tests {
 
         let bool_arr = arr2.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        assert_eq!(false, bool_arr.is_valid(0));
+        assert!(!bool_arr.is_valid(0));
 
-        assert_eq!(true, bool_arr.is_valid(1));
-        assert_eq!(true, bool_arr.value(1));
+        assert!(bool_arr.is_valid(1));
+        assert!(bool_arr.value(1));
 
-        assert_eq!(true, bool_arr.is_valid(2));
-        assert_eq!(false, bool_arr.value(2));
+        assert!(bool_arr.is_valid(2));
+        assert!(!bool_arr.value(2));
 
-        assert_eq!(true, bool_arr.is_valid(3));
-        assert_eq!(true, bool_arr.value(3));
+        assert!(bool_arr.is_valid(3));
+        assert!(bool_arr.value(3));
 
-        assert_eq!(true, bool_arr.is_valid(4));
-        assert_eq!(false, bool_arr.value(4));
+        assert!(bool_arr.is_valid(4));
+        assert!(!bool_arr.value(4));
     }
 
     #[test]

--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -465,12 +465,12 @@ mod tests {
         assert_eq!(5, c0.len());
         assert_eq!(3, c0.null_count());
         assert!(c0.is_valid(0));
-        assert_eq!(false, c0.value(0));
+        assert!(!c0.value(0));
         assert!(c0.is_null(1));
         assert!(c0.is_null(2));
         assert!(c0.is_null(3));
         assert!(c0.is_valid(4));
-        assert_eq!(true, c0.value(4));
+        assert!(c0.value(4));
 
         let c1 = struct_array.column(1);
         let c1 = c1.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -500,7 +500,7 @@ mod tests {
         assert!(sliced_c0.is_null(0));
         assert!(sliced_c0.is_null(1));
         assert!(sliced_c0.is_valid(2));
-        assert_eq!(true, sliced_c0.value(2));
+        assert!(sliced_c0.value(2));
 
         let sliced_c1 = sliced_array.column(1);
         let sliced_c1 = sliced_c1.as_any().downcast_ref::<Int32Array>().unwrap();

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -390,7 +390,7 @@ mod tests {
 
         assert_eq!(expected_array_values.len(), union.len());
         for (i, expected_value) in expected_array_values.iter().enumerate() {
-            assert_eq!(false, union.is_null(i));
+            assert!(!union.is_null(i));
             let slot = union.value(i);
             let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
             assert_eq!(slot.len(), 1);
@@ -412,7 +412,7 @@ mod tests {
         assert_eq!(5, union.len());
         for i in 0..union.len() {
             let slot = union.value(i);
-            assert_eq!(false, union.is_null(i));
+            assert!(!union.is_null(i));
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -465,21 +465,21 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(1_i32, value);
                 }
                 1 => {
                     let slot = slot.as_any().downcast_ref::<Int64Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(3_i64, value);
                 }
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(10_i32, value);
@@ -487,7 +487,7 @@ mod tests {
                 3 => assert!(union.is_null(i)),
                 4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
@@ -516,7 +516,7 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(10_i32, value);
@@ -524,7 +524,7 @@ mod tests {
                 1 => assert!(new_union.is_null(i)),
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
@@ -666,7 +666,7 @@ mod tests {
 
         assert_eq!(expected_array_values.len(), union.len());
         for (i, expected_value) in expected_array_values.iter().enumerate() {
-            assert_eq!(false, union.is_null(i));
+            assert!(!union.is_null(i));
             let slot = union.value(i);
             let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
             assert_eq!(slot.len(), 1);
@@ -701,7 +701,7 @@ mod tests {
 
         for i in 0..union.len() {
             let slot = union.value(i);
-            assert_eq!(false, union.is_null(i));
+            assert!(!union.is_null(i));
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -766,7 +766,7 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(1_i32, value);
@@ -774,14 +774,14 @@ mod tests {
                 1 => assert!(union.is_null(i)),
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(value - 3_f64 < f64::EPSILON);
                 }
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, union.is_null(i));
+                    assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);
@@ -811,7 +811,7 @@ mod tests {
                 0 => assert!(new_union.is_null(i)),
                 1 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
-                    assert_eq!(false, new_union.is_null(i));
+                    assert!(!new_union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(value - 3_f64 < f64::EPSILON);
@@ -819,7 +819,7 @@ mod tests {
                 2 => assert!(new_union.is_null(i)),
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert_eq!(false, new_union.is_null(i));
+                    assert!(!new_union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2264,11 +2264,11 @@ mod tests {
         assert_eq!(a.len(), 7);
         let array = a.finish();
         assert_eq!(array.value(0), 1);
-        assert_eq!(array.is_null(1), true);
+        assert!(array.is_null(1));
         assert_eq!(array.value(2), -2);
         assert_eq!(array.value(3), 1);
         assert_eq!(array.value(4), 2);
-        assert_eq!(array.is_null(5), true);
+        assert!(array.is_null(5));
         assert_eq!(array.value(6), 4);
 
         Ok(())
@@ -3201,9 +3201,9 @@ mod tests {
         let ava: &UInt32Array = av.as_any().downcast_ref::<UInt32Array>().unwrap();
         let avs: &[u32] = ava.values();
 
-        assert_eq!(array.is_null(0), false);
-        assert_eq!(array.is_null(1), true);
-        assert_eq!(array.is_null(2), false);
+        assert!(!array.is_null(0), false);
+        assert!(array.is_null(1));
+        assert!(!array.is_null(2));
 
         assert_eq!(avs, &[12345678, 22345678]);
     }
@@ -3258,7 +3258,7 @@ mod tests {
         let av = array.values();
         let ava: &StringArray = av.as_any().downcast_ref::<StringArray>().unwrap();
 
-        assert_eq!(ava.is_valid(0), false);
+        assert!(!ava.is_valid(0));
         assert_eq!(ava.value(1), "def");
         assert_eq!(ava.value(2), "abc");
         assert_eq!(ava.value(3), "ghi");
@@ -3279,13 +3279,13 @@ mod tests {
         builder.append("abc").unwrap();
         let array = builder.finish();
 
-        assert_eq!(array.is_null(1), true);
-        assert_eq!(array.is_valid(1), false);
+        assert!(array.is_null(1));
+        assert!(!array.is_valid(1));
 
         let keys = array.keys();
 
         assert_eq!(keys.value(0), 1);
-        assert_eq!(keys.is_null(1), true);
+        assert!(keys.is_null(1));
         // zero initialization is currently guaranteed by Buffer allocation and resizing
         assert_eq!(keys.value(1), 0);
         assert_eq!(keys.value(2), 2);

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -361,18 +361,18 @@ mod tests {
         let b =
             BooleanArray::from(vec![true, false, false, false, true, false, true, true]);
         let b = b.data();
-        assert_eq!(equal(a, b), false);
-        assert_eq!(equal(b, a), false);
+        assert!(!equal(a, b));
+        assert!(!equal(b, a));
 
         let a_slice = a.slice(2, 3);
         let b_slice = b.slice(3, 3);
-        assert_eq!(equal(&a_slice, &b_slice), true);
-        assert_eq!(equal(&b_slice, &a_slice), true);
+        assert!(equal(&a_slice, &b_slice));
+        assert!(equal(&b_slice, &a_slice));
 
         let a_slice = a.slice(3, 4);
         let b_slice = b.slice(4, 4);
-        assert_eq!(equal(&a_slice, &b_slice), false);
-        assert_eq!(equal(&b_slice, &a_slice), false);
+        assert!(!equal(&a_slice, &b_slice));
+        assert!(!equal(&b_slice, &a_slice));
 
         // Test the optimization cases where null_count == 0 and starts at 0 and len >= size_of(u8)
 
@@ -486,8 +486,8 @@ mod tests {
 
     fn test_equal(lhs: &ArrayData, rhs: &ArrayData, expected: bool) {
         // equality is symmetric
-        assert_eq!(equal(lhs, lhs), true, "\n{:?}\n{:?}", lhs, lhs);
-        assert_eq!(equal(rhs, rhs), true, "\n{:?}\n{:?}", rhs, rhs);
+        assert!(equal(lhs, lhs), "\n{:?}\n{:?}", lhs, lhs);
+        assert!(equal(rhs, rhs), "\n{:?}\n{:?}", rhs, rhs);
 
         assert_eq!(equal(lhs, rhs), expected, "\n{:?}\n{:?}", lhs, rhs);
         assert_eq!(equal(rhs, lhs), expected, "\n{:?}\n{:?}", rhs, lhs);

--- a/arrow/src/array/null.rs
+++ b/arrow/src/array/null.rs
@@ -132,7 +132,7 @@ mod tests {
 
         assert_eq!(null_arr.len(), 32);
         assert_eq!(null_arr.null_count(), 32);
-        assert_eq!(null_arr.is_valid(0), false);
+        assert!(!null_arr.is_valid(0));
 
         assert_eq!(0, null_arr.get_buffer_memory_size());
         assert_eq!(

--- a/arrow/src/array/ord.rs
+++ b/arrow/src/array/ord.rs
@@ -241,7 +241,6 @@ pub mod tests {
     use crate::array::{Float64Array, Int32Array};
     use crate::error::Result;
     use std::cmp::Ordering;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_i32() -> Result<()> {
@@ -298,7 +297,7 @@ pub mod tests {
     #[test]
     fn test_dict() -> Result<()> {
         let data = vec!["a", "b", "c", "a", "a", "c", "c"];
-        let array = DictionaryArray::<Int16Type>::from_iter(data.into_iter());
+        let array = data.into_iter().collect::<DictionaryArray<Int16Type>>();
 
         let cmp = build_compare(&array, &array)?;
 
@@ -311,9 +310,9 @@ pub mod tests {
     #[test]
     fn test_multiple_dict() -> Result<()> {
         let d1 = vec!["a", "b", "c", "d"];
-        let a1 = DictionaryArray::<Int16Type>::from_iter(d1.into_iter());
+        let a1 = d1.into_iter().collect::<DictionaryArray<Int16Type>>();
         let d2 = vec!["e", "f", "g", "a"];
-        let a2 = DictionaryArray::<Int16Type>::from_iter(d2.into_iter());
+        let a2 = d2.into_iter().collect::<DictionaryArray<Int16Type>>();
 
         let cmp = build_compare(&a1, &a2)?;
 

--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -145,13 +145,13 @@ mod tests {
     #[test]
     fn test_bitmap_is_set() {
         let bitmap = Bitmap::from(Buffer::from([0b01001010]));
-        assert_eq!(false, bitmap.is_set(0));
-        assert_eq!(true, bitmap.is_set(1));
-        assert_eq!(false, bitmap.is_set(2));
-        assert_eq!(true, bitmap.is_set(3));
-        assert_eq!(false, bitmap.is_set(4));
-        assert_eq!(false, bitmap.is_set(5));
-        assert_eq!(true, bitmap.is_set(6));
-        assert_eq!(false, bitmap.is_set(7));
+        assert!(!bitmap.is_set(0));
+        assert!(bitmap.is_set(1));
+        assert!(!bitmap.is_set(2));
+        assert!(bitmap.is_set(3));
+        assert!(!bitmap.is_set(4));
+        assert!(!bitmap.is_set(5));
+        assert!(bitmap.is_set(6));
+        assert!(!bitmap.is_set(7));
     }
 }

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1314,11 +1314,11 @@ mod tests {
         let b = Int32Array::from(vec![Some(5), Some(6), Some(8), Some(9), None, None]);
         let c = divide(&a, &b).unwrap();
         assert_eq!(3, c.value(0));
-        assert_eq!(true, c.is_null(1));
+        assert!(c.is_null(1));
         assert_eq!(1, c.value(2));
         assert_eq!(0, c.value(3));
-        assert_eq!(true, c.is_null(4));
-        assert_eq!(true, c.is_null(5));
+        assert!(c.is_null(4));
+        assert!(c.is_null(5));
     }
 
     #[test]
@@ -1327,11 +1327,11 @@ mod tests {
         let b = Int32Array::from(vec![Some(5), Some(6), Some(8), Some(9), None, None]);
         let c = modulus(&a, &b).unwrap();
         assert_eq!(0, c.value(0));
-        assert_eq!(true, c.is_null(1));
+        assert!(c.is_null(1));
         assert_eq!(0, c.value(2));
         assert_eq!(1, c.value(3));
-        assert_eq!(true, c.is_null(4));
-        assert_eq!(true, c.is_null(5));
+        assert!(c.is_null(4));
+        assert!(c.is_null(5));
     }
 
     #[test]
@@ -1400,11 +1400,11 @@ mod tests {
         let c = divide(&a, &b).unwrap();
         assert_eq!(6, c.len());
         assert_eq!(3, c.value(0));
-        assert_eq!(true, c.is_null(1));
+        assert!(c.is_null(1));
         assert_eq!(1, c.value(2));
         assert_eq!(0, c.value(3));
-        assert_eq!(true, c.is_null(4));
-        assert_eq!(true, c.is_null(5));
+        assert!(c.is_null(4));
+        assert!(c.is_null(5));
     }
 
     #[test]
@@ -1453,11 +1453,11 @@ mod tests {
         let c = modulus(&a, &b).unwrap();
         assert_eq!(6, c.len());
         assert_eq!(0, c.value(0));
-        assert_eq!(true, c.is_null(1));
+        assert!(c.is_null(1));
         assert_eq!(0, c.value(2));
         assert_eq!(1, c.value(3));
-        assert_eq!(true, c.is_null(4));
-        assert_eq!(true, c.is_null(5));
+        assert!(c.is_null(4));
+        assert!(c.is_null(5));
     }
 
     #[test]
@@ -1491,10 +1491,10 @@ mod tests {
         let a = Int32Array::from(vec![Some(5), None, Some(7), None]);
         let b = Int32Array::from(vec![None, None, Some(6), Some(7)]);
         let c = add(&a, &b).unwrap();
-        assert_eq!(true, c.is_null(0));
-        assert_eq!(true, c.is_null(1));
-        assert_eq!(false, c.is_null(2));
-        assert_eq!(true, c.is_null(3));
+        assert!(c.is_null(0));
+        assert!(c.is_null(1));
+        assert!(!c.is_null(2));
+        assert!(c.is_null(3));
         assert_eq!(13, c.value(2));
     }
 

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1793,12 +1793,12 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::UInt8).unwrap();
         let c = b.as_any().downcast_ref::<UInt8Array>().unwrap();
-        assert_eq!(false, c.is_valid(0));
+        assert!(!c.is_valid(0));
         assert_eq!(6, c.value(1));
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
         assert_eq!(8, c.value(3));
         // overflows return None
-        assert_eq!(false, c.is_valid(4));
+        assert!(!c.is_valid(4));
     }
 
     #[test]
@@ -1812,10 +1812,10 @@ mod tests {
         assert_eq!(3, b.len());
         assert_eq!(0, b.offset());
         let c = b.as_any().downcast_ref::<UInt8Array>().unwrap();
-        assert_eq!(false, c.is_valid(0));
+        assert!(!c.is_valid(0));
         assert_eq!(8, c.value(1));
         // overflows return None
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
     }
 
     #[test]
@@ -1879,7 +1879,7 @@ mod tests {
         let c = values.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(1, c.null_count());
         assert_eq!(5, c.value(0));
-        assert_eq!(false, c.is_valid(1));
+        assert!(!c.is_valid(1));
         assert_eq!(7, c.value(2));
         assert_eq!(8, c.value(3));
         assert_eq!(9, c.value(4));
@@ -1908,7 +1908,7 @@ mod tests {
         assert_eq!(1, c.null_count());
         assert!(7.0 - c.value(0) < f64::EPSILON);
         assert!(8.0 - c.value(1) < f64::EPSILON);
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
         assert!(10.0 - c.value(3) < f64::EPSILON);
     }
 
@@ -1920,9 +1920,9 @@ mod tests {
         let c = b.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(5, c.value(0));
         assert_eq!(6, c.value(1));
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
         assert_eq!(8, c.value(3));
-        assert_eq!(false, c.is_valid(4));
+        assert!(!c.is_valid(4));
     }
 
     #[test]
@@ -1949,7 +1949,7 @@ mod tests {
         let c = b.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(1, c.value(0));
         assert_eq!(0, c.value(1));
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
     }
 
     #[test]
@@ -1960,7 +1960,7 @@ mod tests {
         let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
         assert!(1.0 - c.value(0) < f64::EPSILON);
         assert!(0.0 - c.value(1) < f64::EPSILON);
-        assert_eq!(false, c.is_valid(2));
+        assert!(!c.is_valid(2));
     }
 
     #[test]
@@ -2023,11 +2023,11 @@ mod tests {
         assert_eq!(0, u16arr.value(0));
         assert_eq!(0, u16arr.value(1));
         assert_eq!(0, u16arr.value(2));
-        assert_eq!(false, u16arr.is_valid(3));
-        assert_eq!(false, u16arr.is_valid(4));
-        assert_eq!(false, u16arr.is_valid(5));
+        assert!(!u16arr.is_valid(3));
+        assert!(!u16arr.is_valid(4));
+        assert!(!u16arr.is_valid(5));
         assert_eq!(2, u16arr.value(6));
-        assert_eq!(false, u16arr.is_valid(7));
+        assert!(!u16arr.is_valid(7));
     }
 
     #[test]
@@ -3479,18 +3479,18 @@ mod tests {
         // test valid inputs
         let date_value = since(NaiveDate::from_ymd(2000, 1, 1), from_ymd(1970, 1, 1))
             .num_days() as i32;
-        assert_eq!(true, c.is_valid(0)); // "2000-01-01"
+        assert!(c.is_valid(0)); // "2000-01-01"
         assert_eq!(date_value, c.value(0));
 
         let date_value = since(NaiveDate::from_ymd(2000, 2, 2), from_ymd(1970, 1, 1))
             .num_days() as i32;
-        assert_eq!(true, c.is_valid(1)); // "2000-2-2"
+        assert!(c.is_valid(1)); // "2000-2-2"
         assert_eq!(date_value, c.value(1));
 
         // test invalid inputs
-        assert_eq!(false, c.is_valid(2)); // "2000-00-00"
-        assert_eq!(false, c.is_valid(3)); // "2000-01-01T12:00:00"
-        assert_eq!(false, c.is_valid(4)); // "2000"
+        assert!(!c.is_valid(2)); // "2000-00-00"
+        assert!(!c.is_valid(3)); // "2000-01-01T12:00:00"
+        assert!(!c.is_valid(4)); // "2000"
     }
 
     #[test]
@@ -3508,17 +3508,17 @@ mod tests {
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
 
         // test valid inputs
-        assert_eq!(true, c.is_valid(0)); // "2000-01-01T12:00:00"
+        assert!(c.is_valid(0)); // "2000-01-01T12:00:00"
         assert_eq!(946728000000, c.value(0));
-        assert_eq!(true, c.is_valid(1)); // "2020-12-15T12:34:56"
+        assert!(c.is_valid(1)); // "2020-12-15T12:34:56"
         assert_eq!(1608035696000, c.value(1));
-        assert_eq!(true, c.is_valid(2)); // "2020-2-2T12:34:56"
+        assert!(c.is_valid(2)); // "2020-2-2T12:34:56"
         assert_eq!(1580646896000, c.value(2));
 
         // test invalid inputs
-        assert_eq!(false, c.is_valid(3)); // "2000-00-00T12:00:00"
-        assert_eq!(false, c.is_valid(4)); // "2000-01-01 12:00:00"
-        assert_eq!(false, c.is_valid(5)); // "2000-01-01"
+        assert!(!c.is_valid(3)); // "2000-00-00T12:00:00"
+        assert!(!c.is_valid(4)); // "2000-01-01 12:00:00"
+        assert!(!c.is_valid(5)); // "2000-01-01"
     }
 
     #[test]

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1043,11 +1043,11 @@ mod tests {
         let b_slice = b.slice(5, 5);
         let c = b_slice.as_any().downcast_ref().unwrap();
         let d = eq(&c, &a).unwrap();
-        assert_eq!(true, d.value(0));
-        assert_eq!(true, d.value(1));
-        assert_eq!(true, d.value(2));
-        assert_eq!(false, d.value(3));
-        assert_eq!(true, d.value(4));
+        assert!(d.value(0));
+        assert!(d.value(1));
+        assert!(d.value(2));
+        assert!(!d.value(3));
+        assert!(d.value(4));
     }
 
     #[test]

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -444,9 +444,9 @@ mod tests {
         assert_eq!(67, d.len());
         assert_eq!(3, d.null_count());
         assert_eq!(1, d.value(0));
-        assert_eq!(true, d.is_null(1));
+        assert!(d.is_null(1));
         assert_eq!(64, d.value(63));
-        assert_eq!(true, d.is_null(64));
+        assert!(d.is_null(64));
         assert_eq!(67, d.value(65));
     }
 
@@ -468,7 +468,7 @@ mod tests {
         let c = filter(&a, &b).unwrap();
         let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(1, d.len());
-        assert_eq!(true, d.is_null(0));
+        assert!(d.is_null(0));
     }
 
     #[test]
@@ -479,8 +479,8 @@ mod tests {
         let d = c.as_ref().as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(2, d.len());
         assert_eq!("hello", d.value(0));
-        assert_eq!(false, d.is_null(0));
-        assert_eq!(true, d.is_null(1));
+        assert!(!d.is_null(0));
+        assert!(d.is_null(1));
     }
 
     #[test]
@@ -492,8 +492,8 @@ mod tests {
         let d = c.as_ref().as_any().downcast_ref::<BinaryArray>().unwrap();
         assert_eq!(2, d.len());
         assert_eq!(b"hello", d.value(0));
-        assert_eq!(false, d.is_null(0));
-        assert_eq!(true, d.is_null(1));
+        assert!(!d.is_null(0));
+        assert!(d.is_null(1));
     }
 
     #[test]
@@ -508,8 +508,8 @@ mod tests {
         let c = filter(a, &b).unwrap();
         let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(2, d.len());
-        assert_eq!(true, d.is_null(0));
-        assert_eq!(false, d.is_null(1));
+        assert!(d.is_null(0));
+        assert!(!d.is_null(1));
         assert_eq!(9, d.value(1));
     }
 
@@ -530,7 +530,7 @@ mod tests {
         assert_eq!(3, values.len());
         // but keys are filtered
         assert_eq!(2, d.len());
-        assert_eq!(true, d.is_null(0));
+        assert!(d.is_null(0));
         assert_eq!("world", values.value(d.keys().value(1) as usize));
     }
 

--- a/arrow/src/compute/kernels/limit.rs
+++ b/arrow/src/compute/kernels/limit.rs
@@ -67,7 +67,7 @@ mod tests {
         let b = limit(&a, 1);
         let c = b.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(1, c.len());
-        assert_eq!(true, c.is_null(0));
+        assert!(c.is_null(0));
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
         assert!(sliced_c0.is_valid(0));
         assert!(sliced_c0.is_null(1));
         assert!(sliced_c0.is_null(2));
-        assert_eq!(false, sliced_c0.value(0));
+        assert!(!sliced_c0.value(0));
 
         let sliced_c1 = sliced_array.column(1);
         let sliced_c1 = sliced_c1.as_any().downcast_ref::<Int32Array>().unwrap();

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -973,7 +973,6 @@ mod tests {
     use rand::rngs::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
     use std::convert::TryFrom;
-    use std::iter::FromIterator;
     use std::sync::Arc;
 
     fn test_sort_to_indices_boolean_arrays(
@@ -1072,7 +1071,7 @@ mod tests {
         limit: Option<usize>,
         expected_data: Vec<Option<&str>>,
     ) {
-        let array = DictionaryArray::<T>::from_iter(data.into_iter());
+        let array = data.into_iter().collect::<DictionaryArray<T>>();
         let array_values = array.values().clone();
         let dict = array_values
             .as_any()

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -111,7 +111,7 @@ mod tests {
 
         let b = hour(&a).unwrap();
         assert_eq!(0, b.value(0));
-        assert_eq!(false, b.is_valid(1));
+        assert!(!b.is_valid(1));
         assert_eq!(4, b.value(2));
     }
 
@@ -121,7 +121,7 @@ mod tests {
 
         let b = hour(&a).unwrap();
         assert_eq!(0, b.value(0));
-        assert_eq!(false, b.is_valid(1));
+        assert!(!b.is_valid(1));
         assert_eq!(0, b.value(2));
     }
 
@@ -160,7 +160,7 @@ mod tests {
 
         let b = year(&a).unwrap();
         assert_eq!(2018, b.value(0));
-        assert_eq!(false, b.is_valid(1));
+        assert!(!b.is_valid(1));
         assert_eq!(2019, b.value(2));
     }
 
@@ -170,7 +170,7 @@ mod tests {
 
         let b = year(&a).unwrap();
         assert_eq!(2011, b.value(0));
-        assert_eq!(false, b.is_valid(1));
+        assert!(!b.is_valid(1));
         assert_eq!(2012, b.value(2));
     }
 
@@ -181,7 +181,7 @@ mod tests {
 
         let b = year(&a).unwrap();
         assert_eq!(2021, b.value(0));
-        assert_eq!(false, b.is_valid(1));
+        assert!(!b.is_valid(1));
         assert_eq!(2024, b.value(2));
     }
 }

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -1243,11 +1243,11 @@ mod tests {
         let mut csv = Reader::new(file, Arc::new(schema), true, None, 1024, None, None);
         let batch = csv.next().unwrap().unwrap();
 
-        assert_eq!(false, batch.column(1).is_null(0));
-        assert_eq!(false, batch.column(1).is_null(1));
-        assert_eq!(true, batch.column(1).is_null(2));
-        assert_eq!(false, batch.column(1).is_null(3));
-        assert_eq!(false, batch.column(1).is_null(4));
+        assert!(!batch.column(1).is_null(0));
+        assert!(!batch.column(1).is_null(1));
+        assert!(batch.column(1).is_null(2));
+        assert!(!batch.column(1).is_null(3));
+        assert!(!batch.column(1).is_null(4));
     }
 
     #[test]
@@ -1290,18 +1290,18 @@ mod tests {
             ]
         );
 
-        assert_eq!(false, schema.field(0).is_nullable());
-        assert_eq!(true, schema.field(1).is_nullable());
-        assert_eq!(true, schema.field(2).is_nullable());
-        assert_eq!(false, schema.field(3).is_nullable());
-        assert_eq!(true, schema.field(4).is_nullable());
-        assert_eq!(true, schema.field(5).is_nullable());
+        assert!(!schema.field(0).is_nullable());
+        assert!(schema.field(1).is_nullable());
+        assert!(schema.field(2).is_nullable());
+        assert!(!schema.field(3).is_nullable());
+        assert!(schema.field(4).is_nullable());
+        assert!(schema.field(5).is_nullable());
 
-        assert_eq!(false, batch.column(1).is_null(0));
-        assert_eq!(false, batch.column(1).is_null(1));
-        assert_eq!(true, batch.column(1).is_null(2));
-        assert_eq!(false, batch.column(1).is_null(3));
-        assert_eq!(false, batch.column(1).is_null(4));
+        assert!(!batch.column(1).is_null(0));
+        assert!(!batch.column(1).is_null(1));
+        assert!(batch.column(1).is_null(2));
+        assert!(!batch.column(1).is_null(3));
+        assert!(!batch.column(1).is_null(4));
     }
 
     #[test]
@@ -1400,10 +1400,10 @@ mod tests {
         )?;
 
         assert_eq!(schema.fields().len(), 4);
-        assert_eq!(false, schema.field(0).is_nullable());
-        assert_eq!(true, schema.field(1).is_nullable());
-        assert_eq!(false, schema.field(2).is_nullable());
-        assert_eq!(false, schema.field(3).is_nullable());
+        assert!(!schema.field(0).is_nullable());
+        assert!(schema.field(1).is_nullable());
+        assert!(!schema.field(2).is_nullable());
+        assert!(!schema.field(3).is_nullable());
 
         assert_eq!(&DataType::Int64, schema.field(0).data_type());
         assert_eq!(&DataType::Utf8, schema.field(1).data_type());

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -863,7 +863,7 @@ mod tests {
         let first_name = &schema.fields()[0];
         assert_eq!(first_name.name(), "first_name");
         assert_eq!(first_name.data_type(), &DataType::Utf8);
-        assert_eq!(first_name.is_nullable(), false);
+        assert!(!first_name.is_nullable());
         assert_eq!(first_name.dict_id(), None);
         assert_eq!(first_name.dict_is_ordered(), None);
 

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -836,7 +836,6 @@ mod tests {
     use crate::compute::kernels;
     use crate::datatypes::Field;
     use std::convert::TryFrom;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_round_trip() -> Result<()> {
@@ -915,11 +914,10 @@ mod tests {
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        let value_offsets = Buffer::from_iter(
-            [0usize, 3, 6, 8]
-                .iter()
-                .map(|i| Offset::from_usize(*i).unwrap()),
-        );
+        let value_offsets = [0usize, 3, 6, 8]
+            .iter()
+            .map(|i| Offset::from_usize(*i).unwrap())
+            .collect::<Buffer>();
 
         // Construct a list array from the above two
         let list_data_type = match std::mem::size_of::<Offset>() {

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -588,7 +588,7 @@ impl<R: Read + Seek> FileReader<R> {
             if message_size == CONTINUATION_MARKER {
                 reader.read_exact(&mut message_size)?;
             }
-            let footer_len =  i32::from_le_bytes(message_size);
+            let footer_len = i32::from_le_bytes(message_size);
 
             let mut block_data = vec![0; footer_len as usize];
 

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -585,12 +585,10 @@ impl<R: Read + Seek> FileReader<R> {
             let mut message_size: [u8; 4] = [0; 4];
             reader.seek(SeekFrom::Start(block.offset() as u64))?;
             reader.read_exact(&mut message_size)?;
-            let footer_len = if message_size == CONTINUATION_MARKER {
+            if message_size == CONTINUATION_MARKER {
                 reader.read_exact(&mut message_size)?;
-                i32::from_le_bytes(message_size)
-            } else {
-                i32::from_le_bytes(message_size)
-            };
+            }
+            let footer_len =  i32::from_le_bytes(message_size);
 
             let mut block_data = vec![0; footer_len as usize];
 

--- a/arrow/src/tensor.rs
+++ b/arrow/src/tensor.rs
@@ -340,9 +340,9 @@ mod tests {
         assert_eq!(None, tensor.shape());
         assert_eq!(None, tensor.names());
         assert_eq!(0, tensor.ndim());
-        assert_eq!(false, tensor.is_row_major().unwrap());
-        assert_eq!(false, tensor.is_column_major().unwrap());
-        assert_eq!(false, tensor.is_contiguous().unwrap());
+        assert!(!tensor.is_row_major().unwrap());
+        assert!(!tensor.is_column_major().unwrap());
+        assert!(!tensor.is_contiguous().unwrap());
 
         let buf = Buffer::from(&[1, 2, 2, 2]);
         let tensor = Int32Tensor::try_new(buf, None, None, None).unwrap();
@@ -350,9 +350,9 @@ mod tests {
         assert_eq!(None, tensor.shape());
         assert_eq!(None, tensor.names());
         assert_eq!(0, tensor.ndim());
-        assert_eq!(false, tensor.is_row_major().unwrap());
-        assert_eq!(false, tensor.is_column_major().unwrap());
-        assert_eq!(false, tensor.is_contiguous().unwrap());
+        assert!(!tensor.is_row_major().unwrap());
+        assert!(!tensor.is_column_major().unwrap());
+        assert!(!tensor.is_contiguous().unwrap());
     }
 
     #[test]
@@ -383,9 +383,9 @@ mod tests {
         assert_eq!(Some(vec![32_usize, 4]).as_ref(), tensor.strides());
         assert_eq!(None, tensor.names());
         assert_eq!(2, tensor.ndim());
-        assert_eq!(true, tensor.is_row_major().unwrap());
-        assert_eq!(false, tensor.is_column_major().unwrap());
-        assert_eq!(true, tensor.is_contiguous().unwrap());
+        assert!(tensor.is_row_major().unwrap());
+        assert!(!tensor.is_column_major().unwrap());
+        assert!(tensor.is_contiguous().unwrap());
     }
 
     #[test]
@@ -401,9 +401,9 @@ mod tests {
         assert_eq!(Some(vec![4_usize, 8]).as_ref(), tensor.strides());
         assert_eq!(None, tensor.names());
         assert_eq!(2, tensor.ndim());
-        assert_eq!(false, tensor.is_row_major().unwrap());
-        assert_eq!(true, tensor.is_column_major().unwrap());
-        assert_eq!(true, tensor.is_contiguous().unwrap());
+        assert!(!tensor.is_row_major().unwrap());
+        assert!(tensor.is_column_major().unwrap());
+        assert!(tensor.is_contiguous().unwrap());
     }
 
     #[test]
@@ -422,9 +422,9 @@ mod tests {
         assert_eq!("Dim 1", tensor.dim_name(0).unwrap());
         assert_eq!("Dim 2", tensor.dim_name(1).unwrap());
         assert_eq!(2, tensor.ndim());
-        assert_eq!(false, tensor.is_row_major().unwrap());
-        assert_eq!(true, tensor.is_column_major().unwrap());
-        assert_eq!(true, tensor.is_contiguous().unwrap());
+        assert!(!tensor.is_row_major().unwrap());
+        assert!(tensor.is_column_major().unwrap());
+        assert!(tensor.is_contiguous().unwrap());
     }
 
     #[test]

--- a/arrow/src/util/bit_util.rs
+++ b/arrow/src/util/bit_util.rs
@@ -146,28 +146,28 @@ mod tests {
     #[test]
     fn test_get_bit() {
         // 00001101
-        assert_eq!(true, get_bit(&[0b00001101], 0));
-        assert_eq!(false, get_bit(&[0b00001101], 1));
-        assert_eq!(true, get_bit(&[0b00001101], 2));
-        assert_eq!(true, get_bit(&[0b00001101], 3));
+        assert!(get_bit(&[0b00001101], 0));
+        assert!(!get_bit(&[0b00001101], 1));
+        assert!(get_bit(&[0b00001101], 2));
+        assert!(get_bit(&[0b00001101], 3));
 
         // 01001001 01010010
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 0));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 1));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 2));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 3));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 4));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 5));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 6));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 7));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 8));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 9));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 10));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 11));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 12));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 13));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 14));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 15));
+        assert!(get_bit(&[0b01001001, 0b01010010], 0));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 1));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 2));
+        assert!(get_bit(&[0b01001001, 0b01010010], 3));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 4));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 5));
+        assert!(get_bit(&[0b01001001, 0b01010010], 6));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 7));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 8));
+        assert!(get_bit(&[0b01001001, 0b01010010], 9));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 10));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 11));
+        assert!(get_bit(&[0b01001001, 0b01010010], 12));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 13));
+        assert!(get_bit(&[0b01001001, 0b01010010], 14));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 15));
     }
 
     #[test]

--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -1404,6 +1404,7 @@ impl<'a> ArrayReaderBuilder {
     }
 
     /// Creates primitive array reader for each primitive type.
+    #[allow(clippy::branches_sharing_code)]
     fn build_for_primitive_type_inner(
         &self,
         cur_type: TypePtr,

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -639,8 +639,8 @@ mod tests {
             Some(Encoding::DELTA_BINARY_PACKED)
         );
         assert_eq!(props.compression(&ColumnPath::from("a")), Compression::GZIP);
-        assert_eq!(props.dictionary_enabled(&ColumnPath::from("a")), false);
-        assert_eq!(props.statistics_enabled(&ColumnPath::from("a")), false);
+        assert!(!props.dictionary_enabled(&ColumnPath::from("a")));
+        assert!(!props.statistics_enabled(&ColumnPath::from("a")));
         assert_eq!(props.max_statistics_size(&ColumnPath::from("a")), 50);
 
         assert_eq!(
@@ -651,8 +651,8 @@ mod tests {
             props.compression(&ColumnPath::from("col")),
             Compression::SNAPPY
         );
-        assert_eq!(props.dictionary_enabled(&ColumnPath::from("col")), true);
-        assert_eq!(props.statistics_enabled(&ColumnPath::from("col")), true);
+        assert!(props.dictionary_enabled(&ColumnPath::from("col")));
+        assert!(props.statistics_enabled(&ColumnPath::from("col")));
         assert_eq!(props.max_statistics_size(&ColumnPath::from("col")), 123);
     }
 

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -579,7 +579,7 @@ mod tests {
                     assert_eq!(buf.len(), 32);
                     assert_eq!(num_values, 8);
                     assert_eq!(encoding, Encoding::PLAIN_DICTIONARY);
-                    assert_eq!(is_sorted, false);
+                    assert!(!is_sorted);
                     true
                 }
                 Page::DataPage {
@@ -671,7 +671,7 @@ mod tests {
                     assert_eq!(buf.len(), 7);
                     assert_eq!(num_values, 1);
                     assert_eq!(encoding, Encoding::PLAIN);
-                    assert_eq!(is_sorted, false);
+                    assert!(!is_sorted);
                     true
                 }
                 Page::DataPageV2 {
@@ -692,7 +692,7 @@ mod tests {
                     assert_eq!(num_rows, 5);
                     assert_eq!(def_levels_byte_len, 2);
                     assert_eq!(rep_levels_byte_len, 0);
-                    assert_eq!(is_compressed, true);
+                    assert!(is_compressed);
                     assert!(statistics.is_some());
                     true
                 }

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -1226,37 +1226,28 @@ mod tests {
         assert!(Field::Decimal(Decimal::from_i32(4, 8, 2)).is_primitive());
 
         // complex types
-        assert_eq!(
-            false,
-            Field::Group(make_row(vec![
-                ("x".to_string(), Field::Null),
-                ("Y".to_string(), Field::Int(2)),
-                ("z".to_string(), Field::Float(3.1)),
-                ("a".to_string(), Field::Str("abc".to_string()))
-            ]))
-            .is_primitive()
-        );
+        assert!(!Field::Group(make_row(vec![
+            ("x".to_string(), Field::Null),
+            ("Y".to_string(), Field::Int(2)),
+            ("z".to_string(), Field::Float(3.1)),
+            ("a".to_string(), Field::Str("abc".to_string()))
+        ]))
+        .is_primitive());
 
-        assert_eq!(
-            false,
-            Field::ListInternal(make_list(vec![
-                Field::Int(2),
-                Field::Int(1),
-                Field::Null,
-                Field::Int(12)
-            ]))
-            .is_primitive()
-        );
+        assert!(!Field::ListInternal(make_list(vec![
+            Field::Int(2),
+            Field::Int(1),
+            Field::Null,
+            Field::Int(12)
+        ]))
+        .is_primitive());
 
-        assert_eq!(
-            false,
-            Field::MapInternal(make_map(vec![
-                (Field::Int(1), Field::Float(1.2)),
-                (Field::Int(2), Field::Float(4.5)),
-                (Field::Int(3), Field::Float(2.3))
-            ]))
-            .is_primitive()
-        );
+        assert!(!Field::MapInternal(make_map(vec![
+            (Field::Int(1), Field::Float(1.2)),
+            (Field::Int(2), Field::Float(4.5)),
+            (Field::Int(3), Field::Float(2.3))
+        ]))
+        .is_primitive());
     }
 
     #[test]
@@ -1371,7 +1362,7 @@ mod tests {
             ("o".to_string(), Field::Decimal(Decimal::from_i32(4, 7, 2))),
         ]);
 
-        assert_eq!(false, row.get_bool(1).unwrap());
+        assert!(!row.get_bool(1).unwrap());
         assert_eq!(3, row.get_byte(2).unwrap());
         assert_eq!(4, row.get_short(3).unwrap());
         assert_eq!(5, row.get_int(4).unwrap());
@@ -1497,7 +1488,7 @@ mod tests {
     fn test_list_primitive_accessors() {
         // primitives
         let list = make_list(vec![Field::Bool(false)]);
-        assert_eq!(false, list.get_bool(0).unwrap());
+        assert!(!list.get_bool(0).unwrap());
 
         let list = make_list(vec![Field::Byte(3), Field::Byte(4)]);
         assert_eq!(4, list.get_byte(1).unwrap());

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -926,8 +926,8 @@ mod tests {
                 .get_value::<bool>(1)
                 .expect("get_value() should return OK");
             match i {
-                0 | 1 | 4 | 5 => assert_eq!(val, false),
-                _ => assert_eq!(val, true),
+                0 | 1 | 4 | 5 => assert!(!val),
+                _ => assert!(val),
             }
         }
     }

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -802,28 +802,28 @@ mod tests {
     #[test]
     fn test_get_bit() {
         // 00001101
-        assert_eq!(true, get_bit(&[0b00001101], 0));
-        assert_eq!(false, get_bit(&[0b00001101], 1));
-        assert_eq!(true, get_bit(&[0b00001101], 2));
-        assert_eq!(true, get_bit(&[0b00001101], 3));
+        assert!(get_bit(&[0b00001101], 0));
+        assert!(!get_bit(&[0b00001101], 1));
+        assert!(get_bit(&[0b00001101], 2));
+        assert!(get_bit(&[0b00001101], 3));
 
         // 01001001 01010010
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 0));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 1));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 2));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 3));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 4));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 5));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 6));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 7));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 8));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 9));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 10));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 11));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 12));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 13));
-        assert_eq!(true, get_bit(&[0b01001001, 0b01010010], 14));
-        assert_eq!(false, get_bit(&[0b01001001, 0b01010010], 15));
+        assert!(get_bit(&[0b01001001, 0b01010010], 0));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 1));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 2));
+        assert!(get_bit(&[0b01001001, 0b01010010], 3));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 4));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 5));
+        assert!(get_bit(&[0b01001001, 0b01010010], 6));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 7));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 8));
+        assert!(get_bit(&[0b01001001, 0b01010010], 9));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 10));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 11));
+        assert!(get_bit(&[0b01001001, 0b01010010], 12));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 13));
+        assert!(get_bit(&[0b01001001, 0b01010010], 14));
+        assert!(!get_bit(&[0b01001001, 0b01010010], 15));
     }
 
     #[test]

--- a/parquet/src/util/memory.rs
+++ b/parquet/src/util/memory.rs
@@ -173,7 +173,7 @@ impl<T: Clone> Buffer<T> {
     /// Buffer data is reset.
     #[inline]
     pub fn consume(&mut self) -> BufferPtr<T> {
-        let old_data = mem::replace(&mut self.data, vec![]);
+        let old_data = mem::take(&mut self.data);
         let mut result = BufferPtr::new(old_data);
         if let Some(ref mc) = self.mem_tracker {
             result = result.with_mem_tracker(mc.clone());


### PR DESCRIPTION
# Which issue does this PR close?

Closes  https://github.com/apache/arrow-rs/issues/467

I started on getting clippy CI running again but ran out of time this morning. Will finish up tomorrow if no one beats me to it

# Rationale for this change
 Rust upgrade cases lots of clippy errors

# What changes are included in this PR?
Do what clippy says


# Are there any user-facing changes?
No
