### PR TITLE
concatenating single element array shortcut

### DIFF
--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -57,6 +57,9 @@ pub fn concat(arrays: &[&Array]) -> Result<ArrayRef> {
         return Err(ArrowError::ComputeError(
             "concat requires input of at least one array".to_string(),
         ));
+    } else if arrays.len() == 1 {
+        let array = arrays[0];
+        return Ok(array.slice(0, array.len()));
     }
 
     if arrays
@@ -111,6 +114,21 @@ mod tests {
     fn test_concat_empty_vec() {
         let re = concat(&[]);
         assert!(re.is_err());
+    }
+
+    #[test]
+    fn test_concat_one_element_vec() -> Result<()> {
+        let arr = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(2),
+            None,
+        ])) as ArrayRef;
+        let result = concat(&[arr.as_ref()])?;
+        assert_eq!(
+            &arr, &result,
+            "concatenating single element array gives back the same result"
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

concatenating single element array shortcut

Closes #.

# Rationale for this change

no need to any work when the given array is single element

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
