### PR TITLE
Update active_release to 4.4 and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@ For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/ar
 
 # Changelog
 
+## [4.4.0](https://github.com/apache/arrow-rs/tree/4.4.0) (2021-06-24)
+
+[Full Changelog](https://github.com/apache/arrow-rs/compare/4.3.0...4.4.0)
+
+* 43b4f721fc31c7c6b700aea8bf4de8800a7f49bc implement second/minute helpers for temporal (#493) (#498)
+* 4d3f826b622273003d133ae9ec481850fb5bb058 concatenating single element array shortcut (#492) (#497)
+* eb1d1e158e2cde8c7f8efed5929d89803a12daa6 Doctest for GenericListArray. (#474) (#496)
+* c0f06d4d1bc5a716c7cab168c97f7ecd65615bc7 Add C data interface for decimal128 and timestamp (#453) (#495)
+* c1f9083ef6db9bdc3b3b6046284f0ca6be99c0ab Use partition for bool sort (#448) (#494)
+* d851decbabd5ff5f72af08602830199404fb08b4 remove stale comment and update unit tests (#472) (#487)
+* 1c3431a15bc7b3d57bb3399ecf8f2702dfcae459 Implement the Iterator trait for the json Reader. (#451) (#486)
+* 638a605a356306ce82ba2ac0b66aee81251cdaad remove clippy unnecessary wraps (#449) (#485)
+* 563a5067a9e722808a298817c153071fb51a6535 remove unnecessary wraps in sortk (#445) (#483)
+* b5e50efa6d8d7499e7785b2862eb60e19770ea11 window::shift to work for all array types (#388) (#464)
+* 93b51718671fecb9511b5eabf069940e07fa4b4c Add Decimal to CsvWriter and improve debug display (#406) (#465)
+* 153085f526939e83f7cad8d38cbdd176728b62af Backport clippy fixes to active release (#475)
+
+
 ## [4.3.0](https://github.com/apache/arrow-rs/tree/4.3.0) (2021-06-10)
 
 [Full Changelog](https://github.com/apache/arrow-rs/compare/4.2.0...4.3.0)

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-flight"
 description = "Apache Arrow Flight"
-version = "4.3.0"
+version = "4.4.0"
 edition = "2018"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-rs"
@@ -26,7 +26,7 @@ repository = "https://github.com/apache/arrow-rs"
 license = "Apache-2.0"
 
 [dependencies]
-arrow = { path = "../arrow", version = "4.3.0" }
+arrow = { path = "../arrow", version = "4.4.0" }
 tonic = "0.4"
 bytes = "1"
 prost = "0.7"

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-pyarrow-integration-testing"
 description = ""
-version = "4.3.0"
+version = "4.4.0"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -31,7 +31,7 @@ name = "arrow_pyarrow_integration_testing"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { path = "../arrow", version = "4.3.0" }
+arrow = { path = "../arrow", version = "4.4.0" }
 pyo3 = { version = "0.12.1", features = ["extension-module"] }
 
 [package.metadata.maturin]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "arrow"
-version = "4.3.0"
+version = "4.4.0"
 description = "Rust implementation of Apache Arrow"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-integration-testing"
 description = "Binaries used in the Arrow integration tests"
-version = "4.3.0"
+version = "4.4.0"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet"
-version = "4.3.0"
+version = "4.4.0"
 license = "Apache-2.0"
 description = "Apache Parquet implementation in Rust"
 homepage = "https://github.com/apache/arrow-rs"
@@ -41,7 +41,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.8", optional = true }
 chrono = "0.4"
 num-bigint = "0.4"
-arrow = { path = "../arrow", version = "4.3.0", optional = true }
+arrow = { path = "../arrow", version = "4.4.0", optional = true }
 base64 = { version = "0.13", optional = true }
 clap = { version = "2.33.3", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
@@ -54,7 +54,7 @@ brotli = "3.3"
 flate2 = "1.0"
 lz4 = "1.23"
 zstd = "0.8"
-arrow = { path = "../arrow", version = "4.3.0" }
+arrow = { path = "../arrow", version = "4.4.0" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]

--- a/parquet_derive/Cargo.toml
+++ b/parquet_derive/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet_derive"
-version = "4.3.0"
+version = "4.4.0"
 license = "Apache-2.0"
 description = "Derive macros for the Rust implementation of Apache Parquet"
 homepage = "https://github.com/apache/arrow-rs"
@@ -39,4 +39,4 @@ uuid = []
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-parquet = { path = "../parquet", version = "4.3.0" }
+parquet = { path = "../parquet", version = "4.4.0" }

--- a/parquet_derive_test/Cargo.toml
+++ b/parquet_derive_test/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet_derive_test"
-version = "4.3.0"
+version = "4.4.0"
 license = "Apache-2.0"
 description = "Integration test package for parquet-derive"
 homepage = "https://github.com/apache/arrow-rs"
@@ -28,5 +28,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-parquet = { path = "../parquet", version = "4.3.0" }
-parquet_derive = { path = "../parquet_derive", version = "4.3.0" }
+parquet = { path = "../parquet", version = "4.4.0" }
+parquet_derive = { path = "../parquet_derive", version = "4.4.0" }


### PR DESCRIPTION
Preparing for the 4.4 release -- this adds CHANGELOG and updates the versions to 4.4

(note it is targeted to `active_release` branch)