### PR TITLE
Correct array memory usage calculation for dictionary arrays

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -204,6 +204,8 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
     }
 
     /// Returns the total number of bytes of memory occupied physically by this array.
+    /// This value will always be greater than returned by `get_buffer_memory_size()` and
+    /// includes the overhead of the data structures that contain the pointers to the various buffers.
     fn get_array_memory_size(&self) -> usize {
         self.data_ref().get_array_memory_size() + std::mem::size_of_val(self)
     }

--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -197,7 +197,8 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
         self.data_ref().null_count()
     }
 
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this array.
+    /// Returns the total number of bytes of memory pointed to by this array.
+    /// The buffers store bytes in the Arrow memory format, and include the data as well as the validity map.
     fn get_buffer_memory_size(&self) -> usize {
         self.data_ref().get_buffer_memory_size()
     }

--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -585,7 +585,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_empty_primitive() {
@@ -683,6 +682,10 @@ mod tests {
             std::mem::size_of::<NullArray>(),
             null_arr.get_array_memory_size()
         );
+        assert_eq!(
+            std::mem::size_of::<NullArray>(),
+            std::mem::size_of::<ArrayData>(),
+        );
     }
 
     #[test]
@@ -706,6 +709,15 @@ mod tests {
                 .add_buffer(MutableBuffer::new(0).into())
                 .null_bit_buffer(MutableBuffer::new_null(0).into())
                 .build(),
+        );
+
+        // expected size is the size of the PrimitiveArray struct,
+        // which includes the optional validity buffer
+        // plus one buffer on the heap
+        assert_eq!(
+            std::mem::size_of::<PrimitiveArray<Int64Type>>()
+                + std::mem::size_of::<Buffer>(),
+            empty_with_bitmap.get_array_memory_size()
         );
 
         // substract empty array to avoid magic numbers for the size of additional fields

--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_memory_size_primitive_nullable() {
-        let arr = PrimitiveArray::<Int64Type>::from_iter((0..128).map(|i| Some(i)));
+        let arr: PrimitiveArray<Int64Type> = (0..128).map(Some).collect();
         let empty_with_bitmap = PrimitiveArray::<Int64Type>::from(
             ArrayData::builder(arr.data_type().clone())
                 .add_buffer(MutableBuffer::new(0).into())

--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -709,6 +709,7 @@ mod tests {
         );
 
         // substract empty array to avoid magic numbers for the size of additional fields
+        // the size of the validity bitmap is rounded up to 64 bytes
         assert_eq!(
             arr.get_array_memory_size() - empty_with_bitmap.get_array_memory_size(),
             128 * std::mem::size_of::<i64>() + 64

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -17,7 +17,6 @@
 
 use std::convert::{From, TryInto};
 use std::fmt;
-use std::mem;
 use std::{any::Any, iter::FromIterator};
 
 use super::{
@@ -198,16 +197,6 @@ impl<OffsetSize: BinaryOffsetSizeTrait> Array for GenericBinaryArray<OffsetSize>
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [$name].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [$name].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -600,16 +589,6 @@ impl Array for FixedSizeBinaryArray {
     fn data(&self) -> &ArrayData {
         &self.data
     }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeBinaryArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [FixedSizeBinaryArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
-    }
 }
 
 /// A type of `DecimalArray` whose elements are binaries.
@@ -779,16 +758,6 @@ impl Array for DecimalArray {
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [DecimalArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [DecimalArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -18,7 +18,6 @@
 use std::borrow::Borrow;
 use std::convert::From;
 use std::iter::{FromIterator, IntoIterator};
-use std::mem;
 use std::{any::Any, fmt};
 
 use super::*;
@@ -113,16 +112,6 @@ impl Array for BooleanArray {
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [BooleanArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [BooleanArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -18,7 +18,6 @@
 use std::any::Any;
 use std::fmt;
 use std::iter::IntoIterator;
-use std::mem;
 use std::{convert::From, iter::FromIterator};
 
 use super::{
@@ -208,18 +207,6 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    fn get_buffer_memory_size(&self) -> usize {
-        // Since both `keys` and `values` derive (are references from) `data`, we only need to account for `data`.
-        self.data.get_buffer_memory_size()
-    }
-
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size()
-            + self.keys.get_array_memory_size()
-            + self.values.get_array_memory_size()
-            + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -17,7 +17,6 @@
 
 use std::any::Any;
 use std::fmt;
-use std::mem;
 
 use num::Num;
 
@@ -261,16 +260,6 @@ impl<OffsetSize: 'static + OffsetSizeTrait> Array for GenericListArray<OffsetSiz
     fn data(&self) -> &ArrayData {
         &self.data
     }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [ListArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [ListArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
-    }
 }
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericListArray<OffsetSize> {
@@ -443,18 +432,6 @@ impl Array for FixedSizeListArray {
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeListArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size() + self.values().get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [FixedSizeListArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size()
-            + self.values().get_array_memory_size()
-            + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -498,9 +498,6 @@ mod tests {
             assert!(arr.is_valid(i));
             assert_eq!(i as i32, arr.value(i));
         }
-
-        assert_eq!(64, arr.get_buffer_memory_size());
-        assert_eq!(136, arr.get_array_memory_size());
     }
 
     #[test]
@@ -520,9 +517,6 @@ mod tests {
                 assert!(!arr.is_valid(i));
             }
         }
-
-        assert_eq!(128, arr.get_buffer_memory_size());
-        assert_eq!(216, arr.get_array_memory_size());
     }
 
     #[test]

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -150,16 +150,6 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     fn data(&self) -> &ArrayData {
         &self.data
     }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [PrimitiveArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [PrimitiveArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of::<RawPtrBox<T::Native>>()
-    }
 }
 
 fn as_datetime<T: ArrowPrimitiveType>(v: i64) -> Option<NaiveDateTime> {

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -17,7 +17,6 @@
 
 use std::convert::From;
 use std::fmt;
-use std::mem;
 use std::{any::Any, iter::FromIterator};
 
 use super::{
@@ -285,16 +284,6 @@ impl<OffsetSize: StringOffsetSizeTrait> Array for GenericStringArray<OffsetSize>
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [$name].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [$name].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -19,7 +19,6 @@ use std::any::Any;
 use std::convert::{From, TryFrom};
 use std::fmt;
 use std::iter::IntoIterator;
-use std::mem;
 
 use super::{make_array, Array, ArrayData, ArrayRef};
 use crate::datatypes::DataType;
@@ -177,16 +176,6 @@ impl Array for StructArray {
     /// Returns the length (i.e., number of elements) of this array
     fn len(&self) -> usize {
         self.data_ref().len()
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [StructArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [StructArray].
-    fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -80,7 +80,6 @@ use crate::error::{ArrowError, Result};
 
 use core::fmt;
 use std::any::Any;
-use std::mem;
 use std::mem::size_of;
 
 /// An Array that can represent slots of varying types.
@@ -275,25 +274,6 @@ impl Array for UnionArray {
 
     fn data(&self) -> &ArrayData {
         &self.data
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [UnionArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        let mut size = self.data.get_buffer_memory_size();
-        for field in &self.boxed_fields {
-            size += field.get_buffer_memory_size();
-        }
-        size
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [UnionArray].
-    fn get_array_memory_size(&self) -> usize {
-        let mut size = self.data.get_array_memory_size();
-        size += mem::size_of_val(self) - mem::size_of_val(&self.boxed_fields);
-        for field in &self.boxed_fields {
-            size += field.get_array_memory_size();
-        }
-        size
     }
 }
 

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -354,12 +354,7 @@ impl ArrayData {
 
     /// Returns the total number of bytes of memory occupied physically by this [ArrayData].
     pub fn get_array_memory_size(&self) -> usize {
-        let mut size = 0;
-        // Calculate size of the fields that don't have [get_array_memory_size] method internally.
-        size += mem::size_of_val(self)
-            - mem::size_of_val(&self.buffers)
-            - mem::size_of_val(&self.null_bitmap)
-            - mem::size_of_val(&self.child_data);
+        let mut size = mem::size_of_val(self);
 
         // Calculate rest of the fields top down which contain actual data
         for buffer in &self.buffers {

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -358,11 +358,14 @@ impl ArrayData {
 
         // Calculate rest of the fields top down which contain actual data
         for buffer in &self.buffers {
-            size += mem::size_of_val(&buffer);
+            size += mem::size_of::<Buffer>();
             size += buffer.capacity();
         }
         if let Some(bitmap) = &self.null_bitmap {
-            size += bitmap.get_array_memory_size()
+            // this includes the size of the bitmap struct itself, since it is stored directly in
+            // this struct we already counted those bytes in the size_of_val(self) above
+            size += bitmap.get_array_memory_size();
+            size -= mem::size_of::<Bitmap>();
         }
         for child in &self.child_data {
             size += child.get_array_memory_size();

--- a/arrow/src/array/null.rs
+++ b/arrow/src/array/null.rs
@@ -19,7 +19,6 @@
 
 use std::any::Any;
 use std::fmt;
-use std::mem;
 
 use crate::array::{Array, ArrayData};
 use crate::datatypes::*;
@@ -83,16 +82,6 @@ impl Array for NullArray {
     /// The null count of a `NullArray` always equals its length.
     fn null_count(&self) -> usize {
         self.data_ref().len()
-    }
-
-    /// Returns the total number of bytes of memory occupied by the buffers owned by this [NullArray].
-    fn get_buffer_memory_size(&self) -> usize {
-        self.data.get_buffer_memory_size()
-    }
-
-    /// Returns the total number of bytes of memory occupied physically by this [NullArray].
-    fn get_array_memory_size(&self) -> usize {
-        mem::size_of_val(self)
     }
 }
 

--- a/arrow/src/array/null.rs
+++ b/arrow/src/array/null.rs
@@ -122,12 +122,6 @@ mod tests {
         assert_eq!(null_arr.len(), 32);
         assert_eq!(null_arr.null_count(), 32);
         assert!(!null_arr.is_valid(0));
-
-        assert_eq!(0, null_arr.get_buffer_memory_size());
-        assert_eq!(
-            null_arr.get_buffer_memory_size() + std::mem::size_of::<NullArray>(),
-            null_arr.get_array_memory_size()
-        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #503.

# Rationale for this change

Some Array implementations have fields for easier access to nested arrays. These point to the same data already contained in ArrayData and so should not be considered to increase the memory usage. Since all the buffers are contained in ArrayData we can instead delegate the whole calculation and remove the specialized implementations.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Fixes overreporting of memory usage in DictionaryArray, FixedSizeListArray and UnionArray and simplified the code.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

`get_array_memory_size` returns slightly different but more correct results

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
