### PR TITLE
Fix parquet benchmark schema

### DIFF
--- a/parquet/benches/arrow_array_reader.rs
+++ b/parquet/benches/arrow_array_reader.rs
@@ -31,13 +31,9 @@ fn build_test_schema() -> SchemaDescPtr {
     let message_type = "
         message test_schema {
             REQUIRED INT32 mandatory_int32_leaf;
-            REPEATED Group test_mid_int32 {
-                OPTIONAL INT32 optional_int32_leaf;
-            }
+            OPTIONAL INT32 optional_int32_leaf;
             REQUIRED BYTE_ARRAY mandatory_string_leaf (UTF8);
-            REPEATED Group test_mid_string {
-                OPTIONAL BYTE_ARRAY optional_string_leaf (UTF8);
-            }
+            OPTIONAL BYTE_ARRAY optional_string_leaf (UTF8);
         }
         ";
     parse_message_type(message_type)


### PR DESCRIPTION
# Which issue does this PR close?

None, I'm banking progress so I don't lose it.

# Rationale for this change
 
The benchmark schema for nullable primitives and strings isn't the same as the non-null ones, leading to a slightly unfair comparison between the two.

# What changes are included in this PR?

Changed the schemas.

# Are there any user-facing changes?

No