### PR TITLE
CI: update rust nightly and packed_simd

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-03-24]
+        rust: [nightly-2021-07-04]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-03-24]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -290,7 +290,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-03-24]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -45,7 +45,7 @@ num = "0.4"
 csv_crate = { version = "1.1", optional = true, package="csv" }
 regex = "1.3"
 lazy_static = "1.4"
-packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
+packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

This updates the nightly version in CI to a recent version. This should fix some problems that arise when compiling `simd` on latest nightly rustc version.

Closes #517