### PR TITLE
Remove unused futures dependency from arrow-flight

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -33,6 +33,8 @@ bytes = "1"
 prost = "0.7"
 prost-derive = "0.7"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+
+[dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]


### PR DESCRIPTION
# Rationale for this change
 
I am trying to keep the `arrow*` dependency stack minimal and this dependency is only used in the examples

# What changes are included in this PR?

Move dependencies to `[dev-dependencies]`

# Are there any user-facing changes?
One less (explicit) dependency on crates.io -- it is likely that the `futures` crate is still a transitive dependency

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
