### PR TITLE
Add tests for building applications using arrow with different feature flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -244,6 +244,7 @@ jobs:
           rustup component add rustfmt
       - name: Run
         run: cargo fmt --all -- --check
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -327,9 +328,9 @@ jobs:
           cd arrow
           cargo build --target wasm32-unknown-unknown
 
-  # test the projects can build without default features
+  # test builds with various feature flags
   default-build:
-    name: Check No Defaults on AMD64 Rust ${{ matrix.rust }}
+    name: Arrow Feature Flag Builds ${{ matrix.rust }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -338,15 +339,10 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-        ARROW_TEST_DATA: /__w/arrow-rs/arrow-rs/testing/data
-        PARQUET_TEST_DATA: /__w/arrow/arrow/parquet-testing/data
+        # Disable debug symbol generation to speed up CI build and keep memory down
+        RUSTFLAGS: "-C debuginfo=0"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
@@ -357,15 +353,22 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /github/home/target
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache-${{ matrix.rust }}
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
           rustup override set ${{ matrix.rust }}
           rustup component add rustfmt
-      - name: Build arrow crate
+      - name: Build with default features
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cd arrow
-          cargo check --all-targets --no-default-features
+          cd arrow/test/dependency/default-features
+          cargo check
+      - name: Build with default-features=false
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cd arrow/test/dependency/no-default-features
+          cargo check

--- a/arrow/test/dependency/README.md
+++ b/arrow/test/dependency/README.md
@@ -1,0 +1,21 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+This directory contains projects that use arrow as a dependency with
+various combinations of feature flags.

--- a/arrow/test/dependency/default-features/Cargo.toml
+++ b/arrow/test/dependency/default-features/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "defeault-features"
+description = "Models a user application of arrow that uses default features of arrow"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow = { path = "../../../../arrow", version = "5.0.0-SNAPSHOT" }
+
+# Workaround for https://github.com/apache/arrow-rs/issues/529
+rand = { version = "0.8" }
+
+[workspace]

--- a/arrow/test/dependency/default-features/src/main.rs
+++ b/arrow/test/dependency/default-features/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/arrow/test/dependency/no-default-features/Cargo.toml
+++ b/arrow/test/dependency/no-default-features/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "no-default-features"
+description = "Models a user application of arrow that specifies no-default-features=true"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow = { path = "../../../../arrow", version = "5.0.0-SNAPSHOT", default-features = false }
+
+# Workaround for https://github.com/apache/arrow-rs/issues/529
+rand = { version = "0.8" }
+
+[workspace]

--- a/arrow/test/dependency/no-default-features/src/main.rs
+++ b/arrow/test/dependency/no-default-features/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -3,6 +3,7 @@ testing/*
 target/*
 dev/release/rat_exclude_files.txt
 arrow/test/data/*
+arrow/test/dependency/*
 .gitattributes
 **.gitignore
 .gitmodules


### PR DESCRIPTION
# Which issue does this PR close?
Re: https://github.com/apache/arrow-rs/issues/529

# Rationale for this change
 The current CI test ([here](https://github.com/apache/arrow-rs/blob/master/.github/workflows/rust.yml#L371)) to ensure arrow builds with various feature flags did not catch #529. This is because it is run in the context of the overall workspace which does not behave the same way as when arrow is used as a dependency

This PR contains the test strategy I propose to use for testing that arrow properly builds with different options. I plan a follow on PR that actually fixed #529

# What changes are included in this PR?

This PR contains the test strategy I propose to use for testing that arrow properly builds with different options. I plan a follow on PR that actually fixed #529

# Changes
1. Create actual projects that specify `arrow` as a dependency with various flags
2. Try to build that project in CI

Here is an example of the test running on CI: https://github.com/apache/arrow-rs/runs/3032269357?check_suite_focus=true (it is quite fast to check the projects)

You easily run these builds locally:
```shell
cd arrow/test/dependency/no-features
cargo check
```

I am sure there is some clever tool somewhere that claims to solve this problem (perhaps `cargo hack`? as suggested by @ritchie46). However, I chose to do it explicitly here because:
1. It is as close as possible to how an actual user will build their app with arrow
2. I can audit how it works without having to review projects and asses how mature / stable they are

# Are there any user-facing changes?

no