### PR TITLE
generate parquet schema from rust struct

### DIFF
--- a/parquet/src/record/record_writer.rs
+++ b/parquet/src/record/record_writer.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::schema::types::TypePtr;
+
 use super::super::errors::ParquetError;
 use super::super::file::writer::RowGroupWriter;
 
@@ -23,4 +25,7 @@ pub trait RecordWriter<T> {
         &self,
         row_group_writer: &mut Box<dyn RowGroupWriter>,
     ) -> Result<(), ParquetError>;
+
+    /// Generated schema
+    fn schema(&self) -> Result<TypePtr, ParquetError>;
 }

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -127,7 +127,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         use parquet::schema::types::Type as ParquetType;
         use parquet::schema::types::TypePtr;
         use parquet::basic::LogicalType;
-        use parquet::basic::Repetition;
+        use parquet::basic::*;
 
         let mut fields: Vec<TypePtr> = Vec::new();
         #(

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -32,11 +32,18 @@ struct ACompleteRecord<'a> {
     pub a_borrowed_string: &'a String,
     pub maybe_a_str: Option<&'a str>,
     pub maybe_a_string: Option<String>,
-    pub magic_number: i32,
-    pub low_quality_pi: f32,
-    pub high_quality_pi: f64,
-    pub maybe_pi: Option<f32>,
-    pub maybe_best_pi: Option<f64>,
+    pub i16: i16,
+    pub i32: i32,
+    pub u64: u64,
+    pub maybe_u8: Option<u8>,
+    pub maybe_i16: Option<i16>,
+    pub maybe_u32: Option<u32>,
+    pub maybe_usize: Option<usize>,
+    pub isize: isize,
+    pub float: f32,
+    pub double: f64,
+    pub maybe_float: Option<f32>,
+    pub maybe_double: Option<f64>,
     pub borrowed_maybe_a_string: &'a Option<String>,
     pub borrowed_maybe_a_str: &'a Option<&'a str>,
 }
@@ -67,11 +74,18 @@ mod tests {
             REQUIRED BINARY          a_borrowed_string (STRING);
             OPTIONAL BINARY          maybe_a_str (STRING);
             OPTIONAL BINARY          maybe_a_string (STRING);
-            REQUIRED INT32           magic_number;
-            REQUIRED FLOAT           low_quality_pi;
-            REQUIRED DOUBLE          high_quality_pi;
-            OPTIONAL FLOAT           maybe_pi;
-            OPTIONAL DOUBLE          maybe_best_pi;
+            REQUIRED INT32           i16 (INTEGER(16,true));
+            REQUIRED INT32           i32;
+            REQUIRED INT64           u64 (INTEGER(64,false));
+            OPTIONAL INT32           maybe_u8 (INTEGER(8,false));
+            OPTIONAL INT32           maybe_i16 (INTEGER(16,true));
+            OPTIONAL INT32           maybe_u32 (INTEGER(32,false));
+            OPTIONAL INT64           maybe_usize (INTEGER(64,false));
+            REQUIRED INT64           isize (INTEGER(64,true));
+            REQUIRED FLOAT           float;
+            REQUIRED DOUBLE          double;
+            OPTIONAL FLOAT           maybe_float;
+            OPTIONAL DOUBLE          maybe_double;
             OPTIONAL BINARY          borrowed_maybe_a_string (STRING);
             OPTIONAL BINARY          borrowed_maybe_a_str (STRING);
         }";
@@ -88,11 +102,18 @@ mod tests {
             a_borrowed_string: &a_borrowed_string,
             maybe_a_str: Some(&a_str[..]),
             maybe_a_string: Some(a_str.clone()),
-            magic_number: 100,
-            low_quality_pi: 3.14,
-            high_quality_pi: 3.1415,
-            maybe_pi: Some(3.14),
-            maybe_best_pi: Some(3.1415),
+            i16: -45,
+            i32: 456,
+            u64: 4563424,
+            maybe_u8: None,
+            maybe_i16: Some(3),
+            maybe_u32: None,
+            maybe_usize: Some(4456),
+            isize: -365,
+            float: 3.5,
+            double: std::f64::NAN,
+            maybe_float: None,
+            maybe_double: Some(std::f64::MAX),
             borrowed_maybe_a_string: &maybe_a_string,
             borrowed_maybe_a_str: &maybe_a_str,
         }];


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
Users of `parquet_derive` currently have to write the schema of their Rust struct by hand.
This is inconvenient, and can be generated for them.

# What changes are included in this PR?

Adds `parquet::record::RecordWriter::schema()` trait member, and an implementation in `parquet_derive` to generate a schema for the user.

# Are there any user-facing changes?

Yes, new API. The breakage is probably irrelevant as I don't think that there are many users of `parquet_derive`.