### PR TITLE
label parquet-derive PRs

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -23,3 +23,6 @@ arrow-flight:
 
 parquet:
   - parquet/**/*
+
+parquet-derive:
+  - parquet_derive/**/*


### PR DESCRIPTION
While reviewing https://github.com/apache/arrow-rs/pull/539 I realized it would be nice to have the 4th published crate, `parquet_derive` automatically labeled as well


# What changes are included in this PR?
label all PRs that change code in `parquet_derive` with the `parquet_derive` label

# Are there any user-facing changes?
No
