### PR TITLE
Fix build, Make the js package a feature that can be enabled for wasm, rather than always on

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -332,7 +332,7 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd arrow
-          cargo build --target --features=js wasm32-unknown-unknown
+          cargo build --features=js --target wasm32-unknown-unknown
 
   # test builds with various feature flags
   default-build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -332,7 +332,7 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd arrow
-          cargo build --target wasm32-unknown-unknown
+          cargo build --target --features=js wasm32-unknown-unknown
 
   # test builds with various feature flags
   default-build:

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -43,7 +43,7 @@ indexmap = "1.6"
 rand = { version = "0.8", default-features = false }
 # getrandom is a dependency of rand, not (directly) of arrow
 # need to specify `js` feature to build on wasm
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.2", optional = true }
 num = "0.4"
 csv_crate = { version = "1.1", optional = true, package="csv" }
 regex = "1.3"
@@ -64,6 +64,7 @@ csv = ["csv_crate"]
 ipc = ["flatbuffers"]
 simd = ["packed_simd"]
 prettyprint = ["prettytable-rs"]
+js = ["getrandom/js"]
 # The test utils feature enables code used in benchmarks and tests but
 # not the core arrow code itself
 test_utils = ["rand/std", "rand/std_rng"]

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -30,6 +30,7 @@ The arrow crate provides the following optional features:
 - `csv` (default) - support for reading and writing Arrow arrays to/from csv files
 - `ipc` (default) - support for the [arrow-flight]((https://crates.io/crates/arrow-flight) IPC and wire format
 - `prettyprint` - support for formatting record batches as textual columns
+- `js` - support for building arrow for WebAssembly / JavaScript
 - `simd` - (_Requires Nightly Rust_) alternate optimized
   implementations of some [compute](https://github.com/apache/arrow/tree/master/rust/arrow/src/compute)
   kernels using explicit SIMD processor intrinsics.


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/544

# Rationale for this change

We upgraded Arrow to the latest version of `rand` in https://github.com/apache/arrow-rs/pull/488 which has changed how they do js/ wasm support

When I tried to use arrow/datafusion in IOx (which depends on both arrow and datafusion) I got this crazy error while trying to resolve dependencies:

```
error: cyclic package dependency: package `ahash v0.7.4` depends on itself. Cycle:
package `ahash v0.7.4`
    ... which is depended on by `hashbrown v0.11.2`
    ... which is depended on by `indexmap v1.7.0`
    ... which is depended on by `serde_json v1.0.64`
    ... which is depended on by `wasm-bindgen v0.2.74`
    ... which is depended on by `js-sys v0.3.51`
    ... which is depended on by `getrandom v0.2.3`
    ... which is depended on by `ahash v0.7.4`
```

The issue appears to be that the `js` feature of rand somehow pulls in ahsah again. 

# What changes are included in this PR?

Make the `getrandom/js` (needed to build for wasm) dependency optional for arrow

# Are there any user-facing changes?

Yes, In order to build for WASM, the previous command

```shell
cargo build --target wasm32-unknown-unknown
```

Fails with an error such as
```
cd /Users/alamb/Software/arrow-rs/arrow && cargo build --target wasm32-unknown-unknown
   Compiling getrandom v0.2.3
error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/alamb/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:219:9
    |
219 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
220 | |                         default, you may need to enable the \"js\" feature. \
221 | |                         For more information see: \
222 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |_________________________________________________________________________^

```

Now, arrow users will have to explicitly specify the `js` feature:
```shell
cargo build --features=js --target wasm32-unknown-unknown
```
