### PR TITLE
Exclude .github in rat files

### DIFF
--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -12,3 +12,4 @@ filtered_rat.txt
 rat.txt
 # auto-generated
 arrow-flight/src/arrow.flight.protocol.rs
+.github/*


### PR DESCRIPTION
Add .github to list of files ignored by license checker