### PR TITLE
Exclude .github in rat files

### DIFF
--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -12,3 +12,4 @@ filtered_rat.txt
 rat.txt
 # auto-generated
 arrow-flight/src/arrow.flight.protocol.rs
+.github/*


### PR DESCRIPTION

# Rationale for this change
I found the .github scripts were not excluded from the tarball while creating the 5.0.0 release candidate, and so updated them on `active_release` in  https://github.com/apache/arrow-rs/pull/550

# What changes are included in this PR?
add .github to the list of files ignored by the RAT check


# Are there any user-facing changes?
No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
