### PR TITLE
Update triplet.rs to support REPEATED field with null value at one place

### DIFF
--- a/parquet/src/record/triplet.rs
+++ b/parquet/src/record/triplet.rs
@@ -136,7 +136,9 @@ impl TripletIter {
 
     /// Updates non-null value for current row.
     pub fn current_value(&self) -> Field {
-        assert!(!self.is_null(), "Value is null");
+        if self.is_null() {
+            return Field::Null;
+        }
         match *self {
             TripletIter::BoolTripletIter(ref typed) => {
                 Field::convert_bool(typed.column_descr(), *typed.current_value())


### PR DESCRIPTION
Update triplet.rs to support REPEATED field with null value at one place

# Which issue does this PR close?

No

# Rationale for this change
 
Used to manage REPEATED fields with null values. Drill generates it for example when creating the parquet.

# What changes are included in this PR?

Replace the assert statement by an if statement that return a `Field::Null` value in the `pub fn current_value(&self) -> Field` locate in record/triplet.rs.

# Are there any user-facing changes?

No
