### PR TITLE
make `has_min_max_set` as pub fn

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -403,7 +403,7 @@ impl<T: DataType> TypedStatistics<T> {
 
     /// Whether or not min and max values are set.
     /// Normally both min/max values will be set to `Some(value)` or `None`.
-    fn has_min_max_set(&self) -> bool {
+    pub fn has_min_max_set(&self) -> bool {
         self.min.is_some() && self.max.is_some()
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
in [arrow-datafusion#640](https://github.com/apache/arrow-datafusion/issues/640) we get column max/min value from parquet `Statistics`. In some cases, if the max/min value is not set, all values are `null`. When we call `max` or `min` method, it will panic. In order to avoid this, we must use `has_min_max_set` method to check it.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
make public for fn `TypedStatistics::has_min_max_set`

# Are there any user-facing changes?

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

- make fn `TypedStatistics::has_min_max_set` as public API

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
