### PR TITLE
Add len() to InMemoryWriteableCursor

### DIFF
--- a/parquet/src/util/cursor.rs
+++ b/parquet/src/util/cursor.rs
@@ -160,6 +160,12 @@ impl InMemoryWriteableCursor {
         let inner = self.buffer.lock().unwrap();
         inner.get_ref().len()
     }
+
+    /// Returns true if the underlying buffer contains no elements
+    pub fn is_empty(&self) -> bool {
+        let inner = self.buffer.lock().unwrap();
+        inner.get_ref().is_empty()
+    }
 }
 
 impl TryClone for InMemoryWriteableCursor {

--- a/parquet/src/util/cursor.rs
+++ b/parquet/src/util/cursor.rs
@@ -154,6 +154,12 @@ impl InMemoryWriteableCursor {
         let inner = self.buffer.lock().unwrap();
         inner.get_ref().to_vec()
     }
+
+    /// Returns a length of the underlying buffer
+    pub fn len(&self) -> usize {
+        let inner = self.buffer.lock().unwrap();
+        inner.get_ref().len()
+    }
 }
 
 impl TryClone for InMemoryWriteableCursor {


### PR DESCRIPTION
# Which issue does this PR close?
Resolves the https://github.com/delta-io/kafka-delta-ingest/issues/38

# Rationale for this change
 There's no efficient way to get buffer length unless copying the data via `.data()` func. These changes provide easy and safe way top achieve that.

# What changes are included in this PR?

Basically the same impl as in `.data()`, but once we've got the ref then the `len()` on the underlying is called instead of copying the bytes.

# Are there any user-facing changes?

new pub api (?).
