### PR TITLE
Cherry pick make `has_min_max_set` as pub fn to active_release

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -403,7 +403,7 @@ impl<T: DataType> TypedStatistics<T> {
 
     /// Whether or not min and max values are set.
     /// Normally both min/max values will be set to `Some(value)` or `None`.
-    fn has_min_max_set(&self) -> bool {
+    pub fn has_min_max_set(&self) -> bool {
         self.min.is_some() && self.max.is_some()
     }
 


### PR DESCRIPTION
Automatic cherry-pick of e658cb8
* Originally appeared in https://github.com/apache/arrow-rs/pull/559: make `has_min_max_set` as pub fn
