### PR TITLE
Update sort kernel docs to note it is unstable

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -27,10 +27,15 @@ use TimeUnit::*;
 
 /// Sort the `ArrayRef` using `SortOptions`.
 ///
-/// Performs a stable sort on values and indices. Nulls are ordered according to the `nulls_first` flag in `options`.
-/// Floats are sorted using IEEE 754 totalOrder
+/// Performs a sort on values and indices. Nulls are ordered according
+/// to the `nulls_first` flag in `options`.  Floats are sorted using
+/// IEEE 754 totalOrder
 ///
-/// Returns an `ArrowError::ComputeError(String)` if the array type is either unsupported by `sort_to_indices` or `take`.
+/// Returns an `ArrowError::ComputeError(String)` if the array type is
+/// either unsupported by `sort_to_indices` or `take`.
+///
+/// Note: this is an unstable_sort, meaning it may not preserve the
+/// order of equal elements.
 ///
 /// # Example
 /// ```rust


### PR DESCRIPTION
# Which issue does this PR close?

Re #553

# Rationale for this change
#552 changed the sort kernel so that it is no longer stable. This PR updates the docstrings to reflect this change. See for more context  https://github.com/apache/arrow-rs/pull/552#issuecomment-882301209
 
# Are there any user-facing changes?
More accurate docs

