### PR TITLE
Cherry pick Update triplet.rs to support REPEATED field with null value at one place to active_release

### DIFF
--- a/parquet/src/record/triplet.rs
+++ b/parquet/src/record/triplet.rs
@@ -136,7 +136,9 @@ impl TripletIter {
 
     /// Updates non-null value for current row.
     pub fn current_value(&self) -> Field {
-        assert!(!self.is_null(), "Value is null");
+        if self.is_null() {
+            return Field::Null;
+        }
         match *self {
             TripletIter::BoolTripletIter(ref typed) => {
                 Field::convert_bool(typed.column_descr(), *typed.current_value())


### PR DESCRIPTION
Automatic cherry-pick of 03269aa
* Originally appeared in https://github.com/apache/arrow-rs/pull/556: Update triplet.rs to support REPEATED field with null value at one place
