### PR TITLE
Cherry pick Add len() to InMemoryWriteableCursor to active_release

### DIFF
--- a/parquet/src/util/cursor.rs
+++ b/parquet/src/util/cursor.rs
@@ -154,6 +154,18 @@ impl InMemoryWriteableCursor {
         let inner = self.buffer.lock().unwrap();
         inner.get_ref().to_vec()
     }
+
+    /// Returns a length of the underlying buffer
+    pub fn len(&self) -> usize {
+        let inner = self.buffer.lock().unwrap();
+        inner.get_ref().len()
+    }
+
+    /// Returns true if the underlying buffer contains no elements
+    pub fn is_empty(&self) -> bool {
+        let inner = self.buffer.lock().unwrap();
+        inner.get_ref().is_empty()
+    }
 }
 
 impl TryClone for InMemoryWriteableCursor {


### PR DESCRIPTION
Automatic cherry-pick of 6c82bdc
* Originally appeared in https://github.com/apache/arrow-rs/pull/564: Add len() to InMemoryWriteableCursor
