### PR TITLE
Validate output of MIRI is successful on CI

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -57,4 +57,4 @@ jobs:
           cargo clean
           # Currently only the arrow crate is tested with miri
           # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json || true
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json


### PR DESCRIPTION
Closes https://github.com/apache/arrow-rs/issues/581

# Rationale for this change
We started running MIRI again in https://github.com/apache/arrow-rs/pull/421, but while discussing with @jorgecarleitao 
 on https://github.com/jorgecarleitao/arrow2/pull/209, it turned out that we were still `||true` ing the output (aka not validating that MIRA was running cleanly)
 
# What changes are included in this PR?
Check output of MIRI return

# Are there any user-facing changes?
No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
