### PR TITLE
support struct array in pretty display

### DIFF
--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -214,14 +214,19 @@ fn append_struct_field_string(
     target.push('"');
     target.push_str(name);
     target.push_str("\": ");
-    match field_col.data_type() {
-        DataType::Utf8 | DataType::LargeUtf8 => {
-            target.push('"');
-            target.push_str(array_value_to_string(field_col, row)?.as_str());
-            target.push('"');
-        }
-        _ => {
-            target.push_str(array_value_to_string(field_col, row)?.as_str());
+
+    if field_col.is_null(row) {
+        target.push_str("null");
+    } else {
+        match field_col.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 => {
+                target.push('"');
+                target.push_str(array_value_to_string(field_col, row)?.as_str());
+                target.push('"');
+            }
+            _ => {
+                target.push_str(array_value_to_string(field_col, row)?.as_str());
+            }
         }
     }
 

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -234,7 +234,7 @@ fn append_struct_field_string(
 /// suitable for converting large arrays or record batches.
 pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<String> {
     if column.is_null(row) {
-        return Ok("".to_string());
+        return Ok("null".to_string());
     }
     match column.data_type() {
         DataType::Utf8 => make_string!(array::StringArray, column, row),

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -234,7 +234,7 @@ fn append_struct_field_string(
 /// suitable for converting large arrays or record batches.
 pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<String> {
     if column.is_null(row) {
-        return Ok("null".to_string());
+        return Ok("".to_string());
     }
     match column.data_type() {
         DataType::Utf8 => make_string!(array::StringArray, column, row),

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -205,6 +205,29 @@ pub fn make_string_from_decimal(column: &Arc<dyn Array>, row: usize) -> Result<S
     Ok(formatted_decimal)
 }
 
+fn append_struct_field_string(
+    target: &mut String,
+    name: &str,
+    field_col: &Arc<dyn Array>,
+    row: usize,
+) -> Result<()> {
+    target.push('"');
+    target.push_str(name);
+    target.push_str("\": ");
+    match field_col.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 => {
+            target.push('"');
+            target.push_str(array_value_to_string(field_col, row)?.as_str());
+            target.push('"');
+        }
+        _ => {
+            target.push_str(array_value_to_string(field_col, row)?.as_str());
+        }
+    }
+
+    Ok(())
+}
+
 /// Get the value at the given row in an array as a String.
 ///
 /// Note this function is quite inefficient and is unlikely to be
@@ -280,6 +303,31 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
                 column.data_type()
             ))),
         },
+        DataType::Struct(_) => {
+            let st = column
+                .as_any()
+                .downcast_ref::<array::StructArray>()
+                .ok_or_else(|| {
+                    ArrowError::InvalidArgumentError(
+                        "Repl error: could not convert struct column to struct array."
+                            .to_string(),
+                    )
+                })?;
+
+            let mut s = String::new();
+            s.push('{');
+            let mut kv_iter = st.columns().into_iter().zip(st.column_names().into_iter());
+            if let Some((col, name)) = kv_iter.next() {
+                append_struct_field_string(&mut s, name, col, row)?;
+            }
+            for (col, name) in kv_iter {
+                s.push_str(", ");
+                append_struct_field_string(&mut s, name, col, row)?;
+            }
+            s.push('}');
+
+            Ok(s)
+        }
         _ => Err(ArrowError::InvalidArgumentError(format!(
             "Pretty printing not implemented for {:?} type",
             column.data_type()

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -507,4 +507,63 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_pretty_format_struct() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new(
+                "c1",
+                DataType::Struct(vec![
+                    Field::new("c11", DataType::Int32, false),
+                    Field::new(
+                        "c12",
+                        DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                        false,
+                    ),
+                ]),
+                false,
+            ),
+            Field::new("c2", DataType::Utf8, false),
+        ]);
+
+        let c1 = StructArray::from(vec![
+            (
+                Field::new("c11", DataType::Int32, false),
+                Arc::new(Int32Array::from(vec![Some(1), None, Some(5)])) as ArrayRef,
+            ),
+            (
+                Field::new(
+                    "c12",
+                    DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                    false,
+                ),
+                Arc::new(StructArray::from(vec![(
+                    Field::new("c121", DataType::Utf8, false),
+                    Arc::new(StringArray::from(vec![Some("e"), Some("f"), Some("g")]))
+                        as ArrayRef,
+                )])) as ArrayRef,
+            ),
+        ]);
+        let c2 = StringArray::from(vec![Some("a"), Some("b"), Some("c")]);
+
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)])
+                .unwrap();
+
+        let table = pretty_format_batches(&[batch])?;
+        let expected = vec![
+            r#"+-------------------------------------+----+"#,
+            r#"| c1                                  | c2 |"#,
+            r#"+-------------------------------------+----+"#,
+            r#"| {"c11": 1, "c12": {"c121": "e"}}    | a  |"#,
+            r#"| {"c11": null, "c12": {"c121": "f"}} | b  |"#,
+            r#"| {"c11": 5, "c12": {"c121": "g"}}    | c  |"#,
+            r#"+-------------------------------------+----+"#,
+        ];
+
+        let actual: Vec<&str> = table.lines().collect();
+        assert_eq!(expected, actual, "Actual result:\n{}", table);
+
+        Ok(())
+    }
 }

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -106,9 +106,9 @@ mod tests {
     use crate::{
         array::{
             self, new_null_array, Array, Date32Array, Date64Array, PrimitiveBuilder,
-            StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
-            Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
-            Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+            StringBuilder, StringDictionaryBuilder, Time32MillisecondArray,
+            Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+            TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray,
         },
         datatypes::{DataType, Field, Int32Type, Schema},
@@ -148,14 +148,14 @@ mod tests {
         let table = pretty_format_batches(&[batch])?;
 
         let expected = vec![
-            "+------+------+",
-            "| a    | b    |",
-            "+------+------+",
-            "| a    | 1    |",
-            "| b    | null |",
-            "| null | 10   |",
-            "| d    | 100  |",
-            "+------+------+",
+            "+---+-----+",
+            "| a | b   |",
+            "+---+-----+",
+            "| a | 1   |",
+            "| b |     |",
+            "|   | 10  |",
+            "| d | 100 |",
+            "+---+-----+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -180,8 +180,8 @@ mod tests {
         let table = pretty_format_columns("a", &columns)?;
 
         let expected = vec![
-            "+------+", "| a    |", "+------+", "| a    |", "| b    |", "| null |",
-            "| d    |", "| e    |", "| null |", "| g    |", "+------+",
+            "+---+", "| a |", "+---+", "| a |", "| b |", "|   |", "| d |", "| e |",
+            "|   |", "| g |", "+---+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -212,14 +212,14 @@ mod tests {
         let table = pretty_format_batches(&[batch]).unwrap();
 
         let expected = vec![
-            "+------+------+------+",
-            "| a    | b    | c    |",
-            "+------+------+------+",
-            "| null | null | null |",
-            "| null | null | null |",
-            "| null | null | null |",
-            "| null | null | null |",
-            "+------+------+------+",
+            "+---+---+---+",
+            "| a | b | c |",
+            "+---+---+---+",
+            "|   |   |   |",
+            "|   |   |   |",
+            "|   |   |   |",
+            "|   |   |   |",
+            "+---+---+---+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -252,7 +252,7 @@ mod tests {
             "| d1    |",
             "+-------+",
             "| one   |",
-            "| null  |",
+            "|       |",
             "| three |",
             "+-------+",
         ];
@@ -297,7 +297,7 @@ mod tests {
             "| f                   |",
             "+---------------------+",
             "| 1970-05-09 14:25:11 |",
-            "| null                |",
+            "|                     |",
             "+---------------------+",
         ];
         check_datetime!(TimestampSecondArray, 11111111, expected);
@@ -310,7 +310,7 @@ mod tests {
             "| f                       |",
             "+-------------------------+",
             "| 1970-01-01 03:05:11.111 |",
-            "| null                    |",
+            "|                         |",
             "+-------------------------+",
         ];
         check_datetime!(TimestampMillisecondArray, 11111111, expected);
@@ -323,7 +323,7 @@ mod tests {
             "| f                          |",
             "+----------------------------+",
             "| 1970-01-01 00:00:11.111111 |",
-            "| null                       |",
+            "|                            |",
             "+----------------------------+",
         ];
         check_datetime!(TimestampMicrosecondArray, 11111111, expected);
@@ -336,7 +336,7 @@ mod tests {
             "| f                             |",
             "+-------------------------------+",
             "| 1970-01-01 00:00:00.011111111 |",
-            "| null                          |",
+            "|                               |",
             "+-------------------------------+",
         ];
         check_datetime!(TimestampNanosecondArray, 11111111, expected);
@@ -349,7 +349,7 @@ mod tests {
             "| f          |",
             "+------------+",
             "| 1973-05-19 |",
-            "| null       |",
+            "|            |",
             "+------------+",
         ];
         check_datetime!(Date32Array, 1234, expected);
@@ -362,7 +362,7 @@ mod tests {
             "| f          |",
             "+------------+",
             "| 2005-03-18 |",
-            "| null       |",
+            "|            |",
             "+------------+",
         ];
         check_datetime!(Date64Array, 1111111100000, expected);
@@ -375,7 +375,7 @@ mod tests {
             "| f        |",
             "+----------+",
             "| 00:18:31 |",
-            "| null     |",
+            "|          |",
             "+----------+",
         ];
         check_datetime!(Time32SecondArray, 1111, expected);
@@ -388,7 +388,7 @@ mod tests {
             "| f            |",
             "+--------------+",
             "| 03:05:11.111 |",
-            "| null         |",
+            "|              |",
             "+--------------+",
         ];
         check_datetime!(Time32MillisecondArray, 11111111, expected);
@@ -401,7 +401,7 @@ mod tests {
             "| f               |",
             "+-----------------+",
             "| 00:00:11.111111 |",
-            "| null            |",
+            "|                 |",
             "+-----------------+",
         ];
         check_datetime!(Time64MicrosecondArray, 11111111, expected);
@@ -414,7 +414,7 @@ mod tests {
             "| f                  |",
             "+--------------------+",
             "| 00:00:00.011111111 |",
-            "| null               |",
+            "|                    |",
             "+--------------------+",
         ];
         check_datetime!(Time64NanosecondArray, 11111111, expected);
@@ -462,7 +462,7 @@ mod tests {
             "| f     |",
             "+-------+",
             "| 1.01  |",
-            "| null  |",
+            "|       |",
             "| 2.00  |",
             "| 30.40 |",
             "+-------+",
@@ -498,7 +498,7 @@ mod tests {
 
         let table = pretty_format_batches(&[batch])?;
         let expected = vec![
-            "+------+", "| f    |", "+------+", "| 101  |", "| null |", "| 200  |",
+            "+------+", "| f    |", "+------+", "| 101  |", "|      |", "| 200  |",
             "| 3040 |", "+------+",
         ];
 

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -106,9 +106,9 @@ mod tests {
     use crate::{
         array::{
             self, new_null_array, Array, Date32Array, Date64Array, PrimitiveBuilder,
-            StringBuilder, StringDictionaryBuilder, Time32MillisecondArray,
-            Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
-            TimestampMicrosecondArray, TimestampMillisecondArray,
+            StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
+            Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+            Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray,
         },
         datatypes::{DataType, Field, Int32Type, Schema},

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -106,9 +106,9 @@ mod tests {
     use crate::{
         array::{
             self, new_null_array, Array, Date32Array, Date64Array, PrimitiveBuilder,
-            StringBuilder, StringDictionaryBuilder, Time32MillisecondArray,
-            Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
-            TimestampMicrosecondArray, TimestampMillisecondArray,
+            StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
+            Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
+            Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray,
         },
         datatypes::{DataType, Field, Int32Type, Schema},
@@ -148,14 +148,14 @@ mod tests {
         let table = pretty_format_batches(&[batch])?;
 
         let expected = vec![
-            "+---+-----+",
-            "| a | b   |",
-            "+---+-----+",
-            "| a | 1   |",
-            "| b |     |",
-            "|   | 10  |",
-            "| d | 100 |",
-            "+---+-----+",
+            "+------+------+",
+            "| a    | b    |",
+            "+------+------+",
+            "| a    | 1    |",
+            "| b    | null |",
+            "| null | 10   |",
+            "| d    | 100  |",
+            "+------+------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -180,8 +180,8 @@ mod tests {
         let table = pretty_format_columns("a", &columns)?;
 
         let expected = vec![
-            "+---+", "| a |", "+---+", "| a |", "| b |", "|   |", "| d |", "| e |",
-            "|   |", "| g |", "+---+",
+            "+------+", "| a    |", "+------+", "| a    |", "| b    |", "| null |",
+            "| d    |", "| e    |", "| null |", "| g    |", "+------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -212,14 +212,14 @@ mod tests {
         let table = pretty_format_batches(&[batch]).unwrap();
 
         let expected = vec![
-            "+---+---+---+",
-            "| a | b | c |",
-            "+---+---+---+",
-            "|   |   |   |",
-            "|   |   |   |",
-            "|   |   |   |",
-            "|   |   |   |",
-            "+---+---+---+",
+            "+------+------+------+",
+            "| a    | b    | c    |",
+            "+------+------+------+",
+            "| null | null | null |",
+            "| null | null | null |",
+            "| null | null | null |",
+            "| null | null | null |",
+            "+------+------+------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -252,7 +252,7 @@ mod tests {
             "| d1    |",
             "+-------+",
             "| one   |",
-            "|       |",
+            "| null  |",
             "| three |",
             "+-------+",
         ];
@@ -297,7 +297,7 @@ mod tests {
             "| f                   |",
             "+---------------------+",
             "| 1970-05-09 14:25:11 |",
-            "|                     |",
+            "| null                |",
             "+---------------------+",
         ];
         check_datetime!(TimestampSecondArray, 11111111, expected);
@@ -310,7 +310,7 @@ mod tests {
             "| f                       |",
             "+-------------------------+",
             "| 1970-01-01 03:05:11.111 |",
-            "|                         |",
+            "| null                    |",
             "+-------------------------+",
         ];
         check_datetime!(TimestampMillisecondArray, 11111111, expected);
@@ -323,7 +323,7 @@ mod tests {
             "| f                          |",
             "+----------------------------+",
             "| 1970-01-01 00:00:11.111111 |",
-            "|                            |",
+            "| null                       |",
             "+----------------------------+",
         ];
         check_datetime!(TimestampMicrosecondArray, 11111111, expected);
@@ -336,7 +336,7 @@ mod tests {
             "| f                             |",
             "+-------------------------------+",
             "| 1970-01-01 00:00:00.011111111 |",
-            "|                               |",
+            "| null                          |",
             "+-------------------------------+",
         ];
         check_datetime!(TimestampNanosecondArray, 11111111, expected);
@@ -349,7 +349,7 @@ mod tests {
             "| f          |",
             "+------------+",
             "| 1973-05-19 |",
-            "|            |",
+            "| null       |",
             "+------------+",
         ];
         check_datetime!(Date32Array, 1234, expected);
@@ -362,7 +362,7 @@ mod tests {
             "| f          |",
             "+------------+",
             "| 2005-03-18 |",
-            "|            |",
+            "| null       |",
             "+------------+",
         ];
         check_datetime!(Date64Array, 1111111100000, expected);
@@ -375,7 +375,7 @@ mod tests {
             "| f        |",
             "+----------+",
             "| 00:18:31 |",
-            "|          |",
+            "| null     |",
             "+----------+",
         ];
         check_datetime!(Time32SecondArray, 1111, expected);
@@ -388,7 +388,7 @@ mod tests {
             "| f            |",
             "+--------------+",
             "| 03:05:11.111 |",
-            "|              |",
+            "| null         |",
             "+--------------+",
         ];
         check_datetime!(Time32MillisecondArray, 11111111, expected);
@@ -401,7 +401,7 @@ mod tests {
             "| f               |",
             "+-----------------+",
             "| 00:00:11.111111 |",
-            "|                 |",
+            "| null            |",
             "+-----------------+",
         ];
         check_datetime!(Time64MicrosecondArray, 11111111, expected);
@@ -414,7 +414,7 @@ mod tests {
             "| f                  |",
             "+--------------------+",
             "| 00:00:00.011111111 |",
-            "|                    |",
+            "| null               |",
             "+--------------------+",
         ];
         check_datetime!(Time64NanosecondArray, 11111111, expected);
@@ -462,7 +462,7 @@ mod tests {
             "| f     |",
             "+-------+",
             "| 1.01  |",
-            "|       |",
+            "| null  |",
             "| 2.00  |",
             "| 30.40 |",
             "+-------+",
@@ -498,7 +498,7 @@ mod tests {
 
         let table = pretty_format_batches(&[batch])?;
         let expected = vec![
-            "+------+", "| f    |", "+------+", "| 101  |", "|      |", "| 200  |",
+            "+------+", "| f    |", "+------+", "| 101  |", "| null |", "| 200  |",
             "| 3040 |", "+------+",
         ];
 


### PR DESCRIPTION
# Which issue does this PR close?

support struct array in pretty print

# Rationale for this change
 
support display of nested fields in downstream projects that displays record batches in console.

# What changes are included in this PR?

code to format struct arrays in pretty print
print null value as null string to be consistent with postgresql

# Are there any user-facing changes?

better pretty print