### PR TITLE
Cherry pick Update readme link to point at the right codecoverage location to active_release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # Native Rust implementation of Apache Arrow and Parquet
 
-[![Coverage Status](https://codecov.io/gh/apache/arrow/rust/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/arrow?branch=master)
+[![Coverage Status](https://codecov.io/gh/apache/arrow-rs/rust/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/arrow-rs?branch=master)
 
 Welcome to the implementation of Arrow, the popular in-memory columnar format, in [Rust](https://www.rust-lang.org/).
 


### PR DESCRIPTION
Automatic cherry-pick of 0a87516
* Originally appeared in https://github.com/apache/arrow-rs/pull/577: Update readme link to point at the right codecoverage location
