### PR TITLE
use rust edition 2021

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -287,6 +287,8 @@ jobs:
           export ARROW_TEST_DATA=$(pwd)/testing/data
           export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
 
+          rustup toolchain install stable
+          rustup default stable
           cargo install --version 0.18.2 cargo-tarpaulin
           cargo tarpaulin --all --out Xml
       - name: Report coverage

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -19,7 +19,8 @@
 name = "arrow-flight"
 description = "Apache Arrow Flight"
 version = "7.0.0-SNAPSHOT"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -24,7 +24,8 @@ repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow" ]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 name = "arrow_pyarrow_integration_testing"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -29,7 +29,8 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
 ]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 name = "arrow"

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -182,8 +182,6 @@ fn build_extend_dictionary(
     max: usize,
 ) -> Option<Extend> {
     use crate::datatypes::*;
-    use std::convert::TryInto;
-
     match array.data_type() {
         DataType::Dictionary(child_data_type, _) => match child_data_type.as_ref() {
             DataType::UInt8 => {

--- a/arrow/test/dependency/default-features/Cargo.toml
+++ b/arrow/test/dependency/default-features/Cargo.toml
@@ -19,7 +19,8 @@
 name = "defeault-features"
 description = "Models a user application of arrow that uses default features of arrow"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/arrow/test/dependency/no-default-features/Cargo.toml
+++ b/arrow/test/dependency/no-default-features/Cargo.toml
@@ -19,7 +19,8 @@
 name = "no-default-features"
 description = "Models a user application of arrow that specifies no-default-features=true"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/arrow/test/dependency/simd/Cargo.toml
+++ b/arrow/test/dependency/simd/Cargo.toml
@@ -19,7 +19,8 @@
 name = "defeault-features"
 description = "Models a user application of arrow that uses the simd feature of arrow"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -23,8 +23,9 @@ homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
+rust-version = "1.56"
 
 [features]
 logging = ["tracing-subscriber"]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -26,7 +26,8 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "arrow", "parquet", "hadoop" ]
 readme = "README.md"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 # update note: pin `parquet-format` to specific version until it does not break at minor

--- a/parquet_derive/Cargo.toml
+++ b/parquet_derive/Cargo.toml
@@ -25,7 +25,8 @@ repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/parquet_derive/README.md
+++ b/parquet_derive/README.md
@@ -27,7 +27,9 @@ supported.
 Derive also has some support for the chrono time library. You must must enable the `chrono` feature to get this support.
 
 ## Usage
+
 Add this to your Cargo.toml:
+
 ```toml
 [dependencies]
 parquet = "7.0.0-SNAPSHOT"
@@ -35,6 +37,7 @@ parquet_derive = "7.0.0-SNAPSHOT"
 ```
 
 and this to your crate root:
+
 ```rust
 extern crate parquet;
 #[macro_use] extern crate parquet_derive;
@@ -75,24 +78,29 @@ writer.close().unwrap();
 ```
 
 ## Features
-- [X] Support writing `String`, `&str`, `bool`, `i32`, `f32`, `f64`, `Vec<u8>`
+
+- [x] Support writing `String`, `&str`, `bool`, `i32`, `f32`, `f64`, `Vec<u8>`
 - [ ] Support writing dictionaries
-- [X] Support writing logical types like timestamp
-- [X] Derive definition_levels for `Option`
+- [x] Support writing logical types like timestamp
+- [x] Derive definition_levels for `Option`
 - [ ] Derive definition levels for nested structures
 - [ ] Derive writing tuple struct
 - [ ] Derive writing `tuple` container types
 
 ## Requirements
+
 - Same as `parquet-rs`
 
 ## Test
+
 Testing a `*_derive` crate requires an intermediate crate. Go to `parquet_derive_test` and run `cargo test` for
 unit tests.
 
 ## Docs
+
 To build documentation, run `cargo doc --no-deps`.
 To compile and view in the browser, run `cargo doc --no-deps --open`.
 
 ## License
+
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0.

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -25,7 +25,7 @@ extern crate quote;
 
 extern crate parquet;
 
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput};
+use ::syn::{parse_macro_input, Data, DataStruct, DeriveInput};
 
 mod parquet_field;
 
@@ -103,7 +103,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
     impl #generics RecordWriter<#derived_for #generics> for &[#derived_for #generics] {
       fn write_to_row_group(
         &self,
-        row_group_writer: &mut Box<parquet::file::writer::RowGroupWriter>
+        row_group_writer: &mut Box<dyn parquet::file::writer::RowGroupWriter>
       ) -> Result<(), parquet::errors::ParquetError> {
         let mut row_group_writer = row_group_writer;
         let records = &self; // Used by all the writer snippets to be more clear

--- a/parquet_derive/test/dependency/default-features/Cargo.toml
+++ b/parquet_derive/test/dependency/default-features/Cargo.toml
@@ -19,7 +19,8 @@
 name = "defeault-features"
 description = "Models a user application of parquet_derive that uses no additional features of arrow"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/parquet_derive_test/Cargo.toml
+++ b/parquet_derive_test/Cargo.toml
@@ -24,8 +24,9 @@ homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
-edition = "2018"
+edition = "2021"
 publish = false
+rust-version = "1.56"
 
 [dependencies]
 parquet = { path = "../parquet", version = "7.0.0-SNAPSHOT" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 max_width = 90
 
 # ignore generated files


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
Blocked by https://github.com/apache/arrow/pull/11557
Related #714

# Rationale for this change
 
https://blog.rust-lang.org/2021/05/11/edition-2021.html

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
