### PR TITLE
fix dyn syntax for trait objects

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -54,7 +54,7 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
     /// # Ok(())
     /// # }
     /// ```
-    fn as_any(&self) -> &Any;
+    fn as_any(&self) -> &dyn Any;
 
     /// Returns a reference to the underlying data of this array.
     fn data(&self) -> &ArrayData;
@@ -224,7 +224,7 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
 }
 
 /// A reference-counted reference to a generic `Array`.
-pub type ArrayRef = Arc<Array>;
+pub type ArrayRef = Arc<dyn Array>;
 
 /// Constructs an array using the input `data`.
 /// Returns a reference-counted `Array` instance.

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -191,7 +191,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> fmt::Debug for GenericBinaryArray<Offset
 }
 
 impl<OffsetSize: BinaryOffsetSizeTrait> Array for GenericBinaryArray<OffsetSize> {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
@@ -582,7 +582,7 @@ impl fmt::Debug for FixedSizeBinaryArray {
 }
 
 impl Array for FixedSizeBinaryArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
@@ -752,7 +752,7 @@ impl fmt::Debug for DecimalArray {
 }
 
 impl Array for DecimalArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -106,7 +106,7 @@ impl BooleanArray {
 }
 
 impl Array for BooleanArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -201,7 +201,7 @@ impl<'a, T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'a str>
 }
 
 impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -253,7 +253,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
 }
 
 impl<OffsetSize: 'static + OffsetSizeTrait> Array for GenericListArray<OffsetSize> {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
@@ -426,7 +426,7 @@ impl From<ArrayData> for FixedSizeListArray {
 }
 
 impl Array for FixedSizeListArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -143,7 +143,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 }
 
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -281,7 +281,7 @@ impl<OffsetSize: StringOffsetSizeTrait> fmt::Debug for GenericStringArray<Offset
 }
 
 impl<OffsetSize: StringOffsetSizeTrait> Array for GenericStringArray<OffsetSize> {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -186,7 +186,7 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
 }
 
 impl Array for StructArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -268,7 +268,7 @@ impl From<ArrayData> for UnionArray {
 }
 
 impl Array for UnionArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -458,17 +458,17 @@ pub trait ArrayBuilder: Any + Send {
     /// This is most useful when one wants to call non-mutable APIs on a specific builder
     /// type. In this case, one can first cast this into a `Any`, and then use
     /// `downcast_ref` to get a reference on the specific builder.
-    fn as_any(&self) -> &Any;
+    fn as_any(&self) -> &dyn Any;
 
     /// Returns the builder as a mutable `Any` reference.
     ///
     /// This is most useful when one wants to call mutable APIs on a specific builder
     /// type. In this case, one can first cast this into a `Any`, and then use
     /// `downcast_mut` to get a reference on the specific builder.
-    fn as_any_mut(&mut self) -> &mut Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any>;
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 ///  Array builder for fixed-width primitive types
@@ -557,17 +557,17 @@ impl BooleanBuilder {
 
 impl ArrayBuilder for BooleanBuilder {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -598,17 +598,17 @@ pub struct PrimitiveBuilder<T: ArrowPrimitiveType> {
 
 impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveBuilder<T> {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -793,17 +793,17 @@ where
     T: 'static,
 {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -921,17 +921,17 @@ where
     T: 'static,
 {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -1044,17 +1044,17 @@ impl<OffsetSize: BinaryOffsetSizeTrait> ArrayBuilder
     for GenericBinaryBuilder<OffsetSize>
 {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -1078,17 +1078,17 @@ impl<OffsetSize: StringOffsetSizeTrait> ArrayBuilder
     for GenericStringBuilder<OffsetSize>
 {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -1111,17 +1111,17 @@ impl<OffsetSize: StringOffsetSizeTrait> ArrayBuilder
 
 impl ArrayBuilder for FixedSizeBinaryBuilder {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -1143,17 +1143,17 @@ impl ArrayBuilder for FixedSizeBinaryBuilder {
 
 impl ArrayBuilder for DecimalBuilder {
     /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -1381,7 +1381,7 @@ impl DecimalBuilder {
 /// properly called to maintain the consistency of the data structure.
 pub struct StructBuilder {
     fields: Vec<Field>,
-    field_builders: Vec<Box<ArrayBuilder>>,
+    field_builders: Vec<Box<dyn ArrayBuilder>>,
     bitmap_builder: BooleanBufferBuilder,
     len: usize,
 }
@@ -1421,7 +1421,7 @@ impl ArrayBuilder for StructBuilder {
     /// This is most useful when one wants to call non-mutable APIs on a specific builder
     /// type. In this case, one can first cast this into a `Any`, and then use
     /// `downcast_ref` to get a reference on the specific builder.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
@@ -1430,12 +1430,12 @@ impl ArrayBuilder for StructBuilder {
     /// This is most useful when one wants to call mutable APIs on a specific builder
     /// type. In this case, one can first cast this into a `Any`, and then use
     /// `downcast_mut` to get a reference on the specific builder.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 }
@@ -1443,7 +1443,7 @@ impl ArrayBuilder for StructBuilder {
 /// Returns a builder with capacity `capacity` that corresponds to the datatype `DataType`
 /// This function is useful to construct arrays from an arbitrary vectors with known/expected
 /// schema.
-pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<ArrayBuilder> {
+pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<dyn ArrayBuilder> {
     match datatype {
         DataType::Null => unimplemented!(),
         DataType::Boolean => Box::new(BooleanBuilder::new(capacity)),
@@ -1517,7 +1517,7 @@ pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<ArrayBuilder> {
 }
 
 impl StructBuilder {
-    pub fn new(fields: Vec<Field>, field_builders: Vec<Box<ArrayBuilder>>) -> Self {
+    pub fn new(fields: Vec<Field>, field_builders: Vec<Box<dyn ArrayBuilder>>) -> Self {
         Self {
             fields,
             field_builders,
@@ -1893,17 +1893,17 @@ where
     V: ArrowPrimitiveType,
 {
     /// Returns the builder as an non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as an mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 
@@ -2083,17 +2083,17 @@ where
     K: ArrowDictionaryKeyType,
 {
     /// Returns the builder as an non-mutable `Any` reference.
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     /// Returns the builder as an mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut Any {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 

--- a/arrow/src/array/null.rs
+++ b/arrow/src/array/null.rs
@@ -58,7 +58,7 @@ impl NullArray {
 }
 
 impl Array for NullArray {
-    fn as_any(&self) -> &Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 

--- a/arrow/src/array/ord.rs
+++ b/arrow/src/array/ord.rs
@@ -39,7 +39,10 @@ fn cmp_nans_last<T: Float>(a: &T, b: &T) -> Ordering {
     }
 }
 
-fn compare_primitives<T: ArrowPrimitiveType>(left: &Array, right: &Array) -> DynComparator
+fn compare_primitives<T: ArrowPrimitiveType>(
+    left: &dyn Array,
+    right: &dyn Array,
+) -> DynComparator
 where
     T::Native: Ord,
 {
@@ -48,14 +51,17 @@ where
     Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
-fn compare_boolean(left: &Array, right: &Array) -> DynComparator {
+fn compare_boolean(left: &dyn Array, right: &dyn Array) -> DynComparator {
     let left: BooleanArray = BooleanArray::from(left.data().clone());
     let right: BooleanArray = BooleanArray::from(right.data().clone());
 
     Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
-fn compare_float<T: ArrowPrimitiveType>(left: &Array, right: &Array) -> DynComparator
+fn compare_float<T: ArrowPrimitiveType>(
+    left: &dyn Array,
+    right: &dyn Array,
+) -> DynComparator
 where
     T::Native: Float,
 {
@@ -64,7 +70,7 @@ where
     Box::new(move |i, j| cmp_nans_last(&left.value(i), &right.value(j)))
 }
 
-fn compare_string<T>(left: &Array, right: &Array) -> DynComparator
+fn compare_string<T>(left: &dyn Array, right: &dyn Array) -> DynComparator
 where
     T: StringOffsetSizeTrait,
 {
@@ -74,7 +80,7 @@ where
     Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
-fn compare_dict_string<T>(left: &Array, right: &Array) -> DynComparator
+fn compare_dict_string<T>(left: &dyn Array, right: &dyn Array) -> DynComparator
 where
     T: ArrowDictionaryKeyType,
 {
@@ -115,7 +121,7 @@ where
 /// ```
 // This is a factory of comparisons.
 // The lifetime 'a enforces that we cannot use the closure beyond any of the array's lifetime.
-pub fn build_compare(left: &Array, right: &Array) -> Result<DynComparator> {
+pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparator> {
     use DataType::*;
     use IntervalUnit::*;
     use TimeUnit::*;

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -38,12 +38,12 @@ mod structure;
 mod utils;
 mod variable_size;
 
-type ExtendNullBits<'a> = Box<Fn(&mut _MutableArrayData, usize, usize) + 'a>;
+type ExtendNullBits<'a> = Box<dyn Fn(&mut _MutableArrayData, usize, usize) + 'a>;
 // function that extends `[start..start+len]` to the mutable array.
-// this is dynamic because different data_types influence how buffers and childs are extended.
-type Extend<'a> = Box<Fn(&mut _MutableArrayData, usize, usize, usize) + 'a>;
+// this is dynamic because different data_types influence how buffers and children are extended.
+type Extend<'a> = Box<dyn Fn(&mut _MutableArrayData, usize, usize, usize) + 'a>;
 
-type ExtendNulls = Box<Fn(&mut _MutableArrayData, usize) -> ()>;
+type ExtendNulls = Box<dyn Fn(&mut _MutableArrayData, usize)>;
 
 /// A mutable [ArrayData] that knows how to freeze itself into an [ArrayData].
 /// This is just a data container.

--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -407,7 +407,7 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn is_null(input: &Array) -> Result<BooleanArray> {
+pub fn is_null(input: &dyn Array) -> Result<BooleanArray> {
     let len = input.len();
 
     let output = match input.data_ref().null_buffer() {
@@ -439,7 +439,7 @@ pub fn is_null(input: &Array) -> Result<BooleanArray> {
 /// # Ok(())
 /// # }
 /// ```
-pub fn is_not_null(input: &Array) -> Result<BooleanArray> {
+pub fn is_not_null(input: &dyn Array) -> Result<BooleanArray> {
     let len = input.len();
 
     let output = match input.data_ref().null_buffer() {

--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -52,7 +52,7 @@ fn compute_str_values_length<Offset: StringOffsetSizeTrait>(
 }
 
 /// Concatenate multiple [Array] of the same type into a single [ArrayRef].
-pub fn concat(arrays: &[&Array]) -> Result<ArrayRef> {
+pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef> {
     if arrays.is_empty() {
         return Err(ArrowError::ComputeError(
             "concat requires input of at least one array".to_string(),

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -25,7 +25,7 @@ use crate::{array::*, util::bit_chunk_iterator::BitChunkIterator};
 use std::iter::Enumerate;
 
 /// Function that can filter arbitrary arrays
-pub type Filter<'a> = Box<Fn(&ArrayData) -> ArrayData + 'a>;
+pub type Filter<'a> = Box<dyn Fn(&ArrayData) -> ArrayData + 'a>;
 
 /// Internal state of [SlicesIterator]
 #[derive(Debug, PartialEq)]
@@ -245,7 +245,7 @@ pub fn prep_null_mask_filter(filter: &BooleanArray) -> BooleanArray {
 /// # Ok(())
 /// # }
 /// ```
-pub fn filter(array: &Array, predicate: &BooleanArray) -> Result<ArrayRef> {
+pub fn filter(array: &dyn Array, predicate: &BooleanArray) -> Result<ArrayRef> {
     if predicate.null_count() > 0 {
         // this greatly simplifies subsequent filtering code
         // now we only have a boolean mask to deal with

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -101,7 +101,7 @@ where
 /// * this only accepts StringArray/Utf8 and LargeString/LargeUtf8
 /// * length of null is null.
 /// * length is in number of bytes
-pub fn length(array: &Array) -> Result<ArrayRef> {
+pub fn length(array: &dyn Array) -> Result<ArrayRef> {
     match array.data_type() {
         DataType::Utf8 => Ok(octet_length::<i32, Int32Type>(array)),
         DataType::LargeUtf8 => Ok(octet_length::<i64, Int64Type>(array)),
@@ -117,7 +117,7 @@ pub fn length(array: &Array) -> Result<ArrayRef> {
 /// * this only accepts StringArray/Utf8 and LargeString/LargeUtf8
 /// * bit_length of null is null.
 /// * bit_length is in number of bits
-pub fn bit_length(array: &Array) -> Result<ArrayRef> {
+pub fn bit_length(array: &dyn Array) -> Result<ArrayRef> {
     match array.data_type() {
         DataType::Utf8 => Ok(bit_length_impl::<i32, Int32Type>(array)),
         DataType::LargeUtf8 => Ok(bit_length_impl::<i64, Int64Type>(array)),

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -765,7 +765,7 @@ where
 }
 
 /// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).
-fn cmp_array(a: &Array, b: &Array) -> Ordering {
+fn cmp_array(a: &dyn Array, b: &dyn Array) -> Ordering {
     let cmp_op = build_compare(a, b).unwrap();
     let length = a.len().max(b.len());
 

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -92,7 +92,11 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
 /// Returns an ArrayRef with a substring starting from `start` and with optional length `length` of each of the elements in `array`.
 /// `start` can be negative, in which case the start counts from the end of the string.
 /// this function errors when the passed array is not a \[Large\]String array.
-pub fn substring(array: &Array, start: i64, length: &Option<u64>) -> Result<ArrayRef> {
+pub fn substring(
+    array: &dyn Array,
+    start: i64,
+    length: &Option<u64>,
+) -> Result<ArrayRef> {
     match array.data_type() {
         DataType::LargeUtf8 => generic_substring(
             array

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -77,7 +77,7 @@ macro_rules! downcast_dict_take {
 /// # }
 /// ```
 pub fn take<IndexType>(
-    values: &Array,
+    values: &dyn Array,
     indices: &PrimitiveArray<IndexType>,
     options: Option<TakeOptions>,
 ) -> Result<ArrayRef>
@@ -89,7 +89,7 @@ where
 }
 
 fn take_impl<IndexType>(
-    values: &Array,
+    values: &dyn Array,
     indices: &PrimitiveArray<IndexType>,
     options: Option<TakeOptions>,
 ) -> Result<ArrayRef>

--- a/arrow/src/compute/kernels/window.rs
+++ b/arrow/src/compute/kernels/window.rs
@@ -56,7 +56,7 @@ use num::{abs, clamp};
 /// let expected: Int32Array = vec![None, None, None].into();
 /// assert_eq!(res.as_ref(), &expected);
 /// ```
-pub fn shift(array: &Array, offset: i64) -> Result<ArrayRef> {
+pub fn shift(array: &dyn Array, offset: i64) -> Result<ArrayRef> {
     let value_len = array.len() as i64;
     if offset == 0 {
         Ok(make_array(array.data_ref().clone()))

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -40,7 +40,7 @@ use crate::error::{ArrowError, Result};
 #[derive(Clone, Debug)]
 pub struct RecordBatch {
     schema: SchemaRef,
-    columns: Vec<Arc<Array>>,
+    columns: Vec<Arc<dyn Array>>,
 }
 
 impl RecordBatch {


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Fixes some issues from #591, mostly because for trait objects we'll have to prefix the `dyn` keyword which is mandatory in rust 2021 edition.

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
