### PR TITLE
Add links in docstrings

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -42,6 +42,8 @@ impl BinaryOffsetSizeTrait for i64 {
     const DATA_TYPE: DataType = DataType::LargeBinary;
 }
 
+/// See [`BinaryArray`] and [`LargeBinaryArray`] for storing
+/// binary data.
 pub struct GenericBinaryArray<OffsetSize: BinaryOffsetSizeTrait> {
     data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -341,6 +341,8 @@ pub type LargeListArray = GenericListArray<i64>;
 
 /// A list array where each element is a fixed-size sequence of values with the same
 /// type whose maximum length is represented by a i32.
+///
+/// For non generic lists, you may wish to consider using [`FixedSizeBinaryArray`]
 pub struct FixedSizeListArray {
     data: ArrayData,
     values: ArrayRef,

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -42,6 +42,9 @@ impl StringOffsetSizeTrait for i64 {
 }
 
 /// Generic struct for \[Large\]StringArray
+///
+/// See [`StringArray`] and [`LargeStringArray`] for storing
+/// specific string data.
 pub struct GenericStringArray<OffsetSize: StringOffsetSizeTrait> {
     data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
While reviewing the docs on https://docs.rs/arrow/5.0.0/arrow/array/trait.Array.html#implementors as part of  https://github.com/apache/arrow-rs/pull/603 (thanks @novemberkilo !)  I found a few structs that are not often used directly but that might not be clear from the docs


# Are there any user-facing changes?
Add some doc links to the structs that users might be looking for

