### PR TITLE
Cherry pick Fix typo to active_release

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -41,7 +41,7 @@ In order to compile Arrow for Web Assembly (the `wasm32-unknown-unknown` WASM ta
 
 ```toml
 [dependencies]
-arrow = {version = "5.0" default-features = false, features = ["js"] }
+arrow = { version = "5.0", default-features = false, features = ["js"] }
 ```
 
 ## Examples


### PR DESCRIPTION
Automatic cherry-pick of 80a2964
* Originally appeared in https://github.com/apache/arrow-rs/pull/604: Fix typo
