### PR TITLE
Cherry pick Validate output of MIRI is successful on CI to active_release

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -57,4 +57,4 @@ jobs:
           cargo clean
           # Currently only the arrow crate is tested with miri
           # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json || true
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json


### PR DESCRIPTION
Automatic cherry-pick of 30f1b1f
* Originally appeared in https://github.com/apache/arrow-rs/pull/578: Validate output of MIRI is successful on CI
