### PR TITLE
make FFI_ArrowArray::empty() public

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -416,8 +416,8 @@ impl FFI_ArrowArray {
         }
     }
 
-    // create an empty `FFI_ArrowArray`, which can be used to import data into
-    fn empty() -> Self {
+    /// create an empty `FFI_ArrowArray`, which can be used to import data into
+    pub fn empty() -> Self {
         Self {
             length: 0,
             null_count: 0,


### PR DESCRIPTION
Same as FFI_ArrowSchema::empty(), we should also make FFI_ArrowArray::empty() public, which makes it easy to create empty struct and query from FFI library.

close #602 