### PR TITLE
Cherry pick Fix newline in changelog to active_release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
   under the License.
 -->
 
-For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/arrow/blob/master/CHANGELOG.md)\n# Changelog
+For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/arrow/blob/master/CHANGELOG.md)
+
+# Changelog
 
 ## [5.0.0](https://github.com/apache/arrow-rs/tree/5.0.0) (2021-07-14)
 


### PR DESCRIPTION
Automatic cherry-pick of 7b57d91
* Originally appeared in https://github.com/apache/arrow-rs/pull/588: Fix newline in changelog
