### PR TITLE
Cherry pick make FFI_ArrowArray::empty() public to active_release

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -416,8 +416,8 @@ impl FFI_ArrowArray {
         }
     }
 
-    // create an empty `FFI_ArrowArray`, which can be used to import data into
-    fn empty() -> Self {
+    /// create an empty `FFI_ArrowArray`, which can be used to import data into
+    pub fn empty() -> Self {
         Self {
             length: 0,
             null_count: 0,


### PR DESCRIPTION
Automatic cherry-pick of 42a7163
* Originally appeared in https://github.com/apache/arrow-rs/pull/612: make FFI_ArrowArray::empty() public
