### PR TITLE
Cherry pick disallow bare trait objects to active_release

### DIFF
--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -412,7 +412,7 @@ mod tests {
             (
                 Field::new("b", DataType::Int16, false),
                 Arc::new(BooleanArray::from(vec![false, false, true, true]))
-                    as Arc<Array>,
+                    as Arc<dyn Array>,
             ),
             (
                 Field::new("c", DataType::Utf8, false),
@@ -515,7 +515,7 @@ mod tests {
         StructArray::from(vec![
             (
                 Field::new("b", DataType::Float32, false),
-                Arc::new(Float32Array::from(vec![1.1])) as Arc<Array>,
+                Arc::new(Float32Array::from(vec![1.1])) as Arc<dyn Array>,
             ),
             (
                 Field::new("c", DataType::Float64, false),

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -526,7 +526,7 @@ mod tests {
         let type_id_buffer = Buffer::from_slice_ref(&type_ids);
         let value_offsets_buffer = Buffer::from_slice_ref(&value_offsets);
 
-        let mut children: Vec<(Field, Arc<Array>)> = Vec::new();
+        let mut children: Vec<(Field, Arc<dyn Array>)> = Vec::new();
         children.push((
             Field::new("A", DataType::Utf8, false),
             Arc::new(string_array),

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -3026,9 +3026,9 @@ mod tests {
         let mut fields = Vec::new();
         let mut field_builders = Vec::new();
         fields.push(Field::new("f1", DataType::Utf8, false));
-        field_builders.push(Box::new(string_builder) as Box<ArrayBuilder>);
+        field_builders.push(Box::new(string_builder) as Box<dyn ArrayBuilder>);
         fields.push(Field::new("f2", DataType::Int32, false));
-        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+        field_builders.push(Box::new(int_builder) as Box<dyn ArrayBuilder>);
 
         let mut builder = StructBuilder::new(fields, field_builders);
         assert_eq!(2, builder.num_fields());
@@ -3089,9 +3089,9 @@ mod tests {
         let mut fields = Vec::new();
         let mut field_builders = Vec::new();
         fields.push(Field::new("f1", DataType::Int32, false));
-        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+        field_builders.push(Box::new(int_builder) as Box<dyn ArrayBuilder>);
         fields.push(Field::new("f2", DataType::Boolean, false));
-        field_builders.push(Box::new(bool_builder) as Box<ArrayBuilder>);
+        field_builders.push(Box::new(bool_builder) as Box<dyn ArrayBuilder>);
 
         let mut builder = StructBuilder::new(fields, field_builders);
         builder
@@ -3182,7 +3182,7 @@ mod tests {
         let mut fields = Vec::new();
         let mut field_builders = Vec::new();
         fields.push(Field::new("f1", DataType::Int32, false));
-        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+        field_builders.push(Box::new(int_builder) as Box<dyn ArrayBuilder>);
 
         let mut builder = StructBuilder::new(fields, field_builders);
         assert!(builder.field_builder::<BinaryBuilder>(0).is_none());

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -3620,7 +3620,7 @@ mod tests {
                 (
                     Field::new("a", DataType::Boolean, false),
                     Arc::new(BooleanArray::from(vec![false, false, true, true]))
-                        as Arc<Array>,
+                        as Arc<dyn Array>,
                 ),
                 (
                     Field::new("b", DataType::Int32, false),

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -139,7 +139,6 @@
     clippy::upper_case_acronyms,
     clippy::vec_init_then_push
 )]
-#![allow(bare_trait_objects)]
 #![warn(missing_debug_implementations)]
 
 pub mod alloc;


### PR DESCRIPTION
Automatic cherry-pick of fa5c39b
* Originally appeared in https://github.com/apache/arrow-rs/pull/615: disallow bare trait objects
