### PR TITLE
Cherry pick Doctests for BinaryArray and LargeBinaryArray. to active_release

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -268,9 +268,80 @@ where
 }
 
 /// An array where each element is a byte whose maximum length is represented by a i32.
+///
+/// Examples
+///
+/// Create a BinaryArray from a vector of byte slices.
+///
+/// ```
+/// use arrow::array::{Array, BinaryArray};
+/// let values: Vec<&[u8]> =
+///     vec![b"one", b"two", b"", b"three"];
+/// let array = BinaryArray::from_vec(values);
+/// assert_eq!(4, array.len());
+/// assert_eq!(b"one", array.value(0));
+/// assert_eq!(b"two", array.value(1));
+/// assert_eq!(b"", array.value(2));
+/// assert_eq!(b"three", array.value(3));
+/// ```
+///
+/// Create a BinaryArray from a vector of Optional (null) byte slices.
+///
+/// ```
+/// use arrow::array::{Array, BinaryArray};
+/// let values: Vec<Option<&[u8]>> =
+///     vec![Some(b"one"), Some(b"two"), None, Some(b""), Some(b"three")];
+/// let array = BinaryArray::from_opt_vec(values);
+/// assert_eq!(5, array.len());
+/// assert_eq!(b"one", array.value(0));
+/// assert_eq!(b"two", array.value(1));
+/// assert_eq!(b"", array.value(3));
+/// assert_eq!(b"three", array.value(4));
+/// assert!(!array.is_null(0));
+/// assert!(!array.is_null(1));
+/// assert!(array.is_null(2));
+/// assert!(!array.is_null(3));
+/// assert!(!array.is_null(4));
+/// ```
+///
 pub type BinaryArray = GenericBinaryArray<i32>;
 
 /// An array where each element is a byte whose maximum length is represented by a i64.
+/// Examples
+///
+/// Create a LargeBinaryArray from a vector of byte slices.
+///
+/// ```
+/// use arrow::array::{Array, LargeBinaryArray};
+/// let values: Vec<&[u8]> =
+///     vec![b"one", b"two", b"", b"three"];
+/// let array = LargeBinaryArray::from_vec(values);
+/// assert_eq!(4, array.len());
+/// assert_eq!(b"one", array.value(0));
+/// assert_eq!(b"two", array.value(1));
+/// assert_eq!(b"", array.value(2));
+/// assert_eq!(b"three", array.value(3));
+/// ```
+///
+/// Create a LargeBinaryArray from a vector of Optional (null) byte slices.
+///
+/// ```
+/// use arrow::array::{Array, LargeBinaryArray};
+/// let values: Vec<Option<&[u8]>> =
+///     vec![Some(b"one"), Some(b"two"), None, Some(b""), Some(b"three")];
+/// let array = LargeBinaryArray::from_opt_vec(values);
+/// assert_eq!(5, array.len());
+/// assert_eq!(b"one", array.value(0));
+/// assert_eq!(b"two", array.value(1));
+/// assert_eq!(b"", array.value(3));
+/// assert_eq!(b"three", array.value(4));
+/// assert!(!array.is_null(0));
+/// assert!(!array.is_null(1));
+/// assert!(array.is_null(2));
+/// assert!(!array.is_null(3));
+/// assert!(!array.is_null(4));
+/// ```
+///
 pub type LargeBinaryArray = GenericBinaryArray<i64>;
 
 impl<'a, T: BinaryOffsetSizeTrait> IntoIterator for &'a GenericBinaryArray<T> {


### PR DESCRIPTION
Automatic cherry-pick of 6e1dbb4
* Originally appeared in https://github.com/apache/arrow-rs/pull/625: Doctests for BinaryArray and LargeBinaryArray.
