### PR TITLE
Cherry pick Add links in docstrings to active_release

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -42,6 +42,8 @@ impl BinaryOffsetSizeTrait for i64 {
     const DATA_TYPE: DataType = DataType::LargeBinary;
 }
 
+/// See [`BinaryArray`] and [`LargeBinaryArray`] for storing
+/// binary data.
 pub struct GenericBinaryArray<OffsetSize: BinaryOffsetSizeTrait> {
     data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -341,6 +341,8 @@ pub type LargeListArray = GenericListArray<i64>;
 
 /// A list array where each element is a fixed-size sequence of values with the same
 /// type whose maximum length is represented by a i32.
+///
+/// For non generic lists, you may wish to consider using [`FixedSizeBinaryArray`]
 pub struct FixedSizeListArray {
     data: ArrayData,
     values: ArrayRef,

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -42,6 +42,9 @@ impl StringOffsetSizeTrait for i64 {
 }
 
 /// Generic struct for \[Large\]StringArray
+///
+/// See [`StringArray`] and [`LargeStringArray`] for storing
+/// specific string data.
 pub struct GenericStringArray<OffsetSize: StringOffsetSizeTrait> {
     data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,


### PR DESCRIPTION
Automatic cherry-pick of b46115b0ade9cd911771995ba39402a80557ec73
* Originally appeared in https://github.com/apache/arrow-rs/pull/605: Add links in docstrings
