### PR TITLE
Cherry pick Fix clippy lints for Rust 1.54 to active_release

### DIFF
--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -307,11 +307,11 @@ mod tests {
         let a = a.data();
         let b = NullArray::new(12);
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
 
         let b = NullArray::new(10);
         let b = b.data();
-        test_equal(&a, &b, false);
+        test_equal(a, b, false);
 
         // Test the case where offset != 0
 
@@ -330,11 +330,11 @@ mod tests {
         let a = a.data();
         let b = BooleanArray::from(vec![false, false, true]);
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
 
         let b = BooleanArray::from(vec![false, false, false]);
         let b = b.data();
-        test_equal(&a, &b, false);
+        test_equal(a, b, false);
     }
 
     #[test]
@@ -343,15 +343,15 @@ mod tests {
         let a = a.data();
         let b = BooleanArray::from(vec![Some(false), None, None, Some(true)]);
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
 
         let b = BooleanArray::from(vec![None, None, None, Some(true)]);
         let b = b.data();
-        test_equal(&a, &b, false);
+        test_equal(a, b, false);
 
         let b = BooleanArray::from(vec![Some(true), None, None, Some(true)]);
         let b = b.data();
-        test_equal(&a, &b, false);
+        test_equal(a, b, false);
     }
 
     #[test]
@@ -382,7 +382,7 @@ mod tests {
         let a = a.data();
         let b = BooleanArray::from(vector.clone());
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
 
         // Elements fill in `u8`s + suffix bits.
         vector.push(true);
@@ -390,7 +390,7 @@ mod tests {
         let a = a.data();
         let b = BooleanArray::from(vector);
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
     }
 
     #[test]
@@ -428,7 +428,7 @@ mod tests {
             let lhs = lhs.data();
             let rhs = Int32Array::from(rhs);
             let rhs = rhs.data();
-            test_equal(&lhs, &rhs, expected);
+            test_equal(lhs, rhs, expected);
         }
     }
 
@@ -588,7 +588,7 @@ mod tests {
         let b = StringArray::from(vec![Some("b")]);
         let b = b.data();
 
-        test_equal(&a, &b, true);
+        test_equal(&a, b, true);
     }
 
     #[test]
@@ -609,11 +609,11 @@ mod tests {
         let a = a.data();
         let b = NullArray::new(2);
         let b = b.data();
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
 
         let b = NullArray::new(1);
         let b = b.data();
-        test_equal(&a, &b, false);
+        test_equal(a, b, false);
     }
 
     fn create_list_array<U: AsRef<[i32]>, T: AsRef<[Option<U>]>>(data: T) -> ArrayData {
@@ -1016,7 +1016,7 @@ mod tests {
         let b = StructArray::try_from(vec![("f1", strings), ("f2", ints)]).unwrap();
         let b = b.data();
 
-        test_equal(&a, &b, true);
+        test_equal(a, b, true);
     }
 
     #[test]

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1184,7 +1184,7 @@ mod tests {
         assert_eq!(5, a.value(0));
         assert_eq!(6, b.value(0));
 
-        let c = add(&a, &b).unwrap();
+        let c = add(a, b).unwrap();
         assert_eq!(5, c.len());
         assert_eq!(11, c.value(0));
         assert_eq!(13, c.value(1));
@@ -1281,7 +1281,7 @@ mod tests {
         let a = a.as_any().downcast_ref::<Int32Array>().unwrap();
         let b = b.as_any().downcast_ref::<Int32Array>().unwrap();
 
-        let c = divide(&a, &b).unwrap();
+        let c = divide(a, b).unwrap();
         assert_eq!(5, c.len());
         assert_eq!(3, c.value(0));
         assert_eq!(2, c.value(1));
@@ -1299,7 +1299,7 @@ mod tests {
         let a = a.as_any().downcast_ref::<Int32Array>().unwrap();
         let b = b.as_any().downcast_ref::<Int32Array>().unwrap();
 
-        let c = modulus(&a, &b).unwrap();
+        let c = modulus(a, b).unwrap();
         assert_eq!(5, c.len());
         assert_eq!(0, c.value(0));
         assert_eq!(3, c.value(1));
@@ -1397,7 +1397,7 @@ mod tests {
         let b = b.slice(8, 6);
         let b = b.as_any().downcast_ref::<Int32Array>().unwrap();
 
-        let c = divide(&a, &b).unwrap();
+        let c = divide(a, b).unwrap();
         assert_eq!(6, c.len());
         assert_eq!(3, c.value(0));
         assert!(c.is_null(1));
@@ -1450,7 +1450,7 @@ mod tests {
         let b = b.slice(8, 6);
         let b = b.as_any().downcast_ref::<Int32Array>().unwrap();
 
-        let c = modulus(&a, &b).unwrap();
+        let c = modulus(a, b).unwrap();
         assert_eq!(6, c.len());
         assert_eq!(0, c.value(0));
         assert!(c.is_null(1));
@@ -1516,7 +1516,7 @@ mod tests {
         let b = b.slice(63, 65);
         let b = b.as_any().downcast_ref::<UInt8Array>().unwrap();
 
-        let actual = add(&a, &b).unwrap();
+        let actual = add(a, b).unwrap();
         let actual: Vec<Option<u8>> = actual.iter().collect();
         let expected: Vec<Option<u8>> = (63..63_u8 + 65_u8)
             .into_iter()

--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -818,7 +818,7 @@ mod tests {
         let a = BooleanArray::from(vec![None, Some(true), Some(false), None, Some(true)]);
         let a = a.slice(1, 4);
         let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
-        let c = not(&a).unwrap();
+        let c = not(a).unwrap();
 
         let expected =
             BooleanArray::from(vec![Some(false), Some(true), None, Some(false)]);
@@ -883,7 +883,7 @@ mod tests {
         let b = b.slice(8, 4);
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        let c = and(&a, &b).unwrap();
+        let c = and(a, b).unwrap();
 
         let expected = BooleanArray::from(vec![false, false, false, true]);
 
@@ -906,7 +906,7 @@ mod tests {
         let b = b.slice(8, 4);
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        let c = and(&a, &b).unwrap();
+        let c = and(a, b).unwrap();
 
         let expected = BooleanArray::from(vec![false, false, false, true]);
 
@@ -924,7 +924,7 @@ mod tests {
         let a = a.slice(8, 4);
         let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        let c = and(&a, &b).unwrap();
+        let c = and(a, &b).unwrap();
 
         let expected = BooleanArray::from(vec![false, false, false, true]);
 
@@ -942,7 +942,7 @@ mod tests {
         let b = b.slice(8, 4);
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        let c = and(&a, &b).unwrap();
+        let c = and(&a, b).unwrap();
 
         let expected = BooleanArray::from(vec![false, false, false, true]);
 
@@ -967,7 +967,7 @@ mod tests {
         let b = b.slice(2, 4);
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-        let c = and(&a, &b).unwrap();
+        let c = and(a, b).unwrap();
 
         let expected =
             BooleanArray::from(vec![Some(false), Some(false), None, Some(true)]);
@@ -1147,7 +1147,7 @@ mod tests {
         ]);
         let comp = comp.slice(2, 3); // Some(false), None, Some(true)
         let comp = comp.as_any().downcast_ref::<BooleanArray>().unwrap();
-        let res = nullif(&a, &comp).unwrap();
+        let res = nullif(a, comp).unwrap();
 
         let expected = Int32Array::from(vec![
             Some(15), // False => keep it

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -3229,7 +3229,7 @@ mod tests {
     where
         T: ArrowNumericType,
     {
-        let c = cast(&array, dt).unwrap();
+        let c = cast(array, dt).unwrap();
         let a = c.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
         let mut v: Vec<String> = vec![];
         for i in 0..array.len() {
@@ -3533,7 +3533,7 @@ mod tests {
         for array in get_arrays_of_all_types() {
             for to_type in &all_types {
                 println!("Test casting {:?} --> {:?}", array.data_type(), to_type);
-                let cast_result = cast(&array, &to_type);
+                let cast_result = cast(&array, to_type);
                 let reported_cast_ability = can_cast_types(array.data_type(), to_type);
 
                 // check for mismatch

--- a/arrow/src/compute/kernels/cast_utils.rs
+++ b/arrow/src/compute/kernels/cast_utils.rs
@@ -209,7 +209,7 @@ mod tests {
         // Note: Use chrono APIs that are different than
         // naive_datetime_to_timestamp to compute the utc offset to
         // try and double check the logic
-        let utc_offset_secs = match Local.offset_from_local_datetime(&naive_datetime) {
+        let utc_offset_secs = match Local.offset_from_local_datetime(naive_datetime) {
             LocalResult::Single(local_offset) => {
                 local_offset.fix().local_minus_utc() as i64
             }

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1042,7 +1042,7 @@ mod tests {
         let b = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let b_slice = b.slice(5, 5);
         let c = b_slice.as_any().downcast_ref().unwrap();
-        let d = eq(&c, &a).unwrap();
+        let d = eq(c, &a).unwrap();
         assert!(d.value(0));
         assert!(d.value(1));
         assert!(d.value(2));
@@ -1238,7 +1238,7 @@ mod tests {
         let b: Int32Array = (100..200).map(Some).collect();
         let b = b.slice(50, 50);
         let b = b.as_any().downcast_ref::<Int32Array>().unwrap();
-        let actual = lt(&a, &b).unwrap();
+        let actual = lt(a, b).unwrap();
         let expected: BooleanArray = (0..50).map(|_| Some(true)).collect();
         assert_eq!(expected, actual);
     }
@@ -1248,7 +1248,7 @@ mod tests {
         let a: Int32Array = (0..100).map(Some).collect();
         let a = a.slice(50, 50);
         let a = a.as_any().downcast_ref::<Int32Array>().unwrap();
-        let actual = lt_scalar(&a, 200).unwrap();
+        let actual = lt_scalar(a, 200).unwrap();
         let expected: BooleanArray = (0..50).map(|_| Some(true)).collect();
         assert_eq!(expected, actual);
     }

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1015,7 +1015,7 @@ mod tests {
 
         test_take_primitive_arrays_non_null::<Int64Type>(
             vec![0, 10, 20, 30, 40, 50],
-            &index,
+            index,
             None,
             vec![Some(20), Some(30), None, None],
         )
@@ -1036,7 +1036,7 @@ mod tests {
 
         test_take_primitive_arrays::<Int64Type>(
             vec![None, None, Some(20), Some(30), Some(40), Some(50)],
-            &index,
+            index,
             None,
             vec![Some(20), Some(30), None, None],
         )
@@ -1291,7 +1291,7 @@ mod tests {
         // boolean
         test_take_boolean_arrays(
             vec![Some(false), None, Some(true), Some(false), None],
-            &index,
+            index,
             None,
             vec![None, Some(false), Some(true), None],
         );

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -796,11 +796,11 @@ mod tests {
                     "Key": "Value"
                 }
             }"#;
-        let value: Value = serde_json::from_str(&json).unwrap();
+        let value: Value = serde_json::from_str(json).unwrap();
         assert_eq!(expected, value);
 
         // convert back to a schema
-        let value: Value = serde_json::from_str(&json).unwrap();
+        let value: Value = serde_json::from_str(json).unwrap();
         let schema2 = Schema::from(&value).unwrap();
 
         assert_eq!(schema, schema2);
@@ -819,7 +819,7 @@ mod tests {
                 ],
                 "metadata": {}
             }"#;
-        let value: Value = serde_json::from_str(&json).unwrap();
+        let value: Value = serde_json::from_str(json).unwrap();
         let schema = Schema::from(&value).unwrap();
         assert!(schema.metadata.is_empty());
 
@@ -836,7 +836,7 @@ mod tests {
                     }
                 ]
             }"#;
-        let value: Value = serde_json::from_str(&json).unwrap();
+        let value: Value = serde_json::from_str(json).unwrap();
         let schema = Schema::from(&value).unwrap();
         assert!(schema.metadata.is_empty());
     }

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -777,7 +777,7 @@ mod tests {
 
         // perform some operation
         let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
-        let array = kernels::arithmetic::add(&array, &array).unwrap();
+        let array = kernels::arithmetic::add(array, array).unwrap();
 
         // verify
         assert_eq!(array, Int32Array::from(vec![2, 4, 6]));
@@ -982,7 +982,7 @@ mod tests {
 
         // perform some operation
         let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-        let array = kernels::boolean::not(&array)?;
+        let array = kernels::boolean::not(array)?;
 
         // verify
         assert_eq!(

--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -128,7 +128,7 @@ async fn send_batch(
     options: &writer::IpcWriteOptions,
 ) -> Result {
     let (dictionary_flight_data, mut batch_flight_data) =
-        arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
+        arrow_flight::utils::flight_data_from_arrow_batch(batch, options);
 
     upload_tx
         .send_all(&mut stream::iter(dictionary_flight_data).map(Ok))
@@ -166,7 +166,7 @@ async fn verify_data(
             consume_flight_location(
                 location,
                 ticket.clone(),
-                &expected_data,
+                expected_data,
                 expected_schema.clone(),
             )
             .await?;

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -294,7 +294,7 @@ async fn record_batch_from_message(
         data_body,
         ipc_batch,
         schema_ref,
-        &dictionaries_by_field,
+        dictionaries_by_field,
     );
 
     arrow_batch_result.map_err(|e| {

--- a/integration-testing/src/lib.rs
+++ b/integration-testing/src/lib.rs
@@ -405,7 +405,7 @@ fn array_from_json(
             let null_buf = create_null_buf(&json_col);
             let children = json_col.children.clone().unwrap();
             let child_array = array_from_json(
-                &child_field,
+                child_field,
                 children.get(0).unwrap().clone(),
                 dictionaries,
             )?;
@@ -428,7 +428,7 @@ fn array_from_json(
             let null_buf = create_null_buf(&json_col);
             let children = json_col.children.clone().unwrap();
             let child_array = array_from_json(
-                &child_field,
+                child_field,
                 children.get(0).unwrap().clone(),
                 dictionaries,
             )?;
@@ -454,7 +454,7 @@ fn array_from_json(
         DataType::FixedSizeList(child_field, _) => {
             let children = json_col.children.clone().unwrap();
             let child_array = array_from_json(
-                &child_field,
+                child_field,
                 children.get(0).unwrap().clone(),
                 dictionaries,
             )?;

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -142,7 +142,7 @@ fn write_batch(batch: &RecordBatch) -> Result<()> {
     let cursor = InMemoryWriteableCursor::default();
     let mut writer = ArrowWriter::try_new(cursor, batch.schema(), None)?;
 
-    writer.write(&batch)?;
+    writer.write(batch)?;
     writer.close()?;
     Ok(())
 }

--- a/parquet/src/encodings/levels.rs
+++ b/parquet/src/encodings/levels.rs
@@ -290,7 +290,7 @@ mod tests {
         } else {
             LevelEncoder::v1(enc, max_level, vec![0; size])
         };
-        encoder.put(&levels).expect("put() should be OK");
+        encoder.put(levels).expect("put() should be OK");
         let encoded_levels = encoder.consume().expect("consume() should be OK");
 
         let byte_buf = ByteBufferPtr::new(encoded_levels);
@@ -322,7 +322,7 @@ mod tests {
         } else {
             LevelEncoder::v1(enc, max_level, vec![0; size])
         };
-        encoder.put(&levels).expect("put() should be OK");
+        encoder.put(levels).expect("put() should be OK");
         let encoded_levels = encoder.consume().expect("consume() should be OK");
 
         let byte_buf = ByteBufferPtr::new(encoded_levels);
@@ -408,7 +408,7 @@ mod tests {
         let mut found_err = false;
         // Insert a large number of values, so we run out of space
         for _ in 0..100 {
-            if let Err(err) = encoder.put(&levels) {
+            if let Err(err) = encoder.put(levels) {
                 assert!(format!("{}", err).contains("Not enough bytes left"));
                 found_err = true;
                 break;

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -481,7 +481,7 @@ mod tests {
             .map(|p| SerializedFileReader::try_from(p.as_path()).unwrap())
             .flat_map(|r| {
                 let schema = "message schema { OPTIONAL INT32 id; }";
-                let proj = parse_message_type(&schema).ok();
+                let proj = parse_message_type(schema).ok();
 
                 r.into_iter().project(proj).unwrap()
             })

--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -1292,7 +1292,7 @@ mod tests {
         REQUIRED INT32 b;
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         let rows =
             test_file_reader_rows("nested_maps.snappy.parquet", Some(schema)).unwrap();
         let expected_rows = vec![
@@ -1360,7 +1360,7 @@ mod tests {
         }
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         let rows =
             test_file_reader_rows("nested_maps.snappy.parquet", Some(schema)).unwrap();
         let expected_rows = vec![
@@ -1427,7 +1427,7 @@ mod tests {
         }
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         let rows =
             test_file_reader_rows("nested_lists.snappy.parquet", Some(schema)).unwrap();
         let expected_rows = vec![
@@ -1474,7 +1474,7 @@ mod tests {
         REQUIRED BOOLEAN value;
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         let res = test_file_reader_rows("nested_maps.snappy.parquet", Some(schema));
         assert!(res.is_err());
         assert_eq!(
@@ -1491,7 +1491,7 @@ mod tests {
         REQUIRED BOOLEAN value;
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         let res = test_row_group_rows("nested_maps.snappy.parquet", Some(schema));
         assert!(res.is_err());
         assert_eq!(
@@ -1517,7 +1517,7 @@ mod tests {
         }
       }
     ";
-        let schema = parse_message_type(&schema).unwrap();
+        let schema = parse_message_type(schema).unwrap();
         test_file_reader_rows("nested_maps.snappy.parquet", Some(schema)).unwrap();
     }
 
@@ -1542,7 +1542,7 @@ mod tests {
             .map(|p| SerializedFileReader::try_from(p.as_path()).unwrap())
             .flat_map(|r| {
                 let schema = "message schema { OPTIONAL INT32 id; }";
-                let proj = parse_message_type(&schema).ok();
+                let proj = parse_message_type(schema).ok();
 
                 RowIter::from_file_into(Box::new(r)).project(proj).unwrap()
             })
@@ -1561,7 +1561,7 @@ mod tests {
         REQUIRED BOOLEAN value;
       }
     ";
-        let proj = parse_message_type(&schema).ok();
+        let proj = parse_message_type(schema).ok();
         let path = get_test_path("nested_maps.snappy.parquet");
         let reader = SerializedFileReader::try_from(path.as_path()).unwrap();
         let res = RowIter::from_file_into(Box::new(reader)).project(proj);

--- a/parquet/src/record/triplet.rs
+++ b/parquet/src/record/triplet.rs
@@ -42,6 +42,7 @@ macro_rules! triplet_enum_func {
 
 /// High level API wrapper on column reader.
 /// Provides per-element access for each primitive column.
+#[allow(clippy::enum_variant_names)]
 pub enum TripletIter {
     BoolTripletIter(TypedTripletIter<BoolType>),
     Int32TripletIter(TypedTripletIter<Int32Type>),

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -225,7 +225,7 @@ mod tests {
             }
         ";
 
-        let parquet_type = Arc::new(parse_message_type(&message_type).unwrap());
+        let parquet_type = Arc::new(parse_message_type(message_type).unwrap());
 
         let mut visitor = TestVisitor::new(parquet_type.clone());
         for f in parquet_type.get_fields() {


### PR DESCRIPTION
Automatic cherry-pick of 2b2ec7ee99e91adf4c373aaa34b7dc806ddd2411
* Originally appeared in https://github.com/apache/arrow-rs/pull/631: Fix clippy lints for Rust 1.54
