### PR TITLE
Speed up filter_record_batch with one array

### DIFF
--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -292,7 +292,7 @@ pub fn filter_record_batch(
 
     let filtered_arrays = match num_colums {
         1 => {
-            vec![filter(record_batch.columns()[0].as_ref(), predicate)?.into()]
+            vec![filter(record_batch.columns()[0].as_ref(), predicate)?]
         }
         _ => {
             let filter = build_filter(predicate)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #636

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Performance improvement of ~20% (less than in arrow2, the normal filter implementation is a bit faster there for primitives).

```
Benchmarking filter single record batch: Collecting 100 samples in estimated 5.2                                                                                filter single record batch                        
                        time:   [517.32 us 519.86 us 523.30 us]
                        change: [-22.399% -21.849% -21.217%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  9 (9.00%) high severe
```

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
