### PR TITLE
Add human readable Format for parquet ByteArray

### DIFF
--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -109,9 +109,21 @@ impl fmt::Display for Int96 {
 
 /// Rust representation for BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY Parquet physical types.
 /// Value is backed by a byte buffer.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ByteArray {
     data: Option<ByteBufferPtr>,
+}
+
+// Special case Debug that prints out byte arrays that are vaid utf8 as &str's
+impl std::fmt::Debug for ByteArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("ByteArray");
+        match self.as_utf8() {
+            Ok(s) => debug_struct.field("data", &s),
+            Err(_) => debug_struct.field("data", &self.data),
+        };
+        debug_struct.finish()
+    }
 }
 
 impl PartialOrd for ByteArray {


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/641

# Rationale for this change
While working on https://github.com/apache/arrow-rs/issues/641 I found it challenging to determine what values weere in what ByteArray while debugging with `"{:?}"`

# What changes are included in this PR?
1. Add more human readable std::debug::Format impl for ByteArray

Before this PR the output for a string looks like this
```
ByteArray { data: Some(BufferPtr { data: [97, 110, 100, 111, 118, 101, 114], start: 0, len: 7, mem_tracker: None }) }
```

After this PR, the output looks like:

```
ByteArray { data: "andover" }
```
# Are there any user-facing changes?

Debugging output is different for `ByteArray`

It also makes test failure output easier to understand:

```

---- column::writer::tests::test_byte_array_statistics stdout ----
thread 'column::writer::tests::test_byte_array_statistics' panicked at 'assertion failed: `(left == right)`
  left: `ByteArray { data: "lexington" }`,
 right: `ByteArray { data: "tewsbury" }`', parquet/src/column/writer.rs:1708:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Rather than a list of individual bytes