### PR TITLE
rough draft of time arithmetic

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -50,6 +50,7 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
+chronoutil = "0.2"
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes 527.

# What changes are included in this PR?

Adds an `ArrowTimeDeltaType` for primitive types that can be added to time values. These allow writing the generic `add_time` kernel in a straightforward way.

The `add_time` kernel for time arithmetic.

# Are there any user-facing changes?

Adds the `add_time` kernel for time arithmetic.