### PR TITLE
allocate enough bytes when writing booleans

### DIFF
--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -593,6 +593,7 @@ pub(crate) mod private {
     use crate::util::bit_util::{BitReader, BitWriter};
     use crate::util::memory::ByteBufferPtr;
 
+    use arrow::util::bit_util::round_upto_multiple_of_64;
     use byteorder::ByteOrder;
     use std::convert::TryInto;
 
@@ -674,7 +675,12 @@ pub(crate) mod private {
             bit_writer: &mut BitWriter,
         ) -> Result<()> {
             if bit_writer.bytes_written() + values.len() / 8 >= bit_writer.capacity() {
-                bit_writer.extend(256);
+                let bits_available =
+                    (bit_writer.capacity() - bit_writer.bytes_written()) * 8;
+                let bits_needed = values.len() - bits_available;
+                let bytes_needed = (bits_needed + 7) / 8;
+                let bytes_needed = round_upto_multiple_of_64(bytes_needed);
+                bit_writer.extend(bytes_needed);
             }
             for value in values {
                 if !bit_writer.put_value(*value as u64, 1) {

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -593,7 +593,7 @@ pub(crate) mod private {
     use crate::util::bit_util::{BitReader, BitWriter};
     use crate::util::memory::ByteBufferPtr;
 
-    use arrow::util::bit_util::round_upto_multiple_of_64;
+    use arrow::util::bit_util::round_upto_power_of_2;
     use byteorder::ByteOrder;
     use std::convert::TryInto;
 
@@ -679,7 +679,7 @@ pub(crate) mod private {
                     (bit_writer.capacity() - bit_writer.bytes_written()) * 8;
                 let bits_needed = values.len() - bits_available;
                 let bytes_needed = (bits_needed + 7) / 8;
-                let bytes_needed = round_upto_multiple_of_64(bytes_needed);
+                let bytes_needed = round_upto_power_of_2(bytes_needed, 256);
                 bit_writer.extend(bytes_needed);
             }
             for value in values {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #657.

# Rationale for this change

Without this change, writing a batch with more than 2048 boolean values may fail to extend the bit vector enough.

# What changes are included in this PR?

* A test demonstrating the failure
* A change to allocate enough bytes for the boolean values being written
 
# Are there any user-facing changes?

No