### PR TITLE
Write boolean stats for boolean columns (not i32 stats)

### DIFF
--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -919,7 +919,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         };
         match self.descr.physical_type() {
             Type::INT32 => gen_stats_section!(i32, int32, min, max, distinct, nulls),
-            Type::BOOLEAN => gen_stats_section!(i32, int32, min, max, distinct, nulls),
+            Type::BOOLEAN => gen_stats_section!(bool, boolean, min, max, distinct, nulls),
             Type::INT64 => gen_stats_section!(i64, int64, min, max, distinct, nulls),
             Type::INT96 => gen_stats_section!(Int96, int96, min, max, distinct, nulls),
             Type::FLOAT => gen_stats_section!(f32, float, min, max, distinct, nulls),
@@ -1691,13 +1691,11 @@ mod tests {
     fn test_bool_statistics() {
         let stats = statistics_roundtrip::<BoolType>(&[true, false, false, true]);
         assert!(stats.has_min_max_set());
-        // should it be BooleanStatistics??
-        // https://github.com/apache/arrow-rs/issues/659
-        if let Statistics::Int32(stats) = stats {
-            assert_eq!(stats.min(), &0);
-            assert_eq!(stats.max(), &1);
+        if let Statistics::Boolean(stats) = stats {
+            assert_eq!(stats.min(), &false);
+            assert_eq!(stats.max(), &true);
         } else {
-            panic!("expecting Statistics::Int32, got {:?}", stats);
+            panic!("expecting Statistics::Boolean, got {:?}", stats);
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Resolves https://github.com/apache/arrow-rs/issues/659

# Rationale for this change
 
Bool columns were writing the wrong type of statistics

# What changes are included in this PR?

Write boolean stats for boolean columns (not i32 stats)

# Are there any user-facing changes?
Statistics for bool columns in parquet files are now boolean. I am not sure if this is visible to users though, as when I used `parquet-tools` to create a parquet file with a boolean column, the min/max statistics look correct to me (aka are boolean)

```
alamb@MacBook-Pro rust_parquet % parquet-tools dump -n  /tmp/test_bool.parquet 
parquet-tools dump -n  /tmp/test_bool.parquet 
row group 0 
------------------------------------------------------------------------------------------------------------------
bool_col:  BOOLEAN UNCOMPRESSED DO:0 FPO:4 SZ:40/40/1.00 VC:6 ENC:PLAIN,RLE ST:[min: false, max: true, num_nulls: 1]

    bool_col TV=6 RL=0 DL=1
    --------------------------------------------------------------------------------------------------------------
    page 0:  DLE:RLE RLE:RLE VLE:PLAIN ST:[min: false, max: true, num_nulls: 1] CRC:[none] SZ:7 VC:6

BOOLEAN bool_col 
------------------------------------------------------------------------------------------------------------------
*** row group 1 of 1, values 1 to 6 *** 
value 1: R:0 D:1 V:true
value 2: R:0 D:1 V:true
value 3: R:0 D:1 V:false
value 4: R:0 D:0 V:<null>
value 5: R:0 D:1 V:false
value 6: R:0 D:1 V:true
alamb@MacBook-Pro rust_parquet % 
```