### PR TITLE
Add some doc comments to parquet bit_util

### DIFF
--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -223,7 +223,7 @@ impl BitWriter {
         }
     }
 
-    /// Extend buffer size
+    /// Extend buffer size by `increment` bytes
     #[inline]
     pub fn extend(&mut self, increment: usize) {
         self.max_bytes += increment;
@@ -231,7 +231,7 @@ impl BitWriter {
         self.buffer.extend(extra);
     }
 
-    /// Report buffer size
+    /// Report buffer size, in bytes
     #[inline]
     pub fn capacity(&mut self) -> usize {
         self.max_bytes
@@ -332,6 +332,7 @@ impl BitWriter {
         self.max_bytes
     }
 
+    /// Writes the entire byte `value` at the byte `offset`
     pub fn write_at(&mut self, offset: usize, value: u8) {
         self.buffer[offset] = value;
     }


### PR DESCRIPTION
# Rationale for this change
 
I had to double check a few times what units (bits or bytes) were used for some functions in `bit_utils.rs`  while reviewing https://github.com/apache/arrow-rs/pull/658

# What changes are included in this PR?
Encode units in doc comments

