### PR TITLE
Make rand an optional dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -327,12 +327,14 @@ jobs:
           rustup override set ${{ matrix.rust }}
           rustup component add rustfmt
           rustup target add wasm32-unknown-unknown
+          rustup target add wasm32-wasi
       - name: Build arrow crate
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd arrow
-          cargo build --features=js --target wasm32-unknown-unknown
+          cargo build --no-default-features --features=csv,ipc,simd --target wasm32-unknown-unknown
+          cargo build --no-default-features --features=csv,ipc,simd --target wasm32-wasi
 
   # test builds with various feature flags
   default-build:

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -40,10 +40,7 @@ serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = "1.6"
-rand = { version = "0.8", default-features = false }
-# getrandom is a dependency of rand, not (directly) of arrow
-# need to specify `js` feature to build on wasm
-getrandom = { version = "0.2", optional = true }
+rand = { version = "0.8", optional = true }
 num = "0.4"
 csv_crate = { version = "1.1", optional = true, package="csv" }
 regex = "1.3"
@@ -64,16 +61,18 @@ csv = ["csv_crate"]
 ipc = ["flatbuffers"]
 simd = ["packed_simd"]
 prettyprint = ["prettytable-rs"]
-js = ["getrandom/js"]
 # The test utils feature enables code used in benchmarks and tests but
-# not the core arrow code itself
-test_utils = ["rand/std", "rand/std_rng"]
+# not the core arrow code itself. Be aware that `rand` must be kept as 
+# an optional dependency for supporting compile to wasm32-unknown-unknown 
+# target without assuming an environment containing JavaScript.
+test_utils = ["rand"]
 # this is only intended to be used in single-threaded programs: it verifies that
 # all allocated memory is being released (no memory leaks).
 # See README for details
 memory-check = []
 
 [dev-dependencies]
+rand = "0.8"
 criterion = "0.3"
 flate2 = "1"
 tempfile = "3"

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -59,11 +59,13 @@ println!("{:?}", array.value(1));
 
 ## Building for WASM
 
-In order to compile Arrow for Web Assembly (the `wasm32-unknown-unknown` WASM target), you will likely need to turn off this crate's default features and use the `js` feature.
+Arrow can compile to WebAssembly using the `wasm32-unknown-unknown` and `wasm32-wasi` targets.
+
+In order to compile Arrow for `wasm32-unknown-unknown` you will need to disable default features, then include the desired features, but exclude test dependencies (the `test_utils` feature). For example, use this snippet in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-arrow = { version = "5.0", default-features = false, features = ["js"] }
+arrow = { version = "5.0", default-features = false, features = ["csv", "ipc", "simd"] }
 ```
 
 ## Examples


### PR DESCRIPTION
# Which issue does this PR close?

Closes #671

# Rationale for this change
 
Support wasm32-unknown-unknown target in environments without JavaScript.

# What changes are included in this PR?

1. Change `rand` to be an optional dependency
2. Add `rand` as a dev dependency
3. Updated Building for WASM section in README
4. Add wasm32-wasi test in CI

# Are there any user-facing changes?

Instructions for compiling to wasm32-unknown-unknown changed