### PR TITLE
Add get_bit to BooleanBufferBuilder

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -312,6 +312,11 @@ impl BooleanBufferBuilder {
     }
 
     #[inline]
+    pub fn get_bit(&mut self, index: usize) -> bool {
+        bit_util::get_bit(self.buffer.as_slice(), index)
+    }
+
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -2645,6 +2650,31 @@ mod tests {
         buffer.set_bit(13, false);
         assert_eq!(buffer.len(), 15);
         assert_eq!(buffer.finish().as_slice(), &[0b01010110_u8, 0b1011100_u8]);
+    }
+
+    #[test]
+    fn test_bool_buffer_builder_get_first_bit() {
+        let mut buffer = BooleanBufferBuilder::new(16);
+        buffer.append_n(8, true);
+        buffer.append_n(8, false);
+        assert_eq!(buffer.get_bit(0), true);
+    }
+
+    #[test]
+    fn test_bool_buffer_builder_get_last_bit() {
+        let mut buffer = BooleanBufferBuilder::new(16);
+        buffer.append_n(8, true);
+        buffer.append_n(8, false);
+        assert_eq!(buffer.get_bit(15), false);
+    }
+
+    #[test]
+    fn test_bool_buffer_builder_get_an_inner_bit() {
+        let mut buffer = BooleanBufferBuilder::new(16);
+        buffer.append_n(4, false);
+        buffer.append_n(8, true);
+        buffer.append_n(4, false);
+        assert_eq!(buffer.get_bit(11), true);
     }
 
     #[test]

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2657,7 +2657,7 @@ mod tests {
         let mut buffer = BooleanBufferBuilder::new(16);
         buffer.append_n(8, true);
         buffer.append_n(8, false);
-        assert_eq!(buffer.get_bit(0), true);
+        assert!(buffer.get_bit(0));
     }
 
     #[test]
@@ -2665,7 +2665,7 @@ mod tests {
         let mut buffer = BooleanBufferBuilder::new(16);
         buffer.append_n(8, true);
         buffer.append_n(8, false);
-        assert_eq!(buffer.get_bit(15), false);
+        assert!(!buffer.get_bit(15));
     }
 
     #[test]
@@ -2674,7 +2674,7 @@ mod tests {
         buffer.append_n(4, false);
         buffer.append_n(8, true);
         buffer.append_n(4, false);
-        assert_eq!(buffer.get_bit(11), true);
+        assert!(buffer.get_bit(11));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Ref https://github.com/apache/arrow-datafusion/pull/342
Ref https://github.com/apache/arrow-datafusion/issues/240

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Described in the DataFusion issue. To make BooleanBufferBuilder useable as a bit vector within DataFusion code I needed this api exposed as well.


# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->