### PR TITLE
Cherry pick Doctest for PrimitiveArray using from_iter_values. to active_release

### DIFF
--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -44,6 +44,19 @@ const MICROSECONDS: i64 = 1_000_000;
 const NANOSECONDS: i64 = 1_000_000_000;
 
 /// Array whose elements are of primitive types.
+///
+/// # Example: From an iterator of values
+///
+/// ```
+/// use arrow::array::{Array, PrimitiveArray};
+/// use arrow::datatypes::Int32Type;
+/// let arr: PrimitiveArray<Int32Type> = PrimitiveArray::from_iter_values((0..10).map(|x| x + 1));
+/// assert_eq!(10, arr.len());
+/// assert_eq!(0, arr.null_count());
+/// for i in 0..10i32 {
+///     assert_eq!(i + 1, arr.value(i as usize));
+/// }
+/// ```
 pub struct PrimitiveArray<T: ArrowPrimitiveType> {
     /// Underlying ArrayData
     /// # Safety


### PR DESCRIPTION
Automatic cherry-pick of 38e5d22
* Originally appeared in https://github.com/apache/arrow-rs/pull/694: Doctest for PrimitiveArray using from_iter_values.
