### PR TITLE
Support binary data type in `build_struct_array`.

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -668,7 +668,7 @@ mod tests {
                 "entry",
                 DataType::Struct(vec![
                     Field::new("key", DataType::Utf8, false),
-                    Field::new("key", DataType::Int32, true),
+                    Field::new("value", DataType::Int32, true),
                 ]),
                 false,
             )),

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -3170,7 +3170,7 @@ mod tests {
 
         let schema = Schema::new(vec![Field::new("c1", DataType::Binary, true)]);
         let binary_values = BinaryArray::from(vec![
-            "\u{2081}\u{2082}\u{2083}".as_bytes(),
+            "₁₂₃".as_bytes(),
             "foo".as_bytes(),
         ]);
         let expected_batch =

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1225,6 +1225,14 @@ impl Decoder {
                             })
                             .collect::<StringArray>(),
                     ) as ArrayRef),
+                    DataType::Binary => Ok(Arc::new(
+                        rows.iter()
+                            .map(|row| {
+                                let maybe_value = row.get(field.name());
+                                maybe_value.and_then(|value| value.as_str())
+                            })
+                            .collect::<BinaryArray>(),
+                    ) as ArrayRef),
                     DataType::List(ref list_field) => {
                         match list_field.data_type() {
                             DataType::Dictionary(ref key_ty, _) => {
@@ -3138,6 +3146,41 @@ mod tests {
 
         assert_eq!(batch.num_columns(), 1);
         assert_eq!(batch.num_rows(), 3);
+    }
+
+    #[test]
+    fn test_json_read_binary_structs() {
+        let schema = Schema::new(vec![Field::new("c1", DataType::Binary, true)]);
+        let decoder = Decoder::new(Arc::new(schema), 1024, None);
+        let batch = decoder
+            .next_batch(
+                &mut vec![
+                    Ok(serde_json::json!({
+                        "c1": "₁₂₃",
+                    })),
+                    Ok(serde_json::json!({
+                        "c1": "foo",
+                    })),
+                ]
+                .into_iter(),
+            )
+            .unwrap()
+            .unwrap();
+        let data = batch.columns().iter().collect::<Vec<_>>();
+
+        let schema = Schema::new(vec![Field::new("c1", DataType::Binary, true)]);
+        let binary_values = BinaryArray::from(vec![
+            "\u{2081}\u{2082}\u{2083}".as_bytes(),
+            "foo".as_bytes(),
+        ]);
+        let expected_batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(binary_values)])
+                .unwrap();
+        let expected_data = expected_batch.columns().iter().collect::<Vec<_>>();
+
+        assert_eq!(data, expected_data);
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.num_rows(), 2);
     }
 
     #[test]

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -3169,10 +3169,7 @@ mod tests {
         let data = batch.columns().iter().collect::<Vec<_>>();
 
         let schema = Schema::new(vec![Field::new("c1", DataType::Binary, true)]);
-        let binary_values = BinaryArray::from(vec![
-            "₁₂₃".as_bytes(),
-            "foo".as_bytes(),
-        ]);
+        let binary_values = BinaryArray::from(vec!["₁₂₃".as_bytes(), "foo".as_bytes()]);
         let expected_batch =
             RecordBatch::try_new(Arc::new(schema), vec![Arc::new(binary_values)])
                 .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #701 

# Rationale for this change
 
We encounter this issue in delta-rs project where `partitionValues` in delta spec could contain binary type values.

# What changes are included in this PR?

Add binary type support and corresponding test case.

# Are there any user-facing changes?

No.
