### PR TITLE
chore: Reduce the amount of code generated by monomorphization

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -530,12 +530,22 @@ impl MutableBuffer {
             std::ptr::write(dst, item?);
             dst = dst.add(1);
         }
-        assert_eq!(
-            dst.offset_from(buffer.data.as_ptr() as *mut T) as usize,
-            upper,
-            "Trusted iterator length was not accurately reported"
-        );
-        buffer.len = len;
+        // try_from_trusted_len_iter is instantiated a lot, so we extract part of it into a less
+        // generic method to reduce compile time
+        unsafe fn finalize_buffer<T>(
+            dst: *mut T,
+            buffer: &mut MutableBuffer,
+            upper: usize,
+            len: usize,
+        ) {
+            assert_eq!(
+                dst.offset_from(buffer.data.as_ptr() as *mut T) as usize,
+                upper,
+                "Trusted iterator length was not accurately reported"
+            );
+            buffer.len = len;
+        }
+        finalize_buffer(dst, &mut buffer, upper, len);
         Ok(buffer)
     }
 }

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -425,7 +425,7 @@ impl Default for SortOptions {
 fn sort_boolean(
     values: &ArrayRef,
     value_indices: Vec<u32>,
-    null_indices: Vec<u32>,
+    mut null_indices: Vec<u32>,
     options: &SortOptions,
     limit: Option<usize>,
 ) -> UInt32Array {
@@ -446,15 +446,8 @@ fn sort_boolean(
             .into_iter()
             .map(|index| (index, values.value(index as usize)))
             .collect::<Vec<(u32, bool)>>();
-        if !descending {
-            sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-                cmp(a.1, b.1)
-            });
-        } else {
-            sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-                cmp(a.1, b.1).reverse()
-            });
-        }
+
+        sort_valids(descending, &mut valids, &mut null_indices, len, cmp);
         valids
     } else {
         // when limit is not present, we have a better way than sorting: we can just partition
@@ -465,13 +458,13 @@ fn sort_boolean(
             .map(|index| (index, values.value(index as usize)))
             .partition(|(_, value)| *value == descending);
         a.extend(b);
+        if descending {
+            null_indices.reverse();
+        }
         a
     };
 
-    let mut nulls = null_indices;
-    if descending {
-        nulls.reverse();
-    }
+    let nulls = null_indices;
 
     // collect results directly into a buffer instead of a vec to avoid another aligned allocation
     let result_capacity = len * std::mem::size_of::<u32>();
@@ -556,17 +549,8 @@ where
     if let Some(limit) = limit {
         len = limit.min(len);
     }
-    if !options.descending {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            cmp(a.1, b.1)
-        });
-    } else {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            cmp(a.1, b.1).reverse()
-        });
-        // reverse to keep a stable ordering
-        nulls.reverse();
-    }
+
+    sort_valids(options.descending, &mut valids, &mut nulls, len, cmp);
 
     // collect results directly into a buffer instead of a vec to avoid another aligned allocation
     let result_capacity = len * std::mem::size_of::<u32>();
@@ -689,22 +673,12 @@ where
     let mut nulls = null_indices;
     let descending = options.descending;
     let mut len = values.len();
-    let nulls_len = nulls.len();
 
     if let Some(limit) = limit {
         len = limit.min(len);
     }
-    if !descending {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            cmp(a.1, b.1)
-        });
-    } else {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            cmp(a.1, b.1).reverse()
-        });
-        // reverse to keep a stable ordering
-        nulls.reverse();
-    }
+
+    sort_valids(descending, &mut valids, &mut nulls, len, cmp);
     // collect the order of valid tuplies
     let mut valid_indices: Vec<u32> = valids.iter().map(|tuple| tuple.0).collect();
 
@@ -773,6 +747,7 @@ where
     if let Some(limit) = limit {
         len = limit.min(len);
     }
+
     if !descending {
         sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
             cmp_array(a.1.as_ref(), b.1.as_ref())
@@ -830,21 +805,12 @@ where
 
     let mut len = values.len();
     let descending = options.descending;
-    let nulls_len = null_indices.len();
 
     if let Some(limit) = limit {
         len = limit.min(len);
     }
-    if !descending {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            a.1.cmp(b.1)
-        });
-    } else {
-        sort_unstable_by(&mut valids, len.saturating_sub(nulls_len), |a, b| {
-            a.1.cmp(b.1).reverse()
-        });
-        null_indices.reverse();
-    }
+
+    sort_valids(descending, &mut valids, &mut null_indices, len, cmp);
 
     let mut valid_indices: Vec<u32> = valids.iter().map(|tuple| tuple.0).collect();
     if options.nulls_first {
@@ -1062,6 +1028,27 @@ impl LexicographicalComparator<'_> {
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(LexicographicalComparator { compare_items })
+    }
+}
+
+fn sort_valids<T, U>(
+    descending: bool,
+    valids: &mut [(u32, T)],
+    nulls: &mut [U],
+    len: usize,
+    mut cmp: impl FnMut(T, T) -> Ordering,
+) where
+    T: ?Sized + Copy,
+{
+    let nulls_len = nulls.len();
+    if !descending {
+        sort_unstable_by(valids, len.saturating_sub(nulls_len), |a, b| cmp(a.1, b.1));
+    } else {
+        sort_unstable_by(valids, len.saturating_sub(nulls_len), |a, b| {
+            cmp(a.1, b.1).reverse()
+        });
+        // reverse to keep a stable ordering
+        nulls.reverse();
     }
 }
 

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -723,7 +723,7 @@ where
 fn sort_list<S, T>(
     values: &ArrayRef,
     value_indices: Vec<u32>,
-    mut null_indices: Vec<u32>,
+    null_indices: Vec<u32>,
     options: &SortOptions,
     limit: Option<usize>,
 ) -> UInt32Array
@@ -731,6 +731,19 @@ where
     S: OffsetSizeTrait,
     T: ArrowPrimitiveType,
     T::Native: std::cmp::PartialOrd,
+{
+    sort_list_inner::<S>(values, value_indices, null_indices, options, limit)
+}
+
+fn sort_list_inner<S>(
+    values: &ArrayRef,
+    value_indices: Vec<u32>,
+    mut null_indices: Vec<u32>,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> UInt32Array
+where
+    S: OffsetSizeTrait,
 {
     let mut valids: Vec<(u32, ArrayRef)> = values
         .as_any()

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -302,20 +302,17 @@ impl Default for TakeOptions {
 }
 
 #[inline(always)]
-fn maybe_usize<I: ArrowPrimitiveType>(index: I::Native) -> Result<usize> {
+fn maybe_usize<I: ArrowNativeType>(index: I) -> Result<usize> {
     index
         .to_usize()
         .ok_or_else(|| ArrowError::ComputeError("Cast to usize failed".to_string()))
 }
 
 // take implementation when neither values nor indices contain nulls
-fn take_no_nulls<T, I>(
-    values: &[T::Native],
-    indices: &[I::Native],
-) -> Result<(Buffer, Option<Buffer>)>
+fn take_no_nulls<T, I>(values: &[T], indices: &[I]) -> Result<(Buffer, Option<Buffer>)>
 where
-    T: ArrowPrimitiveType,
-    I: ArrowNumericType,
+    T: ArrowNativeType,
+    I: ArrowNativeType,
 {
     let values = indices
         .iter()
@@ -329,12 +326,11 @@ where
 // take implementation when only values contain nulls
 fn take_values_nulls<T, I>(
     values: &PrimitiveArray<T>,
-    indices: &[I::Native],
+    indices: &[I],
 ) -> Result<(Buffer, Option<Buffer>)>
 where
     T: ArrowPrimitiveType,
-    I: ArrowNumericType,
-    I::Native: ToPrimitive,
+    I: ArrowNativeType,
 {
     let num_bytes = bit_util::ceil(indices.len(), 8);
     let mut nulls = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
@@ -366,21 +362,21 @@ where
 
 // take implementation when only indices contain nulls
 fn take_indices_nulls<T, I>(
-    values: &[T::Native],
+    values: &[T],
     indices: &PrimitiveArray<I>,
 ) -> Result<(Buffer, Option<Buffer>)>
 where
-    T: ArrowPrimitiveType,
+    T: ArrowNativeType,
     I: ArrowNumericType,
     I::Native: ToPrimitive,
 {
     let values = indices.values().iter().map(|index| {
-        let index = maybe_usize::<I>(*index)?;
+        let index = maybe_usize::<I::Native>(*index)?;
         Result::Ok(match values.get(index) {
             Some(value) => *value,
             None => {
                 if indices.is_null(index) {
-                    T::Native::default()
+                    T::default()
                 } else {
                     panic!("Out-of-bounds index {}", index)
                 }
@@ -418,7 +414,7 @@ where
     let values_values = values.values();
     let values = indices.iter().enumerate().map(|(i, index)| match index {
         Some(index) => {
-            let index = maybe_usize::<I>(index)?;
+            let index = maybe_usize::<I::Native>(index)?;
             if values.is_null(index) {
                 null_count += 1;
                 bit_util::unset_bit(null_slice, i);
@@ -471,17 +467,17 @@ where
         (false, false) => {
             // * no nulls
             // * all `indices.values()` are valid
-            take_no_nulls::<T, I>(values.values(), indices.values())?
+            take_no_nulls::<T::Native, I::Native>(values.values(), indices.values())?
         }
         (true, false) => {
             // * nulls come from `values` alone
             // * all `indices.values()` are valid
-            take_values_nulls::<T, I>(values, indices.values())?
+            take_values_nulls::<T, I::Native>(values, indices.values())?
         }
         (false, true) => {
             // in this branch it is unsound to read and use `index.values()`,
             // as doing so is UB when they come from a null slot.
-            take_indices_nulls::<T, I>(values.values(), indices)?
+            take_indices_nulls::<T::Native, I>(values.values(), indices)?
         }
         (true, true) => {
             // in this branch it is unsound to read and use `index.values()`,
@@ -795,7 +791,7 @@ where
         .values()
         .iter()
         .map(|idx| {
-            let idx = maybe_usize::<IndexType>(*idx)?;
+            let idx = maybe_usize::<IndexType::Native>(*idx)?;
             if data_ref.is_valid(idx) {
                 Ok(Some(values.value(idx)))
             } else {
@@ -821,7 +817,7 @@ where
         .values()
         .iter()
         .map(|idx| {
-            let idx = maybe_usize::<IndexType>(*idx)?;
+            let idx = maybe_usize::<IndexType::Native>(*idx)?;
             if data_ref.is_valid(idx) {
                 Ok(Some(values.value(idx)))
             } else {


### PR DESCRIPTION
# Rationale for this change
 
The arrow crate takes a long time to compile due to excessive monomorphizations.

# What changes are included in this PR?

This extracts parts of generic functions into smaller ones, thereby reducing the amount of llvm IR instantiated by roughly 32%

```
cargo llvm-lines -p arrow --lib | tee ../llvm-lines | sponge | head -30'
```