### PR TITLE
Optimize array::transform::utils::set_bits

### DIFF
--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -61,7 +61,7 @@ pub(super) fn set_bits(
     });
 
     // Set individual bits both to align write_data to a byte offset and the remainder bits not covered by the bit chunk iterator
-    let remainder_offset = len - &chunks.remainder_len();
+    let remainder_offset = len - chunks.remainder_len();
     (0..bits_to_align)
         .chain(remainder_offset..len)
         .for_each(|i| {

--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -54,7 +54,7 @@ pub(super) fn set_bits(
     let chunks = BitChunks::new(data, offset_read + bits_to_align, len - bits_to_align);
     chunks.iter().for_each(|chunk| {
         null_count += chunk.count_zeros();
-        chunk.to_ne_bytes().iter().for_each(|b| {
+        chunk.to_le_bytes().iter().for_each(|b| {
             write_data[byte_index] = *b;
             byte_index += 1;
         })

--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -50,6 +50,7 @@ pub(super) fn set_bits(
     }
     let mut byte_index = ceil(offset_write + bits_to_align, 8);
 
+    // Set full bytes provided by bit chunk iterator
     let chunks = BitChunks::new(data, offset_read + bits_to_align, len - bits_to_align);
     chunks.iter().for_each(|chunk| {
         null_count += chunk.count_zeros();
@@ -59,6 +60,7 @@ pub(super) fn set_bits(
         })
     });
 
+    // Set individual bits both to align write_data to a byte offset and the remainder bits not covered by the bit chunk iterator
     let remainder_offset = len - &chunks.remainder_len();
     (0..bits_to_align)
         .chain(remainder_offset..len)
@@ -71,24 +73,6 @@ pub(super) fn set_bits(
         });
 
     null_count as usize
-}
-
-pub(super) fn set_bits_old(
-    write_data: &mut [u8],
-    data: &[u8],
-    offset_write: usize,
-    offset_read: usize,
-    len: usize,
-) -> usize {
-    let mut count = 0;
-    (0..len).for_each(|i| {
-        if bit_util::get_bit(data, offset_read + i) {
-            bit_util::set_bit(write_data, offset_write + i);
-        } else {
-            count += 1;
-        }
-    });
-    count
 }
 
 pub(super) fn extend_offsets<T: OffsetSizeTrait>(

--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -35,6 +35,7 @@ pub(super) fn resize_for_bits(buffer: &mut MutableBuffer, len: usize) {
 
 /// sets all bits on `write_data` on the range `[offset_write..offset_write+len]` to be equal to the
 /// bits on `data` on the range `[offset_read..offset_read+len]`
+/// returns the number of `0` bits `data[offset_read..offset_read+len]`
 pub(super) fn set_bits(
     write_data: &mut [u8],
     data: &[u8],
@@ -48,15 +49,15 @@ pub(super) fn set_bits(
     if bits_to_align > 0 {
         bits_to_align = std::cmp::min(len, 8 - bits_to_align);
     }
-    let mut byte_index = ceil(offset_write + bits_to_align, 8);
+    let mut write_byte_index = ceil(offset_write + bits_to_align, 8);
 
-    // Set full bytes provided by bit chunk iterator
+    // Set full bytes provided by bit chunk iterator (which iterates in 64 bits at a time)
     let chunks = BitChunks::new(data, offset_read + bits_to_align, len - bits_to_align);
     chunks.iter().for_each(|chunk| {
         null_count += chunk.count_zeros();
         chunk.to_le_bytes().iter().for_each(|b| {
-            write_data[byte_index] = *b;
-            byte_index += 1;
+            write_data[write_byte_index] = *b;
+            write_byte_index += 1;
         })
     });
 

--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -113,8 +113,8 @@ mod tests {
     fn test_set_bits_aligned() {
         let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let source: &[u8] = &[
-            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101,
         ];
 
         let destination_offset = 8;
@@ -123,10 +123,10 @@ mod tests {
         let len = 64;
 
         let expected_data: &[u8] = &[
-            0, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111, 0,
+            0, 0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101, 0,
         ];
-        let expected_null_count = 16;
+        let expected_null_count = 24;
         let result = set_bits(
             destination.as_mut_slice(),
             source,
@@ -143,8 +143,8 @@ mod tests {
     fn test_set_bits_unaligned_destination_start() {
         let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let source: &[u8] = &[
-            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101,
         ];
 
         let destination_offset = 3;
@@ -153,10 +153,10 @@ mod tests {
         let len = 64;
 
         let expected_data: &[u8] = &[
-            0b00111000, 0b00111111, 0b00111111, 0b00111111, 0b00111111, 0b00111111,
-            0b00111111, 0b00111111, 0b00000111, 0b00000000,
+            0b00111000, 0b00101111, 0b11001101, 0b11011100, 0b01011110, 0b00011111,
+            0b00111110, 0b00101111, 0b00000101, 0b00000000,
         ];
-        let expected_null_count = 16;
+        let expected_null_count = 24;
         let result = set_bits(
             destination.as_mut_slice(),
             source,
@@ -173,8 +173,8 @@ mod tests {
     fn test_set_bits_unaligned_destination_end() {
         let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let source: &[u8] = &[
-            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101,
         ];
 
         let destination_offset = 8;
@@ -183,10 +183,10 @@ mod tests {
         let len = 62;
 
         let expected_data: &[u8] = &[
-            0, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b00100111, 0,
+            0, 0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b00100101, 0,
         ];
-        let expected_null_count = 16;
+        let expected_null_count = 23;
         let result = set_bits(
             destination.as_mut_slice(),
             source,
@@ -203,9 +203,9 @@ mod tests {
     fn test_set_bits_unaligned() {
         let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let source: &[u8] = &[
-            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
-            0b11100111, 0b11100111, 0b11100111,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
+            0b11100111, 0b10100101, 0b10011001, 0b11011011, 0b11101011, 0b11000011,
         ];
 
         let destination_offset = 3;
@@ -214,11 +214,11 @@ mod tests {
         let len = 95;
 
         let expected_data: &[u8] = &[
-            0b11111000, 0b11111001, 0b11111001, 0b11111001, 0b11111001, 0b11111001,
-            0b11111001, 0b11111001, 0b11111001, 0b11111001, 0b11111001, 0b11111001,
+            0b01111000, 0b01101001, 0b11100110, 0b11110110, 0b11111010, 0b11110000,
+            0b01111001, 0b01101001, 0b11100110, 0b11110110, 0b11111010, 0b11110000,
             0b00000001,
         ];
-        let expected_null_count = 23;
+        let expected_null_count = 35;
         let result = set_bits(
             destination.as_mut_slice(),
             source,

--- a/arrow/src/array/transform/utils.rs
+++ b/arrow/src/array/transform/utils.rs
@@ -15,7 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{array::OffsetSizeTrait, buffer::MutableBuffer, util::bit_util};
+use crate::{
+    array::OffsetSizeTrait,
+    buffer::MutableBuffer,
+    util::{
+        bit_chunk_iterator::BitChunks,
+        bit_util::{self, ceil},
+    },
+};
 
 /// extends the `buffer` to be able to hold `len` bits, setting all bits of the new size to zero.
 #[inline]
@@ -35,19 +42,36 @@ pub(super) fn set_bits(
     offset_read: usize,
     len: usize,
 ) -> usize {
-    // write to write_data until it is at a whole-byte offset
-    // create bit chunk iterator for data
-    // write whole bytes from iterator to write_data
+    let mut null_count = 0;
 
-    let mut count = 0;
-    (0..len).for_each(|i| {
-        if bit_util::get_bit(data, offset_read + i) {
-            bit_util::set_bit(write_data, offset_write + i);
-        } else {
-            count += 1;
-        }
+    let mut bits_to_align = offset_write % 8;
+    if bits_to_align > 0 {
+        bits_to_align = std::cmp::min(len, 8 - bits_to_align);
+    }
+    let bytes_to_copy = ceil(offset_write + bits_to_align, 8)
+        ..ceil(offset_write + len - bits_to_align, 8);
+
+    let chunks = BitChunks::new(data, offset_read + bits_to_align, len - bits_to_align);
+    let mut bytes: Vec<u8> = Vec::with_capacity(bytes_to_copy.len());
+    chunks.iter().for_each(|chunk| {
+        null_count += chunk.count_zeros();
+        bytes.extend_from_slice(&chunk.to_ne_bytes());
     });
-    count
+
+    let remainder_bits = &chunks.remainder_len();
+    (0..bits_to_align)
+        .chain(len - remainder_bits..len)
+        .for_each(|i| {
+            if bit_util::get_bit(data, offset_read + i) {
+                bit_util::set_bit(write_data, offset_write + i);
+            } else {
+                null_count += 1;
+            }
+        });
+    bytes_to_copy.zip(bytes.iter()).for_each(|(i, b)| {
+        write_data[i] = *b;
+    });
+    null_count as usize
 }
 
 pub(super) fn extend_offsets<T: OffsetSizeTrait>(
@@ -85,16 +109,22 @@ mod tests {
 
     #[test]
     fn test_set_bits_aligned() {
-        let mut destination: Vec<u8> = vec![0b01010101, 0b00000000];
-        let source: &[u8] = &[0b00110011];
+        let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let source: &[u8] = &[
+            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
+            0b11100111, 0b11100111,
+        ];
 
         let destination_offset = 8;
         let source_offset = 0;
 
-        let len = 8;
+        let len = 64;
 
-        let expected_data: &[u8] = &[0b01010101, 0b00110011];
-        let expected_null_count = 4;
+        let expected_data: &[u8] = &[
+            0, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
+            0b11100111, 0b11100111, 0,
+        ];
+        let expected_null_count = 16;
         let result = set_bits(
             destination.as_mut_slice(),
             source,
@@ -108,17 +138,23 @@ mod tests {
     }
 
     #[test]
-    fn test_set_bits_unaligned() {
-        let mut destination: Vec<u8> = vec![0, 0];
-        let source: &[u8] = &[0b11111111];
+    fn test_set_bits_unaligned_unset() {
+        let mut destination: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let source: &[u8] = &[
+            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
+            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
+        ];
 
         let destination_offset = 4;
-        let source_offset = 2;
+        let source_offset = 4;
 
-        let len = 6;
+        let len = 88;
 
-        let expected_data: &[u8] = &[0b11110000, 0b00000011];
-        let expected_null_count = 0;
+        let expected_data: &[u8] = &[
+            0b11100000, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111,
+            0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b11100111, 0b0000111,
+        ];
+        let expected_null_count = 22;
         let result = set_bits(
             destination.as_mut_slice(),
             source,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #397 

# Rationale for this change
 
See issue.

# What changes are included in this PR?

Two changes:

1. I added unit tests to make sure the function behaves the same as before my changes
2. I updated the function body to follow the proposed algorithm in the issue which in a nutshell is:
    - Set individual bytes to the next byte offset
    - Use a `BitChunkIterator` on the remaining bytes to set entire `u8`s
    - Set remaining bits individually

# Are there any user-facing changes?

Sort of.

The way `set_bits` is called currently is that it's always applied to byte arrays where all bits are set to 0. As long as that is true there are no user facing changes. However, the old implementation would not overwrite a `1` with a `0` if that is what the data says but in the current implementation it will sometimes do that. Where it's setting individual bits (initial bits to get to a byte alignment and remainder bits after bit chunk iterator has run out of full u64) it behaves like the old implementation, but the section where it's setting full bytes sets the bytes regardless of the value in `data` and `write_data`.
