### PR TITLE
Cherry pick run results of `cargo --fix` for edition 2021 to active_release

### DIFF
--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -242,7 +242,7 @@ pub mod flight_service_client {
             interceptor: F,
         ) -> FlightServiceClient<InterceptedService<T, F>>
         where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+            F: tonic::service::Interceptor,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
                 Response = http::Response<
@@ -666,7 +666,7 @@ pub mod flight_service_server {
             interceptor: F,
         ) -> InterceptedService<Self, F>
         where
-            F: FnMut(tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status>,
+            F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }

--- a/arrow/src/alloc/types.rs
+++ b/arrow/src/alloc/types.rs
@@ -36,7 +36,7 @@ pub unsafe trait NativeType:
 }
 
 macro_rules! create_native {
-    ($native_ty:ty,$($impl_pattern:pat)|+) => {
+    ($native_ty:ty,$($impl_pattern:pat_param)|+) => {
         unsafe impl NativeType for $native_ty {
             type Bytes = [u8; std::mem::size_of::<Self>()];
 

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -1265,7 +1265,7 @@ impl FromBytes for FixedLenByteArray {
 
 /// Macro to reduce repetition in making type assertions on the physical type against `T`
 macro_rules! ensure_phys_ty {
-    ($($ty: pat)|+ , $err: literal) => {
+    ($($ty:pat_param)|+ , $err: literal) => {
         match T::get_physical_type() {
             $($ty => (),)*
             _ => panic!($err),

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -100,7 +100,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         field_infos.iter().map(|x| x.parquet_type()).collect();
 
     (quote! {
-    impl#generics RecordWriter<#derived_for#generics> for &[#derived_for#generics] {
+    impl #generics RecordWriter<#derived_for #generics> for &[#derived_for #generics] {
       fn write_to_row_group(
         &self,
         row_group_writer: &mut Box<parquet::file::writer::RowGroupWriter>


### PR DESCRIPTION
Automatic cherry-pick of 9d6ca6b
* Originally appeared in https://github.com/apache/arrow-rs/pull/714: run results of `cargo --fix` for edition 2021
