### PR TITLE
specifying rust 1.53 for `arrow` and `parquet` crate

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -30,6 +30,7 @@ include = [
     "Cargo.toml",
 ]
 edition = "2018"
+rust = "1.53"
 
 [lib]
 name = "arrow"
@@ -62,8 +63,8 @@ ipc = ["flatbuffers"]
 simd = ["packed_simd"]
 prettyprint = ["comfy-table"]
 # The test utils feature enables code used in benchmarks and tests but
-# not the core arrow code itself. Be aware that `rand` must be kept as 
-# an optional dependency for supporting compile to wasm32-unknown-unknown 
+# not the core arrow code itself. Be aware that `rand` must be kept as
+# an optional dependency for supporting compile to wasm32-unknown-unknown
 # target without assuming an environment containing JavaScript.
 test_utils = ["rand"]
 # this is only intended to be used in single-threaded programs: it verifies that

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -27,6 +27,7 @@ keywords = [ "arrow", "parquet", "hadoop" ]
 readme = "README.md"
 build = "build.rs"
 edition = "2018"
+rust = "1.53"
 
 [dependencies]
 # update note: pin `parquet-format` to specific version until it does not break at minor


### PR DESCRIPTION
# Which issue does this PR close?

specifying rust 1.53 for `arrow` and `parquet` crate.

related #714, as in [here](https://dev-doc.rust-lang.org/stable/edition-guide/rust-2021/or-patterns-macro-rules.html) the `pat_params` is introduced.

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
