### PR TITLE
Add a note on rust compiler testing and compatibility

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -27,7 +27,6 @@ This crate contains the official Native Rust implementation of [Apache Arrow](ht
 
 This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
 
-
 ## Versioning / Releases
 
 Unlike many other crates in the Rust ecosystem which spend extended time in "pre 1.0.0" state, releasing versions 0.x, the arrow-rs crate follows the versioning scheme of the overall [Apache Arrow](https://arrow.apache.org/) project in an effort to signal which language implementations have been integration tested with each other.

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -23,6 +23,11 @@
 
 This crate contains the official Native Rust implementation of [Apache Arrow](https://arrow.apache.org/) in memory format. Please see the API documents for additional details.
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
+
 ## Versioning / Releases
 
 Unlike many other crates in the Rust ecosystem which spend extended time in "pre 1.0.0" state, releasing versions 0.x, the arrow-rs crate follows the versioning scheme of the overall [Apache Arrow](https://arrow.apache.org/) project in an effort to signal which language implementations have been integration tested with each other.

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -42,6 +42,10 @@ while let Some(record) = iter.next() {
 
 See [crate documentation](https://docs.rs/crate/parquet) on available API.
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
 ## Upgrading from versions prior to 4.0
 
 If you are upgrading from version 3.0 or previous of this crate, you


### PR DESCRIPTION
# Rationale for this change

@jhorstmann  noticed  a change that was introduced in https://github.com/apache/arrow-rs/pull/714#discussion_r696837777 (and included in the arrow 5.3.0 RC0) that is incompatible with rust 1.52.1 (rust is currently on 1.54.0). 
 
# What changes are included in this PR?

Propose explicitly document that arrow and parquet are only tested with the latest stable version of Rust.

Though this maybe also should serve as a way to solicit opinions about how important compatibility with older versions of Rust is (and if anyone would be willing to spend the time to setup CI to make sure that happens)

# Are there any user-facing changes?

Different readme
