### PR TITLE
Add `append_nulls` and `append_trusted_len_iter` to `PrimitiveBuilder`

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2788,6 +2788,35 @@ mod tests {
     }
 
     #[test]
+    fn test_primitive_array_builder_i32_append_iter() {
+        let mut builder = Int32Array::builder(5);
+        unsafe { builder.append_trusted_len_iter(0..5) }.unwrap();
+        let arr = builder.finish();
+        assert_eq!(5, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(0, arr.null_count());
+        for i in 0..5 {
+            assert!(!arr.is_null(i));
+            assert!(arr.is_valid(i));
+            assert_eq!(i as i32, arr.value(i));
+        }
+    }
+
+    #[test]
+    fn test_primitive_array_builder_i32_append_nulls() {
+        let mut builder = Int32Array::builder(5);
+        builder.append_nulls(5).unwrap();
+        let arr = builder.finish();
+        assert_eq!(5, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(5, arr.null_count());
+        for i in 0..5 {
+            assert!(arr.is_null(i));
+            assert!(!arr.is_valid(i));
+        }
+    }
+
+    #[test]
     fn test_primitive_array_builder_date32() {
         let mut builder = Date32Array::builder(5);
         for i in 0..5 {

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -261,8 +261,11 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
         self.len += slice.len();
     }
 
+    /// # Safety
+    /// This requires the iterator be a trusted length. This could instead require
+    /// the iterator implement `TrustedLen` once that is stabilized.
     #[inline]
-    pub fn append_trusted_len_iter(&mut self, iter: impl IntoIterator<Item = T>) {
+    pub unsafe fn append_trusted_len_iter(&mut self, iter: impl IntoIterator<Item = T>) {
         let iter = iter.into_iter();
         let len = iter
             .size_hint()
@@ -760,12 +763,16 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     }
 
     /// Appends values from a trusted length iterator.
+    ///
+    /// # Safety
+    /// This requires the iterator be a trusted length. This could instead require
+    /// the iterator implement `TrustedLen` once that is stabilized.
     #[inline]
-    pub fn append_trusted_len_iter(
+    pub unsafe fn append_trusted_len_iter(
         &mut self,
         iter: impl IntoIterator<Item = T::Native>,
     ) -> Result<()> {
-        let mut iter = iter.into_iter();
+        let iter = iter.into_iter();
         let len = iter
             .size_hint()
             .1


### PR DESCRIPTION
# Which issue does this PR close?

Closes #725.

# Rationale for this change
 
Allows appending multiple values / nulls in a single call. This avoids re-checking capacity, etc.

# What changes are included in this PR?

Adds `append_nulls` and `append_trusted_len_iter` methods to `PrimitiveBuilder`.

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->