### PR TITLE
fix: Allow parquet to be compiled without arrow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,6 +118,9 @@ jobs:
           cargo run --example dynamic_types
           cargo run --example read_csv
           cargo run --example read_csv_infer_schema
+          (cd parquet && cargo check --no-default-features)
+          (cd arrow && cargo check --no-default-features)
+          (cd arrow-flight && cargo check --no-default-features)
 
   # test the --features "simd" of the arrow crate. This requires nightly.
   linux-test-simd:

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -60,6 +60,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 cli = ["serde_json", "base64", "clap"]
+test = []
 
 [[ bin ]]
 name = "parquet-read"

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -585,10 +585,9 @@ impl AsBytes for str {
 
 pub(crate) mod private {
     use crate::encodings::decoding::PlainDecoderDetails;
-    use crate::util::bit_util::{BitReader, BitWriter};
+    use crate::util::bit_util::{round_upto_power_of_2, BitReader, BitWriter};
     use crate::util::memory::ByteBufferPtr;
 
-    use arrow::util::bit_util::round_upto_power_of_2;
     use byteorder::ByteOrder;
     use std::convert::TryInto;
 

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -680,6 +680,15 @@ impl From<Vec<u8>> for BitReader {
     }
 }
 
+/// Returns the nearest multiple of `factor` that is `>=` than `num`. Here `factor` must
+/// be a power of 2.
+///
+/// Copied from the arrow crate to make arrow optional
+pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
+    debug_assert!(factor > 0 && (factor & (factor - 1)) == 0);
+    (num + (factor - 1)) & !(factor - 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_common::*;

--- a/parquet/src/util/mod.rs
+++ b/parquet/src/util/mod.rs
@@ -22,7 +22,9 @@ pub mod bit_util;
 mod bit_packing;
 pub mod cursor;
 pub mod hash_util;
+#[cfg(feature = "test")]
 pub(crate) mod test_common;
+#[cfg(feature = "test")]
 pub use self::test_common::page_util::{
     DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
 };


### PR DESCRIPTION
`--no-default-features` is currently broken in the parquet crate due to
arrow being required. With some small tweaks it can be made entirely
optional.

Added some extra steps to catch when `--no-default-features` does not
work on CI as well.

# Are there any user-facing changes?

BREAKING CHANGE

The items exported from `parquet`'s `test_common` module is now only exported if the `test` feature is used.