### PR TITLE
fix: Handle slices in unary kernel

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -184,7 +184,7 @@ impl Buffer {
     /// If the offset is byte-aligned the returned buffer is a shallow clone,
     /// otherwise a new buffer is allocated and filled with a copy of the bits in the range.
     pub fn bit_slice(&self, offset: usize, len: usize) -> Self {
-        if offset % 8 == 0 && len % 8 == 0 {
+        if offset % 8 == 0 {
             return self.slice(offset / 8);
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #738.

# Rationale for this change
 
Fixes the handling of slices in the `unary` kernel.

# What changes are included in this PR?

# Are there any user-facing changes?