### PR TITLE
Cherry pick 6ee9bc03 - Add a note on rust compiler testing and compatibility #726

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -23,6 +23,14 @@
 
 This crate contains the official Native Rust implementation of [Apache Arrow](https://arrow.apache.org/) in memory format. Please see the API documents for additional details.
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
+## Versioning / Releases
+
+Unlike many other crates in the Rust ecosystem which spend extended time in "pre 1.0.0" state, releasing versions 0.x, the arrow-rs crate follows the versioning scheme of the overall [Apache Arrow](https://arrow.apache.org/) project in an effort to signal which language implementations have been integration tested with each other.
+
 ## Features
 
 The arrow crate provides the following optional features:

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -42,6 +42,10 @@ while let Some(record) = iter.next() {
 
 See [crate documentation](https://docs.rs/crate/parquet) on available API.
 
+## Rust Version Compatbility
+
+This crate is tested with the latest stable version of Rust. We do not currrently test against other, older versions of the Rust compiler.
+
 ## Upgrading from versions prior to 4.0
 
 If you are upgrading from version 3.0 or previous of this crate, you


### PR DESCRIPTION
Manual cherry-pick of 6ee9bc03 originally appearing in https://github.com/apache/arrow-rs/pull/726

Note it also contains some content from master about versioning which I think is ok. 