### PR TITLE
Cherry pick fix: Handle slices in unary kernel to active_release

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -184,7 +184,7 @@ impl Buffer {
     /// If the offset is byte-aligned the returned buffer is a shallow clone,
     /// otherwise a new buffer is allocated and filled with a copy of the bits in the range.
     pub fn bit_slice(&self, offset: usize, len: usize) -> Self {
-        if offset % 8 == 0 && len % 8 == 0 {
+        if offset % 8 == 0 {
             return self.slice(offset / 8);
         }
 


### PR DESCRIPTION
Automatic cherry-pick of 7ae6910
* Originally appeared in https://github.com/apache/arrow-rs/pull/739: fix: Handle slices in unary kernel
