### PR TITLE
Export `RowColumnIter` to fix doc

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -90,6 +90,7 @@ impl Row {
     }
 }
 
+/// Iterator of columns in a Row.
 pub struct RowColumnIter<'a> {
     fields: &'a Vec<(String, Field)>,
     curr: usize,

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -90,7 +90,7 @@ impl Row {
     }
 }
 
-/// Iterator of columns in a Row.
+/// `RowColumnIter` represents an iterator over column names and values in a Row.
 pub struct RowColumnIter<'a> {
     fields: &'a Vec<(String, Field)>,
     curr: usize,

--- a/parquet/src/record/mod.rs
+++ b/parquet/src/record/mod.rs
@@ -23,6 +23,6 @@ mod record_writer;
 mod triplet;
 
 pub use self::{
-    api::{Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor},
+    api::{Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowColumnIter},
     record_writer::RecordWriter,
 };


### PR DESCRIPTION
# Which issue does this PR close?

Closes #762 .

# Rationale for this change
 
Improve documentation and usability.

# What changes are included in this PR?

Export `RowColumnIter`.

# Are there any user-facing changes?

Yes, users can import `RowColumnIter` now.
