### PR TITLE
Cherry pick Use latest nightly in CI to Fix CI for SIMD  to active_release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-07-04]
+        rust: [nightly]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -297,7 +297,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-07-04]
+        rust: [nightly]
     container:
       image: ${{ matrix.arch }}/rust
       env:


### PR DESCRIPTION
Automatic cherry-pick of 2f78c7a
* Originally appeared in https://github.com/apache/arrow-rs/pull/767: Use latest nightly in CI to Fix CI for SIMD 
