### PR TITLE
Make BooleanBufferBuilder get_bit not require mutable reference

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -329,7 +329,7 @@ impl BooleanBufferBuilder {
     }
 
     #[inline]
-    pub fn get_bit(&mut self, index: usize) -> bool {
+    pub fn get_bit(&self, index: usize) -> bool {
         bit_util::get_bit(self.buffer.as_slice(), index)
     }
 
@@ -2705,6 +2705,17 @@ mod tests {
         let mut buffer = BooleanBufferBuilder::new(16);
         buffer.append_n(8, true);
         buffer.append_n(8, false);
+        assert!(buffer.get_bit(0));
+    }
+
+    #[test]
+    fn test_bool_buffer_builder_get_first_bit_not_requires_mutability() {
+        let buffer = {
+            let mut buffer = BooleanBufferBuilder::new(16);
+            buffer.append_n(8, true);
+            buffer
+        };
+
         assert!(buffer.get_bit(0));
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
This PR is a followup to https://github.com/apache/arrow-rs/pull/693 in which I did the insanely stupid mistake of requiring a mutable reference instead of immutable reference. This PR fixes this (and adds a test to validate it...).

This is required to finish https://github.com/apache/arrow-datafusion/pull/884
<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
