### PR TITLE
add wasm32 to hash, fix wasm32 build

### DIFF
--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64", target_arch = "wasm32"))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,12 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64", target_arch = "wasm32"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv64",
+        target_arch = "wasm32"
+    ))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }


### PR DESCRIPTION
# Rationale for this change
 
The `parquet` crate cannot compile to WASM due to the `hash_` implementation not having a target for `target_arch = "wasm32"`. This change adds it.

# What changes are included in this PR?

Adds `target_arch = "wasm32"` to the list of targets for the `hash_` function.

# Are there any user-facing changes?

No user changes.