### PR TITLE
Cherry pick Add support for riscv64 to active_release

### DIFF
--- a/arrow/src/alloc/alignment.rs
+++ b/arrow/src/alloc/alignment.rs
@@ -62,7 +62,7 @@ pub const ALIGNMENT: usize = 1 << 6;
 // - https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/riscv/sifive-l2-cache.txt#L41
 // in general all of them are the same.
 /// Cache and allocation multiple alignment size
-#[cfg(target_arch = "riscv")]
+#[cfg(target_arch = "riscv64")]
 pub const ALIGNMENT: usize = 1 << 6;
 
 // This size is same across all hardware for this architecture.

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }


### PR DESCRIPTION
Automatic cherry-pick of 4b6ea06
* Originally appeared in https://github.com/apache/arrow-rs/pull/769: Add support for riscv64
