### PR TITLE
Cherry pick fix: nanosecond timestamp scaling during string conversion (#780) to active_release

### DIFF
--- a/arrow/src/compute/kernels/cast_utils.rs
+++ b/arrow/src/compute/kernels/cast_utils.rs
@@ -95,7 +95,7 @@ pub fn string_to_timestamp_nanos(s: &str) -> Result<i64> {
 
     // without a timezone specifier as a local time, using T as a separator
     // Example: 2020-09-08T13:42:29.190855
-    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S.%f") {
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
         return naive_datetime_to_timestamp(s, ts);
     }
 
@@ -108,7 +108,7 @@ pub fn string_to_timestamp_nanos(s: &str) -> Result<i64> {
 
     // without a timezone specifier as a local time, using ' ' as a separator
     // Example: 2020-09-08 13:42:29.190855
-    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S.%f") {
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f") {
         return naive_datetime_to_timestamp(s, ts);
     }
 
@@ -227,7 +227,7 @@ mod tests {
         // somewhat suceptable to bugs in the use of chrono
         let naive_datetime = NaiveDateTime::new(
             NaiveDate::from_ymd(2020, 9, 8),
-            NaiveTime::from_hms_nano(13, 42, 29, 190855),
+            NaiveTime::from_hms_nano(13, 42, 29, 190855000),
         );
 
         // Ensure both T and ' ' variants work


### PR DESCRIPTION
Automatic cherry-pick of 499301c
* Originally appeared in https://github.com/apache/arrow-rs/pull/781: fix: nanosecond timestamp scaling during string conversion (#780)
