### PR TITLE
Cherry pick Export `RowColumnIter` to fix doc to active_release

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -90,6 +90,7 @@ impl Row {
     }
 }
 
+/// `RowColumnIter` represents an iterator over column names and values in a Row.
 pub struct RowColumnIter<'a> {
     fields: &'a Vec<(String, Field)>,
     curr: usize,

--- a/parquet/src/record/mod.rs
+++ b/parquet/src/record/mod.rs
@@ -23,6 +23,6 @@ mod record_writer;
 mod triplet;
 
 pub use self::{
-    api::{Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor},
+    api::{Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowColumnIter},
     record_writer::RecordWriter,
 };


### PR DESCRIPTION
Automatic cherry-pick of d2cec2c
* Originally appeared in https://github.com/apache/arrow-rs/pull/763: Export `RowColumnIter` to fix doc
