### PR TITLE
Cherry pick add wasm32 to hash, fix wasm32 build to active_release

### DIFF
--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,12 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv64",
+        target_arch = "wasm32"
+    ))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }


### PR DESCRIPTION
Automatic cherry-pick of 9ca59b6
* Originally appeared in https://github.com/apache/arrow-rs/pull/787: add wasm32 to hash, fix wasm32 build
