### PR TITLE
Make parquet's optional arrow dependency skip the default features

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -41,7 +41,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.9", optional = true }
 chrono = "0.4"
 num-bigint = "0.4"
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", optional = true }
+arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", optional = true }
 clap = { version = "2.33.3", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -41,7 +41,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.9", optional = true }
 chrono = "0.4"
 num-bigint = "0.4"
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", optional = true, default-features = false, features = ["ipc"] }
+arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 clap = { version = "2.33.3", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #800.

# Rationale for this change
This change makes builds much faster for folks who depend on parquet but don't need CSV handling. It also ensures that most users don't have to build the testutils feature which brings in dependencies on rand.

Building arrow for parquet is the slowest part of my build by far and most of that time is spent building things I don't use.

# What changes are included in this PR?
This PR changes one line, making the optional dependency on arrow skip the default features.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
