### PR TITLE
Minor: Remove extra quote in release instructions

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -80,7 +80,7 @@ git log --pretty=oneline 5.0.0..apache/active_release
 This command will make markdown links that work when rendered outside of github:
 
 ```shell
-git log --pretty=oneline 5.1.0..apache/active_release | sed -e 's|\(^[0-9a-f]*\) |* [\1](https://github.com/apache/arrow-rs/commit/\1) |' | sed -e 's|#\([0-9]*\)|[#\1](https://github.com/apache/arrow-rs/pull/\1)|g''
+git log --pretty=oneline 5.1.0..apache/active_release | sed -e 's|\(^[0-9a-f]*\) |* [\1](https://github.com/apache/arrow-rs/commit/\1) |' | sed -e 's|#\([0-9]*\)|[#\1](https://github.com/apache/arrow-rs/pull/\1)|g'
 ```
 
 # Mechanics of creating a release


### PR DESCRIPTION
Found while preparing the 5.5.0 release candidate