### PR TITLE
parquet: only enable base64 if needed

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -58,8 +58,9 @@ arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
+default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd"]
 cli = ["serde_json", "base64", "clap"]
+arrow = ["base64"]
 test_common = []
 
 [[ bin ]]


### PR DESCRIPTION
Closes #811.