### PR TITLE
Investigate usages of ArrayData::new (WIP)

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -520,15 +520,17 @@ impl FixedSizeBinaryArray {
         }
 
         let size = size.unwrap_or(0);
-        let array_data = ArrayData::new(
-            DataType::FixedSizeBinary(size as i32),
-            len,
-            None,
-            Some(null_buf.into()),
-            0,
-            vec![buffer.into()],
-            vec![],
-        );
+        let array_data = unsafe {
+            ArrayData::new_unchecked(
+                DataType::FixedSizeBinary(size as i32),
+                len,
+                None,
+                Some(null_buf.into()),
+                0,
+                vec![buffer.into()],
+                vec![],
+            )
+        };
         Ok(FixedSizeBinaryArray::from(array_data))
     }
 

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -212,14 +212,10 @@ impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
             }
         });
 
-        let data = ArrayData::new(
-            DataType::Boolean,
+        let data = ArrayData::new_boolean(
             data_len,
-            None,
             Some(null_buf.into()),
-            0,
-            vec![val_buf.into()],
-            vec![],
+            val_buf.into(),
         );
         BooleanArray::from(data)
     }

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -130,15 +130,18 @@ impl<T: ArrowPrimitiveType> From<ArrayData> for DictionaryArray<T> {
                 panic!("DictionaryArray's data type must match.")
             };
             // create a zero-copy of the keys' data
-            let keys = PrimitiveArray::<T>::from(ArrayData::new(
-                T::DATA_TYPE,
-                data.len(),
-                Some(data.null_count()),
-                data.null_buffer().cloned(),
-                data.offset(),
-                data.buffers().to_vec(),
-                vec![],
-            ));
+            let keys_data = unsafe {
+                ArrayData::new_unchecked(
+                    T::DATA_TYPE,
+                    data.len(),
+                    Some(data.null_count()),
+                    data.null_buffer().cloned(),
+                    data.offset(),
+                    data.buffers().to_vec(),
+                    vec![],
+                )
+            };
+            let keys = PrimitiveArray::<T>::from(keys_data);
             let values = make_array(data.child_data()[0].clone());
             Self {
                 data,

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -124,14 +124,10 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Creates a PrimitiveArray based on an iterator of values without nulls
     pub fn from_iter_values<I: IntoIterator<Item = T::Native>>(iter: I) -> Self {
         let val_buf: Buffer = iter.into_iter().collect();
-        let data = ArrayData::new(
-            T::DATA_TYPE,
+        let data = ArrayData::new_primitive::<T>(
             val_buf.len() / mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
             None,
-            None,
-            0,
-            vec![val_buf],
-            vec![],
+            val_buf,
         );
         PrimitiveArray::from(data)
     }
@@ -140,14 +136,10 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     pub fn from_value(value: T::Native, count: usize) -> Self {
         // # Safety: length is known
         let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
-        let data = ArrayData::new(
-            T::DATA_TYPE,
+        let data = ArrayData::new_primitive::<T>(
             val_buf.len() / mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
             None,
-            None,
-            0,
-            vec![val_buf],
-            vec![],
+            val_buf,
         );
         PrimitiveArray::from(data)
     }
@@ -338,14 +330,10 @@ impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native
             })
             .collect();
 
-        let data = ArrayData::new(
-            T::DATA_TYPE,
+        let data = ArrayData::new_primitive::<T>(
             null_buf.len(),
-            None,
             Some(null_buf.into()),
-            0,
-            vec![buffer],
-            vec![],
+            buffer,
         );
         PrimitiveArray::from(data)
     }
@@ -369,7 +357,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let (null, buffer) = trusted_len_unzip(iterator);
 
         let data =
-            ArrayData::new(T::DATA_TYPE, len, None, Some(null), 0, vec![buffer], vec![]);
+            ArrayData::new_primitive::<T>(len, Some(null), buffer);
         PrimitiveArray::from(data)
     }
 }

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -1150,15 +1150,17 @@ mod tests {
         ]);
         let list_value_offsets =
             Buffer::from_slice_ref(&[0i32, 3, 5, 11, 13, 13, 15, 15, 17]);
-        let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
-            8,
-            None,
-            None,
-            0,
-            vec![list_value_offsets],
-            vec![expected_int_array.data().clone()],
-        );
+        let expected_list_data = unsafe {
+            ArrayData::new_unchecked(
+                DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
+                8,
+                None,
+                None,
+                0,
+                vec![list_value_offsets],
+                vec![expected_int_array.data().clone()],
+            )
+        };
         assert_eq!(finished, expected_list_data);
 
         Ok(())
@@ -1231,15 +1233,17 @@ mod tests {
         ]);
         let list_value_offsets =
             Buffer::from_slice_ref(&[0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23]);
-        let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
-            12,
-            None,
-            Some(Buffer::from(&[0b11011011, 0b1110])),
-            0,
-            vec![list_value_offsets],
-            vec![expected_int_array.data().clone()],
-        );
+        let expected_list_data = unsafe {
+            ArrayData::new_unchecked(
+                DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
+                12,
+                None,
+                Some(Buffer::from(&[0b11011011, 0b1110])),
+                0,
+                vec![list_value_offsets],
+                vec![expected_int_array.data().clone()],
+            )
+        };
         assert_eq!(result, expected_list_data);
 
         Ok(())
@@ -1302,15 +1306,17 @@ mod tests {
             // extend b[0..0]
         ]);
         let list_value_offsets = Buffer::from_slice_ref(&[0, 3, 5, 6, 9, 10, 13]);
-        let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
-            6,
-            None,
-            None,
-            0,
-            vec![list_value_offsets],
-            vec![expected_string_array.data().clone()],
-        );
+        let expected_list_data = unsafe {
+            ArrayData::new_unchecked(
+                DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+                6,
+                None,
+                None,
+                0,
+                vec![list_value_offsets],
+                vec![expected_string_array.data().clone()],
+            )
+        };
         assert_eq!(result, expected_list_data);
         Ok(())
     }

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -182,14 +182,10 @@ where
     //      `values` is an iterator with a known size.
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
+    let data = ArrayData::new_primitive::<T>(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![buffer],
-        vec![],
+        buffer,
     );
     Ok(PrimitiveArray::<T>::from(data))
 }
@@ -250,14 +246,10 @@ where
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     }?;
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
+    let data = ArrayData::new_primitive::<T>(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![buffer],
-        vec![],
+        buffer,
     );
     Ok(PrimitiveArray::<T>::from(data))
 }
@@ -318,14 +310,10 @@ where
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     }?;
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
+    let data = ArrayData::new_primitive::<T>(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![buffer],
-        vec![],
+        buffer,
     );
     Ok(PrimitiveArray::<T>::from(data))
 }

--- a/arrow/src/compute/kernels/arity.rs
+++ b/arrow/src/compute/kernels/arity.rs
@@ -26,17 +26,13 @@ fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
     array: &PrimitiveArray<I>,
     buffer: Buffer,
 ) -> ArrayData {
-    ArrayData::new(
-        O::DATA_TYPE,
+    ArrayData::new_primitive::<O>(
         array.len(),
-        None,
         array
             .data_ref()
             .null_buffer()
             .map(|b| b.bit_slice(array.offset(), array.len())),
-        0,
-        vec![buffer],
-        vec![],
+        buffer,
     )
 }
 

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -691,47 +691,59 @@ pub fn cast_with_options(
         // end numeric casts
 
         // temporal casts
-        (Int32, Date32) => cast_array_data::<Date32Type>(array, to_type.clone()),
+        (Int32, Date32) => unsafe {
+            cast_array_data::<Date32Type>(array, to_type.clone())
+        },
         (Int32, Date64) => cast_with_options(
             &cast_with_options(array, &DataType::Date32, cast_options)?,
             &DataType::Date64,
             cast_options,
         ),
-        (Int32, Time32(TimeUnit::Second)) => {
+        (Int32, Time32(TimeUnit::Second)) => unsafe {
             cast_array_data::<Time32SecondType>(array, to_type.clone())
         }
-        (Int32, Time32(TimeUnit::Millisecond)) => {
+        (Int32, Time32(TimeUnit::Millisecond)) => unsafe {
             cast_array_data::<Time32MillisecondType>(array, to_type.clone())
         }
         // No support for microsecond/nanosecond with i32
-        (Date32, Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
+        (Date32, Int32) => unsafe {
+            cast_array_data::<Int32Type>(array, to_type.clone())
+        },
         (Date32, Int64) => cast_with_options(
             &cast_with_options(array, &DataType::Int32, cast_options)?,
             &DataType::Int64,
             cast_options,
         ),
-        (Time32(_), Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
-        (Int64, Date64) => cast_array_data::<Date64Type>(array, to_type.clone()),
+        (Time32(_), Int32) => unsafe {
+            cast_array_data::<Int32Type>(array, to_type.clone())
+        },
+        (Int64, Date64) => unsafe {
+            cast_array_data::<Date64Type>(array, to_type.clone())
+        },
         (Int64, Date32) => cast_with_options(
             &cast_with_options(array, &DataType::Int32, cast_options)?,
             &DataType::Date32,
             cast_options,
         ),
         // No support for second/milliseconds with i64
-        (Int64, Time64(TimeUnit::Microsecond)) => {
+        (Int64, Time64(TimeUnit::Microsecond)) => unsafe {
             cast_array_data::<Time64MicrosecondType>(array, to_type.clone())
         }
-        (Int64, Time64(TimeUnit::Nanosecond)) => {
+        (Int64, Time64(TimeUnit::Nanosecond)) => unsafe {
             cast_array_data::<Time64NanosecondType>(array, to_type.clone())
         }
 
-        (Date64, Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
+        (Date64, Int64) => unsafe {
+            cast_array_data::<Int64Type>(array, to_type.clone())
+        },
         (Date64, Int32) => cast_with_options(
             &cast_with_options(array, &DataType::Int64, cast_options)?,
             &DataType::Int32,
             cast_options,
         ),
-        (Time64(_), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
+        (Time64(_), Int64) => unsafe {
+            cast_array_data::<Int64Type>(array, to_type.clone())
+        },
         (Date32, Date64) => {
             let date_array = array.as_any().downcast_ref::<Date32Array>().unwrap();
 
@@ -783,14 +795,18 @@ pub fn cast_with_options(
             let array_ref = Arc::new(converted) as ArrayRef;
             use TimeUnit::*;
             match to_unit {
-                Microsecond => cast_array_data::<TimestampMicrosecondType>(
-                    &array_ref,
-                    to_type.clone(),
-                ),
-                Nanosecond => cast_array_data::<TimestampNanosecondType>(
-                    &array_ref,
-                    to_type.clone(),
-                ),
+                Microsecond => unsafe {
+                    cast_array_data::<TimestampMicrosecondType>(
+                        &array_ref,
+                        to_type.clone(),
+                    )
+                },
+                Nanosecond => unsafe {
+                    cast_array_data::<TimestampNanosecondType>(
+                        &array_ref,
+                        to_type.clone(),
+                    )
+                },
                 _ => unreachable!("array type not supported"),
             }
         }
@@ -835,8 +851,10 @@ pub fn cast_with_options(
                 _ => unreachable!("array type not supported"),
             }
         }
-        (Timestamp(_, _), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
-        (Int64, Timestamp(to_unit, _)) => {
+        (Timestamp(_, _), Int64) => unsafe {
+            cast_array_data::<Int64Type>(array, to_type.clone())
+        }
+        (Int64, Timestamp(to_unit, _)) => unsafe {
             use TimeUnit::*;
             match to_unit {
                 Second => cast_array_data::<TimestampSecondType>(array, to_type.clone()),
@@ -871,21 +889,27 @@ pub fn cast_with_options(
             let array_ref = Arc::new(converted) as ArrayRef;
             use TimeUnit::*;
             match to_unit {
-                Second => {
+                Second => unsafe {
                     cast_array_data::<TimestampSecondType>(&array_ref, to_type.clone())
                 }
-                Millisecond => cast_array_data::<TimestampMillisecondType>(
-                    &array_ref,
-                    to_type.clone(),
-                ),
-                Microsecond => cast_array_data::<TimestampMicrosecondType>(
-                    &array_ref,
-                    to_type.clone(),
-                ),
-                Nanosecond => cast_array_data::<TimestampNanosecondType>(
-                    &array_ref,
-                    to_type.clone(),
-                ),
+                Millisecond => unsafe {
+                    cast_array_data::<TimestampMillisecondType>(
+                        &array_ref,
+                        to_type.clone(),
+                    )
+                },
+                Microsecond => unsafe {
+                    cast_array_data::<TimestampMicrosecondType>(
+                        &array_ref,
+                        to_type.clone(),
+                    )
+                },
+                Nanosecond => unsafe {
+                    cast_array_data::<TimestampNanosecondType>(
+                        &array_ref,
+                        to_type.clone(),
+                    )
+                },
             }
         }
         (Timestamp(from_unit, _), Date32) => {
@@ -918,7 +942,7 @@ pub fn cast_with_options(
                         &Date64Array::from(vec![from_size / to_size; array.len()]),
                     )?) as ArrayRef)
                 }
-                std::cmp::Ordering::Equal => {
+                std::cmp::Ordering::Equal => unsafe {
                     cast_array_data::<Date64Type>(array, to_type.clone())
                 }
                 std::cmp::Ordering::Greater => {
@@ -931,7 +955,7 @@ pub fn cast_with_options(
             }
         }
         // date64 to timestamp might not make sense,
-        (Int64, Duration(to_unit)) => {
+        (Int64, Duration(to_unit)) => unsafe {
             use TimeUnit::*;
             match to_unit {
                 Second => cast_array_data::<DurationSecondType>(array, to_type.clone()),
@@ -985,11 +1009,12 @@ const EPOCH_DAYS_FROM_CE: i32 = 719_163;
 /// Arrays should have the same primitive data type, otherwise this should fail.
 /// We do not perform this check on primitive data types as we only use this
 /// function internally, where it is guaranteed to be infallible.
-fn cast_array_data<TO>(array: &ArrayRef, to_type: DataType) -> Result<ArrayRef>
+// Safety: from and to data types must have the same layout
+unsafe fn cast_array_data<TO>(array: &ArrayRef, to_type: DataType) -> Result<ArrayRef>
 where
     TO: ArrowNumericType,
 {
-    let data = ArrayData::new(
+    let data = ArrayData::new_unchecked(
         to_type,
         array.len(),
         Some(array.null_count()),
@@ -1432,19 +1457,21 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
             }
 
             // keys are data, child_data is values (dictionary)
-            let data = ArrayData::new(
-                to_type.clone(),
-                cast_keys.len(),
-                Some(cast_keys.null_count()),
-                cast_keys
-                    .data()
-                    .null_bitmap()
-                    .clone()
-                    .map(|bitmap| bitmap.bits),
-                cast_keys.data().offset(),
-                cast_keys.data().buffers().to_vec(),
-                vec![cast_values.data().clone()],
-            );
+            let data = unsafe {
+                ArrayData::new_unchecked(
+                    to_type.clone(),
+                    cast_keys.len(),
+                    Some(cast_keys.null_count()),
+                    cast_keys
+                        .data()
+                        .null_bitmap()
+                        .clone()
+                        .map(|bitmap| bitmap.bits),
+                    cast_keys.data().offset(),
+                    cast_keys.data().buffers().to_vec(),
+                    vec![cast_values.data().clone()],
+                )
+            };
 
             // create the appropriate array type
             let new_array: ArrayRef = match **to_index_type {
@@ -1648,19 +1675,21 @@ fn cast_primitive_to_list<OffsetSize: OffsetSizeTrait + NumCast>(
         )
     };
 
-    let list_data = ArrayData::new(
-        to_type.clone(),
-        array.len(),
-        Some(cast_array.null_count()),
-        cast_array
-            .data()
-            .null_bitmap()
-            .clone()
-            .map(|bitmap| bitmap.bits),
-        0,
-        vec![offsets.into()],
-        vec![cast_array.data().clone()],
-    );
+    let list_data = unsafe {
+        ArrayData::new_unchecked(
+            to_type.clone(),
+            array.len(),
+            Some(cast_array.null_count()),
+            cast_array
+                .data()
+                .null_bitmap()
+                .clone()
+                .map(|bitmap| bitmap.bits),
+            0,
+            vec![offsets.into()],
+            vec![cast_array.data().clone()],
+        )
+    };
     let list_array =
         Arc::new(GenericListArray::<OffsetSize>::from(list_data)) as ArrayRef;
 
@@ -1677,20 +1706,22 @@ fn cast_list_inner<OffsetSize: OffsetSizeTrait>(
     let data = array.data_ref();
     let underlying_array = make_array(data.child_data()[0].clone());
     let cast_array = cast_with_options(&underlying_array, to.data_type(), cast_options)?;
-    let array_data = ArrayData::new(
-        to_type.clone(),
-        array.len(),
-        Some(cast_array.null_count()),
-        cast_array
-            .data()
-            .null_bitmap()
-            .clone()
-            .map(|bitmap| bitmap.bits),
-        array.offset(),
-        // reuse offset buffer
-        data.buffers().to_vec(),
-        vec![cast_array.data().clone()],
-    );
+    let array_data = unsafe {
+        ArrayData::new_unchecked(
+            to_type.clone(),
+            array.len(),
+            Some(cast_array.null_count()),
+            cast_array
+                .data()
+                .null_bitmap()
+                .clone()
+                .map(|bitmap| bitmap.bits),
+            array.offset(),
+            // reuse offset buffer
+            data.buffers().to_vec(),
+            vec![cast_array.data().clone()],
+        )
+    };
     let list = GenericListArray::<OffsetSize>::from(array_data);
     Ok(Arc::new(list) as ArrayRef)
 }

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -53,14 +53,10 @@ macro_rules! compare_op {
         // same size as $left.len() and $right.len()
         let buffer = unsafe { MutableBuffer::from_trusted_len_iter_bool(comparison) };
 
-        let data = ArrayData::new(
-            DataType::Boolean,
+        let data = ArrayData::new_boolean(
             $left.len(),
-            None,
             null_bit_buffer,
-            0,
-            vec![Buffer::from(buffer)],
-            vec![],
+            Buffer::from(buffer),
         );
         Ok(BooleanArray::from(data))
     }};
@@ -108,14 +104,10 @@ macro_rules! compare_op_primitive {
                     *last |= if $op(lhs, rhs) { 1 << i } else { 0 };
                 });
         };
-        let data = ArrayData::new(
-            DataType::Boolean,
+        let data = ArrayData::new_boolean(
             $left.len(),
-            None,
             null_bit_buffer,
-            0,
-            vec![Buffer::from(values)],
-            vec![],
+            Buffer::from(values),
         );
         Ok(BooleanArray::from(data))
     }};
@@ -135,14 +127,10 @@ macro_rules! compare_op_scalar {
         // same as $left.len()
         let buffer = unsafe { MutableBuffer::from_trusted_len_iter_bool(comparison) };
 
-        let data = ArrayData::new(
-            DataType::Boolean,
+        let data = ArrayData::new_boolean(
             $left.len(),
-            None,
             null_bit_buffer,
-            0,
-            vec![Buffer::from(buffer)],
-            vec![],
+            Buffer::from(buffer),
         );
         Ok(BooleanArray::from(data))
     }};
@@ -175,14 +163,10 @@ macro_rules! compare_op_scalar_primitive {
             });
         };
 
-        let data = ArrayData::new(
-            DataType::Boolean,
+        let data = ArrayData::new_boolean(
             $left.len(),
-            None,
             null_bit_buffer,
-            0,
-            vec![Buffer::from(values)],
-            vec![],
+            Buffer::from(values),
         );
         Ok(BooleanArray::from(data))
     }};
@@ -270,14 +254,10 @@ pub fn like_utf8<OffsetSize: StringOffsetSizeTrait>(
         result.append(re.is_match(haystack));
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![result.finish()],
-        vec![],
+        result.finish(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -340,14 +320,10 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
         }
     };
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![bool_buf.into()],
-        vec![],
+        bool_buf.into(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -392,14 +368,10 @@ pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
         result.append(!re.is_match(haystack));
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![result.finish()],
-        vec![],
+        result.finish(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -445,14 +417,10 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
         }
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![result.finish()],
-        vec![],
+        result.finish(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -530,14 +498,10 @@ pub fn regexp_is_match_utf8<OffsetSize: StringOffsetSizeTrait>(
         })
         .collect::<Result<Vec<()>>>()?;
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         array.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![result.finish()],
-        vec![],
+        result.finish(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -575,14 +539,10 @@ pub fn regexp_is_match_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
         }
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         array.len(),
-        None,
         null_bit_buffer,
-        0,
-        vec![result.finish()],
-        vec![],
+        result.finish(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -1046,14 +1006,10 @@ where
         }
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
         None,
-        None,
-        0,
-        vec![bool_buf.into()],
-        vec![],
+        bool_buf.into(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -1104,14 +1060,10 @@ where
         }
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         left.len(),
         None,
-        None,
-        0,
-        vec![bool_buf.into()],
-        vec![],
+        bool_buf.into(),
     );
     Ok(BooleanArray::from(data))
 }

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -488,14 +488,10 @@ fn sort_boolean(
         }
     }
 
-    let result_data = ArrayData::new(
-        DataType::UInt32,
+    let result_data = ArrayData::new_primitive::<UInt32Type>(
         len,
-        Some(0),
         None,
-        0,
-        vec![result.into()],
-        vec![],
+        result.into(),
     );
 
     UInt32Array::from(result_data)
@@ -574,14 +570,10 @@ where
         }
     }
 
-    let result_data = ArrayData::new(
-        DataType::UInt32,
+    let result_data = ArrayData::new_primitive::<UInt32Type>(
         len,
-        Some(0),
         None,
-        0,
-        vec![result.into()],
-        vec![],
+        result.into(),
     );
 
     UInt32Array::from(result_data)

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -74,18 +74,20 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
         new_values.extend_from_slice(&data[start..start + length]);
     });
 
-    let data = ArrayData::new(
-        <OffsetSize as StringOffsetSizeTrait>::DATA_TYPE,
-        array.len(),
-        None,
-        null_bit_buffer,
-        0,
-        vec![
-            Buffer::from_slice_ref(&new_offsets),
-            Buffer::from_slice_ref(&new_values),
-        ],
-        vec![],
-    );
+    let data = unsafe {
+        ArrayData::new_unchecked(
+            <OffsetSize as StringOffsetSizeTrait>::DATA_TYPE,
+            array.len(),
+            None,
+            null_bit_buffer,
+            0,
+            vec![
+                Buffer::from_slice_ref(&new_offsets),
+                Buffer::from_slice_ref(&new_values),
+            ],
+            vec![],
+        )
+    };
     Ok(make_array(data))
 }
 

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -523,14 +523,10 @@ where
         }
     };
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
+    let data = ArrayData::new_primitive::<T>(
         indices.len(),
-        None,
         nulls,
-        0,
-        vec![buffer],
-        vec![],
+        buffer,
     );
     Ok(PrimitiveArray::<T>::from(data))
 }
@@ -598,14 +594,10 @@ where
         };
     }
 
-    let data = ArrayData::new(
-        DataType::Boolean,
+    let data = ArrayData::new_boolean(
         indices.len(),
-        None,
         nulls,
-        0,
-        vec![val_buf.into()],
-        vec![],
+        val_buf.into(),
     );
     Ok(BooleanArray::from(data))
 }
@@ -884,15 +876,17 @@ where
     let new_keys = take_primitive::<T, I>(values.keys(), indices)?;
     let new_keys_data = new_keys.data_ref();
 
-    let data = ArrayData::new(
-        values.data_type().clone(),
-        new_keys.len(),
-        Some(new_keys_data.null_count()),
-        new_keys_data.null_buffer().cloned(),
-        0,
-        new_keys_data.buffers().to_vec(),
-        values.data().child_data().to_vec(),
-    );
+    let data = unsafe {
+        ArrayData::new_unchecked(
+            values.data_type().clone(),
+            new_keys.len(),
+            Some(new_keys_data.null_count()),
+            new_keys_data.null_buffer().cloned(),
+            0,
+            new_keys_data.buffers().to_vec(),
+            values.data().child_data().to_vec(),
+        )
+    };
 
     Ok(DictionaryArray::<T>::from(data))
 }

--- a/arrow/src/compute/util.rs
+++ b/arrow/src/compute/util.rs
@@ -184,16 +184,20 @@ pub(super) mod tests {
         offset: usize,
         null_bit_buffer: Option<Buffer>,
     ) -> Arc<ArrayData> {
-        // empty vec for buffers and children is not really correct, but for these tests we only care about the null bitmap
-        Arc::new(ArrayData::new(
-            DataType::UInt8,
-            len,
-            None,
-            null_bit_buffer,
-            offset,
-            vec![],
-            vec![],
-        ))
+        if let Some(ref b) = null_bit_buffer {
+            assert!(b.len()*8 >= offset+len);
+        }
+        unsafe {
+            Arc::new(ArrayData::new_unchecked(
+                DataType::UInt8,
+                len,
+                None,
+                null_bit_buffer,
+                offset,
+                vec![Buffer::from(vec![0; offset + len])],
+                vec![],
+            ))
+        }
     }
 
     #[test]

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -477,6 +477,12 @@ impl DataType {
         )
     }
 
+    /// Returns true if this type is numeric: (UInt*, Unit*, or Float*).
+    pub fn is_primitive(t: &DataType) -> bool {
+        use DataType::*;
+        DataType::is_numeric(t) || matches!(t, Time32(_) | Time64(_) | Date32 | Date64 | Timestamp(_, _) | Duration(_) | Interval(_))
+    }
+
     /// Compares the datatype with another, ignoring nested field names
     /// and metadata.
     pub(crate) fn equals_datatype(&self, other: &DataType) -> bool {

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -514,15 +514,17 @@ pub trait ArrowArrayRef {
             .map(|d| d.unwrap())
             .collect();
 
-        Ok(ArrayData::new(
-            data_type,
-            len,
-            Some(null_count),
-            null_bit_buffer,
-            offset,
-            buffers,
-            child_data,
-        ))
+        unsafe {
+            Ok(ArrayData::new_unchecked(
+                data_type,
+                len,
+                Some(null_count),
+                null_bit_buffer,
+                offset,
+                buffers,
+                child_data,
+            ))
+        }
     }
 
     /// returns all buffers, as organized by Rust (i.e. null buffer is skipped)

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1388,26 +1388,28 @@ impl Decoder {
             &[],
         )?;
 
-        Ok(make_array(ArrayData::new(
-            map_type.clone(),
-            rows_len,
-            None,
-            Some(list_bitmap.into()),
-            0,
-            vec![Buffer::from_slice_ref(&list_offsets)],
-            vec![ArrayData::new(
-                struct_field.data_type().clone(),
-                struct_children[0].len(),
+        unsafe {
+            Ok(make_array(ArrayData::new_unchecked(
+                map_type.clone(),
+                rows_len,
                 None,
-                None,
+                Some(list_bitmap.into()),
                 0,
-                vec![],
-                struct_children
-                    .into_iter()
-                    .map(|array| array.data().clone())
-                    .collect(),
-            )],
-        )))
+                vec![Buffer::from_slice_ref(&list_offsets)],
+                vec![ArrayData::new_unchecked(
+                    struct_field.data_type().clone(),
+                    struct_children[0].len(),
+                    None,
+                    None,
+                    0,
+                    vec![],
+                    struct_children
+                        .into_iter()
+                        .map(|array| array.data().clone())
+                        .collect(),
+                )],
+            )))
+        }
     }
 
     #[inline(always)]

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -192,15 +192,17 @@ fn create_random_list_array(
         true => Some(create_random_null_buffer(size, null_density)),
         false => None,
     };
-    let list_data = ArrayData::new(
-        field.data_type().clone(),
-        size,
-        None,
-        null_buffer,
-        0,
-        vec![offsets],
-        vec![child_data.clone()],
-    );
+    let list_data = unsafe {
+        ArrayData::new_unchecked(
+            field.data_type().clone(),
+            size,
+            None,
+            null_buffer,
+            0,
+            vec![offsets],
+            vec![child_data.clone()],
+        )
+    };
     Ok(make_array(list_data))
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Related/complementary to the validation in #810, this PR investigates our usages of `ArrayData::new` and whether they are actually safe. Creating primitive or boolean arrays can be done safely with minimal validation. For other data types this introduces an unsafe `new_unchecked` method for usages in performane critical kernels.

Todo:

- [ ] Add `Safety` annotations to all usages of `new_unchecked` or decide whether to use a safe and validating alternative
- [ ] In debug mode we should validate the buffers even in `new_unchecked`
- [ ] `ArrayDataBuilder::build` needs to be either unsafe or do validation
- [ ] Investigate whether setting a `null_count` that differs from the actual `null_bitmap` violates any invariants

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

"Closes" #806, #704, #705, #706 and possibly #777 since it would be no longer possible to create invalid ArrayData without unsafe code. We shouldn't close those issues without having a safe alternative.

# Rationale for this change

The above mentioned security issues all start by creating `ArrayData` objects that violate the invariants of those arrays. Marking this creation unsafe thus satisfies the rust guidelines.
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The `ArrayData::new` method is removed in this PR but should be reintroduced with full validation of all parameters.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
