### PR TITLE
Separate parquet writer benchmarks

### DIFF
--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -36,26 +36,103 @@ fn create_primitive_bench_batch(
     true_density: f32,
 ) -> Result<RecordBatch> {
     let fields = vec![
-        Field::new("_1", DataType::Int8, true),
-        Field::new("_2", DataType::Int16, true),
-        Field::new("_3", DataType::Int32, true),
-        Field::new("_4", DataType::Int64, true),
-        Field::new("_5", DataType::UInt8, true),
-        Field::new("_6", DataType::UInt16, true),
-        Field::new("_7", DataType::UInt32, true),
-        Field::new("_8", DataType::UInt64, true),
-        Field::new("_9", DataType::Float32, true),
-        Field::new("_10", DataType::Float64, true),
-        Field::new("_11", DataType::Date32, true),
-        Field::new("_12", DataType::Date64, true),
-        Field::new("_13", DataType::Time32(TimeUnit::Second), true),
-        Field::new("_14", DataType::Time32(TimeUnit::Millisecond), true),
-        Field::new("_15", DataType::Time64(TimeUnit::Microsecond), true),
-        Field::new("_16", DataType::Time64(TimeUnit::Nanosecond), true),
-        Field::new("_17", DataType::Utf8, true),
-        Field::new("_18", DataType::LargeUtf8, true),
-        Field::new("_19", DataType::Boolean, true),
+        Field::new("_1", DataType::Int32, true),
+        Field::new("_2", DataType::Int64, true),
+        Field::new("_3", DataType::UInt32, true),
+        Field::new("_4", DataType::UInt64, true),
+        Field::new("_5", DataType::Float32, true),
+        Field::new("_6", DataType::Float64, true),
+        Field::new("_7", DataType::Date64, true),
     ];
+    let schema = Schema::new(fields);
+    Ok(create_random_batch(
+        Arc::new(schema),
+        size,
+        null_density,
+        true_density,
+    )?)
+}
+
+fn create_primitive_bench_batch_non_null(
+    size: usize,
+    null_density: f32,
+    true_density: f32,
+) -> Result<RecordBatch> {
+    let fields = vec![
+        Field::new("_1", DataType::Int32, false),
+        Field::new("_2", DataType::Int64, false),
+        Field::new("_3", DataType::UInt32, false),
+        Field::new("_4", DataType::UInt64, false),
+        Field::new("_5", DataType::Float32, false),
+        Field::new("_6", DataType::Float64, false),
+        Field::new("_7", DataType::Date64, false),
+    ];
+    let schema = Schema::new(fields);
+    Ok(create_random_batch(
+        Arc::new(schema),
+        size,
+        null_density,
+        true_density,
+    )?)
+}
+
+fn create_string_bench_batch(
+    size: usize,
+    null_density: f32,
+    true_density: f32,
+) -> Result<RecordBatch> {
+    let fields = vec![
+        Field::new("_1", DataType::Utf8, true),
+        Field::new("_2", DataType::LargeUtf8, true),
+    ];
+    let schema = Schema::new(fields);
+    Ok(create_random_batch(
+        Arc::new(schema),
+        size,
+        null_density,
+        true_density,
+    )?)
+}
+
+fn create_string_bench_batch_non_null(
+    size: usize,
+    null_density: f32,
+    true_density: f32,
+) -> Result<RecordBatch> {
+    let fields = vec![
+        Field::new("_1", DataType::Utf8, false),
+        Field::new("_2", DataType::LargeUtf8, false),
+    ];
+    let schema = Schema::new(fields);
+    Ok(create_random_batch(
+        Arc::new(schema),
+        size,
+        null_density,
+        true_density,
+    )?)
+}
+
+fn create_bool_bench_batch(
+    size: usize,
+    null_density: f32,
+    true_density: f32,
+) -> Result<RecordBatch> {
+    let fields = vec![Field::new("_1", DataType::Boolean, true)];
+    let schema = Schema::new(fields);
+    Ok(create_random_batch(
+        Arc::new(schema),
+        size,
+        null_density,
+        true_density,
+    )?)
+}
+
+fn create_bool_bench_batch_non_null(
+    size: usize,
+    null_density: f32,
+    true_density: f32,
+) -> Result<RecordBatch> {
+    let fields = vec![Field::new("_1", DataType::Boolean, false)];
     let schema = Schema::new(fields);
     Ok(create_random_batch(
         Arc::new(schema),
@@ -148,18 +225,8 @@ fn write_batch(batch: &RecordBatch) -> Result<()> {
 }
 
 fn bench_primitive_writer(c: &mut Criterion) {
-    let batch = create_primitive_bench_batch(1024, 0.25, 0.75).unwrap();
-    let mut group = c.benchmark_group("write_batch primitive");
-    group.throughput(Throughput::Bytes(
-        batch
-            .columns()
-            .iter()
-            .map(|f| f.get_array_memory_size() as u64)
-            .sum(),
-    ));
-    group.bench_function("1024 values", |b| b.iter(|| write_batch(&batch).unwrap()));
-
     let batch = create_primitive_bench_batch(4096, 0.25, 0.75).unwrap();
+    let mut group = c.benchmark_group("write_batch");
     group.throughput(Throughput::Bytes(
         batch
             .columns()
@@ -167,14 +234,76 @@ fn bench_primitive_writer(c: &mut Criterion) {
             .map(|f| f.get_array_memory_size() as u64)
             .sum(),
     ));
-    group.bench_function("4096 values", |b| b.iter(|| write_batch(&batch).unwrap()));
+    group.bench_function("4096 values primitive", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
+
+    let batch = create_primitive_bench_batch_non_null(4096, 0.25, 0.75).unwrap();
+    group.throughput(Throughput::Bytes(
+        batch
+            .columns()
+            .iter()
+            .map(|f| f.get_array_memory_size() as u64)
+            .sum(),
+    ));
+    group.bench_function("4096 values primitive non-null", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
+
+    let batch = create_bool_bench_batch(4096, 0.25, 0.75).unwrap();
+    group.throughput(Throughput::Bytes(
+        batch
+            .columns()
+            .iter()
+            .map(|f| f.get_array_memory_size() as u64)
+            .sum(),
+    ));
+    group.bench_function("4096 values bool", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
+
+    let batch = create_bool_bench_batch_non_null(4096, 0.25, 0.75).unwrap();
+    group.throughput(Throughput::Bytes(
+        batch
+            .columns()
+            .iter()
+            .map(|f| f.get_array_memory_size() as u64)
+            .sum(),
+    ));
+    group.bench_function("4096 values bool non-null", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
+
+    let batch = create_string_bench_batch(4096, 0.25, 0.75).unwrap();
+    group.throughput(Throughput::Bytes(
+        batch
+            .columns()
+            .iter()
+            .map(|f| f.get_array_memory_size() as u64)
+            .sum(),
+    ));
+    group.bench_function("4096 values string", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
+
+    let batch = create_string_bench_batch_non_null(4096, 0.25, 0.75).unwrap();
+    group.throughput(Throughput::Bytes(
+        batch
+            .columns()
+            .iter()
+            .map(|f| f.get_array_memory_size() as u64)
+            .sum(),
+    ));
+    group.bench_function("4096 values string non-null", |b| {
+        b.iter(|| write_batch(&batch).unwrap())
+    });
 
     group.finish();
 }
 
 // This bench triggers a write error, it is ignored for now
 fn _bench_nested_writer(c: &mut Criterion) {
-    let batch = _create_nested_bench_batch(1024, 0.25, 0.75).unwrap();
+    let batch = _create_nested_bench_batch(4096, 0.25, 0.75).unwrap();
     let mut group = c.benchmark_group("write_batch nested");
     group.throughput(Throughput::Bytes(
         batch
@@ -183,7 +312,7 @@ fn _bench_nested_writer(c: &mut Criterion) {
             .map(|f| f.get_array_memory_size() as u64)
             .sum(),
     ));
-    group.bench_function("1024 values", |b| b.iter(|| write_batch(&batch).unwrap()));
+    group.bench_function("4096 values", |b| b.iter(|| write_batch(&batch).unwrap()));
 
     let batch = create_primitive_bench_batch(4096, 0.25, 0.75).unwrap();
     group.throughput(Throughput::Bytes(


### PR DESCRIPTION
# Which issue does this PR close?

Not yet created


# Rationale for this change
 
I've been tracking a tricky nested list write bug, and because I've been away for a while, I've got a lot of changes that I've made, and would like to commit them bit by bit so I can complete the list bug from a clean slate.

This PR just splits benchmarks better so it's easier to see regressions for specific data type writers.

# What changes are included in this PR?

Splits the `arrow_writer` benchmarks in parquet into several smaller benchmarks.

# Are there any user-facing changes?

No
