### PR TITLE
Add support for parsing timezone using chrono-tz

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -47,6 +47,7 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
+chrono-tz = {version = "0.4", optional = true}
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"
 comfy-table = { version = "4.0", optional = true, default-features = false }

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -42,6 +42,7 @@ The arrow crate provides the following features which may be enabled:
 - `simd` - (_Requires Nightly Rust_) alternate optimized
   implementations of some [compute](https://github.com/apache/arrow/tree/master/rust/arrow/src/compute)
   kernels using explicit SIMD processor intrinsics.
+- `chrono-tz` - support of parsing timezone using [chrono-tz](https://docs.rs/chrono-tz/0.6.0/chrono_tz/)
 
 ## Safety
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #500 

# Rationale for this change
This is the 2nd part of the change as expected by the issue. The first part was done in #771  

# What changes are included in this PR?
The PR implements parsing of tz using the chrono-tz optional dependency. Without this tz of the form eg:Europe/Berlin are considered an error.
 
# Are there any user-facing changes?
Yes. There is a new feature. Not sure how it should be documented.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
