### PR TITLE
Update version to 7.0.0-SNAPSHOT

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-flight"
 description = "Apache Arrow Flight"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 edition = "2018"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-rs"
@@ -26,7 +26,7 @@ repository = "https://github.com/apache/arrow-rs"
 license = "Apache-2.0"
 
 [dependencies]
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT" }
+arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT" }
 base64 = "0.13"
 tonic = "0.5"
 bytes = "1"

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-pyarrow-integration-testing"
 description = ""
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -31,7 +31,7 @@ name = "arrow_pyarrow_integration_testing"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", features = ["pyarrow"] }
+arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT", features = ["pyarrow"] }
 pyo3 = { version = "0.14", features = ["extension-module"] }
 
 [package.metadata.maturin]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "arrow"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 description = "Rust implementation of Apache Arrow"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"

--- a/arrow/test/dependency/default-features/Cargo.toml
+++ b/arrow/test/dependency/default-features/Cargo.toml
@@ -24,6 +24,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { path = "../../../../arrow", version = "6.0.0-SNAPSHOT" }
+arrow = { path = "../../../../arrow", version = "7.0.0-SNAPSHOT" }
 
 [workspace]

--- a/arrow/test/dependency/no-default-features/Cargo.toml
+++ b/arrow/test/dependency/no-default-features/Cargo.toml
@@ -24,6 +24,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { path = "../../../../arrow", version = "6.0.0-SNAPSHOT", default-features = false }
+arrow = { path = "../../../../arrow", version = "7.0.0-SNAPSHOT", default-features = false }
 
 [workspace]

--- a/arrow/test/dependency/simd/Cargo.toml
+++ b/arrow/test/dependency/simd/Cargo.toml
@@ -24,6 +24,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { path = "../../../../arrow", version = "6.0.0-SNAPSHOT", features = ["simd"]}
+arrow = { path = "../../../../arrow", version = "7.0.0-SNAPSHOT", features = ["simd"]}
 
 [workspace]

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "arrow-integration-testing"
 description = "Binaries used in the Arrow integration tests"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 license = "Apache-2.0"
 description = "Apache Parquet implementation in Rust"
 homepage = "https://github.com/apache/arrow-rs"
@@ -41,7 +41,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.9", optional = true }
 chrono = "0.4"
 num-bigint = "0.4"
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT", optional = true, default-features = false }
+arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 clap = { version = "2.33.3", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
@@ -54,7 +54,7 @@ snap = "1.0"
 brotli = "3.3"
 flate2 = "1.0"
 lz4 = "1.23"
-arrow = { path = "../arrow", version = "6.0.0-SNAPSHOT" }
+arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]

--- a/parquet_derive/Cargo.toml
+++ b/parquet_derive/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet_derive"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 license = "Apache-2.0"
 description = "Derive macros for the Rust implementation of Apache Parquet"
 homepage = "https://github.com/apache/arrow-rs"
@@ -34,4 +34,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-parquet = { path = "../parquet", version = "6.0.0-SNAPSHOT" }
+parquet = { path = "../parquet", version = "7.0.0-SNAPSHOT" }

--- a/parquet_derive/README.md
+++ b/parquet_derive/README.md
@@ -30,8 +30,8 @@ Derive also has some support for the chrono time library. You must must enable t
 Add this to your Cargo.toml:
 ```toml
 [dependencies]
-parquet = "6.0.0-SNAPSHOT"
-parquet_derive = "6.0.0-SNAPSHOT"
+parquet = "7.0.0-SNAPSHOT"
+parquet_derive = "7.0.0-SNAPSHOT"
 ```
 
 and this to your crate root:

--- a/parquet_derive_test/Cargo.toml
+++ b/parquet_derive_test/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet_derive_test"
-version = "6.0.0-SNAPSHOT"
+version = "7.0.0-SNAPSHOT"
 license = "Apache-2.0"
 description = "Integration test package for parquet-derive"
 homepage = "https://github.com/apache/arrow-rs"
@@ -28,6 +28,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-parquet = { path = "../parquet", version = "6.0.0-SNAPSHOT" }
-parquet_derive = { path = "../parquet_derive", version = "6.0.0-SNAPSHOT" }
+parquet = { path = "../parquet", version = "7.0.0-SNAPSHOT" }
+parquet_derive = { path = "../parquet_derive", version = "7.0.0-SNAPSHOT" }
 chrono = "0.4.19"


### PR DESCRIPTION
Prepares master for 7.0.0 development. https://github.com/apache/arrow-rs/pull/828 changes the version on `active_release` to be 6.0.0