### PR TITLE
fix(ipc): Support serializing structs containing dictionaries

### DIFF
--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -779,13 +779,14 @@ mod tests {
                 ),
                 Field::new(
                     "struct<dictionary<int32, utf8>>",
-                    DataType::Struct(vec![
-                        Field::new("dictionary<int32, utf8>",
-                                   DataType::Dictionary(
-                                       Box::new(DataType::Int32),
-                                       Box::new(DataType::Utf8)),
-                                       false),
-                    ]),
+                    DataType::Struct(vec![Field::new(
+                        "dictionary<int32, utf8>",
+                        DataType::Dictionary(
+                            Box::new(DataType::Int32),
+                            Box::new(DataType::Utf8),
+                        ),
+                        false,
+                    )]),
                     false,
                 ),
                 Field::new(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #847 and is a part of #846.

# What changes are included in this PR?

Dictionary fields nested in structs are not properly marked as dictionary fields when serializing a schema to FB. This PR fixes that issue and adds a new test case.