### PR TITLE
Cherry pick [Minor] Fix clippy errors with new rust version (1.56) and float formatting with nightly to active_release

### DIFF
--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -2340,35 +2340,41 @@ mod tests {
         let f64_array: ArrayRef = Arc::new(Float64Array::from(f64_values));
 
         let f64_expected = vec![
-            "-9223372036854776000.0",
-            "-2147483648.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967295.0",
-            "18446744073709552000.0",
+            -9223372036854776000.0,
+            -2147483648.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            255.0,
+            65535.0,
+            4294967295.0,
+            18446744073709552000.0,
         ];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&f64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
         let f32_expected = vec![
-            "-9223372000000000000.0",
-            "-2147483600.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967300.0",
-            "18446744000000000000.0",
+            -9223372000000000000.0,
+            -2147483600.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            255.0,
+            65535.0,
+            4294967300.0,
+            18446744000000000000.0,
         ];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&f64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec![
@@ -2615,28 +2621,24 @@ mod tests {
         ];
         let u64_array: ArrayRef = Arc::new(UInt64Array::from(u64_values));
 
-        let f64_expected = vec![
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967295.0",
-            "18446744073709552000.0",
-        ];
+        let f64_expected =
+            vec![0.0, 255.0, 65535.0, 4294967295.0, 18446744073709552000.0];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&u64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
-        let f32_expected = vec![
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967300.0",
-            "18446744000000000000.0",
-        ];
+        let f32_expected =
+            vec![0.0, 255.0, 65535.0, 4294967300.0, 18446744000000000000.0];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&u64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec!["0", "255", "65535", "4294967295", "null"];
@@ -2908,35 +2910,41 @@ mod tests {
         let i64_array: ArrayRef = Arc::new(Int64Array::from(i64_values));
 
         let f64_expected = vec![
-            "-9223372036854776000.0",
-            "-2147483648.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "127.0",
-            "32767.0",
-            "2147483647.0",
-            "9223372036854776000.0",
+            -9223372036854776000.0,
+            -2147483648.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            127.0,
+            32767.0,
+            2147483647.0,
+            9223372036854776000.0,
         ];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&i64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
         let f32_expected = vec![
-            "-9223372000000000000.0",
-            "-2147483600.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "127.0",
-            "32767.0",
-            "2147483600.0",
-            "9223372000000000000.0",
+            -9223372000000000000.0,
+            -2147483600.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            127.0,
+            32767.0,
+            2147483600.0,
+            9223372000000000000.0,
         ];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&i64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec![

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -347,18 +347,7 @@ fn create_list_array(
     buffers: &[Buffer],
     child_array: ArrayRef,
 ) -> ArrayRef {
-    if let DataType::List(_) = *data_type {
-        let null_count = field_node.null_count() as usize;
-        let mut builder = ArrayData::builder(data_type.clone())
-            .len(field_node.length() as usize)
-            .buffers(buffers[1..2].to_vec())
-            .offset(0)
-            .child_data(vec![child_array.data().clone()]);
-        if null_count > 0 {
-            builder = builder.null_bit_buffer(buffers[0].clone())
-        }
-        make_array(unsafe { builder.build_unchecked() })
-    } else if let DataType::LargeList(_) = *data_type {
+    if let DataType::List(_) | DataType::LargeList(_) = *data_type {
         let null_count = field_node.null_count() as usize;
         let mut builder = ArrayData::builder(data_type.clone())
             .len(field_node.length() as usize)

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -371,19 +371,14 @@ impl<'a> Parser<'a> {
                                     "Failed to parse scale for DECIMAL type",
                                 )?;
                                 assert_token(self.tokenizer.next(), ")")?;
-                                logical = Some(LogicalType::DECIMAL(DecimalType {
-                                    scale,
-                                    precision,
-                                }));
-                                converted = ConvertedType::from(logical.clone());
                             } else {
-                                scale = 0;
-                                logical = Some(LogicalType::DECIMAL(DecimalType {
-                                    scale,
-                                    precision,
-                                }));
-                                converted = ConvertedType::from(logical.clone());
+                                scale = 0
                             }
+                            logical = Some(LogicalType::DECIMAL(DecimalType {
+                                scale,
+                                precision,
+                            }));
+                            converted = ConvertedType::from(logical.clone());
                         }
                     }
                     LogicalType::TIME(_) => {


### PR DESCRIPTION
Automatic cherry-pick of bd9d561a66a685ce94e968cc03fa250b186e0e2d
* Originally appeared in https://github.com/apache/arrow-rs/pull/845: [Minor] Fix clippy errors with new rust version (1.56) and float formatting with nightly
