### PR TITLE
Cherry pick Force fresh cargo cache key in CI to active_release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: /github/home/.cargo
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
@@ -91,7 +91,7 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
@@ -148,7 +148,7 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
@@ -223,7 +223,7 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
@@ -320,7 +320,7 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
@@ -361,7 +361,7 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Automatic cherry-pick of 491e564
* Originally appeared in https://github.com/apache/arrow-rs/pull/839: Force fresh cargo cache key in CI
