### PR TITLE
Cherry pick fix(ipc): Support serializing structs containing dictionaries to active_release

### DIFF
--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -610,21 +610,7 @@ pub(crate) fn get_fb_field_type<'a>(
             // struct's fields are children
             let mut children = vec![];
             for field in fields {
-                let inner_types =
-                    get_fb_field_type(field.data_type(), field.is_nullable(), fbb);
-                let field_name = fbb.create_string(field.name());
-                children.push(ipc::Field::create(
-                    fbb,
-                    &ipc::FieldArgs {
-                        name: Some(field_name),
-                        nullable: field.is_nullable(),
-                        type_type: inner_types.type_type,
-                        type_: Some(inner_types.type_),
-                        dictionary: None,
-                        children: inner_types.children,
-                        custom_metadata: None,
-                    },
-                ));
+                children.push(build_field(fbb, field));
             }
             FBFieldType {
                 type_type: ipc::Type::Struct_,
@@ -789,6 +775,18 @@ mod tests {
                         ]),
                         true,
                     ))),
+                    false,
+                ),
+                Field::new(
+                    "struct<dictionary<int32, utf8>>",
+                    DataType::Struct(vec![Field::new(
+                        "dictionary<int32, utf8>",
+                        DataType::Dictionary(
+                            Box::new(DataType::Int32),
+                            Box::new(DataType::Utf8),
+                        ),
+                        false,
+                    )]),
                     false,
                 ),
                 Field::new(


### PR DESCRIPTION
Automatic cherry-pick of e44f1ad
* Originally appeared in https://github.com/apache/arrow-rs/pull/848: fix(ipc): Support serializing structs containing dictionaries
