### PR TITLE
Fix instances of UB that cause tests to not pass under miri

### DIFF
--- a/parquet/src/util/bit_packing.rs
+++ b/parquet/src/util/bit_packing.rs
@@ -79,3584 +79,3584 @@ unsafe fn nullunpacker32(in_buf: *const u32, mut out: *mut u32) -> *const u32 {
 }
 
 unsafe fn unpack1_32(in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) & 1;
+    *out = (in_buf.read_unaligned()) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 1) & 1;
+    *out = ((in_buf.read_unaligned()) >> 1) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) & 1;
+    *out = ((in_buf.read_unaligned()) >> 2) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 3) & 1;
+    *out = ((in_buf.read_unaligned()) >> 3) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) & 1;
+    *out = ((in_buf.read_unaligned()) >> 4) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) & 1;
+    *out = ((in_buf.read_unaligned()) >> 5) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) & 1;
+    *out = ((in_buf.read_unaligned()) >> 6) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) & 1;
+    *out = ((in_buf.read_unaligned()) >> 7) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) & 1;
+    *out = ((in_buf.read_unaligned()) >> 8) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) & 1;
+    *out = ((in_buf.read_unaligned()) >> 9) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) & 1;
+    *out = ((in_buf.read_unaligned()) >> 10) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) & 1;
+    *out = ((in_buf.read_unaligned()) >> 11) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) & 1;
+    *out = ((in_buf.read_unaligned()) >> 12) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) & 1;
+    *out = ((in_buf.read_unaligned()) >> 13) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) & 1;
+    *out = ((in_buf.read_unaligned()) >> 14) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) & 1;
+    *out = ((in_buf.read_unaligned()) >> 15) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) & 1;
+    *out = ((in_buf.read_unaligned()) >> 16) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) & 1;
+    *out = ((in_buf.read_unaligned()) >> 17) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) & 1;
+    *out = ((in_buf.read_unaligned()) >> 18) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) & 1;
+    *out = ((in_buf.read_unaligned()) >> 19) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) & 1;
+    *out = ((in_buf.read_unaligned()) >> 20) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) & 1;
+    *out = ((in_buf.read_unaligned()) >> 21) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) & 1;
+    *out = ((in_buf.read_unaligned()) >> 22) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) & 1;
+    *out = ((in_buf.read_unaligned()) >> 23) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) & 1;
+    *out = ((in_buf.read_unaligned()) >> 24) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) & 1;
+    *out = ((in_buf.read_unaligned()) >> 25) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) & 1;
+    *out = ((in_buf.read_unaligned()) >> 26) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 27) & 1;
+    *out = ((in_buf.read_unaligned()) >> 27) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) & 1;
+    *out = ((in_buf.read_unaligned()) >> 28) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 29) & 1;
+    *out = ((in_buf.read_unaligned()) >> 29) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 30) & 1;
+    *out = ((in_buf.read_unaligned()) >> 30) & 1;
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack2_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 2);
+    *out = (in_buf.read_unaligned()) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 2);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
-    *out = (*in_buf) % (1u32 << 2);
+    *out = (in_buf.read_unaligned()) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 2);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack3_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 3);
+    *out = (in_buf.read_unaligned()) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 3) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 27) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 27) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (3 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (3 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 25) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (3 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (3 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack4_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack5_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 5);
+    *out = (in_buf.read_unaligned()) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 25) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (5 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (5 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 5);
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (5 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (5 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (5 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (5 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (5 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (5 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack6_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 6);
+    *out = (in_buf.read_unaligned()) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (6 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (6 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (6 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (6 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 6);
+    *out = (in_buf.read_unaligned()) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (6 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (6 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (6 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (6 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack7_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 7);
+    *out = (in_buf.read_unaligned()) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (7 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (7 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (7 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (7 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (7 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (7 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (7 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (7 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (7 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (7 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (7 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (7 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack8_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack9_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 9);
+    *out = (in_buf.read_unaligned()) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (9 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (9 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (9 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (9 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (9 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (9 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (9 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (9 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (9 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (9 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (9 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (9 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (9 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (9 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (9 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (9 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack10_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 10);
+    *out = (in_buf.read_unaligned()) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (10 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (10 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (10 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (10 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (10 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (10 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (10 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (10 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 10);
+    *out = (in_buf.read_unaligned()) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (10 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (10 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (10 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (10 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (10 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (10 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (10 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (10 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack11_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 11);
+    *out = (in_buf.read_unaligned()) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (11 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (11 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (11 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (11 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (11 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (11 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (11 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (11 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (11 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (11 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (11 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (11 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (11 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (11 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (11 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (11 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (11 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (11 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (11 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (11 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack12_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 12);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 20;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack13_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 13);
+    *out = (in_buf.read_unaligned()) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (13 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (13 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (13 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (13 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (13 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (13 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (13 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (13 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (13 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (13 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (13 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (13 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (13 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (13 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (13 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (13 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (13 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (13 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (13 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (13 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (13 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (13 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (13 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (13 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack14_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 14);
+    *out = (in_buf.read_unaligned()) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (14 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (14 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (14 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (14 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (14 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (14 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (14 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (14 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (14 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (14 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (14 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (14 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 14);
+    *out = (in_buf.read_unaligned()) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (14 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (14 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (14 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (14 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (14 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (14 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (14 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (14 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (14 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (14 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (14 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (14 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack15_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 15);
+    *out = (in_buf.read_unaligned()) % (1u32 << 15);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (15 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (15 - 13);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 13) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (15 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (15 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (15 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (15 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (15 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (15 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (15 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (15 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (15 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (15 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (15 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (15 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 15);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (15 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (15 - 14);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 14) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (15 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (15 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (15 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (15 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (15 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (15 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (15 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (15 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (15 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (15 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (15 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (15 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack16_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack17_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 17);
+    *out = (in_buf.read_unaligned()) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (17 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (17 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (17 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (17 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (17 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (17 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (17 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (17 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (17 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (17 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (17 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (17 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (17 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (17 - 14);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 14) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (17 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (17 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (17 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (17 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (17 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (17 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (17 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (17 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (17 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (17 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (17 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (17 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (17 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (17 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (17 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (17 - 13);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 13) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (17 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (17 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack18_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 18);
+    *out = (in_buf.read_unaligned()) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (18 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (18 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (18 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (18 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (18 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (18 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (18 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (18 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (18 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (18 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (18 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (18 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (18 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (18 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (18 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (18 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 18);
+    *out = (in_buf.read_unaligned()) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (18 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (18 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (18 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (18 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (18 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (18 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (18 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (18 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (18 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (18 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (18 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (18 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (18 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (18 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (18 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (18 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack19_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 19);
+    *out = (in_buf.read_unaligned()) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (19 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (19 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (19 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (19 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (19 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (19 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (19 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (19 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (19 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (19 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (19 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (19 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (19 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (19 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (19 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (19 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (19 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (19 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (19 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (19 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (19 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (19 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (19 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (19 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (19 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (19 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (19 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (19 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (19 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (19 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (19 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (19 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (19 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (19 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (19 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (19 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack20_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 12;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack21_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 21);
+    *out = (in_buf.read_unaligned()) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (21 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (21 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (21 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (21 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (21 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (21 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (21 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (21 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (21 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (21 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (21 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (21 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (21 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (21 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (21 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (21 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (21 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (21 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (21 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (21 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (21 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (21 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (21 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (21 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (21 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (21 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (21 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (21 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (21 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (21 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (21 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (21 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (21 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (21 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (21 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (21 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (21 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (21 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (21 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (21 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack22_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 22);
+    *out = (in_buf.read_unaligned()) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (22 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (22 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (22 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (22 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (22 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (22 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (22 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (22 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (22 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (22 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (22 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (22 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (22 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (22 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (22 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (22 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (22 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (22 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (22 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (22 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 22);
+    *out = (in_buf.read_unaligned()) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (22 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (22 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (22 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (22 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (22 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (22 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (22 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (22 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (22 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (22 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (22 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (22 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (22 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (22 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (22 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (22 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (22 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (22 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (22 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (22 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack23_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 23);
+    *out = (in_buf.read_unaligned()) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (23 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (23 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (23 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (23 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (23 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (23 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (23 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (23 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (23 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (23 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (23 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (23 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (23 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (23 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (23 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (23 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (23 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (23 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (23 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (23 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (23 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (23 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (23 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (23 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (23 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (23 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (23 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (23 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (23 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (23 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (23 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (23 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (23 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (23 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (23 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (23 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (23 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (23 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (23 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (23 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (23 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (23 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (23 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (23 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack24_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack25_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 25);
+    *out = (in_buf.read_unaligned()) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (25 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (25 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (25 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (25 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (25 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (25 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (25 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (25 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (25 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (25 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (25 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (25 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (25 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (25 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (25 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (25 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (25 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (25 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (25 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (25 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (25 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (25 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (25 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (25 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (25 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (25 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (25 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (25 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (25 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (25 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (25 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (25 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (25 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (25 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (25 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (25 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (25 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (25 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (25 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (25 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (25 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (25 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (25 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (25 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (25 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (25 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (25 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (25 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack26_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 26);
+    *out = (in_buf.read_unaligned()) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (26 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (26 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (26 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (26 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (26 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (26 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (26 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (26 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (26 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (26 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (26 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (26 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (26 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (26 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (26 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (26 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (26 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (26 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (26 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (26 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (26 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (26 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (26 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (26 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 26);
+    *out = (in_buf.read_unaligned()) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (26 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (26 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (26 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (26 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (26 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (26 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (26 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (26 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (26 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (26 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (26 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (26 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (26 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (26 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (26 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (26 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (26 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (26 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (26 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (26 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (26 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (26 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (26 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (26 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack27_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 27);
+    *out = (in_buf.read_unaligned()) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (27 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (27 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (27 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (27 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (27 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (27 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (27 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (27 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (27 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (27 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (27 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (27 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (27 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (27 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (27 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (27 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (27 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (27 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (27 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (27 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (27 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (27 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (27 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (27 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (27 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (27 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (27 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (27 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (27 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (27 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (27 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (27 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (27 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (27 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (27 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (27 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (27 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (27 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (27 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (27 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (27 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (27 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (27 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (27 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (27 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (27 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (27 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (27 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (27 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (27 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (27 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (27 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack28_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 28);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 12;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 12;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 4;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack29_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 29);
+    *out = (in_buf.read_unaligned()) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (29 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (29 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (29 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (29 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (29 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (29 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (29 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (29 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (29 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (29 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (29 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (29 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (29 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (29 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (29 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (29 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (29 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (29 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 29);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (29 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (29 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (29 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (29 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (29 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (29 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (29 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (29 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (29 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (29 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (29 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (29 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (29 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (29 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (29 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (29 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (29 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (29 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (29 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (29 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 29);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 27)) << (29 - 27);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 27)) << (29 - 27);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (29 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (29 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (29 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (29 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (29 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (29 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (29 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (29 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (29 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (29 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (29 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (29 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (29 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (29 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (29 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (29 - 3);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 3;
+    *out = (in_buf.read_unaligned()) >> 3;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack30_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 30);
+    *out = (in_buf.read_unaligned()) % (1u32 << 30);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (30 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (30 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (30 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (30 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (30 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (30 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (30 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (30 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (30 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (30 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (30 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (30 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (30 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (30 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (30 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (30 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (30 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (30 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (30 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (30 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (30 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (30 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (30 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (30 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (30 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (30 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (30 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (30 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 30);
+    *out = (in_buf.read_unaligned()) % (1u32 << 30);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (30 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (30 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (30 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (30 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (30 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (30 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (30 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (30 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (30 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (30 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (30 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (30 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (30 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (30 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (30 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (30 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (30 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (30 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (30 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (30 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (30 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (30 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (30 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (30 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (30 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (30 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (30 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (30 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack31_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 31);
+    *out = (in_buf.read_unaligned()) % (1u32 << 31);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 30)) << (31 - 30);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 30)) << (31 - 30);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 29)) << (31 - 29);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 29)) << (31 - 29);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (31 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (31 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 27)) << (31 - 27);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 27)) << (31 - 27);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (31 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (31 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (31 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (31 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (31 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (31 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (31 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (31 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (31 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (31 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (31 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (31 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (31 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (31 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (31 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (31 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (31 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (31 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (31 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (31 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (31 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (31 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (31 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (31 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (31 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (31 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (31 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (31 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (31 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (31 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (31 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (31 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (31 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (31 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (31 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (31 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (31 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (31 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (31 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (31 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (31 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (31 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (31 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (31 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (31 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (31 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (31 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (31 - 3);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 3;
+    *out = (in_buf.read_unaligned()) >> 3;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (31 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (31 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (31 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (31 - 1);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 1;
+    *out = (in_buf.read_unaligned()) >> 1;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack32_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
 
     in_buf.offset(1)
 }

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -554,7 +554,6 @@ impl BitReader {
         unsafe {
             let in_buf = &self.buffer.data()[self.byte_offset..];
             let mut in_ptr = in_buf as *const [u8] as *const u8 as *const u32;
-            // FIXME assert!(memory::is_ptr_aligned(in_ptr));
             if size_of::<T>() == 4 {
                 while values_to_read - i >= 32 {
                     let out_ptr = &mut batch[i..] as *mut [T] as *mut T as *mut u32;

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -51,16 +51,15 @@ const MURMUR_R: i32 = 47;
 ///
 /// SAFTETY Only safe on platforms which support unaligned loads (like x86_64)
 unsafe fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
+    use std::convert::TryInto;
     let len = data_bytes.len();
     let len_64 = (len / 8) * 8;
-    let data_bytes_64 = std::slice::from_raw_parts(
-        &data_bytes[0..len_64] as *const [u8] as *const u64,
-        len / 8,
-    );
 
     let mut h = seed ^ (MURMUR_PRIME.wrapping_mul(data_bytes.len() as u64));
-    for v in data_bytes_64 {
-        let mut k = *v;
+    for mut k in data_bytes
+        .chunks_exact(8)
+        .map(|chunk| u64::from_ne_bytes(chunk.try_into().unwrap()))
+    {
         k = k.wrapping_mul(MURMUR_PRIME);
         k ^= k >> MURMUR_R;
         k = k.wrapping_mul(MURMUR_PRIME);

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -25,9 +25,9 @@ pub fn hash<T: AsBytes>(data: &T, seed: u32) -> u32 {
 
 fn hash_(data: &[u8], seed: u32) -> u32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
+    {
         if is_x86_feature_detected!("sse4.2") {
-            crc32_hash(data, seed)
+            unsafe { crc32_hash(data, seed) }
         } else {
             murmur_hash2_64a(data, seed as u64) as u32
         }
@@ -39,7 +39,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         target_arch = "riscv64",
         target_arch = "wasm32"
     ))]
-    unsafe {
+    {
         murmur_hash2_64a(data, seed as u64) as u32
     }
 }
@@ -48,9 +48,7 @@ const MURMUR_PRIME: u64 = 0xc6a4a7935bd1e995;
 const MURMUR_R: i32 = 47;
 
 /// Rust implementation of MurmurHash2, 64-bit version for 64-bit platforms
-///
-/// SAFTETY Only safe on platforms which support unaligned loads (like x86_64)
-unsafe fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
+fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
     use std::convert::TryInto;
     let len = data_bytes.len();
     let len_64 = (len / 8) * 8;
@@ -145,16 +143,14 @@ mod tests {
 
     #[test]
     fn test_murmur2_64a() {
-        unsafe {
-            let result = murmur_hash2_64a(b"hello", 123);
-            assert_eq!(result, 2597646618390559622);
+        let result = murmur_hash2_64a(b"hello", 123);
+        assert_eq!(result, 2597646618390559622);
 
-            let result = murmur_hash2_64a(b"helloworld", 123);
-            assert_eq!(result, 4934371746140206573);
+        let result = murmur_hash2_64a(b"helloworld", 123);
+        assert_eq!(result, 4934371746140206573);
 
-            let result = murmur_hash2_64a(b"helloworldparquet", 123);
-            assert_eq!(result, 2392198230801491746);
-        }
+        let result = murmur_hash2_64a(b"helloworldparquet", 123);
+        assert_eq!(result, 2392198230801491746);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/877.

# What changes are included in this PR?
This fixes the UB in the parquet `bit_util` modules by explicitly doing unaligned reads. This also fixes the UB in `murmur_hash2_64a` by converting groups of `u8` into `u64` with a mechanism that does not require unsafe code.

# Are there any user-facing changes?
There are no API changes. The performance impact is mixed. It's a bit hard to imagine how this makes anything faster, but comforting that not all changes are regressions and none are major.
<details><summary>cargo bench --all-features before/after</summary>

arrow_array_reader/read Int32Array, plain encoded, mandatory, no NULLs - old
                        time:   [3.9834 us 3.9850 us 3.9867 us]
                        change: [-1.1683% -1.1126% -1.0585%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
arrow_array_reader/read Int32Array, plain encoded, mandatory, no NULLs - new
                        time:   [2.6234 us 2.6241 us 2.6249 us]
                        change: [-1.5826% -1.5200% -1.4451%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
arrow_array_reader/read Int32Array, plain encoded, optional, no NULLs - old
                        time:   [82.701 us 83.250 us 83.935 us]
                        change: [+2.6263% +3.3494% +4.1849%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
arrow_array_reader/read Int32Array, plain encoded, optional, no NULLs - new
                        time:   [21.341 us 21.364 us 21.406 us]
                        change: [+0.1475% +0.3773% +0.6109%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
arrow_array_reader/read Int32Array, plain encoded, optional, half NULLs - old
                        time:   [198.46 us 198.62 us 198.79 us]
                        change: [-1.5860% -0.4918% +0.3755%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high severe
arrow_array_reader/read Int32Array, plain encoded, optional, half NULLs - new
                        time:   [198.12 us 198.21 us 198.35 us]
                        change: [-0.7897% +0.7633% +2.0061%] (p = 0.34 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
arrow_array_reader/read Int32Array, dictionary encoded, mandatory, no NULLs - old
                        time:   [26.411 us 26.416 us 26.420 us]
                        change: [-2.8843% -2.8415% -2.8043%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
arrow_array_reader/read Int32Array, dictionary encoded, mandatory, no NULLs - new
                        time:   [100.27 us 100.29 us 100.31 us]
                        change: [+0.0819% +0.1397% +0.1824%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
arrow_array_reader/read Int32Array, dictionary encoded, optional, no NULLs - old
                        time:   [103.82 us 103.85 us 103.88 us]
                        change: [-0.0918% -0.0199% +0.0564%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
arrow_array_reader/read Int32Array, dictionary encoded, optional, no NULLs - new
                        time:   [118.97 us 118.99 us 119.00 us]
                        change: [-0.6533% -0.5571% -0.4697%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
arrow_array_reader/read Int32Array, dictionary encoded, optional, half NULLs - old
                        time:   [209.75 us 209.93 us 210.14 us]
                        change: [-0.4593% -0.3419% -0.1866%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
arrow_array_reader/read Int32Array, dictionary encoded, optional, half NULLs - new
                        time:   [248.36 us 248.41 us 248.46 us]
                        change: [-0.6660% -0.6152% -0.5610%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high severe
Benchmarking arrow_array_reader/read StringArray, plain encoded, mandatory, no NULLs - old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, enable flat sampling, or reduce sample count to 60.
arrow_array_reader/read StringArray, plain encoded, mandatory, no NULLs - old
                        time:   [1.0652 ms 1.0653 ms 1.0655 ms]
                        change: [-0.4593% -0.3777% -0.2848%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
arrow_array_reader/read StringArray, plain encoded, mandatory, no NULLs - new
                        time:   [129.79 us 129.82 us 129.84 us]
                        change: [-2.1307% -1.8979% -1.6514%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking arrow_array_reader/read StringArray, plain encoded, optional, no NULLs - old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.8s, enable flat sampling, or reduce sample count to 60.
arrow_array_reader/read StringArray, plain encoded, optional, no NULLs - old
                        time:   [1.1470 ms 1.1471 ms 1.1472 ms]
                        change: [-0.0405% +0.0185% +0.0813%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe
arrow_array_reader/read StringArray, plain encoded, optional, no NULLs - new
                        time:   [150.03 us 150.36 us 150.84 us]
                        change: [+0.5729% +0.7597% +0.9920%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
Benchmarking arrow_array_reader/read StringArray, plain encoded, optional, half NULLs - old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, enable flat sampling, or reduce sample count to 70.
arrow_array_reader/read StringArray, plain encoded, optional, half NULLs - old
                        time:   [1.0030 ms 1.0031 ms 1.0032 ms]
                        change: [-0.5887% -0.5500% -0.5089%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
arrow_array_reader/read StringArray, plain encoded, optional, half NULLs - new
                        time:   [313.06 us 313.10 us 313.13 us]
                        change: [+0.6358% +0.6714% +0.7022%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking arrow_array_reader/read StringArray, dictionary encoded, mandatory, no NULLs - old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 60.
arrow_array_reader/read StringArray, dictionary encoded, mandatory, no NULLs - old
                        time:   [1.0317 ms 1.0319 ms 1.0320 ms]
                        change: [+1.1671% +1.2760% +1.3809%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
arrow_array_reader/read StringArray, dictionary encoded, mandatory, no NULLs - new
                        time:   [143.50 us 143.52 us 143.56 us]
                        change: [-0.6198% -0.5818% -0.5399%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  5 (5.00%) high severe
Benchmarking arrow_array_reader/read StringArray, dictionary encoded, optional, no NULLs - old: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.6s, enable flat sampling, or reduce sample count to 60.
arrow_array_reader/read StringArray, dictionary encoded, optional, no NULLs - old
                        time:   [1.1055 ms 1.1057 ms 1.1058 ms]
                        change: [+1.1655% +1.2473% +1.3045%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
arrow_array_reader/read StringArray, dictionary encoded, optional, no NULLs - new
                        time:   [162.32 us 162.34 us 162.36 us]
                        change: [-0.6968% -0.6660% -0.6240%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
arrow_array_reader/read StringArray, dictionary encoded, optional, half NULLs - old
                        time:   [972.11 us 972.42 us 972.68 us]
                        change: [+0.1393% +0.2384% +0.3296%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
arrow_array_reader/read StringArray, dictionary encoded, optional, half NULLs - new
                        time:   [309.08 us 309.11 us 309.15 us]
                        change: [+1.2438% +1.3455% +1.4354%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

     Running unittests (/home/ben/arrow-rs/target/release/deps/arrow_writer-0035a5c9607ed91b)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Benchmarking write_batch primitive/4096 values primitive: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, enable flat sampling, or reduce sample count to 50.
write_batch primitive/4096 values primitive
                        time:   [1.5769 ms 1.5772 ms 1.5774 ms]
                        thrpt:  [111.73 MiB/s 111.75 MiB/s 111.77 MiB/s]
                 change:
                        time:   [+1.2878% +1.3426% +1.3959%] (p = 0.00 < 0.05)
                        thrpt:  [-1.3767% -1.3249% -1.2715%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking write_batch primitive/4096 values primitive non-null: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, enable flat sampling, or reduce sample count to 50.
write_batch primitive/4096 values primitive non-null
                        time:   [1.4060 ms 1.4064 ms 1.4067 ms]
                        thrpt:  [125.30 MiB/s 125.33 MiB/s 125.36 MiB/s]
                 change:
                        time:   [-1.5148% -1.4121% -1.3052%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3224% +1.4323% +1.5381%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
write_batch primitive/4096 values bool
                        time:   [94.494 us 94.521 us 94.551 us]
                        thrpt:  [11.781 MiB/s 11.785 MiB/s 11.788 MiB/s]
                 change:
                        time:   [-1.5791% -1.4230% -1.2750%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2914% +1.4435% +1.6044%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  12 (12.00%) high severe
write_batch primitive/4096 values bool non-null
                        time:   [64.259 us 64.289 us 64.324 us]
                        thrpt:  [17.317 MiB/s 17.326 MiB/s 17.334 MiB/s]
                 change:
                        time:   [-4.3881% -4.0095% -3.5526%] (p = 0.00 < 0.05)
                        thrpt:  [+3.6834% +4.1770% +4.5895%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
write_batch primitive/4096 values string
                        time:   [787.41 us 788.07 us 788.64 us]
                        thrpt:  [100.86 MiB/s 100.93 MiB/s 101.02 MiB/s]
                 change:
                        time:   [-0.2931% +0.4413% +1.4753%] (p = 0.50 > 0.05)
                        thrpt:  [-1.4539% -0.4394% +0.2939%]
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe
write_batch primitive/4096 values string non-null
                        time:   [822.71 us 823.52 us 824.30 us]
                        thrpt:  [96.499 MiB/s 96.590 MiB/s 96.686 MiB/s]
                 change:
                        time:   [-0.4183% -0.2902% -0.1596%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1598% +0.2911% +0.4200%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

Benchmarking write_batch nested/4096 values primitive list: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.6s, enable flat sampling, or reduce sample count to 50.
write_batch nested/4096 values primitive list
                        time:   [1.6931 ms 1.6933 ms 1.6936 ms]
                        thrpt:  [96.624 MiB/s 96.640 MiB/s 96.655 MiB/s]
                 change:
                        time:   [-0.9455% -0.8252% -0.7078%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7129% +0.8321% +0.9546%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe
write_batch nested/4096 values primitive list non-null
                        time:   [2.0181 ms 2.0191 ms 2.0202 ms]
                        thrpt:  [95.746 MiB/s 95.800 MiB/s 95.849 MiB/s]
                 change:
                        time:   [-0.6942% -0.6250% -0.5530%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5561% +0.6289% +0.6991%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

</details>