### PR TITLE
Update Union Array to add `UnionMode`,  match latest Arrow Spec, and rename `new` -> `unsafe new_unchecked()`

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -301,7 +301,7 @@ pub fn make_array(data: ArrayData) -> ArrayRef {
         DataType::LargeList(_) => Arc::new(LargeListArray::from(data)) as ArrayRef,
         DataType::Struct(_) => Arc::new(StructArray::from(data)) as ArrayRef,
         DataType::Map(_, _) => Arc::new(MapArray::from(data)) as ArrayRef,
-        DataType::Union(_) => Arc::new(UnionArray::from(data)) as ArrayRef,
+        DataType::Union(_, _) => Arc::new(UnionArray::from(data)) as ArrayRef,
         DataType::FixedSizeList(_, _) => {
             Arc::new(FixedSizeListArray::from(data)) as ArrayRef
         }
@@ -472,7 +472,7 @@ pub fn new_null_array(data_type: &DataType, length: usize) -> ArrayRef {
         DataType::Map(field, _keys_sorted) => {
             new_null_list_array::<i32>(data_type, field.data_type(), length)
         }
-        DataType::Union(_) => {
+        DataType::Union(_, _) => {
             unimplemented!("Creating null Union array not yet supported")
         }
         DataType::Dictionary(key, value) => {

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -55,9 +55,9 @@ impl UnionArray {
     /// are used to index into the `child_arrays`.
     ///
     /// The `value_offsets` `Buffer` is only provided in the case of a dense union, sparse unions
-    /// should use `None`.  If provided the `value_offsets` `Buffer` should contain `i32` values
-    /// The values in this array should be greater than zero and must be less than the length of the overall
-    /// array.
+    /// should use `None`.  If provided the `value_offsets` `Buffer` should contain `i32` values.
+    /// The values in this array should be greater than zero and must be less than the length of the
+    /// overall array.
     ///
     /// In both cases above we use signed integer types to maintain compatibility with other
     /// Arrow implementations.

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -56,7 +56,7 @@ impl UnionArray {
     ///
     /// The `value_offsets` `Buffer` is only provided in the case of a dense union, sparse unions
     /// should use `None`.  If provided the `value_offsets` `Buffer` should contain `i32` values
-    /// Thee values in this array should be greater than zero and must be less than the length of the overall
+    /// The values in this array should be greater than zero and must be less than the length of the overall
     /// array.
     ///
     /// In both cases above we use signed integer types to maintain compatibility with other

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2143,12 +2143,16 @@ impl UnionBuilder {
 
         self.type_id_builder.append(i8::default());
 
-        // Handle sparse union
-        if self.value_offset_builder.is_none() {
-            for (_, fd) in self.fields.iter_mut() {
-                fd.append_null_dynamic()?;
+        match &mut self.value_offset_builder {
+            // Handle dense union
+            Some(value_offset_builder) => value_offset_builder.append(i32::default()),
+            // Handle sparse union
+            None => {
+                for (_, fd) in self.fields.iter_mut() {
+                    fd.append_null_dynamic()?;
+                }
             }
-        }
+        };
         self.len += 1;
         Ok(())
     }

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -18,7 +18,7 @@
 //! Contains `ArrayData`, a generic representation of Arrow array data which encapsulates
 //! common attributes and operations for Arrow array.
 
-use crate::datatypes::{DataType, IntervalUnit};
+use crate::datatypes::{DataType, IntervalUnit, UnionMode};
 use crate::error::{ArrowError, Result};
 use crate::{bitmap::Bitmap, datatypes::ArrowNativeType};
 use crate::{
@@ -194,7 +194,7 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
             MutableBuffer::new(capacity * mem::size_of::<u8>()),
             empty_buffer,
         ],
-        DataType::Union(_) => unimplemented!(),
+        DataType::Union(_, _) => unimplemented!(),
     }
 }
 
@@ -560,7 +560,7 @@ impl ArrayData {
             DataType::Map(field, _) => {
                 vec![Self::new_empty(field.data_type())]
             }
-            DataType::Union(_) => unimplemented!(),
+            DataType::Union(_, _) => unimplemented!(),
             DataType::Dictionary(_, data_type) => {
                 vec![Self::new_empty(data_type)]
             }
@@ -597,11 +597,6 @@ impl ArrayData {
         // Check that the data layout conforms to the spec
         let layout = layout(&self.data_type);
 
-        // Will validate Union when conforms to new spec:
-        // https://github.com/apache/arrow-rs/issues/85
-        if matches!(&self.data_type, DataType::Union(_)) {
-            return Ok(());
-        }
         if self.buffers.len() != layout.buffers.len() {
             return Err(ArrowError::InvalidArgumentError(format!(
                 "Expected {} buffers in array of type {:?}, got {}",
@@ -827,10 +822,21 @@ impl ArrayData {
                 }
                 Ok(())
             }
-            DataType::Union(_fields) => {
-                // Validate Union Array as part of implementing new Union semantics
-                // See comments in `ArrayData::validate()`
-                // https://github.com/apache/arrow-rs/issues/85
+            DataType::Union(fields, mode) => {
+                self.validate_num_child_data(fields.len())?;
+
+                for (i, field) in fields.iter().enumerate() {
+                    let field_data = self.get_valid_child_data(i, field.data_type())?;
+
+                    if mode == &UnionMode::Sparse
+                        && field_data.len < (self.len + self.offset)
+                    {
+                        return Err(ArrowError::InvalidArgumentError(format!(
+                            "Sparse union child array #{} has length smaller than expected for union array ({} < {})",
+                            i, field_data.len, self.len + self.offset
+                        )));
+                    }
+                }
                 Ok(())
             }
             DataType::Dictionary(_key_type, value_type) => {
@@ -951,10 +957,12 @@ impl ArrayData {
                 let child = &self.child_data[0];
                 self.validate_offsets_full::<i64>(child.len + child.offset)?;
             }
-            DataType::Union(_) => {
+            DataType::Union(_, _) => {
                 // Validate Union Array as part of implementing new Union semantics
                 // See comments in `ArrayData::validate()`
                 // https://github.com/apache/arrow-rs/issues/85
+                //
+                // TODO file follow on ticket for full union validation
             }
             DataType::Dictionary(key_type, _value_type) => {
                 let dictionary_length: i64 = self.child_data[0].len.try_into().unwrap();
@@ -1200,11 +1208,26 @@ fn layout(data_type: &DataType) -> DataTypeLayout {
         DataType::FixedSizeList(_, _) => DataTypeLayout::new_empty(), // all in child data
         DataType::LargeList(_) => DataTypeLayout::new_fixed_width(size_of::<i32>()),
         DataType::Struct(_) => DataTypeLayout::new_empty(), // all in child data,
-        DataType::Union(_) => {
-            DataTypeLayout::new_fixed_width(size_of::<u8>())
-            // Note sparse unions only have one buffer (u8) type_ids,
-            // and dense unions have 2 (type_ids as well as offsets).
-            // https://github.com/apache/arrow-rs/issues/85
+        DataType::Union(_, mode) => {
+            let type_ids = BufferSpec::FixedWidth {
+                byte_width: size_of::<i8>(),
+            };
+
+            DataTypeLayout {
+                buffers: match mode {
+                    UnionMode::Sparse => {
+                        vec![type_ids]
+                    }
+                    UnionMode::Dense => {
+                        vec![
+                            type_ids,
+                            BufferSpec::FixedWidth {
+                                byte_width: size_of::<i32>(),
+                            },
+                        ]
+                    }
+                },
+            }
         }
         DataType::Dictionary(key_type, _value_type) => layout(key_type),
         DataType::Decimal(_, _) => {
@@ -1389,8 +1412,8 @@ mod tests {
     use super::*;
 
     use crate::array::{
-        Array, BooleanBuilder, Int32Array, Int32Builder, StringArray, StructBuilder,
-        UInt64Array,
+        Array, BooleanBuilder, Int32Array, Int32Builder, Int64Array, StringArray,
+        StructBuilder, UInt64Array,
     };
     use crate::buffer::Buffer;
     use crate::datatypes::Field;
@@ -2270,6 +2293,121 @@ mod tests {
     /// returns a buffer initialized with some constant value for tests
     fn make_f32_buffer(n: usize) -> Buffer {
         Buffer::from_slice_ref(&vec![42f32; n])
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected Int64 but child data had Int32")]
+    fn test_validate_union_different_types() {
+        let field1 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
+
+        let field2 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
+
+        let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+
+        ArrayData::try_new(
+            DataType::Union(
+                vec![
+                    Field::new("field1", DataType::Int32, true),
+                    Field::new("field2", DataType::Int64, true), // data is int32
+                ],
+                UnionMode::Sparse,
+            ),
+            2,
+            None,
+            None,
+            0,
+            vec![type_ids],
+            vec![field1.data().clone(), field2.data().clone()],
+        )
+        .unwrap();
+    }
+
+    // sparse with wrong sized children
+    #[test]
+    #[should_panic(
+        expected = "Sparse union child array #1 has length smaller than expected for union array (1 < 2)"
+    )]
+    fn test_validate_union_sparse_different_child_len() {
+        let field1 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
+
+        // field 2 only has 1 item but array should have 2
+        let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
+
+        let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+
+        ArrayData::try_new(
+            DataType::Union(
+                vec![
+                    Field::new("field1", DataType::Int32, true),
+                    Field::new("field2", DataType::Int64, true),
+                ],
+                UnionMode::Sparse,
+            ),
+            2,
+            None,
+            None,
+            0,
+            vec![type_ids],
+            vec![field1.data().clone(), field2.data().clone()],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected 2 buffers in array of type Union")]
+    fn test_validate_union_dense_without_offsets() {
+        let field1 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
+
+        let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
+
+        let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+
+        ArrayData::try_new(
+            DataType::Union(
+                vec![
+                    Field::new("field1", DataType::Int32, true),
+                    Field::new("field2", DataType::Int64, true),
+                ],
+                UnionMode::Dense,
+            ),
+            2,
+            None,
+            None,
+            0,
+            vec![type_ids], // need offsets buffer here too
+            vec![field1.data().clone(), field2.data().clone()],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Need at least 8 bytes in buffers[1] in array of type Union"
+    )]
+    fn test_validate_union_dense_with_bad_len() {
+        let field1 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
+
+        let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
+
+        let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+        let offsets = Buffer::from_slice_ref(&[0i32]); // should have 2 offsets, but only have 1
+
+        ArrayData::try_new(
+            DataType::Union(
+                vec![
+                    Field::new("field1", DataType::Int32, true),
+                    Field::new("field2", DataType::Int64, true),
+                ],
+                UnionMode::Dense,
+            ),
+            2,
+            None,
+            None,
+            0,
+            vec![type_ids, offsets],
+            vec![field1.data().clone(), field2.data().clone()],
+        )
+        .unwrap();
     }
 
     #[test]

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -226,7 +226,7 @@ fn equal_values(
         DataType::Struct(_) => {
             struct_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
         }
-        DataType::Union(_) => unimplemented!("See ARROW-8576"),
+        DataType::Union(_, _) => unimplemented!("See ARROW-8576"),
         DataType::Dictionary(data_type, _) => match data_type.as_ref() {
             DataType::Int8 => dictionary_equal::<i8>(
                 lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,

--- a/arrow/src/array/equal/utils.rs
+++ b/arrow/src/array/equal/utils.rs
@@ -161,7 +161,7 @@ pub(super) fn child_logical_null_buffer(
             });
             Some(buffer.into())
         }
-        DataType::Union(_) => {
+        DataType::Union(_, _) => {
             unimplemented!("Logical equality not yet implemented for union arrays")
         }
         DataType::Dictionary(_, _) => {

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -4135,10 +4135,13 @@ mod tests {
                 Field::new("f1", DataType::Int32, false),
                 Field::new("f2", DataType::Utf8, true),
             ]),
-            Union(vec![
-                Field::new("f1", DataType::Int32, false),
-                Field::new("f2", DataType::Utf8, true),
-            ]),
+            Union(
+                vec![
+                    Field::new("f1", DataType::Int32, false),
+                    Field::new("f2", DataType::Utf8, true),
+                ],
+                UnionMode::Dense,
+            ),
             Dictionary(Box::new(DataType::Int8), Box::new(DataType::Int32)),
             Dictionary(Box::new(DataType::Int16), Box::new(DataType::Utf8)),
             Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -115,7 +115,7 @@ pub enum DataType {
     /// A nested datatype that contains a number of sub-fields.
     Struct(Vec<Field>),
     /// A nested datatype that can represent slots of differing types.
-    Union(Vec<Field>),
+    Union(Vec<Field>, UnionMode),
     /// A dictionary encoded array (`key_type`, `value_type`), where
     /// each array element is an index of `key_type` into an
     /// associated dictionary of `value_type`.
@@ -174,6 +174,13 @@ pub enum IntervalUnit {
     /// as days or that the quantity of nanoseconds represents less
     /// than a day's worth of time).
     MonthDayNano,
+}
+
+// Sparse or Dense union layouts
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum UnionMode {
+    Sparse,
+    Dense,
 }
 
 impl fmt::Display for DataType {
@@ -406,7 +413,7 @@ impl DataType {
                 json!({"name": "fixedsizebinary", "byteWidth": byte_width})
             }
             DataType::Struct(_) => json!({"name": "struct"}),
-            DataType::Union(_) => json!({"name": "union"}),
+            DataType::Union(_, _) => json!({"name": "union"}),
             DataType::List(_) => json!({ "name": "list"}),
             DataType::LargeList(_) => json!({ "name": "largelist"}),
             DataType::FixedSizeList(_, length) => {

--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -111,7 +111,7 @@ impl Field {
     pub(crate) fn fields(&self) -> Vec<&Field> {
         let mut collected_fields = vec![self];
         match &self.data_type {
-            DataType::Struct(fields) | DataType::Union(fields) => {
+            DataType::Struct(fields) | DataType::Union(fields, _) => {
                 collected_fields.extend(fields.iter().map(|f| f.fields()).flatten())
             }
             DataType::List(field)
@@ -484,8 +484,8 @@ impl Field {
                     ));
                 }
             },
-            DataType::Union(nested_fields) => match &from.data_type {
-                DataType::Union(from_nested_fields) => {
+            DataType::Union(nested_fields, _) => match &from.data_type {
+                DataType::Union(from_nested_fields, _) => {
                     for from_field in from_nested_fields {
                         let mut is_new_field = true;
                         for self_field in nested_fields.iter_mut() {

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -1379,28 +1379,37 @@ mod tests {
             Schema::try_merge(vec![
                 Schema::new(vec![Field::new(
                     "c1",
-                    DataType::Union(vec![
-                        Field::new("c11", DataType::Utf8, true),
-                        Field::new("c12", DataType::Utf8, true),
-                    ]),
+                    DataType::Union(
+                        vec![
+                            Field::new("c11", DataType::Utf8, true),
+                            Field::new("c12", DataType::Utf8, true),
+                        ],
+                        UnionMode::Dense
+                    ),
                     false
                 ),]),
                 Schema::new(vec![Field::new(
                     "c1",
-                    DataType::Union(vec![
-                        Field::new("c12", DataType::Utf8, true),
-                        Field::new("c13", DataType::Time64(TimeUnit::Second), true),
-                    ]),
+                    DataType::Union(
+                        vec![
+                            Field::new("c12", DataType::Utf8, true),
+                            Field::new("c13", DataType::Time64(TimeUnit::Second), true),
+                        ],
+                        UnionMode::Dense
+                    ),
                     false
                 ),])
             ])?,
             Schema::new(vec![Field::new(
                 "c1",
-                DataType::Union(vec![
-                    Field::new("c11", DataType::Utf8, true),
-                    Field::new("c12", DataType::Utf8, true),
-                    Field::new("c13", DataType::Time64(TimeUnit::Second), true),
-                ]),
+                DataType::Union(
+                    vec![
+                        Field::new("c11", DataType::Utf8, true),
+                        Field::new("c12", DataType::Utf8, true),
+                        Field::new("c13", DataType::Time64(TimeUnit::Second), true),
+                    ],
+                    UnionMode::Dense
+                ),
                 false
             ),]),
         );

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -159,7 +159,7 @@ impl IpcDataGenerator {
                     )?;
                 }
             }
-            DataType::Union(fields) => {
+            DataType::Union(fields, _) => {
                 let union = as_union_array(column);
                 for (field, ref column) in fields
                     .iter()

--- a/parquet/src/arrow/arrow_writer.rs
+++ b/parquet/src/arrow/arrow_writer.rs
@@ -224,7 +224,7 @@ fn write_leaves(
         ArrowDataType::Float16 => Err(ParquetError::ArrowError(
             "Float16 arrays not supported".to_string(),
         )),
-        ArrowDataType::FixedSizeList(_, _) | ArrowDataType::Union(_) => {
+        ArrowDataType::FixedSizeList(_, _) | ArrowDataType::Union(_, _) => {
             Err(ParquetError::NYI(
                 format!(
                     "Attempting to write an Arrow type {:?} to parquet that is not yet implemented",

--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -241,7 +241,7 @@ impl LevelInfo {
                         list_level.calculate_array_levels(&child_array, list_field)
                     }
                     DataType::FixedSizeList(_, _) => unimplemented!(),
-                    DataType::Union(_) => unimplemented!(),
+                    DataType::Union(_, _) => unimplemented!(),
                 }
             }
             DataType::Map(map_field, _) => {
@@ -304,7 +304,7 @@ impl LevelInfo {
                     });
                 struct_levels
             }
-            DataType::Union(_) => unimplemented!(),
+            DataType::Union(_, _) => unimplemented!(),
             DataType::Dictionary(_, _) => {
                 // Need to check for these cases not implemented in C++:
                 // - "Writing DictionaryArray with nested dictionary type not yet supported"
@@ -743,7 +743,7 @@ impl LevelInfo {
                     array_mask,
                 )
             }
-            DataType::FixedSizeList(_, _) | DataType::Union(_) => {
+            DataType::FixedSizeList(_, _) | DataType::Union(_, _) => {
                 unimplemented!("Getting offsets not yet implemented")
             }
         }

--- a/parquet/src/arrow/schema.rs
+++ b/parquet/src/arrow/schema.rs
@@ -536,7 +536,7 @@ fn arrow_to_parquet_type(field: &Field) -> Result<Type> {
                 ))
             }
         }
-        DataType::Union(_) => unimplemented!("See ARROW-8817."),
+        DataType::Union(_, _) => unimplemented!("See ARROW-8817."),
         DataType::Dictionary(_, ref value) => {
             // Dictionary encoding not handled at the schema level
             let dict_field = Field::new(name, *value.clone(), field.is_nullable());


### PR DESCRIPTION
~(Built on https://github.com/apache/arrow-rs/pull/810, so to see the changes proposed in this PR just look at the last commit)~

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/814
Closes https://github.com/apache/arrow-rs/issues/85
Related to https://github.com/apache/arrow-rs/issues/817

# Rationale for this change
Follow Arrow spec for `UnionArray`, make it possible to validate with generic code added in https://github.com/apache/arrow-rs/pull/810, and conform to Rust safety conventions. 

See https://arrow.apache.org/docs/format/Columnar.html#union-layout for a description of the Union layout

# What changes are included in this PR?

1. Rename `UnionArray::new` to `unsafe UnionArray::new_unchecked()` to follow standard Rust safety conventions
2. Add `UnionMode` to `DataType::Union` so the type carries information on expected format
3. Update null values offset handling to match https://arrow.apache.org/docs/format/Columnar.html#union-layout 
4. Add validation in ArrayData::validate 

# Are there any user-facing changes?
1. `UnionArray::new` has been renamed to `unsafe UnionArray::new_unchecked()` 
2. Must specify `Dense` or `Sparse` when creating a `DataType::Union`
2. Accepted `UnionArray` format is different
