### PR TITLE
Use a single test thread when running miri

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -56,4 +56,5 @@ jobs:
           cargo clean
           # Currently only the arrow crate is tested with miri
           # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+          # Use a single thread to avoid OOM kills on github
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json --test-threads=1

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -34,13 +34,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}


### PR DESCRIPTION
# Which issue does this PR close?

Testing to see if this closes https://github.com/apache/arrow-rs/issues/879 

Theory is that something about the new version of MIRI uses more memory

# Rationale for this change
 MIRI is failing on master for reasons that are not reproducible (yet) locally for myself or @Jimexist 

# What changes are included in this PR?

add `--test-threads=1` command

# Are there any user-facing changes?
No
