### PR TITLE
Use different caching for MIRI runs

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -34,13 +34,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions/cache@v2
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+          path: /github/home/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-miri-cache-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -34,6 +34,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache2-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/879

# Rationale for this change
 
MIRI is failing in some "can not reproduce" way on github.

We have previously seen github fail due to ancient stuff in the cache (e.g. https://github.com/apache/arrow-rs/pull/878), though in that case it was related to the cargo cache

# What changes are included in this PR?
Change the cache setting for the MIRI job to:
1. Be different (and thus not use whatever is wrong with the current one)
2. More closely follow the other jobs caching

# Are there any user-facing changes?
No