### PR TITLE
fix ffi warning on failed to drop

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -132,9 +132,9 @@ unsafe extern "C" fn release_schema(schema: *mut FFI_ArrowSchema) {
     let schema = &mut *schema;
 
     // take ownership back to release it.
-    CString::from_raw(schema.format as *mut c_char);
+    drop(CString::from_raw(schema.format as *mut c_char));
     if !schema.name.is_null() {
-        CString::from_raw(schema.name as *mut c_char);
+        drop(CString::from_raw(schema.name as *mut c_char));
     }
     if !schema.private_data.is_null() {
         let private_data = Box::from_raw(schema.private_data as *mut SchemaPrivateData);


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
fix ffi warning on failed to drop

```
warning: unused return value of `CString::from_raw` that must be used
   --> arrow/src/ffi.rs:135:5
    |
135 |     CString::from_raw(schema.format as *mut c_char);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: call `drop(from_raw(ptr))` if you intend to drop the `CString`

warning: unused return value of `CString::from_raw` that must be used
   --> arrow/src/ffi.rs:137:9
    |
137 |         CString::from_raw(schema.name as *mut c_char);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(from_raw(ptr))` if you intend to drop the `CString`

```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
