### PR TITLE
Fix clippy

### DIFF
--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -49,7 +49,6 @@ const MURMUR_R: i32 = 47;
 
 /// Rust implementation of MurmurHash2, 64-bit version for 64-bit platforms
 fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
-    use std::convert::TryInto;
     let len = data_bytes.len();
     let len_64 = (len / 8) * 8;
 


### PR DESCRIPTION

# Rationale for this change
 
Fix a clippy error introduced by https://github.com/apache/arrow-rs/pull/878

I think due to a logical conflict with https://github.com/apache/arrow-rs/pull/591

# What changes are included in this PR?
remove unnecessary `use` 

# Are there any user-facing changes?
no