### PR TITLE
Fix references to changelog to (6.1.0 -> 6.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/ar
 ## [6.1.0](https://github.com/apache/arrow-rs/tree/6.1.0) (2021-10-29)
 
 
-[Full Changelog](https://github.com/apache/arrow-rs/compare/6.1.0...6.1.0)
+[Full Changelog](https://github.com/apache/arrow-rs/compare/6.0.0...6.1.0)
 
 **Features / Fixes:**
 
@@ -46,9 +46,9 @@ For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/ar
 
 # Changelog
 
-## [6.1.0](https://github.com/apache/arrow-rs/tree/6.1.0) (2021-10-13)
+## [6.0.0](https://github.com/apache/arrow-rs/tree/6.0.0) (2021-10-13)
 
-[Full Changelog](https://github.com/apache/arrow-rs/compare/5.5.0...6.1.0)
+[Full Changelog](https://github.com/apache/arrow-rs/compare/5.5.0...6.0.0)
 
 **Breaking changes:**
 


### PR DESCRIPTION
Notes targets `active_release` branch


# Rationale for this change
 
Changelog mistakenly refers to 6.0 as 6.1

# What changes are included in this PR?

Correct version issues identified by @Dandandan  on https://github.com/apache/arrow-rs/pull/880 https://github.com/apache/arrow-rs/pull/880#discussion_r740190076 and https://github.com/apache/arrow-rs/pull/880#discussion_r739877971

# Are there any user-facing changes?
No
