### PR TITLE
(WIP) Run MIRI in a single thread

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -49,4 +49,4 @@ jobs:
           cargo clean
           # Currently only the arrow crate is tested with miri
           # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+          cargo miri test -p arrow -- --skip csv --skip ipc --skip json --test-threads=1


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/879

# Rationale for this change
 
try to get a reliably passing MIRI run

The symptoms of the failing MIRI runs seem to be the same as would happen if the system OOM'd -- https://github.com/apache/arrow-rs/issues/879#issuecomment-957879870 so try running with a single thread to avoid blowing out memory