### PR TITLE
(WIP) Use latest nightly for MIRI runs

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-10-23]
+        rust: [nightly]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/879

# Rationale for this change
 
try to get a reliably passing MIRI run

The symptoms of the failing MIRI runs seem to be the same as would happen if the system OOM'd -- https://github.com/apache/arrow-rs/issues/879#issuecomment-957879870 so try running with latest nightly to see if that helps

I admit this is likely grasping at straws 🥤 