### PR TITLE
Disable test under MIRI which appears to exceed memory limits intermittently on github CI

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -2036,6 +2036,41 @@ mod tests {
         };
     }
 
+    // These macros are the same as `test_flag_utf8` but they are not run under miri
+    macro_rules! test_flag_utf8_skip_miri {
+        ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+            #[test]
+            #[cfg_attr(miri, ignore)]
+            fn $test_name() {
+                let left = StringArray::from($left);
+                let right = StringArray::from($right);
+                let res = $op(&left, &right, None).unwrap();
+                let expected = $expected;
+                assert_eq!(expected.len(), res.len());
+                for i in 0..res.len() {
+                    let v = res.value(i);
+                    assert_eq!(v, expected[i]);
+                }
+            }
+        };
+        ($test_name:ident, $left:expr, $right:expr, $flag:expr, $op:expr, $expected:expr) => {
+            #[test]
+            #[cfg_attr(miri, ignore)]
+            fn $test_name() {
+                let left = StringArray::from($left);
+                let right = StringArray::from($right);
+                let flag = Some(StringArray::from($flag));
+                let res = $op(&left, &right, flag.as_ref()).unwrap();
+                let expected = $expected;
+                assert_eq!(expected.len(), res.len());
+                for i in 0..res.len() {
+                    let v = res.value(i);
+                    assert_eq!(v, expected[i]);
+                }
+            }
+        };
+    }
+
     macro_rules! test_flag_utf8_scalar {
         ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
             #[test]
@@ -2270,8 +2305,8 @@ mod tests {
         regexp_is_match_utf8,
         vec![true, false, true, false, false, true]
     );
-    #[cfg_attr(miri, ignore)] // error: this test uses too much memory to run on CI
-    test_flag_utf8!(
+        // error: this test uses too much memory to run on CI
+    test_flag_utf8_skip_miri!(
         test_utf8_array_regexp_is_match_insensitive,
         vec!["arrow", "arrow", "arrow", "arrow", "arrow", "arrow"],
         vec!["^ar", "^AR", "ow$", "OW$", "foo", ""],

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -2270,6 +2270,7 @@ mod tests {
         regexp_is_match_utf8,
         vec![true, false, true, false, false, true]
     );
+    #[cfg_attr(miri, ignore)] // error: this test uses too much memory to run on CI
     test_flag_utf8!(
         test_utf8_array_regexp_is_match_insensitive,
         vec!["arrow", "arrow", "arrow", "arrow", "arrow", "arrow"],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #879 

# Rationale for this change
 
The MIRI CI check is failing intermittently on master. The symptoms of the failing MIRI tests seem to be the same as would happen if miri is killed by the github OOM killer -- see https://github.com/apache/arrow-rs/issues/879#issuecomment-957879870 

We can't reproduce any MIRI failures locally so this seems like either a bug in MIRI or it is using too many resources for github. 

Note the test in question was added relatively recently in #706 by @b41sh  (but then MIRI started failing after updating to a new rust version)

# What changes are included in this PR?

Disable the failing test

# Are there any user-facing changes?
No

