### PR TITLE
Cherry pick Update parquet module documentation to reflect correct SerializedFileReader location to active_release

### DIFF
--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! Provides access to file and row group readers and writers, record API, metadata, etc.
 //!
-//! See [`reader::SerializedFileReader`](reader/struct.SerializedFileReader.html) or
+//! See [`serialized_reader::SerializedFileReader`](serialized_reader/struct.SerializedFileReader.html) or
 //! [`writer::SerializedFileWriter`](writer/struct.SerializedFileWriter.html) for a
 //! starting reference, [`metadata::ParquetMetaData`](metadata/index.html) for file
 //! metadata, and [`statistics`](statistics/index.html) for working with statistics.


### PR DESCRIPTION
Automatic cherry-pick of 67af0d0
* Originally appeared in https://github.com/apache/arrow-rs/pull/909: Update parquet module documentation to reflect correct SerializedFileReader location
