### PR TITLE
Cherry pick Mark boolean comparison kernels public to active_release

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -657,37 +657,37 @@ where
 }
 
 /// Perform `left == right` operation on [`BooleanArray`]
-fn eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| !(a ^ b))
 }
 
 /// Perform `left != right` operation on [`BooleanArray`]
-fn neq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn neq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| (a ^ b))
 }
 
 /// Perform `left < right` operation on [`BooleanArray`]
-fn lt_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn lt_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| ((!a) & b))
 }
 
 /// Perform `left <= right` operation on [`BooleanArray`]
-fn lt_eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn lt_eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| !(a & (!b)))
 }
 
 /// Perform `left > right` operation on [`BooleanArray`]
-fn gt_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn gt_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| (a & (!b)))
 }
 
 /// Perform `left >= right` operation on [`BooleanArray`]
-fn gt_eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
+pub fn gt_eq_bool(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     binary_boolean_op(left, right, |a, b| !((!a) & b))
 }
 
 /// Perform `left == right` operation on [`BooleanArray`] and a scalar
-fn eq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray> {
+pub fn eq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray> {
     let len = left.len();
     let left_offset = left.offset();
 
@@ -716,7 +716,7 @@ fn eq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray> {
 }
 
 /// Perform `left != right` operation on [`BooleanArray`] and a scalar
-fn neq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray> {
+pub fn neq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray> {
     eq_bool_scalar(left, !right)
 }
 


### PR DESCRIPTION
Automatic cherry-pick of bb05b00
* Originally appeared in https://github.com/apache/arrow-rs/pull/913: Mark boolean comparison kernels public
