### PR TITLE
Automatically retry failed MIRI runs to work around intermittent failures

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Script
+#
+# Must be run with nightly rust for example
+# rustup default nightly
+export MIRIFLAGS="-Zmiri-disable-isolation"
+cargo miri setup
+cargo clean
+# Currently only the arrow crate is tested with miri
+# IO related tests and some unsupported tests are skipped
+cargo miri test -p arrow -- --skip csv --skip ipc --skip json

--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -4,9 +4,23 @@
 #
 # Must be run with nightly rust for example
 # rustup default nightly
+
+
 export MIRIFLAGS="-Zmiri-disable-isolation"
 cargo miri setup
 cargo clean
-# Currently only the arrow crate is tested with miri
-# IO related tests and some unsupported tests are skipped
-cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+
+run_miri() {
+    # Currently only the arrow crate is tested with miri
+    # IO related tests and some unsupported tests are skipped
+    cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+}
+
+# If MIRI fails, automatically retry
+# Seems like miri is occasionally killed by the github runner
+# https://github.com/apache/arrow-rs/issues/879
+for i in `seq 1 5`; do
+    echo "Starting Arrow MIRI run..."
+    run_miri && break
+    echo "foo" > /tmp/data.txt
+done

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -44,9 +44,4 @@ jobs:
           RUST_BACKTRACE: full
           RUST_LOG: "trace"
         run: |
-          export MIRIFLAGS="-Zmiri-disable-isolation"
-          cargo miri setup
-          cargo clean
-          # Currently only the arrow crate is tested with miri
-          # IO related tests and some unsupported tests are skipped
-          cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+          bash .github/workflows/miri.sh


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/879

# Rationale for this change
 
We are seeing intermittent failures while running MIRI checks on CI that are not reproducible locally and whose symptoms are consistent with miri being killed by the OOM killer (for example, perhaps github has over provisioned their runners so that the upper memory limit is not consistent)

When we manually rerun the MIRI run it often passes

# What changes are included in this PR?

Automatically re-run MIRI up to 5 times looking for a clean run

# Are there any user-facing changes?
