### PR TITLE
Cherry pick fix some clippy warnings to active_release

### DIFF
--- a/arrow/src/error.rs
+++ b/arrow/src/error.rs
@@ -65,7 +65,7 @@ impl From<csv_crate::Error> for ArrowError {
             csv_crate::ErrorKind::Io(error) => ArrowError::CsvError(error.to_string()),
             csv_crate::ErrorKind::Utf8 { pos: _, err } => ArrowError::CsvError(format!(
                 "Encountered UTF-8 error while reading CSV file: {}",
-                err.to_string()
+                err
             )),
             csv_crate::ErrorKind::UnequalLengths {
                 expected_len, len, ..

--- a/arrow/src/util/test_util.rs
+++ b/arrow/src/util/test_util.rs
@@ -124,7 +124,7 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
             } else {
                 return Err(format!(
                     "the data dir `{}` defined by env {} not found",
-                    pb.display().to_string(),
+                    pb.display(),
                     udf_env
                 )
                 .into());

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -36,7 +36,7 @@ use crate::util::{
 
 /// Rust representation for logical type INT96, value is backed by an array of `u32`.
 /// The type only takes 12 bytes, without extra padding.
-#[derive(Clone, Debug, PartialOrd)]
+#[derive(Clone, Debug, PartialOrd, Default)]
 pub struct Int96 {
     value: Option<[u32; 3]>,
 }
@@ -75,12 +75,6 @@ impl Int96 {
     }
 }
 
-impl Default for Int96 {
-    fn default() -> Self {
-        Self { value: None }
-    }
-}
-
 impl PartialEq for Int96 {
     fn eq(&self, other: &Int96) -> bool {
         match (&self.value, &other.value) {
@@ -109,7 +103,7 @@ impl fmt::Display for Int96 {
 
 /// Rust representation for BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY Parquet physical types.
 /// Value is backed by a byte buffer.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ByteArray {
     data: Option<ByteBufferPtr>,
 }
@@ -228,12 +222,6 @@ impl From<ByteBuffer> for ByteArray {
         Self {
             data: Some(buf.consume()),
         }
-    }
-}
-
-impl Default for ByteArray {
-    fn default() -> Self {
-        ByteArray { data: None }
     }
 }
 

--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -136,7 +136,7 @@ impl TreeBuilder {
                 .column_descr_ptr();
             let col_reader = row_group_reader.get_column_reader(orig_index).unwrap();
             let column = TripletIter::new(col_descr, col_reader, self.batch_size);
-            Reader::PrimitiveReader(field, column)
+            Reader::PrimitiveReader(field, Box::new(column))
         } else {
             match field.get_basic_info().converted_type() {
                 // List types
@@ -319,7 +319,7 @@ impl TreeBuilder {
 /// Reader tree for record assembly
 pub enum Reader {
     // Primitive reader with type information and triplet iterator
-    PrimitiveReader(TypePtr, TripletIter),
+    PrimitiveReader(TypePtr, Box<TripletIter>),
     // Optional reader with definition level of a parent and a reader
     OptionReader(i16, Box<Reader>),
     // Group (struct) reader with type information, definition level and list of child

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -77,7 +77,7 @@ impl<'a> Tokenizer<'a> {
     pub fn from_str(string: &'a str) -> Self {
         let vec = string
             .split_whitespace()
-            .flat_map(|t| Self::split_token(t))
+            .flat_map(Self::split_token)
             .collect();
         Tokenizer {
             tokens: vec,

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -85,10 +85,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         Data::Union(_) => unimplemented!("Union currently is not supported"),
     };
 
-    let field_infos: Vec<_> = fields
-        .iter()
-        .map(|f: &syn::Field| parquet_field::Field::from(f))
-        .collect();
+    let field_infos: Vec<_> = fields.iter().map(parquet_field::Field::from).collect();
 
     let writer_snippets: Vec<proc_macro2::TokenStream> =
         field_infos.iter().map(|x| x.writer_snippet()).collect();


### PR DESCRIPTION
Automatic cherry-pick of b79c600
* Originally appeared in https://github.com/apache/arrow-rs/pull/896: fix some clippy warnings
