### PR TITLE
Cherry pick fix some warning about unused variables in panic tests to active_release

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1138,7 +1138,7 @@ mod tests {
             .build()
             .unwrap();
         let list_array = ListArray::from(array_data);
-        BinaryArray::from(list_array);
+        drop(BinaryArray::from(list_array));
     }
 
     #[test]
@@ -1217,7 +1217,7 @@ mod tests {
         .build()
         .unwrap();
         let list_array = FixedSizeListArray::from(array_data);
-        FixedSizeBinaryArray::from(list_array);
+        drop(FixedSizeBinaryArray::from(list_array));
     }
 
     #[test]

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -336,6 +336,6 @@ mod tests {
             .len(5)
             .build()
             .unwrap();
-        BooleanArray::from(data);
+        drop(BooleanArray::from(data));
     }
 }

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -768,7 +768,7 @@ mod tests {
             .add_child_data(value_data)
             .build()
             .unwrap();
-        FixedSizeListArray::from(list_data);
+        drop(FixedSizeListArray::from(list_data));
     }
 
     #[test]
@@ -1050,7 +1050,7 @@ mod tests {
             .add_child_data(value_data)
             .build()
             .unwrap();
-        ListArray::from(list_data);
+        drop(ListArray::from(list_data));
     }
 
     #[test]
@@ -1066,7 +1066,7 @@ mod tests {
             .add_buffer(value_offsets)
             .build()
             .unwrap();
-        ListArray::from(list_data);
+        drop(ListArray::from(list_data));
     }
 
     #[test]
@@ -1088,7 +1088,7 @@ mod tests {
             .add_child_data(value_data)
             .build()
             .unwrap();
-        ListArray::from(list_data);
+        drop(ListArray::from(list_data));
     }
 
     #[test]
@@ -1101,7 +1101,7 @@ mod tests {
             .add_buffer(buf2)
             .build()
             .unwrap();
-        Int32Array::from(array_data);
+        drop(Int32Array::from(array_data));
     }
 
     #[test]
@@ -1124,7 +1124,7 @@ mod tests {
             .add_child_data(value_data)
             .build()
             .unwrap();
-        ListArray::from(list_data);
+        drop(ListArray::from(list_data));
     }
 
     #[test]

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -951,7 +951,7 @@ mod tests {
                                (values buffer)")]
     fn test_primitive_array_invalid_buffer_len() {
         let data = ArrayData::builder(DataType::Int32).len(5).build().unwrap();
-        Int32Array::from(data);
+        drop(Int32Array::from(data));
     }
 
     #[test]

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -405,7 +405,7 @@ mod tests {
     #[should_panic(expected = "[Large]StringArray expects Datatype::[Large]Utf8")]
     fn test_string_array_from_int() {
         let array = LargeStringArray::from(vec!["a", "b"]);
-        StringArray::from(array.data().clone());
+        drop(StringArray::from(array.data().clone()));
     }
 
     #[test]

--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -408,7 +408,7 @@ mod tests {
         expected = "the field data types must match the array data in a StructArray"
     )]
     fn test_struct_array_from_mismatched_types() {
-        StructArray::from(vec![
+        drop(StructArray::from(vec![
             (
                 Field::new("b", DataType::Int16, false),
                 Arc::new(BooleanArray::from(vec![false, false, true, true]))
@@ -418,7 +418,7 @@ mod tests {
                 Field::new("c", DataType::Utf8, false),
                 Arc::new(Int32Array::from(vec![42, 28, 19, 31])),
             ),
-        ]);
+        ]));
     }
 
     #[test]
@@ -515,7 +515,7 @@ mod tests {
         expected = "all child arrays of a StructArray must have the same length"
     )]
     fn test_invalid_struct_child_array_lengths() {
-        StructArray::from(vec![
+        drop(StructArray::from(vec![
             (
                 Field::new("b", DataType::Float32, false),
                 Arc::new(Float32Array::from(vec![1.1])) as Arc<dyn Array>,
@@ -524,6 +524,6 @@ mod tests {
                 Field::new("c", DataType::Float64, false),
                 Arc::new(Float64Array::from(vec![2.2, 3.3])),
             ),
-        ]);
+        ]));
     }
 }


### PR DESCRIPTION
Automatic cherry-pick of 43d1c85
* Originally appeared in https://github.com/apache/arrow-rs/pull/894: fix some warning about unused variables in panic tests
