### PR TITLE
Backporting prost/tonic upgrade to 6.x line

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -267,6 +267,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt clippy
       - name: Cache Cargo
         uses: actions/cache@v2
         with:

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -28,20 +28,20 @@ license = "Apache-2.0"
 [dependencies]
 arrow = { path = "../arrow", version = "6.1.0" }
 base64 = "0.13"
-tonic = "0.5"
+tonic = "0.6"
 bytes = "1"
-prost = "0.8"
-prost-derive = "0.8"
+prost = "0.9"
+prost-derive = "0.9"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.6"
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
-proc-macro2 = "=1.0.27"
+proc-macro2 = "=1.0.30"
 
 #[lib]
 #name = "flight"

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -229,7 +229,7 @@ pub mod flight_service_client {
     impl<T> FlightServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
@@ -513,7 +513,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the Handshake method."]
         type HandshakeStream: futures_core::Stream<Item = Result<super::HandshakeResponse, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Handshake between client and server. Depending on the server, the"]
@@ -527,7 +526,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the ListFlights method."]
         type ListFlightsStream: futures_core::Stream<Item = Result<super::FlightInfo, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Get a list of available streams given a particular criteria. Most flight"]
@@ -567,7 +565,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the DoGet method."]
         type DoGetStream: futures_core::Stream<Item = Result<super::FlightData, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Retrieve a single stream associated with a particular descriptor"]
@@ -581,7 +578,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the DoPut method."]
         type DoPutStream: futures_core::Stream<Item = Result<super::PutResult, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Push a stream to the flight service associated with a particular"]
@@ -597,7 +593,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the DoExchange method."]
         type DoExchangeStream: futures_core::Stream<Item = Result<super::FlightData, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Open a bidirectional data channel for a given descriptor. This"]
@@ -612,7 +607,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the DoAction method."]
         type DoActionStream: futures_core::Stream<Item = Result<super::Result, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " Flight services can support an arbitrary number of simple actions in"]
@@ -628,7 +622,6 @@ pub mod flight_service_server {
         #[doc = "Server streaming response type for the ListActions method."]
         type ListActionsStream: futures_core::Stream<Item = Result<super::ActionType, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = ""]
         #[doc = " A flight service exposes all of the available action types that it has"]
@@ -674,7 +667,7 @@ pub mod flight_service_server {
     impl<T, B> tonic::codegen::Service<http::Request<B>> for FlightServiceServer<T>
     where
         T: FlightService,
-        B: Body + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -36,10 +36,10 @@ async-trait = "0.1.41"
 clap = "2.33"
 futures = "0.3"
 hex = "0.4"
-prost = "0.8"
+prost = "0.9"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-tonic = "0.5"
-tracing-subscriber = { version = "0.2.15", optional = true }
+tonic = "0.6"
+tracing-subscriber = { version = "0.3.1", optional = true }

--- a/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -191,7 +191,8 @@ impl FlightService for AuthBasicProtoScenarioImpl {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
-        self.check_auth(request.metadata()).await?;
+        let metadata = request.metadata();
+        self.check_auth(metadata).await?;
         Err(Status::unimplemented("Not yet implemented"))
     }
 
@@ -219,7 +220,8 @@ impl FlightService for AuthBasicProtoScenarioImpl {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        self.check_auth(request.metadata()).await?;
+        let metadata = request.metadata();
+        self.check_auth(metadata).await?;
         Err(Status::unimplemented("Not yet implemented"))
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A (related to #897 )

# Rationale for this change
 
Various downstream projects such as IOx would like to upgrade to the latest version of `prost` / `tonic`, etc (0.9 and 0.6 respectively at the time of writing). However, we have avoided such potentially incompatible version upgrades in the past. 

However, in consultation with @shepmaster  and others, there are cases when upgrading dependencies even to new "semver incompatible" versions may not actually break sematic versioning

# What changes are included in this PR?

cherry-pick 1d3d5e3 which originally appeared in https://github.com/apache/arrow-rs/pull/864 from @PsiACE  to `active_relaese` (aka propose to include in the arrow `6.2.0` release). I will then use this branch to see what effects it has on datafusion and others. 

# Are there any user-facing changes?
Versions of `prost` and `tonic` are upated

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
