### PR TITLE
Cherry pick Remove unpassable cargo publish check from verify-release-candidate.sh to active_release

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -139,17 +139,9 @@ test_source_distribution() {
     cargo publish --dry-run
   popd
 
-  pushd arrow-flight
-    cargo publish --dry-run
-  popd
+  # Note can't verify parquet/arrow-flight/parquet-derive until arrow is actually published
+  # as they depend on arrow
 
-  pushd parquet
-    cargo publish --dry-run
-  popd
-
-  pushd parquet_derive
-    cargo publish --dry-run
-  popd
 }
 
 TEST_SUCCESS=no


### PR DESCRIPTION
Automatic cherry-pick of 898924f
* Originally appeared in https://github.com/apache/arrow-rs/pull/882: Remove unpassable cargo publish check from verify-release-candidate.sh


Resolves #948 

This bug got introduced in 6.1.0 and I fixed in on master, but I didn't realize people used the release verification script from the tarball itself. Hopefully this will be in the 6.3.0 release

cc @xudong963