### PR TITLE
Update comfy-table to 5.0

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -51,7 +51,7 @@ chrono = "0.4"
 chrono-tz = {version = "0.4", optional = true}
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"
-comfy-table = { version = "4.0", optional = true, default-features = false }
+comfy-table = { version = "5.0", optional = true, default-features = false }
 pyo3 = { version = "0.14", optional = true }
 lexical-core = "^0.8"
 multiversion = "0.6.1"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #956.

# What changes are included in this PR?

Upgrading comfy-table from 4.0 to 5.0.

# Are there any user-facing changes?

Not that I know of. The [breaking changes in comfy-table](https://github.com/Nukesor/comfy-table/blob/main/CHANGELOG.md#500---2021-11-07) are renaming of some constants that Arrow isn't using. I ran `cargo test --features prettyprint pretty` in `arrow` and all tests passed.

