### PR TITLE
Fix CI for latest nightly

### DIFF
--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -47,8 +47,6 @@
 //!
 //! # Example
 //! ```
-//! extern crate arrow;
-//!
 //! use arrow::array::Int16Array;
 //!
 //! // Create a new builder with a capacity of 100

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -53,7 +53,6 @@ impl Schema {
     /// # Example
     ///
     /// ```
-    /// # extern crate arrow;
     /// # use arrow::datatypes::{Field, DataType, Schema};
     /// let field_a = Field::new("a", DataType::Int64, false);
     /// let field_b = Field::new("b", DataType::Boolean, false);
@@ -70,7 +69,6 @@ impl Schema {
     /// # Example
     ///
     /// ```
-    /// # extern crate arrow;
     /// # use arrow::datatypes::{Field, DataType, Schema};
     /// # use std::collections::HashMap;
     /// let field_a = Field::new("a", DataType::Int64, false);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #969 

# Rationale for this change

CI jobs that use the nightly rust toolchain started failing 
https://github.com/apache/arrow-rs/runs/4286145388?check_suite_focus=true

I think this is related to something included in the 2021-11-22 nightly release that makes the `extern crate ..` syntax not work anymore

# What changes are included in this PR?

Remove some uses of `extern crate`

# Are there any user-facing changes?
Small changes to examples