### PR TITLE
Cherry pick Fix CI for latest nightly to active_release

### DIFF
--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -47,8 +47,6 @@
 //!
 //! # Example
 //! ```
-//! extern crate arrow;
-//!
 //! use arrow::array::Int16Array;
 //!
 //! // Create a new builder with a capacity of 100

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -53,7 +53,6 @@ impl Schema {
     /// # Example
     ///
     /// ```
-    /// # extern crate arrow;
     /// # use arrow::datatypes::{Field, DataType, Schema};
     /// let field_a = Field::new("a", DataType::Int64, false);
     /// let field_b = Field::new("b", DataType::Boolean, false);
@@ -70,7 +69,6 @@ impl Schema {
     /// # Example
     ///
     /// ```
-    /// # extern crate arrow;
     /// # use arrow::datatypes::{Field, DataType, Schema};
     /// # use std::collections::HashMap;
     /// let field_a = Field::new("a", DataType::Int64, false);


### PR DESCRIPTION
Automatic cherry-pick of d40cdc1
* Originally appeared in https://github.com/apache/arrow-rs/pull/970: Fix CI for latest nightly
