### PR TITLE
Remove unneeded `rc` feature of serde

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -37,7 +37,7 @@ name = "arrow"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0", features = ["rc"] }
+serde = { version = "1.0" }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = "1.6"


### PR DESCRIPTION
Fixes #989.

This feature opts into impls for `Rc` and `Arc`, but none of the data
structures that use Serialize/Deserialize actually contain `Rc` or
`Arc`s.

See:

- [Serde docs](https://serde.rs/feature-flags.html#-features-rc)
- [PR adding this](https://github.com/apache/arrow/pull/3016)

# Which issue does this PR close?

Closes #989.

# Rationale for this change

Compile less code, enable fewer features for crates depending on Arrow. The tests still pass without this feature. 

# What changes are included in this PR?

Remove a feature enabled.

# Are there any user-facing changes?

Projects depending on this crate that accidentally took advantage of feature unification to use the functionality added by `rc` might have to add the `rc` feature themselves... but that would be a bug in their project.

I don't think this is documented anywhere user-facing, and I don't think this qualifies as a breaking change to a public API, but I could be wrong, Cargo feature usage is tricky. Please let me know if I'm missing something!
