### PR TITLE
Minimize features of indexmap and chrono

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -40,7 +40,7 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
-indexmap = "1.6"
+indexmap = { version = "1.6", features = ["std"] }
 rand = { version = "0.8", optional = true }
 num = "0.4"
 half = "1.8"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -48,7 +48,7 @@ csv_crate = { version = "1.1", optional = true, package="csv" }
 regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = {version = "0.4", optional = true}
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -38,7 +38,7 @@ brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.9", optional = true }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 num-bigint = "0.4"
 arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #999.

# Rationale for this change

In the case of chrono, making sure these crates aren't turning on a feature name that's deprecated and will be removed eventually, and that they're turning on the minimal number of features actually used to minimize the features projects depending on these crates will be forced to turn on.

In the case of indexmap, by explicitly enabling the "std" feature since arrow isn't targetting no_std environments, this might save a bit of build time done by the indexmap crate at build time to try to automatically detect whether the target has std available or not.

# What changes are included in this PR?

Adjustments to the feature sets of chrono and indexmap

# Are there any user-facing changes?

If projects depending on arrow/parquet are making use of the coincidence that arrow/parquet turns on chrono features, this might mean they have to turn on the features themselves, but that would be a bug in that project's use of chrono.

I can't imagine the indexmap change would affect anyone except for maybe building slightly faster :)