### PR TITLE
Address benchmarks that aren't compiling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,6 +239,46 @@ jobs:
           export CARGO_TARGET_DIR="/github/home/target"
           cargo clippy --features test_common --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
 
+  check_benches:
+    name: Check Benchmarks (but don't run them)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [stable]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache2-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt clippy
+      - name: Check benchmarks
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cargo check --benches --workspace
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -261,13 +261,13 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
           # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -79,4 +79,5 @@ harness = false
 
 [[bench]]
 name = "arrow_array_reader"
+required-features = ["test_common"]
 harness = false


### PR DESCRIPTION
# Which issue does this PR close?

Connects to #770. I'm not sure if this PR completely fixes it or not 😅 

# Rationale for this change

The parquet benchmarks use some types that are behind the test_common feature. The benchmarks don't build without turning on that feature. CI doesn't currently check that benches build, nor is this feature requirement documented anywhere.

# What changes are included in this PR?

The first commit adds a job to CI to build (but not run) all benches in the workspace. I pushed this commit up first to [demonstrate that it's currently failing](https://github.com/apache/arrow-rs/runs/4413576380?check_suite_focus=true#step:7:298).

The second commit adds `--features test_common` to the CI job, and it now passes. I've also documented the need for this flag in parquet/CONTRIBUTING.md.

Ideally, it'd be nice to be able to turn on a feature in Cargo.toml `[bench]` targets, but afaik that isn't possible currently.

Another possible solution is removing the `cfg` from these types, but I wasn't sure if that was desired or not.

# Are there any user-facing changes?

Users trying to build parquet's benchmarks should be able to if they read the docs or check what CI does :)