### PR TITLE
Cherry pick fix some typos in code and comments to active_release

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -119,7 +119,7 @@ impl Buffer {
     }
 
     /// Returns the capacity of this buffer.
-    /// For exernally owned buffers, this returns zero
+    /// For externally owned buffers, this returns zero
     pub fn capacity(&self) -> usize {
         self.data.capacity()
     }

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -1,14 +1,3 @@
-use std::ptr::NonNull;
-
-use crate::{
-    alloc,
-    bytes::{Bytes, Deallocation},
-    datatypes::{ArrowNativeType, ToByteSlice},
-    util::bit_util,
-};
-
-use super::Buffer;
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -25,6 +14,15 @@ use super::Buffer;
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use super::Buffer;
+use crate::{
+    alloc,
+    bytes::{Bytes, Deallocation},
+    datatypes::{ArrowNativeType, ToByteSlice},
+    util::bit_util,
+};
+use std::ptr::NonNull;
 
 /// A [`MutableBuffer`] is Arrow's interface to build a [`Buffer`] out of items or slices of items.
 /// [`Buffer`]s created from [`MutableBuffer`] (via `into`) are guaranteed to have its pointer aligned

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -28,7 +28,7 @@ use crate::{alloc, ffi};
 
 /// Mode of deallocating memory regions
 pub enum Deallocation {
-    /// Native deallocation, using Rust deallocator with Arrow-specific memory aligment
+    /// Native deallocation, using Rust deallocator with Arrow-specific memory alignment
     Native(usize),
     /// Foreign interface, via a callback
     Foreign(Arc<ffi::FFI_ArrowArray>),
@@ -49,17 +49,17 @@ impl Debug for Deallocation {
 
 /// A continuous, fixed-size, immutable memory region that knows how to de-allocate itself.
 /// This structs' API is inspired by the `bytes::Bytes`, but it is not limited to using rust's
-/// global allocator nor u8 aligmnent.
+/// global allocator nor u8 alignment.
 ///
 /// In the most common case, this buffer is allocated using [`allocate_aligned`](memory::allocate_aligned)
 /// and deallocated accordingly [`free_aligned`](memory::free_aligned).
 /// When the region is allocated by an foreign allocator, [Deallocation::Foreign], this calls the
 /// foreign deallocator to deallocate the region when it is no longer needed.
 pub struct Bytes {
-    /// The raw pointer to be begining of the region
+    /// The raw pointer to be beginning of the region
     ptr: NonNull<u8>,
 
-    /// The number of bytes visible to this region. This is always smaller than its capacity (when avaliable).
+    /// The number of bytes visible to this region. This is always smaller than its capacity (when available).
     len: usize,
 
     /// how to deallocate this region

--- a/arrow/src/compute/kernels/arity.rs
+++ b/arrow/src/compute/kernels/arity.rs
@@ -42,12 +42,12 @@ fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
     }
 }
 
-/// Applies an unary and infalible function to a primitive array.
+/// Applies an unary and infallible function to a primitive array.
 /// This is the fastest way to perform an operation on a primitive array when
 /// the benefits of a vectorized operation outweights the cost of branching nulls and non-nulls.
 /// # Implementation
 /// This will apply the function for all values, including those on null slots.
-/// This implies that the operation must be infalible for any value of the corresponding type
+/// This implies that the operation must be infallible for any value of the corresponding type
 /// or this function may panic.
 /// # Example
 /// ```rust

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1570,9 +1570,9 @@ where
     // Note take requires first casting the indices to u32
     let keys_array: ArrayRef =
         Arc::new(PrimitiveArray::<K>::from(dict_array.keys().data().clone()));
-    let indicies = cast_with_options(&keys_array, &DataType::UInt32, cast_options)?;
-    let u32_indicies =
-        indicies
+    let indices = cast_with_options(&keys_array, &DataType::UInt32, cast_options)?;
+    let u32_indices =
+        indices
             .as_any()
             .downcast_ref::<UInt32Array>()
             .ok_or_else(|| {
@@ -1581,7 +1581,7 @@ where
                 )
             })?;
 
-    take(cast_dict_values.as_ref(), u32_indicies, None)
+    take(cast_dict_values.as_ref(), u32_indices, None)
 }
 
 /// Attempts to encode an array into an `ArrayDictionary` with index

--- a/arrow/src/compute/kernels/cast_utils.rs
+++ b/arrow/src/compute/kernels/cast_utils.rs
@@ -54,7 +54,7 @@ use chrono::{prelude::*, LocalResult};
 ///
 /// Numerical values of timestamps are stored compared to offset UTC.
 ///
-/// This function intertprets strings without an explicit time zone as
+/// This function interprets strings without an explicit time zone as
 /// timestamps with offsets of the local time on the machine
 ///
 /// For example, `1997-01-31 09:26:56.123Z` is interpreted as UTC, as
@@ -202,7 +202,7 @@ mod tests {
         Ok(())
     }
 
-    /// Interprets a naive_datetime (with no explicit timzone offset)
+    /// Interprets a naive_datetime (with no explicit timezone offset)
     /// using the local timezone and returns the timestamp in UTC (0
     /// offset)
     fn naive_datetime_to_timestamp(naive_datetime: &NaiveDateTime) -> i64 {
@@ -224,7 +224,7 @@ mod tests {
     fn string_to_timestamp_no_timezone() -> Result<()> {
         // This test is designed to succeed in regardless of the local
         // timezone the test machine is running. Thus it is still
-        // somewhat suceptable to bugs in the use of chrono
+        // somewhat susceptible to bugs in the use of chrono
         let naive_datetime = NaiveDateTime::new(
             NaiveDate::from_ymd(2020, 9, 8),
             NaiveTime::from_hms_nano(13, 42, 29, 190855000),

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -34,7 +34,7 @@ enum State {
     Bits(u64),
     // it is iterating over chunks (steps of size of 64 slots)
     Chunks,
-    // it is iterating over the remainding bits (steps of size of 1 slot)
+    // it is iterating over the remaining bits (steps of size of 1 slot)
     Remainder,
     // nothing more to iterate.
     Finish,
@@ -290,9 +290,9 @@ pub fn filter_record_batch(
         return filter_record_batch(record_batch, &predicate);
     }
 
-    let num_colums = record_batch.columns().len();
+    let num_columns = record_batch.columns().len();
 
-    let filtered_arrays = match num_colums {
+    let filtered_arrays = match num_columns {
         1 => {
             vec![filter(record_batch.columns()[0].as_ref(), predicate)?]
         }
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_primative_array_with_null() {
+    fn test_filter_primitive_array_with_null() {
         let a = Int32Array::from(vec![Some(5), None]);
         let b = BooleanArray::from(vec![false, true]);
         let c = filter(&a, &b).unwrap();

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -425,7 +425,7 @@ impl<R: Read> Reader<R> {
 
         // First we will skip `start` rows
         // note that this skips by iteration. This is because in general it is not possible
-        // to seek in CSV. However, skiping still saves the burden of creating arrow arrays,
+        // to seek in CSV. However, skipping still saves the burden of creating arrow arrays,
         // which is a slow operation that scales with the number of columns
 
         let mut record = ByteRecord::new();
@@ -964,9 +964,9 @@ pub struct ReaderBuilder {
     has_header: bool,
     /// An optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,
-    /// An optional escape charactor. Defaults None
+    /// An optional escape character. Defaults None
     escape: Option<u8>,
-    /// An optional quote charactor. Defaults b'\"'
+    /// An optional quote character. Defaults b'\"'
     quote: Option<u8>,
     /// An optional record terminator. Defaults CRLF
     terminator: Option<u8>,

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -283,7 +283,7 @@ impl Schema {
         }
     }
 
-    /// Check to see if `self` is a superset of `other` schema. Here are the comparision rules:
+    /// Check to see if `self` is a superset of `other` schema. Here are the comparison rules:
     ///
     /// * `self` and `other` should contain the same number of fields
     /// * for every field `f` in `other`, the field in `self` with corresponding index should be a


### PR DESCRIPTION
Automatic cherry-pick of 6a6e7f7
* Originally appeared in https://github.com/apache/arrow-rs/pull/985: fix some typos in code and comments
