### PR TITLE
Remove out of date comment

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -164,10 +164,6 @@ impl Buffer {
     /// `ArrowNativeType` is public so that it can be used as a trait bound for other public
     /// components, such as the `ToByteSlice` trait.  However, this means that it can be
     /// implemented by user defined types, which it is not intended for.
-    ///
-    /// Also `typed_data::<bool>` is unsafe as `0x00` and `0x01` are the only valid values for
-    /// `bool` in Rust.  However, `bool` arrays in Arrow are bit-packed which breaks this condition.
-    /// View buffer as typed slice.
     pub unsafe fn typed_data<T: ArrowNativeType + num::Num>(&self) -> &[T] {
         // JUSTIFICATION
         //  Benefit


### PR DESCRIPTION
re #996 

@jhorstmann  points out that `bool` no longer implements `ArrowNativeType` and thus this comment it out of date. Remove it

Here are the types that implement `ArrowNativeType`
```
/Users/alamb/Software/arrow-rs/arrow/src/datatypes/native.rs
118: impl ArrowNativeType for i8 {
141: impl ArrowNativeType for i16 {
164: impl ArrowNativeType for i32 {
193: impl ArrowNativeType for i64 {
222: impl ArrowNativeType for u8 {
245: impl ArrowNativeType for u16 {
268: impl ArrowNativeType for u32 {
291: impl ArrowNativeType for u64 {
326: impl ArrowNativeType for f16 {}
327: impl ArrowNativeType for f32 {}
328: impl ArrowNativeType for f64 {}
```