### PR TITLE
Cherry pick Remove unneeded `rc` feature of serde to active_release

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -36,7 +36,7 @@ name = "arrow"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0", features = ["rc"] }
+serde = { version = "1.0" }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = "1.6"


### PR DESCRIPTION
Automatic cherry-pick of 771b248
* Originally appeared in https://github.com/apache/arrow-rs/pull/990: Remove unneeded `rc` feature of serde
