### PR TITLE
Cherry pick Fix: fixes a broken link and some missing styling in the main docs to active_release

### DIFF
--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -89,7 +89,7 @@
 //!
 //! ## Compute
 //!
-//! This crate offers many operations (called kernels) to operate on `Array`s, that you can find at [compute::kernels].
+//! This crate offers many operations (called kernels) to operate on [`Array`](array::Array)s, that you can find at [`Kernel`](compute::kernels).
 //! It has both vertical and horizontal operations, and some of them have an SIMD implementation.
 //!
 //! ## Status
@@ -118,9 +118,9 @@
 //!
 //! Finally, this crate implements some readers and writers to different formats:
 //!
-//! * json: [reader](json::reader::Reader)
-//! * csv: [reader](csv::reader::Reader) and [writer](csv::writer::Writer)
-//! * ipc: [reader](ipc::reader::StreamReader) and [writer](ipc::writer::FileWriter)
+//! * JSON: [`Reader`](json::reader::Reader)
+//! * CSV: [`Reader`](csv::reader::Reader) and [`Writer`](csv::writer::Writer)
+//! * IPC: [`Reader`](ipc::reader::StreamReader) and [`Writer`](ipc::writer::FileWriter)
 //!
 //! The parquet implementation is on a [separate crate](https://crates.io/crates/parquet)
 


### PR DESCRIPTION
Automatic cherry-pick of 2e46ede
* Originally appeared in https://github.com/apache/arrow-rs/pull/1013: Fix: fixes a broken link and some missing styling in the main docs
