### PR TITLE
Force new cargo and target caching to fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,14 +46,14 @@ jobs:
           # these represent dependencies downloaded by cargo
           # and thus do not depend on the OS, arch nor rust version.
           path: /github/home/.cargo
-          key: cargo-cache2-
+          key: cargo-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           # these represent compiled steps of both dependencies and arrow
           # and thus are specific for a particular OS, arch and rust version.
           path: /github/home/target
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}-
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache3-${{ matrix.rust }}-
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -91,13 +91,13 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
           # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -147,14 +147,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /github/home/.cargo
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-nightly-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-nightly-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -223,13 +221,13 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
           # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -277,13 +275,13 @@ jobs:
         with:
           path: /home/runner/.cargo
           # this key is not equal because the user is different than on a container (runner vs github)
-          key: cargo-coverage-cache-
+          key: cargo-coverage-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /home/runner/target
           # this key is not equal because coverage uses different compilation flags.
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-coverage-cache-${{ matrix.rust }}-
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-coverage-cache3-${{ matrix.rust }}-
       - name: Run coverage
         run: |
           export CARGO_HOME="/home/runner/.cargo"
@@ -324,13 +322,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /github/home/.cargo
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-wasm32-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}
@@ -366,13 +363,13 @@ jobs:
         with:
           path: /github/home/.cargo
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache2-
+          key: cargo-cache3-
       - name: Cache Rust dependencies
         uses: actions/cache@v2
         with:
           path: /github/home/target
           # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }}


### PR DESCRIPTION
# Which issue does this PR close?

closes https://github.com/apache/arrow-rs/issues/1022 (I hope)

# Rationale for this change
 

The arrow CI tests that rely on nightly are crashing with some sort of rustc internal compiler error due to the internal serialization format changing.

for example: https://github.com/apache/arrow-rs/runs/4468916693?check_suite_focus=true

```

thread 'rustc' panicked at 'assertion failed: sentinel == STR_SENTINEL', /rustc/e6b883c74f49f32cb5d1cbad3457f2b8805a4a38/compiler/rustc_serialize/src/opaque.rs:669:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Also on master: https://github.com/apache/arrow-rs/runs/4474503693?check_suite_focus=true


As @b41sh pointed out https://github.com/apache/arrow-rs/pull/779#issuecomment-989733760, it seems to be a bug in rust: https://github.com/rust-lang/rust/issues/91663

# What changes are included in this PR?
Use a new cache key (and thus force clean builds)

# Are there any user-facing changes?
No -- CI only
