### PR TITLE
Add Schema::project and RecordBatch::project functions 

### DIFF
--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -90,7 +90,8 @@ impl Schema {
     /// Returns a new schema with only the specified columns in the new schema
     /// This carries metadata from the parent schema over as well
     pub fn project(&self, indices: &[usize]) -> Result<Schema> {
-        let new_fields = indices.into_iter()
+        let new_fields = indices
+            .iter()
             .map(|i| {
                 self.fields.get(*i).cloned().ok_or_else(|| {
                     ArrowError::SchemaError(format!(
@@ -132,7 +133,7 @@ impl Schema {
     ///     ]),
     /// );
     /// ```
-    pub fn try_merge(schemas: impl IntoIterator<Item=Self>) -> Result<Self> {
+    pub fn try_merge(schemas: impl IntoIterator<Item = Self>) -> Result<Self> {
         schemas
             .into_iter()
             .try_fold(Self::empty(), |mut merged, schema| {
@@ -423,11 +424,14 @@ mod tests {
             metadata,
         );
 
-        let projected: Result<Schema> = schema.project(&vec![0, 3]);
+        let projected: Result<Schema> = schema.project(&[0, 3]);
 
         assert!(projected.is_err());
         if let Err(e) = projected {
-            assert_eq!(e.to_string(), "Schema error: project index 3 out of bounds, max field 3".to_string())
+            assert_eq!(
+                e.to_string(),
+                "Schema error: project index 3 out of bounds, max field 3".to_string()
+            )
         }
     }
 }

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -89,11 +89,10 @@ impl Schema {
 
     /// Returns a new schema with only the specified columns in the new schema
     /// This carries metadata from the parent schema over as well
-    pub fn project(&self, indices: impl IntoIterator<Item = usize>) -> Result<Schema> {
-        let new_fields = indices
-            .into_iter()
-            .map(|i: usize| {
-                self.fields.get(i).cloned().ok_or_else(|| {
+    pub fn project(&self, indices: &[usize]) -> Result<Schema> {
+        let new_fields = indices.into_iter()
+            .map(|i| {
+                self.fields.get(*i).cloned().ok_or_else(|| {
                     ArrowError::SchemaError(format!(
                         "project index {} out of bounds, max field {}",
                         i,
@@ -133,7 +132,7 @@ impl Schema {
     ///     ]),
     /// );
     /// ```
-    pub fn try_merge(schemas: impl IntoIterator<Item = Self>) -> Result<Self> {
+    pub fn try_merge(schemas: impl IntoIterator<Item=Self>) -> Result<Self> {
         schemas
             .into_iter()
             .try_fold(Self::empty(), |mut merged, schema| {
@@ -402,7 +401,7 @@ mod tests {
             metadata,
         );
 
-        let projected: Schema = schema.project(vec![0, 2]).unwrap();
+        let projected: Schema = schema.project(&[0, 2]).unwrap();
 
         assert_eq!(projected.fields().len(), 2);
         assert_eq!(projected.fields()[0].name(), "name");
@@ -424,7 +423,7 @@ mod tests {
             metadata,
         );
 
-        let projected: Result<Schema> = schema.project(vec![0, 3]);
+        let projected: Result<Schema> = schema.project(&vec![0, 3]);
 
         assert!(projected.is_err());
         if let Err(e) = projected {

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -87,6 +87,18 @@ impl Schema {
         Self { fields, metadata }
     }
 
+
+    /// Returns a new schema with only the specified columns in the new schema
+    /// This carries metadata from the parent schema over as well
+    pub fn project(&self, indices: impl IntoIterator<Item=usize>) -> Result<Schema> {
+        let mut new_fields = vec![];
+        for i in indices {
+            let f = self.fields[i].clone();
+            new_fields.push(f);
+        }
+        Ok(Self::new_with_metadata(new_fields, self.metadata.clone()))
+    }
+
     /// Merge schema into self if it is compatible. Struct fields will be merged recursively.
     ///
     /// Example:
@@ -115,7 +127,7 @@ impl Schema {
     ///     ]),
     /// );
     /// ```
-    pub fn try_merge(schemas: impl IntoIterator<Item = Self>) -> Result<Self> {
+    pub fn try_merge(schemas: impl IntoIterator<Item=Self>) -> Result<Self> {
         schemas
             .into_iter()
             .try_fold(Self::empty(), |mut merged, schema| {
@@ -368,5 +380,24 @@ mod tests {
         let de_schema = serde_json::from_str(&json).unwrap();
 
         assert_eq!(schema, de_schema);
+    }
+
+    #[test]
+    fn test_project() {
+        let mut metadata = HashMap::new();
+        metadata.insert("meta".to_string(), "data".to_string());
+
+        let schema = Schema::new_with_metadata(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("address", DataType::Utf8, false),
+            Field::new("priority", DataType::UInt8, false),
+        ], metadata);
+
+        let projected: Schema = schema.project(vec![0, 2]).unwrap();
+
+        assert_eq!(projected.fields().len(), 2);
+        assert_eq!(projected.fields()[0].name(), "name");
+        assert_eq!(projected.fields()[1].name(), "priority");
+        assert_eq!(projected.metadata.get("meta").unwrap(), "data")
     }
 }

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -175,6 +175,12 @@ impl RecordBatch {
         self.schema.clone()
     }
 
+
+    /// Projects the schema onto the specified columns
+    pub fn project(&self, indices: impl IntoIterator<Item=usize>) -> Result<Schema> {
+        self.schema.project(indices)
+    }
+
     /// Returns the number of columns in the record batch.
     ///
     /// # Example

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -179,7 +179,7 @@ impl RecordBatch {
     pub fn project(&self, indices: &[usize]) -> Result<RecordBatch> {
         let projected_schema = self.schema.project(indices)?;
         let batch_fields = indices
-            .into_iter()
+            .iter()
             .map(|f| {
                 self.columns.get(*f).cloned().ok_or_else(|| {
                     ArrowError::SchemaError(format!(
@@ -922,20 +922,20 @@ mod tests {
 
     #[test]
     fn project() {
-        let a: ArrayRef = Arc::new(Int32Array::from(vec![
-            Some(1),
-            None,
-            Some(3),
-        ]));
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]));
         let b: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
         let c: ArrayRef = Arc::new(StringArray::from(vec!["d", "e", "f"]));
 
-        let record_batch = RecordBatch::try_from_iter(vec![("a", a.clone()), ("b", b.clone()), ("c", c.clone())])
-            .expect("valid conversion");
+        let record_batch = RecordBatch::try_from_iter(vec![
+            ("a", a.clone()),
+            ("b", b.clone()),
+            ("c", c.clone()),
+        ])
+        .expect("valid conversion");
 
         let expected = RecordBatch::try_from_iter(vec![("a", a), ("c", c)])
             .expect("valid conversion");
 
-        assert_eq!(expected, record_batch.project(&vec![0, 2]).unwrap());
+        assert_eq!(expected, record_batch.project(&[0, 2]).unwrap());
     }
 }

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -176,15 +176,12 @@ impl RecordBatch {
     }
 
     /// Projects the schema onto the specified columns
-    pub fn project(
-        &self,
-        indices: impl IntoIterator<Item = usize> + Clone,
-    ) -> Result<RecordBatch> {
-        let projected_schema = self.schema.project(indices.clone())?;
+    pub fn project(&self, indices: &[usize]) -> Result<RecordBatch> {
+        let projected_schema = self.schema.project(indices)?;
         let batch_fields = indices
             .into_iter()
-            .map(|f: usize| {
-                self.columns.get(f).cloned().ok_or_else(|| {
+            .map(|f| {
+                self.columns.get(*f).cloned().ok_or_else(|| {
                     ArrowError::SchemaError(format!(
                         "project index {} out of bounds, max field {}",
                         f,
@@ -921,5 +918,24 @@ mod tests {
         .unwrap();
 
         assert_ne!(batch1, batch2);
+    }
+
+    #[test]
+    fn project() {
+        let a: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(3),
+        ]));
+        let b: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+        let c: ArrayRef = Arc::new(StringArray::from(vec!["d", "e", "f"]));
+
+        let record_batch = RecordBatch::try_from_iter(vec![("a", a.clone()), ("b", b.clone()), ("c", c.clone())])
+            .expect("valid conversion");
+
+        let expected = RecordBatch::try_from_iter(vec![("a", a), ("c", c)])
+            .expect("valid conversion");
+
+        assert_eq!(expected, record_batch.project(&vec![0, 2]).unwrap());
     }
 }


### PR DESCRIPTION
…eturning a new schema with those columns only

# Which issue does this PR close?

 

Closes #1014.

# Rationale for this change
 
See #1014 but a lot of code can be simplified and also fix silent bugs with handling metadata.

# What changes are included in this PR?

2 methods on Schema and RecordBatch to allow them to project on their schemas.

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
