### PR TITLE
 Generify ColumnReaderImpl and RecordReader (#1040) 

### DIFF
--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::any::Any;
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
@@ -62,12 +63,13 @@ use crate::arrow::converter::{
     IntervalYearMonthConverter, LargeBinaryArrayConverter, LargeBinaryConverter,
     LargeUtf8ArrayConverter, LargeUtf8Converter,
 };
-use crate::arrow::record_reader::RecordReader;
+use crate::arrow::record_reader::buffer::{ScalarValue, ValuesBuffer};
+use crate::arrow::record_reader::{GenericRecordReader, RecordReader};
 use crate::arrow::schema::parquet_to_arrow_field;
 use crate::basic::{ConvertedType, Repetition, Type as PhysicalType};
 use crate::column::page::PageIterator;
+use crate::column::reader::decoder::ColumnValueDecoder;
 use crate::column::reader::ColumnReaderImpl;
-use crate::data_type::private::ScalarDataType;
 use crate::data_type::{
     BoolType, ByteArrayType, DataType, DoubleType, FixedLenByteArrayType, FloatType,
     Int32Type, Int64Type, Int96Type,
@@ -78,7 +80,6 @@ use crate::schema::types::{
     ColumnDescPtr, ColumnDescriptor, ColumnPath, SchemaDescPtr, Type, TypePtr,
 };
 use crate::schema::visitor::TypeVisitor;
-use std::any::Any;
 
 /// Array reader reads parquet data into arrow array.
 pub trait ArrayReader {
@@ -105,11 +106,15 @@ pub trait ArrayReader {
 ///
 /// Returns the number of records read, which can be less than batch_size if
 /// pages is exhausted.
-fn read_records<T: ScalarDataType>(
-    record_reader: &mut RecordReader<T>,
+fn read_records<V, CV>(
+    record_reader: &mut GenericRecordReader<V, CV>,
     pages: &mut dyn PageIterator,
     batch_size: usize,
-) -> Result<usize> {
+) -> Result<usize>
+where
+    V: ValuesBuffer + Default,
+    CV: ColumnValueDecoder<Slice = V::Slice>,
+{
     let mut records_read = 0usize;
     while records_read < batch_size {
         let records_to_read = batch_size - records_read;
@@ -133,7 +138,11 @@ fn read_records<T: ScalarDataType>(
 
 /// A NullArrayReader reads Parquet columns stored as null int32s with an Arrow
 /// NullArray type.
-pub struct NullArrayReader<T: ScalarDataType> {
+pub struct NullArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     data_type: ArrowType,
     pages: Box<dyn PageIterator>,
     def_levels_buffer: Option<Buffer>,
@@ -143,7 +152,11 @@ pub struct NullArrayReader<T: ScalarDataType> {
     _type_marker: PhantomData<T>,
 }
 
-impl<T: ScalarDataType> NullArrayReader<T> {
+impl<T> NullArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     /// Construct null array reader.
     pub fn new(pages: Box<dyn PageIterator>, column_desc: ColumnDescPtr) -> Result<Self> {
         let record_reader = RecordReader::<T>::new(column_desc.clone());
@@ -161,7 +174,11 @@ impl<T: ScalarDataType> NullArrayReader<T> {
 }
 
 /// Implementation of primitive array reader.
-impl<T: ScalarDataType> ArrayReader for NullArrayReader<T> {
+impl<T> ArrayReader for NullArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -201,7 +218,11 @@ impl<T: ScalarDataType> ArrayReader for NullArrayReader<T> {
 
 /// Primitive array readers are leaves of array reader tree. They accept page iterator
 /// and read them into primitive arrays.
-pub struct PrimitiveArrayReader<T: ScalarDataType> {
+pub struct PrimitiveArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     data_type: ArrowType,
     pages: Box<dyn PageIterator>,
     def_levels_buffer: Option<Buffer>,
@@ -210,7 +231,11 @@ pub struct PrimitiveArrayReader<T: ScalarDataType> {
     record_reader: RecordReader<T>,
 }
 
-impl<T: ScalarDataType> PrimitiveArrayReader<T> {
+impl<T> PrimitiveArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     /// Construct primitive array reader.
     pub fn new(
         pages: Box<dyn PageIterator>,
@@ -239,7 +264,11 @@ impl<T: ScalarDataType> PrimitiveArrayReader<T> {
 }
 
 /// Implementation of primitive array reader.
-impl<T: ScalarDataType> ArrayReader for PrimitiveArrayReader<T> {
+impl<T> ArrayReader for PrimitiveArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -1907,7 +1936,26 @@ impl<'a> ArrayReaderBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::any::Any;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use rand::distributions::uniform::SampleUniform;
+    use rand::{thread_rng, Rng};
+
+    use arrow::array::{
+        Array, ArrayRef, LargeListArray, ListArray, PrimitiveArray, StringArray,
+        StructArray,
+    };
+    use arrow::datatypes::{
+        ArrowPrimitiveType, DataType as ArrowType, Date32Type as ArrowDate32, Field,
+        Int32Type as ArrowInt32, Int64Type as ArrowInt64,
+        Time32MillisecondType as ArrowTime32MillisecondArray,
+        Time64MicrosecondType as ArrowTime64MicrosecondArray,
+        TimestampMicrosecondType as ArrowTimestampMicrosecondType,
+        TimestampMillisecondType as ArrowTimestampMillisecondType,
+    };
+
     use crate::arrow::converter::{Utf8ArrayConverter, Utf8Converter};
     use crate::arrow::schema::parquet_to_arrow_schema;
     use crate::basic::{Encoding, Type as PhysicalType};
@@ -1921,23 +1969,8 @@ mod tests {
         DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
     };
     use crate::util::test_common::{get_test_file, make_pages};
-    use arrow::array::{
-        Array, ArrayRef, LargeListArray, ListArray, PrimitiveArray, StringArray,
-        StructArray,
-    };
-    use arrow::datatypes::{
-        ArrowPrimitiveType, DataType as ArrowType, Date32Type as ArrowDate32, Field,
-        Int32Type as ArrowInt32, Int64Type as ArrowInt64,
-        Time32MillisecondType as ArrowTime32MillisecondArray,
-        Time64MicrosecondType as ArrowTime64MicrosecondArray,
-        TimestampMicrosecondType as ArrowTimestampMicrosecondType,
-        TimestampMillisecondType as ArrowTimestampMillisecondType,
-    };
-    use rand::distributions::uniform::SampleUniform;
-    use rand::{thread_rng, Rng};
-    use std::any::Any;
-    use std::collections::VecDeque;
-    use std::sync::Arc;
+
+    use super::*;
 
     fn make_column_chunks<T: DataType>(
         column_desc: ColumnDescPtr,

--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -200,7 +200,6 @@ pub struct PrimitiveArrayReader<T: DataType> {
     rep_levels_buffer: Option<Buffer>,
     column_desc: ColumnDescPtr,
     record_reader: RecordReader<T>,
-    _type_marker: PhantomData<T>,
 }
 
 impl<T: DataType> PrimitiveArrayReader<T> {
@@ -230,7 +229,6 @@ impl<T: DataType> PrimitiveArrayReader<T> {
             rep_levels_buffer: None,
             column_desc,
             record_reader,
-            _type_marker: PhantomData,
         })
     }
 }

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -45,6 +45,11 @@ pub type RecordReader<T> =
     GenericRecordReader<TypedBuffer<<T as DataType>::T>, ColumnValueDecoderImpl<T>>;
 
 #[doc(hidden)]
+/// A generic stateful column reader that delimits semantic records
+///
+/// This type is hidden from the docs, and relies on private traits with no
+/// public implementations. As such this type signature may be changed without
+/// breaking downstream users as it can only be constructed through type aliases
 pub struct GenericRecordReader<V, CV> {
     column_desc: ColumnDescPtr,
 

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -183,6 +183,7 @@ pub(crate) mod private {
                 unsafe { self.buffer.as_slice().align_to::<i16>() };
             assert!(prefix.is_empty() && suffix.is_empty());
 
+            null_mask.reserve(range.end - range.start);
             for i in &buf[range] {
                 null_mask.append(*i == max_level)
             }

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -158,7 +158,7 @@ pub(crate) mod private {
             let mut end_of_last_record = start;
 
             for current in range {
-                if buf[current] == 0 && current != end_of_last_record {
+                if buf[current] == 0 && current != start {
                     records_read += 1;
                     end_of_last_record = current;
 

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -236,7 +236,7 @@ where
                 )
             })?;
 
-            let iter = def_levels.valid_position_iter(
+            let iter = def_levels.rev_valid_positions_iter(
                 self.values_written..self.values_written + levels_read,
             );
 

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -106,6 +106,8 @@ pub(crate) mod private {
         type Writer = [T];
 
         fn split(&mut self, len: usize) -> Self::Output {
+            assert!(len <= self.len);
+
             let num_bytes = len * std::mem::size_of::<T>();
             let remaining_bytes = self.buffer.len() - num_bytes;
             // TODO: Optimize to reduce the copy
@@ -119,6 +121,7 @@ pub(crate) mod private {
                 .copy_from_slice(&self.buffer.as_slice()[num_bytes..]);
 
             self.buffer.resize(num_bytes, 0);
+            self.len -= len;
 
             replace(&mut self.buffer, remaining).into()
         }

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -27,7 +27,7 @@ use crate::arrow::record_reader::{
 use crate::column::{
     page::PageReader,
     reader::{
-        private::{ColumnLevelDecoderImpl, ColumnValueDecoder, ColumnValueDecoderImpl},
+        decoder::{ColumnLevelDecoderImpl, ColumnValueDecoder, ColumnValueDecoderImpl},
         GenericColumnReader,
     },
 };

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -43,10 +43,8 @@ pub struct RecordReader<T: DataType> {
     /// Number of values `num_records` contains.
     num_values: usize,
 
-    values_seen: usize,
     /// Starts from 1, number of values have been written to buffer
     values_written: usize,
-    in_middle_of_record: bool,
 }
 
 impl<T: DataType> RecordReader<T> {
@@ -75,9 +73,7 @@ impl<T: DataType> RecordReader<T> {
             column_desc: column_schema,
             num_records: 0,
             num_values: 0,
-            values_seen: 0,
             values_written: 0,
-            in_middle_of_record: false,
         }
     }
 
@@ -107,21 +103,25 @@ impl<T: DataType> RecordReader<T> {
         loop {
             // Try to find some records from buffers that has been read into memory
             // but not counted as seen records.
-            records_read += self.split_records(num_records - records_read)?;
+            let (record_count, value_count) =
+                self.count_records(num_records - records_read);
 
-            // Since page reader contains complete records, so if we reached end of a
-            // page reader, we should reach the end of a record
-            if end_of_column
-                && self.values_seen >= self.values_written
-                && self.in_middle_of_record
-            {
-                self.num_records += 1;
-                self.num_values = self.values_seen;
-                self.in_middle_of_record = false;
-                records_read += 1;
+            self.num_records += record_count;
+            self.num_values += value_count;
+            records_read += record_count;
+
+            if records_read == num_records {
+                break;
             }
 
-            if (records_read >= num_records) || end_of_column {
+            if end_of_column {
+                // Since page reader contains complete records, if we reached end of a
+                // page reader, we should reach the end of a record
+                if self.rep_levels.is_some() {
+                    self.num_records += 1;
+                    self.num_values = self.values_written;
+                    records_read += 1;
+                }
                 break;
             }
 
@@ -265,8 +265,6 @@ impl<T: DataType> RecordReader<T> {
         self.values_written -= self.num_values;
         self.num_records = 0;
         self.num_values = 0;
-        self.values_seen = 0;
-        self.in_middle_of_record = false;
     }
 
     /// Returns bitmap data.
@@ -367,10 +365,11 @@ impl<T: DataType> RecordReader<T> {
         Ok(values_read)
     }
 
-    /// Split values into records according repetition definition and returns number of
-    /// records read.
-    #[allow(clippy::unnecessary_wraps)]
-    fn split_records(&mut self, records_to_read: usize) -> Result<usize> {
+    /// Inspects the buffered repetition levels in the range `self.num_values..self.values_written`
+    /// and returns the number of "complete" records along with the corresponding number of values
+    ///
+    /// A "complete" record is one where the buffer contains a subsequent repetition level of 0
+    fn count_records(&self, records_to_read: usize) -> (usize, usize) {
         let rep_levels = self.rep_levels.as_ref().map(|buf| {
             let (prefix, rep_levels, suffix) =
                 unsafe { buf.as_slice().align_to::<i16>() };
@@ -381,32 +380,28 @@ impl<T: DataType> RecordReader<T> {
         match rep_levels {
             Some(buf) => {
                 let mut records_read = 0;
+                let mut end_of_last_record = self.num_values;
 
-                while (self.values_seen < self.values_written)
-                    && (records_read < records_to_read)
-                {
-                    if buf[self.values_seen] == 0 {
-                        if self.in_middle_of_record {
+                for current in self.num_values..self.values_written {
+                    if buf[current] == 0 {
+                        if current != end_of_last_record {
                             records_read += 1;
-                            self.num_records += 1;
-                            self.num_values = self.values_seen;
+                            end_of_last_record = current;
+
+                            if records_read == records_to_read {
+                                break;
+                            }
                         }
-                        self.in_middle_of_record = true;
                     }
-                    self.values_seen += 1;
                 }
 
-                Ok(records_read)
+                (records_read, end_of_last_record - self.num_values)
             }
             None => {
                 let records_read =
-                    min(records_to_read, self.values_written - self.values_seen);
-                self.num_records += records_read;
-                self.num_values += records_read;
-                self.values_seen += records_read;
-                self.in_middle_of_record = false;
+                    min(records_to_read, self.values_written - self.num_values);
 
-                Ok(records_read)
+                (records_read, records_read)
             }
         }
     }

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -241,7 +241,23 @@ where
     fn count_records(&self, records_to_read: usize) -> (usize, usize) {
         match self.rep_levels.as_ref() {
             Some(buf) => {
-                buf.count_records(self.num_values..self.values_written, records_to_read)
+                let buf = buf.as_slice();
+
+                let mut records_read = 0;
+                let mut end_of_last_record = self.num_values;
+
+                for current in self.num_values..self.values_written {
+                    if buf[current] == 0 && current != self.num_values {
+                        records_read += 1;
+                        end_of_last_record = current;
+
+                        if records_read == records_to_read {
+                            break;
+                        }
+                    }
+                }
+
+                (records_read, end_of_last_record - self.num_values)
             }
             None => {
                 let records_read =

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -66,7 +66,7 @@ pub struct GenericRecordReader<V, CV> {
 impl<V, CV> GenericRecordReader<V, CV>
 where
     V: ValuesBuffer + Default,
-    CV: ColumnValueDecoder<Slice= V::Slice>,
+    CV: ColumnValueDecoder<Slice = V::Slice>,
 {
     pub fn new(desc: ColumnDescPtr) -> Self {
         let def_levels =

--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -21,7 +21,7 @@ use arrow::bitmap::Bitmap;
 use arrow::buffer::Buffer;
 
 use crate::arrow::record_reader::{
-    buffer::{BufferQueue, TypedBuffer, ValuesBuffer},
+    buffer::{BufferQueue, ScalarBuffer, ValuesBuffer},
     definition_levels::{DefinitionLevelBuffer, DefinitionLevelDecoder},
 };
 use crate::column::{
@@ -42,7 +42,7 @@ const MIN_BATCH_SIZE: usize = 1024;
 
 /// A `RecordReader` is a stateful column reader that delimits semantic records.
 pub type RecordReader<T> =
-    GenericRecordReader<TypedBuffer<<T as DataType>::T>, ColumnValueDecoderImpl<T>>;
+    GenericRecordReader<ScalarBuffer<<T as DataType>::T>, ColumnValueDecoderImpl<T>>;
 
 #[doc(hidden)]
 /// A generic stateful column reader that delimits semantic records
@@ -55,7 +55,7 @@ pub struct GenericRecordReader<V, CV> {
 
     records: V,
     def_levels: Option<DefinitionLevelBuffer>,
-    rep_levels: Option<TypedBuffer<i16>>,
+    rep_levels: Option<ScalarBuffer<i16>>,
     column_reader:
         Option<GenericColumnReader<ColumnLevelDecoderImpl, DefinitionLevelDecoder, CV>>,
 
@@ -77,7 +77,7 @@ where
         let def_levels =
             (desc.max_def_level() > 0).then(|| DefinitionLevelBuffer::new(&desc));
 
-        let rep_levels = (desc.max_rep_level() > 0).then(TypedBuffer::new);
+        let rep_levels = (desc.max_rep_level() > 0).then(ScalarBuffer::new);
 
         Self {
             records: Default::default(),

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -1,0 +1,141 @@
+use std::marker::PhantomData;
+use std::ops::Range;
+
+use arrow::buffer::{Buffer, MutableBuffer};
+
+use crate::schema::types::ColumnDescPtr;
+
+pub trait RecordBuffer: Sized {
+    type Output: Sized;
+
+    type Writer: ?Sized;
+
+    /// Create buffer
+    fn create(desc: &ColumnDescPtr) -> Self;
+
+    /// Split out `len` items
+    fn split(&mut self, len: usize) -> Self::Output;
+
+    /// Get a writer with `batch_size` capacity
+    fn writer(&mut self, batch_size: usize) -> &mut Self::Writer;
+
+    /// Record a write of `len` items
+    fn commit(&mut self, len: usize);
+}
+
+pub struct TypedBuffer<T> {
+    buffer: MutableBuffer,
+
+    /// Length in elements of size T
+    len: usize,
+
+    /// Placeholder to allow `T` as an invariant generic parameter
+    _phantom: PhantomData<*mut T>,
+}
+
+impl<T> TypedBuffer<T> {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        let (prefix, buf, suffix) = unsafe { self.buffer.as_slice().align_to::<T>() };
+        assert!(prefix.is_empty() && suffix.is_empty());
+        buf
+    }
+
+    #[inline]
+    pub fn as_slice_mut(&mut self) -> &mut [T] {
+        let (prefix, buf, suffix) =
+            unsafe { self.buffer.as_slice_mut().align_to_mut::<T>() };
+        assert!(prefix.is_empty() && suffix.is_empty());
+        buf
+    }
+}
+
+impl<T> RecordBuffer for TypedBuffer<T> {
+    type Output = Buffer;
+
+    type Writer = [T];
+
+    fn create(_desc: &ColumnDescPtr) -> Self {
+        Self {
+            buffer: MutableBuffer::new(0),
+            len: 0,
+            _phantom: Default::default(),
+        }
+    }
+
+    fn split(&mut self, len: usize) -> Self::Output {
+        assert!(len <= self.len);
+
+        let num_bytes = len * std::mem::size_of::<T>();
+        let remaining_bytes = self.buffer.len() - num_bytes;
+        // TODO: Optimize to reduce the copy
+        // create an empty buffer, as it will be resized below
+        let mut remaining = MutableBuffer::new(0);
+        remaining.resize(remaining_bytes, 0);
+
+        let new_records = remaining.as_slice_mut();
+
+        new_records[0..remaining_bytes]
+            .copy_from_slice(&self.buffer.as_slice()[num_bytes..]);
+
+        self.buffer.resize(num_bytes, 0);
+        self.len -= len;
+
+        std::mem::replace(&mut self.buffer, remaining).into()
+    }
+
+    fn writer(&mut self, batch_size: usize) -> &mut Self::Writer {
+        self.buffer
+            .resize((self.len + batch_size) * std::mem::size_of::<T>(), 0);
+
+        let range = self.len..self.len + batch_size;
+        &mut self.as_slice_mut()[range]
+    }
+
+    fn commit(&mut self, len: usize) {
+        self.len = len;
+
+        let new_bytes = self.len * std::mem::size_of::<T>();
+        assert!(new_bytes <= self.buffer.len());
+        self.buffer.resize(new_bytes, 0);
+    }
+}
+
+impl TypedBuffer<i16> {
+    /// Inspects the buffered repetition levels in `range` and returns the number of
+    /// "complete" records along with the corresponding number of values
+    ///
+    /// A "complete" record is one where the buffer contains a subsequent repetition level of 0
+    pub fn count_records(
+        &self,
+        range: Range<usize>,
+        max_records: usize,
+    ) -> (usize, usize) {
+        let buf = self.as_slice();
+
+        let start = range.start;
+        let mut records_read = 0;
+        let mut end_of_last_record = start;
+
+        for current in range {
+            if buf[current] == 0 && current != start {
+                records_read += 1;
+                end_of_last_record = current;
+
+                if records_read == max_records {
+                    break;
+                }
+            }
+        }
+
+        (records_read, end_of_last_record - start)
+    }
+}

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -162,8 +162,13 @@ pub trait ValuesBuffer: BufferQueue {
     /// Iterate through the indexes in `range` in reverse order, moving the value at each
     /// index to the next index returned by `rev_valid_position_iter`
     ///
-    /// It is guaranteed that the `i`th index returned by `rev_valid_position_iter` is greater
-    /// than or equal to `range.end - i - 1`
+    /// It is required that:
+    ///
+    /// - `rev_valid_position_iter` has at least `range.end - range.start` elements
+    /// - `rev_valid_position_iter` returns strictly monotonically decreasing values
+    /// - the `i`th index returned by `rev_valid_position_iter` is `>= range.end - i - 1`
+    ///
+    /// Implementations may panic or otherwise misbehave if this is not the case
     ///
     fn pad_nulls(
         &mut self,

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::ops::Range;
 
 use arrow::buffer::{Buffer, MutableBuffer};
 
@@ -107,36 +106,5 @@ impl<T> RecordBuffer for TypedBuffer<T> {
         let new_bytes = self.len * std::mem::size_of::<T>();
         assert!(new_bytes <= self.buffer.len());
         self.buffer.resize(new_bytes, 0);
-    }
-}
-
-impl TypedBuffer<i16> {
-    /// Inspects the buffered repetition levels in `range` and returns the number of
-    /// "complete" records along with the corresponding number of values
-    ///
-    /// A "complete" record is one where the buffer contains a subsequent repetition level of 0
-    pub fn count_records(
-        &self,
-        range: Range<usize>,
-        max_records: usize,
-    ) -> (usize, usize) {
-        let buf = self.as_slice();
-
-        let start = range.start;
-        let mut records_read = 0;
-        let mut end_of_last_record = start;
-
-        for current in range {
-            if buf[current] == 0 && current != start {
-                records_read += 1;
-                end_of_last_record = current;
-
-                if records_read == max_records {
-                    break;
-                }
-            }
-        }
-
-        (records_read, end_of_last_record - start)
     }
 }

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -3,15 +3,10 @@ use std::ops::Range;
 
 use arrow::buffer::{Buffer, MutableBuffer};
 
-use crate::schema::types::ColumnDescPtr;
-
 pub trait RecordBuffer: Sized {
     type Output: Sized;
 
     type Writer: ?Sized;
-
-    /// Create buffer
-    fn create(desc: &ColumnDescPtr) -> Self;
 
     /// Split out `len` items
     fn split(&mut self, len: usize) -> Self::Output;
@@ -33,7 +28,21 @@ pub struct TypedBuffer<T> {
     _phantom: PhantomData<*mut T>,
 }
 
+impl<T> Default for TypedBuffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> TypedBuffer<T> {
+    pub fn new() -> Self {
+        Self {
+            buffer: MutableBuffer::new(0),
+            len: 0,
+            _phantom: Default::default(),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }
@@ -62,14 +71,6 @@ impl<T> RecordBuffer for TypedBuffer<T> {
     type Output = Buffer;
 
     type Writer = [T];
-
-    fn create(_desc: &ColumnDescPtr) -> Self {
-        Self {
-            buffer: MutableBuffer::new(0),
-            len: 0,
-            _phantom: Default::default(),
-        }
-    }
 
     fn split(&mut self, len: usize) -> Self::Output {
         assert!(len <= self.len);

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::marker::PhantomData;
 use std::ops::Range;
 

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -7,7 +7,7 @@ use crate::column::reader::decoder::ColumnLevelDecoderImpl;
 use crate::schema::types::ColumnDescPtr;
 
 use super::{
-    buffer::{RecordBuffer, TypedBuffer},
+    buffer::{BufferQueue, TypedBuffer},
     MIN_BATCH_SIZE,
 };
 
@@ -17,21 +17,21 @@ pub struct DefinitionLevelBuffer {
     max_level: i16,
 }
 
-impl RecordBuffer for DefinitionLevelBuffer {
+impl BufferQueue for DefinitionLevelBuffer {
     type Output = Buffer;
-    type Writer = [i16];
+    type Slice = [i16];
 
-    fn split(&mut self, len: usize) -> Self::Output {
-        self.buffer.split(len)
+    fn split_off(&mut self, len: usize) -> Self::Output {
+        self.buffer.split_off(len)
     }
 
-    fn writer(&mut self, batch_size: usize) -> &mut Self::Writer {
+    fn spare_capacity_mut(&mut self, batch_size: usize) -> &mut Self::Slice {
         assert_eq!(self.buffer.len(), self.builder.len());
-        self.buffer.writer(batch_size)
+        self.buffer.spare_capacity_mut(batch_size)
     }
 
-    fn commit(&mut self, len: usize) {
-        self.buffer.commit(len);
+    fn set_len(&mut self, len: usize) {
+        self.buffer.set_len(len);
         let buf = self.buffer.as_slice();
 
         let range = self.builder.len()..len;

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -20,14 +20,6 @@ impl RecordBuffer for DefinitionLevelBuffer {
     type Output = Buffer;
     type Writer = [i16];
 
-    fn create(desc: &ColumnDescPtr) -> Self {
-        Self {
-            buffer: RecordBuffer::create(desc),
-            builder: BooleanBufferBuilder::new(0),
-            max_level: desc.max_def_level(),
-        }
-    }
-
     fn split(&mut self, len: usize) -> Self::Output {
         self.buffer.split(len)
     }
@@ -50,6 +42,14 @@ impl RecordBuffer for DefinitionLevelBuffer {
 }
 
 impl DefinitionLevelBuffer {
+    pub fn new(desc: &ColumnDescPtr) -> Self {
+        Self {
+            buffer: TypedBuffer::new(),
+            builder: BooleanBufferBuilder::new(0),
+            max_level: desc.max_def_level(),
+        }
+    }
+
     /// Split `len` levels out of `self`
     pub fn split_bitmask(&mut self, len: usize) -> Bitmap {
         let old_len = self.builder.len();

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -2,7 +2,7 @@ use arrow::array::BooleanBufferBuilder;
 use arrow::bitmap::Bitmap;
 use arrow::buffer::Buffer;
 
-use crate::column::reader::private::ColumnLevelDecoderImpl;
+use crate::column::reader::decoder::ColumnLevelDecoderImpl;
 use crate::schema::types::ColumnDescPtr;
 
 use super::{

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -86,7 +86,8 @@ impl DefinitionLevelBuffer {
         old_bitmap
     }
 
-    pub fn valid_position_iter(
+    /// Returns an iterator of the valid positions in `range` in descending order
+    pub fn rev_valid_positions_iter(
         &self,
         range: Range<usize>,
     ) -> impl Iterator<Item = usize> + '_ {

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -1,0 +1,72 @@
+use arrow::array::BooleanBufferBuilder;
+use arrow::bitmap::Bitmap;
+use arrow::buffer::Buffer;
+
+use crate::column::reader::private::ColumnLevelDecoderImpl;
+use crate::schema::types::ColumnDescPtr;
+
+use super::{
+    buffer::{RecordBuffer, TypedBuffer},
+    MIN_BATCH_SIZE,
+};
+
+pub struct DefinitionLevelBuffer {
+    buffer: TypedBuffer<i16>,
+    builder: BooleanBufferBuilder,
+    max_level: i16,
+}
+
+impl RecordBuffer for DefinitionLevelBuffer {
+    type Output = Buffer;
+    type Writer = [i16];
+
+    fn create(desc: &ColumnDescPtr) -> Self {
+        Self {
+            buffer: RecordBuffer::create(desc),
+            builder: BooleanBufferBuilder::new(0),
+            max_level: desc.max_def_level(),
+        }
+    }
+
+    fn split(&mut self, len: usize) -> Self::Output {
+        self.buffer.split(len)
+    }
+
+    fn writer(&mut self, batch_size: usize) -> &mut Self::Writer {
+        assert_eq!(self.buffer.len(), self.builder.len());
+        self.buffer.writer(batch_size)
+    }
+
+    fn commit(&mut self, len: usize) {
+        self.buffer.commit(len);
+        let buf = self.buffer.as_slice();
+
+        let range = self.builder.len()..len;
+        self.builder.reserve(range.end - range.start);
+        for i in &buf[range] {
+            self.builder.append(*i == self.max_level)
+        }
+    }
+}
+
+impl DefinitionLevelBuffer {
+    /// Split `len` levels out of `self`
+    pub fn split_bitmask(&mut self, len: usize) -> Bitmap {
+        let old_len = self.builder.len();
+        let num_left_values = old_len - len;
+        let new_bitmap_builder =
+            BooleanBufferBuilder::new(MIN_BATCH_SIZE.max(num_left_values));
+
+        let old_bitmap =
+            std::mem::replace(&mut self.builder, new_bitmap_builder).finish();
+        let old_bitmap = Bitmap::from(old_bitmap);
+
+        for i in len..old_len {
+            self.builder.append(old_bitmap.is_set(i));
+        }
+
+        old_bitmap
+    }
+}
+
+pub type DefinitionLevelDecoder = ColumnLevelDecoderImpl;

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -24,12 +24,12 @@ use crate::column::reader::decoder::ColumnLevelDecoderImpl;
 use crate::schema::types::ColumnDescPtr;
 
 use super::{
-    buffer::{BufferQueue, TypedBuffer},
+    buffer::{BufferQueue, ScalarBuffer},
     MIN_BATCH_SIZE,
 };
 
 pub struct DefinitionLevelBuffer {
-    buffer: TypedBuffer<i16>,
+    buffer: ScalarBuffer<i16>,
     builder: BooleanBufferBuilder,
     max_level: i16,
 }
@@ -62,7 +62,7 @@ impl BufferQueue for DefinitionLevelBuffer {
 impl DefinitionLevelBuffer {
     pub fn new(desc: &ColumnDescPtr) -> Self {
         Self {
-            buffer: TypedBuffer::new(),
+            buffer: ScalarBuffer::new(),
             builder: BooleanBufferBuilder::new(0),
             max_level: desc.max_def_level(),
         }

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -1,6 +1,7 @@
 use arrow::array::BooleanBufferBuilder;
 use arrow::bitmap::Bitmap;
 use arrow::buffer::Buffer;
+use std::ops::Range;
 
 use crate::column::reader::decoder::ColumnLevelDecoderImpl;
 use crate::schema::types::ColumnDescPtr;
@@ -66,6 +67,15 @@ impl DefinitionLevelBuffer {
         }
 
         old_bitmap
+    }
+
+    pub fn valid_position_iter(
+        &self,
+        range: Range<usize>,
+    ) -> impl Iterator<Item = usize> + '_ {
+        let max_def_level = self.max_level;
+        let slice = self.buffer.as_slice();
+        range.rev().filter(move |x| slice[*x] == max_def_level)
     }
 }
 

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use arrow::array::BooleanBufferBuilder;
 use arrow::bitmap::Bitmap;
 use arrow::buffer::Buffer;

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -17,24 +17,20 @@
 
 //! Contains column reader API.
 
-use std::{
-    cmp::{max, min},
-    collections::HashMap,
-    ops::Range,
-};
+use std::cmp::{max, min};
 
 use super::page::{Page, PageReader};
 use crate::basic::*;
-use crate::column::reader::private::{
+use crate::column::reader::decoder::{
     ColumnLevelDecoder, ColumnValueDecoder, LevelsWriter, ValuesWriter,
 };
 use crate::data_type::*;
-use crate::encodings::decoding::{get_decoder, Decoder, DictDecoder, PlainDecoder};
-use crate::encodings::rle::RleDecoder;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
-use crate::util::bit_util::{ceil, BitReader};
+use crate::util::bit_util::ceil;
 use crate::util::memory::ByteBufferPtr;
+
+pub(crate) mod decoder;
 
 /// Column reader for a Parquet type.
 pub enum ColumnReader {
@@ -104,261 +100,11 @@ pub fn get_typed_column_reader<T: DataType>(
     })
 }
 
-pub(crate) mod private {
-    use super::*;
-
-    /// A type that can have level data written to it by a [`ColumnLevelDecoder`]
-    pub trait LevelsWriter {
-        fn capacity(&self) -> usize;
-
-        fn get(&self, idx: usize) -> i16;
-    }
-
-    impl LevelsWriter for [i16] {
-        fn capacity(&self) -> usize {
-            self.len()
-        }
-
-        fn get(&self, idx: usize) -> i16 {
-            self[idx]
-        }
-    }
-
-    /// A type that can have value data written to it by a [`ColumnValueDecoder`]
-    pub trait ValuesWriter {
-        fn capacity(&self) -> usize;
-    }
-
-    impl<T> ValuesWriter for [T] {
-        fn capacity(&self) -> usize {
-            self.len()
-        }
-    }
-
-    /// Decodes level data to a [`LevelsWriter`]
-    pub trait ColumnLevelDecoder {
-        type Writer: LevelsWriter + ?Sized;
-
-        fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self;
-
-        fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize>;
-    }
-
-    /// Decodes value data to a [`ValuesWriter`]
-    pub trait ColumnValueDecoder {
-        type Writer: ValuesWriter + ?Sized;
-
-        fn create(col: &ColumnDescPtr, pad_nulls: bool) -> Self;
-
-        fn set_dict(
-            &mut self,
-            buf: ByteBufferPtr,
-            num_values: u32,
-            encoding: Encoding,
-            is_sorted: bool,
-        ) -> Result<()>;
-
-        fn set_data(
-            &mut self,
-            encoding: Encoding,
-            data: ByteBufferPtr,
-            num_values: usize,
-        ) -> Result<()>;
-
-        fn read(
-            &mut self,
-            out: &mut Self::Writer,
-            levels: Range<usize>,
-            values_read: usize,
-            is_valid: impl Fn(usize) -> bool,
-        ) -> Result<usize>;
-    }
-
-    /// An implementation of [`ColumnValueDecoder`] for `[T::T]`
-    pub struct ColumnValueDecoderImpl<T: DataType> {
-        descr: ColumnDescPtr,
-
-        pad_nulls: bool,
-
-        current_encoding: Option<Encoding>,
-
-        // Cache of decoders for existing encodings
-        decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
-    }
-
-    impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
-        type Writer = [T::T];
-
-        fn create(descr: &ColumnDescPtr, pad_nulls: bool) -> Self {
-            Self {
-                descr: descr.clone(),
-                pad_nulls,
-                current_encoding: None,
-                decoders: Default::default(),
-            }
-        }
-
-        fn set_dict(
-            &mut self,
-            buf: ByteBufferPtr,
-            num_values: u32,
-            mut encoding: Encoding,
-            _is_sorted: bool,
-        ) -> Result<()> {
-            if encoding == Encoding::PLAIN || encoding == Encoding::PLAIN_DICTIONARY {
-                encoding = Encoding::RLE_DICTIONARY
-            }
-
-            if self.decoders.contains_key(&encoding) {
-                return Err(general_err!("Column cannot have more than one dictionary"));
-            }
-
-            if encoding == Encoding::RLE_DICTIONARY {
-                let mut dictionary = PlainDecoder::<T>::new(self.descr.type_length());
-                dictionary.set_data(buf, num_values as usize)?;
-
-                let mut decoder = DictDecoder::new();
-                decoder.set_dict(Box::new(dictionary))?;
-                self.decoders.insert(encoding, Box::new(decoder));
-                Ok(())
-            } else {
-                Err(nyi_err!(
-                    "Invalid/Unsupported encoding type for dictionary: {}",
-                    encoding
-                ))
-            }
-        }
-
-        fn set_data(
-            &mut self,
-            mut encoding: Encoding,
-            data: ByteBufferPtr,
-            num_values: usize,
-        ) -> Result<()> {
-            if encoding == Encoding::PLAIN_DICTIONARY {
-                encoding = Encoding::RLE_DICTIONARY;
-            }
-
-            let decoder = if encoding == Encoding::RLE_DICTIONARY {
-                self.decoders
-                    .get_mut(&encoding)
-                    .expect("Decoder for dict should have been set")
-            } else {
-                // Search cache for data page decoder
-                #[allow(clippy::map_entry)]
-                if !self.decoders.contains_key(&encoding) {
-                    // Initialize decoder for this page
-                    let data_decoder = get_decoder::<T>(self.descr.clone(), encoding)?;
-                    self.decoders.insert(encoding, data_decoder);
-                }
-                self.decoders.get_mut(&encoding).unwrap()
-            };
-
-            decoder.set_data(data, num_values)?;
-            self.current_encoding = Some(encoding);
-            Ok(())
-        }
-
-        fn read(
-            &mut self,
-            out: &mut Self::Writer,
-            levels: Range<usize>,
-            values_read: usize,
-            is_valid: impl Fn(usize) -> bool,
-        ) -> Result<usize> {
-            let encoding = self
-                .current_encoding
-                .expect("current_encoding should be set");
-
-            let current_decoder = self.decoders.get_mut(&encoding).unwrap_or_else(|| {
-                panic!("decoder for encoding {} should be set", encoding)
-            });
-
-            let values_to_read = levels.clone().filter(|x| is_valid(*x)).count();
-
-            match self.pad_nulls {
-                true => {
-                    // Read into start of buffer
-                    let values_read = current_decoder
-                        .get(&mut out[levels.start..levels.start + values_to_read])?;
-
-                    if values_read != values_to_read {
-                        return Err(general_err!("insufficient values in page"));
-                    }
-
-                    // Shuffle nulls
-                    let mut values_pos = levels.start + values_to_read;
-                    let mut level_pos = levels.end;
-
-                    while level_pos > values_pos {
-                        if is_valid(level_pos - 1) {
-                            // This values is not empty
-                            // We use swap rather than assign here because T::T doesn't
-                            // implement Copy
-                            out.swap(level_pos - 1, values_pos - 1);
-                            values_pos -= 1;
-                        } else {
-                            out[level_pos - 1] = T::T::default();
-                        }
-
-                        level_pos -= 1;
-                    }
-
-                    Ok(values_read)
-                }
-                false => current_decoder
-                    .get(&mut out[values_read..values_read + values_to_read]),
-            }
-        }
-    }
-
-    /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
-    pub struct ColumnLevelDecoderImpl {
-        inner: LevelDecoderInner,
-    }
-
-    enum LevelDecoderInner {
-        Packed(BitReader, u8),
-        /// Boxed as `RleDecoder` contains an inline buffer
-        Rle(Box<RleDecoder>),
-    }
-
-    impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
-        type Writer = [i16];
-
-        fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
-            let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
-            match encoding {
-                Encoding::RLE => {
-                    let mut decoder = Box::new(RleDecoder::new(bit_width));
-                    decoder.set_data(data);
-                    Self {
-                        inner: LevelDecoderInner::Rle(decoder),
-                    }
-                }
-                Encoding::BIT_PACKED => Self {
-                    inner: LevelDecoderInner::Packed(BitReader::new(data), bit_width),
-                },
-                _ => unreachable!("invalid level encoding: {}", encoding),
-            }
-        }
-
-        fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize> {
-            match &mut self.inner {
-                LevelDecoderInner::Packed(reader, bit_width) => {
-                    Ok(reader.get_batch::<i16>(&mut out[range], *bit_width as usize))
-                }
-                LevelDecoderInner::Rle(reader) => reader.get_batch(&mut out[range]),
-            }
-        }
-    }
-}
-
 /// Typed value reader for a particular primitive column.
 pub type ColumnReaderImpl<T> = GenericColumnReader<
-    private::ColumnLevelDecoderImpl,
-    private::ColumnLevelDecoderImpl,
-    private::ColumnValueDecoderImpl<T>,
+    decoder::ColumnLevelDecoderImpl,
+    decoder::ColumnLevelDecoderImpl,
+    decoder::ColumnValueDecoderImpl<T>,
 >;
 
 #[doc(hidden)]

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -334,11 +334,8 @@ where
                                 )?;
                                 offset = level_data.end();
 
-                                let decoder = R::new(
-                                    max_rep_level,
-                                    rep_level_encoding,
-                                    level_data,
-                                );
+                                let decoder =
+                                    R::new(max_rep_level, rep_level_encoding, level_data);
 
                                 self.rep_level_decoder = Some(decoder);
                             }
@@ -352,11 +349,8 @@ where
                                 )?;
                                 offset = level_data.end();
 
-                                let decoder = D::new(
-                                    max_def_level,
-                                    def_level_encoding,
-                                    level_data,
-                                );
+                                let decoder =
+                                    D::new(max_def_level, def_level_encoding, level_data);
 
                                 self.def_level_decoder = Some(decoder);
                             }

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -20,17 +20,20 @@
 use std::{
     cmp::{max, min},
     collections::HashMap,
+    ops::Range,
 };
 
 use super::page::{Page, PageReader};
 use crate::basic::*;
-use crate::data_type::*;
-use crate::encodings::{
-    decoding::{get_decoder, Decoder, DictDecoder, PlainDecoder},
-    levels::LevelDecoder,
+use crate::column::reader::private::{
+    ColumnLevelDecoder, ColumnValueDecoder, LevelsWriter, ValuesWriter,
 };
+use crate::data_type::*;
+use crate::encodings::decoding::{get_decoder, Decoder, DictDecoder, PlainDecoder};
+use crate::encodings::rle::RleDecoder;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
+use crate::util::bit_util::{ceil, BitReader};
 use crate::util::memory::ByteBufferPtr;
 
 /// Column reader for a Parquet type.
@@ -101,37 +104,319 @@ pub fn get_typed_column_reader<T: DataType>(
     })
 }
 
-/// Typed value reader for a particular primitive column.
-pub struct ColumnReaderImpl<T: DataType> {
-    descr: ColumnDescPtr,
-    def_level_decoder: Option<LevelDecoder>,
-    rep_level_decoder: Option<LevelDecoder>,
-    page_reader: Box<dyn PageReader>,
-    current_encoding: Option<Encoding>,
+pub(crate) mod private {
+    use super::*;
 
-    // The total number of values stored in the data page.
-    num_buffered_values: u32,
+    /// A type that can have level data written to it by a [`ColumnLevelDecoder`]
+    pub trait LevelsWriter {
+        fn capacity(&self) -> usize;
 
-    // The number of values from the current data page that has been decoded into memory
-    // so far.
-    num_decoded_values: u32,
+        fn get(&self, idx: usize) -> i16;
+    }
 
-    // Cache of decoders for existing encodings
-    decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
+    impl LevelsWriter for [i16] {
+        fn capacity(&self) -> usize {
+            self.len()
+        }
+
+        fn get(&self, idx: usize) -> i16 {
+            self[idx]
+        }
+    }
+
+    /// A type that can have value data written to it by a [`ColumnValueDecoder`]
+    pub trait ValuesWriter {
+        fn capacity(&self) -> usize;
+    }
+
+    impl<T> ValuesWriter for [T] {
+        fn capacity(&self) -> usize {
+            self.len()
+        }
+    }
+
+    /// Decodes level data to a [`LevelsWriter`]
+    pub trait ColumnLevelDecoder {
+        type Writer: LevelsWriter + ?Sized;
+
+        fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self;
+
+        fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize>;
+    }
+
+    /// Decodes value data to a [`ValuesWriter`]
+    pub trait ColumnValueDecoder {
+        type Writer: ValuesWriter + ?Sized;
+
+        fn create(col: &ColumnDescPtr, pad_nulls: bool) -> Self;
+
+        fn set_dict(
+            &mut self,
+            buf: ByteBufferPtr,
+            num_values: u32,
+            encoding: Encoding,
+            is_sorted: bool,
+        ) -> Result<()>;
+
+        fn set_data(
+            &mut self,
+            encoding: Encoding,
+            data: ByteBufferPtr,
+            num_values: usize,
+        ) -> Result<()>;
+
+        fn read(
+            &mut self,
+            out: &mut Self::Writer,
+            levels: Range<usize>,
+            values_read: usize,
+            is_valid: impl Fn(usize) -> bool,
+        ) -> Result<usize>;
+    }
+
+    /// An implementation of [`ColumnValueDecoder`] for `[T::T]`
+    pub struct ColumnValueDecoderImpl<T: DataType> {
+        descr: ColumnDescPtr,
+
+        pad_nulls: bool,
+
+        current_encoding: Option<Encoding>,
+
+        // Cache of decoders for existing encodings
+        decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
+    }
+
+    impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
+        type Writer = [T::T];
+
+        fn create(descr: &ColumnDescPtr, pad_nulls: bool) -> Self {
+            Self {
+                descr: descr.clone(),
+                pad_nulls,
+                current_encoding: None,
+                decoders: Default::default(),
+            }
+        }
+
+        fn set_dict(
+            &mut self,
+            buf: ByteBufferPtr,
+            num_values: u32,
+            mut encoding: Encoding,
+            _is_sorted: bool,
+        ) -> Result<()> {
+            if encoding == Encoding::PLAIN || encoding == Encoding::PLAIN_DICTIONARY {
+                encoding = Encoding::RLE_DICTIONARY
+            }
+
+            if self.decoders.contains_key(&encoding) {
+                return Err(general_err!("Column cannot have more than one dictionary"));
+            }
+
+            if encoding == Encoding::RLE_DICTIONARY {
+                let mut dictionary = PlainDecoder::<T>::new(self.descr.type_length());
+                dictionary.set_data(buf, num_values as usize)?;
+
+                let mut decoder = DictDecoder::new();
+                decoder.set_dict(Box::new(dictionary))?;
+                self.decoders.insert(encoding, Box::new(decoder));
+                Ok(())
+            } else {
+                Err(nyi_err!(
+                    "Invalid/Unsupported encoding type for dictionary: {}",
+                    encoding
+                ))
+            }
+        }
+
+        fn set_data(
+            &mut self,
+            mut encoding: Encoding,
+            data: ByteBufferPtr,
+            num_values: usize,
+        ) -> Result<()> {
+            if encoding == Encoding::PLAIN_DICTIONARY {
+                encoding = Encoding::RLE_DICTIONARY;
+            }
+
+            let decoder = if encoding == Encoding::RLE_DICTIONARY {
+                self.decoders
+                    .get_mut(&encoding)
+                    .expect("Decoder for dict should have been set")
+            } else {
+                // Search cache for data page decoder
+                #[allow(clippy::map_entry)]
+                if !self.decoders.contains_key(&encoding) {
+                    // Initialize decoder for this page
+                    let data_decoder = get_decoder::<T>(self.descr.clone(), encoding)?;
+                    self.decoders.insert(encoding, data_decoder);
+                }
+                self.decoders.get_mut(&encoding).unwrap()
+            };
+
+            decoder.set_data(data, num_values)?;
+            self.current_encoding = Some(encoding);
+            Ok(())
+        }
+
+        fn read(
+            &mut self,
+            out: &mut Self::Writer,
+            levels: Range<usize>,
+            values_read: usize,
+            is_valid: impl Fn(usize) -> bool,
+        ) -> Result<usize> {
+            let encoding = self
+                .current_encoding
+                .expect("current_encoding should be set");
+
+            let current_decoder = self.decoders.get_mut(&encoding).unwrap_or_else(|| {
+                panic!("decoder for encoding {} should be set", encoding)
+            });
+
+            let values_to_read = levels.clone().filter(|x| is_valid(*x)).count();
+
+            match self.pad_nulls {
+                true => {
+                    // Read into start of buffer
+                    let values_read = current_decoder
+                        .get(&mut out[levels.start..levels.start + values_to_read])?;
+
+                    if values_read != values_to_read {
+                        return Err(general_err!("insufficient values in page"));
+                    }
+
+                    // Shuffle nulls
+                    let mut values_pos = levels.start + values_to_read;
+                    let mut level_pos = levels.end;
+
+                    while level_pos > values_pos {
+                        if is_valid(level_pos - 1) {
+                            // This values is not empty
+                            // We use swap rather than assign here because T::T doesn't
+                            // implement Copy
+                            out.swap(level_pos - 1, values_pos - 1);
+                            values_pos -= 1;
+                        } else {
+                            out[level_pos - 1] = T::T::default();
+                        }
+
+                        level_pos -= 1;
+                    }
+
+                    Ok(values_read)
+                }
+                false => current_decoder
+                    .get(&mut out[values_read..values_read + values_to_read]),
+            }
+        }
+    }
+
+    /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
+    pub struct ColumnLevelDecoderImpl {
+        inner: LevelDecoderInner,
+    }
+
+    enum LevelDecoderInner {
+        Packed(BitReader, u8),
+        /// Boxed as `RleDecoder` contains an inline buffer
+        Rle(Box<RleDecoder>),
+    }
+
+    impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
+        type Writer = [i16];
+
+        fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
+            let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
+            match encoding {
+                Encoding::RLE => {
+                    let mut decoder = Box::new(RleDecoder::new(bit_width));
+                    decoder.set_data(data);
+                    Self {
+                        inner: LevelDecoderInner::Rle(decoder),
+                    }
+                }
+                Encoding::BIT_PACKED => Self {
+                    inner: LevelDecoderInner::Packed(BitReader::new(data), bit_width),
+                },
+                _ => unreachable!("invalid level encoding: {}", encoding),
+            }
+        }
+
+        fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize> {
+            match &mut self.inner {
+                LevelDecoderInner::Packed(reader, bit_width) => {
+                    Ok(reader.get_batch::<i16>(&mut out[range], *bit_width as usize))
+                }
+                LevelDecoderInner::Rle(reader) => reader.get_batch(&mut out[range]),
+            }
+        }
+    }
 }
 
-impl<T: DataType> ColumnReaderImpl<T> {
+/// Typed value reader for a particular primitive column.
+pub type ColumnReaderImpl<T> = GenericColumnReader<
+    private::ColumnLevelDecoderImpl,
+    private::ColumnLevelDecoderImpl,
+    private::ColumnValueDecoderImpl<T>,
+>;
+
+#[doc(hidden)]
+pub struct GenericColumnReader<R, D, V> {
+    descr: ColumnDescPtr,
+
+    page_reader: Box<dyn PageReader>,
+
+    /// The total number of values stored in the data page.
+    num_buffered_values: u32,
+
+    /// The number of values from the current data page that has been decoded into memory
+    /// so far.
+    num_decoded_values: u32,
+
+    /// The decoder for the definition levels if any
+    def_level_decoder: Option<D>,
+
+    /// The decoder for the repetition levels if any
+    rep_level_decoder: Option<R>,
+
+    /// The decoder for the values
+    values_decoder: V,
+}
+
+impl<R, D, V> GenericColumnReader<R, D, V>
+where
+    R: ColumnLevelDecoder,
+    D: ColumnLevelDecoder,
+    V: ColumnValueDecoder,
+{
     /// Creates new column reader based on column descriptor and page reader.
     pub fn new(descr: ColumnDescPtr, page_reader: Box<dyn PageReader>) -> Self {
+        let values_decoder = V::create(&descr, false);
+        Self::new_with_decoder(descr, page_reader, values_decoder)
+    }
+
+    pub(crate) fn new_null_padding(
+        descr: ColumnDescPtr,
+        page_reader: Box<dyn PageReader>,
+    ) -> Self {
+        let values_decoder = V::create(&descr, true);
+        Self::new_with_decoder(descr, page_reader, values_decoder)
+    }
+
+    fn new_with_decoder(
+        descr: ColumnDescPtr,
+        page_reader: Box<dyn PageReader>,
+        values_decoder: V,
+    ) -> Self {
         Self {
             descr,
             def_level_decoder: None,
             rep_level_decoder: None,
             page_reader,
-            current_encoding: None,
             num_buffered_values: 0,
             num_decoded_values: 0,
-            decoders: HashMap::new(),
+            values_decoder,
         }
     }
 
@@ -159,20 +444,20 @@ impl<T: DataType> ColumnReaderImpl<T> {
     pub fn read_batch(
         &mut self,
         batch_size: usize,
-        mut def_levels: Option<&mut [i16]>,
-        mut rep_levels: Option<&mut [i16]>,
-        values: &mut [T::T],
+        mut def_levels: Option<&mut D::Writer>,
+        mut rep_levels: Option<&mut R::Writer>,
+        values: &mut V::Writer,
     ) -> Result<(usize, usize)> {
         let mut values_read = 0;
         let mut levels_read = 0;
 
         // Compute the smallest batch size we can read based on provided slices
-        let mut batch_size = min(batch_size, values.len());
+        let mut batch_size = min(batch_size, values.capacity());
         if let Some(ref levels) = def_levels {
-            batch_size = min(batch_size, levels.len());
+            batch_size = min(batch_size, levels.capacity());
         }
         if let Some(ref levels) = rep_levels {
-            batch_size = min(batch_size, levels.len());
+            batch_size = min(batch_size, levels.capacity());
         }
 
         // Read exhaustively all pages until we read all batch_size values/levels
@@ -200,57 +485,57 @@ impl<T: DataType> ColumnReaderImpl<T> {
                 adjusted_size
             };
 
-            let mut values_to_read = 0;
-            let mut num_def_levels = 0;
-            let mut num_rep_levels = 0;
-
             // If the field is required and non-repeated, there are no definition levels
-            if self.descr.max_def_level() > 0 && def_levels.as_ref().is_some() {
-                if let Some(ref mut levels) = def_levels {
-                    num_def_levels = self.read_def_levels(
-                        &mut levels[levels_read..levels_read + iter_batch_size],
-                    )?;
-                    for i in levels_read..levels_read + num_def_levels {
-                        if levels[i] == self.descr.max_def_level() {
-                            values_to_read += 1;
-                        }
-                    }
-                }
-            } else {
-                // If max definition level == 0, then it is REQUIRED field, read all
-                // values. If definition levels are not provided, we still
-                // read all values.
-                values_to_read = iter_batch_size;
-            }
+            let num_def_levels = match def_levels.as_mut() {
+                Some(levels) if self.descr.max_def_level() > 0 => self
+                    .def_level_decoder
+                    .as_mut()
+                    .expect("def_level_decoder be set")
+                    .read(*levels, levels_read..levels_read + iter_batch_size)?,
+                _ => 0,
+            };
 
-            if self.descr.max_rep_level() > 0 && rep_levels.is_some() {
-                if let Some(ref mut levels) = rep_levels {
-                    num_rep_levels = self.read_rep_levels(
-                        &mut levels[levels_read..levels_read + iter_batch_size],
-                    )?;
-
-                    // If definition levels are defined, check that rep levels == def
-                    // levels
-                    if def_levels.is_some() {
-                        assert_eq!(
-                            num_def_levels, num_rep_levels,
-                            "Number of decoded rep / def levels did not match"
-                        );
-                    }
-                }
-            }
+            let num_rep_levels = match rep_levels.as_mut() {
+                Some(levels) if self.descr.max_rep_level() > 0 => self
+                    .rep_level_decoder
+                    .as_mut()
+                    .expect("rep_level_decoder be set")
+                    .read(levels, levels_read..levels_read + iter_batch_size)?,
+                _ => 0,
+            };
 
             // At this point we have read values, definition and repetition levels.
             // If both definition and repetition levels are defined, their counts
             // should be equal. Values count is always less or equal to definition levels.
-            //
+            if num_def_levels != 0 && num_rep_levels != 0 {
+                assert_eq!(
+                    num_def_levels, num_rep_levels,
+                    "Number of decoded rep / def levels did not match"
+                );
+            }
+
             // Note that if field is not required, but no definition levels are provided,
             // we would read values of batch size and (if provided, of course) repetition
             // levels of batch size - [!] they will not be synced, because only definition
             // levels enforce number of non-null values to read.
 
-            let curr_values_read =
-                self.read_values(&mut values[values_read..values_read + values_to_read])?;
+            let curr_values_read = match def_levels.as_ref() {
+                Some(def_levels) => {
+                    let max_def_level = self.descr.max_def_level();
+                    self.values_decoder.read(
+                        values,
+                        levels_read..levels_read + iter_batch_size,
+                        values_read,
+                        |x| def_levels.get(x) == max_def_level,
+                    )?
+                }
+                None => self.values_decoder.read(
+                    values,
+                    levels_read..levels_read + iter_batch_size,
+                    values_read,
+                    |_| true,
+                )?,
+            };
 
             // Update all "return" counters and internal state.
 
@@ -275,8 +560,14 @@ impl<T: DataType> ColumnReaderImpl<T> {
                 Some(current_page) => {
                     match current_page {
                         // 1. Dictionary page: configure dictionary for this page.
-                        p @ Page::DictionaryPage { .. } => {
-                            self.configure_dictionary(p)?;
+                        Page::DictionaryPage {
+                            buf,
+                            num_values,
+                            encoding,
+                            is_sorted,
+                        } => {
+                            self.values_decoder
+                                .set_dict(buf, num_values, encoding, is_sorted)?;
                             continue;
                         }
                         // 2. Data page v1
@@ -291,40 +582,50 @@ impl<T: DataType> ColumnReaderImpl<T> {
                             self.num_buffered_values = num_values;
                             self.num_decoded_values = 0;
 
-                            let mut buffer_ptr = buf;
+                            let max_rep_level = self.descr.max_rep_level();
+                            let max_def_level = self.descr.max_def_level();
 
-                            if self.descr.max_rep_level() > 0 {
-                                let mut rep_decoder = LevelDecoder::v1(
+                            let mut offset = 0;
+
+                            if max_rep_level > 0 {
+                                let level_data = parse_v1_level(
+                                    max_rep_level,
+                                    num_values,
                                     rep_level_encoding,
-                                    self.descr.max_rep_level(),
+                                    buf.start_from(offset),
+                                )?;
+                                offset = level_data.end();
+
+                                let decoder = R::create(
+                                    max_rep_level,
+                                    rep_level_encoding,
+                                    level_data,
                                 );
-                                let total_bytes = rep_decoder.set_data(
-                                    self.num_buffered_values as usize,
-                                    buffer_ptr.all(),
-                                );
-                                buffer_ptr = buffer_ptr.start_from(total_bytes);
-                                self.rep_level_decoder = Some(rep_decoder);
+
+                                self.rep_level_decoder = Some(decoder);
                             }
 
-                            if self.descr.max_def_level() > 0 {
-                                let mut def_decoder = LevelDecoder::v1(
+                            if max_def_level > 0 {
+                                let level_data = parse_v1_level(
+                                    max_def_level,
+                                    num_values,
                                     def_level_encoding,
-                                    self.descr.max_def_level(),
+                                    buf.start_from(offset),
+                                )?;
+                                offset = level_data.end();
+
+                                let decoder = D::create(
+                                    max_def_level,
+                                    def_level_encoding,
+                                    level_data,
                                 );
-                                let total_bytes = def_decoder.set_data(
-                                    self.num_buffered_values as usize,
-                                    buffer_ptr.all(),
-                                );
-                                buffer_ptr = buffer_ptr.start_from(total_bytes);
-                                self.def_level_decoder = Some(def_decoder);
+
+                                self.def_level_decoder = Some(decoder);
                             }
 
-                            // Data page v1 does not have offset, all content of buffer
-                            // should be passed
-                            self.set_current_page_encoding(
+                            self.values_decoder.set_data(
                                 encoding,
-                                &buffer_ptr,
-                                0,
+                                buf.start_from(offset),
                                 num_values as usize,
                             )?;
                             return Ok(true);
@@ -344,42 +645,36 @@ impl<T: DataType> ColumnReaderImpl<T> {
                             self.num_buffered_values = num_values;
                             self.num_decoded_values = 0;
 
-                            let mut offset = 0;
-
                             // DataPage v2 only supports RLE encoding for repetition
                             // levels
                             if self.descr.max_rep_level() > 0 {
-                                let mut rep_decoder =
-                                    LevelDecoder::v2(self.descr.max_rep_level());
-                                let bytes_read = rep_decoder.set_data_range(
-                                    self.num_buffered_values as usize,
-                                    &buf,
-                                    offset,
-                                    rep_levels_byte_len as usize,
+                                let decoder = R::create(
+                                    self.descr.max_rep_level(),
+                                    Encoding::RLE,
+                                    buf.range(0, rep_levels_byte_len as usize),
                                 );
-                                offset += bytes_read;
-                                self.rep_level_decoder = Some(rep_decoder);
+                                self.rep_level_decoder = Some(decoder);
                             }
 
                             // DataPage v2 only supports RLE encoding for definition
                             // levels
                             if self.descr.max_def_level() > 0 {
-                                let mut def_decoder =
-                                    LevelDecoder::v2(self.descr.max_def_level());
-                                let bytes_read = def_decoder.set_data_range(
-                                    self.num_buffered_values as usize,
-                                    &buf,
-                                    offset,
-                                    def_levels_byte_len as usize,
+                                let decoder = D::create(
+                                    self.descr.max_def_level(),
+                                    Encoding::RLE,
+                                    buf.range(
+                                        rep_levels_byte_len as usize,
+                                        def_levels_byte_len as usize,
+                                    ),
                                 );
-                                offset += bytes_read;
-                                self.def_level_decoder = Some(def_decoder);
+                                self.def_level_decoder = Some(decoder);
                             }
 
-                            self.set_current_page_encoding(
+                            self.values_decoder.set_data(
                                 encoding,
-                                &buf,
-                                offset,
+                                buf.start_from(
+                                    (rep_levels_byte_len + def_levels_byte_len) as usize,
+                                ),
                                 num_values as usize,
                             )?;
                             return Ok(true);
@@ -390,38 +685,6 @@ impl<T: DataType> ColumnReaderImpl<T> {
         }
 
         Ok(true)
-    }
-
-    /// Resolves and updates encoding and set decoder for the current page
-    fn set_current_page_encoding(
-        &mut self,
-        mut encoding: Encoding,
-        buffer_ptr: &ByteBufferPtr,
-        offset: usize,
-        len: usize,
-    ) -> Result<()> {
-        if encoding == Encoding::PLAIN_DICTIONARY {
-            encoding = Encoding::RLE_DICTIONARY;
-        }
-
-        let decoder = if encoding == Encoding::RLE_DICTIONARY {
-            self.decoders
-                .get_mut(&encoding)
-                .expect("Decoder for dict should have been set")
-        } else {
-            // Search cache for data page decoder
-            #[allow(clippy::map_entry)]
-            if !self.decoders.contains_key(&encoding) {
-                // Initialize decoder for this page
-                let data_decoder = get_decoder::<T>(self.descr.clone(), encoding)?;
-                self.decoders.insert(encoding, data_decoder);
-            }
-            self.decoders.get_mut(&encoding).unwrap()
-        };
-
-        decoder.set_data(buffer_ptr.start_from(offset), len as usize)?;
-        self.current_encoding = Some(encoding);
-        Ok(())
     }
 
     #[inline]
@@ -440,63 +703,29 @@ impl<T: DataType> ColumnReaderImpl<T> {
             Ok(true)
         }
     }
+}
 
-    #[inline]
-    fn read_rep_levels(&mut self, buffer: &mut [i16]) -> Result<usize> {
-        let level_decoder = self
-            .rep_level_decoder
-            .as_mut()
-            .expect("rep_level_decoder be set");
-        level_decoder.get(buffer)
-    }
-
-    #[inline]
-    fn read_def_levels(&mut self, buffer: &mut [i16]) -> Result<usize> {
-        let level_decoder = self
-            .def_level_decoder
-            .as_mut()
-            .expect("def_level_decoder be set");
-        level_decoder.get(buffer)
-    }
-
-    #[inline]
-    fn read_values(&mut self, buffer: &mut [T::T]) -> Result<usize> {
-        let encoding = self
-            .current_encoding
-            .expect("current_encoding should be set");
-        let current_decoder = self
-            .decoders
-            .get_mut(&encoding)
-            .unwrap_or_else(|| panic!("decoder for encoding {} should be set", encoding));
-        current_decoder.get(buffer)
-    }
-
-    #[inline]
-    fn configure_dictionary(&mut self, page: Page) -> Result<bool> {
-        let mut encoding = page.encoding();
-        if encoding == Encoding::PLAIN || encoding == Encoding::PLAIN_DICTIONARY {
-            encoding = Encoding::RLE_DICTIONARY
+fn parse_v1_level(
+    max_level: i16,
+    num_buffered_values: u32,
+    encoding: Encoding,
+    buf: ByteBufferPtr,
+) -> Result<ByteBufferPtr> {
+    match encoding {
+        Encoding::RLE => {
+            let i32_size = std::mem::size_of::<i32>();
+            let data_size = read_num_bytes!(i32, i32_size, buf.as_ref()) as usize;
+            Ok(buf.range(i32_size, data_size))
         }
-
-        if self.decoders.contains_key(&encoding) {
-            return Err(general_err!("Column cannot have more than one dictionary"));
+        Encoding::BIT_PACKED => {
+            let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
+            let num_bytes = ceil(
+                (num_buffered_values as usize * bit_width as usize) as i64,
+                8,
+            );
+            Ok(buf.range(0, num_bytes as usize))
         }
-
-        if encoding == Encoding::RLE_DICTIONARY {
-            let mut dictionary = PlainDecoder::<T>::new(self.descr.type_length());
-            let num_values = page.num_values();
-            dictionary.set_data(page.buffer().clone(), num_values as usize)?;
-
-            let mut decoder = DictDecoder::new();
-            decoder.set_dict(Box::new(dictionary))?;
-            self.decoders.insert(encoding, Box::new(decoder));
-            Ok(true)
-        } else {
-            Err(nyi_err!(
-                "Invalid/Unsupported encoding type for dictionary: {}",
-                encoding
-            ))
-        }
+        _ => Err(general_err!("invalid level encoding: {}", encoding)),
     }
 }
 

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -272,6 +272,10 @@ where
                         values,
                         levels_read..levels_read + iter_batch_size,
                         values_read,
+                        def_levels.count_nulls(
+                            levels_read..levels_read + iter_batch_size,
+                            max_def_level,
+                        ),
                         |x| def_levels.get(x) == max_def_level,
                     )?
                 }
@@ -279,6 +283,7 @@ where
                     values,
                     levels_read..levels_read + iter_batch_size,
                     values_read,
+                    0,
                     |_| true,
                 )?,
             };

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 
 use crate::basic::Encoding;
 use crate::data_type::DataType;
-use crate::decoding::{Decoder, DictDecoder, get_decoder, PlainDecoder};
+use crate::decoding::{get_decoder, Decoder, DictDecoder, PlainDecoder};
 use crate::encodings::rle::RleDecoder;
-use crate::errors::{Result, ParquetError};
+use crate::errors::{ParquetError, Result};
 use crate::memory::ByteBufferPtr;
 use crate::schema::types::ColumnDescPtr;
 use crate::util::bit_util::BitReader;

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -1,0 +1,259 @@
+use std::collections::HashMap;
+use std::ops::Range;
+
+use crate::basic::Encoding;
+use crate::data_type::DataType;
+use crate::decoding::{Decoder, DictDecoder, get_decoder, PlainDecoder};
+use crate::encodings::rle::RleDecoder;
+use crate::errors::{Result, ParquetError};
+use crate::memory::ByteBufferPtr;
+use crate::schema::types::ColumnDescPtr;
+use crate::util::bit_util::BitReader;
+
+/// A type that can have level data written to it by a [`ColumnLevelDecoder`]
+pub trait LevelsWriter {
+    fn capacity(&self) -> usize;
+
+    fn get(&self, idx: usize) -> i16;
+}
+
+impl LevelsWriter for [i16] {
+    fn capacity(&self) -> usize {
+        self.len()
+    }
+
+    fn get(&self, idx: usize) -> i16 {
+        self[idx]
+    }
+}
+
+/// A type that can have value data written to it by a [`ColumnValueDecoder`]
+pub trait ValuesWriter {
+    fn capacity(&self) -> usize;
+}
+
+impl<T> ValuesWriter for [T] {
+    fn capacity(&self) -> usize {
+        self.len()
+    }
+}
+
+/// Decodes level data to a [`LevelsWriter`]
+pub trait ColumnLevelDecoder {
+    type Writer: LevelsWriter + ?Sized;
+
+    fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self;
+
+    fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize>;
+}
+
+/// Decodes value data to a [`ValuesWriter`]
+pub trait ColumnValueDecoder {
+    type Writer: ValuesWriter + ?Sized;
+
+    fn create(col: &ColumnDescPtr, pad_nulls: bool) -> Self;
+
+    fn set_dict(
+        &mut self,
+        buf: ByteBufferPtr,
+        num_values: u32,
+        encoding: Encoding,
+        is_sorted: bool,
+    ) -> Result<()>;
+
+    fn set_data(
+        &mut self,
+        encoding: Encoding,
+        data: ByteBufferPtr,
+        num_values: usize,
+    ) -> Result<()>;
+
+    fn read(
+        &mut self,
+        out: &mut Self::Writer,
+        levels: Range<usize>,
+        values_read: usize,
+        is_valid: impl Fn(usize) -> bool,
+    ) -> Result<usize>;
+}
+
+/// An implementation of [`ColumnValueDecoder`] for `[T::T]`
+pub struct ColumnValueDecoderImpl<T: DataType> {
+    descr: ColumnDescPtr,
+
+    pad_nulls: bool,
+
+    current_encoding: Option<Encoding>,
+
+    // Cache of decoders for existing encodings
+    decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
+}
+
+impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
+    type Writer = [T::T];
+
+    fn create(descr: &ColumnDescPtr, pad_nulls: bool) -> Self {
+        Self {
+            descr: descr.clone(),
+            pad_nulls,
+            current_encoding: None,
+            decoders: Default::default(),
+        }
+    }
+
+    fn set_dict(
+        &mut self,
+        buf: ByteBufferPtr,
+        num_values: u32,
+        mut encoding: Encoding,
+        _is_sorted: bool,
+    ) -> Result<()> {
+        if encoding == Encoding::PLAIN || encoding == Encoding::PLAIN_DICTIONARY {
+            encoding = Encoding::RLE_DICTIONARY
+        }
+
+        if self.decoders.contains_key(&encoding) {
+            return Err(general_err!("Column cannot have more than one dictionary"));
+        }
+
+        if encoding == Encoding::RLE_DICTIONARY {
+            let mut dictionary = PlainDecoder::<T>::new(self.descr.type_length());
+            dictionary.set_data(buf, num_values as usize)?;
+
+            let mut decoder = DictDecoder::new();
+            decoder.set_dict(Box::new(dictionary))?;
+            self.decoders.insert(encoding, Box::new(decoder));
+            Ok(())
+        } else {
+            Err(nyi_err!(
+                "Invalid/Unsupported encoding type for dictionary: {}",
+                encoding
+            ))
+        }
+    }
+
+    fn set_data(
+        &mut self,
+        mut encoding: Encoding,
+        data: ByteBufferPtr,
+        num_values: usize,
+    ) -> Result<()> {
+        if encoding == Encoding::PLAIN_DICTIONARY {
+            encoding = Encoding::RLE_DICTIONARY;
+        }
+
+        let decoder = if encoding == Encoding::RLE_DICTIONARY {
+            self.decoders
+                .get_mut(&encoding)
+                .expect("Decoder for dict should have been set")
+        } else {
+            // Search cache for data page decoder
+            #[allow(clippy::map_entry)]
+            if !self.decoders.contains_key(&encoding) {
+                // Initialize decoder for this page
+                let data_decoder = get_decoder::<T>(self.descr.clone(), encoding)?;
+                self.decoders.insert(encoding, data_decoder);
+            }
+            self.decoders.get_mut(&encoding).unwrap()
+        };
+
+        decoder.set_data(data, num_values)?;
+        self.current_encoding = Some(encoding);
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        out: &mut Self::Writer,
+        levels: Range<usize>,
+        values_read: usize,
+        is_valid: impl Fn(usize) -> bool,
+    ) -> Result<usize> {
+        let encoding = self
+            .current_encoding
+            .expect("current_encoding should be set");
+
+        let current_decoder = self
+            .decoders
+            .get_mut(&encoding)
+            .unwrap_or_else(|| panic!("decoder for encoding {} should be set", encoding));
+
+        let values_to_read = levels.clone().filter(|x| is_valid(*x)).count();
+
+        match self.pad_nulls {
+            true => {
+                // Read into start of buffer
+                let values_read = current_decoder
+                    .get(&mut out[levels.start..levels.start + values_to_read])?;
+
+                if values_read != values_to_read {
+                    return Err(general_err!("insufficient values in page"));
+                }
+
+                // Shuffle nulls
+                let mut values_pos = levels.start + values_to_read;
+                let mut level_pos = levels.end;
+
+                while level_pos > values_pos {
+                    if is_valid(level_pos - 1) {
+                        // This values is not empty
+                        // We use swap rather than assign here because T::T doesn't
+                        // implement Copy
+                        out.swap(level_pos - 1, values_pos - 1);
+                        values_pos -= 1;
+                    } else {
+                        out[level_pos - 1] = T::T::default();
+                    }
+
+                    level_pos -= 1;
+                }
+
+                Ok(values_read)
+            }
+            false => {
+                current_decoder.get(&mut out[values_read..values_read + values_to_read])
+            }
+        }
+    }
+}
+
+/// An implementation of [`ColumnLevelDecoder`] for `[i16]`
+pub struct ColumnLevelDecoderImpl {
+    inner: LevelDecoderInner,
+}
+
+enum LevelDecoderInner {
+    Packed(BitReader, u8),
+    /// Boxed as `RleDecoder` contains an inline buffer
+    Rle(Box<RleDecoder>),
+}
+
+impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
+    type Writer = [i16];
+
+    fn create(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
+        let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
+        match encoding {
+            Encoding::RLE => {
+                let mut decoder = Box::new(RleDecoder::new(bit_width));
+                decoder.set_data(data);
+                Self {
+                    inner: LevelDecoderInner::Rle(decoder),
+                }
+            }
+            Encoding::BIT_PACKED => Self {
+                inner: LevelDecoderInner::Packed(BitReader::new(data), bit_width),
+            },
+            _ => unreachable!("invalid level encoding: {}", encoding),
+        }
+    }
+
+    fn read(&mut self, out: &mut Self::Writer, range: Range<usize>) -> Result<usize> {
+        match &mut self.inner {
+            LevelDecoderInner::Packed(reader, bit_width) => {
+                Ok(reader.get_batch::<i16>(&mut out[range], *bit_width as usize))
+            }
+            LevelDecoderInner::Rle(reader) => reader.get_batch(&mut out[range]),
+        }
+    }
+}

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::collections::HashMap;
 use std::ops::Range;
 

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -572,7 +572,6 @@ impl AsBytes for str {
 }
 
 pub(crate) mod private {
-    use super::*;
     use crate::encodings::decoding::PlainDecoderDetails;
     use crate::util::bit_util::{round_upto_power_of_2, BitReader, BitWriter};
     use crate::util::memory::ByteBufferPtr;
@@ -1033,21 +1032,6 @@ pub(crate) mod private {
             self
         }
     }
-
-    /// A marker trait for [`DataType`] with a [scalar] physical type
-    ///
-    /// This means that a `[Self::T::default()]` of length `len` can be safely created from a
-    /// zero-initialized `[u8]` with length `len * Self::get_type_size()` and
-    /// alignment of `Self::get_type_size()`
-    ///
-    /// [scalar]: https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types
-    ///
-    pub trait ScalarDataType: DataType {}
-    impl ScalarDataType for BoolType {}
-    impl ScalarDataType for Int32Type {}
-    impl ScalarDataType for Int64Type {}
-    impl ScalarDataType for FloatType {}
-    impl ScalarDataType for DoubleType {}
 }
 
 /// Contains the Parquet physical type information as well as the Rust primitive type

--- a/parquet/src/util/memory.rs
+++ b/parquet/src/util/memory.rs
@@ -328,6 +328,12 @@ impl<T> BufferPtr<T> {
         self.start
     }
 
+    /// Returns the end position of this buffer
+    #[inline]
+    pub fn end(&self) -> usize {
+        self.start + self.len
+    }
+
     /// Returns length of this buffer
     #[inline]
     pub fn len(&self) -> usize {


### PR DESCRIPTION
~~This is highly experimental, I want to get further fleshing out #171 and #1037 before settling on this. In particular I want to get some numbers about performance. However, I wanted to give some visibility into what I'm doing~~

~~Builds on top of #1021~~

This introduces some limited generics into `RecordReader` and `ColumnReaderImpl` to allow for optimisations such as #1054 and #1082. Having implemented initial cuts of these, I am happy that this interface is sufficiently flexible for implementing various arrow-related optimisations.

# Which issue does this PR close?

Closes #1040.

# Rationale for this change
 
See ticket

# What changes are included in this PR?

See ticket

# Are there any user-facing changes?

No :grin: 
