### PR TITLE
Cherry pick Remove outdated safety example from readme to active_release

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -46,21 +46,13 @@ The arrow crate provides the following features which may be enabled:
 
 ## Safety
 
-TLDR: You should avoid using the `alloc` and `buffer` and `bitmap` modules if at all possible. These modules contain `unsafe` code and are easy to misuse.
+TLDR: You should avoid using the `alloc` and `buffer` and `bitmap` modules if at all possible. These modules contain `unsafe` code, are easy to misuse, and are not needed for most users.
 
-As with all open source code, you should carefully evaluate the suitability of `arrow` for your project, taking into consideration your needs and risk tolerance prior to use.
+As with all open source code, you should carefully evaluate the suitability of `arrow` for your project, taking into consideration your needs and risk tolerance prior to doing so.
 
 _Background_: There are various parts of the `arrow` crate which use `unsafe` and `transmute` code internally. We are actively working as a community to minimize undefined behavior and remove `unsafe` usage to align more with Rust's core principles of safety (e.g. the arrow2 project).
 
-As `arrow` exists today, it is fairly easy to misuse the APIs, leading to undefined behavior, and it is especially easy to misuse code in modules named above. For an example, as described in [the arrow2 crate](https://github.com/jorgecarleitao/arrow2#why), the following code compiles, does not panic, but results in undefined behavior:
-
-```rust
-let buffer = Buffer::from_slice_ref(&[0i32, 2i32])
-let data = ArrayData::new(DataType::Int64, 10, 0, None, 0, vec![buffer], vec![]);
-let array = Float64Array::from(Arc::new(data));
-
-println!("{:?}", array.value(1));
-```
+As `arrow` exists today, it is fairly easy to misuse the APIs, leading to undefined behavior, and it is especially easy to misuse code in modules named above.
 
 ## Building for WASM
 


### PR DESCRIPTION
Automatic cherry-pick of caa52ef
* Originally appeared in https://github.com/apache/arrow-rs/pull/1050: Remove outdated safety example from readme
