### PR TITLE
Update pyo3 to 0.15

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -33,7 +33,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT", features = ["pyarrow"] }
-pyo3 = { version = "0.14", features = ["extension-module"] }
+pyo3 = { version = "0.15", features = ["extension-module"] }
 
 [package.metadata.maturin]
 requires-dist = ["pyarrow>=1"]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -53,7 +53,7 @@ chrono-tz = {version = "0.4", optional = true}
 flatbuffers = { version = "=2.0.0", optional = true }
 hex = "0.4"
 comfy-table = { version = "5.0", optional = true, default-features = false }
-pyo3 = { version = "0.14", optional = true }
+pyo3 = { version = "0.15", optional = true }
 lexical-core = "^0.8"
 multiversion = "0.6.1"
 bitflags = "1.2.1"


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1075

# Rationale for this change
 
Described in #1075

# What changes are included in this PR?

Just changed version in Cargo.toml

# Are there any user-facing changes?

I think this is technically a breaking change, but not sure exactly how changing an indirect-dependency-behind-a-feature-flag is considered!