### PR TITLE
Cherry pick BooleanBufferBuilder correct buffer length (#1051) to active_release

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -310,7 +310,7 @@ impl BooleanBufferBuilder {
     #[inline]
     pub fn new(capacity: usize) -> Self {
         let byte_capacity = bit_util::ceil(capacity, 8);
-        let buffer = MutableBuffer::from_len_zeroed(byte_capacity);
+        let buffer = MutableBuffer::new(byte_capacity);
         Self { buffer, len: 0 }
     }
 
@@ -2713,7 +2713,8 @@ mod tests {
         let buffer = b.finish();
         assert_eq!(1, buffer.len());
 
-        let mut b = BooleanBufferBuilder::new(4);
+        // Overallocate capacity
+        let mut b = BooleanBufferBuilder::new(8);
         b.append_slice(&[false, true, false, true]);
         assert_eq!(4, b.len());
         assert_eq!(512, b.capacity());


### PR DESCRIPTION
Automatic cherry-pick of cd75a13
* Originally appeared in https://github.com/apache/arrow-rs/pull/1052: BooleanBufferBuilder correct buffer length (#1051)
