### PR TITLE
Add Schema::with_metadata and Field::with_metadata

### DIFF
--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -83,6 +83,12 @@ impl Field {
         }
     }
 
+    /// Sets the metadata of this `Field` to be `metadata` and returns self
+    pub fn with_metadata(mut self, metadata: Option<BTreeMap<String, String>>) -> Self {
+        self.set_metadata(metadata);
+        self
+    }
+
     /// Returns the immutable reference to the `Field`'s optional custom metadata.
     #[inline]
     pub const fn metadata(&self) -> &Option<BTreeMap<String, String>> {

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -123,12 +123,12 @@ mod tests {
         let field_metadata: BTreeMap<String, String> = kv_array.iter().cloned().collect();
 
         // Non-empty map: should be converted as JSON obj { ... }
-        let mut first_name = Field::new("first_name", DataType::Utf8, false);
-        first_name.set_metadata(Some(field_metadata));
+        let first_name = Field::new("first_name", DataType::Utf8, false)
+            .with_metadata(Some(field_metadata));
 
         // Empty map: should be omitted.
-        let mut last_name = Field::new("last_name", DataType::Utf8, false);
-        last_name.set_metadata(Some(BTreeMap::default()));
+        let last_name = Field::new("last_name", DataType::Utf8, false)
+            .with_metadata(Some(BTreeMap::default()));
 
         let person = DataType::Struct(vec![
             first_name,
@@ -1154,8 +1154,7 @@ mod tests {
         assert!(schema2 != schema4);
         assert!(schema3 != schema4);
 
-        let mut f = Field::new("c1", DataType::Utf8, false);
-        f.set_metadata(Some(
+        let f = Field::new("c1", DataType::Utf8, false).with_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()
@@ -1195,8 +1194,8 @@ mod tests {
     fn person_schema() -> Schema {
         let kv_array = [("k".to_string(), "v".to_string())];
         let field_metadata: BTreeMap<String, String> = kv_array.iter().cloned().collect();
-        let mut first_name = Field::new("first_name", DataType::Utf8, false);
-        first_name.set_metadata(Some(field_metadata));
+        let first_name = Field::new("first_name", DataType::Utf8, false)
+            .with_metadata(Some(field_metadata));
 
         Schema::new(vec![
             first_name,
@@ -1227,16 +1226,16 @@ mod tests {
                 .iter()
                 .cloned()
                 .collect();
-        let mut f1 = Field::new("first_name", DataType::Utf8, false);
-        f1.set_metadata(Some(metadata1));
+        let f1 = Field::new("first_name", DataType::Utf8, false)
+            .with_metadata(Some(metadata1));
 
         let metadata2: BTreeMap<String, String> =
             [("foo".to_string(), "baz".to_string())]
                 .iter()
                 .cloned()
                 .collect();
-        let mut f2 = Field::new("first_name", DataType::Utf8, false);
-        f2.set_metadata(Some(metadata2));
+        let f2 = Field::new("first_name", DataType::Utf8, false)
+            .with_metadata(Some(metadata2));
 
         assert!(
             Schema::try_merge(vec![Schema::new(vec![f1]), Schema::new(vec![f2])])
@@ -1250,8 +1249,8 @@ mod tests {
                 .iter()
                 .cloned()
                 .collect();
-        let mut f2 = Field::new("first_name", DataType::Utf8, false);
-        f2.set_metadata(Some(metadata2));
+        let f2 = Field::new("first_name", DataType::Utf8, false)
+            .with_metadata(Some(metadata2));
 
         assert!(f1.try_merge(&f2).is_ok());
         assert!(f1.metadata().is_some());
@@ -1261,15 +1260,13 @@ mod tests {
         );
 
         // 3. Some + Some
-        let mut f1 = Field::new("first_name", DataType::Utf8, false);
-        f1.set_metadata(Some(
+        let mut f1 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()
                 .collect(),
         ));
-        let mut f2 = Field::new("first_name", DataType::Utf8, false);
-        f2.set_metadata(Some(
+        let f2 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
             [("foo2".to_string(), "bar2".to_string())]
                 .iter()
                 .cloned()
@@ -1290,8 +1287,7 @@ mod tests {
         );
 
         // 4. Some + None.
-        let mut f1 = Field::new("first_name", DataType::Utf8, false);
-        f1.set_metadata(Some(
+        let mut f1 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -87,6 +87,12 @@ impl Schema {
         Self { fields, metadata }
     }
 
+    /// Sets the metadata of this `Schema` to be `metadata` and returns self
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
     /// Returns a new schema with only the specified columns in the new schema
     /// This carries metadata from the parent schema over as well
     pub fn project(&self, indices: &[usize]) -> Result<Schema> {
@@ -366,7 +372,7 @@ mod tests {
     #[test]
     fn test_ser_de_metadata() {
         // ser/de with empty metadata
-        let mut schema = Schema::new(vec![
+        let schema = Schema::new(vec![
             Field::new("name", DataType::Utf8, false),
             Field::new("address", DataType::Utf8, false),
             Field::new("priority", DataType::UInt8, false),
@@ -378,10 +384,8 @@ mod tests {
         assert_eq!(schema, de_schema);
 
         // ser/de with non-empty metadata
-        schema.metadata = [("key".to_owned(), "val".to_owned())]
-            .iter()
-            .cloned()
-            .collect();
+        let schema = schema
+            .with_metadata([("key".to_owned(), "val".to_owned())].into_iter().collect());
         let json = serde_json::to_string(&schema).unwrap();
         let de_schema = serde_json::from_str(&json).unwrap();
 
@@ -393,14 +397,12 @@ mod tests {
         let mut metadata = HashMap::new();
         metadata.insert("meta".to_string(), "data".to_string());
 
-        let schema = Schema::new_with_metadata(
-            vec![
-                Field::new("name", DataType::Utf8, false),
-                Field::new("address", DataType::Utf8, false),
-                Field::new("priority", DataType::UInt8, false),
-            ],
-            metadata,
-        );
+        let schema = Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("address", DataType::Utf8, false),
+            Field::new("priority", DataType::UInt8, false),
+        ])
+        .with_metadata(metadata);
 
         let projected: Schema = schema.project(&[0, 2]).unwrap();
 
@@ -415,14 +417,12 @@ mod tests {
         let mut metadata = HashMap::new();
         metadata.insert("meta".to_string(), "data".to_string());
 
-        let schema = Schema::new_with_metadata(
-            vec![
-                Field::new("name", DataType::Utf8, false),
-                Field::new("address", DataType::Utf8, false),
-                Field::new("priority", DataType::UInt8, false),
-            ],
-            metadata,
-        );
+        let schema = Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("address", DataType::Utf8, false),
+            Field::new("priority", DataType::UInt8, false),
+        ])
+        .with_metadata(metadata);
 
         let projected: Result<Schema> = schema.project(&[0, 3]);
 

--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -72,7 +72,7 @@ pub fn schema_to_fb_offset<'a>(
 /// Convert an IPC Field to Arrow Field
 impl<'a> From<ipc::Field<'a>> for Field {
     fn from(field: ipc::Field) -> Field {
-        let mut arrow_field = if let Some(dictionary) = field.dictionary() {
+        let arrow_field = if let Some(dictionary) = field.dictionary() {
             Field::new_dict(
                 field.name().unwrap(),
                 get_data_type(field, true),
@@ -99,8 +99,7 @@ impl<'a> From<ipc::Field<'a>> for Field {
             metadata = Some(metadata_map);
         }
 
-        arrow_field.set_metadata(metadata);
-        arrow_field
+        arrow_field.with_metadata(metadata)
     }
 }
 
@@ -705,11 +704,7 @@ mod tests {
             .collect();
         let schema = Schema::new_with_metadata(
             vec![
-                {
-                    let mut f = Field::new("uint8", DataType::UInt8, false);
-                    f.set_metadata(Some(field_md));
-                    f
-                },
+                Field::new("uint8", DataType::UInt8, false).with_metadata(Some(field_md)),
                 Field::new("uint16", DataType::UInt16, true),
                 Field::new("uint32", DataType::UInt32, false),
                 Field::new("uint64", DataType::UInt64, true),

--- a/arrow/src/util/integration_util.rs
+++ b/arrow/src/util/integration_util.rs
@@ -783,97 +783,90 @@ mod tests {
         let micros_tz = Some("UTC".to_string());
         let nanos_tz = Some("Africa/Johannesburg".to_string());
 
-        let schema = Schema::new(vec![
-            {
-                let mut f =
-                    Field::new("bools-with-metadata-map", DataType::Boolean, true);
-                f.set_metadata(Some(
-                    [("k".to_string(), "v".to_string())]
-                        .iter()
-                        .cloned()
-                        .collect(),
-                ));
-                f
-            },
-            {
-                let mut f =
-                    Field::new("bools-with-metadata-vec", DataType::Boolean, true);
-                f.set_metadata(Some(
-                    [("k2".to_string(), "v2".to_string())]
-                        .iter()
-                        .cloned()
-                        .collect(),
-                ));
-                f
-            },
-            Field::new("bools", DataType::Boolean, true),
-            Field::new("int8s", DataType::Int8, true),
-            Field::new("int16s", DataType::Int16, true),
-            Field::new("int32s", DataType::Int32, true),
-            Field::new("int64s", DataType::Int64, true),
-            Field::new("uint8s", DataType::UInt8, true),
-            Field::new("uint16s", DataType::UInt16, true),
-            Field::new("uint32s", DataType::UInt32, true),
-            Field::new("uint64s", DataType::UInt64, true),
-            Field::new("float32s", DataType::Float32, true),
-            Field::new("float64s", DataType::Float64, true),
-            Field::new("date_days", DataType::Date32, true),
-            Field::new("date_millis", DataType::Date64, true),
-            Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
-            Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
-            Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
-            Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
-            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
-            Field::new(
-                "ts_millis",
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_micros",
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_nanos",
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_secs_tz",
-                DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_millis_tz",
-                DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_micros_tz",
-                DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_nanos_tz",
-                DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
-                true,
-            ),
-            Field::new("utf8s", DataType::Utf8, true),
-            Field::new(
-                "lists",
-                DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
-                true,
-            ),
-            Field::new(
-                "structs",
-                DataType::Struct(vec![
-                    Field::new("int32s", DataType::Int32, true),
-                    Field::new("utf8s", DataType::Utf8, true),
-                ]),
-                true,
-            ),
-        ]);
+        let schema =
+            Schema::new(vec![
+                Field::new("bools-with-metadata-map", DataType::Boolean, true)
+                    .with_metadata(Some(
+                        [("k".to_string(), "v".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect(),
+                    )),
+                Field::new("bools-with-metadata-vec", DataType::Boolean, true)
+                    .with_metadata(Some(
+                        [("k2".to_string(), "v2".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect(),
+                    )),
+                Field::new("bools", DataType::Boolean, true),
+                Field::new("int8s", DataType::Int8, true),
+                Field::new("int16s", DataType::Int16, true),
+                Field::new("int32s", DataType::Int32, true),
+                Field::new("int64s", DataType::Int64, true),
+                Field::new("uint8s", DataType::UInt8, true),
+                Field::new("uint16s", DataType::UInt16, true),
+                Field::new("uint32s", DataType::UInt32, true),
+                Field::new("uint64s", DataType::UInt64, true),
+                Field::new("float32s", DataType::Float32, true),
+                Field::new("float64s", DataType::Float64, true),
+                Field::new("date_days", DataType::Date32, true),
+                Field::new("date_millis", DataType::Date64, true),
+                Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
+                Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
+                Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
+                Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
+                Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
+                Field::new(
+                    "ts_millis",
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    true,
+                ),
+                Field::new(
+                    "ts_micros",
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    true,
+                ),
+                Field::new(
+                    "ts_nanos",
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    true,
+                ),
+                Field::new(
+                    "ts_secs_tz",
+                    DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_millis_tz",
+                    DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_micros_tz",
+                    DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_nanos_tz",
+                    DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
+                    true,
+                ),
+                Field::new("utf8s", DataType::Utf8, true),
+                Field::new(
+                    "lists",
+                    DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                    true,
+                ),
+                Field::new(
+                    "structs",
+                    DataType::Struct(vec![
+                        Field::new("int32s", DataType::Int32, true),
+                        Field::new("utf8s", DataType::Utf8, true),
+                    ]),
+                    true,
+                ),
+            ]);
 
         let bools_with_metadata_map =
             BooleanArray::from(vec![Some(true), None, Some(false)]);


### PR DESCRIPTION
# Which issue does this PR close?


Re https://github.com/apache/arrow-rs/issues/1091


# Rationale for this change
It is annoying to add metadata to `Field`s (and to a lesser degree `Schema`s)


# What changes are included in this PR?

1. Add `Schema::with_metadata` and `Field::with_metadata`
2. Update code to use `with_metadata` which I think is much nicer


# Are there any user-facing changes?
New functions
