### PR TITLE
Print the 'FixedSizeBinaryArray' like a normal 'BinaryArray'

### DIFF
--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -301,7 +301,9 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::LargeUtf8 => make_string!(array::LargeStringArray, column, row),
         DataType::Binary => make_string_hex!(array::BinaryArray, column, row),
         DataType::LargeBinary => make_string_hex!(array::LargeBinaryArray, column, row),
-        DataType::FixedSizeBinary(_) => make_string_hex!(array::FixedSizeBinaryArray, column, row),
+        DataType::FixedSizeBinary(_) => {
+            make_string_hex!(array::FixedSizeBinaryArray, column, row)
+        }
         DataType::Boolean => make_string!(array::BooleanArray, column, row),
         DataType::Int8 => make_string!(array::Int8Array, column, row),
         DataType::Int16 => make_string!(array::Int16Array, column, row),

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -301,6 +301,7 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::LargeUtf8 => make_string!(array::LargeStringArray, column, row),
         DataType::Binary => make_string_hex!(array::BinaryArray, column, row),
         DataType::LargeBinary => make_string_hex!(array::LargeBinaryArray, column, row),
+        DataType::FixedSizeBinary(_) => make_string_hex!(array::FixedSizeBinaryArray, column, row),
         DataType::Boolean => make_string!(array::BooleanArray, column, row),
         DataType::Int8 => make_string!(array::Int8Array, column, row),
         DataType::Int16 => make_string!(array::Int16Array, column, row),

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -108,11 +108,12 @@ fn create_column(field: &str, columns: &[ArrayRef]) -> Result<Table> {
 mod tests {
     use crate::{
         array::{
-            self, new_null_array, Array, Date32Array, Date64Array, PrimitiveBuilder,
-            StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
-            Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
-            Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-            TimestampNanosecondArray, TimestampSecondArray, FixedSizeBinaryBuilder,
+            self, new_null_array, Array, Date32Array, Date64Array,
+            FixedSizeBinaryBuilder, PrimitiveBuilder, StringArray, StringBuilder,
+            StringDictionaryBuilder, StructArray, Time32MillisecondArray,
+            Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+            TimestampMicrosecondArray, TimestampMillisecondArray,
+            TimestampNanosecondArray, TimestampSecondArray,
         },
         datatypes::{DataType, Field, Int32Type, Schema},
     };
@@ -311,9 +312,7 @@ mod tests {
     #[test]
     fn test_pretty_format_fixed_size_binary() -> Result<()> {
         // define a schema.
-        let field_type = DataType::FixedSizeBinary(
-            3,
-        );
+        let field_type = DataType::FixedSizeBinary(3);
         let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
         let mut builder = FixedSizeBinaryBuilder::new(3, 3);

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -112,7 +112,7 @@ mod tests {
             StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
             Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
             Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-            TimestampNanosecondArray, TimestampSecondArray,
+            TimestampNanosecondArray, TimestampSecondArray, FixedSizeBinaryBuilder,
         },
         datatypes::{DataType, Field, Int32Type, Schema},
     };
@@ -299,6 +299,41 @@ mod tests {
             "|           |",
             "| [7, 8, 9] |",
             "+-----------+",
+        ];
+
+        let actual: Vec<&str> = table.lines().collect();
+
+        assert_eq!(expected, actual, "Actual result:\n{}", table);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_pretty_format_fixed_size_binary() -> Result<()> {
+        // define a schema.
+        let field_type = DataType::FixedSizeBinary(
+            3,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
+
+        let mut builder = FixedSizeBinaryBuilder::new(3, 3);
+
+        builder.append_value(&[1, 2, 3]).unwrap();
+        builder.append_null();
+        builder.append_value(&[7, 8, 9]).unwrap();
+
+        let array = Arc::new(builder.finish());
+
+        let batch = RecordBatch::try_new(schema, vec![array])?;
+        let table = pretty_format_batches(&[batch])?.to_string();
+        let expected = vec![
+            "+--------+",
+            "| d1     |",
+            "+--------+",
+            "| 010203 |",
+            "|        |",
+            "| 070809 |",
+            "+--------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1096.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
See #1096.

# What changes are included in this PR?

A new match arm has been added to the `array_value_to_string` function to allow pretty printing `FixedSizeBinaryArray`.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Not directly.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
