### PR TITLE
Allow proc-macro2 dependency to be flexible in arrow-flight

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -42,7 +42,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"]}
 tonic-build = "0.6"
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
-proc-macro2 = "=1.0.30"
+proc-macro2 = ">1.0.30"
 
 #[lib]
 #name = "flight"


### PR DESCRIPTION
# Which issue does this PR close?

Resolves https://github.com/apache/arrow-rs/issues/1101

# Rationale for this change
 
Hard pinning the version means fixes that require updates to the `proc-macro2` library are not possible 

Specifically this also fixes this  breakage with the`quote 1.11.0` release
```
cd /Users/alamb/Software/arrow-rs && CARGO_TARGET_DIR=/Users/alamb/Software/df-target cargo test --all
    Updating crates.io index
   Compiling quote v1.0.11
error[E0599]: no function or associated item named `from_str_unchecked` found for struct `proc_macro2::Literal` in the current scope
   --> /Users/alamb/.cargo/registry/src/github.com-1ecc6299db9ec823/quote-1.0.11/src/runtime.rs:301:41
    |
301 |         let literal = unsafe { Literal::from_str_unchecked(repr) };
    |                                         ^^^^^^^^^^^^^^^^^^ function or associated item not found in `proc_macro2::Literal`

error[E0599]: no function or associated item named `from_str_unchecked` found for struct `proc_macro2::Literal` in the current scope
   --> /Users/alamb/.cargo/registry/src/github.com-1ecc6299db9ec823/quote-1.0.11/src/runtime.rs:310:45
    |
310 |         let mut literal = unsafe { Literal::from_str_unchecked(repr) };
    |                                             ^^^^^^^^^^^^^^^^^^ function or associated item not found in `proc_macro2::Literal`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `quote` due to 2 previous errors

```

# What changes are included in this PR?

Make pin to proc-macro2 more flexble

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
