### PR TITLE
Dyn comparison of interval arrays (#1106)

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -28,7 +28,8 @@ use crate::compute::binary_boolean_kernel;
 use crate::compute::util::combine_option_bitmap;
 use crate::datatypes::{
     ArrowNumericType, DataType, Float32Type, Float64Type, Int16Type, Int32Type,
-    Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+    Int64Type, Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit,
+    IntervalYearMonthType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
@@ -1136,6 +1137,42 @@ macro_rules! typed_compares {
             (DataType::LargeUtf8, DataType::LargeUtf8) => {
                 typed_cmp!($LEFT, $RIGHT, LargeStringArray, $OP_STR, i64)
             }
+            (
+                DataType::Interval(IntervalUnit::YearMonth),
+                DataType::Interval(IntervalUnit::YearMonth),
+            ) => {
+                typed_cmp!(
+                    $LEFT,
+                    $RIGHT,
+                    IntervalYearMonthArray,
+                    $OP_PRIM,
+                    IntervalYearMonthType
+                )
+            }
+            (
+                DataType::Interval(IntervalUnit::DayTime),
+                DataType::Interval(IntervalUnit::DayTime),
+            ) => {
+                typed_cmp!(
+                    $LEFT,
+                    $RIGHT,
+                    IntervalDayTimeArray,
+                    $OP_PRIM,
+                    IntervalDayTimeType
+                )
+            }
+            (
+                DataType::Interval(IntervalUnit::MonthDayNano),
+                DataType::Interval(IntervalUnit::MonthDayNano),
+            ) => {
+                typed_cmp!(
+                    $LEFT,
+                    $RIGHT,
+                    IntervalMonthDayNanoArray,
+                    $OP_PRIM,
+                    IntervalMonthDayNanoType
+                )
+            }
             (t1, t2) if t1 == t2 => Err(ArrowError::NotYetImplemented(format!(
                 "Comparing arrays of type {} is not yet implemented",
                 t1
@@ -2022,6 +2059,57 @@ mod tests {
                 .downcast_ref::<BooleanArray>()
                 .unwrap(),
             &BooleanArray::from(vec![true, false, false, false]),
+        );
+    }
+
+    #[test]
+    fn test_interval_array() {
+        let a = IntervalDayTimeArray::from(
+            vec![Some(0), Some(6), Some(834), None, Some(3), None],
+        );
+        let b = IntervalDayTimeArray::from(
+            vec![Some(70), Some(6), Some(833), Some(6), Some(3), None],
+        );
+        let res = eq(&a, &b).unwrap();
+        let res_dyn = eq_dyn(&a, &b).unwrap();
+        assert_eq!(res, res_dyn);
+        assert_eq!(
+            &res_dyn,
+            &BooleanArray::from(
+                vec![Some(false), Some(true), Some(false), None, Some(true), None]
+            )
+        );
+
+        let a = IntervalMonthDayNanoArray::from(
+            vec![Some(0), Some(6), Some(834), None, Some(3), None],
+        );
+        let b = IntervalMonthDayNanoArray::from(
+            vec![Some(86), Some(5), Some(8), Some(6), Some(3), None],
+        );
+        let res = lt(&a, &b).unwrap();
+        let res_dyn = lt_dyn(&a, &b).unwrap();
+        assert_eq!(res, res_dyn);
+        assert_eq!(
+            &res_dyn,
+            &BooleanArray::from(
+                vec![Some(true), Some(false), Some(false), None, Some(false), None]
+            )
+        );
+
+        let a = IntervalYearMonthArray::from(
+            vec![Some(0), Some(623), Some(834), None, Some(3), None],
+        );
+        let b = IntervalYearMonthArray::from(
+            vec![Some(86), Some(5), Some(834), Some(6), Some(86), None],
+        );
+        let res = gt_eq(&a, &b).unwrap();
+        let res_dyn = gt_eq_dyn(&a, &b).unwrap();
+        assert_eq!(res, res_dyn);
+        assert_eq!(
+            &res_dyn,
+            &BooleanArray::from(
+                vec![Some(false), Some(true), Some(true), None, Some(false), None]
+            )
         );
     }
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -2759,6 +2759,8 @@ mod tests {
         );
     }
 
+    // Fails when simd is enabled: https://github.com/apache/arrow-rs/issues/1136
+    #[cfg(not(feature = "simd"))]
     #[test]
     fn test_interval_array() {
         let a = IntervalDayTimeArray::from(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -28,8 +28,8 @@ use crate::buffer::{bitwise_bin_op_helper, buffer_unary_not, Buffer, MutableBuff
 use crate::compute::binary_boolean_kernel;
 use crate::compute::util::combine_option_bitmap;
 use crate::datatypes::{
-    ArrowNativeType, ArrowNumericType, DataType, Date32Type, Date64Type, Float32Type, Float64Type,
-    Int16Type, Int32Type, Int64Type, Int8Type, IntervalDayTimeType,
+    ArrowNativeType, ArrowNumericType, DataType, Date32Type, Date64Type, Float32Type,
+    Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, IntervalDayTimeType,
     IntervalMonthDayNanoType, IntervalUnit, IntervalYearMonthType, TimeUnit,
     TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
     TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1106.

# Rationale for this change
 
See ticket

# What changes are included in this PR?

See ticket

# Are there any user-facing changes?

Dyn comparison kernels work with interval arrays