### PR TITLE
Extends parquet fuzz tests to also tests nulls, dictionaries and row groups with multiple pages  (#1053)

### DIFF
--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -60,7 +60,7 @@ use crate::arrow::converter::{
     Int96ArrayConverter, Int96Converter, IntervalDayTimeArrayConverter,
     IntervalDayTimeConverter, IntervalYearMonthArrayConverter,
     IntervalYearMonthConverter, LargeBinaryArrayConverter, LargeBinaryConverter,
-    LargeUtf8ArrayConverter, LargeUtf8Converter, Utf8ArrayConverter, Utf8Converter,
+    LargeUtf8ArrayConverter, LargeUtf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -1690,24 +1690,12 @@ impl<'a> ArrayReaderBuilder {
                             arrow_type,
                         )?))
                     } else {
-                        // use crate::arrow::arrow_array_reader::{
-                        //     ArrowArrayReader, StringArrayConverter,
-                        // };
-                        // let converter = StringArrayConverter::new();
-                        // Ok(Box::new(ArrowArrayReader::try_new(
-                        //     *page_iterator,
-                        //     column_desc,
-                        //     converter,
-                        //     arrow_type,
-                        // )?))
-
-                        // TODO: TEMPORARY
-                        let converter = Utf8Converter::new(Utf8ArrayConverter {});
-                        Ok(Box::new(ComplexObjectArrayReader::<
-                            ByteArrayType,
-                            Utf8Converter,
-                        >::new(
-                            page_iterator,
+                        use crate::arrow::arrow_array_reader::{
+                            ArrowArrayReader, StringArrayConverter,
+                        };
+                        let converter = StringArrayConverter::new();
+                        Ok(Box::new(ArrowArrayReader::try_new(
+                            *page_iterator,
                             column_desc,
                             converter,
                             arrow_type,

--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -60,7 +60,7 @@ use crate::arrow::converter::{
     Int96ArrayConverter, Int96Converter, IntervalDayTimeArrayConverter,
     IntervalDayTimeConverter, IntervalYearMonthArrayConverter,
     IntervalYearMonthConverter, LargeBinaryArrayConverter, LargeBinaryConverter,
-    LargeUtf8ArrayConverter, LargeUtf8Converter,
+    LargeUtf8ArrayConverter, LargeUtf8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -1690,12 +1690,24 @@ impl<'a> ArrayReaderBuilder {
                             arrow_type,
                         )?))
                     } else {
-                        use crate::arrow::arrow_array_reader::{
-                            ArrowArrayReader, StringArrayConverter,
-                        };
-                        let converter = StringArrayConverter::new();
-                        Ok(Box::new(ArrowArrayReader::try_new(
-                            *page_iterator,
+                        // use crate::arrow::arrow_array_reader::{
+                        //     ArrowArrayReader, StringArrayConverter,
+                        // };
+                        // let converter = StringArrayConverter::new();
+                        // Ok(Box::new(ArrowArrayReader::try_new(
+                        //     *page_iterator,
+                        //     column_desc,
+                        //     converter,
+                        //     arrow_type,
+                        // )?))
+
+                        // TODO: TEMPORARY
+                        let converter = Utf8Converter::new(Utf8ArrayConverter {});
+                        Ok(Box::new(ComplexObjectArrayReader::<
+                            ByteArrayType,
+                            Utf8Converter,
+                        >::new(
+                            page_iterator,
                             column_desc,
                             converter,
                             arrow_type,

--- a/parquet/src/util/test_common/rand_gen.rs
+++ b/parquet/src/util/test_common/rand_gen.rs
@@ -91,13 +91,8 @@ impl RandGen<ByteArrayType> for ByteArrayType {
 
 impl RandGen<FixedLenByteArrayType> for FixedLenByteArrayType {
     fn gen(len: i32) -> FixedLenByteArray {
-        let mut rng = thread_rng();
-        let value_len = if len < 0 {
-            rng.gen_range(0..128)
-        } else {
-            len as usize
-        };
-        let value = random_bytes(value_len);
+        assert!(len >= 0);
+        let value = random_bytes(len as usize);
         ByteArray::from(value).into()
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1053.

# Rationale for this change
 
See ticket

# What changes are included in this PR?

This extends the parquet fuzz tests to also tests nulls, dictionaries and row groups with multiple pages. ~Currently this runs into what appears to be a bug in the null handling for ArrowArrayReader. This is likely the same as in https://github.com/apache/arrow-datafusion/issues/1441 - I have temporarily switched back to ComplexObjectArrayReader to get the test to pass, and will look into a fix prior to marking this ready for review.~ This has been fixed by #1130

# Are there any user-facing changes?

No, this only adds tests
