### PR TITLE
allow using custom datetime format for inference and parsing csv file

### DIFF
--- a/arrow/examples/read_csv.rs
+++ b/arrow/examples/read_csv.rs
@@ -38,7 +38,7 @@ fn main() {
         let file = File::open("test/data/uk_cities.csv").unwrap();
 
         let mut csv =
-            csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None);
+            csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None, None);
         let _batch = csv.next().unwrap().unwrap();
         #[cfg(feature = "prettyprint")]
         {

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -36,7 +36,7 @@
 //!
 //! let file = File::open("test/data/uk_cities.csv").unwrap();
 //!
-//! let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None);
+//! let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None, None);
 //! let batch = csv.next().unwrap().unwrap();
 //! ```
 
@@ -76,7 +76,8 @@ lazy_static! {
 }
 
 /// Infer the data type of a record
-fn infer_field_schema(string: &str) -> DataType {
+fn infer_field_schema(string: &str, datetime_re: Option<Regex>) -> DataType {
+    let datetime_re = datetime_re.unwrap_or_else(|| DATETIME_RE.clone());
     // when quoting is enabled in the reader, these quotes aren't escaped, we default to
     // Utf8 for them
     if string.starts_with('"') {
@@ -89,7 +90,7 @@ fn infer_field_schema(string: &str) -> DataType {
         DataType::Float64
     } else if INTEGER_RE.is_match(string) {
         DataType::Int64
-    } else if DATETIME_RE.is_match(string) {
+    } else if datetime_re.is_match(string) {
         DataType::Date64
     } else if DATE_RE.is_match(string) {
         DataType::Date32
@@ -119,6 +120,7 @@ pub fn infer_file_schema<R: Read + Seek>(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -130,6 +132,7 @@ fn infer_file_schema_with_csv_options<R: Read + Seek>(
     escape: Option<u8>,
     quote: Option<u8>,
     terminator: Option<u8>,
+    datetime_re: Option<Regex>,
 ) -> Result<(Schema, usize)> {
     let saved_offset = reader.seek(SeekFrom::Current(0))?;
 
@@ -141,6 +144,7 @@ fn infer_file_schema_with_csv_options<R: Read + Seek>(
         escape,
         quote,
         terminator,
+        datetime_re,
     )?;
 
     // return the reader seek back to the start
@@ -169,6 +173,7 @@ pub fn infer_reader_schema<R: Read>(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -180,6 +185,7 @@ fn infer_reader_schema_with_csv_options<R: Read>(
     escape: Option<u8>,
     quote: Option<u8>,
     terminator: Option<u8>,
+    datetime_re: Option<Regex>,
 ) -> Result<(Schema, usize)> {
     let mut csv_reader = Reader::build_csv_reader(
         reader,
@@ -224,7 +230,8 @@ fn infer_reader_schema_with_csv_options<R: Read>(
                 if string.is_empty() {
                     nulls[i] = true;
                 } else {
-                    column_types[i].insert(infer_field_schema(string));
+                    column_types[i]
+                        .insert(infer_field_schema(string, datetime_re.clone()));
                 }
             }
         }
@@ -316,6 +323,11 @@ pub struct Reader<R: Read> {
     batch_size: usize,
     /// Vector that can hold the `StringRecord`s of the batches
     batch_records: Vec<StringRecord>,
+    /// datetime format used to parse datetime values, (format understood by chrono)
+    ///
+    /// For format refer to chrono docs:
+    /// https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html
+    datetime_format: Option<String>,
 }
 
 impl<R> fmt::Debug for Reader<R>
@@ -327,6 +339,7 @@ where
             .field("schema", &self.schema)
             .field("projection", &self.projection)
             .field("line_number", &self.line_number)
+            .field("datetime_format", &self.datetime_format)
             .finish()
     }
 }
@@ -345,9 +358,17 @@ impl<R: Read> Reader<R> {
         batch_size: usize,
         bounds: Bounds,
         projection: Option<Vec<usize>>,
+        datetime_format: Option<String>,
     ) -> Self {
         Self::from_reader(
-            reader, schema, has_header, delimiter, batch_size, bounds, projection,
+            reader,
+            schema,
+            has_header,
+            delimiter,
+            batch_size,
+            bounds,
+            projection,
+            datetime_format,
         )
     }
 
@@ -378,11 +399,18 @@ impl<R: Read> Reader<R> {
         batch_size: usize,
         bounds: Bounds,
         projection: Option<Vec<usize>>,
+        datetime_format: Option<String>,
     ) -> Self {
         let csv_reader =
             Self::build_csv_reader(reader, has_header, delimiter, None, None, None);
         Self::from_csv_reader(
-            csv_reader, schema, has_header, batch_size, bounds, projection,
+            csv_reader,
+            schema,
+            has_header,
+            batch_size,
+            bounds,
+            projection,
+            datetime_format,
         )
     }
 
@@ -417,6 +445,7 @@ impl<R: Read> Reader<R> {
         batch_size: usize,
         bounds: Bounds,
         projection: Option<Vec<usize>>,
+        datetime_format: Option<String>,
     ) -> Self {
         let (start, end) = match bounds {
             None => (0, usize::MAX),
@@ -450,6 +479,7 @@ impl<R: Read> Reader<R> {
             batch_size,
             end,
             batch_records,
+            datetime_format,
         }
     }
 }
@@ -482,6 +512,11 @@ impl<R: Read> Iterator for Reader<R> {
             return None;
         }
 
+        let format: Option<&str> = match self.datetime_format {
+            Some(ref format) => Some(format.as_ref()),
+            _ => None,
+        };
+
         // parse the batches into a RecordBatch
         let result = parse(
             &self.batch_records[..read_records],
@@ -489,6 +524,7 @@ impl<R: Read> Iterator for Reader<R> {
             Some(self.schema.metadata.clone()),
             &self.projection,
             self.line_number,
+            format,
         );
 
         self.line_number += read_records;
@@ -504,6 +540,7 @@ fn parse(
     metadata: Option<std::collections::HashMap<String, String>>,
     projection: &Option<Vec<usize>>,
     line_number: usize,
+    datetime_format: Option<&str>,
 ) -> Result<RecordBatch> {
     let projection: Vec<usize> = match projection {
         Some(ref v) => v.clone(),
@@ -520,47 +557,60 @@ fn parse(
                 DataType::Decimal(precision, scale) => {
                     build_decimal_array(line_number, rows, i, *precision, *scale)
                 }
-                DataType::Int8 => build_primitive_array::<Int8Type>(line_number, rows, i),
+                DataType::Int8 => {
+                    build_primitive_array::<Int8Type>(line_number, rows, i, None)
+                }
                 DataType::Int16 => {
-                    build_primitive_array::<Int16Type>(line_number, rows, i)
+                    build_primitive_array::<Int16Type>(line_number, rows, i, None)
                 }
                 DataType::Int32 => {
-                    build_primitive_array::<Int32Type>(line_number, rows, i)
+                    build_primitive_array::<Int32Type>(line_number, rows, i, None)
                 }
                 DataType::Int64 => {
-                    build_primitive_array::<Int64Type>(line_number, rows, i)
+                    build_primitive_array::<Int64Type>(line_number, rows, i, None)
                 }
                 DataType::UInt8 => {
-                    build_primitive_array::<UInt8Type>(line_number, rows, i)
+                    build_primitive_array::<UInt8Type>(line_number, rows, i, None)
                 }
                 DataType::UInt16 => {
-                    build_primitive_array::<UInt16Type>(line_number, rows, i)
+                    build_primitive_array::<UInt16Type>(line_number, rows, i, None)
                 }
                 DataType::UInt32 => {
-                    build_primitive_array::<UInt32Type>(line_number, rows, i)
+                    build_primitive_array::<UInt32Type>(line_number, rows, i, None)
                 }
                 DataType::UInt64 => {
-                    build_primitive_array::<UInt64Type>(line_number, rows, i)
+                    build_primitive_array::<UInt64Type>(line_number, rows, i, None)
                 }
                 DataType::Float32 => {
-                    build_primitive_array::<Float32Type>(line_number, rows, i)
+                    build_primitive_array::<Float32Type>(line_number, rows, i, None)
                 }
                 DataType::Float64 => {
-                    build_primitive_array::<Float64Type>(line_number, rows, i)
+                    build_primitive_array::<Float64Type>(line_number, rows, i, None)
                 }
                 DataType::Date32 => {
-                    build_primitive_array::<Date32Type>(line_number, rows, i)
+                    build_primitive_array::<Date32Type>(line_number, rows, i, None)
                 }
-                DataType::Date64 => {
-                    build_primitive_array::<Date64Type>(line_number, rows, i)
-                }
-                DataType::Timestamp(TimeUnit::Microsecond, _) => build_primitive_array::<
-                    TimestampMicrosecondType,
-                >(
-                    line_number, rows, i
+                DataType::Date64 => build_primitive_array::<Date64Type>(
+                    line_number,
+                    rows,
+                    i,
+                    datetime_format,
                 ),
+                DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                    build_primitive_array::<TimestampMicrosecondType>(
+                        line_number,
+                        rows,
+                        i,
+                        None,
+                    )
+                }
                 DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                    build_primitive_array::<TimestampNanosecondType>(line_number, rows, i)
+                    build_primitive_array::<TimestampNanosecondType>(
+                        line_number,
+                        rows,
+                        i,
+                        None,
+                    )
                 }
                 DataType::Utf8 => Ok(Arc::new(
                     rows.iter().map(|row| row.get(i)).collect::<StringArray>(),
@@ -639,6 +689,10 @@ trait Parser: ArrowPrimitiveType {
     fn parse(string: &str) -> Option<Self::Native> {
         string.parse::<Self::Native>().ok()
     }
+
+    fn parse_formatted(string: &str, _format: &str) -> Option<Self::Native> {
+        Self::parse(string)
+    }
 }
 
 impl Parser for Float32Type {
@@ -696,6 +750,16 @@ impl Parser for Date64Type {
             _ => None,
         }
     }
+
+    fn parse_formatted(string: &str, format: &str) -> Option<i64> {
+        match Self::DATA_TYPE {
+            DataType::Date64 => {
+                let date_time = chrono::DateTime::parse_from_str(string, format).ok()?;
+                Self::Native::from_i64(date_time.timestamp_millis())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Parser for TimestampNanosecondType {
@@ -723,6 +787,10 @@ impl Parser for TimestampMicrosecondType {
 
 fn parse_item<T: Parser>(string: &str) -> Option<T::Native> {
     T::parse(string)
+}
+
+fn parse_formatted<T: Parser>(string: &str, format: &str) -> Option<T::Native> {
+    T::parse_formatted(string, format)
 }
 
 fn parse_bool(string: &str) -> Option<bool> {
@@ -886,6 +954,7 @@ fn build_primitive_array<T: ArrowPrimitiveType + Parser>(
     line_number: usize,
     rows: &[StringRecord],
     col_idx: usize,
+    format: Option<&str>,
 ) -> Result<ArrayRef> {
     rows.iter()
         .enumerate()
@@ -896,7 +965,10 @@ fn build_primitive_array<T: ArrowPrimitiveType + Parser>(
                         return Ok(None);
                     }
 
-                    let parsed = parse_item::<T>(s);
+                    let parsed = match format {
+                        Some(format) => parse_formatted::<T>(s, format),
+                        _ => parse_item::<T>(s),
+                    };
                     match parsed {
                         Some(e) => Ok(Some(e)),
                         None => Err(ArrowError::ParseError(format!(
@@ -982,6 +1054,10 @@ pub struct ReaderBuilder {
     bounds: Bounds,
     /// Optional projection for which columns to load (zero-based column indices)
     projection: Option<Vec<usize>>,
+    /// DateTime format to be used while trying to infer datetime format
+    datetime_re: Option<Regex>,
+    /// DateTime format to be used while parsing datetime format
+    datetime_format: Option<String>,
 }
 
 impl Default for ReaderBuilder {
@@ -997,6 +1073,8 @@ impl Default for ReaderBuilder {
             batch_size: 1024,
             bounds: None,
             projection: None,
+            datetime_re: None,
+            datetime_format: None,
         }
     }
 }
@@ -1038,6 +1116,24 @@ impl ReaderBuilder {
     /// Set whether the CSV file has headers
     pub fn has_header(mut self, has_header: bool) -> Self {
         self.has_header = has_header;
+        self
+    }
+
+    /// Set the datetime regex used to parse the string to Date64Type
+    /// this regex is used while infering schema
+    pub fn with_datetime_re(mut self, datetime_re: Regex) -> Self {
+        self.datetime_re = Some(datetime_re);
+        self
+    }
+
+    /// Set the datetime fromat used to parse the string to Date64Type
+    /// this fromat is used while when the schema wants to parse Date64Type.
+    ///
+    /// For format refer to chrono docs:
+    /// https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html
+    ///
+    pub fn with_datetime_format(mut self, datetime_format: String) -> Self {
+        self.datetime_format = Some(datetime_format);
         self
     }
 
@@ -1097,6 +1193,7 @@ impl ReaderBuilder {
                     self.escape,
                     self.quote,
                     self.terminator,
+                    self.datetime_re,
                 )?;
 
                 Arc::new(inferred_schema)
@@ -1117,6 +1214,7 @@ impl ReaderBuilder {
             self.batch_size,
             None,
             self.projection.clone(),
+            self.datetime_format,
         ))
     }
 }
@@ -1136,44 +1234,49 @@ mod tests {
 
     #[test]
     fn test_csv() {
-        let schema = Schema::new(vec![
-            Field::new("city", DataType::Utf8, false),
-            Field::new("lat", DataType::Float64, false),
-            Field::new("lng", DataType::Float64, false),
-        ]);
+        let _: Vec<()> = vec![None, Some("%Y-%m-%dT%H:%M:%S%.f%:z".to_string())]
+            .into_iter()
+            .map(|format| {
+                let schema = Schema::new(vec![
+                    Field::new("city", DataType::Utf8, false),
+                    Field::new("lat", DataType::Float64, false),
+                    Field::new("lng", DataType::Float64, false),
+                ]);
 
-        let file = File::open("test/data/uk_cities.csv").unwrap();
+                let file = File::open("test/data/uk_cities.csv").unwrap();
+                let mut csv = Reader::new(
+                    file,
+                    Arc::new(schema.clone()),
+                    false,
+                    None,
+                    1024,
+                    None,
+                    None,
+                    format,
+                );
+                assert_eq!(Arc::new(schema), csv.schema());
+                let batch = csv.next().unwrap().unwrap();
+                assert_eq!(37, batch.num_rows());
+                assert_eq!(3, batch.num_columns());
 
-        let mut csv = Reader::new(
-            file,
-            Arc::new(schema.clone()),
-            false,
-            None,
-            1024,
-            None,
-            None,
-        );
-        assert_eq!(Arc::new(schema), csv.schema());
-        let batch = csv.next().unwrap().unwrap();
-        assert_eq!(37, batch.num_rows());
-        assert_eq!(3, batch.num_columns());
+                // access data from a primitive array
+                let lat = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap();
+                assert!(57.653484 - lat.value(0) < f64::EPSILON);
 
-        // access data from a primitive array
-        let lat = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .unwrap();
-        assert!(57.653484 - lat.value(0) < f64::EPSILON);
+                // access data from a string array (ListArray<u8>)
+                let city = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap();
 
-        // access data from a string array (ListArray<u8>)
-        let city = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-
-        assert_eq!("Aberdeen, Aberdeen City, UK", city.value(13));
+                assert_eq!("Aberdeen, Aberdeen City, UK", city.value(13));
+            })
+            .collect();
     }
 
     #[test]
@@ -1199,6 +1302,7 @@ mod tests {
             1024,
             None,
             None,
+            None,
         );
         assert_eq!(Arc::new(schema), csv.schema());
         let batch = csv.next().unwrap().unwrap();
@@ -1218,7 +1322,8 @@ mod tests {
 
         let file = File::open("test/data/decimal_test.csv").unwrap();
 
-        let mut csv = Reader::new(file, Arc::new(schema), false, None, 1024, None, None);
+        let mut csv =
+            Reader::new(file, Arc::new(schema), false, None, 1024, None, None, None);
         let batch = csv.next().unwrap().unwrap();
         // access data from a primitive array
         let lat = batch
@@ -1259,6 +1364,7 @@ mod tests {
             true,
             None,
             1024,
+            None,
             None,
             None,
         );
@@ -1358,6 +1464,7 @@ mod tests {
             1024,
             None,
             Some(vec![0, 1]),
+            None,
         );
         let projected_schema = Arc::new(Schema::new(vec![
             Field::new("city", DataType::Utf8, false),
@@ -1392,6 +1499,7 @@ mod tests {
             1024,
             None,
             Some(vec![0, 1]),
+            None,
         );
         let projected_schema = Arc::new(Schema::new(vec![
             Field::new(
@@ -1425,7 +1533,8 @@ mod tests {
 
         let file = File::open("test/data/null_test.csv").unwrap();
 
-        let mut csv = Reader::new(file, Arc::new(schema), true, None, 1024, None, None);
+        let mut csv =
+            Reader::new(file, Arc::new(schema), true, None, 1024, None, None, None);
         let batch = csv.next().unwrap().unwrap();
 
         assert!(!batch.column(1).is_null(0));
@@ -1522,18 +1631,31 @@ mod tests {
 
     #[test]
     fn test_infer_field_schema() {
-        assert_eq!(infer_field_schema("A"), DataType::Utf8);
-        assert_eq!(infer_field_schema("\"123\""), DataType::Utf8);
-        assert_eq!(infer_field_schema("10"), DataType::Int64);
-        assert_eq!(infer_field_schema("10.2"), DataType::Float64);
-        assert_eq!(infer_field_schema(".2"), DataType::Float64);
-        assert_eq!(infer_field_schema("2."), DataType::Float64);
-        assert_eq!(infer_field_schema("true"), DataType::Boolean);
-        assert_eq!(infer_field_schema("false"), DataType::Boolean);
-        assert_eq!(infer_field_schema("2020-11-08"), DataType::Date32);
-        assert_eq!(infer_field_schema("2020-11-08T14:20:01"), DataType::Date64);
-        assert_eq!(infer_field_schema("-5.13"), DataType::Float64);
-        assert_eq!(infer_field_schema("0.1300"), DataType::Float64);
+        assert_eq!(infer_field_schema("A", None), DataType::Utf8);
+        assert_eq!(infer_field_schema("\"123\"", None), DataType::Utf8);
+        assert_eq!(infer_field_schema("10", None), DataType::Int64);
+        assert_eq!(infer_field_schema("10.2", None), DataType::Float64);
+        assert_eq!(infer_field_schema(".2", None), DataType::Float64);
+        assert_eq!(infer_field_schema("2.", None), DataType::Float64);
+        assert_eq!(infer_field_schema("true", None), DataType::Boolean);
+        assert_eq!(infer_field_schema("false", None), DataType::Boolean);
+        assert_eq!(infer_field_schema("2020-11-08", None), DataType::Date32);
+        assert_eq!(
+            infer_field_schema("2020-11-08T14:20:01", None),
+            DataType::Date64
+        );
+        // to be inferred as a date64 this needs a custom datetime_re
+        assert_eq!(
+            infer_field_schema("2020-11-08 14:20:01", None),
+            DataType::Utf8
+        );
+        let reg = Regex::new(r"^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$").ok();
+        assert_eq!(
+            infer_field_schema("2020-11-08 14:20:01", reg),
+            DataType::Date64
+        );
+        assert_eq!(infer_field_schema("-5.13", None), DataType::Float64);
+        assert_eq!(infer_field_schema("0.1300", None), DataType::Float64);
     }
 
     #[test]
@@ -1556,6 +1678,11 @@ mod tests {
         );
         assert_eq!(
             parse_item::<Date64Type>("1900-02-28T12:34:56").unwrap(),
+            -2203932304000
+        );
+        assert_eq!(
+            parse_formatted::<Date64Type>("1900-02-28 12:34:56", "%Y-%m-%d %H:%M:%S")
+                .unwrap(),
             -2203932304000
         );
     }
@@ -1789,6 +1916,7 @@ mod tests {
             // starting at row 2 and up to row 6.
             Some((2, 6)),
             Some(vec![0]),
+            None,
         );
 
         let batch = csv.next().unwrap().unwrap();

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -736,6 +736,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03,foo
             // starting at row 2 and up to row 6.
             None,
             None,
+            None,
         );
         let rb = reader.next().unwrap().unwrap();
         let c1 = rb.column(0).as_any().downcast_ref::<Date32Array>().unwrap();


### PR DESCRIPTION
The patch extends the current implementation to allow passing a custom
datetime_re and datetime_format to the ReaderBuilder.

datetime_re is used infer schema of the csv and then datetime_format is
used to parse the actual string to a Date64.
ofcourse  passing non-compatible datetime_re and datetime_format values
is going to fail the parsing or inference, however it is an expected but
hard-to-detect failure.

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
Sometimes csv files follow non-standard datetime format. Arrow does not really care for the datetime format stored in the csv but merely guesses/assumes it to be of a certain fomrat. The change extends the csv reader to use a custom fromat.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Any external libraries relying on ReaderBuilder and Reader structs will have to be updated to the new new API, 

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
