### PR TITLE
Implement Array for ArrayRef, Improve as_* kernels to take `&dyn Array`

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -227,6 +227,69 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
 /// A reference-counted reference to a generic `Array`.
 pub type ArrayRef = Arc<dyn Array>;
 
+/// Ergonomics: Allow use of an ArrayRef as an `&dyn Array`
+impl Array for ArrayRef {
+    fn as_any(&self) -> &dyn Any {
+        self.as_ref().as_any()
+    }
+
+    fn data(&self) -> &ArrayData {
+        self.as_ref().data()
+    }
+
+    fn data_ref(&self) -> &ArrayData {
+        self.as_ref().data_ref()
+    }
+
+    fn data_type(&self) -> &DataType {
+        self.as_ref().data_type()
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> ArrayRef {
+        self.as_ref().slice(offset, length)
+    }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.as_ref().is_empty()
+    }
+
+    fn offset(&self) -> usize {
+        self.as_ref().offset()
+    }
+
+    fn is_null(&self, index: usize) -> bool {
+        self.as_ref().is_null(index)
+    }
+
+    fn is_valid(&self, index: usize) -> bool {
+        self.as_ref().is_valid(index)
+    }
+
+    fn null_count(&self) -> usize {
+        self.as_ref().null_count()
+    }
+
+    fn get_buffer_memory_size(&self) -> usize {
+        self.as_ref().get_buffer_memory_size()
+    }
+
+    fn get_array_memory_size(&self) -> usize {
+        self.as_ref().get_array_memory_size()
+    }
+
+    fn to_raw(
+        &self,
+    ) -> Result<(*const ffi::FFI_ArrowArray, *const ffi::FFI_ArrowSchema)> {
+        let data = self.data().clone();
+        let array = ffi::ArrowArray::try_from(data)?;
+        Ok(ffi::ArrowArray::into_raw(array))
+    }
+}
+
 /// Constructs an array using the input `data`.
 /// Returns a reference-counted `Array` instance.
 pub fn make_array(data: ArrayData) -> ArrayRef {
@@ -842,5 +905,23 @@ mod tests {
             arr.get_array_memory_size() - empty.get_array_memory_size(),
             expected_size
         );
+    }
+
+    /// Test function that takes an &dyn Array
+    fn compute_my_thing(arr: &dyn Array) -> bool {
+        !arr.is_empty()
+    }
+
+    #[test]
+    fn test_array_ref_as_array() {
+        let arr: Int32Array = vec![1, 2, 3].into_iter().map(Some).collect();
+
+        // works well!
+        assert!(compute_my_thing(&arr));
+
+        // Should also work when wrapped as an ArrayRef
+        let arr: ArrayRef = Arc::new(arr);
+        assert!(compute_my_thing(&arr));
+        assert!(compute_my_thing(arr.as_ref()));
     }
 }

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -441,6 +441,12 @@ impl PartialEq<Value> for NullArray {
     }
 }
 
+impl JsonEqual for ArrayRef {
+    fn equals_json(&self, json: &[&Value]) -> bool {
+        self.as_ref().equals_json(json)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -26,7 +26,7 @@ use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-use crate::array::{make_array, Array, ArrayData, ArrayRef};
+use crate::array::{Array, ArrayData, ArrayRef};
 use crate::datatypes::{DataType, Field, Schema};
 use crate::error::ArrowError;
 use crate::ffi;
@@ -145,16 +145,6 @@ impl PyArrowConvert for ArrayData {
             ),
         )?;
         Ok(array.to_object(py))
-    }
-}
-
-impl PyArrowConvert for ArrayRef {
-    fn from_pyarrow(value: &PyAny) -> PyResult<Self> {
-        Ok(make_array(ArrayData::from_pyarrow(value)?))
-    }
-
-    fn to_pyarrow(&self, py: Python) -> PyResult<PyObject> {
-        self.data().to_pyarrow(py)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1128

# Rationale for this change
 
See ticket -- I am trying to make writing compute kernels more ergonomic while working on https://github.com/apache/arrow-rs/pull/1127

# What changes are included in this PR?
1. `impl Array for ArrayRef`
2. Change signature from`arr: &ArrayRef` to `arr: &dyn Array` in cast kernels
2. tests for same

# Are there any user-facing changes?
Better ergonomics (users can avoid `.as_ref()` in some places)
