### PR TITLE
Make parquet::arrow::array_reader experimental (#1032)

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -60,6 +60,8 @@ arrow = { path = "../arrow", version = "7.0.0-SNAPSHOT", default-features = fals
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 cli = ["serde_json", "base64", "clap"]
 test_common = []
+# Experimental, unstable functionality primarily used for testing
+experimental = []
 
 [[ bin ]]
 name = "parquet-read"
@@ -79,5 +81,5 @@ harness = false
 
 [[bench]]
 name = "arrow_array_reader"
-required-features = ["test_common"]
+required-features = ["test_common", "experimental"]
 harness = false

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -118,7 +118,7 @@
 //!}
 //! ```
 
-pub mod array_reader;
+experimental_mod!(array_reader);
 pub mod arrow_array_reader;
 pub mod arrow_reader;
 pub mod arrow_writer;

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -35,6 +35,22 @@
     clippy::vec_init_then_push
 )]
 
+/// Defines a module with an experimental public API
+///
+/// The module will not be documented, and will only be public if the
+/// experimental feature flag is enabled
+///
+/// Experimental modules have no stability guarantees
+macro_rules! experimental_mod {
+    ($module:ident) => {
+        #[cfg(feature = "experimental")]
+        #[doc(hidden)]
+        pub mod $module;
+        #[cfg(not(feature = "experimental"))]
+        mod $module;
+    };
+}
+
 #[macro_use]
 pub mod errors;
 pub mod basic;


### PR DESCRIPTION
# Which issue does this PR close?

Relates to #1032.

# Rationale for this change
 
I wish to make breaking changes to the APIs in array_reader to address #1132 among others. The APIs are somewhat convoluted to use and so I'm not sure these are intentionally public. 

# What changes are included in this PR?

This PR makes `parquet::arrow::array_reader` public only if the `experimental` feature flag is enabled

# Are there any user-facing changes?

This is a breaking change as it removes code from the public API
