### PR TITLE
feat: union schema serialization/deserialization for ipc

### DIFF
--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -17,7 +17,7 @@
 
 //! Utilities for converting between IPC types and native Arrow types
 
-use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
+use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit, UnionMode};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 
@@ -321,6 +321,24 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
         ipc::Type::Decimal => {
             let fsb = field.type_as_decimal().unwrap();
             DataType::Decimal(fsb.precision() as usize, fsb.scale() as usize)
+        }
+        ipc::Type::Union => {
+            let union = field.type_as_union().unwrap();
+
+            let union_mode = match union.mode() {
+                ipc::UnionMode::Dense => UnionMode::Dense,
+                ipc::UnionMode::Sparse => UnionMode::Sparse,
+                mode => panic!("Unexpected union mode: {:?}", mode),
+            };
+
+            let mut fields = vec![];
+            if let Some(children) = field.children() {
+                for i in 0..children.len() {
+                    fields.push(children.get(i).into());
+                }
+            };
+
+            DataType::Union(fields, union_mode)
         }
         t => unimplemented!("Type {:?} not supported", t),
     }
@@ -648,7 +666,26 @@ pub(crate) fn get_fb_field_type<'a>(
                 children: Some(fbb.create_vector(&empty_fields[..])),
             }
         }
-        t => unimplemented!("Type {:?} not supported", t),
+        Union(fields, mode) => {
+            let mut children = vec![];
+            for field in fields {
+                children.push(build_field(fbb, field));
+            }
+
+            let union_mode = match mode {
+                UnionMode::Sparse => ipc::UnionMode::Sparse,
+                UnionMode::Dense => ipc::UnionMode::Dense,
+            };
+
+            let mut builder = ipc::UnionBuilder::new(fbb);
+            builder.add_mode(union_mode);
+
+            FBFieldType {
+                type_type: ipc::Type::Union,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&children[..])),
+            }
+        }
     }
 }
 
@@ -690,7 +727,7 @@ pub(crate) fn get_fb_dictionary<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datatypes::{DataType, Field, Schema};
+    use crate::datatypes::{DataType, Field, Schema, UnionMode};
 
     #[test]
     fn convert_schema_round_trip() {
@@ -820,7 +857,45 @@ mod tests {
                     ]),
                     false,
                 ),
+                Field::new(
+                    "union<int64, list[union<date32, list[union<>]>]>",
+                    DataType::Union(
+                        vec![
+                            Field::new("int64", DataType::Int64, true),
+                            Field::new(
+                                "list[union<date32, list[union<>]>]",
+                                DataType::List(Box::new(Field::new(
+                                    "union<date32, list[union<>]>",
+                                    DataType::Union(
+                                        vec![
+                                            Field::new("date32", DataType::Date32, true),
+                                            Field::new(
+                                                "list[union<>]",
+                                                DataType::List(Box::new(Field::new(
+                                                    "union",
+                                                    DataType::Union(
+                                                        vec![],
+                                                        UnionMode::Sparse,
+                                                    ),
+                                                    false,
+                                                ))),
+                                                false,
+                                            ),
+                                        ],
+                                        UnionMode::Dense,
+                                    ),
+                                    false,
+                                ))),
+                                false,
+                            ),
+                        ],
+                        UnionMode::Sparse,
+                    ),
+                    false,
+                ),
                 Field::new("struct<>", DataType::Struct(vec![]), true),
+                Field::new("union<>", DataType::Union(vec![], UnionMode::Dense), true),
+                Field::new("union<>", DataType::Union(vec![], UnionMode::Sparse), true),
                 Field::new_dict(
                     "dictionary<int32, utf8>",
                     DataType::Dictionary(


### PR DESCRIPTION
# Which issue does this PR close?

Adds support for serializing a schema containing a union for ipc.  Needed for #654, but does not close it.

# What changes are included in this PR?

Instead of throwing a not implemented error, schema containing a union can now be serialized and deserialized properly from ipc.
