### PR TITLE
Implement SIMD comparison operations for types with less than 4 lanes (i128)

### DIFF
--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -22,7 +22,7 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::compute::*;
-use arrow::datatypes::ArrowNumericType;
+use arrow::datatypes::{ArrowNumericType, IntervalMonthDayNanoType};
 use arrow::util::bench_util::*;
 use arrow::{array::*, datatypes::Float32Type};
 
@@ -138,6 +138,11 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array_with_seed::<Float32Type>(size, 0.0, 42);
     let arr_b = create_primitive_array_with_seed::<Float32Type>(size, 0.0, 43);
 
+    let arr_month_day_nano_a =
+        create_primitive_array_with_seed::<IntervalMonthDayNanoType>(size, 0.0, 43);
+    let arr_month_day_nano_b =
+        create_primitive_array_with_seed::<IntervalMonthDayNanoType>(size, 0.0, 43);
+
     let arr_string = create_string_array::<i32>(size, 0.0);
 
     c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
@@ -168,6 +173,13 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
     c.bench_function("gt_eq scalar Float32", |b| {
         b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
+    });
+
+    c.bench_function("eq MonthDayNano", |b| {
+        b.iter(|| bench_eq(&arr_month_day_nano_a, &arr_month_day_nano_b))
+    });
+    c.bench_function("eq scalar MonthDayNano", |b| {
+        b.iter(|| bench_eq_scalar(&arr_month_day_nano_a, 123))
     });
 
     c.bench_function("like_utf8 scalar equals", |b| {

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1482,8 +1482,8 @@ where
         "Number of vector lanes must be at most 64"
     );
 
-    let buffer_size = round_upto_multiple_of_64(len);
-    let mut result = MutableBuffer::new_null(buffer_size);
+    let buffer_size = bit_util::ceil(len, 8);
+    let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
 
     let mut left_chunks = left.values().chunks_exact(CHUNK_SIZE);
     let mut right_chunks = right.values().chunks_exact(CHUNK_SIZE);
@@ -1527,8 +1527,9 @@ where
                 mask |= bit << i;
                 mask
             });
-        let remainder_mask_as_bytes = remainder_bitmask.to_le_bytes();
-        result_remainder.copy_from_slice(&remainder_mask_as_bytes);
+        let remainder_mask_as_bytes =
+            &remainder_bitmask.to_le_bytes()[0..bit_util::ceil(left_remainder.len(), 8)];
+        result_remainder.copy_from_slice(remainder_mask_as_bytes);
     }
 
     let data = unsafe {
@@ -1573,8 +1574,8 @@ where
         "Number of vector lanes must be at most 64"
     );
 
-    let buffer_size = round_upto_multiple_of_64(len);
-    let mut result = MutableBuffer::new_null(buffer_size);
+    let buffer_size = bit_util::ceil(len, 8);
+    let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
 
     let mut left_chunks = left.values().chunks_exact(CHUNK_SIZE);
     let simd_right = T::init(right);
@@ -1613,8 +1614,9 @@ where
                 mask
             },
         );
-        let remainder_mask_as_bytes = remainder_bitmask.to_le_bytes();
-        result_remainder.copy_from_slice(&remainder_mask_as_bytes);
+        let remainder_mask_as_bytes =
+            &remainder_bitmask.to_le_bytes()[0..bit_util::ceil(left_remainder.len(), 8)];
+        result_remainder.copy_from_slice(remainder_mask_as_bytes);
     }
 
     let null_bit_buffer = left

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1471,7 +1471,7 @@ where
 
     let null_bit_buffer = combine_option_bitmap(left.data_ref(), right.data_ref(), len)?;
 
-    // we process the data in chunks to that each iteration results in one u64 of comparison result bits
+    // we process the data in chunks so that each iteration results in one u64 of comparison result bits
     const CHUNK_SIZE: usize = 64;
     let lanes = T::lanes();
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1563,7 +1563,7 @@ where
 
     let len = left.len();
 
-    // we process the data in chunks to that each iteration results in one u64 of comparison result bits
+    // we process the data in chunks so that each iteration results in one u64 of comparison result bits
     const CHUNK_SIZE: usize = 64;
     let lanes = T::lanes();
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -36,6 +36,7 @@ use crate::datatypes::{
 };
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
+use crate::util::bit_util::round_upto_multiple_of_64;
 use regex::{escape, Regex};
 use std::any::type_name;
 use std::collections::HashMap;
@@ -1471,14 +1472,21 @@ where
 
     let null_bit_buffer = combine_option_bitmap(left.data_ref(), right.data_ref(), len)?;
 
+    // we process the data in chunks to that each iteration results in one u64 of comparison result bits
+    const CHUNK_SIZE: usize = 64;
     let lanes = T::lanes();
-    let buffer_size = bit_util::ceil(len, 8);
-    let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
 
     // this is currently the case for all our datatypes and allows us to always append full bytes
-    assert_eq!(lanes % 8, 0, "Number of vector lanes must be multiple of 8");
-    let mut left_chunks = left.values().chunks_exact(lanes);
-    let mut right_chunks = right.values().chunks_exact(lanes);
+    assert!(
+        lanes <= CHUNK_SIZE,
+        "Number of vector lanes must be at most 64"
+    );
+
+    let buffer_size = round_upto_multiple_of_64(len);
+    let mut result = MutableBuffer::new_null(buffer_size);
+
+    let mut left_chunks = left.values().chunks_exact(CHUNK_SIZE);
+    let mut right_chunks = right.values().chunks_exact(CHUNK_SIZE);
 
     // safety: result is newly created above, always written as a T below
     let result_chunks = unsafe { result.typed_data_mut() };
@@ -1486,15 +1494,22 @@ where
         .borrow_mut()
         .zip(right_chunks.borrow_mut())
         .fold(result_chunks, |result_slice, (left_slice, right_slice)| {
-            let simd_left = T::load(left_slice);
-            let simd_right = T::load(right_slice);
-            let simd_result = simd_op(simd_left, simd_right);
+            let mut i = 0;
+            let mut bitmask = 0_u64;
+            while i < CHUNK_SIZE {
+                let simd_left = T::load(&left_slice[i..]);
+                let simd_right = T::load(&right_slice[i..]);
+                let simd_result = simd_op(simd_left, simd_right);
 
-            let bitmask = T::mask_to_u64(&simd_result);
+                let m = T::mask_to_u64(&simd_result);
+                bitmask |= m << (i / lanes);
+
+                i += lanes;
+            }
             let bytes = bitmask.to_le_bytes();
-            result_slice[0..lanes / 8].copy_from_slice(&bytes[0..lanes / 8]);
+            result_slice[0..8].copy_from_slice(&bytes);
 
-            &mut result_slice[lanes / 8..]
+            &mut result_slice[8..]
         });
 
     let left_remainder = left_chunks.remainder();
@@ -1502,22 +1517,19 @@ where
 
     assert_eq!(left_remainder.len(), right_remainder.len());
 
-    let remainder_bitmask = left_remainder
-        .iter()
-        .zip(right_remainder.iter())
-        .enumerate()
-        .fold(0_u64, |mut mask, (i, (scalar_left, scalar_right))| {
-            let bit = if scalar_op(*scalar_left, *scalar_right) {
-                1_u64
-            } else {
-                0_u64
-            };
-            mask |= bit << i;
-            mask
-        });
-    let remainder_mask_as_bytes =
-        &remainder_bitmask.to_le_bytes()[0..bit_util::ceil(left_remainder.len(), 8)];
-    result_remainder.copy_from_slice(remainder_mask_as_bytes);
+    if !left_remainder.is_empty() {
+        let remainder_bitmask = left_remainder
+            .iter()
+            .zip(right_remainder.iter())
+            .enumerate()
+            .fold(0_u64, |mut mask, (i, (scalar_left, scalar_right))| {
+                let bit = scalar_op(*scalar_left, *scalar_right) as u64;
+                mask |= bit << i;
+                mask
+            });
+        let remainder_mask_as_bytes = remainder_bitmask.to_le_bytes();
+        result_remainder.copy_from_slice(&remainder_mask_as_bytes);
+    }
 
     let data = unsafe {
         ArrayData::new_unchecked(
@@ -1551,16 +1563,20 @@ where
 
     let len = left.len();
 
+    // we process the data in chunks to that each iteration results in one u64 of comparison result bits
+    const CHUNK_SIZE: usize = 64;
     let lanes = T::lanes();
-    let buffer_size = bit_util::ceil(len, 8);
-    let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
 
     // this is currently the case for all our datatypes and allows us to always append full bytes
     assert!(
-        lanes % 8 == 0,
-        "Number of vector lanes must be multiple of 8"
+        lanes <= CHUNK_SIZE,
+        "Number of vector lanes must be at most 64"
     );
-    let mut left_chunks = left.values().chunks_exact(lanes);
+
+    let buffer_size = round_upto_multiple_of_64(len);
+    let mut result = MutableBuffer::new_null(buffer_size);
+
+    let mut left_chunks = left.values().chunks_exact(CHUNK_SIZE);
     let simd_right = T::init(right);
 
     // safety: result is newly created above, always written as a T below
@@ -1569,34 +1585,37 @@ where
         left_chunks
             .borrow_mut()
             .fold(result_chunks, |result_slice, left_slice| {
-                let simd_left = T::load(left_slice);
-                let simd_result = simd_op(simd_left, simd_right);
+                let mut i = 0;
+                let mut bitmask = 0_u64;
+                while i < CHUNK_SIZE {
+                    let simd_left = T::load(&left_slice[i..]);
+                    let simd_result = simd_op(simd_left, simd_right);
 
-                let bitmask = T::mask_to_u64(&simd_result);
+                    let m = T::mask_to_u64(&simd_result);
+                    bitmask |= m << (i / lanes);
+
+                    i += lanes;
+                }
                 let bytes = bitmask.to_le_bytes();
-                result_slice[0..lanes / 8].copy_from_slice(&bytes[0..lanes / 8]);
+                result_slice[0..8].copy_from_slice(&bytes);
 
-                &mut result_slice[lanes / 8..]
+                &mut result_slice[8..]
             });
 
     let left_remainder = left_chunks.remainder();
 
-    let remainder_bitmask =
-        left_remainder
-            .iter()
-            .enumerate()
-            .fold(0_u64, |mut mask, (i, scalar_left)| {
-                let bit = if scalar_op(*scalar_left, right) {
-                    1_u64
-                } else {
-                    0_u64
-                };
+    if !left_remainder.is_empty() {
+        let remainder_bitmask = left_remainder.iter().enumerate().fold(
+            0_u64,
+            |mut mask, (i, scalar_left)| {
+                let bit = scalar_op(*scalar_left, right) as u64;
                 mask |= bit << i;
                 mask
-            });
-    let remainder_mask_as_bytes =
-        &remainder_bitmask.to_le_bytes()[0..bit_util::ceil(left_remainder.len(), 8)];
-    result_remainder.copy_from_slice(remainder_mask_as_bytes);
+            },
+        );
+        let remainder_mask_as_bytes = remainder_bitmask.to_le_bytes();
+        result_remainder.copy_from_slice(&remainder_mask_as_bytes);
+    }
 
     let null_bit_buffer = left
         .data_ref()
@@ -2723,8 +2742,6 @@ mod tests {
         );
     }
 
-    // Fails when simd is enabled: https://github.com/apache/arrow-rs/issues/1136
-    #[cfg(not(feature = "simd"))]
     #[test]
     fn test_interval_array() {
         let a = IntervalDayTimeArray::from(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -36,7 +36,6 @@ use crate::datatypes::{
 };
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
-use crate::util::bit_util::round_upto_multiple_of_64;
 use regex::{escape, Regex};
 use std::any::type_name;
 use std::collections::HashMap;


### PR DESCRIPTION
# Which issue does this PR close?

Implements comparison for simd types with less than 8 lanes.

Closes #1136 .

# What changes are included in this PR?

This PR changes the comparison kernel so that the simd portion can always append 64 bits at a time. Since the simd types are 512 bits wide, this means the inner comparison is unrolled, for example 8 times for Float64 (8 x 8lanes) or 4 times for Float32 (4 x 16lanes). For Int8 types it does not get unrolled since one comparison already results in 64 bits.

This should even speed up the comparison kernel a bit for common types, because there is less loop overhead.

On my laptop the simd version for `i128` `MonthDayNano` types is not actually faster than the scalar version, on a more modern or server class machine there should be a slight speedup.

Unrelated to this change I also noticed that the code generation for non-avx512 machines is sub-optimal since the compiler has to emulate the 512bit wider operations using smaller vector registers, and for the bitmap generating code this has some overhead.




<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
