### PR TITLE
Internal Remove `GenericStringArray::from_vec` and `GenericStringArray::from_opt_vec`

### DIFF
--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -137,34 +137,6 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         Self::from(array_data)
     }
 
-    pub(crate) fn from_vec<Ptr>(v: Vec<Ptr>) -> Self
-    where
-        Ptr: AsRef<str>,
-    {
-        let mut offsets =
-            MutableBuffer::new((v.len() + 1) * std::mem::size_of::<OffsetSize>());
-        let mut values = MutableBuffer::new(0);
-
-        let mut length_so_far = OffsetSize::zero();
-        offsets.push(length_so_far);
-
-        for s in &v {
-            length_so_far += OffsetSize::from_usize(s.as_ref().len()).unwrap();
-            offsets.push(length_so_far);
-            values.extend_from_slice(s.as_ref().as_bytes());
-        }
-        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
-            .len(v.len())
-            .add_buffer(offsets.into())
-            .add_buffer(values.into());
-        let array_data = unsafe { array_data.build_unchecked() };
-        Self::from(array_data)
-    }
-
-    pub(crate) fn from_opt_vec(v: Vec<Option<&str>>) -> Self {
-        v.into_iter().collect()
-    }
-
     /// Creates a `GenericStringArray` based on an iterator of values without nulls
     pub fn from_iter_values<Ptr, I: IntoIterator<Item = Ptr>>(iter: I) -> Self
     where
@@ -321,7 +293,7 @@ impl<OffsetSize: StringOffsetSizeTrait> From<Vec<Option<&str>>>
     for GenericStringArray<OffsetSize>
 {
     fn from(v: Vec<Option<&str>>) -> Self {
-        GenericStringArray::<OffsetSize>::from_opt_vec(v)
+        v.into_iter().collect()
     }
 }
 
@@ -329,7 +301,7 @@ impl<OffsetSize: StringOffsetSizeTrait> From<Vec<&str>>
     for GenericStringArray<OffsetSize>
 {
     fn from(v: Vec<&str>) -> Self {
-        GenericStringArray::<OffsetSize>::from_vec(v)
+        GenericStringArray::<OffsetSize>::from_iter_values(v)
     }
 }
 
@@ -337,7 +309,7 @@ impl<OffsetSize: StringOffsetSizeTrait> From<Vec<String>>
     for GenericStringArray<OffsetSize>
 {
     fn from(v: Vec<String>) -> Self {
-        GenericStringArray::<OffsetSize>::from_vec(v)
+        GenericStringArray::<OffsetSize>::from_iter_values(v)
     }
 }
 

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -544,11 +544,9 @@ mod tests {
         let cases = binary_cases();
 
         for (lhs, rhs, expected) in cases {
-            let lhs = lhs.iter().map(|x| x.as_deref()).collect();
-            let rhs = rhs.iter().map(|x| x.as_deref()).collect();
-            let lhs = GenericStringArray::<OffsetSize>::from_opt_vec(lhs);
+            let lhs: GenericStringArray<OffsetSize> = lhs.into_iter().collect();
             let lhs = lhs.data();
-            let rhs = GenericStringArray::<OffsetSize>::from_opt_vec(rhs);
+            let rhs: GenericStringArray<OffsetSize> = rhs.into_iter().collect();
             let rhs = rhs.data();
             test_equal(lhs, rhs, expected);
         }


### PR DESCRIPTION
# Which issue does this PR close?

Minor change

# Rationale for this change
 
Less code is easier to maintain and faster to compile

I noticed this while working on https://github.com/apache/arrow-rs/pull/1145. These two functions are totally redundant, and are not part of the public api (are `pub(crate)`)

# What changes are included in this PR?
1. remove named functions (including one `unsafe` usage) and update callsites

# Are there any user-facing changes?
1. No all functions are `pub(crate)`

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
