### PR TITLE
Document safety justification of some uses of `from_trusted_len_iter`

### DIFF
--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -140,7 +140,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
     /// Creates a PrimitiveArray based on a constant value with `count` elements
     pub fn from_value(value: T::Native, count: usize) -> Self {
-        // # Safety: length is known
+        // # Safety: iterator (0..count) correctly reports its length
         let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
         let data = unsafe {
             ArrayData::new_unchecked(

--- a/arrow/src/buffer/ops.rs
+++ b/arrow/src/buffer/ops.rs
@@ -140,7 +140,8 @@ where
         .iter()
         .zip(right_chunks.iter())
         .map(|(left, right)| op(left, right));
-    // Soundness: `BitChunks` is a trusted len iterator
+    // Soundness: `BitChunks` is a `BitChunks` iterator which
+    // correctly reports its upper bound
     let mut buffer = unsafe { MutableBuffer::from_trusted_len_iter(chunks) };
 
     let remainder_bytes = ceil(left_chunks.remainder_len(), 8);

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -185,7 +185,7 @@ where
     //  Benefit
     //      ~60% speedup
     //  Soundness
-    //      `values` is an iterator with a known size.
+    //      `values` is an iterator with a known size from a PrimitiveArray
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
     let data = unsafe {
@@ -241,6 +241,7 @@ where
                 }
             },
         );
+        // Safety: Iterator comes from a PrimitiveArray which reports its size correctly
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     } else {
         // no value is null
@@ -255,6 +256,7 @@ where
                     Ok(*left % *right)
                 }
             });
+        // Safety: Iterator comes from a PrimitiveArray which reports its size correctly
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     }?;
 
@@ -311,6 +313,7 @@ where
                 }
             },
         );
+        // Safety: Iterator comes from a PrimitiveArray which reports its size correctly
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     } else {
         // no value is null
@@ -325,6 +328,7 @@ where
                     Ok(*left / *right)
                 }
             });
+        // Safety: Iterator comes from a PrimitiveArray which reports its size correctly
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     }?;
 

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -48,7 +48,7 @@ where
     //  Benefit
     //      ~60% speedup
     //  Soundness
-    //      `values` is an iterator with a known size.
+    //      `values` come from a slice iterator with a known size.
     let buffer = unsafe { Buffer::from_trusted_len_iter(lengths) };
 
     let null_bit_buffer = array


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/197

# Rationale for this change
 
As part of #197 I reviewed all uses of `from_trusted_len_iter`; While doing so I found some without a safety justification, and so I added the results of my review as comments

# What changes are included in this PR?

Code comments justifying why (existing) calls to `from_trusted_len_iter()` are sound

# Are there any user-facing changes?

No