### PR TITLE
feat(json): support for map arrays in json writer

### DIFF
--- a/arrow/src/array/cast.rs
+++ b/arrow/src/array/cast.rs
@@ -95,6 +95,7 @@ array_downcast_fn!(as_boolean_array, BooleanArray);
 array_downcast_fn!(as_null_array, NullArray);
 array_downcast_fn!(as_struct_array, StructArray);
 array_downcast_fn!(as_union_array, UnionArray);
+array_downcast_fn!(as_map_array, MapArray);
 
 #[cfg(test)]
 mod tests {

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -515,7 +515,8 @@ pub use self::ord::{build_compare, DynComparator};
 pub use self::cast::{
     as_boolean_array, as_dictionary_array, as_generic_binary_array,
     as_generic_list_array, as_large_list_array, as_largestring_array, as_list_array,
-    as_null_array, as_primitive_array, as_string_array, as_struct_array, as_union_array,
+    as_map_array, as_null_array, as_primitive_array, as_string_array, as_struct_array,
+    as_union_array,
 };
 
 // ------------------------------ C Data Interface ---------------------------


### PR DESCRIPTION
# Which issue does this PR close?

This PR adds map arrays into the json writer, tracked by #538. 

# What changes are included in this PR?

This PR adds support for writing map arrays to json and a new test for this functionality in the json writer.

# Are there any user-facing changes?

Adds a new public function, `as_map_array`,  to `arrow::array::cast`. 

