### PR TITLE
Move simd right out of for_each loop

### DIFF
--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -908,12 +908,13 @@ where
     let mut result_chunks = unsafe { result.typed_data_mut().chunks_exact_mut(lanes) };
     let mut array_chunks = array.values().chunks_exact(lanes);
 
+    let simd_right = T::init(modulo);
+
     result_chunks
         .borrow_mut()
         .zip(array_chunks.borrow_mut())
         .for_each(|(result_slice, array_slice)| {
             let simd_left = T::load(array_slice);
-            let simd_right = T::init(modulo);
 
             let simd_result = T::bin_op(simd_left, simd_right, |a, b| a % b);
             T::write(simd_result, result_slice);
@@ -960,12 +961,13 @@ where
     let mut result_chunks = unsafe { result.typed_data_mut().chunks_exact_mut(lanes) };
     let mut array_chunks = array.values().chunks_exact(lanes);
 
+    let simd_right = T::init(divisor);
+
     result_chunks
         .borrow_mut()
         .zip(array_chunks.borrow_mut())
         .for_each(|(result_slice, array_slice)| {
             let simd_left = T::load(array_slice);
-            let simd_right = T::init(divisor);
 
             let simd_result = T::bin_op(simd_left, simd_right, |a, b| a / b);
             T::write(simd_result, result_slice);


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

For the scalar part of simd array and scalar operation, we don't need to initiate a vector for the scalar every time.

# What changes are included in this PR?

Move scalar part out of `for_each` loop in simd operation between array and scalar.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
