### PR TITLE
Restrict RecordReader and friends to scalar types (#1132)

### DIFF
--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -19,7 +19,7 @@ use std::cmp::{max, min};
 use std::mem::{replace, size_of};
 
 use crate::column::{page::PageReader, reader::ColumnReaderImpl};
-use crate::data_type::DataType;
+use crate::data_type::private::ScalarDataType;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 use arrow::array::BooleanBufferBuilder;
@@ -29,7 +29,7 @@ use arrow::buffer::{Buffer, MutableBuffer};
 const MIN_BATCH_SIZE: usize = 1024;
 
 /// A `RecordReader` is a stateful column reader that delimits semantic records.
-pub struct RecordReader<T: DataType> {
+pub struct RecordReader<T: ScalarDataType> {
     column_desc: ColumnDescPtr,
 
     records: MutableBuffer,
@@ -47,7 +47,7 @@ pub struct RecordReader<T: DataType> {
     values_written: usize,
 }
 
-impl<T: DataType> RecordReader<T> {
+impl<T: ScalarDataType> RecordReader<T> {
     pub fn new(column_schema: ColumnDescPtr) -> Self {
         let (def_levels, null_map) = if column_schema.max_def_level() > 0 {
             (

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -572,6 +572,7 @@ impl AsBytes for str {
 }
 
 pub(crate) mod private {
+    use super::*;
     use crate::encodings::decoding::PlainDecoderDetails;
     use crate::util::bit_util::{round_upto_power_of_2, BitReader, BitWriter};
     use crate::util::memory::ByteBufferPtr;
@@ -1032,6 +1033,21 @@ pub(crate) mod private {
             self
         }
     }
+
+    /// A marker trait for [`DataType`] with a [scalar] physical type
+    ///
+    /// This means that a `[Self::T::default()]` of length `len` can be safely created from a
+    /// zero-initialized `[u8]` with length `len * Self::get_type_size()` and
+    /// alignment of `Self::get_type_size()`
+    ///
+    /// [scalar]: https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types
+    ///
+    pub trait ScalarDataType: DataType {}
+    impl ScalarDataType for BoolType {}
+    impl ScalarDataType for Int32Type {}
+    impl ScalarDataType for Int64Type {}
+    impl ScalarDataType for FloatType {}
+    impl ScalarDataType for DoubleType {}
 }
 
 /// Contains the Parquet physical type information as well as the Rust primitive type


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1132.

# Rationale for this change
 
See ticket

# What changes are included in this PR?

This restricts RecordReader and friends to only permit legal types

# Are there any user-facing changes?

No 
