### PR TITLE
Fix compilation error with simd feature

### DIFF
--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -628,7 +628,11 @@ where
     #[cfg(feature = "simd")]
     {
         let scalar_vector = T::init(scalar);
-        return simd_unary_math_op(array, |x| x - scalar_vector, |x| x - scalar);
+        return Ok(simd_unary_math_op(
+            array,
+            |x| x - scalar_vector,
+            |x| x - scalar,
+        ));
     }
     #[cfg(not(feature = "simd"))]
     return Ok(unary(array, |value| value - scalar));
@@ -706,7 +710,11 @@ where
     #[cfg(feature = "simd")]
     {
         let scalar_vector = T::init(scalar);
-        return simd_unary_math_op(array, |x| x * scalar_vector, |x| x * scalar);
+        return Ok(simd_unary_math_op(
+            array,
+            |x| x * scalar_vector,
+            |x| x * scalar,
+        ));
     }
     #[cfg(not(feature = "simd"))]
     return Ok(unary(array, |value| value * scalar));


### PR DESCRIPTION
# Which issue does this PR close?

Fixes a compilation error introduced in the last commit of PR #1161 

That commit was supposed to only add some comments, but I also removed one unneeded Result return type and did not try to compile with the simd feature afterwards.

cc @alamb 