### PR TITLE
Fix new clippy lints introduced in Rust 1.58

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -244,6 +244,7 @@ impl std::ops::Deref for Buffer {
 }
 
 unsafe impl Sync for Buffer {}
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for Buffer {}
 
 impl From<MutableBuffer> for Buffer {

--- a/arrow/src/util/test_util.rs
+++ b/arrow/src/util/test_util.rs
@@ -147,7 +147,7 @@ fn get_data_dir(udf_env: &str, submodule_data: &str) -> Result<PathBuf, Box<dyn 
             "env `{}` is undefined or has empty value, and the pre-defined data dir `{}` not found\n\
              HINT: try running `git submodule update --init`",
             udf_env,
-            pb.display().to_string(),
+            pb.display(),
         ).into())
     }
 }

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -246,7 +246,7 @@ fn print_logical_and_converted(
         None => {
             // Also print converted type if it is available
             match converted_type {
-                ConvertedType::NONE => format!(""),
+                ConvertedType::NONE => String::new(),
                 decimal @ ConvertedType::DECIMAL => {
                     // For decimal type we should print precision and scale if they
                     // are > 0, e.g. DECIMAL(9,2) -
@@ -256,7 +256,7 @@ fn print_logical_and_converted(
                             format!("({},{})", p, s)
                         }
                         (p, 0) if p > 0 => format!("({})", p),
-                        _ => format!(""),
+                        _ => String::new(),
                     };
                     format!("{}{}", decimal, precision_scale)
                 }


### PR DESCRIPTION
Its that time of month! Rust 1.58 has been released and with it some new clippy lints.

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13

