### PR TITLE
Update test output for Rust 1.58 release

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -244,6 +244,7 @@ impl std::ops::Deref for Buffer {
 }
 
 unsafe impl Sync for Buffer {}
+// false positive, see https://github.com/apache/arrow-rs/pull/1169
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for Buffer {}
 

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -1081,9 +1081,9 @@ mod tests {
     fn test_convert_float_to_string() {
         assert_eq!(format!("{}", Field::Float(1.0)), "1.0");
         assert_eq!(format!("{}", Field::Float(9.63)), "9.63");
-        assert_eq!(format!("{}", Field::Float(1e-15)), "0.000000000000001");
+        assert_eq!(format!("{}", Field::Float(1e-15)), "1e-15");
         assert_eq!(format!("{}", Field::Float(1e-16)), "1E-16");
-        assert_eq!(format!("{}", Field::Float(1e19)), "10000000000000000000.0");
+        assert_eq!(format!("{}", Field::Float(1e19)), "1e19");
         assert_eq!(format!("{}", Field::Float(1e20)), "1E20");
         assert_eq!(format!("{}", Field::Float(1.7976931E30)), "1.7976931E30");
         assert_eq!(format!("{}", Field::Float(-1.7976931E30)), "-1.7976931E30");
@@ -1093,9 +1093,9 @@ mod tests {
     fn test_convert_double_to_string() {
         assert_eq!(format!("{}", Field::Double(1.0)), "1.0");
         assert_eq!(format!("{}", Field::Double(9.63)), "9.63");
-        assert_eq!(format!("{}", Field::Double(1e-15)), "0.000000000000001");
+        assert_eq!(format!("{}", Field::Double(1e-15)), "1e-15");
         assert_eq!(format!("{}", Field::Double(1e-16)), "1E-16");
-        assert_eq!(format!("{}", Field::Double(1e19)), "10000000000000000000.0");
+        assert_eq!(format!("{}", Field::Double(1e19)), "1e19");
         assert_eq!(format!("{}", Field::Double(1e20)), "1E20");
         assert_eq!(
             format!("{}", Field::Double(1.79769313486E308)),


### PR DESCRIPTION
# Rationale for this change
 
Test output changed with rust 1.58

# What changes are included in this PR?
1. Add a reference to https://github.com/rust-lang/rust-clippy/issues/8045  explaining why that lint is disabled
2. Update test output due to change in rust: https://github.com/rust-lang/rust/commit/8731d4dfb479914a91f650f4f124528e332e8128#diff-363ad34c0858be71721f73b0880238813baf8f8b36ebbb494baa6b29103dd8d5 / https://github.com/rust-lang/rust/pull/86479

Kudos to @jhorstmann  for researching both of those

# Are there any user-facing changes?
No