### PR TITLE
Serialize i128 as JSON string

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0" }
 serde_derive = "1.0"
-serde_json = { version = "1.0", features = ["preserve_order", "arbitrary_precision"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = { version = "1.6", features = ["std"] }
 rand = { version = "0.8", optional = true }
 num = "0.4"

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -46,7 +46,7 @@ pub type SchemaRef = Arc<Schema>;
 mod tests {
     use super::*;
     use crate::error::Result;
-    use serde_json::Value::{Bool, Number as VNumber};
+    use serde_json::Value::{Bool, Number as VNumber, String as VString};
     use serde_json::{Number, Value};
     use std::{
         collections::{BTreeMap, HashMap},
@@ -1175,7 +1175,7 @@ mod tests {
         assert_eq!(Some(VNumber(Number::from(1))), 1i16.into_json_value());
         assert_eq!(Some(VNumber(Number::from(1))), 1i32.into_json_value());
         assert_eq!(Some(VNumber(Number::from(1))), 1i64.into_json_value());
-        assert_eq!(Some(VNumber(Number::from(1))), 1i128.into_json_value());
+        assert_eq!(Some(VString("1".to_string())), 1i128.into_json_value());
         assert_eq!(Some(VNumber(Number::from(1))), 1u8.into_json_value());
         assert_eq!(Some(VNumber(Number::from(1))), 1u16.into_json_value());
         assert_eq!(Some(VNumber(Number::from(1))), 1u32.into_json_value());

--- a/arrow/src/datatypes/native.rs
+++ b/arrow/src/datatypes/native.rs
@@ -209,7 +209,11 @@ impl ArrowNativeType for i64 {
 
 impl JsonSerializable for i128 {
     fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
+        // Serialize as string to avoid issues with arbitrary_precision serde_json feature
+        // - https://github.com/serde-rs/json/issues/559
+        // - https://github.com/serde-rs/json/issues/845
+        // - https://github.com/serde-rs/json/issues/846
+        Some(self.to_string().into())
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1174

# Rationale for this change
 
See ticket

# What changes are included in this PR?

This changes i128 to be JSON serialized as a string

# Are there any user-facing changes?

I think so, I'm not very familiar with arrow's JSON interface nor what it is used for