### PR TITLE
Fix record formatting in 1.58

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -716,15 +716,19 @@ impl fmt::Display for Field {
             Field::Float(value) => {
                 if !(1e-15..=1e19).contains(&value) {
                     write!(f, "{:E}", value)
+                } else if value.trunc() == value {
+                    write!(f, "{}.0", value)
                 } else {
-                    write!(f, "{:?}", value)
+                    write!(f, "{}", value)
                 }
             }
             Field::Double(value) => {
                 if !(1e-15..=1e19).contains(&value) {
                     write!(f, "{:E}", value)
+                } else if value.trunc() == value {
+                    write!(f, "{}.0", value)
                 } else {
-                    write!(f, "{:?}", value)
+                    write!(f, "{}", value)
                 }
             }
             Field::Decimal(ref value) => {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1177 

# Rationale for this change
 
Fixes failing tests

# What changes are included in this PR?

There appears to have been a change in the debug formatting of floats in 1.58 that causes the debug output to change - in particular it prints in scientific notation where previously it did not. I can't find explicit mention of this in the release notes, but have confirmed it locally. 

I've replicated the behavior tested by the tests, but I'm not entirely sure this is exactly what it would have previously output for all cases. The debug outputs are not stable.

# Are there any user-facing changes?

No