### PR TITLE
Add ticket reference for false positive in clippy

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -244,6 +244,7 @@ impl std::ops::Deref for Buffer {
 }
 
 unsafe impl Sync for Buffer {}
+// false positive, see https://github.com/apache/arrow-rs/pull/1169
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for Buffer {}
 


### PR DESCRIPTION
1. Add a reference to https://github.com/rust-lang/rust-clippy/issues/8045  explaining why that lint is disabled

Found by @jhorstmann 