### PR TITLE
Truncate bitmask on split

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -367,6 +367,14 @@ impl BooleanBufferBuilder {
         }
     }
 
+    /// Resizes the buffer, either truncating its contents (with no change in capacity), or
+    /// growing it (potentially reallocating it) and writing `false` in the newly available bits.
+    #[inline]
+    pub fn resize(&mut self, len: usize) {
+        let len_bytes = bit_util::ceil(len, 8);
+        self.buffer.resize(len_bytes, 0)
+    }
+
     #[inline]
     pub fn append(&mut self, v: bool) {
         self.advance(1);

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2949,7 +2949,10 @@ mod tests {
         builder.resize(20);
 
         assert_eq!(builder.len, 20);
-        assert_eq!(builder.buffer.as_slice(), &[0b00001111, 0b00011000, 0b00000000]);
+        assert_eq!(
+            builder.buffer.as_slice(),
+            &[0b00001111, 0b00011000, 0b00000000]
+        );
 
         builder.resize(5);
         assert_eq!(builder.len, 5);

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -372,7 +372,8 @@ impl BooleanBufferBuilder {
     #[inline]
     pub fn resize(&mut self, len: usize) {
         let len_bytes = bit_util::ceil(len, 8);
-        self.buffer.resize(len_bytes, 0)
+        self.buffer.resize(len_bytes, 0);
+        self.len = len;
     }
 
     #[inline]
@@ -2937,6 +2938,26 @@ mod tests {
         let arr2 = builder.finish();
 
         assert_eq!(arr1, arr2);
+    }
+
+    #[test]
+    fn test_boolean_array_builder_resize() {
+        let mut builder = BooleanBufferBuilder::new(20);
+        builder.append_n(4, true);
+        builder.append_n(7, false);
+        builder.append_n(2, true);
+        builder.resize(20);
+
+        assert_eq!(builder.len, 20);
+        assert_eq!(builder.buffer.as_slice(), &[0b00001111, 0b00011000, 0b00000000]);
+
+        builder.resize(5);
+        assert_eq!(builder.len, 5);
+        assert_eq!(builder.buffer.as_slice(), &[0b00001111]);
+
+        builder.append_n(4, true);
+        assert_eq!(builder.len, 9);
+        assert_eq!(builder.buffer.as_slice(), &[0b11101111, 0b00000001]);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Relates to #1037 .

# Rationale for this change
 
When splitting a null bitmask off, the code added in #1054 would return the entire bitmask that was read. This isn't a problem as `ArrayData` doesn't care about trailing data in buffers, in fact it is critical for packed bitmasks and array data slices to work, but it can be a tad surprising.

# What changes are included in this PR?

Modifies `DefinitionLevelBuffer::split_bitmask` to truncate the returned `Bitmap` for the avoidance of confusion. Also uses a more efficient `append_packed_range` to construct the remainder buffer.

# Are there any user-facing changes?

Adds a `BooleanBufferBuilder::resize` method
