### PR TITLE
fix: Fix a bug in how filter indices are calculated

### DIFF
--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -758,6 +758,13 @@ impl LevelInfo {
 
     /// Given a level's information, calculate the offsets required to index an array correctly.
     pub(crate) fn filter_array_indices(&self) -> Vec<usize> {
+        if !matches!(self.level_type, LevelType::Primitive(_)) {
+            panic!(
+                "Cannot filter indices on a non-primitive array, found {:?}",
+                self.level_type
+            );
+        }
+
         // happy path if not dealing with lists
         if self.repetition.is_none() {
             return self
@@ -780,8 +787,9 @@ impl LevelInfo {
 
         for len in self.array_offsets.windows(2).map(|s| s[1] - s[0]) {
             if len == 0 {
-                // Skip this definition level (it should be less than max_definition)
-                definition_levels.next();
+                // Skip this definition level--the iterator should not be empty, and the definition
+                // level be less than max_definition, i.e., a null value)
+                assert!(*definition_levels.next().unwrap() < self.max_definition);
             } else {
                 for (_, def) in (0..len).zip(&mut definition_levels) {
                     if *def == self.max_definition {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1184.

# What changes are included in this PR?

Using the definition level and the nullability of the column only produces the
correct indices if `max_definition - 1` is the list level.  For deeper nesting
(struct in a list) this produces incorrect indices, silently causing incorrect
data to be written.

This PR fixes the bug by using the array offsets to compute the indices
instead, also adds a regression test.

# Are there any user-facing changes?

No.