### PR TITLE
Fix in display of `Float16Array`

### DIFF
--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -313,7 +313,7 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::UInt16 => make_string!(array::UInt16Array, column, row),
         DataType::UInt32 => make_string!(array::UInt32Array, column, row),
         DataType::UInt64 => make_string!(array::UInt64Array, column, row),
-        DataType::Float16 => make_string!(array::Float32Array, column, row),
+        DataType::Float16 => make_string!(array::Float16Array, column, row),
         DataType::Float32 => make_string!(array::Float32Array, column, row),
         DataType::Float64 => make_string!(array::Float64Array, column, row),
         DataType::Decimal(..) => make_string_from_decimal(column, row),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1193 .

# What changes are included in this PR?

Due to a typo the float16 array was being cast to a float32 array,
causing a crash when pretty printing a record batch containing float16.
Fixed that typo and added a test.

# Are there any user-facing changes?

No.