### PR TITLE
Revert "update nightly version for miri (#1189)"

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2022-01-17]
+        rust: [nightly-2021-10-23]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/1198

# Rationale for this change
 Master CI checks seem to be broken

# What changes are included in this PR?
This reverts commit 548c96101e9f9cb06099a630d7d58f6a4e70f2f9.


# Are there any user-facing changes?

No (this just controls what version of Rust is used in CI checks)
