### PR TITLE
temporarily update packed_simd reference

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -47,7 +47,8 @@ half = "1.8"
 csv_crate = { version = "1.1", optional = true, package="csv" }
 regex = "1.3"
 lazy_static = "1.4"
-packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
+#packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
+packed_simd = { git = "https://github.com/hkratz/packed_simd.git", rev="27e2c89704fc2d1d8dcc506bad210c703187d74e", version = "0.3", optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = {version = "0.4", optional = true}
 flatbuffers = { version = "=2.0.0", optional = true }


### PR DESCRIPTION
Demonstrates that https://github.com/rust-lang/packed_simd/pull/341 fixes the arrow CI tests