### PR TITLE
Pin WASM / packed SIMD tests to nightly-2022-01-17

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,8 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly]
+        # pin nightly until  https://github.com/rust-lang/packed_simd/pull/341 is resolved
+        rust: [nightly-2022-01-17]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -345,7 +346,8 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly]
+        # pin nightly until  https://github.com/rust-lang/packed_simd/pull/341 is resolved
+        rust: [nightly-2022-01-17]
     container:
       image: ${{ matrix.arch }}/rust
       env:


### PR DESCRIPTION
# Which issue does this PR close?

Closses https://github.com/apache/arrow-rs/issues/1198 (I hope)

# Rationale for this change

`packed_simd` -- relies on some feature in rust nightly which has since been removed. Here is a PR that should fix the underlying issue: https://github.com/rust-lang/packed_simd/pull/341

If / until a maintainer to releases an updated version this PR attempts to get the arrow CI checks back to green

# What changes are included in this PR?
pin nightly rust used in WASM and SIMD CI checks to nightly-2022-01-17

# Are there any user-facing changes?

Nope (though arrow is not going to compile on the latest nightly)