### PR TITLE
fix a bug in variable sized equality

### DIFF
--- a/arrow/src/array/equal/variable_size.rs
+++ b/arrow/src/array/equal/variable_size.rs
@@ -86,13 +86,13 @@ pub(super) fn variable_sized_equal<T: OffsetSizeTrait>(
             let lhs_pos = lhs_start + i;
             let rhs_pos = rhs_start + i;
 
-            // the null bits can still be `None`, so we don't unwrap
+            // the null bits can still be `None`, indicating that the value is valid.
             let lhs_is_null = !lhs_nulls
                 .map(|v| get_bit(v.as_slice(), lhs.offset() + lhs_pos))
-                .unwrap_or(false);
+                .unwrap_or(true);
             let rhs_is_null = !rhs_nulls
                 .map(|v| get_bit(v.as_slice(), rhs.offset() + rhs_pos))
-                .unwrap_or(false);
+                .unwrap_or(true);
 
             lhs_is_null
                 || (lhs_is_null == rhs_is_null)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1208.

# What changes are included in this PR?

A missing validity buffer was being treated as all values being null,
rather than all values being valid, causing equality to fail on some
equivalent string and binary arrays. This PR fixes the bug and adds tests.

# Are there any user-facing changes?

No.