### PR TITLE
Improve changelog generator script settings

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -21,7 +21,7 @@
 # Add special sections for documentation, security and performance
 add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]},"security":{"prefix":"**Security updates:**","labels":["security"]},"performance":{"prefix":"**Performance improvements:**","labels":["performance"]}}
 # uncomment to not show PRs. TBD if we shown them or not.
-#pull-requests=false3
+#pull-requests=false
 # so that the component is shown associated with the issue
 issue-line-labels=arrow,parquet,arrow-flight
 exclude-labels=development-process,invalid

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -18,12 +18,10 @@
 # under the License.
 #
 
-# point to the old changelog in apache/arrow
-front-matter=For older versions, see [apache/arrow/CHANGELOG.md](https://github.com/apache/arrow/blob/master/CHANGELOG.md)\n
-# some issues are just documentation
-add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}
+# Add special sections for documentation, security and performance
+add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]},"security":{"prefix":"**Security updates:**","labels":["security"]},"performance":{"prefix":"**Performance improvements:**","labels":["performance"]}}
 # uncomment to not show PRs. TBD if we shown them or not.
-#pull-requests=false
+#pull-requests=false3
 # so that the component is shown associated with the issue
 issue-line-labels=arrow,parquet,arrow-flight
 exclude-labels=development-process,invalid

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ rusty-tags.vi
 venv/*
 # created by doctests
 parquet/data.parquet
+# release notes cache
+.githubchangeloggenerator.cache
+.githubchangeloggenerator.cache.log

--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -36,7 +36,9 @@ pushd ${SOURCE_TOP_DIR}
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN=$CHANGELOG_GITHUB_TOKEN -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator \
     --user apache \
     --project arrow-rs \
-    --since-tag 6.0.0 \
-    --future-release 7.0.0
-
-sed -i "s/\\\n/\n\n/" CHANGELOG.md
+    --cache-file=.githubchangeloggenerator.cache \
+    --cache-log=.githubchangeloggenerator.cache.log \
+    --http-cache \
+    --max-issues=300 \
+    --since-tag 7.0.0 \
+    --future-release 8.0.0


### PR DESCRIPTION
While preparing the 8.0.0 release notes, I kept encountering github api rate limits when trying to use the `githubchangeloggenerator` script. 

I also then tweaked some settings so we can highlight performance and security headings

