### PR TITLE
Faster bitmask iteration

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -21,7 +21,7 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 use std::{convert::AsRef, usize};
 
-use crate::util::bit_chunk_iterator::BitChunks;
+use crate::util::bit_chunk_iterator::{BitChunks, UnalignedBitChunk};
 use crate::{
     bytes::{Bytes, Deallocation},
     datatypes::ArrowNativeType,
@@ -205,11 +205,7 @@ impl Buffer {
     /// Returns the number of 1-bits in this buffer, starting from `offset` with `length` bits
     /// inspected. Note that both `offset` and `length` are measured in bits.
     pub fn count_set_bits_offset(&self, offset: usize, len: usize) -> usize {
-        let chunks = self.bit_chunks(offset, len);
-        let mut count = chunks.iter().map(|c| c.count_ones() as usize).sum();
-        count += chunks.remainder_bits().count_ones() as usize;
-
-        count
+        UnalignedBitChunk::new(self.as_slice(), offset, len).count_ones()
     }
 }
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -631,6 +631,32 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_slices() {
+        // takes up 2 u64s
+        let bools = std::iter::repeat(true).take(10)
+            .chain(std::iter::repeat(false).take(30))
+            .chain(std::iter::repeat(true).take(20))
+            .chain(std::iter::repeat(false).take(17))
+            .chain(std::iter::repeat(true).take(4));
+
+        let bool_array: BooleanArray = bools.map(Some).collect();
+
+        let slices: Vec<_> = SlicesIterator::new(&bool_array).collect();
+        let expected = vec![(0, 10), (40, 60), (77, 81)];
+        assert_eq!(slices, expected);
+
+        // slice with offset and truncated len
+        let len = bool_array.len();
+        let sliced_array = bool_array.slice(7, len-10);
+        let sliced_array = sliced_array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        let slices: Vec<_> = SlicesIterator::new(&sliced_array).collect();
+        let expected = vec![(0, 3), (33, 53), (70, 71)];
+        assert_eq!(slices, expected);
+    }
     fn test_slices_fuzz(mask_len: usize, offset: usize, truncate: usize) {
         let mut rng = thread_rng();
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -105,7 +105,7 @@ impl<'a> Iterator for SlicesIterator<'a> {
                 }
                 None => {
                     return Some((
-                        start_chunk + start_bit as usize,
+                        start_chunk + start_bit as usize - 64,
                         std::mem::replace(&mut self.len, 0),
                     ));
                 }

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -56,6 +56,11 @@ impl<'a> SlicesIterator<'a> {
         }
     }
 
+    /// Returns `Some((chunk_offset, bit_offset))` for the next chunk that has at
+    /// least one bit set, or None if there is no such chunk.
+    ///
+    /// Where `chunk_offset` is the bit offset to the current `usize`d chunk
+    /// and `bit_offset` is the offset of the first `1` bit in that chunk
     fn advance_to_set_bit(&mut self) -> Option<(usize, u32)> {
         loop {
             if self.current_chunk != 0 {
@@ -634,7 +639,8 @@ mod tests {
     #[test]
     fn test_slices() {
         // takes up 2 u64s
-        let bools = std::iter::repeat(true).take(10)
+        let bools = std::iter::repeat(true)
+            .take(10)
             .chain(std::iter::repeat(false).take(30))
             .chain(std::iter::repeat(true).take(20))
             .chain(std::iter::repeat(false).take(17))
@@ -648,15 +654,16 @@ mod tests {
 
         // slice with offset and truncated len
         let len = bool_array.len();
-        let sliced_array = bool_array.slice(7, len-10);
+        let sliced_array = bool_array.slice(7, len - 10);
         let sliced_array = sliced_array
             .as_any()
             .downcast_ref::<BooleanArray>()
             .unwrap();
-        let slices: Vec<_> = SlicesIterator::new(&sliced_array).collect();
+        let slices: Vec<_> = SlicesIterator::new(sliced_array).collect();
         let expected = vec![(0, 3), (33, 53), (70, 71)];
         assert_eq!(slices, expected);
     }
+
     fn test_slices_fuzz(mask_len: usize, offset: usize, truncate: usize) {
         let mut rng = thread_rng();
 

--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -476,7 +476,10 @@ mod tests {
         assert_eq!(unaligned.lead_padding(), 0);
         assert_eq!(unaligned.trailing_padding(), 24);
         // 24x 1 bit then 40x 0 bits
-        assert_eq!(unaligned.prefix(), Some(0b0000000000000000000000001111111111111111111111111111111111111111));
+        assert_eq!(
+            unaligned.prefix(),
+            Some(0b0000000000000000000000001111111111111111111111111111111111111111)
+        );
         assert_eq!(unaligned.suffix(), None);
 
         let buffer = buffer.slice(1);
@@ -486,7 +489,10 @@ mod tests {
         assert_eq!(unaligned.lead_padding(), 0);
         assert_eq!(unaligned.trailing_padding(), 32);
         // 32x 1 bit then 32x 0 bits
-        assert_eq!(unaligned.prefix(), Some(0b0000000000000000000000000000000011111111111111111111111111111111));
+        assert_eq!(
+            unaligned.prefix(),
+            Some(0b0000000000000000000000000000000011111111111111111111111111111111)
+        );
         assert_eq!(unaligned.suffix(), None);
 
         let unaligned = UnalignedBitChunk::new(buffer.as_slice(), 5, 27);
@@ -495,7 +501,10 @@ mod tests {
         assert_eq!(unaligned.lead_padding(), 5); // 5 % 8 == 5
         assert_eq!(unaligned.trailing_padding(), 32);
         // 5x 0 bit, 27x 1 bit then 32x 0 bits
-        assert_eq!(unaligned.prefix(), Some(0b0000000000000000000000000000000011111111111111111111111111100000));
+        assert_eq!(
+            unaligned.prefix(),
+            Some(0b0000000000000000000000000000000011111111111111111111111111100000)
+        );
         assert_eq!(unaligned.suffix(), None);
 
         let unaligned = UnalignedBitChunk::new(buffer.as_slice(), 12, 20);
@@ -504,7 +513,10 @@ mod tests {
         assert_eq!(unaligned.lead_padding(), 4); // 12 % 8 == 4
         assert_eq!(unaligned.trailing_padding(), 40);
         // 4x 0 bit, 20x 1 bit then 40x 0 bits
-        assert_eq!(unaligned.prefix(), Some(0b0000000000000000000000000000000000000000111111111111111111110000));
+        assert_eq!(
+            unaligned.prefix(),
+            Some(0b0000000000000000000000000000000000000000111111111111111111110000)
+        );
         assert_eq!(unaligned.suffix(), None);
 
         let buffer = Buffer::from(&[0xFF; 14]);

--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -571,10 +571,14 @@ mod tests {
             let bools: Vec<_> = std::iter::from_fn(|| Some(rng.gen()))
                 .take(mask_len)
                 .collect();
+
             let buffer = Buffer::from_iter(bools.iter().cloned());
 
-            let offset = rng.gen_range(0..(64.min(mask_len)));
-            let truncate = rng.gen_range(0..(128.min(mask_len - offset)));
+            let max_offset = 64.min(mask_len);
+            let offset = rng.gen::<usize>().checked_rem(max_offset).unwrap_or(0);
+
+            let max_truncate = 128.min(mask_len - offset);
+            let truncate = rng.gen::<usize>().checked_rem(max_truncate).unwrap_or(0);
 
             let unaligned = UnalignedBitChunk::new(
                 buffer.as_slice(),

--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -151,7 +151,7 @@ impl<'a> UnalignedBitChunk<'a> {
         self.chunks
     }
 
-    pub fn iter(&self) -> UnalignedBitChunkIterator<'a> {
+    pub(crate) fn iter(&self) -> UnalignedBitChunkIterator<'a> {
         self.prefix
             .into_iter()
             .chain(self.chunks.iter().cloned())
@@ -164,7 +164,7 @@ impl<'a> UnalignedBitChunk<'a> {
     }
 }
 
-pub type UnalignedBitChunkIterator<'a> = std::iter::Chain<
+pub(crate) type UnalignedBitChunkIterator<'a> = std::iter::Chain<
     std::iter::Chain<
         std::option::IntoIter<u64>,
         std::iter::Cloned<std::slice::Iter<'a, u64>>,

--- a/parquet/src/arrow/bit_util.rs
+++ b/parquet/src/arrow/bit_util.rs
@@ -40,7 +40,7 @@ pub fn iter_set_bits_rev(bytes: &[u8]) -> impl Iterator<Item = usize> + '_ {
                 chunk ^= 1 << bit_pos;
                 return Some(chunk_idx + (bit_pos as usize));
             }
-            return None;
+            None
         })
     })
 }

--- a/parquet/src/arrow/bit_util.rs
+++ b/parquet/src/arrow/bit_util.rs
@@ -31,7 +31,13 @@ pub fn iter_set_bits_rev(bytes: &[u8]) -> impl Iterator<Item = usize> + '_ {
     let mut chunk_end_idx =
         bit_length + unaligned.lead_padding() + unaligned.trailing_padding();
 
-    unaligned.iter().rev().flat_map(move |mut chunk| {
+    let iter = unaligned
+        .prefix()
+        .into_iter()
+        .chain(unaligned.chunks().iter().cloned())
+        .chain(unaligned.suffix().into_iter());
+
+    iter.rev().flat_map(move |mut chunk| {
         let chunk_idx = chunk_end_idx - 64;
         chunk_end_idx = chunk_idx;
         std::iter::from_fn(move || {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1227.

# Rationale for this change
 
This improves the filter benchmarks by a factor of 2x, and likely will have similar benefits elsewhere

```
filter u8               time:   [140.44 us 140.61 us 140.76 us]                      
                        change: [-51.558% -51.392% -51.226%] (p = 0.00 < 0.05)
                        Performance has improved.

filter u8 high selectivity                                                                             
                        time:   [2.4576 us 2.4587 us 2.4601 us]
                        change: [-53.091% -52.977% -52.863%] (p = 0.00 < 0.05)
                        Performance has improved.

filter u8 low selectivity                                                                             
                        time:   [1.6956 us 1.6981 us 1.7010 us]
                        change: [-60.543% -60.284% -59.829%] (p = 0.00 < 0.05)
                        Performance has improved.
                        
filter f32              time:   [418.84 us 419.45 us 420.15 us]                       
                        change: [-26.414% -26.286% -26.141%] (p = 0.00 < 0.05)
                        Performance has improved.

filter single record batch                                                                            
                        time:   [183.96 us 188.44 us 193.16 us]
                        change: [-33.234% -31.549% -29.597%] (p = 0.00 < 0.05)
                        Performance has improved.

```
Note: the filter **context** benchmarks don't see any change as the filter is computed outside the benchmark body.

# What changes are included in this PR?

This adds an UnalignedBitChunkIterator and updates SlicesIterator to use it

# Are there any user-facing changes?

No
