### PR TITLE
Improve documentation for Bitmap

### DIFF
--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines a bitmap, which is used to track which values in an Arrow array are null.
-//! This is called a "validity bitmap" in the Arrow documentation.
+//! Defines [Bitmap] for tracking validity bitmaps
 
 use crate::buffer::Buffer;
 use crate::error::Result;
@@ -26,6 +25,10 @@ use std::mem;
 use std::ops::{BitAnd, BitOr};
 
 #[derive(Debug, Clone)]
+/// Defines a bitmap, which is used to track which values in an Arrow
+/// array are null.
+///
+/// This is called a "validity bitmap" in the Arrow documentation.
 pub struct Bitmap {
     pub(crate) bits: Buffer,
 }
@@ -44,6 +47,7 @@ impl Bitmap {
         }
     }
 
+    /// Return the length of this Bitmap in bits (not bytes)
     pub fn len(&self) -> usize {
         self.bits.len() * 8
     }


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/1233

and related to https://github.com/apache/arrow-rs/pull/1232

# Rationale for this change
 
the `len()` method on `Bitmap` is very confusing (it is in terms of bits rather than bytes)

# What changes are included in this PR?

1. Add doc comments for `Bitmap::len()`
2. Move some doc comments into the `Bitmap` struct rather than the module definition

# Are there any user-facing changes?
better docs

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
