### PR TITLE
dyn compare for binary array

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -4040,8 +4040,8 @@ mod tests {
         let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
-        let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(true), Some(true), None]);
+        let scalar = &[0xff, 0xf8];
+        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(false), Some(false), Some(true), None]);
 
         assert_eq!(gt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -3966,7 +3966,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(false), Some(false), None]);
+        let expected = BooleanArray::from(
+            vec![Some(false), Some(false), Some(true), Some(false), Some(false), None],
+        );
 
         assert_eq!(eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -3981,7 +3983,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), Some(true), None]);
+        let expected = BooleanArray::from(
+            vec![Some(true), Some(true), Some(false), Some(true), Some(true), None],
+        );
 
         assert_eq!(neq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -3996,7 +4000,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), Some(false), None]);
+        let expected = BooleanArray::from(
+            vec![Some(true), Some(true), Some(false), Some(false), Some(false), None],
+        );
 
         assert_eq!(lt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4011,7 +4017,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), Some(false), None]);
+        let expected = BooleanArray::from(
+            vec![Some(true), Some(true), Some(true), Some(false), Some(false), None],
+        );
 
         assert_eq!(lt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4026,7 +4034,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(false), Some(true), Some(true), None]);
+        let expected = BooleanArray::from(
+            vec![Some(false), Some(false), Some(false), Some(true), Some(true), None],
+        );
 
         assert_eq!(gt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4041,7 +4051,9 @@ mod tests {
         let array = BinaryArray::from(data.clone());
         let large_array = LargeBinaryArray::from(data);
         let scalar = &[0xff, 0xf8];
-        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(false), Some(false), Some(true), None]);
+        let expected = BooleanArray::from(
+            vec![Some(false), Some(false), Some(false), Some(false), Some(true), None],
+        );
 
         assert_eq!(gt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1770,7 +1770,7 @@ macro_rules! typed_cmp {
 }
 
 macro_rules! typed_compares {
-    ($LEFT: expr, $RIGHT: expr, $OP_BOOL: ident, $OP_PRIM: ident, $OP_STR: ident) => {{
+    ($LEFT: expr, $RIGHT: expr, $OP_BOOL: ident, $OP_PRIM: ident, $OP_STR: ident, $OP_BINARY: ident) => {{
         match ($LEFT.data_type(), $RIGHT.data_type()) {
             (DataType::Boolean, DataType::Boolean) => {
                 typed_cmp!($LEFT, $RIGHT, BooleanArray, $OP_BOOL)
@@ -1810,6 +1810,12 @@ macro_rules! typed_compares {
             }
             (DataType::LargeUtf8, DataType::LargeUtf8) => {
                 typed_cmp!($LEFT, $RIGHT, LargeStringArray, $OP_STR, i64)
+            }
+            (DataType::Binary, DataType::Binary) => {
+                typed_cmp!($LEFT, $RIGHT, BinaryArray, $OP_BINARY, i32)
+            }
+            (DataType::LargeBinary, DataType::LargeBinary) => {
+                typed_cmp!($LEFT, $RIGHT, LargeBinaryArray, $OP_BINARY, i64)
             }
             (
                 DataType::Timestamp(TimeUnit::Nanosecond, _),
@@ -1918,7 +1924,7 @@ macro_rules! typed_compares {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, eq_bool, eq, eq_utf8)
+    typed_compares!(left, right, eq_bool, eq, eq_utf8, eq_binary)
 }
 
 /// Perform `left != right` operation on two (dynamic) [`Array`]s.
@@ -1926,7 +1932,7 @@ pub fn eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn neq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, neq_bool, neq, neq_utf8)
+    typed_compares!(left, right, neq_bool, neq, neq_utf8, neq_binary)
 }
 
 /// Perform `left < right` operation on two (dynamic) [`Array`]s.
@@ -1934,7 +1940,7 @@ pub fn neq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn lt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, lt_bool, lt, lt_utf8)
+    typed_compares!(left, right, lt_bool, lt, lt_utf8, lt_binary)
 }
 
 /// Perform `left <= right` operation on two (dynamic) [`Array`]s.
@@ -1942,7 +1948,7 @@ pub fn lt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn lt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, lt_eq_bool, lt_eq, lt_eq_utf8)
+    typed_compares!(left, right, lt_eq_bool, lt_eq, lt_eq_utf8, lt_eq_binary)
 }
 
 /// Perform `left > right` operation on two (dynamic) [`Array`]s.
@@ -1950,7 +1956,7 @@ pub fn lt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn gt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, gt_bool, gt, gt_utf8)
+    typed_compares!(left, right, gt_bool, gt, gt_utf8, gt_binary)
 }
 
 /// Perform `left >= right` operation on two (dynamic) [`Array`]s.
@@ -1958,7 +1964,7 @@ pub fn gt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 /// Only when two arrays are of the same type the comparison will happen otherwise it will err
 /// with a casting error.
 pub fn gt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
-    typed_compares!(left, right, gt_eq_bool, gt_eq, gt_eq_utf8)
+    typed_compares!(left, right, gt_eq_bool, gt_eq, gt_eq_utf8, gt_eq_binary)
 }
 
 /// Perform `left == right` operation on two [`PrimitiveArray`]s.

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -3962,14 +3962,11 @@ mod tests {
 
     #[test]
     fn test_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![false, false, true, false, false]);
+        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(false), Some(false), None]);
 
         assert_eq!(eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -3980,14 +3977,11 @@ mod tests {
 
     #[test]
     fn test_neq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![true, true, false, true, true]);
+        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), Some(true), None]);
 
         assert_eq!(neq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -3998,14 +3992,11 @@ mod tests {
 
     #[test]
     fn test_lt_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![true, true, false, false, false]);
+        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), Some(false), None]);
 
         assert_eq!(lt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4016,14 +4007,11 @@ mod tests {
 
     #[test]
     fn test_lt_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![true, true, true, false, false]);
+        let expected = BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), Some(false), None]);
 
         assert_eq!(lt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4034,14 +4022,11 @@ mod tests {
 
     #[test]
     fn test_gt_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![false, false, false, true, true]);
+        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(false), Some(true), Some(true), None]);
 
         assert_eq!(gt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(
@@ -4052,14 +4037,11 @@ mod tests {
 
     #[test]
     fn test_gt_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
-        let large_array = LargeBinaryArray::from_vec(
-            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
-        );
+        let data: Vec<Option<&[u8]>> = vec![Some(b"arrow"), Some(b"datafusion"), Some(b"flight"), Some(b"parquet"), Some(&[0xff, 0xf8]), None];
+        let array = BinaryArray::from(data.clone());
+        let large_array = LargeBinaryArray::from(data);
         let scalar = "flight".as_bytes();
-        let expected = BooleanArray::from(vec![false, false, true, true, true]);
+        let expected = BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(true), Some(true), None]);
 
         assert_eq!(gt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
         assert_eq!(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1129,54 +1129,6 @@ macro_rules! dyn_compare_scalar {
     }};
 }
 
-macro_rules! dyn_compare_binary_scalar {
-    ($LEFT: expr, $RIGHT: expr, $KT: ident, $OP: ident) => {
-        match $KT.as_ref() {
-            DataType::UInt8 => {
-                let left = as_dictionary_array::<UInt8Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::UInt16 => {
-                let left = as_dictionary_array::<UInt16Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::UInt32 => {
-                let left = as_dictionary_array::<UInt32Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::UInt64 => {
-                let left = as_dictionary_array::<UInt64Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::Int8 => {
-                let left = as_dictionary_array::<Int8Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::Int16 => {
-                let left = as_dictionary_array::<Int16Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::Int32 => {
-                let left = as_dictionary_array::<Int32Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            DataType::Int64 => {
-                let left = as_dictionary_array::<Int64Type>($LEFT);
-                let values = as_generic_binary_array::<i32>(left.values());
-                unpack_dict_comparison(left, $OP(values, $RIGHT)?)
-            }
-            _ => Err(ArrowError::ComputeError(String::from("Unknown key type"))),
-        }
-    };
-}
-
 macro_rules! dyn_compare_utf8_scalar {
     ($LEFT: expr, $RIGHT: expr, $KT: ident, $OP: ident) => {{
         match $KT.as_ref() {
@@ -1310,17 +1262,9 @@ where
 }
 
 /// Perform `left == right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, eq_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "eq_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             eq_binary_scalar(left, right)
@@ -1331,22 +1275,14 @@ pub fn eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArr
         }
         _ => Err(ArrowError::ComputeError(
             "eq_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+        )),
     }
 }
 
 /// Perform `left != right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn neq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, neq_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "neq_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             neq_binary_scalar(left, right)
@@ -1356,23 +1292,16 @@ pub fn neq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanAr
             neq_binary_scalar(left, right)
         }
         _ => Err(ArrowError::ComputeError(
-            "neq_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+            "neq_dyn_binary_scalar only supports Binary or LargeBinary arrays"
+                .to_string(),
+        )),
     }
 }
 
 /// Perform `left < right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn lt_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, lt_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "lt_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             lt_binary_scalar(left, right)
@@ -1383,22 +1312,14 @@ pub fn lt_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArr
         }
         _ => Err(ArrowError::ComputeError(
             "lt_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+        )),
     }   
 }
 
 /// Perform `left <= right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn lt_eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, lt_eq_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "lt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             lt_eq_binary_scalar(left, right)
@@ -1408,23 +1329,16 @@ pub fn lt_eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<Boolean
             lt_eq_binary_scalar(left, right)
         }
         _ => Err(ArrowError::ComputeError(
-            "lt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+            "lt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays"
+                .to_string(),
+        )),
     }
 }
 
 /// Perform `left > right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn gt_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, gt_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "gt_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             gt_binary_scalar(left, right)
@@ -1435,22 +1349,14 @@ pub fn gt_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArr
         }
         _ => Err(ArrowError::ComputeError(
             "gt_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+        )),
     }
 }
 
 /// Perform `left >= right` operation on an array and a numeric scalar
-/// value. Supports BinaryArrays, and DictionaryArrays that have binary values
+/// value. Supports BinaryArray and LargeBinaryArray
 pub fn gt_eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArray> {
     match left.data_type() {
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
-            DataType::Binary | DataType::LargeBinary => {
-                dyn_compare_binary_scalar!(left, right, key_type, gt_eq_binary_scalar)
-            }
-            _ => Err(ArrowError::ComputeError(
-                "gt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays or DictionaryArray with Binary or LargeBinary values".to_string(),
-            )),
-        },
         DataType::Binary => {
             let left = as_generic_binary_array::<i32>(left);
             gt_eq_binary_scalar(left, right)
@@ -1460,8 +1366,9 @@ pub fn gt_eq_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<Boolean
             gt_eq_binary_scalar(left, right)
         }
         _ => Err(ArrowError::ComputeError(
-            "gt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
-        ))
+            "gt_eq_dyn_binary_scalar only supports Binary or LargeBinary arrays"
+                .to_string(),
+        )),
     }
 }
 
@@ -4055,128 +3962,92 @@ mod tests {
 
     #[test]
     fn test_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, true, false, false]);
 
-        assert_eq!(
-            eq_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            eq_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
+        assert_eq!(eq_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(eq_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
 
     #[test]
-    fn test_eq_dyn_binary_scalar_with_dict() {
-        
-    }
-    #[test]
     fn test_neq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, false, true, true]);
 
-        assert_eq!(
-            neq_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            neq_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
+        assert_eq!(neq_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(neq_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
 
     #[test]
-    fn test_neq_dyn_binary_scalar_with_dict() {
-        
-    }
-    #[test]
     fn test_lt_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, false, false, false]);
 
-        assert_eq!(
-            lt_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            lt_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
+        assert_eq!(lt_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(lt_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
-    #[test]
-    fn test_lt_dyn_binary_scalar_with_dict() {
-        
-    }
+
     #[test]
     fn test_lt_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, true, false, false]);
 
-        assert_eq!(
-            lt_eq_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            lt_eq_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
+        assert_eq!(lt_eq_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(lt_eq_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
 
     #[test]
-    fn test_lt_eq_dyn_binary_scalar_with_dict() {
-        
-    }
-    #[test]
     fn test_gt_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, false, true, true]);
 
-        assert_eq!(
-            gt_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            gt_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
-    }
-    #[test]
-    fn test_gt_dyn_binary_scalar_with_dict() {
-        
+        assert_eq!(gt_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(gt_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
 
     #[test]
     fn test_gt_eq_dyn_binary_scalar() {
-        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
-        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let array = BinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
+        let large_array = LargeBinaryArray::from_vec(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
+        );
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, true, true, true]);
 
-        assert_eq!(
-            gt_eq_binary_scalar(&array, scalar).unwrap(),
-            expected
-        );
-        assert_eq!(
-            gt_eq_binary_scalar(&large_array, scalar).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn test_gt_eq_dyn_binary_scalar_with_dict() {
-        
+        assert_eq!(gt_eq_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(gt_eq_binary_scalar(&large_array, scalar).unwrap(), expected);
     }
 
     #[test]

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1313,7 +1313,7 @@ pub fn lt_dyn_binary_scalar(left: &dyn Array, right: &[u8]) -> Result<BooleanArr
         _ => Err(ArrowError::ComputeError(
             "lt_dyn_binary_scalar only supports Binary or LargeBinary arrays".to_string(),
         )),
-    }   
+    }
 }
 
 /// Perform `left <= right` operation on an array and a numeric scalar
@@ -3971,8 +3971,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, true, false, false]);
 
-        assert_eq!(eq_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(eq_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            eq_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3986,8 +3989,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, false, true, true]);
 
-        assert_eq!(neq_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(neq_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(neq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            neq_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -4001,8 +4007,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, false, false, false]);
 
-        assert_eq!(lt_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(lt_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(lt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            lt_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -4016,8 +4025,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![true, true, true, false, false]);
 
-        assert_eq!(lt_eq_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(lt_eq_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(lt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            lt_eq_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -4031,8 +4043,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, false, true, true]);
 
-        assert_eq!(gt_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(gt_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(gt_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            gt_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -4046,8 +4061,11 @@ mod tests {
         let scalar = "flight".as_bytes();
         let expected = BooleanArray::from(vec![false, false, true, true, true]);
 
-        assert_eq!(gt_eq_binary_scalar(&array, scalar).unwrap(), expected);
-        assert_eq!(gt_eq_binary_scalar(&large_array, scalar).unwrap(), expected);
+        assert_eq!(gt_eq_dyn_binary_scalar(&array, scalar).unwrap(), expected);
+        assert_eq!(
+            gt_eq_dyn_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
     }
 
     #[test]

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -3265,10 +3265,10 @@ mod tests {
     );
     test_binary_scalar!(
         test_binary_array_gt_eq_scalar,
-        vec![b"arrow", b"datafusion", b"flight", b"parquet"],
+        vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]],
         "flight".as_bytes(),
         gt_eq_binary_scalar,
-        vec![false, false, true, true]
+        vec![false, false, true, true, true]
     );
 
     // Expected behaviour:
@@ -4051,6 +4051,132 @@ mod tests {
         let array: ArrayRef = Arc::new(array);
         let array = crate::compute::cast(&array, &DataType::Float64).unwrap();
         assert_eq!(neq_dyn_scalar(&array, 8).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_eq_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![false, false, true, false, false]);
+
+        assert_eq!(
+            eq_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            eq_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_eq_dyn_binary_scalar_with_dict() {
+        
+    }
+    #[test]
+    fn test_neq_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![true, true, false, true, true]);
+
+        assert_eq!(
+            neq_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            neq_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_neq_dyn_binary_scalar_with_dict() {
+        
+    }
+    #[test]
+    fn test_lt_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![true, true, false, false, false]);
+
+        assert_eq!(
+            lt_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            lt_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+    #[test]
+    fn test_lt_dyn_binary_scalar_with_dict() {
+        
+    }
+    #[test]
+    fn test_lt_eq_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![true, true, true, false, false]);
+
+        assert_eq!(
+            lt_eq_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            lt_eq_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_lt_eq_dyn_binary_scalar_with_dict() {
+        
+    }
+    #[test]
+    fn test_gt_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![false, false, false, true, true]);
+
+        assert_eq!(
+            gt_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            gt_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+    #[test]
+    fn test_gt_dyn_binary_scalar_with_dict() {
+        
+    }
+
+    #[test]
+    fn test_gt_eq_dyn_binary_scalar() {
+        let array = BinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let large_array = LargeBinaryArray::from_vec(vec![b"arrow", b"datafusion", b"flight", b"parquet", &[0xff, 0xf8]]);
+        let scalar = "flight".as_bytes();
+        let expected = BooleanArray::from(vec![false, false, true, true, true]);
+
+        assert_eq!(
+            gt_eq_binary_scalar(&array, scalar).unwrap(),
+            expected
+        );
+        assert_eq!(
+            gt_eq_binary_scalar(&large_array, scalar).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_gt_eq_dyn_binary_scalar_with_dict() {
+        
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1108 

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Update the API of `typed_compare`, so that it supports compare 2 binary arrays
2. Add dynamic dispatched functions to compare a binary array and a scalar
3. Add tests for functions `*_dyn_binary_scalar`.
4. `DictionaryArray` with binary values is not supported so far, because I could not find an easy way to build a binary dictionary array. Is there any builder such as `StringDictionaryBuilder` can be used for binary type?
# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
