### PR TITLE
Rename the function `len` to `bit_len` for `Bitmap`

### DIFF
--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -48,7 +48,7 @@ impl Bitmap {
     }
 
     /// Return the length of this Bitmap in bits (not bytes)
-    pub fn len(&self) -> usize {
+    pub fn bit_len(&self) -> usize {
         self.bits.len() * 8
     }
 
@@ -121,9 +121,9 @@ mod tests {
 
     #[test]
     fn test_bitmap_length() {
-        assert_eq!(512, Bitmap::new(63 * 8).len());
-        assert_eq!(512, Bitmap::new(64 * 8).len());
-        assert_eq!(1024, Bitmap::new(65 * 8).len());
+        assert_eq!(512, Bitmap::new(63 * 8).bit_len());
+        assert_eq!(512, Bitmap::new(64 * 8).bit_len());
+        assert_eq!(1024, Bitmap::new(65 * 8).bit_len());
     }
 
     #[test]

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -411,7 +411,7 @@ mod tests {
         let bitmap = buffer.split_bitmask(19);
 
         // Should have split off 19 records leaving, 81 behind
-        assert_eq!(bitmap.len(), 3 * 8); // Note: bitmask only tracks bytes not bits
+        assert_eq!(bitmap.bit_len(), 3 * 8); // Note: bitmask only tracks bytes not bits
         assert_eq!(buffer.nulls().len(), 81);
     }
 }


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1233 .

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The name `bit_len` is more clear because the function return the length of bits (not bytes).
# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

The function name is changed.
