### PR TITLE
Remove Copy trait from dyn scalar kernels

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1181,7 +1181,7 @@ macro_rules! dyn_compare_utf8_scalar {
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn eq_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {
@@ -1195,7 +1195,7 @@ where
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn lt_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {
@@ -1209,7 +1209,7 @@ where
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn lt_eq_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {
@@ -1223,7 +1223,7 @@ where
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn gt_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {
@@ -1237,7 +1237,7 @@ where
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn gt_eq_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {
@@ -1251,7 +1251,7 @@ where
 /// value. Supports PrimitiveArrays, and DictionaryArrays that have primitive values
 pub fn neq_dyn_scalar<T>(left: &dyn Array, right: T) -> Result<BooleanArray>
 where
-    T: num::ToPrimitive + Copy + std::fmt::Debug,
+    T: num::ToPrimitive + std::fmt::Debug,
 {
     match left.data_type() {
         DataType::Dictionary(key_type, _value_type) => {


### PR DESCRIPTION
# Which issue does this PR close?

No existing issue.

# Rationale for this change
 
In the context of https://github.com/apache/arrow-datafusion/pull/1685 I am trying to use datafusions `ScalarValue` with the dyn scalar kernels.  We now use the `ToPrimitive` trait for the dyn scalar kernels and I am looking to implement that on `ScalarValue` as well.  While testing that locally the last issue i came across was `ScalarValue` not implementing `Copy` which the dyn scalar kernels require.  I tried removing that constraint locally and had no issues compiling / testing / linting so im thinking the constraint isnt needed.

@alamb FYI.
# What changes are included in this PR?

Removing `Copy` trait requirement on the dyn scalar kernels.

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
