### PR TITLE
Revert making parquet::data_type and parquet::arrow::schema experimental

### DIFF
--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -131,7 +131,6 @@ pub use self::arrow_reader::ArrowReader;
 pub use self::arrow_reader::ParquetFileArrowReader;
 pub use self::arrow_writer::ArrowWriter;
 
-#[cfg(feature = "experimental")]
 pub use self::schema::{
     arrow_to_parquet_schema, parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns,
     parquet_to_arrow_schema_by_root_columns,

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -56,7 +56,9 @@ macro_rules! experimental_mod {
 #[macro_use]
 pub mod errors;
 pub mod basic;
-experimental_mod!(data_type, #[macro_use]);
+
+#[macro_use]
+pub mod data_type;
 
 // Exported for external use, such as benchmarks
 #[cfg(feature = "experimental")]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1032

# Rationale for this change
 
#1134 was a tad overzealous and moved some functionality behind the experimental flags that downstream projects depend on.

# What changes are included in this PR?

* arrow schema conversion functions are made public, these are used by [IOx](https://github.com/influxdata/influxdb_iox/) to get the arrow schema from parquet metadata cached in its catalog
* `data_type` is made public, this is used by [sqlite2parquet](https://github.com/asayers/sqlite2parquet) in order to interface with the `ColumnWriter` APIs

I debated spending the time to instead mark the various bits of these modules experimental, but since the move to more frequent breaking releases (#1120) there seems to be limited value add from such an undertaking. The concept of experimental made sense when breaking changes were quarterly, now that they're biweekly...

# Are there any user-facing changes?

No breaking changes, this can (and perhaps should be) a patch release.
