### PR TITLE
Fix NullArrayReader (#1245)

### DIFF
--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -214,6 +214,10 @@ where
         // save definition and repetition buffers
         self.def_levels_buffer = self.record_reader.consume_def_levels()?;
         self.rep_levels_buffer = self.record_reader.consume_rep_levels()?;
+
+        // Must consume bitmap buffer
+        self.record_reader.consume_bitmap_buffer()?;
+
         self.record_reader.reset();
         Ok(Arc::new(array))
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1245.

# Rationale for this change
 
Originally reported by @bjchambers, a sanity check added in #1054 fires when reading NullArrays. 

This highlighted two problems:

* `NullArrayReader` has always been somewhat broken as it would never flush the accumulated null buffer, instead just growing it indefinitely
* There were literally no tests for NullArrayReader :scream: 

# What changes are included in this PR?

Fixes the panic, and adds a basic test of the `NullArrayReader`

# Are there any user-facing changes?

NullArrayReader should work again