### PR TITLE
Specialized filter kernels

### DIFF
--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -48,127 +48,131 @@ fn add_benchmark(c: &mut Criterion) {
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.0);
 
-    c.bench_function("filter optimize", |b| {
+    c.bench_function("filter optimize (1/2)", |b| {
         b.iter(|| FilterBuilder::new(&filter_array).optimize().build())
     });
 
-    c.bench_function("filter optimize high selectivity", |b| {
+    c.bench_function("filter optimize high selectivity (1023/1024)", |b| {
         b.iter(|| FilterBuilder::new(&dense_filter_array).optimize().build())
     });
 
-    c.bench_function("filter optimize low selectivity", |b| {
+    c.bench_function("filter optimize low selectivity (1/1024)", |b| {
         b.iter(|| FilterBuilder::new(&sparse_filter_array).optimize().build())
     });
 
-    c.bench_function("filter u8", |b| {
+    c.bench_function("filter u8 (1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter u8 high selectivity", |b| {
+    c.bench_function("filter u8 high selectivity (1023/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
-    c.bench_function("filter u8 low selectivity", |b| {
+    c.bench_function("filter u8 low selectivity (1/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &sparse_filter_array))
     });
 
-    c.bench_function("filter context u8", |b| {
+    c.bench_function("filter context u8 (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context u8 high selectivity", |b| {
+    c.bench_function("filter context u8 high selectivity (1023/1024)", |b| {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
-    c.bench_function("filter context u8 low selectivity", |b| {
+    c.bench_function("filter context u8 low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Int32Type>(size, 0.0);
-    c.bench_function("filter i32", |b| {
+    c.bench_function("filter i32 (1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter i32 high selectivity", |b| {
+    c.bench_function("filter i32 high selectivity (1023/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
-    c.bench_function("filter i32 low selectivity", |b| {
+    c.bench_function("filter i32 low selectivity (1/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &sparse_filter_array))
     });
 
-    c.bench_function("filter context i32", |b| {
+    c.bench_function("filter context i32 (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context i32 high selectivity", |b| {
+    c.bench_function("filter context i32 high selectivity (1023/1024)", |b| {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
-    c.bench_function("filter context i32 low selectivity", |b| {
+    c.bench_function("filter context i32 low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Int32Type>(size, 0.5);
-    c.bench_function("filter context i32 w NULLs", |b| {
+    c.bench_function("filter context i32 w NULLs (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context i32 w NULLs high selectivity", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context i32 w NULLs low selectivity", |b| {
+    c.bench_function(
+        "filter context i32 w NULLs high selectivity (1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function("filter context i32 w NULLs low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.5);
-    c.bench_function("filter context u8 w NULLs", |b| {
+    c.bench_function("filter context u8 w NULLs (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context u8 w NULLs high selectivity", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context u8 w NULLs low selectivity", |b| {
+    c.bench_function(
+        "filter context u8 w NULLs high selectivity (1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function("filter context u8 w NULLs low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Float32Type>(size, 0.5);
-    c.bench_function("filter f32", |b| {
+    c.bench_function("filter f32 (1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter context f32", |b| {
+    c.bench_function("filter context f32 (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context f32 high selectivity", |b| {
+    c.bench_function("filter context f32 high selectivity (1023/1024)", |b| {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
-    c.bench_function("filter context f32 low selectivity", |b| {
+    c.bench_function("filter context f32 low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_string_array::<i32>(size, 0.5);
-    c.bench_function("filter context string", |b| {
+    c.bench_function("filter context string (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context string high selectivity", |b| {
+    c.bench_function("filter context string high selectivity (1023/1024)", |b| {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
-    c.bench_function("filter context string low selectivity", |b| {
+    c.bench_function("filter context string low selectivity (1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_string_dict_array::<Int32Type>(size, 0.0);
-    c.bench_function("filter context string dictionary", |b| {
-        b.iter(|| bench_built_filter(&filter, &data_array))
-    });
-    c.bench_function("filter context string dictionary high selectivity", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context string dictionary low selectivity", |b| {
-        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
-    });
-
-    let data_array = create_string_dict_array::<Int32Type>(size, 0.5);
-    c.bench_function("filter context string dictionary w NULLs", |b| {
+    c.bench_function("filter context string dictionary (1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function(
-        "filter context string dictionary w NULLs high selectivity",
+        "filter context string dictionary high selectivity (1023/1024)",
         |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
     );
     c.bench_function(
-        "filter context string dictionary w NULLs low selectivity",
+        "filter context string dictionary low selectivity (1/1024)",
+        |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
+    );
+
+    let data_array = create_string_dict_array::<Int32Type>(size, 0.5);
+    c.bench_function("filter context string dictionary w NULLs (1/2)", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function(
+        "filter context string dictionary w NULLs high selectivity (1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function(
+        "filter context string dictionary w NULLs low selectivity (1/1024)",
         |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
     );
 

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -48,131 +48,136 @@ fn add_benchmark(c: &mut Criterion) {
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.0);
 
-    c.bench_function("filter optimize (1/2)", |b| {
+    c.bench_function("filter optimize (kept 1/2)", |b| {
         b.iter(|| FilterBuilder::new(&filter_array).optimize().build())
     });
 
-    c.bench_function("filter optimize high selectivity (1023/1024)", |b| {
+    c.bench_function("filter optimize high selectivity (kept 1023/1024)", |b| {
         b.iter(|| FilterBuilder::new(&dense_filter_array).optimize().build())
     });
 
-    c.bench_function("filter optimize low selectivity (1/1024)", |b| {
+    c.bench_function("filter optimize low selectivity (kept 1/1024)", |b| {
         b.iter(|| FilterBuilder::new(&sparse_filter_array).optimize().build())
     });
 
-    c.bench_function("filter u8 (1/2)", |b| {
+    c.bench_function("filter u8 (kept 1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter u8 high selectivity (1023/1024)", |b| {
+    c.bench_function("filter u8 high selectivity (kept 1023/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
-    c.bench_function("filter u8 low selectivity (1/1024)", |b| {
+    c.bench_function("filter u8 low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &sparse_filter_array))
     });
 
-    c.bench_function("filter context u8 (1/2)", |b| {
+    c.bench_function("filter context u8 (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context u8 high selectivity (1023/1024)", |b| {
+    c.bench_function("filter context u8 high selectivity (kept 1023/1024)", |b| {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
-    c.bench_function("filter context u8 low selectivity (1/1024)", |b| {
+    c.bench_function("filter context u8 low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Int32Type>(size, 0.0);
-    c.bench_function("filter i32 (1/2)", |b| {
+    c.bench_function("filter i32 (kept 1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter i32 high selectivity (1023/1024)", |b| {
+    c.bench_function("filter i32 high selectivity (kept 1023/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
-    c.bench_function("filter i32 low selectivity (1/1024)", |b| {
+    c.bench_function("filter i32 low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_filter(&data_array, &sparse_filter_array))
     });
 
-    c.bench_function("filter context i32 (1/2)", |b| {
+    c.bench_function("filter context i32 (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context i32 high selectivity (1023/1024)", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context i32 low selectivity (1/1024)", |b| {
+    c.bench_function(
+        "filter context i32 high selectivity (kept 1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function("filter context i32 low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Int32Type>(size, 0.5);
-    c.bench_function("filter context i32 w NULLs (1/2)", |b| {
+    c.bench_function("filter context i32 w NULLs (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function(
-        "filter context i32 w NULLs high selectivity (1023/1024)",
+        "filter context i32 w NULLs high selectivity (kept 1023/1024)",
         |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
     );
-    c.bench_function("filter context i32 w NULLs low selectivity (1/1024)", |b| {
-        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
-    });
+    c.bench_function(
+        "filter context i32 w NULLs low selectivity (kept 1/1024)",
+        |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
+    );
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.5);
-    c.bench_function("filter context u8 w NULLs (1/2)", |b| {
+    c.bench_function("filter context u8 w NULLs (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function(
-        "filter context u8 w NULLs high selectivity (1023/1024)",
+        "filter context u8 w NULLs high selectivity (kept 1023/1024)",
         |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
     );
-    c.bench_function("filter context u8 w NULLs low selectivity (1/1024)", |b| {
-        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
-    });
+    c.bench_function(
+        "filter context u8 w NULLs low selectivity (kept 1/1024)",
+        |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
+    );
 
     let data_array = create_primitive_array::<Float32Type>(size, 0.5);
-    c.bench_function("filter f32 (1/2)", |b| {
+    c.bench_function("filter f32 (kept 1/2)", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
-    c.bench_function("filter context f32 (1/2)", |b| {
+    c.bench_function("filter context f32 (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context f32 high selectivity (1023/1024)", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context f32 low selectivity (1/1024)", |b| {
+    c.bench_function(
+        "filter context f32 high selectivity (kept 1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function("filter context f32 low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_string_array::<i32>(size, 0.5);
-    c.bench_function("filter context string (1/2)", |b| {
+    c.bench_function("filter context string (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
-    c.bench_function("filter context string high selectivity (1023/1024)", |b| {
-        b.iter(|| bench_built_filter(&dense_filter, &data_array))
-    });
-    c.bench_function("filter context string low selectivity (1/1024)", |b| {
+    c.bench_function(
+        "filter context string high selectivity (kept 1023/1024)",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function("filter context string low selectivity (kept 1/1024)", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_string_dict_array::<Int32Type>(size, 0.0);
-    c.bench_function("filter context string dictionary (1/2)", |b| {
+    c.bench_function("filter context string dictionary (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function(
-        "filter context string dictionary high selectivity (1023/1024)",
+        "filter context string dictionary high selectivity (kept 1023/1024)",
         |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
     );
     c.bench_function(
-        "filter context string dictionary low selectivity (1/1024)",
+        "filter context string dictionary low selectivity (kept 1/1024)",
         |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
     );
 
     let data_array = create_string_dict_array::<Int32Type>(size, 0.5);
-    c.bench_function("filter context string dictionary w NULLs (1/2)", |b| {
+    c.bench_function("filter context string dictionary w NULLs (kept 1/2)", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function(
-        "filter context string dictionary w NULLs high selectivity (1023/1024)",
+        "filter context string dictionary w NULLs high selectivity (kept 1023/1024)",
         |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
     );
     c.bench_function(
-        "filter context string dictionary w NULLs low selectivity (1/1024)",
+        "filter context string dictionary w NULLs low selectivity (kept 1/1024)",
         |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
     );
 

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -42,9 +42,9 @@ fn add_benchmark(c: &mut Criterion) {
     let dense_filter_array = create_boolean_array(size, 0.0, 1.0 - 1.0 / 1024.0);
     let sparse_filter_array = create_boolean_array(size, 0.0, 1.0 / 1024.0);
 
-    let filter = FilterBuilder::new(&filter_array).cache().build();
-    let dense_filter = FilterBuilder::new(&dense_filter_array).cache().build();
-    let sparse_filter = FilterBuilder::new(&sparse_filter_array).cache().build();
+    let filter = FilterBuilder::new(&filter_array).optimize().build();
+    let dense_filter = FilterBuilder::new(&dense_filter_array).optimize().build();
+    let sparse_filter = FilterBuilder::new(&sparse_filter_array).optimize().build();
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.0);
 

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -24,7 +24,7 @@ use arrow::util::bench_util::*;
 
 use arrow::array::*;
 use arrow::compute::filter;
-use arrow::datatypes::{Field, Float32Type, Schema, UInt8Type};
+use arrow::datatypes::{Field, Float32Type, Int32Type, Schema, UInt8Type};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
@@ -77,6 +77,38 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
     c.bench_function("filter context u8 low selectivity", |b| {
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
+    });
+
+    let data_array = create_primitive_array::<Int32Type>(size, 0.0);
+    c.bench_function("filter i32", |b| {
+        b.iter(|| bench_filter(&data_array, &filter_array))
+    });
+    c.bench_function("filter i32 high selectivity", |b| {
+        b.iter(|| bench_filter(&data_array, &dense_filter_array))
+    });
+    c.bench_function("filter i32 low selectivity", |b| {
+        b.iter(|| bench_filter(&data_array, &sparse_filter_array))
+    });
+
+    c.bench_function("filter context i32", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function("filter context i32 high selectivity", |b| {
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
+    });
+    c.bench_function("filter context i32 low selectivity", |b| {
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
+    });
+
+    let data_array = create_primitive_array::<Int32Type>(size, 0.5);
+    c.bench_function("filter context i32 w NULLs", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function("filter context i32 w NULLs high selectivity", |b| {
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
+    });
+    c.bench_function("filter context i32 w NULLs low selectivity", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -32,7 +32,7 @@ fn bench_filter(data_array: &dyn Array, filter_array: &BooleanArray) {
     criterion::black_box(filter(data_array, filter_array).unwrap());
 }
 
-fn bench_built_filter<'a>(filter: &FilterPredicate, array: &dyn Array) {
+fn bench_built_filter(filter: &FilterPredicate, array: &dyn Array) {
     criterion::black_box(filter.filter(array).unwrap());
 }
 

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -148,6 +148,30 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
+    let data_array = create_string_dict_array::<Int32Type>(size, 0.0);
+    c.bench_function("filter context string dictionary", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function("filter context string dictionary high selectivity", |b| {
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
+    });
+    c.bench_function("filter context string dictionary low selectivity", |b| {
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
+    });
+
+    let data_array = create_string_dict_array::<Int32Type>(size, 0.5);
+    c.bench_function("filter context string dictionary w NULLs", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function(
+        "filter context string dictionary w NULLs high selectivity",
+        |b| b.iter(|| bench_built_filter(&dense_filter, &data_array)),
+    );
+    c.bench_function(
+        "filter context string dictionary w NULLs low selectivity",
+        |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
+    );
+
     let data_array = create_primitive_array::<Float32Type>(size, 0.0);
 
     let field = Field::new("c1", data_array.data_type().clone(), true);

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -48,6 +48,18 @@ fn add_benchmark(c: &mut Criterion) {
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.0);
 
+    c.bench_function("filter optimize", |b| {
+        b.iter(|| FilterBuilder::new(&filter_array).optimize().build())
+    });
+
+    c.bench_function("filter optimize high selectivity", |b| {
+        b.iter(|| FilterBuilder::new(&dense_filter_array).optimize().build())
+    });
+
+    c.bench_function("filter optimize low selectivity", |b| {
+        b.iter(|| FilterBuilder::new(&sparse_filter_array).optimize().build())
+    });
+
     c.bench_function("filter u8", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -475,36 +475,35 @@ impl MutableBuffer {
         let (_, upper) = iterator.size_hint();
         let upper = upper.expect("from_trusted_len_iter requires an upper limit");
 
-        let aligned_len = bit_util::ceil(upper, 64) * 8;
-        let mut result = MutableBuffer::new(aligned_len);
+        let mut result = {
+            let byte_capacity: usize = upper.saturating_add(7) / 8;
+            MutableBuffer::new(byte_capacity)
+        };
 
         'a: loop {
-            let mut accum: u64 = 0;
-            let mut mask: u64 = 1;
+            let mut byte_accum: u8 = 0;
+            let mut mask: u8 = 1;
 
-            //collect (up to) 64 bits into a u64
+            //collect (up to) 8 bits into a byte
             while mask != 0 {
                 if let Some(value) = iterator.next() {
-                    accum |= match value {
+                    byte_accum |= match value {
                         true => mask,
                         false => 0,
                     };
                     mask <<= 1;
                 } else {
                     if mask != 1 {
-                        // Add accumulator
-                        result.push_unchecked(accum);
+                        // Add last byte
+                        result.push_unchecked(byte_accum);
                     }
                     break 'a;
                 }
             }
 
             // Soundness: from_trusted_len
-            result.push_unchecked(accum);
+            result.push_unchecked(byte_accum);
         }
-
-        // Truncate to byte length - technically not necessary but cannot hurt
-        result.resize(bit_util::ceil(upper, 8), 0);
         result
     }
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -1393,14 +1393,15 @@ mod tests {
 
             // Construct a predicate
             let filter_offset = rng.gen_range(0..10);
+            let filter_truncate = rng.gen_range(0..10);
             let bools: Vec<_> = std::iter::from_fn(|| Some(rng.gen_bool(filter_percent)))
-                .take(array_len + filter_offset)
+                .take(array_len + filter_offset - filter_truncate)
                 .collect();
 
             let predicate = BooleanArray::from_iter(bools.iter().cloned().map(Some));
 
             // Offset predicate
-            let predicate = predicate.slice(filter_offset, array_len);
+            let predicate = predicate.slice(filter_offset, array_len - filter_truncate);
             let predicate = predicate.as_any().downcast_ref::<BooleanArray>().unwrap();
             let bools = &bools[filter_offset..];
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -65,7 +65,7 @@ macro_rules! downcast_dict_filter {
 /// slots of a [BooleanArray] are true. Each interval corresponds to a contiguous region of memory
 /// to be "taken" from an array to be filtered.
 ///
-/// This is only performant for the least selective filters that copy across long contiguous runs
+/// This is only performant for filters that copy across long contiguous runs
 #[derive(Debug)]
 pub struct SlicesIterator<'a> {
     iter: UnalignedBitChunkIterator<'a>,
@@ -157,8 +157,8 @@ impl<'a> Iterator for SlicesIterator<'a> {
 
 /// An iterator of `usize` whose index in [`BooleanArray`] is true
 ///
-/// This provides the best performance on all but the least selective predicates (which keep most
-/// / all rows), where the benefits of copying large runs instead favours [`SlicesIterator`]
+/// This provides the best performance on most predicates, apart from those which keep
+/// large runs and therefore favour [`SlicesIterator`]
 struct IndexIterator<'a> {
     current_chunk: u64,
     chunk_offset: i64,

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -186,6 +186,8 @@ fn filter_count(filter: &BooleanArray) -> usize {
 }
 
 /// Function that can filter arbitrary arrays
+///
+/// Deprecated: Use [`FilterPredicate`] instead
 #[deprecated]
 pub type Filter<'a> = Box<dyn Fn(&ArrayData) -> ArrayData + 'a>;
 
@@ -194,6 +196,8 @@ pub type Filter<'a> = Box<dyn Fn(&ArrayData) -> ArrayData + 'a>;
 /// same filter needs to be applied to multiple arrays (e.g. a multi-column `RecordBatch`).
 /// WARNING: the nulls of `filter` are ignored and the value on its slot is considered.
 /// Therefore, it is considered undefined behavior to pass `filter` with null values.
+///
+/// Deprecated: Use [`FilterBuilder`] instead
 #[deprecated]
 #[allow(deprecated)]
 pub fn build_filter(filter: &BooleanArray) -> Result<Filter> {
@@ -281,7 +285,7 @@ pub struct FilterBuilder {
 }
 
 impl FilterBuilder {
-    /// Create a new [`FilterBuilder`] that can be used construct [`FilterPredicate`]
+    /// Create a new [`FilterBuilder`] that can be used to construct a [`FilterPredicate`]
     pub fn new(filter: &BooleanArray) -> Self {
         let filter = match filter.null_count() {
             0 => BooleanArray::from(filter.data().clone()),
@@ -485,6 +489,9 @@ fn filter_array(values: &dyn Array, predicate: &FilterPredicate) -> Result<Array
     }
 }
 
+/// Computes a new null mask for `data` based on `predicate`
+///
+/// Returns `None` if no nulls in the result
 fn filter_null_mask(
     data: &ArrayData,
     predicate: &FilterPredicate,
@@ -503,6 +510,7 @@ fn filter_null_mask(
     Some((null_count, nulls))
 }
 
+/// Filter the packed bitmask `buffer`, with `predicate` starting at bit offset `offset`
 fn filter_bits(buffer: &Buffer, offset: usize, predicate: &FilterPredicate) -> Buffer {
     let src = buffer.as_slice();
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -62,10 +62,10 @@ macro_rules! downcast_dict_filter {
 }
 
 /// An iterator of `(usize, usize)` each representing an interval `[start,end[` whose
-/// slots of a [BooleanArray] are true. Each interval corresponds to a contiguous region of memory to be
-/// "taken" from an array to be filtered.
+/// slots of a [BooleanArray] are true. Each interval corresponds to a contiguous region of memory
+/// to be "taken" from an array to be filtered.
 ///
-/// This is most performant for highly selective filters with long contiguous runs
+/// This is only performant for the least selective filters that copy across long contiguous runs
 #[derive(Debug)]
 pub struct SlicesIterator<'a> {
     iter: UnalignedBitChunkIterator<'a>,

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -297,7 +297,12 @@ pub fn filter_record_batch(
     record_batch: &RecordBatch,
     predicate: &BooleanArray,
 ) -> Result<RecordBatch> {
-    let filter = FilterBuilder::new(predicate).optimize().build();
+    let mut filter_builder = FilterBuilder::new(predicate);
+    if record_batch.num_columns() > 1 {
+        // Only optimize if filtering more than one column
+        filter_builder = filter_builder.optimize();
+    }
+    let filter = filter_builder.build();
 
     let filtered_arrays = record_batch
         .columns()

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -252,7 +252,7 @@ pub fn prep_null_mask_filter(filter: &BooleanArray) -> BooleanArray {
 /// # }
 /// ```
 pub fn filter(values: &dyn Array, predicate: &BooleanArray) -> Result<ArrayRef> {
-    let predicate = FilterBuilder::new(&predicate).build();
+    let predicate = FilterBuilder::new(predicate).build();
     filter_array(values, &predicate)
 }
 
@@ -261,7 +261,7 @@ pub fn filter_record_batch(
     record_batch: &RecordBatch,
     predicate: &BooleanArray,
 ) -> Result<RecordBatch> {
-    let filter = FilterBuilder::new(&predicate).optimize().build();
+    let filter = FilterBuilder::new(predicate).optimize().build();
 
     let filtered_arrays = record_batch
         .columns()

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -111,6 +111,7 @@ pub fn create_string_array<Offset: StringOffsetSizeTrait>(
 }
 
 /// Creates an random (but fixed-seeded) array of a given size and null density
+/// consisting of random 4 character alphanumeric strings
 pub fn create_string_dict_array<K: ArrowDictionaryKeyType>(
     size: usize,
     null_density: f32,

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -110,6 +110,28 @@ pub fn create_string_array<Offset: StringOffsetSizeTrait>(
         .collect()
 }
 
+/// Creates an random (but fixed-seeded) array of a given size and null density
+pub fn create_string_dict_array<K: ArrowDictionaryKeyType>(
+    size: usize,
+    null_density: f32,
+) -> DictionaryArray<K> {
+    let rng = &mut seedable_rng();
+
+    let data: Vec<_> = (0..size)
+        .map(|_| {
+            if rng.gen::<f32>() < null_density {
+                None
+            } else {
+                let value = rng.sample_iter(&Alphanumeric).take(4).collect();
+                let value = String::from_utf8(value).unwrap();
+                Some(value)
+            }
+        })
+        .collect();
+
+    data.iter().map(|x| x.as_deref()).collect()
+}
+
 /// Creates an random (but fixed-seeded) binary array of a given size and null density
 pub fn create_binary_array<Offset: BinaryOffsetSizeTrait>(
     size: usize,


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1288

# Rationale for this change
 
Make filter kernels faster. This relates to the observation underlying #1225 and #1229, that the filter kernels are surprisingly slow for what they are doing. In many cases the filter kernels on master are slower than converting the filter to a list of indices and using `take`...

Currently this PR is ~10x faster than master, and I suspect this could be pushed further.

```
filter u8               time:   [47.525 us 47.538 us 47.554 us]                       
                        change: [-90.065% -90.056% -90.048%] (p = 0.00 < 0.05)
                        Performance has improved.

filter u8 high selectivity                                                                             
                        time:   [2.3351 us 2.3358 us 2.3365 us]
                        change: [-81.582% -81.570% -81.558%] (p = 0.00 < 0.05)
                        Performance has improved.

filter u8 low selectivity                                                                             
                        time:   [1.3204 us 1.3218 us 1.3233 us]
                        change: [-70.639% -70.572% -70.512%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# What changes are included in this PR?

This builds on #1228 and adds specialized filter implementations for primitive array types. I suspect specialized implementations for byte array types, and dictionaries would likely yield similarly significant benefits and I may include them in this PR or a follow up.

Aside from the  performance benefits, having specialized impls, much like we do for the `take` kernels will also allow us to take advantage of SIMD intrinsics either through manual implementation, or just helping the compiler's auto-vectorization. 

# Are there any user-facing changes?

No