### PR TITLE
Use new DecimalArray creation API in arrow crate

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1579,7 +1579,7 @@ mod tests {
 
     #[test]
     fn test_decimal_array_value_as_string() {
-        let arr = vec![123450, -123450, 100, -100, 10, -10, 0]
+        let arr = [123450, -123450, 100, -100, 10, -10, 0]
             .into_iter()
             .map(Some)
             .collect::<DecimalArray>()
@@ -1648,8 +1648,8 @@ mod tests {
 
     #[test]
     fn test_decimal_array_fmt_debug() {
-        let arr = vec![Some(8887000000), Some(-8887000000), None]
-            .into_iter()
+        let arr = [Some(8887000000), Some(-8887000000), None]
+            .iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(23, 6)
             .unwrap();

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1573,11 +1573,12 @@ mod tests {
 
     #[test]
     fn test_decimal_array_value_as_string() {
-        let mut decimal_builder = DecimalBuilder::new(7, 6, 3);
-        for value in [123450, -123450, 100, -100, 10, -10, 0] {
-            decimal_builder.append_value(value).unwrap();
-        }
-        let arr = decimal_builder.finish();
+        let arr = vec![123450, -123450, 100, -100, 10, -10, 0]
+            .into_iter()
+            .map(Some)
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(6, 3)
+            .unwrap();
 
         assert_eq!("123.450", arr.value_as_string(0));
         assert_eq!("-123.450", arr.value_as_string(1));
@@ -1641,14 +1642,12 @@ mod tests {
 
     #[test]
     fn test_decimal_array_fmt_debug() {
-        let values: Vec<i128> = vec![8887000000, -8887000000];
-        let mut decimal_builder = DecimalBuilder::new(3, 23, 6);
+        let arr = vec![Some(8887000000), Some(-8887000000), None]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(23, 6)
+            .unwrap();
 
-        values.iter().for_each(|&value| {
-            decimal_builder.append_value(value).unwrap();
-        });
-        decimal_builder.append_null().unwrap();
-        let arr = decimal_builder.finish();
         assert_eq!(
             "DecimalArray<23, 6>\n[\n  8887.000000,\n  -8887.000000,\n  null,\n]",
             format!("{:?}", arr)

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -943,6 +943,12 @@ impl From<ArrayData> for DecimalArray {
     }
 }
 
+impl From<DecimalArray> for ArrayData {
+    fn from(array: DecimalArray) -> Self {
+        array.data
+    }
+}
+
 /// an iterator that returns Some(i128) or None, that can be used on a
 /// DecimalArray
 #[derive(Debug)]

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -702,7 +702,7 @@ impl Array for FixedSizeBinaryArray {
 /// # Examples
 ///
 /// ```
-///    use arrow::array::{Array, DecimalArray, DecimalBuilder};
+///    use arrow::array::{Array, DecimalArray};
 ///    use arrow::datatypes::DataType;
 ///
 ///    // Create a DecimalArray with the default precision and scale

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -305,9 +305,9 @@ mod tests {
 
     use crate::array::{
         array::Array, ArrayData, ArrayDataBuilder, ArrayRef, BinaryOffsetSizeTrait,
-        BooleanArray, DecimalBuilder, FixedSizeBinaryBuilder, FixedSizeListBuilder,
-        GenericBinaryArray, Int32Builder, ListBuilder, NullArray, PrimitiveBuilder,
-        StringArray, StringDictionaryBuilder, StringOffsetSizeTrait, StructArray,
+        BooleanArray, FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray,
+        Int32Builder, ListBuilder, NullArray, PrimitiveBuilder, StringArray,
+        StringDictionaryBuilder, StringOffsetSizeTrait, StructArray,
     };
     use crate::array::{GenericStringArray, Int32Array};
     use crate::buffer::Buffer;
@@ -810,16 +810,11 @@ mod tests {
     }
 
     fn create_decimal_array(data: &[Option<i128>]) -> ArrayData {
-        let mut builder = DecimalBuilder::new(20, 23, 6);
-
-        for d in data {
-            if let Some(v) = d {
-                builder.append_value(*v).unwrap();
-            } else {
-                builder.append_null().unwrap();
-            }
-        }
-        builder.finish().data().clone()
+        data.into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(23, 6)
+            .unwrap()
+            .into()
     }
 
     #[test]

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -810,7 +810,7 @@ mod tests {
     }
 
     fn create_decimal_array(data: &[Option<i128>]) -> ArrayData {
-        data.into_iter()
+        data.iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(23, 6)
             .unwrap()

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -937,11 +937,11 @@ mod tests {
     #[test]
     fn test_decimal_json_equal() {
         // Test the equal case
-        let mut builder = DecimalBuilder::new(30, 23, 6);
-        builder.append_value(1_000).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(-250).unwrap();
-        let arrow_array: DecimalArray = builder.finish();
+        let arrow_array = [Some(1_000), None, Some(-250)]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(23, 6)
+            .unwrap();
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -956,10 +956,11 @@ mod tests {
         assert!(json_array.eq(&arrow_array));
 
         // Test unequal case
-        builder.append_value(1_000).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(55).unwrap();
-        let arrow_array: DecimalArray = builder.finish();
+        let arrow_array = [Some(1_000), None, Some(55)]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(23, 6)
+            .unwrap();
         let json_array: Value = serde_json::from_str(
             r#"
             [

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -938,7 +938,7 @@ mod tests {
     fn test_decimal_json_equal() {
         // Test the equal case
         let arrow_array = [Some(1_000), None, Some(-250)]
-            .into_iter()
+            .iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(23, 6)
             .unwrap();
@@ -957,7 +957,7 @@ mod tests {
 
         // Test unequal case
         let arrow_array = [Some(1_000), None, Some(55)]
-            .into_iter()
+            .iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(23, 6)
             .unwrap();

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -692,7 +692,7 @@ mod tests {
         scale: usize,
     ) -> DecimalArray {
         array
-            .into_iter()
+            .iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(precision, scale)
             .unwrap()

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -670,7 +670,7 @@ mod tests {
 
     use super::*;
 
-    use crate::array::{DecimalArray, DecimalBuilder};
+    use crate::array::DecimalArray;
     use crate::{
         array::{
             Array, ArrayData, ArrayRef, BooleanArray, DictionaryArray,
@@ -691,18 +691,11 @@ mod tests {
         precision: usize,
         scale: usize,
     ) -> DecimalArray {
-        let mut decimal_builder = DecimalBuilder::new(array.len(), precision, scale);
-        for value in array {
-            match value {
-                None => {
-                    decimal_builder.append_null().unwrap();
-                }
-                Some(v) => {
-                    decimal_builder.append_value(*v).unwrap();
-                }
-            }
-        }
-        decimal_builder.finish()
+        array
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(precision, scale)
+            .unwrap()
     }
 
     #[test]

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -2074,7 +2074,7 @@ mod tests {
         scale: usize,
     ) -> Result<DecimalArray> {
         array
-            .into_iter()
+            .iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(precision, scale)
     }

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -1107,16 +1107,10 @@ mod tests {
     use std::sync::Arc;
 
     fn create_decimal_array(data: &[Option<i128>]) -> DecimalArray {
-        let mut builder = DecimalBuilder::new(20, 23, 6);
-
-        for d in data {
-            if let Some(v) = d {
-                builder.append_value(*v).unwrap();
-            } else {
-                builder.append_null().unwrap();
-            }
-        }
-        builder.finish()
+        data.into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(23, 6)
+            .unwrap()
     }
 
     fn test_sort_to_indices_decimal_array(

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -1107,7 +1107,7 @@ mod tests {
     use std::sync::Arc;
 
     fn create_decimal_array(data: &[Option<i128>]) -> DecimalArray {
-        data.into_iter()
+        data.iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(23, 6)
             .unwrap()

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -760,8 +760,8 @@ mod tests {
     use super::*;
     use crate::array::{
         make_array, Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
-        DecimalBuilder, GenericBinaryArray, GenericListArray, GenericStringArray,
-        Int32Array, OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
+        GenericBinaryArray, GenericListArray, GenericStringArray, Int32Array,
+        OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
         TimestampMillisecondArray,
     };
     use crate::compute::kernels;
@@ -794,11 +794,11 @@ mod tests {
     #[test]
     fn test_decimal_round_trip() -> Result<()> {
         // create an array natively
-        let mut builder = DecimalBuilder::new(5, 6, 2);
-        builder.append_value(12345_i128).unwrap();
-        builder.append_value(-12345_i128).unwrap();
-        builder.append_null().unwrap();
-        let original_array = builder.finish();
+        let original_array = vec![Some(12345_i128), Some(-12345_i128), None]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(6, 2)
+            .unwrap();
 
         // export it
         let array = ArrowArray::try_from(original_array.data().clone())?;

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -794,7 +794,7 @@ mod tests {
     #[test]
     fn test_decimal_round_trip() -> Result<()> {
         // create an array natively
-        let original_array = vec![Some(12345_i128), Some(-12345_i128), None]
+        let original_array = [Some(12345_i128), Some(-12345_i128), None]
             .into_iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(6, 2)

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -520,7 +520,7 @@ mod tests {
         let precision = 10;
         let scale = 2;
 
-        let array = vec![Some(101), None, Some(200), Some(3040)]
+        let array = [Some(101), None, Some(200), Some(3040)]
             .into_iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(precision, scale)
@@ -560,7 +560,7 @@ mod tests {
         let precision = 5;
         let scale = 0;
 
-        let array = vec![Some(101), None, Some(200), Some(3040)]
+        let array = [Some(101), None, Some(200), Some(3040)]
             .into_iter()
             .collect::<DecimalArray>()
             .with_precision_and_scale(precision, scale)

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -119,7 +119,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::array::{DecimalBuilder, FixedSizeListBuilder, Int32Array};
+    use crate::array::{DecimalArray, FixedSizeListBuilder, Int32Array};
     use std::fmt::Write;
     use std::sync::Arc;
 
@@ -517,17 +517,16 @@ mod tests {
 
     #[test]
     fn test_decimal_display() -> Result<()> {
-        let capacity = 10;
         let precision = 10;
         let scale = 2;
 
-        let mut builder = DecimalBuilder::new(capacity, precision, scale);
-        builder.append_value(101).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(200).unwrap();
-        builder.append_value(3040).unwrap();
+        let array = vec![Some(101), None, Some(200), Some(3040)]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(precision, scale)
+            .unwrap();
 
-        let dm = Arc::new(builder.finish()) as ArrayRef;
+        let dm = Arc::new(array) as ArrayRef;
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "f",
@@ -558,17 +557,16 @@ mod tests {
 
     #[test]
     fn test_decimal_display_zero_scale() -> Result<()> {
-        let capacity = 10;
         let precision = 5;
         let scale = 0;
 
-        let mut builder = DecimalBuilder::new(capacity, precision, scale);
-        builder.append_value(101).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(200).unwrap();
-        builder.append_value(3040).unwrap();
+        let array = vec![Some(101), None, Some(200), Some(3040)]
+            .into_iter()
+            .collect::<DecimalArray>()
+            .with_precision_and_scale(precision, scale)
+            .unwrap();
 
-        let dm = Arc::new(builder.finish()) as ArrayRef;
+        let dm = Arc::new(array) as ArrayRef;
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "f",


### PR DESCRIPTION
~Builds on https://github.com/apache/arrow-rs/pull/1223 so draft until that is done~

Rationale:

https://github.com/apache/arrow-rs/pull/1223 introduces a more performant and idiomatic API for creating `DecimalArray`s than `DecimalBuilder` so update the code to use that.
