### PR TITLE
Revert "Pin WASM / packed SIMD tests to nightly-2022-01-17 (#1204)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,8 +131,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        # pin nightly until  https://github.com/rust-lang/packed_simd/pull/341 is resolved
-        rust: [nightly-2022-01-17]
+        rust: [nightly]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -346,8 +345,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        # pin nightly until  https://github.com/rust-lang/packed_simd/pull/341 is resolved
-        rust: [nightly-2022-01-17]
+        rust: [nightly]
     container:
       image: ${{ matrix.arch }}/rust
       env:


### PR DESCRIPTION
This reverts commit d68c4ae14077d60326eb57fe28133645f800d7e5.

# Which issue does this PR close?
Re https://github.com/apache/arrow-rs/issues/1198


# Rationale for this change
 
Upstream issue https://github.com/rust-lang/packed_simd/pull/341 seems to be resolved, so we can remove the pin and go back to using latest nightly for testing simd

# What changes are included in this PR?
Revert https://github.com/apache/arrow-rs/pull/1204

# Are there any user-facing changes?
No (CI only fix)