### PR TITLE
Update parquet crate documentation and examples

### DIFF
--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -15,16 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Provides API for reading/writing Arrow
+//! [RecordBatch](arrow::record_batch::RecordBatch)es and
+//! [Array](arrow::array::Arrays) to/from Parquet Files.
+//!
 //! [Apache Arrow](http://arrow.apache.org/) is a cross-language development platform for
 //! in-memory data.
-//!
-//! This mod provides API for converting between arrow and parquet.
 //!
 //!# Example of writing Arrow record batch to Parquet file
 //!
 //!```rust
-//! use arrow::array::Int32Array;
-//! use arrow::datatypes::{DataType, Field, Schema};
+//! use arrow::array::{Int32Array, ArrayRef};
 //! use arrow::record_batch::RecordBatch;
 //! use parquet::arrow::arrow_writer::ArrowWriter;
 //! use parquet::file::properties::WriterProperties;
@@ -32,25 +33,21 @@
 //! use std::sync::Arc;
 //! let ids = Int32Array::from(vec![1, 2, 3, 4]);
 //! let vals = Int32Array::from(vec![5, 6, 7, 8]);
-//! let schema = Arc::new(Schema::new(vec![
-//!     Field::new("id", DataType::Int32, false),
-//!     Field::new("val", DataType::Int32, false),
-//! ]));
+//! let batch = RecordBatch::try_from_iter(vec![
+//!   ("id", Arc::new(ids) as ArrayRef),
+//!   ("val", Arc::new(vals) as ArrayRef),
+//! ]).unwrap();
 //!
 //! let file = File::create("data.parquet").unwrap();
-//!
-//! let batch =
-//!     RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(ids), Arc::new(vals)]).unwrap();
-//! let batches = vec![batch];
 //!
 //! // Default writer properties
 //! let props = WriterProperties::builder().build();
 //!
-//! let mut writer = ArrowWriter::try_new(file, Arc::clone(&schema), Some(props)).unwrap();
+//! let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
 //!
-//! for batch in batches {
-//!     writer.write(&batch).expect("Writing batch");
-//! }
+//! writer.write(&batch).expect("Writing batch");
+//!
+//! // writer must be closed to write footer
 //! writer.close().unwrap();
 //! ```
 //!
@@ -134,6 +131,8 @@ experimental_mod!(schema);
 pub use self::arrow_reader::ArrowReader;
 pub use self::arrow_reader::ParquetFileArrowReader;
 pub use self::arrow_writer::ArrowWriter;
+#[cfg(feature = "async")]
+pub use self::async_reader::ParquetRecordBatchStreamBuilder;
 
 pub use self::schema::{
     arrow_to_parquet_schema, parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns,

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -15,6 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! This crate contains the official Native Rust implementation of
+//! [Apache Parquet](https://parquet.apache.org/), part of
+//! the [Apache Arrow](https://arrow.apache.org/) project.
+//!
+//! # Getting Started
+//! Start with some examples:
+//!
+//! 1. [mod@file] for reading and writing parquet files using the
+//! [ColumnReader](column::reader::ColumnReader) API.
+//!
+//! 2. [arrow] for reading and writing parquet files to Arrow
+//! `RecordBatch`es
+//!
+//! 3. [arrow::async_reader] for `async` reading and writing parquet
+//! files to Arrow `RecordBatch`es (requires the `async` feature).
 #![allow(incomplete_features)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
~Builds on https://github.com/apache/arrow-rs/pull/1154 so draft until that is merged~

# Which issue does this PR close?
Re https://github.com/apache/arrow-rs/issues/111

# Rationale for changes 

The docs.rs page is pretty sparse https://docs.rs/parquet/8.0.0/parquet/
![Screen Shot 2022-02-01 at 8 51 37 AM](https://user-images.githubusercontent.com/490673/151980725-578169b1-35ea-4cd4-9b43-4c900b2eda20.png)

And there are no doc examples for using the new async reader api defined in #111


# What changes are included in this PR?

1. Moved async parquet test to doc example
2. Cleaned up the landing page to make the examples more discoverable
3. Cleaned up sync arrow writer doc example:
![Screen Shot 2022-02-01 at 8 52 03 AM](https://user-images.githubusercontent.com/490673/151980840-db66fe92-281b-4190-bb19-9451ab78f334.png)

![Screen Shot 2022-02-01 at 8 52 19 AM](https://user-images.githubusercontent.com/490673/151980883-12caa55b-d3e2-4676-b57a-2ba415ff3dfa.png)


# Are there any user-facing changes?

Docs