### PR TITLE
Upgrade clap to 3.0.0

### DIFF
--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -34,7 +34,7 @@ logging = ["tracing-subscriber"]
 arrow = { path = "../arrow" }
 arrow-flight = { path = "../arrow-flight" }
 async-trait = "0.1.41"
-clap = "2.33"
+clap = { version = "3", features = ["derive", "env"] }
 futures = "0.3"
 hex = "0.4"
 prost = "0.9"

--- a/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -15,18 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
-use std::fs::File;
-use std::io::{self, BufReader};
-
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
+use clap::Parser;
+use std::fs::File;
+use std::io::{self, BufReader};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Read an arrow file and stream to stdout"), long_about = None)]
+struct Args {
+    file_name: String,
+}
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    let filename = &args[1];
-    let f = File::open(filename)?;
+    let args = Args::parse();
+    let f = File::open(&args.file_name)?;
     let reader = BufReader::new(f);
     let mut reader = FileReader::try_new(reader)?;
     let schema = reader.schema();

--- a/integration-testing/src/bin/flight-test-integration-client.rs
+++ b/integration-testing/src/bin/flight-test-integration-client.rs
@@ -16,44 +16,53 @@
 // under the License.
 
 use arrow_integration_testing::flight_client_scenarios;
-
-use clap::{App, Arg};
-
+use clap::Parser;
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T = (), E = Error> = std::result::Result<T, E>;
+
+#[derive(clap::ArgEnum, Debug, Clone)]
+enum Scenario {
+    Middleware,
+    #[clap(name = "auth:basic_proto")]
+    AuthBasicProto,
+}
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("rust flight-test-integration-client"), long_about = None)]
+struct Args {
+    #[clap(long, help = "host of flight server")]
+    host: String,
+    #[clap(long, help = "port of flight server")]
+    port: u16,
+    #[clap(
+        short,
+        long,
+        help = "path to the descriptor file, only used when scenario is not provided"
+    )]
+    path: Option<String>,
+    #[clap(long, arg_enum)]
+    scenario: Option<Scenario>,
+}
 
 #[tokio::main]
 async fn main() -> Result {
     #[cfg(feature = "logging")]
     tracing_subscriber::fmt::init();
 
-    let matches = App::new("rust flight-test-integration-client")
-        .arg(Arg::with_name("host").long("host").takes_value(true))
-        .arg(Arg::with_name("port").long("port").takes_value(true))
-        .arg(Arg::with_name("path").long("path").takes_value(true))
-        .arg(
-            Arg::with_name("scenario")
-                .long("scenario")
-                .takes_value(true),
-        )
-        .get_matches();
+    let args = Args::parse();
+    let host = args.host;
+    let port = args.port;
 
-    let host = matches.value_of("host").expect("Host is required");
-    let port = matches.value_of("port").expect("Port is required");
-
-    match matches.value_of("scenario") {
-        Some("middleware") => {
-            flight_client_scenarios::middleware::run_scenario(host, port).await?
+    match args.scenario {
+        Some(Scenario::Middleware) => {
+            flight_client_scenarios::middleware::run_scenario(&host, port).await?
         }
-        Some("auth:basic_proto") => {
-            flight_client_scenarios::auth_basic_proto::run_scenario(host, port).await?
+        Some(Scenario::AuthBasicProto) => {
+            flight_client_scenarios::auth_basic_proto::run_scenario(&host, port).await?
         }
-        Some(scenario_name) => unimplemented!("Scenario not found: {}", scenario_name),
         None => {
-            let path = matches
-                .value_of("path")
-                .expect("Path is required if scenario is not specified");
-            flight_client_scenarios::integration_test::run_scenario(host, port, path)
+            let path = args.path.expect("No path is given");
+            flight_client_scenarios::integration_test::run_scenario(&host, port, &path)
                 .await?;
         }
     }

--- a/integration-testing/src/flight_client_scenarios/auth_basic_proto.rs
+++ b/integration-testing/src/flight_client_scenarios/auth_basic_proto.rs
@@ -29,7 +29,7 @@ type Result<T = (), E = Error> = std::result::Result<T, E>;
 
 type Client = FlightServiceClient<tonic::transport::Channel>;
 
-pub async fn run_scenario(host: &str, port: &str) -> Result {
+pub async fn run_scenario(host: &str, port: u16) -> Result {
     let url = format!("http://{}:{}", host, port);
     let mut client = FlightServiceClient::connect(url).await?;
 

--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -38,7 +38,7 @@ type Result<T = (), E = Error> = std::result::Result<T, E>;
 
 type Client = FlightServiceClient<tonic::transport::Channel>;
 
-pub async fn run_scenario(host: &str, port: &str, path: &str) -> Result {
+pub async fn run_scenario(host: &str, port: u16, path: &str) -> Result {
     let url = format!("http://{}:{}", host, port);
 
     let client = FlightServiceClient::connect(url).await?;

--- a/integration-testing/src/flight_client_scenarios/middleware.rs
+++ b/integration-testing/src/flight_client_scenarios/middleware.rs
@@ -24,7 +24,7 @@ use tonic::{Request, Status};
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T = (), E = Error> = std::result::Result<T, E>;
 
-pub async fn run_scenario(host: &str, port: &str) -> Result {
+pub async fn run_scenario(host: &str, port: u16) -> Result {
     let url = format!("http://{}:{}", host, port);
     let conn = tonic::transport::Endpoint::new(url)?.connect().await?;
     let mut client = FlightServiceClient::with_interceptor(conn, middleware_interceptor);

--- a/integration-testing/src/flight_server_scenarios.rs
+++ b/integration-testing/src/flight_server_scenarios.rs
@@ -27,7 +27,7 @@ pub mod middleware;
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T = (), E = Error> = std::result::Result<T, E>;
 
-pub async fn listen_on(port: &str) -> Result<SocketAddr> {
+pub async fn listen_on(port: u16) -> Result<SocketAddr> {
     let addr: SocketAddr = format!("0.0.0.0:{}", port).parse()?;
 
     let listener = TcpListener::bind(addr).await?;

--- a/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -37,7 +37,7 @@ use prost::Message;
 
 use crate::{AUTH_PASSWORD, AUTH_USERNAME};
 
-pub async fn scenario_setup(port: &str) -> Result {
+pub async fn scenario_setup(port: u16) -> Result {
     let service = AuthBasicProtoScenarioImpl {
         username: AUTH_USERNAME.into(),
         password: AUTH_PASSWORD.into(),

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -43,7 +43,7 @@ type TonicStream<T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'static>>;
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T = (), E = Error> = std::result::Result<T, E>;
 
-pub async fn scenario_setup(port: &str) -> Result {
+pub async fn scenario_setup(port: u16) -> Result {
     let addr = super::listen_on(port).await?;
 
     let service = FlightServiceImpl {

--- a/integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/integration-testing/src/flight_server_scenarios/middleware.rs
@@ -31,7 +31,7 @@ type TonicStream<T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'static>>;
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 type Result<T = (), E = Error> = std::result::Result<T, E>;
 
-pub async fn scenario_setup(port: &str) -> Result {
+pub async fn scenario_setup(port: u16) -> Result {
     let service = MiddlewareScenarioImpl {};
     let svc = FlightServiceServer::new(service);
     let addr = super::listen_on(port).await?;

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -42,7 +42,7 @@ chrono = { version = "0.4", default-features = false }
 num-bigint = "0.4"
 arrow = { path = "../arrow", version = "8.0.0", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", optional = true }
-clap = { version = "2.33.3", optional = true }
+clap = { version = "3", optional = true, features = ["derive", "env"] }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 rand = "0.8"
 futures = { version = "0.3", optional = true }

--- a/parquet/src/bin/parquet-read.rs
+++ b/parquet/src/bin/parquet-read.rs
@@ -21,7 +21,7 @@
 //!
 //! `parquet-read` can be installed using `cargo`:
 //! ```
-//! cargo install parquet
+//! cargo install parquet --features=cli
 //! ```
 //! After this `parquet-read` should be globally available:
 //! ```
@@ -30,85 +30,55 @@
 //!
 //! The binary can also be built from the source code and run as follows:
 //! ```
-//! cargo run --bin parquet-read XYZ.parquet
+//! cargo run --features=cli --bin parquet-read XYZ.parquet
 //! ```
-//!
-//! # Usage
-//! ```
-//! parquet-read <file-path> [num-records]
-//! ```
-//!
-//! ## Flags
-//!     -h, --help       Prints help information
-//!     -j, --json       Print Parquet file in JSON lines Format
-//!     -V, --version    Prints version information
-//!
-//! ## Args
-//!     <file-path>      Path to a Parquet file
-//!     <num-records>    Number of records to read. When not provided, all records are read.
 //!
 //! Note that `parquet-read` reads full file schema, no projection or filtering is
 //! applied.
 
 extern crate parquet;
 
-use std::{env, fs::File, path::Path};
-
-use clap::{crate_authors, crate_version, App, Arg};
-
+use clap::Parser;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::record::Row;
+use std::{fs::File, path::Path};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Binary file to read data from a Parquet file"), long_about = None)]
+struct Args {
+    #[clap(short, long, help("Path to a parquet file"))]
+    file_name: String,
+    #[clap(
+        short,
+        long,
+        default_value_t = 0_usize,
+        help("Number of records to read. When not provided or 0, all records are read")
+    )]
+    num_records: usize,
+    #[clap(short, long, help("Print Parquet file in JSON lines format"))]
+    json: bool,
+}
 
 fn main() {
-    let app = App::new("parquet-read")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Read data from a Parquet file and print output in console, in either built-in or JSON format")
-        .arg(
-            Arg::with_name("file_path")
-                .value_name("file-path")
-                .required(true)
-                .index(1)
-                .help("Path to a parquet file"),
-        )
-        .arg(
-            Arg::with_name("num_records")
-                .value_name("num-records")
-                .index(2)
-                .help(
-                    "Number of records to read. When not provided, all records are read.",
-                ),
-        )
-        .arg(
-            Arg::with_name("json")
-                .short("j")
-                .long("json")
-                .takes_value(false)
-                .help("Print Parquet file in JSON lines format"),
-        );
+    let args = Args::parse();
 
-    let matches = app.get_matches();
-    let filename = matches.value_of("file_path").unwrap();
-    let num_records: Option<usize> = if matches.is_present("num_records") {
-        match matches.value_of("num_records").unwrap().parse() {
-            Ok(value) => Some(value),
-            Err(e) => panic!("Error when reading value for [num-records], {}", e),
-        }
-    } else {
-        None
-    };
+    let filename = args.file_name;
+    let num_records = args.num_records;
+    let json = args.json;
 
-    let json = matches.is_present("json");
     let path = Path::new(&filename);
-    let file = File::open(&path).unwrap();
-    let parquet_reader = SerializedFileReader::new(file).unwrap();
+    let file = File::open(&path).expect("Unable to open file");
+    let parquet_reader =
+        SerializedFileReader::new(file).expect("Failed to create reader");
 
     // Use full schema as projected schema
-    let mut iter = parquet_reader.get_row_iter(None).unwrap();
+    let mut iter = parquet_reader
+        .get_row_iter(None)
+        .expect("Failed to create row iterator");
 
     let mut start = 0;
-    let end = num_records.unwrap_or(0);
-    let all_records = num_records.is_none();
+    let end = num_records;
+    let all_records = end == 0;
 
     while all_records || start < end {
         match iter.next() {

--- a/parquet/src/bin/parquet-rowcount.rs
+++ b/parquet/src/bin/parquet-rowcount.rs
@@ -21,7 +21,7 @@
 //!
 //! `parquet-rowcount` can be installed using `cargo`:
 //! ```
-//! cargo install parquet
+//! cargo install parquet --features=cli
 //! ```
 //! After this `parquet-rowcount` should be globally available:
 //! ```
@@ -30,51 +30,37 @@
 //!
 //! The binary can also be built from the source code and run as follows:
 //! ```
-//! cargo run --bin parquet-rowcount XYZ.parquet ABC.parquet ZXC.parquet
+//! cargo run --features=cli --bin parquet-rowcount XYZ.parquet ABC.parquet ZXC.parquet
 //! ```
-//!
-//! # Usage
-//! ```
-//! parquet-rowcount <file-paths>...
-//! ```
-//!
-//! ## Flags
-//!     -h, --help       Prints help information
-//!     -V, --version    Prints version information
-//!
-//! ## Args
-//!     <file-paths>...    List of Parquet files to read from
 //!
 //! Note that `parquet-rowcount` reads full file schema, no projection or filtering is
 //! applied.
 
 extern crate parquet;
-
-use std::{env, fs::File, path::Path};
-
-use clap::{crate_authors, crate_version, App, Arg};
-
+use clap::Parser;
 use parquet::file::reader::{FileReader, SerializedFileReader};
+use std::{fs::File, path::Path};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Binary file to return the number of rows found from Parquet file(s)"), long_about = None)]
+struct Args {
+    #[clap(
+        short,
+        long,
+        multiple_values(true),
+        help("List of Parquet files to read from separated by space")
+    )]
+    file_paths: Vec<String>,
+}
 
 fn main() {
-    let matches = App::new("parquet-rowcount")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Return number of rows in Parquet file")
-        .arg(
-            Arg::with_name("file_paths")
-                .value_name("file-paths")
-                .required(true)
-                .multiple(true)
-                .help("List of Parquet files to read from separated by space"),
-        )
-        .get_matches();
+    let args = Args::parse();
 
-    let filenames: Vec<&str> = matches.values_of("file_paths").unwrap().collect();
-    for filename in &filenames {
-        let path = Path::new(filename);
-        let file = File::open(path).unwrap();
-        let parquet_reader = SerializedFileReader::new(file).unwrap();
+    for filename in args.file_paths {
+        let path = Path::new(&filename);
+        let file = File::open(path).expect("Unable to open file");
+        let parquet_reader =
+            SerializedFileReader::new(file).expect("Unable to read file");
         let row_group_metadata = parquet_reader.metadata().row_groups();
         let mut total_num_rows = 0;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1260 

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

### `parquet-read`

```
❯ cargo run --features=cli -q --bin parquet-read -- -h
parquet 8.0.0
Apache Arrow <dev@arrow.apache.org>
Binary file to read data from a Parquet file

USAGE:
    parquet-read [OPTIONS] --file-name <FILE_NAME>

OPTIONS:
    -f, --file-name <FILE_NAME>        Path to a parquet file
    -h, --help                         Print help information
    -j, --json                         Print Parquet file in JSON lines format
    -n, --num-records <NUM_RECORDS>    Number of records to read. When not provided or 0, all
                                       records are read [default: 0]
    -V, --version                      Print version information
```

### `parquet-rowcount`

```
❯ cargo run --features=cli -q --bin parquet-rowcount -- -h
parquet 8.0.0
Apache Arrow <dev@arrow.apache.org>
Binary file to return the number of rows found from Parquet file(s)

USAGE:
    parquet-rowcount [OPTIONS]

OPTIONS:
    -f, --file-paths <FILE_PATHS>...    List of Parquet files to read from separated by space
    -h, --help                          Print help information
    -V, --version                       Print version information
```

### `parquet-schema`

```
❯ cargo run --features=cli -q --bin parquet-schema -- -h
parquet 8.0.0
Apache Arrow <dev@arrow.apache.org>
Binary file to print the schema and metadata of a Parquet file

USAGE:
    parquet-schema [OPTIONS] --file-path <FILE_PATH>

OPTIONS:
    -f, --file-path <FILE_PATH>
    -h, --help                     Print help information
    -v, --verbose                  Enable printing full file metadata
    -V, --version                  Print version information
```

### `arrow-file-to-stream`

```
❯ cargo run --features=cli -q --bin arrow-file-to-stream -- -h
arrow-integration-testing 8.0.0
Apache Arrow <dev@arrow.apache.org>
Read an arrow file and stream to stdout

USAGE:
    arrow-file-to-stream --file-name <FILE_NAME>

OPTIONS:
    -f, --file-name <FILE_NAME>
    -h, --help                     Print help information
    -V, --version                  Print version information
```

### `arrow-json-integration-test`

```
❯ cargo run --features=cli -q --bin arrow-json-integration-test -- -h
arrow-integration-testing 8.0.0
Apache Arrow <dev@arrow.apache.org>
rust arrow-json-integration-test

USAGE:
    arrow-json-integration-test [OPTIONS] --integration <INTEGRATION> --arrow <ARROW> --json <JSON>

OPTIONS:
    -a, --arrow <ARROW>                path to ARROW file
    -h, --help                         Print help information
    -i, --integration <INTEGRATION>    integration
    -j, --json <JSON>                  path to JSON file
    -m, --mode <MODE>                  mode of integration testing tool [default: validate]
                                       [possible values: arrow-to-json, json-to-arrow, validate]
    -v, --verbose
    -V, --version                      Print version information
```

### `flight-test-integration-client`

```
❯ cargo run --features=cli -q --bin flight-test-integration-client -- -h
arrow-integration-testing 8.0.0
Apache Arrow <dev@arrow.apache.org>
rust flight-test-integration-client

USAGE:
    flight-test-integration-client [OPTIONS] --host <HOST> --port <PORT> --path <PATH>

OPTIONS:
    -h, --help                   Print help information
        --host <HOST>
        --path <PATH>
        --port <PORT>
        --scenario <SCENARIO>    [default: customized] [possible values: middleware, auth-basic-
                                 proto, customized]
    -V, --version                Print version information
```

### `flight-test-integration-server`

```
❯ cargo run --features=cli -q --bin flight-test-integration-server -- -h
arrow-integration-testing 8.0.0
Apache Arrow <dev@arrow.apache.org>
rust flight-test-integration-server

USAGE:
    flight-test-integration-server [OPTIONS] --port <PORT>

OPTIONS:
    -h, --help                   Print help information
        --port <PORT>
        --scenario <SCENARIO>    [default: customized] [possible values: middleware, auth-basic-
                                 proto, customized]
    -V, --version                Print version information
```