### PR TITLE
Remove unsupported flag in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -16,7 +16,6 @@
 # under the License.
 
 edition = "2021"
-rust-version = "1.57"
 max_width = 90
 
 # ignore generated files


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/1240

# Rationale for this change
This item is not supported resulting in `Warning: Unknown configuration option 'rust-version'` when `cargo fmt` us run 
 

# What changes are included in this PR?
Remove unsupported key as suggested by @HaoYang670 https://github.com/apache/arrow-rs/issues/1240#issuecomment-1022770513

# Are there any user-facing changes?
No

cc @HaoYang670 
