### PR TITLE
Run rustdoc in CI and error if warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,9 @@ jobs:
         # "1" means line tables only, which is useful for panic tracebacks.
         RUSTFLAGS: "-C debuginfo=1"
     steps:
+      - name: Install python dev
+        run: |
+          sudo apt install libpython3.9-dev
       - uses: actions/checkout@v2
       - name: Cache Cargo
         uses: actions/cache@v2
@@ -59,6 +62,7 @@ jobs:
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
+
       - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -413,7 +413,8 @@ jobs:
           submodules: true
       - name: Install python dev
         run: |
-          apt install libpython3.9-dev
+          apt update
+          apt install -y libpython3.9-dev
       - name: Cache Cargo
         uses: actions/cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,9 +39,6 @@ jobs:
         # "1" means line tables only, which is useful for panic tracebacks.
         RUSTFLAGS: "-C debuginfo=1"
     steps:
-      - name: Install python dev
-        run: |
-          sudo apt install libpython3.9-dev
       - uses: actions/checkout@v2
       - name: Cache Cargo
         uses: actions/cache@v2
@@ -414,6 +411,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install python dev
+        run: |
+          apt install libpython3.9-dev
       - name: Cache Cargo
         uses: actions/cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -424,6 +424,7 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
       - name: Run cargo doc
         run: |
           export CARGO_HOME="/github/home/.cargo"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -252,7 +252,7 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           export RUSTDOCFLAGS="-Dwarnings"
-          cargo doc --document-private-items --no-deps --workspace
+          cargo doc --document-private-items --no-deps --workspace --all-features
 
   check_benches:
     name: Check Benchmarks (but don't run them)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -208,7 +208,7 @@ jobs:
           cargo test
 
   clippy:
-    name: Clippy + Docs
+    name: Clippy
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
     strategy:
@@ -247,12 +247,6 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cargo clippy --features test_common --features prettyprint  --features=async --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
-      - name: Run cargo doc
-        run: |
-          export CARGO_HOME="/github/home/.cargo"
-          export CARGO_TARGET_DIR="/github/home/target"
-          export RUSTDOCFLAGS="-Dwarnings"
-          cargo doc --document-private-items --no-deps --workspace --all-features
 
   check_benches:
     name: Check Benchmarks (but don't run them)
@@ -295,7 +289,7 @@ jobs:
           cargo check --benches --workspace
 
   lint:
-    name: cargo fmt
+    name: Lint (cargo fmt)
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -397,6 +391,46 @@ jobs:
           cd arrow
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-unknown-unknown
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-wasi
+
+  # test doc links still work
+  docs:
+    name: Docs are clean on AMD64 Rust ${{ matrix.rust }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [nightly]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          key: cargo-nightly-cache3-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-nightly-cache3-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+      - name: Run cargo doc
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          export RUSTDOCFLAGS="-Dwarnings"
+          cargo doc --document-private-items --no-deps --workspace --all-features
+
 
   # test builds with various feature flag combinations outside the main workspace
   default-build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,10 +107,10 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          
+
           # run tests on all workspace members with default feature list
           cargo test
-          
+
           # Switch to arrow crate
           cd arrow
           # re-run tests on arrow crate with additional features
@@ -122,13 +122,13 @@ jobs:
           cargo run --example read_csv
           cargo run --example read_csv_infer_schema
           cargo check --no-default-features
-          
+
           # Switch to parquet crate
           cd ../parquet
           # re-run tests on parquet crate with async feature enabled
           cargo test --features=async
           cargo check --no-default-features
-          
+
           # Switch to arrow-flight
           cd ../arrow-flight
           cargo check --no-default-features
@@ -208,7 +208,7 @@ jobs:
           cargo test
 
   clippy:
-    name: Clippy
+    name: Clippy + Docs
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
     strategy:
@@ -247,6 +247,12 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cargo clippy --features test_common --features prettyprint  --features=async --all-targets --workspace -- -D warnings -A clippy::redundant_field_names
+      - name: Run cargo doc
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          export RUSTDOCFLAGS="-Dwarnings"
+          cargo doc --document-private-items --no-deps --workspace
 
   check_benches:
     name: Check Benchmarks (but don't run them)
@@ -289,7 +295,7 @@ jobs:
           cargo check --benches --workspace
 
   lint:
-    name: Lint
+    name: cargo fmt
     runs-on: ubuntu-latest
     container:
       image: amd64/rust


### PR DESCRIPTION
# Which issue does this PR close?
Re https://github.com/apache/arrow-rs/issues/1267
closes https://github.com/apache/arrow-rs/issues/232

# Rationale for this change
 
Once we have doc links fixed, ensure they don't get broken again by checking in CI

# What changes are included in this PR?
Update the clippy check to also run `cargo doc` and fail on any warnings

# Are there any user-facing changes?
No