### PR TITLE
Fix warnings in `cargo doc`

### DIFF
--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -343,7 +343,8 @@ pub type LargeListArray = GenericListArray<i64>;
 /// A list array where each element is a fixed-size sequence of values with the same
 /// type whose maximum length is represented by a i32.
 ///
-/// For non generic lists, you may wish to consider using [`FixedSizeBinaryArray`]
+/// For non generic lists, you may wish to consider using
+/// [crate::array::FixedSizeBinaryArray]
 pub struct FixedSizeListArray {
     data: ArrayData,
     values: ArrayRef,

--- a/arrow/src/array/array_map.rs
+++ b/arrow/src/array/array_map.rs
@@ -29,8 +29,8 @@ use crate::error::ArrowError;
 /// A nested array type where each record is a key-value map.
 /// Keys should always be non-null, but values can be null.
 ///
-/// [MapArray] is physically a [ListArray] that has a [StructArray]
-/// with 2 child fields.
+/// [MapArray] is physically a [crate::array::ListArray] that has a
+/// [crate::array::StructArray] with 2 child fields.
 pub struct MapArray {
     data: ArrayData,
     values: ArrayRef,

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -27,13 +27,17 @@ use std::any::Any;
 
 /// An Array that can represent slots of varying types.
 ///
-/// Each slot in a `UnionArray` can have a value chosen from a number of types.  Each of the
-/// possible types are named like the fields of a [`StructArray`](crate::array::StructArray).
-/// A `UnionArray` can have two possible memory layouts, "dense" or "sparse".  For more information
-/// on please see the [specification](https://arrow.apache.org/docs/format/Columnar.html#union-layout).
+/// Each slot in a [UnionArray] can have a value chosen from a number
+/// of types.  Each of the possible types are named like the fields of
+/// a [`StructArray`](crate::array::StructArray).  A `UnionArray` can
+/// have two possible memory layouts, "dense" or "sparse".  For more
+/// information on please see the
+/// [specification](https://arrow.apache.org/docs/format/Columnar.html#union-layout).
 ///
-/// [`UnionBuilder`]can be used to create  `UnionArray`'s of primitive types.  `UnionArray`'s of nested
-/// types are also supported but not via `UnionBuilder`, see the tests for examples.
+/// [UnionBuilder](crate::array::UnionBuilder) can be used to
+/// create [UnionArray]'s of primitive types. `UnionArray`'s of nested
+/// types are also supported but not via `UnionBuilder`, see the tests
+/// for examples.
 ///
 /// # Examples
 /// ## Create a dense UnionArray `[1, 3.2, 34]`

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -588,7 +588,7 @@ impl ArrayData {
     /// contents of the buffers (e.g. that all offsets for UTF8 arrays
     /// are within the bounds of the values buffer).
     ///
-    /// See [`validate_full`] to validate fully the offset content
+    /// See [ArrayData::validate_full] to validate fully the offset content
     /// and the validitiy of utf8 data
     pub fn validate(&self) -> Result<()> {
         // Need at least this mich space in each buffer
@@ -918,7 +918,7 @@ impl ArrayData {
     /// 3. All dictionary offsets are valid
     ///
     /// Does not (yet) check
-    /// 1. Union type_ids are valid (see https://github.com/apache/arrow-rs/issues/85)
+    /// 1. Union type_ids are valid see [#85](https://github.com/apache/arrow-rs/issues/85)
     /// Note calls `validate()` internally
     pub fn validate_full(&self) -> Result<()> {
         // Check all buffer sizes prior to looking at them more deeply in this function
@@ -1075,8 +1075,8 @@ impl ArrayData {
             })
     }
 
-    /// Ensures that all strings formed by the offsets in buffers[0]
-    /// into buffers[1] are valid utf8 sequences
+    /// Ensures that all strings formed by the offsets in `buffers[0]`
+    /// into `buffers[1]` are valid utf8 sequences
     fn validate_utf8<T>(&self) -> Result<()>
     where
         T: ArrowNativeType + std::convert::TryInto<usize> + num::Num + std::fmt::Display,
@@ -1099,7 +1099,7 @@ impl ArrayData {
         )
     }
 
-    /// Ensures that all offsets in buffers[0] into buffers[1] are
+    /// Ensures that all offsets in `buffers[0]` into `buffers[1]` are
     /// between `0` and `offset_limit`
     fn validate_offsets_full<T>(&self, offset_limit: usize) -> Result<()>
     where

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -325,8 +325,8 @@ pub type UInt32DictionaryArray = DictionaryArray<UInt32Type>;
 /// ```
 pub type UInt64DictionaryArray = DictionaryArray<UInt64Type>;
 ///
-/// A primitive array where each element is of type `TimestampSecondType.`
-/// See also [`Timestamp.`](crate::datatypes::Timestamp)
+/// A primitive array where each element is of type [TimestampSecondType].
+/// See also [`Timestamp`](crate::datatypes::DataType::Timestamp).
 ///
 /// # Example: UTC timestamps post epoch
 /// ```

--- a/arrow/src/array/raw_pointer.rs
+++ b/arrow/src/array/raw_pointer.rs
@@ -17,8 +17,10 @@
 
 use std::ptr::NonNull;
 
-/// This struct is highly `unsafe` and offers the possibility to self-reference a [arrow::Buffer] from [arrow::array::ArrayData].
-/// as a pointer to the beginning of its contents.
+/// This struct is highly `unsafe` and offers the possibility to
+/// self-reference a [crate::buffer::Buffer] from
+/// [crate::array::ArrayData], as a pointer to the beginning of its
+/// contents.
 pub(super) struct RawPtrBox<T> {
     ptr: NonNull<T>,
 }

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -384,8 +384,8 @@ impl<'a> MutableArrayData<'a> {
         Self::with_capacities(arrays, use_nulls, Capacities::Array(capacity))
     }
 
-    /// Similar to [MutableArray::new], but lets users define the preallocated capacities of the array.
-    /// See also [MutableArray::new] for more information on the arguments.
+    /// Similar to [MutableArrayData::new], but lets users define the preallocated capacities of the array.
+    /// See also [MutableArrayData::new] for more information on the arguments.
     ///
     /// # Panic
     /// This function panics if the given `capacities` don't match the data type of `arrays`. Or when

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -51,8 +51,8 @@ impl Debug for Deallocation {
 /// This structs' API is inspired by the `bytes::Bytes`, but it is not limited to using rust's
 /// global allocator nor u8 alignment.
 ///
-/// In the most common case, this buffer is allocated using [`allocate_aligned`](memory::allocate_aligned)
-/// and deallocated accordingly [`free_aligned`](memory::free_aligned).
+/// In the most common case, this buffer is allocated using [`allocate_aligned`](crate::alloc::allocate_aligned)
+/// and deallocated accordingly [`free_aligned`](crate::alloc::free_aligned).
 /// When the region is allocated by an foreign allocator, [Deallocation::Foreign], this calls the
 /// foreign deallocator to deallocate the region when it is no longer needed.
 pub struct Bytes {

--- a/arrow/src/compute/kernels/partition.rs
+++ b/arrow/src/compute/kernels/partition.rs
@@ -113,7 +113,7 @@ fn exponential_search_next_partition_point(
 ///
 /// The values corresponding to those indices are assumed to be partitioned according to the given predicate.
 ///
-/// See [`std::slice::partition_point`]
+/// See [`slice::partition_point`]
 #[inline]
 fn partition_point<P: Fn(usize) -> bool>(start: usize, end: usize, pred: P) -> usize {
     let mut left = start;

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -426,8 +426,9 @@ impl Default for SortOptions {
 /// when a limit is present, the sort is pair-comparison based as k-select might be more efficient,
 /// when the limit is absent, binary partition is used to speed up (which is linear).
 ///
-/// TODO maybe partition_validity call can be eliminated in this case and tri-color sort can be used
-/// instead. https://en.wikipedia.org/wiki/Dutch_national_flag_problem
+/// TODO maybe partition_validity call can be eliminated in this case
+/// and [tri-color sort](https://en.wikipedia.org/wiki/Dutch_national_flag_problem)
+/// can be used instead.
 fn sort_boolean(
     values: &ArrayRef,
     value_indices: Vec<u32>,
@@ -848,7 +849,7 @@ where
     }
 }
 
-/// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).
+/// Compare two `Array`s based on the ordering defined in [build_compare]
 fn cmp_array(a: &dyn Array, b: &dyn Array) -> Ordering {
     let cmp_op = build_compare(a, b).unwrap();
     let length = a.len().max(b.len());

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -312,8 +312,7 @@ pub struct Reader<R: Read> {
     batch_records: Vec<StringRecord>,
     /// datetime format used to parse datetime values, (format understood by chrono)
     ///
-    /// For format refer to chrono docs:
-    /// https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html
+    /// For format refer to [chrono docs](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html)
     datetime_format: Option<String>,
 }
 
@@ -522,7 +521,8 @@ impl<R: Read> Iterator for Reader<R> {
     }
 }
 
-/// parses a slice of [csv_crate::StringRecord] into a [array::record_batch::RecordBatch].
+/// parses a slice of [csv_crate::StringRecord] into a
+/// [RecordBatch](crate::record_batch::RecordBatch).
 fn parse(
     rows: &[StringRecord],
     fields: &[Field],
@@ -1141,8 +1141,7 @@ impl ReaderBuilder {
     /// Set the datetime fromat used to parse the string to Date64Type
     /// this fromat is used while when the schema wants to parse Date64Type.
     ///
-    /// For format refer to chrono docs:
-    /// https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html
+    /// For format refer to [chrono docs](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html)
     ///
     pub fn with_datetime_format(mut self, datetime_format: String) -> Self {
         self.datetime_format = Some(datetime_format);

--- a/arrow/src/datatypes/ffi.rs
+++ b/arrow/src/datatypes/ffi.rs
@@ -26,7 +26,7 @@ use crate::{
 impl TryFrom<&FFI_ArrowSchema> for DataType {
     type Error = ArrowError;
 
-    /// See https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
+    /// See [CDataInterface docs](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings)
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self> {
         let dtype = match c_schema.format() {
             "n" => DataType::Null,
@@ -167,7 +167,7 @@ impl TryFrom<&FFI_ArrowSchema> for Schema {
 impl TryFrom<&DataType> for FFI_ArrowSchema {
     type Error = ArrowError;
 
-    /// See https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
+    /// See [CDataInterface docs](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings)
     fn try_from(dtype: &DataType) -> Result<Self> {
         let format = match dtype {
             DataType::Null => "n".to_string(),

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -148,7 +148,8 @@ unsafe extern "C" fn release_schema(schema: *mut FFI_ArrowSchema) {
 }
 
 impl FFI_ArrowSchema {
-    /// create a new [`Ffi_ArrowSchema`]. This fails if the fields' [`DataType`] is not supported.
+    /// create a new [`FFI_ArrowSchema`]. This fails if the fields'
+    /// [`DataType`] is not supported.
     pub fn try_new(format: &str, children: Vec<FFI_ArrowSchema>) -> Result<Self> {
         let mut this = Self::empty();
 
@@ -622,6 +623,7 @@ pub trait ArrowArrayRef {
     fn data_type(&self) -> Result<DataType>;
 }
 
+#[allow(rustdoc::private_intra_doc_links)]
 /// Struct used to move an Array from and to the C Data Interface.
 /// Its main responsibility is to expose functionality that requires
 /// both [FFI_ArrowArray] and [FFI_ArrowSchema].

--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -123,7 +123,7 @@ impl LevelInfo {
     /// The parent struct's nullness is tracked, as it determines whether the child
     /// max_definition should be incremented.
     /// The 'is_parent_struct' variable asks "is this field's parent a struct?".
-    /// * If we are starting at a [RecordBatch], this is `false`.
+    /// * If we are starting at a [RecordBatch](arrow::record_batch::RecordBatch), this is `false`.
     /// * If we are calculating a list's child, this is `false`.
     /// * If we are calculating a struct (i.e. `field.data_type90 == Struct`),
     /// this depends on whether the struct is a child of a struct.

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -17,7 +17,7 @@
 
 //! Provides API for reading/writing Arrow
 //! [RecordBatch](arrow::record_batch::RecordBatch)es and
-//! [Array](arrow::array::Arrays) to/from Parquet Files.
+//! [Array](arrow::array::Array)s to/from Parquet Files.
 //!
 //! [Apache Arrow](http://arrow.apache.org/) is a cross-language development platform for
 //! in-memory data.

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -58,7 +58,7 @@ pub trait BufferQueue: Sized {
     /// This distinction is to allow for implementations that return a default initialized
     /// [BufferQueue::Slice`] which doesn't track capacity and length separately
     ///
-    /// For example, [`TypedBuffer<T>`] returns a default-initialized `&mut [T]`, and does not
+    /// For example, [`BufferQueue`] returns a default-initialized `&mut [T]`, and does not
     /// track how much of this slice is actually written to by the caller. This is still
     /// safe as the slice is default-initialized.
     ///

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -97,7 +97,7 @@ pub fn parse_metadata<R: ChunkReader>(chunk_reader: &R) -> Result<ParquetMetaDat
     }
 }
 
-/// Reads [`FileMetadata`] from the provided [`Read`] starting at the readers current position
+/// Reads [`ParquetMetaData`] from the provided [`Read`] starting at the readers current position
 pub(crate) fn parse_metadata_buffer<T: Read + ?Sized>(
     metadata_read: &mut T,
 ) -> Result<ParquetMetaData> {


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-rs/issues/1267

# Rationale for this change
 
Non broken links are nice!

See https://github.com/apache/arrow-rs/pull/1266 for CI check

# What changes are included in this PR?

Run
```
 cargo doc --document-private-items --no-deps --workspace --
```

Until it is clean

# Are there any user-facing changes?

Doc links work better