### PR TITLE
Skip zero-ing primitive nulls

### DIFF
--- a/parquet/src/arrow/record_reader.rs
+++ b/parquet/src/arrow/record_reader.rs
@@ -355,8 +355,9 @@ where
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{BooleanBufferBuilder, Int16BufferBuilder, Int32BufferBuilder};
+    use arrow::array::{Int16BufferBuilder, Int32BufferBuilder};
     use arrow::bitmap::Bitmap;
+    use arrow::buffer::Buffer;
 
     use crate::basic::Encoding;
     use crate::column::page::Page;
@@ -547,15 +548,6 @@ mod tests {
             assert_eq!(7, record_reader.num_values());
         }
 
-        // Verify result record data
-        let mut bb = Int32BufferBuilder::new(7);
-        bb.append_slice(&[0, 7, 0, 6, 3, 0, 8]);
-        let expected_buffer = bb.finish();
-        assert_eq!(
-            expected_buffer,
-            record_reader.consume_record_data().unwrap()
-        );
-
         // Verify result def levels
         let mut bb = Int16BufferBuilder::new(7);
         bb.append_slice(&[1i16, 2i16, 0i16, 2i16, 2i16, 0i16, 2i16]);
@@ -566,13 +558,28 @@ mod tests {
         );
 
         // Verify bitmap
-        let mut bb = BooleanBufferBuilder::new(7);
-        bb.append_slice(&[false, true, false, true, true, false, true]);
-        let expected_bitmap = Bitmap::from(bb.finish());
+        let expected_valid = &[false, true, false, true, true, false, true];
+        let expected_buffer = Buffer::from_iter(expected_valid.iter().cloned());
+        let expected_bitmap = Bitmap::from(expected_buffer);
         assert_eq!(
             Some(expected_bitmap),
             record_reader.consume_bitmap().unwrap()
         );
+
+        // Verify result record data
+        let actual = record_reader.consume_record_data().unwrap();
+        let actual_values = unsafe { actual.typed_data::<i32>() };
+
+        let expected = &[0, 7, 0, 6, 3, 0, 8];
+        assert_eq!(actual_values.len(), expected.len());
+
+        // Only validate valid values are equal
+        let iter = expected_valid.iter().zip(actual_values).zip(expected);
+        for ((valid, actual), expected) in iter {
+            if *valid {
+                assert_eq!(actual, expected)
+            }
+        }
     }
 
     #[test]
@@ -655,15 +662,6 @@ mod tests {
             assert_eq!(9, record_reader.num_values());
         }
 
-        // Verify result record data
-        let mut bb = Int32BufferBuilder::new(9);
-        bb.append_slice(&[4, 0, 0, 7, 6, 3, 2, 8, 9]);
-        let expected_buffer = bb.finish();
-        assert_eq!(
-            expected_buffer,
-            record_reader.consume_record_data().unwrap()
-        );
-
         // Verify result def levels
         let mut bb = Int16BufferBuilder::new(9);
         bb.append_slice(&[2i16, 0i16, 1i16, 2i16, 2i16, 2i16, 2i16, 2i16, 2i16]);
@@ -674,13 +672,27 @@ mod tests {
         );
 
         // Verify bitmap
-        let mut bb = BooleanBufferBuilder::new(9);
-        bb.append_slice(&[true, false, false, true, true, true, true, true, true]);
-        let expected_bitmap = Bitmap::from(bb.finish());
+        let expected_valid = &[true, false, false, true, true, true, true, true, true];
+        let expected_buffer = Buffer::from_iter(expected_valid.iter().cloned());
+        let expected_bitmap = Bitmap::from(expected_buffer);
         assert_eq!(
             Some(expected_bitmap),
             record_reader.consume_bitmap().unwrap()
         );
+
+        // Verify result record data
+        let actual = record_reader.consume_record_data().unwrap();
+        let actual_values = unsafe { actual.typed_data::<i32>() };
+        let expected = &[4, 0, 0, 7, 6, 3, 2, 8, 9];
+        assert_eq!(actual_values.len(), expected.len());
+
+        // Only validate valid values are equal
+        let iter = expected_valid.iter().zip(actual_values).zip(expected);
+        for ((valid, actual), expected) in iter {
+            if *valid {
+                assert_eq!(actual, expected)
+            }
+        }
     }
 
     #[test]

--- a/parquet/src/arrow/record_reader/buffer.rs
+++ b/parquet/src/arrow/record_reader/buffer.rs
@@ -73,7 +73,7 @@ pub trait BufferQueue: Sized {
 ///
 /// [scalar]: https://doc.rust-lang.org/book/ch03-02-data-types.html#scalar-types
 ///
-pub trait ScalarValue {}
+pub trait ScalarValue: Copy {}
 impl ScalarValue for bool {}
 impl ScalarValue for u8 {}
 impl ScalarValue for i8 {}
@@ -261,7 +261,7 @@ impl<T: ScalarValue> ValuesBuffer for ScalarBuffer<T> {
             if level_pos <= value_pos {
                 break;
             }
-            slice.swap(value_pos, level_pos)
+            slice[level_pos] = slice[value_pos];
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1279.

# Rationale for this change
 
A marginal performance increase, and to gauge the appetite for these sorts of optimizations. In particular the obvious next question is, do we need to be zero-initializing the buffers to start with? I'm not entirely sure what Rust's safety rules state about uninitialized memory of POD types, are there invalid bit sequences for some types (e.g. f32), if not, why does it matter?

```
arrow_array_reader/read Int32Array, plain encoded, optional, half NULLs                                                                             
                        time:   [24.527 us 24.556 us 24.588 us]
                        change: [-6.4746% -5.3769% -4.4004%] (p = 0.00 < 0.05)
                        Performance has improved.
arrow_array_reader/read Int32Array, dictionary encoded, optional, half NULLs                                                                             
                        time:   [32.846 us 32.858 us 32.875 us]
                        change: [-9.1480% -8.3967% -7.9605%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# What changes are included in this PR?

Alters `ScalarBuffer::pad_nulls` to not zero the source location on read.

# Are there any user-facing changes?

Buffers that previously contained zeros in null positions, will now contain arbitrary, but guaranteed to be valid, values

_Edit: we must zero-initialize memory in general at least for floats to avoid accidentally including a signalling NaN_