### PR TITLE
Vectorized DeltaBitPackDecoder (#1281)

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -39,6 +39,7 @@ flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.10", optional = true }
 chrono = { version = "0.4", default-features = false }
+num = "0.4"
 num-bigint = "0.4"
 arrow = { path = "../arrow", version = "9.0.0", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", optional = true }

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -433,9 +433,10 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     initialized: bool,
 
     // Header info
-    // The number of values in each block
+
+    /// The number of values in each block
     block_size: usize,
-    /// The number of values in the current page
+    /// The number of values that remain to be read in the current page
     values_left: usize,
     /// The number of mini-blocks in each block
     mini_blocks_per_block: usize,
@@ -443,6 +444,7 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     values_per_mini_block: usize,
 
     // Per block info
+
     /// The minimum delta in the block
     min_delta: T::T,
     /// The byte offset of the end of the current block
@@ -490,7 +492,8 @@ where
             // If we've exhausted this page report the end of the current block
             // as we may not have consumed the trailing padding
             //
-            // The max is necessary to handle pages with no blocks
+            // The max is necessary to handle pages which don't contain more than
+            // one value and therefore have no blocks, but still contain a page header
             0 => self.bit_reader.get_byte_offset().max(self.block_end_offset),
             _ => self.bit_reader.get_byte_offset(),
         }
@@ -579,9 +582,9 @@ where
         self.values_left = self
             .bit_reader
             .get_vlq_int()
-            .ok_or_else(|| eof_err!("Not enough data to decode 'num_values'"))?
+            .ok_or_else(|| eof_err!("Not enough data to decode 'values_left'"))?
             .try_into()
-            .map_err(|_| general_err!("invalid 'num_values'"))?;
+            .map_err(|_| general_err!("invalid 'values_left'"))?;
 
         let first_value = self
             .bit_reader

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -619,7 +619,7 @@ impl BitReader {
         values_to_read
     }
 
-    /// Reads up to `num_bytes` to `buffer` returning the number of bytes read
+    /// Reads up to `num_bytes` to `buf` returning the number of bytes read
     pub(crate) fn get_aligned_bytes(
         &mut self,
         buf: &mut Vec<u8>,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1281.

# Rationale for this change
 
Make `DeltaBitPackDecoder` faster

# What changes are included in this PR?

Adapts `DeltaBitPackDecoder` to eliminate intermediate buffering, and to vectorize better.

The performance bump is not quite what I was hoping for, I suspect `unpack32` may not be vectorizing correctly, but is still decent.

```
arrow_array_reader/read Int32Array, binary packed, mandatory, no NULLs                                                                             
                        time:   [20.642 us 20.650 us 20.659 us]
                        change: [-73.470% -73.455% -73.441%] (p = 0.00 < 0.05)
                        Performance has improved.
arrow_array_reader/read Int32Array, binary packed, optional, no NULLs                                                                             
                        time:   [32.453 us 32.459 us 32.466 us]
                        change: [-63.907% -63.896% -63.885%] (p = 0.00 < 0.05)
                        Performance has improved.
arrow_array_reader/read Int32Array, binary packed, optional, half NULLs                                                                             
                        time:   [35.435 us 35.445 us 35.456 us]
                        change: [-44.831% -44.794% -44.745%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# Are there any user-facing changes?

No, the encoding module is experimental
