### PR TITLE
Fix bitmask creation also for simd comparisons with scalar

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1799,7 +1799,7 @@ where
                     let simd_result = simd_op(simd_left, simd_right);
 
                     let m = T::mask_to_u64(&simd_result);
-                    bitmask |= m << (i / lanes);
+                    bitmask |= m << i;
 
                     i += lanes;
                 }
@@ -2478,6 +2478,18 @@ mod tests {
             let a = Int64Array::from($A_VEC);
             let c = $KERNEL(&a, $B).unwrap();
             assert_eq!(BooleanArray::from($EXPECTED), c);
+
+            // test with a larger version of the same data to ensure we cover the chunked part of the comparison
+            let mut a = vec![];
+            let mut e = vec![];
+            for _i in 0..10 {
+                a.extend($A_VEC);
+                e.extend($EXPECTED);
+            }
+            let a = Int64Array::from(a);
+            let c = $KERNEL(&a, $B).unwrap();
+            assert_eq!(BooleanArray::from(e), c);
+
         };
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1285 (now also for comparisons with a scalar).

# Rationale for this change
 
Followup to #1286, which only fixed the bitmask creation for comparing two arrays, but missed the same bug when comparing with a scalar.
