### PR TITLE
arrow: enable clippy::vec_init_then_push lint

### DIFF
--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -436,9 +436,10 @@ mod tests {
             .build()
             .unwrap();
 
-        let mut field_types = vec![];
-        field_types.push(Field::new("a", DataType::Boolean, false));
-        field_types.push(Field::new("b", DataType::Int32, false));
+        let field_types = vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Int32, false),
+        ];
         let struct_array_data = ArrayData::builder(DataType::Struct(field_types))
             .len(5)
             .add_child_data(boolean_data.clone())

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -603,16 +603,17 @@ mod tests {
         let type_id_buffer = Buffer::from_slice_ref(&type_ids);
         let value_offsets_buffer = Buffer::from_slice_ref(&value_offsets);
 
-        let mut children: Vec<(Field, Arc<dyn Array>)> = Vec::new();
-        children.push((
-            Field::new("A", DataType::Utf8, false),
-            Arc::new(string_array),
-        ));
-        children.push((Field::new("B", DataType::Int32, false), Arc::new(int_array)));
-        children.push((
-            Field::new("C", DataType::Float64, false),
-            Arc::new(float_array),
-        ));
+        let children: Vec<(Field, Arc<dyn Array>)> = vec![
+            (
+                Field::new("A", DataType::Utf8, false),
+                Arc::new(string_array),
+            ),
+            (Field::new("B", DataType::Int32, false), Arc::new(int_array)),
+            (
+                Field::new("C", DataType::Float64, false),
+                Arc::new(float_array),
+            ),
+        ];
         let array = UnionArray::try_new(
             type_id_buffer,
             Some(value_offsets_buffer),

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -3700,12 +3700,14 @@ mod tests {
 
     #[test]
     fn test_struct_array_builder_from_schema() {
-        let mut fields = Vec::new();
-        fields.push(Field::new("f1", DataType::Float32, false));
-        fields.push(Field::new("f2", DataType::Utf8, false));
-        let mut sub_fields = Vec::new();
-        sub_fields.push(Field::new("g1", DataType::Int32, false));
-        sub_fields.push(Field::new("g2", DataType::Boolean, false));
+        let mut fields = vec![
+            Field::new("f1", DataType::Float32, false),
+            Field::new("f2", DataType::Utf8, false),
+        ];
+        let sub_fields = vec![
+            Field::new("g1", DataType::Int32, false),
+            Field::new("g2", DataType::Boolean, false),
+        ];
         let struct_type = DataType::Struct(sub_fields);
         fields.push(Field::new("f3", struct_type, false));
 
@@ -3721,8 +3723,7 @@ mod tests {
         expected = "Data type List(Field { name: \"item\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }) is not currently supported"
     )]
     fn test_struct_array_builder_from_schema_unsupported_type() {
-        let mut fields = Vec::new();
-        fields.push(Field::new("f1", DataType::Int16, false));
+        let mut fields = vec![Field::new("f1", DataType::Int16, false)];
         let list_type =
             DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
         fields.push(Field::new("f2", list_type, false));

--- a/arrow/src/compute/kernels/limit.rs
+++ b/arrow/src/compute/kernels/limit.rs
@@ -155,9 +155,10 @@ mod tests {
             .build()
             .unwrap();
 
-        let mut field_types = vec![];
-        field_types.push(Field::new("a", DataType::Boolean, false));
-        field_types.push(Field::new("b", DataType::Int32, false));
+        let field_types = vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Int32, false),
+        ];
         let struct_array_data = ArrayData::builder(DataType::Struct(field_types))
             .len(5)
             .add_child_data(boolean_data.clone())

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -137,7 +137,6 @@
     // upper_case_acronyms lint was introduced in Rust 1.51.
     // It is triggered in the ffi module, and ipc::gen, which we have no control over
     clippy::upper_case_acronyms,
-    clippy::vec_init_then_push
 )]
 #![warn(missing_debug_implementations)]
 


### PR DESCRIPTION
# Which issue does this PR close?

This is part of https://github.com/apache/arrow-rs/issues/1255

# Rationale for this change
 
It's beneficial to run clippy as strict as possible.

# What changes are included in this PR?

This PR enables `clippy::vec_init_then_push` lint in the `arrow` crate and fixes all the relates testing code for this check to pass.

# Are there any user-facing changes?

No.
