### PR TITLE
Enable clippy::float_equality_without_abs lint

### DIFF
--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -665,7 +665,7 @@ mod tests {
             .downcast_ref::<Float64Array>()
             .unwrap()
             .value(0);
-        assert!(10.0 - value < f64::EPSILON);
+        assert_eq!(10.0, value);
 
         let slot = array.value(4);
         let value = slot
@@ -770,7 +770,7 @@ mod tests {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert!(value - 3_f64 < f64::EPSILON);
+                    assert_eq!(value, 3_f64);
                 }
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -782,7 +782,7 @@ mod tests {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert!(5_f64 - value < f64::EPSILON);
+                    assert_eq!(5_f64, value);
                 }
                 4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -834,7 +834,7 @@ mod tests {
                     assert!(!union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert!(value - 3_f64 < f64::EPSILON);
+                    assert_eq!(value, 3_f64);
                 }
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -871,7 +871,7 @@ mod tests {
                     assert!(!new_union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert!(value - 3_f64 < f64::EPSILON);
+                    assert_eq!(value, 3_f64);
                 }
                 2 => assert!(new_union.is_null(i)),
                 3 => {

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -641,7 +641,7 @@ mod tests {
     #[test]
     fn test_primitive_array_float_sum() {
         let a = Float64Array::from(vec![1.1, 2.2, 3.3, 4.4, 5.5]);
-        assert!(16.5 - sum(&a).unwrap() < f64::EPSILON);
+        assert_eq!(16.5, sum(&a).unwrap());
     }
 
     #[test]

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1020,9 +1020,9 @@ mod tests {
         let a = Float64Array::from(vec![15.0, 15.0, 8.0]);
         let b = Float64Array::from(vec![5.0, 6.0, 8.0]);
         let c = divide(&a, &b).unwrap();
-        assert!(3.0 - c.value(0) < f64::EPSILON);
-        assert!(2.5 - c.value(1) < f64::EPSILON);
-        assert!(1.0 - c.value(2) < f64::EPSILON);
+        assert_eq!(3.0, c.value(0));
+        assert_eq!(2.5, c.value(1));
+        assert_eq!(1.0, c.value(2));
     }
 
     #[test]

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -2357,11 +2357,11 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Float64).unwrap();
         let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert!(5.0 - c.value(0) < f64::EPSILON);
-        assert!(6.0 - c.value(1) < f64::EPSILON);
-        assert!(7.0 - c.value(2) < f64::EPSILON);
-        assert!(8.0 - c.value(3) < f64::EPSILON);
-        assert!(9.0 - c.value(4) < f64::EPSILON);
+        assert_eq!(5.0, c.value(0));
+        assert_eq!(6.0, c.value(1));
+        assert_eq!(7.0, c.value(2));
+        assert_eq!(8.0, c.value(3));
+        assert_eq!(9.0, c.value(4));
     }
 
     #[test]
@@ -2483,10 +2483,10 @@ mod tests {
         let values = arr.values();
         let c = values.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(1, c.null_count());
-        assert!(7.0 - c.value(0) < f64::EPSILON);
-        assert!(8.0 - c.value(1) < f64::EPSILON);
+        assert_eq!(7.0, c.value(0));
+        assert_eq!(8.0, c.value(1));
         assert!(!c.is_valid(2));
-        assert!(10.0 - c.value(3) < f64::EPSILON);
+        assert_eq!(10.0, c.value(3));
     }
 
     #[test]
@@ -2535,8 +2535,8 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Float64).unwrap();
         let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert!(1.0 - c.value(0) < f64::EPSILON);
-        assert!(0.0 - c.value(1) < f64::EPSILON);
+        assert_eq!(1.0, c.value(0));
+        assert_eq!(0.0, c.value(1));
         assert!(!c.is_valid(2));
     }
 

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -1269,7 +1269,7 @@ mod tests {
                     .as_any()
                     .downcast_ref::<Float64Array>()
                     .unwrap();
-                assert!(57.653484 - lat.value(0) < f64::EPSILON);
+                assert_eq!(57.653484, lat.value(0));
 
                 // access data from a string array (ListArray<u8>)
                 let city = batch
@@ -1400,7 +1400,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!(57.653484 - lat.value(0) < f64::EPSILON);
+        assert_eq!(57.653484, lat.value(0));
 
         // access data from a string array (ListArray<u8>)
         let city = batch
@@ -1438,7 +1438,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!(57.653484 - lat.value(0) < f64::EPSILON);
+        assert_eq!(57.653484, lat.value(0));
 
         // access data from a string array (ListArray<u8>)
         let city = batch

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1750,8 +1750,8 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!(2.0 - bb.value(0) < f64::EPSILON);
-        assert!(-3.5 - bb.value(1) < f64::EPSILON);
+        assert_eq!(2.0, bb.value(0));
+        assert_eq!(-3.5, bb.value(1));
         let cc = batch
             .column(c.0)
             .as_any()
@@ -1873,8 +1873,8 @@ mod tests {
             .as_any()
             .downcast_ref::<Float32Array>()
             .unwrap();
-        assert!(2.0 - bb.value(0) < f32::EPSILON);
-        assert!(-3.5 - bb.value(1) < f32::EPSILON);
+        assert_eq!(2.0, bb.value(0));
+        assert_eq!(-3.5, bb.value(1));
     }
 
     #[test]
@@ -1962,8 +1962,8 @@ mod tests {
         let bb = bb.values();
         let bb = bb.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(9, bb.len());
-        assert!(2.0 - bb.value(0) < f64::EPSILON);
-        assert!(-6.1 - bb.value(5) < f64::EPSILON);
+        assert_eq!(2.0, bb.value(0));
+        assert_eq!(-6.1, bb.value(5));
         assert!(!bb.is_valid(7));
 
         let cc = batch
@@ -2094,7 +2094,7 @@ mod tests {
             let bb = bb.values();
             let bb = bb.as_any().downcast_ref::<Float64Array>().unwrap();
             assert_eq!(10, bb.len());
-            assert!(4.0 - bb.value(9) < f64::EPSILON);
+            assert_eq!(4.0, bb.value(9));
 
             let cc = batch
                 .column(c.0)

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -131,8 +131,6 @@
 #![allow(non_camel_case_types)]
 #![deny(clippy::redundant_clone)]
 #![allow(
-    // introduced to ignore lint errors when upgrading from 2020-04-22 to 2020-11-14
-    clippy::float_equality_without_abs,
     clippy::type_complexity,
     // upper_case_acronyms lint was introduced in Rust 1.51.
     // It is triggered in the ffi module, and ipc::gen, which we have no control over


### PR DESCRIPTION
# Which issue does this PR close?

This is part of https://github.com/apache/arrow-rs/issues/1255

# Rationale for this change
 
It's beneficial to run clippy as strict as possible.

# What changes are included in this PR?

This PR enables `clippy::float_equality_without_abs` lint in the `arrow` crate and fixes all the relates testing code for this check to pass.

# Are there any user-facing changes?

No.