### PR TITLE
Expose has bloom offset

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -349,6 +349,7 @@ pub struct ColumnChunkMetaData {
     index_page_offset: Option<i64>,
     dictionary_page_offset: Option<i64>,
     statistics: Option<Statistics>,
+    bloom_filter_offset: Option<i64>,
 }
 
 /// Represents common operations for a column chunk.
@@ -462,6 +463,16 @@ impl ColumnChunkMetaData {
         self.statistics.as_ref()
     }
 
+    /// Returns `true` if this column chunk contains a bloom filter offset, `false` otherwise.
+    pub fn has_bloom_filter_offset(&self) -> bool {
+        self.bloom_filter_offset.is_some()
+    }
+
+    /// Returns the offset for the bloom filter.
+    pub fn bloom_filter_offset(&self) -> Option<i64> {
+        self.bloom_filter_offset
+    }
+
     /// Method to convert from Thrift.
     pub fn from_thrift(column_descr: ColumnDescPtr, cc: ColumnChunk) -> Result<Self> {
         if cc.meta_data.is_none() {
@@ -485,6 +496,7 @@ impl ColumnChunkMetaData {
         let index_page_offset = col_metadata.index_page_offset;
         let dictionary_page_offset = col_metadata.dictionary_page_offset;
         let statistics = statistics::from_thrift(column_type, col_metadata.statistics);
+        let bloom_filter_offset = col_metadata.bloom_filter_offset;
         let result = ColumnChunkMetaData {
             column_type,
             column_path,
@@ -500,6 +512,7 @@ impl ColumnChunkMetaData {
             index_page_offset,
             dictionary_page_offset,
             statistics,
+            bloom_filter_offset,
         };
         Ok(result)
     }
@@ -551,6 +564,7 @@ pub struct ColumnChunkMetaDataBuilder {
     index_page_offset: Option<i64>,
     dictionary_page_offset: Option<i64>,
     statistics: Option<Statistics>,
+    bloom_filter_offset: Option<i64>,
 }
 
 impl ColumnChunkMetaDataBuilder {
@@ -569,6 +583,7 @@ impl ColumnChunkMetaDataBuilder {
             index_page_offset: None,
             dictionary_page_offset: None,
             statistics: None,
+            bloom_filter_offset: None,
         }
     }
 
@@ -638,6 +653,12 @@ impl ColumnChunkMetaDataBuilder {
         self
     }
 
+    /// Sets optional bloom filter offset in bytes.
+    pub fn set_bloom_filter_offset(mut self, value: Option<i64>) -> Self {
+        self.bloom_filter_offset = value;
+        self
+    }
+
     /// Builds column chunk metadata.
     pub fn build(self) -> Result<ColumnChunkMetaData> {
         Ok(ColumnChunkMetaData {
@@ -655,6 +676,7 @@ impl ColumnChunkMetaDataBuilder {
             index_page_offset: self.index_page_offset,
             dictionary_page_offset: self.dictionary_page_offset,
             statistics: self.statistics,
+            bloom_filter_offset: self.bloom_filter_offset,
         })
     }
 }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -464,7 +464,7 @@ impl ColumnChunkMetaData {
     }
 
     /// Returns `true` if this column chunk contains a bloom filter offset, `false` otherwise.
-    pub fn has_bloom_filter_offset(&self) -> bool {
+    pub fn has_bloom_filter(&self) -> bool {
         self.bloom_filter_offset.is_some()
     }
 

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -767,12 +767,12 @@ mod tests {
         let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
 
         let row_group_metadata = file_reader.metadata.row_group(0);
-        let col1_metadata = row_group_metadata.column(0);
-        let col2_metadata = row_group_metadata.column(1);
+        let col0_metadata = row_group_metadata.column(0);
+        let col1_metadata = row_group_metadata.column(1);
 
         // test optional bloom filter offset
-        assert_eq!(col1_metadata.bloom_filter_offset().unwrap(), 7283);
-        assert_eq!(col2_metadata.bloom_filter_offset().unwrap(), 1055877);
+        assert_eq!(col0_metadata.bloom_filter_offset().unwrap(), 7283);
+        assert_eq!(col1_metadata.bloom_filter_offset().unwrap(), 1055877);
     }
 
     #[test]

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -762,17 +762,15 @@ mod tests {
 
     #[test]
     fn test_file_reader_optional_metadata() {
-        // file with optional metadata: bloom filters, column index and offset index.
-        let file = get_test_file("data_index_bloom.parquet");
+        // file with optional metadata: bloom filters, encoding stats, column index and offset index.
+        let file = get_test_file("data_index_bloom_encoding_stats.parquet");
         let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
 
         let row_group_metadata = file_reader.metadata.row_group(0);
         let col0_metadata = row_group_metadata.column(0);
-        let col1_metadata = row_group_metadata.column(1);
 
         // test optional bloom filter offset
-        assert_eq!(col0_metadata.bloom_filter_offset().unwrap(), 7283);
-        assert_eq!(col1_metadata.bloom_filter_offset().unwrap(), 1055877);
+        assert_eq!(col0_metadata.bloom_filter_offset().unwrap(), 192);
     }
 
     #[test]

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -761,6 +761,21 @@ mod tests {
     }
 
     #[test]
+    fn test_file_reader_optional_metadata() {
+        // file with optional metadata: bloom filters, column index and offset index.
+        let file = get_test_file("data_index_bloom.parquet");
+        let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
+
+        let row_group_metadata = file_reader.metadata.row_group(0);
+        let col1_metadata = row_group_metadata.column(0);
+        let col2_metadata = row_group_metadata.column(1);
+
+        // test optional bloom filter offset
+        assert_eq!(col1_metadata.bloom_filter_offset().unwrap(), 7283);
+        assert_eq!(col2_metadata.bloom_filter_offset().unwrap(), 1055877);
+    }
+
+    #[test]
     fn test_file_reader_filter_row_groups() -> Result<()> {
         let test_file = get_test_file("alltypes_plain.parquet");
         let mut reader = SerializedFileReader::new(test_file)?;

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -163,6 +163,11 @@ fn print_column_chunk_metadata(
         Some(stats) => stats.to_string(),
     };
     writeln!(out, "statistics: {}", statistics_str);
+    let bloom_filter_offset_str = match cc_metadata.bloom_filter_offset() {
+        None => "N/A".to_owned(),
+        Some(bfo) => bfo.to_string(),
+    };
+    writeln!(out, "bloom filter offset: {}", bloom_filter_offset_str);
     writeln!(out);
 }
 


### PR DESCRIPTION
Closes #1308.

Exposing the bloom filter offset in in the column chunk metadata so parquet engines could optimize their reads.

Test file `data_index_bloom.parquet` is added to parquet-testing via https://github.com/apache/parquet-testing/pull/22. 