### PR TITLE
Enable clippy::type_complexity

### DIFF
--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -507,7 +507,9 @@ mod tests {
         assert_eq!(equal(rhs, lhs), expected, "\n{:?}\n{:?}", rhs, lhs);
     }
 
-    fn binary_cases() -> Vec<(Vec<Option<String>>, Vec<Option<String>>, bool)> {
+    type OptionString = Option<String>;
+
+    fn binary_cases() -> Vec<(Vec<OptionString>, Vec<OptionString>, bool)> {
         let base = vec![
             Some("hello".to_owned()),
             None,

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -188,7 +188,9 @@ mod tests {
             })
     }
 
-    fn length_null_cases() -> Vec<(Vec<Option<&'static str>>, usize, Vec<Option<i32>>)> {
+    type OptionStr = Option<&'static str>;
+
+    fn length_null_cases() -> Vec<(Vec<OptionStr>, usize, Vec<Option<i32>>)> {
         vec![(
             vec![Some("one"), None, Some("three"), Some("four")],
             4,
@@ -310,8 +312,7 @@ mod tests {
             })
     }
 
-    fn bit_length_null_cases() -> Vec<(Vec<Option<&'static str>>, usize, Vec<Option<i32>>)>
-    {
+    fn bit_length_null_cases() -> Vec<(Vec<OptionStr>, usize, Vec<Option<i32>>)> {
         vec![(
             vec![Some("one"), None, Some("three"), Some("four")],
             4,

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -460,7 +460,7 @@ fn sort_boolean(
         // when limit is not present, we have a better way than sorting: we can just partition
         // the vec into [false..., true...] or [true..., false...] when descending
         // TODO when https://github.com/rust-lang/rust/issues/62543 is merged we can use partition_in_place
-        let (mut a, b): (Vec<(u32, bool)>, Vec<(u32, bool)>) = value_indices
+        let (mut a, b): (Vec<_>, Vec<_>) = value_indices
             .into_iter()
             .map(|index| (index, values.value(index as usize)))
             .partition(|(_, value)| *value == descending);

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -131,7 +131,6 @@
 #![allow(non_camel_case_types)]
 #![deny(clippy::redundant_clone)]
 #![allow(
-    clippy::type_complexity,
     // upper_case_acronyms lint was introduced in Rust 1.51.
     // It is triggered in the ffi module, and ipc::gen, which we have no control over
     clippy::upper_case_acronyms,


### PR DESCRIPTION
# Which issue does this PR close?

This is part of https://github.com/apache/arrow-rs/issues/1255

# Rationale for this change
 
It's beneficial to run clippy as strict as possible.

# What changes are included in this PR?

This PR enables `clippy::type_complexity` lint in the `arrow` crate and fixes the related code for this check to pass.

# Are there any user-facing changes?

No.