### PR TITLE
Expose column index and offset index

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,7 @@ jobs:
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
+
       - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"
@@ -107,10 +108,10 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          
+
           # run tests on all workspace members with default feature list
           cargo test
-          
+
           # Switch to arrow crate
           cd arrow
           # re-run tests on arrow crate with additional features
@@ -122,13 +123,13 @@ jobs:
           cargo run --example read_csv
           cargo run --example read_csv_infer_schema
           cargo check --no-default-features
-          
+
           # Switch to parquet crate
           cd ../parquet
           # re-run tests on parquet crate with async feature enabled
           cargo test --features=async
           cargo check --no-default-features
-          
+
           # Switch to arrow-flight
           cd ../arrow-flight
           cargo check --no-default-features
@@ -289,7 +290,7 @@ jobs:
           cargo check --benches --workspace
 
   lint:
-    name: Lint
+    name: Lint (cargo fmt)
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -391,6 +392,51 @@ jobs:
           cd arrow
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-unknown-unknown
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-wasi
+
+  # test doc links still work
+  docs:
+    name: Docs are clean on AMD64 Rust ${{ matrix.rust }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [nightly]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install python dev
+        run: |
+          apt update
+          apt install -y libpython3.9-dev
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          key: cargo-nightly-cache3-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-nightly-cache3-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
+      - name: Run cargo doc
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          export RUSTDOCFLAGS="-Dwarnings"
+          cargo doc --document-private-items --no-deps --workspace --all-features
+
 
   # test builds with various feature flag combinations outside the main workspace
   default-build:

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -466,29 +466,10 @@ impl ColumnChunkMetaData {
         self.statistics.as_ref()
     }
 
-    /// Returns `true` if this column chunk contains an offset index offset, `false` otherwise.
-    pub fn has_offset_index_offset(&self) -> bool {
-        self.offset_index_offset.is_some()
-    }
-
-    /// Returns the offset for the offset index.
-    pub fn offset_index_offset(&self) -> Option<i64> {
-        self.offset_index_offset
-    }
-
-    /// Returns `true` if this column chunk contains a offset index offset, `false` otherwise.
-    pub fn has_offset_index_length(&self) -> bool {
-        self.offset_index_length.is_some()
-    }
-
-    /// Returns the offset for the offset index length.
-    pub fn offset_index_length(&self) -> Option<i32> {
-        self.offset_index_length
-    }
-
-    /// Returns `true` if this column chunk contains a column index offset, `false` otherwise.
-    pub fn has_column_index_offset(&self) -> bool {
-        self.column_index_offset.is_some()
+    /// Returns `true` if this column chunk contains a column index, `false` otherwise.
+    pub fn has_column_index(&self) -> bool {
+        self.column_index_offset.is_some() && self.column_index_length.is_some() &&
+            self.offset_index_offset.is_some() && self.offset_index_length.is_some()
     }
 
     /// Returns the offset for the column index.
@@ -496,14 +477,19 @@ impl ColumnChunkMetaData {
         self.column_index_offset
     }
 
-    /// Returns `true` if this column chunk contains a column index offset, `false` otherwise.
-    pub fn has_column_index_length(&self) -> bool {
-        self.column_index_length.is_some()
-    }
-
     /// Returns the offset for the column index length.
     pub fn column_index_length(&self) -> Option<i32> {
         self.column_index_length
+    }
+
+    /// Returns the offset for the offset index.
+    pub fn offset_index_offset(&self) -> Option<i64> {
+        self.offset_index_offset
+    }
+
+    /// Returns the offset for the offset index length.
+    pub fn offset_index_length(&self) -> Option<i32> {
+        self.offset_index_length
     }
 
     /// Method to convert from Thrift.

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -349,6 +349,10 @@ pub struct ColumnChunkMetaData {
     index_page_offset: Option<i64>,
     dictionary_page_offset: Option<i64>,
     statistics: Option<Statistics>,
+    offset_index_offset: Option<i64>,
+    offset_index_length: Option<i32>,
+    column_index_offset: Option<i64>,
+    column_index_length: Option<i32>,
 }
 
 /// Represents common operations for a column chunk.
@@ -462,6 +466,46 @@ impl ColumnChunkMetaData {
         self.statistics.as_ref()
     }
 
+    /// Returns `true` if this column chunk contains an offset index offset, `false` otherwise.
+    pub fn has_offset_index_offset(&self) -> bool {
+        self.offset_index_offset.is_some()
+    }
+
+    /// Returns the offset for the offset index.
+    pub fn offset_index_offset(&self) -> Option<i64> {
+        self.offset_index_offset
+    }
+
+    /// Returns `true` if this column chunk contains a offset index offset, `false` otherwise.
+    pub fn has_offset_index_length(&self) -> bool {
+        self.offset_index_length.is_some()
+    }
+
+    /// Returns the offset for the offset index length.
+    pub fn offset_index_length(&self) -> Option<i32> {
+        self.offset_index_length
+    }
+
+    /// Returns `true` if this column chunk contains a column index offset, `false` otherwise.
+    pub fn has_column_index_offset(&self) -> bool {
+        self.column_index_offset.is_some()
+    }
+
+    /// Returns the offset for the column index.
+    pub fn column_index_offset(&self) -> Option<i64> {
+        self.column_index_offset
+    }
+
+    /// Returns `true` if this column chunk contains a column index offset, `false` otherwise.
+    pub fn has_column_index_length(&self) -> bool {
+        self.column_index_length.is_some()
+    }
+
+    /// Returns the offset for the column index length.
+    pub fn column_index_length(&self) -> Option<i32> {
+        self.column_index_length
+    }
+
     /// Method to convert from Thrift.
     pub fn from_thrift(column_descr: ColumnDescPtr, cc: ColumnChunk) -> Result<Self> {
         if cc.meta_data.is_none() {
@@ -485,6 +529,10 @@ impl ColumnChunkMetaData {
         let index_page_offset = col_metadata.index_page_offset;
         let dictionary_page_offset = col_metadata.dictionary_page_offset;
         let statistics = statistics::from_thrift(column_type, col_metadata.statistics);
+        let offset_index_offset = cc.offset_index_offset;
+        let offset_index_length = cc.offset_index_length;
+        let column_index_offset = cc.column_index_offset;
+        let column_index_length = cc.column_index_length;
         let result = ColumnChunkMetaData {
             column_type,
             column_path,
@@ -500,6 +548,10 @@ impl ColumnChunkMetaData {
             index_page_offset,
             dictionary_page_offset,
             statistics,
+            offset_index_offset,
+            offset_index_length,
+            column_index_offset,
+            column_index_length,
         };
         Ok(result)
     }
@@ -527,10 +579,10 @@ impl ColumnChunkMetaData {
             file_path: self.file_path().map(|s| s.to_owned()),
             file_offset: self.file_offset,
             meta_data: Some(column_metadata),
-            offset_index_offset: None,
-            offset_index_length: None,
-            column_index_offset: None,
-            column_index_length: None,
+            offset_index_offset: self.offset_index_offset,
+            offset_index_length: self.offset_index_length,
+            column_index_offset: self.column_index_offset,
+            column_index_length: self.column_index_length,
             crypto_metadata: None,
             encrypted_column_metadata: None,
         }
@@ -551,6 +603,10 @@ pub struct ColumnChunkMetaDataBuilder {
     index_page_offset: Option<i64>,
     dictionary_page_offset: Option<i64>,
     statistics: Option<Statistics>,
+    offset_index_offset: Option<i64>,
+    offset_index_length: Option<i32>,
+    column_index_offset: Option<i64>,
+    column_index_length: Option<i32>,
 }
 
 impl ColumnChunkMetaDataBuilder {
@@ -569,6 +625,10 @@ impl ColumnChunkMetaDataBuilder {
             index_page_offset: None,
             dictionary_page_offset: None,
             statistics: None,
+            offset_index_offset: None,
+            offset_index_length: None,
+            column_index_offset: None,
+            column_index_length: None,
         }
     }
 
@@ -638,6 +698,30 @@ impl ColumnChunkMetaDataBuilder {
         self
     }
 
+    /// Sets optional offset index offset in bytes.
+    pub fn set_offset_index_offset(mut self, value: Option<i64>) -> Self {
+        self.offset_index_offset = value;
+        self
+    }
+
+    /// Sets optional offset index length in bytes.
+    pub fn set_offset_index_length(mut self, value: Option<i32>) -> Self {
+        self.offset_index_length = value;
+        self
+    }
+
+    /// Sets optional column index offset in bytes.
+    pub fn set_column_index_offset(mut self, value: Option<i64>) -> Self {
+        self.column_index_offset = value;
+        self
+    }
+
+    /// Sets optional column index length in bytes.
+    pub fn set_column_index_length(mut self, value: Option<i32>) -> Self {
+        self.column_index_length = value;
+        self
+    }
+
     /// Builds column chunk metadata.
     pub fn build(self) -> Result<ColumnChunkMetaData> {
         Ok(ColumnChunkMetaData {
@@ -655,6 +739,10 @@ impl ColumnChunkMetaDataBuilder {
             index_page_offset: self.index_page_offset,
             dictionary_page_offset: self.dictionary_page_offset,
             statistics: self.statistics,
+            offset_index_offset: self.offset_index_offset,
+            offset_index_length: self.offset_index_length,
+            column_index_offset: self.column_index_offset,
+            column_index_length: self.column_index_length,
         })
     }
 }
@@ -717,6 +805,10 @@ mod tests {
             .set_total_uncompressed_size(3000)
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
+            .set_offset_index_offset(Some(6000))
+            .set_offset_index_length(Some(100))
+            .set_column_index_offset(Some(7000))
+            .set_column_index_length(Some(100))
             .build()
             .unwrap();
 

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -816,6 +816,10 @@ mod tests {
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
             .set_bloom_filter_offset(Some(6000))
+            .set_offset_index_offset(Some(7000))
+            .set_offset_index_length(Some(25))
+            .set_column_index_offset(Some(8000))
+            .set_column_index_length(Some(25))
             .build()
             .unwrap();
 

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -479,8 +479,10 @@ impl ColumnChunkMetaData {
 
     /// Returns `true` if this column chunk contains a column index, `false` otherwise.
     pub fn has_column_index(&self) -> bool {
-        self.column_index_offset.is_some() && self.column_index_length.is_some() &&
-            self.offset_index_offset.is_some() && self.offset_index_length.is_some()
+        self.column_index_offset.is_some()
+            && self.column_index_length.is_some()
+            && self.offset_index_offset.is_some()
+            && self.offset_index_length.is_some()
     }
 
     /// Returns the offset for the column index.

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -761,6 +761,29 @@ mod tests {
     }
 
     #[test]
+    fn test_file_reader_optional_metadata() {
+        // file with optional metadata: bloom filters, column index and offset index.
+        let file = get_test_file("data_index_bloom.parquet");
+        let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
+
+        let row_group_metadata = file_reader.metadata.row_group(0);
+        let col0_metadata = row_group_metadata.column(0);
+        let col1_metadata = row_group_metadata.column(1);
+
+        // test optional column index offset
+        assert_eq!(col0_metadata.column_index_offset().unwrap(), 7209);
+        assert_eq!(col0_metadata.column_index_length().unwrap(), 27);
+        assert_eq!(col1_metadata.column_index_offset().unwrap(), 7236);
+        assert_eq!(col1_metadata.column_index_length().unwrap(), 23);
+
+        // test optional offset index offset
+        assert_eq!(col0_metadata.offset_index_offset().unwrap(), 7259);
+        assert_eq!(col0_metadata.offset_index_length().unwrap(), 12);
+        assert_eq!(col1_metadata.offset_index_offset().unwrap(), 7271);
+        assert_eq!(col1_metadata.offset_index_length().unwrap(), 12);
+    }
+
+    #[test]
     fn test_file_reader_filter_row_groups() -> Result<()> {
         let test_file = get_test_file("alltypes_plain.parquet");
         let mut reader = SerializedFileReader::new(test_file)?;

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -762,25 +762,22 @@ mod tests {
 
     #[test]
     fn test_file_reader_optional_metadata() {
-        // file with optional metadata: bloom filters, column index and offset index.
-        let file = get_test_file("data_index_bloom.parquet");
+        // file with optional metadata: bloom filters, encoding stats, column index and offset index.
+        let file = get_test_file("data_index_bloom_encoding_stats.parquet");
         let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
 
         let row_group_metadata = file_reader.metadata.row_group(0);
         let col0_metadata = row_group_metadata.column(0);
-        let col1_metadata = row_group_metadata.column(1);
+
+        assert!(col0_metadata.has_column_index());
 
         // test optional column index offset
-        assert_eq!(col0_metadata.column_index_offset().unwrap(), 7209);
-        assert_eq!(col0_metadata.column_index_length().unwrap(), 27);
-        assert_eq!(col1_metadata.column_index_offset().unwrap(), 7236);
-        assert_eq!(col1_metadata.column_index_length().unwrap(), 23);
+        assert_eq!(col0_metadata.column_index_offset().unwrap(), 156);
+        assert_eq!(col0_metadata.column_index_length().unwrap(), 25);
 
         // test optional offset index offset
-        assert_eq!(col0_metadata.offset_index_offset().unwrap(), 7259);
-        assert_eq!(col0_metadata.offset_index_length().unwrap(), 12);
-        assert_eq!(col1_metadata.offset_index_offset().unwrap(), 7271);
-        assert_eq!(col1_metadata.offset_index_length().unwrap(), 12);
+        assert_eq!(col0_metadata.offset_index_offset().unwrap(), 181);
+        assert_eq!(col0_metadata.offset_index_length().unwrap(), 11);
     }
 
     #[test]

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -165,22 +165,22 @@ fn print_column_chunk_metadata(
     writeln!(out, "statistics: {}", statistics_str);
     let offset_index_offset_str = match cc_metadata.offset_index_offset() {
         None => "N/A".to_owned(),
-        Some(dpo) => dpo.to_string(),
+        Some(oio) => oio.to_string(),
     };
     writeln!(out, "offset index offset: {}", offset_index_offset_str);
     let offset_index_length_str = match cc_metadata.offset_index_length() {
         None => "N/A".to_owned(),
-        Some(dpo) => dpo.to_string(),
+        Some(oil) => oil.to_string(),
     };
     writeln!(out, "offset index length: {}", offset_index_length_str);
     let column_index_offset_str = match cc_metadata.column_index_offset() {
         None => "N/A".to_owned(),
-        Some(dpo) => dpo.to_string(),
+        Some(cio) => cio.to_string(),
     };
     writeln!(out, "column index offset: {}", column_index_offset_str);
     let column_index_length_str = match cc_metadata.column_index_length() {
         None => "N/A".to_owned(),
-        Some(dpo) => dpo.to_string(),
+        Some(cil) => cil.to_string(),
     };
     writeln!(out, "column index length: {}", column_index_length_str);
     writeln!(out);

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -163,6 +163,26 @@ fn print_column_chunk_metadata(
         Some(stats) => stats.to_string(),
     };
     writeln!(out, "statistics: {}", statistics_str);
+    let offset_index_offset_str = match cc_metadata.offset_index_offset() {
+        None => "N/A".to_owned(),
+        Some(dpo) => dpo.to_string(),
+    };
+    writeln!(out, "offset index offset: {}", offset_index_offset_str);
+    let offset_index_length_str = match cc_metadata.offset_index_length() {
+        None => "N/A".to_owned(),
+        Some(dpo) => dpo.to_string(),
+    };
+    writeln!(out, "offset index length: {}", offset_index_length_str);
+    let column_index_offset_str = match cc_metadata.column_index_offset() {
+        None => "N/A".to_owned(),
+        Some(dpo) => dpo.to_string(),
+    };
+    writeln!(out, "column index offset: {}", column_index_offset_str);
+    let column_index_length_str = match cc_metadata.column_index_length() {
+        None => "N/A".to_owned(),
+        Some(dpo) => dpo.to_string(),
+    };
+    writeln!(out, "column index length: {}", column_index_length_str);
     writeln!(out);
 }
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1317.

Exposing the column index and offset index offsets and lengths so parquet engines could optimize their reads.