### PR TITLE
fix test bug and ensure that bloom filter metadata is serialized in `to_thrift`

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -744,7 +744,8 @@ mod tests {
             .unwrap();
 
         let col_chunk_res =
-            ColumnChunkMetaData::from_thrift(column_descr, col_metadata.to_thrift()).unwrap();
+            ColumnChunkMetaData::from_thrift(column_descr, col_metadata.to_thrift())
+                .unwrap();
 
         assert_eq!(col_chunk_res, col_metadata);
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -333,7 +333,7 @@ impl RowGroupMetaDataBuilder {
 }
 
 /// Metadata for a column chunk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ColumnChunkMetaData {
     column_type: Type,
     column_path: ColumnPath,
@@ -533,7 +533,7 @@ impl ColumnChunkMetaData {
             dictionary_page_offset: self.dictionary_page_offset,
             statistics: statistics::to_thrift(self.statistics.as_ref()),
             encoding_stats: None,
-            bloom_filter_offset: None,
+            bloom_filter_offset: self.bloom_filter_offset,
         };
 
         ColumnChunk {
@@ -739,17 +739,14 @@ mod tests {
             .set_total_uncompressed_size(3000)
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
+            .set_bloom_filter_offset(Some(6000))
             .build()
             .unwrap();
 
-        let col_chunk_exp = col_metadata.to_thrift();
-
         let col_chunk_res =
-            ColumnChunkMetaData::from_thrift(column_descr, col_chunk_exp.clone())
-                .unwrap()
-                .to_thrift();
+            ColumnChunkMetaData::from_thrift(column_descr, col_metadata.to_thrift()).unwrap();
 
-        assert_eq!(col_chunk_res, col_chunk_exp);
+        assert_eq!(col_chunk_res, col_metadata);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1319.

# Rationale for this change
 test_column_chunk_metadata_thrift_conversion didn't check full thrift conversion. It only checked from_thrift as it compared two thrift objects.

I altered it to compare two `ColumnChunkMetaData` objects, thus checking both to_thrift and from_thrift.

