### PR TITLE
Expose page encoding

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -334,7 +334,7 @@ impl RowGroupMetaDataBuilder {
 }
 
 /// Metadata for a column chunk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ColumnChunkMetaData {
     column_type: Type,
     column_path: ColumnPath,
@@ -726,6 +726,7 @@ impl ColumnChunkMetaDataBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::basic::{PageType, Encoding}; // todo see if we can remove
 
     #[test]
     fn test_row_group_metadata_thrift_conversion() {
@@ -781,17 +782,15 @@ mod tests {
             .set_total_uncompressed_size(3000)
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
+            .set_page_encoding_stats(vec![PageEncodingStats{ page_type: PageType::DATA_PAGE, encoding: Encoding::PLAIN, count: 3}])
             .build()
             .unwrap();
 
-        let col_chunk_exp = col_metadata.to_thrift();
-
         let col_chunk_res =
-            ColumnChunkMetaData::from_thrift(column_descr, col_chunk_exp.clone())
-                .unwrap()
-                .to_thrift();
+            ColumnChunkMetaData::from_thrift(column_descr, col_metadata.to_thrift())
+                .unwrap();
 
-        assert_eq!(col_chunk_res, col_chunk_exp);
+        assert_eq!(col_chunk_res, col_metadata);
     }
 
     #[test]

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -566,7 +566,7 @@ impl ColumnChunkMetaData {
             dictionary_page_offset: self.dictionary_page_offset,
             statistics: statistics::to_thrift(self.statistics.as_ref()),
             encoding_stats: page_encoding_stats,
-            bloom_filter_offset: None, // todo verify
+            bloom_filter_offset: self.bloom_filter_offset,
         };
 
         ColumnChunk {
@@ -782,11 +782,18 @@ mod tests {
             .set_total_uncompressed_size(3000)
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
-            .set_page_encoding_stats(vec![PageEncodingStats {
-                page_type: PageType::DATA_PAGE,
-                encoding: Encoding::PLAIN,
-                count: 3,
-            }])
+            .set_page_encoding_stats(vec![
+                PageEncodingStats {
+                    page_type: PageType::DATA_PAGE,
+                    encoding: Encoding::PLAIN,
+                    count: 3,
+                },
+                PageEncodingStats {
+                    page_type: PageType::DATA_PAGE,
+                    encoding: Encoding::RLE,
+                    count: 5,
+                },
+            ])
             .set_bloom_filter_offset(Some(6000))
             .build()
             .unwrap();

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -726,7 +726,7 @@ impl ColumnChunkMetaDataBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic::{PageType, Encoding}; // todo see if we can remove
+    use crate::basic::{Encoding, PageType};
 
     #[test]
     fn test_row_group_metadata_thrift_conversion() {
@@ -782,7 +782,11 @@ mod tests {
             .set_total_uncompressed_size(3000)
             .set_data_page_offset(4000)
             .set_dictionary_page_offset(Some(5000))
-            .set_page_encoding_stats(vec![PageEncodingStats{ page_type: PageType::DATA_PAGE, encoding: Encoding::PLAIN, count: 3}])
+            .set_page_encoding_stats(vec![PageEncodingStats {
+                page_type: PageType::DATA_PAGE,
+                encoding: Encoding::PLAIN,
+                count: 3,
+            }])
             .build()
             .unwrap();
 

--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -97,6 +97,7 @@
 //! ```
 pub mod footer;
 pub mod metadata;
+mod page_encoding_stats;
 pub mod properties;
 pub mod reader;
 pub mod serialized_reader;

--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -97,7 +97,7 @@
 //! ```
 pub mod footer;
 pub mod metadata;
-mod page_encoding_stats;
+pub mod page_encoding_stats;
 pub mod properties;
 pub mod reader;
 pub mod serialized_reader;

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use parquet_format::PageEncodingStats as TPageEncodingStats;
-
 use crate::basic::{Encoding, PageType};
+use parquet_format::{
+    Encoding as TEncoding, PageEncodingStats as TPageEncodingStats, PageType as TPageType,
+};
 
 /// PageEncodingStats for a column chunk and data page.
 #[derive(Clone, Debug, PartialEq)]
@@ -30,19 +31,46 @@ pub struct PageEncodingStats {
     pub count: i32,
 }
 
-impl PageEncodingStats {}
-
 /// Converts Thrift definition into `PageEncodingStats`.
-pub fn from_thrift(
-    thrift_encoding_stats: &TPageEncodingStats,
-) -> Option<PageEncodingStats> {
+pub fn from_thrift(thrift_encoding_stats: &TPageEncodingStats) -> PageEncodingStats {
     let page_type = PageType::from(thrift_encoding_stats.page_type);
     let encoding = Encoding::from(thrift_encoding_stats.encoding);
     let count = thrift_encoding_stats.count;
 
-    Some(PageEncodingStats {
+    PageEncodingStats {
         page_type,
         encoding,
         count,
-    })
+    }
+}
+
+/// Converts `PageEncodingStats` into Thrift definition.
+pub fn to_thrift(encoding_stats: &PageEncodingStats) -> TPageEncodingStats {
+    let page_type = TPageType::from(encoding_stats.page_type);
+    let encoding = TEncoding::from(encoding_stats.encoding);
+    let count = encoding_stats.count;
+
+    TPageEncodingStats {
+        page_type,
+        encoding,
+        count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::basic::{Encoding, PageType};
+    use crate::file::page_encoding_stats::{from_thrift, to_thrift, PageEncodingStats};
+
+    #[test]
+    fn test_page_encoding_stats_from_thrift() {
+        let stats = PageEncodingStats {
+            page_type: PageType::DATA_PAGE,
+            encoding: Encoding::PLAIN,
+            count: 1,
+        };
+
+        let thrift_stats = to_thrift(&stats);
+        assert_eq!(from_thrift(&thrift_stats), stats);
+    }
 }

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use parquet_format::PageEncodingStats as TPageEncodingStats;
+
+use crate::basic::{Encoding, PageType};
+
+/// PageEncodingStats for a column chunk and data page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PageEncodingStats {
+    /// the page type (data/dic/...)
+    pub page_type: PageType,
+    /// encoding of the page
+    pub encoding: Encoding,
+    /// number of pages of this type with this encoding
+    pub count: i32,
+}
+
+impl PageEncodingStats {}
+
+/// Converts Thrift definition into `PageEncodingStats`.
+pub fn from_thrift(
+    thrift_encoding_stats: &TPageEncodingStats,
+) -> Option<PageEncodingStats> {
+    let page_type = PageType::from(thrift_encoding_stats.page_type);
+    let encoding = Encoding::from(thrift_encoding_stats.encoding);
+    let count = thrift_encoding_stats.count;
+
+    Some(PageEncodingStats {
+        page_type,
+        encoding,
+        count,
+    })
+}

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -59,8 +59,8 @@ pub fn to_thrift(encoding_stats: &PageEncodingStats) -> TPageEncodingStats {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::basic::{Encoding, PageType};
-    use crate::file::page_encoding_stats::{from_thrift, to_thrift, PageEncodingStats};
 
     #[test]
     fn test_page_encoding_stats_from_thrift() {
@@ -70,7 +70,6 @@ mod tests {
             count: 1,
         };
 
-        let thrift_stats = to_thrift(&stats);
-        assert_eq!(from_thrift(&thrift_stats), stats);
+        assert_eq!(from_thrift(&to_thrift(&stats)), stats);
     }
 }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -763,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_file_reader_optional_metadata() {
-        let file = get_test_file("data_index_bloom.parquet");
+        let file = get_test_file("data_index_bloom_encoding_stats.parquet");
         let file_reader = Arc::new(SerializedFileReader::new(file).unwrap());
         let col_metadata = file_reader.metadata.row_group(0).column(0);
 

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -774,9 +774,9 @@ mod tests {
         assert_eq!(col0_metadata.bloom_filter_offset().unwrap(), 192);
 
         // test page encoding stats
-        assert!(col_metadata.has_page_encoding_stats());
+        assert!(col0_metadata.has_page_encoding_stats());
         let page_encoding_stats =
-            col_metadata.page_encoding_stats().unwrap().get(0).unwrap();
+            col0_metadata.page_encoding_stats().unwrap().get(0).unwrap();
 
         assert_eq!(page_encoding_stats.page_type, basic::PageType::DATA_PAGE);
         assert_eq!(page_encoding_stats.encoding, Encoding::PLAIN);

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -769,11 +769,8 @@ mod tests {
 
         // test page encoding stats
         assert!(col_metadata.has_page_encoding_stats());
-        let page_encoding_stats = col_metadata
-            .page_encoding_stats()
-            .unwrap()
-            .get(0)
-            .unwrap();
+        let page_encoding_stats =
+            col_metadata.page_encoding_stats().unwrap().get(0).unwrap();
 
         assert_eq!(page_encoding_stats.page_type, basic::PageType::DATA_PAGE);
         assert_eq!(page_encoding_stats.encoding, Encoding::PLAIN);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1321.

# What changes are included in this PR?

Introduced page_encoding_stats struct, with to_thrift and from_thrift conversions, and exposed it from the column chunk metadata.
