### PR TITLE
Fix clippy lint `dead_code`

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -536,6 +536,7 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[test]
     fn test_try_new() {
         let values: StringArray = [Some("foo"), Some("bar"), Some("baz")]
             .into_iter()

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -34,15 +34,6 @@ use crate::{
     util::trusted_len_unzip,
 };
 
-/// Number of seconds in a day
-const SECONDS_IN_DAY: i64 = 86_400;
-/// Number of milliseconds in a second
-const MILLISECONDS: i64 = 1_000;
-/// Number of microseconds in a second
-const MICROSECONDS: i64 = 1_000_000;
-/// Number of nanoseconds in a second
-const NANOSECONDS: i64 = 1_000_000_000;
-
 /// Array whose elements are of primitive types.
 ///
 /// # Example: From an iterator of values

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -1751,6 +1751,7 @@ impl Default for MapFieldNames {
     }
 }
 
+#[allow(dead_code)]
 impl<K: ArrayBuilder, V: ArrayBuilder> MapBuilder<K, V> {
     pub fn new(
         field_names: Option<MapFieldNames>,

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -203,6 +203,7 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
 ///
 /// `buffer_index` is used in error messages to identify which buffer
 /// had the invalid index
+#[allow(dead_code)]
 fn ensure_size(
     data_type: &DataType,
     min_size: usize,
@@ -1354,6 +1355,7 @@ enum BufferSpec {
     BitMap,
     /// Buffer is always null. Unused currently in Rust implementation,
     /// (used in C++ for Union type)
+    #[allow(dead_code)]
     AlwaysNull,
 }
 

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -140,6 +140,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
 /// assert_eq!(Int32Array::from(vec![2, 3, 1, 2, 3]), new_array);
 /// ```
 pub struct MutableArrayData<'a> {
+    #[allow(dead_code)]
     arrays: Vec<&'a ArrayData>,
     // The attributes in [_MutableArrayData] cannot be in [MutableArrayData] due to
     // mutability invariants (interior mutability):

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -4281,7 +4281,7 @@ mod tests {
                     Arc::new(Int32Array::from(vec![42, 28, 19, 31])),
                 ),
             ])),
-            //Arc::new(make_union_array()),
+            Arc::new(make_union_array()),
             Arc::new(NullArray::new(10)),
             Arc::new(StringArray::from(vec!["foo", "bar"])),
             Arc::new(LargeStringArray::from(vec!["foo", "bar"])),

--- a/arrow/src/compute/util.rs
+++ b/arrow/src/compute/util.rs
@@ -62,6 +62,7 @@ pub(super) fn combine_option_bitmap(
 ///
 /// This function is useful when implementing operations on higher level arrays.
 #[allow(clippy::unnecessary_wraps)]
+#[allow(dead_code)]
 pub(super) fn compare_option_bitmap(
     left_data: &ArrayData,
     right_data: &ArrayData,
@@ -343,6 +344,7 @@ pub(super) mod tests {
         GenericListArray::<S>::from(list_data)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn build_fixed_size_list<T>(
         data: Vec<Option<Vec<T::Native>>>,
         length: <Int32Type as ArrowPrimitiveType>::Native,

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -911,6 +911,7 @@ fn parse_decimal_with_parameter(s: &str, precision: usize, scale: usize) -> Resu
 
 // Parse the string format decimal value to i128 format without checking the precision and scale.
 // Like "125.12" to 12512_i128.
+#[cfg(test)]
 fn parse_decimal(s: &str) -> Result<i128> {
     if PARSE_DECIMAL_RE.is_match(s) {
         let mut offset = s.len();
@@ -1055,6 +1056,7 @@ pub struct ReaderBuilder {
     /// The default batch size when using the `ReaderBuilder` is 1024 records
     batch_size: usize,
     /// The bounds over which to scan the reader. `None` starts from 0 and runs until EOF.
+    #[allow(dead_code)]
     bounds: Bounds,
     /// Optional projection for which columns to load (zero-based column indices)
     projection: Option<Vec<usize>>,

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -97,6 +97,7 @@ pub struct Writer<W: Write> {
     /// The object to write to
     writer: csv_crate::Writer<W>,
     /// Column delimiter. Defaults to `b','`
+    #[allow(dead_code)]
     delimiter: u8,
     /// Whether file should be written with headers. Defaults to `true`
     has_headers: bool,
@@ -107,6 +108,7 @@ pub struct Writer<W: Write> {
     /// The timestamp format for timestamp arrays
     timestamp_format: String,
     /// The timestamp format for timestamp (with timezone) arrays
+    #[allow(dead_code)]
     timestamp_tz_format: String,
     /// The time format for time arrays
     time_format: String,

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -361,6 +361,7 @@ unsafe extern "C" fn release_array(array: *mut FFI_ArrowArray) {
 }
 
 struct ArrayPrivateData {
+    #[allow(dead_code)]
     buffers: Vec<Option<Buffer>>,
     buffers_ptr: Box<[*const c_void]>,
     children: Box<[*mut FFI_ArrowArray]>,

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -534,8 +534,6 @@ pub struct StreamWriter<W: Write> {
     writer: BufWriter<W>,
     /// IPC write options
     write_options: IpcWriteOptions,
-    /// A reference to the schema, used in validating record batches
-    schema: Schema,
     /// Whether the writer footer has been written, and the writer is finished
     finished: bool,
     /// Keeps track of dictionaries that have been written
@@ -564,7 +562,6 @@ impl<W: Write> StreamWriter<W> {
         Ok(Self {
             writer,
             write_options,
-            schema: schema.clone(),
             finished: false,
             dictionary_tracker: DictionaryTracker::new(false),
             data_gen,

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -127,7 +127,6 @@
 #![cfg_attr(feature = "avx512", feature(stdsimd))]
 #![cfg_attr(feature = "avx512", feature(repr_simd))]
 #![cfg_attr(feature = "avx512", feature(avx512_target_feature))]
-#![allow(dead_code)]
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1255

# Rationale for this change
 
It's beneficial to run clippy and compiler lints as strict as possible.

# What changes are included in this PR?

This PR drops `#![allow(dead_code)]`, which is the last top level `allow` attribute in the `arrow` crate. Unfortunately, it's the most difficult one to deal with, because there's a lot of code that exists and sometimes even has tests, but it's neither pub exported nor used anywhere. I don't feel comfortable removing it (except for the obvious cases like the unused time consts), that's why I've decided to use local `#[allow(dead_code)]` instead. The existing code is left intact, because it might be needed in the future, while overall the linting process gets more strict.

# Are there any user-facing changes?

No.