### PR TITLE
Implement projection for arrow file / streams

### DIFF
--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -69,6 +69,7 @@ pub fn flight_data_to_arrow_batch(
                 batch,
                 schema,
                 dictionaries_by_field,
+                None,
             )
         })?
 }

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -696,18 +696,13 @@ impl<R: Read + Seek> FileReader<R> {
                 }
             };
         }
-
-        let projection = projection.map(|projection| {
-            let fields = projection
-                .iter()
-                .map(|x| schema.fields[*x].clone())
-                .collect();
-            let schema = Schema {
-                fields,
-                metadata: schema.metadata.clone(),
-            };
-            (projection, schema)
-        });
+        let projection = match projection {
+            Some(projection_indices) => {
+                let schema = schema.project(&projection_indices)?;
+                Some((projection_indices, schema))
+            }
+            _ => None,
+        };
 
         Ok(Self {
             reader,
@@ -888,17 +883,13 @@ impl<R: Read> StreamReader<R> {
         // Create an array of optional dictionary value arrays, one per field.
         let dictionaries_by_field = vec![None; schema.fields().len()];
 
-        let projection = projection.map(|projection| {
-            let fields = projection
-                .iter()
-                .map(|x| schema.fields[*x].clone())
-                .collect();
-            let schema = Schema {
-                fields,
-                metadata: schema.metadata.clone(),
-            };
-            (projection, schema)
-        });
+        let projection = match projection {
+            Some(projection_indices) => {
+                let schema = schema.project(&projection_indices)?;
+                Some((projection_indices, schema))
+            }
+            _ => None,
+        };
         Ok(Self {
             reader,
             schema: Arc::new(schema),

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
-            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52
+            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52 (https://github.com/apache/arrow-rs/issues/859)
             "generated_nested",
             "generated_null_trivial",
             "generated_null",
@@ -1125,7 +1125,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
-            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52
+            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52 (https://github.com/apache/arrow-rs/issues/859)
             "generated_nested",
             "generated_null_trivial",
             "generated_null",
@@ -1145,10 +1145,7 @@ mod tests {
             reader.for_each(|batch| {
                 let batch = batch.unwrap();
                 assert_eq!(batch.columns().len(), 1);
-                assert_eq!(
-                    datatype_0,
-                    batch.schema().fields()[0].data_type().clone()
-                );
+                assert_eq!(datatype_0, batch.schema().fields()[0].data_type().clone());
             });
         });
     }

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
-            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52 (https://github.com/apache/arrow-rs/issues/859)
+            "generated_map",
             "generated_nested",
             "generated_null_trivial",
             "generated_null",
@@ -1111,10 +1111,7 @@ mod tests {
             ))
             .unwrap();
 
-            let reader = FileReader::try_new(file, None).unwrap();
-            reader.for_each(|batch| {
-                batch.unwrap();
-            });
+            FileReader::try_new(file, None).unwrap();
         });
     }
 

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
-            "generated_map",
+            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52
             "generated_nested",
             "generated_null_trivial",
             "generated_null",
@@ -1111,7 +1111,45 @@ mod tests {
             ))
             .unwrap();
 
-            FileReader::try_new(file, None).unwrap();
+            let reader = FileReader::try_new(file, None).unwrap();
+            reader.for_each(|batch| {
+                batch.unwrap();
+            });
+        });
+    }
+
+    #[test]
+    fn projection_should_work() {
+        // complementary to the previous test
+        let testdata = crate::util::test_util::arrow_test_data();
+        let paths = vec![
+            "generated_interval",
+            "generated_datetime",
+            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52
+            "generated_nested",
+            "generated_null_trivial",
+            "generated_null",
+            "generated_primitive_no_batches",
+            "generated_primitive_zerolength",
+            "generated_primitive",
+        ];
+        paths.iter().for_each(|path| {
+            let file = File::open(format!(
+                "{}/arrow-ipc-stream/integration/1.0.0-bigendian/{}.arrow_file",
+                testdata, path
+            ))
+            .unwrap();
+
+            let reader = FileReader::try_new(file, Some(vec![0])).unwrap();
+            let datatype_0 = reader.schema().fields()[0].data_type().clone();
+            reader.for_each(|batch| {
+                let batch = batch.unwrap();
+                assert_eq!(batch.columns().len(), 1);
+                assert_eq!(
+                    datatype_0,
+                    batch.schema().fields()[0].data_type().clone()
+                );
+            });
         });
     }
 

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -1266,7 +1266,19 @@ mod tests {
                     .value(0)
                     != 0.0
             );
-        })
+        });
+
+        let file = File::open("target/debug/testdata/float.stream").unwrap();
+
+        // Read with projection
+        let reader = StreamReader::try_new(file, Some(vec![0, 3])).unwrap();
+
+        reader.for_each(|batch| {
+            let batch = batch.unwrap();
+            assert_eq!(batch.schema().fields().len(), 2);
+            assert_eq!(batch.schema().fields()[0].data_type(), &DataType::Float32);
+            assert_eq!(batch.schema().fields()[1].data_type(), &DataType::Int32);
+        });
     }
 
     fn roundtrip_ipc(rb: &RecordBatch) -> RecordBatch {

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -881,7 +881,7 @@ mod tests {
             let file =
                 File::open(format!("target/debug/testdata/{}.arrow_file", "arrow"))
                     .unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
+            let mut reader = FileReader::try_new(file, None).unwrap();
             while let Some(Ok(read_batch)) = reader.next() {
                 read_batch
                     .columns()
@@ -929,7 +929,7 @@ mod tests {
 
         {
             let file = File::open(&file_name).unwrap();
-            let reader = FileReader::try_new(file).unwrap();
+            let reader = FileReader::try_new(file, None).unwrap();
             reader.for_each(|maybe_batch| {
                 maybe_batch
                     .unwrap()
@@ -999,7 +999,7 @@ mod tests {
             ))
             .unwrap();
 
-            let mut reader = FileReader::try_new(file).unwrap();
+            let mut reader = FileReader::try_new(file, None).unwrap();
 
             // read and rewrite the file to a temp location
             {
@@ -1020,7 +1020,7 @@ mod tests {
                 version, path
             ))
             .unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
+            let mut reader = FileReader::try_new(file, None).unwrap();
 
             // read expected JSON output
             let arrow_json = read_gzip_json(version, path);
@@ -1051,7 +1051,7 @@ mod tests {
             ))
             .unwrap();
 
-            let reader = StreamReader::try_new(file).unwrap();
+            let reader = StreamReader::try_new(file, None).unwrap();
 
             // read and rewrite the stream to a temp location
             {
@@ -1070,7 +1070,7 @@ mod tests {
             let file =
                 File::open(format!("target/debug/testdata/{}-{}.stream", version, path))
                     .unwrap();
-            let mut reader = StreamReader::try_new(file).unwrap();
+            let mut reader = StreamReader::try_new(file, None).unwrap();
 
             // read expected JSON output
             let arrow_json = read_gzip_json(version, path);
@@ -1108,7 +1108,7 @@ mod tests {
             ))
             .unwrap();
 
-            let mut reader = FileReader::try_new(file).unwrap();
+            let mut reader = FileReader::try_new(file, None).unwrap();
 
             // read and rewrite the file to a temp location
             {
@@ -1134,7 +1134,7 @@ mod tests {
                 version, path
             ))
             .unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
+            let mut reader = FileReader::try_new(file, None).unwrap();
 
             // read expected JSON output
             let arrow_json = read_gzip_json(version, path);
@@ -1172,7 +1172,7 @@ mod tests {
             ))
             .unwrap();
 
-            let reader = StreamReader::try_new(file).unwrap();
+            let reader = StreamReader::try_new(file, None).unwrap();
 
             // read and rewrite the stream to a temp location
             {
@@ -1195,7 +1195,7 @@ mod tests {
             let file =
                 File::open(format!("target/debug/testdata/{}-{}.stream", version, path))
                     .unwrap();
-            let mut reader = StreamReader::try_new(file).unwrap();
+            let mut reader = StreamReader::try_new(file, None).unwrap();
 
             // read expected JSON output
             let arrow_json = read_gzip_json(version, path);

--- a/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let f = File::open(&args.file_name)?;
     let reader = BufReader::new(f);
-    let mut reader = FileReader::try_new(reader)?;
+    let mut reader = FileReader::try_new(reader, None)?;
     let schema = reader.schema();
 
     let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;

--- a/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -83,7 +83,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     }
 
     let arrow_file = File::open(arrow_name)?;
-    let reader = FileReader::try_new(arrow_file)?;
+    let reader = FileReader::try_new(arrow_file, None)?;
 
     let mut fields: Vec<ArrowJsonField> = vec![];
     for f in reader.schema().fields() {
@@ -117,7 +117,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
 
     // open Arrow file
     let arrow_file = File::open(arrow_name)?;
-    let mut arrow_reader = FileReader::try_new(arrow_file)?;
+    let mut arrow_reader = FileReader::try_new(arrow_file, None)?;
     let arrow_schema = arrow_reader.schema().as_ref().to_owned();
 
     // compare schemas

--- a/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -22,7 +22,7 @@ use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
 
 fn main() -> Result<()> {
-    let mut arrow_stream_reader = StreamReader::try_new(io::stdin())?;
+    let mut arrow_stream_reader = StreamReader::try_new(io::stdin(), None)?;
     let schema = arrow_stream_reader.schema();
 
     let mut writer = FileWriter::try_new(io::stdout(), &schema)?;

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -295,6 +295,7 @@ async fn record_batch_from_message(
         ipc_batch,
         schema_ref,
         dictionaries_by_field,
+        None,
     );
 
     arrow_batch_result.map_err(|e| {


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1338

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Projection can avoid and loading it into arrays (this PR), and also could avoid reading it in the first place (not yet implemented).

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


* Changing the signature to `try_new(reader: R, projection: Option<Vec<usize>>)`
* Change `read_record_batch` to avoid creating arrays for columns in the projection.

We do not yet skip reading the data in the first place. 

# Are there any user-facing changes?



Yes - adding a second parameter to `FileReader::new` and `StreamReader::new`
<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
