### PR TITLE
Remove delimiter from csv Writer

### DIFF
--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -96,9 +96,6 @@ where
 pub struct Writer<W: Write> {
     /// The object to write to
     writer: csv_crate::Writer<W>,
-    /// Column delimiter. Defaults to `b','`
-    #[allow(dead_code)]
-    delimiter: u8,
     /// Whether file should be written with headers. Defaults to `true`
     has_headers: bool,
     /// The date format for date arrays
@@ -124,7 +121,6 @@ impl<W: Write> Writer<W> {
         let writer = builder.delimiter(delimiter).from_writer(writer);
         Writer {
             writer,
-            delimiter,
             has_headers: true,
             date_format: DEFAULT_DATE_FORMAT.to_string(),
             datetime_format: DEFAULT_TIMESTAMP_FORMAT.to_string(),
@@ -475,7 +471,6 @@ impl WriterBuilder {
         let writer = builder.delimiter(delimiter).from_writer(writer);
         Writer {
             writer,
-            delimiter,
             has_headers: self.has_headers,
             date_format: self
                 .date_format


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1328.

I think that I wrote the issue above in a bit of a rush, the part about changes to `Writer::new()`. The doc comment for `Writer::new()` clearly states that a new CsvWriter is initialized with default options, with `,` being the default delimiter.

A custom delimiter can be configured using already existing `WriterBuilder::with_delimiter`. So, in my view, the scope of the issue is to simply remove unused code without any changes to the API.

# Rationale for this change

There is no use for the `delimiter` field in csv `Writer`.

# What changes are included in this PR?

The unused `delimiter` field is removed.

# Are there any user-facing changes?

No.