### PR TITLE
Remove redundant has_ methods for optional column metadata fields

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -467,22 +467,9 @@ impl ColumnChunkMetaData {
         self.statistics.as_ref()
     }
 
-    /// Returns `true` if this column chunk contains a bloom filter offset, `false` otherwise.
-    pub fn has_bloom_filter(&self) -> bool {
-        self.bloom_filter_offset.is_some()
-    }
-
     /// Returns the offset for the bloom filter.
     pub fn bloom_filter_offset(&self) -> Option<i64> {
         self.bloom_filter_offset
-    }
-
-    /// Returns `true` if this column chunk contains a column index, `false` otherwise.
-    pub fn has_column_index(&self) -> bool {
-        self.column_index_offset.is_some()
-            && self.column_index_length.is_some()
-            && self.offset_index_offset.is_some()
-            && self.offset_index_length.is_some()
     }
 
     /// Returns the offset for the column index.

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -773,7 +773,6 @@ mod tests {
         assert_eq!(col0_metadata.bloom_filter_offset().unwrap(), 192);
 
         // test page encoding stats
-        assert!(col0_metadata.has_page_encoding_stats());
         let page_encoding_stats =
             col0_metadata.page_encoding_stats().unwrap().get(0).unwrap();
 
@@ -782,7 +781,6 @@ mod tests {
         assert_eq!(page_encoding_stats.count, 1);
 
         // test optional column index offset
-        assert!(col0_metadata.has_column_index());
         assert_eq!(col0_metadata.column_index_offset().unwrap(), 156);
         assert_eq!(col0_metadata.column_index_length().unwrap(), 25);
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1344.

# Rationale for this change
 Remove redundant has_ methods for optional column metadata members as they could be access by `if let(Some) = field`.