### PR TITLE
Add with_datetime_format to csv WriterBuilder

### DIFF
--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -456,6 +456,12 @@ impl WriterBuilder {
         self
     }
 
+    /// Set the CSV file's datetime format
+    pub fn with_datetime_format(mut self, format: String) -> Self {
+        self.datetime_format = Some(format);
+        self
+    }
+
     /// Set the CSV file's time format
     pub fn with_time_format(mut self, format: String) -> Self {
         self.time_format = Some(format);


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1272.

# Rationale for this change
 
Users should be able to override the default datetime format.

# What changes are included in this PR?

Add `with_datetime_format()` method to csv `WriterBuilder`.

# Are there any user-facing changes?

Yes, a new method `WriterBuilder::with_datetime_format()`.