### PR TITLE
Fix clippy lints

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -119,8 +119,7 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
 
         (0..rd_buf.len())
             .position(|i| rd_buf.value(i) == value)
-            .map(K::Native::from_usize)
-            .flatten()
+            .and_then(K::Native::from_usize)
     }
 
     /// Returns a reference to the dictionary values array

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -267,7 +267,7 @@ where
         let re = if let Some(ref regex) = map.get(pat) {
             regex
         } else {
-            let re_pattern = escape(pat).replace("%", ".*").replace("_", ".");
+            let re_pattern = escape(pat).replace('%', ".*").replace('_', ".");
             let re = op(&re_pattern)?;
             map.insert(pat, re);
             map.get(pat).unwrap()
@@ -364,7 +364,7 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
             }
         }
     } else {
-        let re_pattern = escape(right).replace("%", ".*").replace("_", ".");
+        let re_pattern = escape(right).replace('%', ".*").replace('_', ".");
         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
             ArrowError::ComputeError(format!(
                 "Unable to build regex from LIKE pattern: {}",
@@ -440,7 +440,7 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
             result.append(!left.value(i).ends_with(&right[1..]));
         }
     } else {
-        let re_pattern = escape(right).replace("%", ".*").replace("_", ".");
+        let re_pattern = escape(right).replace('%', ".*").replace('_', ".");
         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
             ArrowError::ComputeError(format!(
                 "Unable to build regex from LIKE pattern: {}",
@@ -521,7 +521,7 @@ pub fn ilike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
             );
         }
     } else {
-        let re_pattern = escape(right).replace("%", ".*").replace("_", ".");
+        let re_pattern = escape(right).replace('%', ".*").replace('_', ".");
         let re = Regex::new(&format!("(?i)^{}$", re_pattern)).map_err(|e| {
             ArrowError::ComputeError(format!(
                 "Unable to build regex from ILIKE pattern: {}",

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -600,8 +600,7 @@ where
 
     let null_count = values.null_count();
 
-    let nulls;
-    if null_count == 0 {
+    let nulls = if null_count == 0 {
         (0..data_len).try_for_each::<_, Result<()>>(|i| {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
                 ArrowError::ComputeError("Cast to usize failed".to_string())
@@ -614,7 +613,7 @@ where
             Ok(())
         })?;
 
-        nulls = indices.data_ref().null_buffer().cloned();
+        indices.data_ref().null_buffer().cloned()
     } else {
         let mut null_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, true);
         let null_slice = null_buf.as_slice_mut();
@@ -633,7 +632,7 @@ where
             Ok(())
         })?;
 
-        nulls = match indices.data_ref().null_buffer() {
+        match indices.data_ref().null_buffer() {
             Some(buffer) => Some(buffer_bin_and(
                 buffer,
                 indices.offset(),
@@ -642,8 +641,8 @@ where
                 indices.len(),
             )),
             None => Some(null_buf.into()),
-        };
-    }
+        }
+    };
 
     let data = unsafe {
         ArrayData::new_unchecked(

--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -118,7 +118,7 @@ impl Field {
         let mut collected_fields = vec![self];
         match &self.data_type {
             DataType::Struct(fields) | DataType::Union(fields, _) => {
-                collected_fields.extend(fields.iter().map(|f| f.fields()).flatten())
+                collected_fields.extend(fields.iter().flat_map(|f| f.fields()))
             }
             DataType::List(field)
             | DataType::LargeList(field)

--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -184,7 +184,7 @@ impl Schema {
     /// Returns a vector with references to all fields (including nested fields)
     #[inline]
     pub(crate) fn all_fields(&self) -> Vec<&Field> {
-        self.fields.iter().map(|f| f.fields()).flatten().collect()
+        self.fields.iter().flat_map(|f| f.fields()).collect()
     }
 
     /// Returns an immutable reference of a specific `Field` instance selected using an
@@ -203,8 +203,7 @@ impl Schema {
     pub fn fields_with_dict_id(&self, dict_id: i64) -> Vec<&Field> {
         self.fields
             .iter()
-            .map(|f| f.fields_with_dict_id(dict_id))
-            .flatten()
+            .flat_map(|f| f.fields_with_dict_id(dict_id))
             .collect()
     }
 

--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -553,7 +553,7 @@ pub(crate) fn get_fb_field_type<'a>(
             }
         }
         Timestamp(unit, tz) => {
-            let tz = tz.clone().unwrap_or_else(String::new);
+            let tz = tz.clone().unwrap_or_default();
             let tz_str = fbb.create_string(tz.as_str());
             let mut builder = ipc::TimestampBuilder::new(fbb);
             let time_unit = match unit {

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -645,7 +645,7 @@ impl Decoder {
         }
 
         let rows = &rows[..];
-        let projection = self.projection.clone().unwrap_or_else(Vec::new);
+        let projection = self.projection.clone().unwrap_or_default();
         let arrays = self.build_struct_array(rows, self.schema.fields(), &projection);
 
         let projected_fields: Vec<Field> = if projection.is_empty() {
@@ -1275,8 +1275,7 @@ impl Decoder {
                                 (
                                     i,
                                     row.as_object()
-                                        .map(|v| v.get(field.name()))
-                                        .flatten(),
+                                        .and_then(|v| v.get(field.name())),
                                 )
                             })
                             .map(|(i, v)| match v {
@@ -1351,8 +1350,7 @@ impl Decoder {
         let value_map_iter = rows.iter().map(|value| {
             value
                 .get(field_name)
-                .map(|v| v.as_object().map(|map| (map, map.len() as i32)))
-                .flatten()
+                .and_then(|v| v.as_object().map(|map| (map, map.len() as i32)))
         });
         let rows_len = rows.len();
         let mut list_offsets = Vec::with_capacity(rows_len + 1);

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -1271,11 +1271,7 @@ impl Decoder {
                             .iter()
                             .enumerate()
                             .map(|(i, row)| {
-                                (
-                                    i,
-                                    row.as_object()
-                                        .and_then(|v| v.get(field.name())),
-                                )
+                                (i, row.as_object().and_then(|v| v.get(field.name())))
                             })
                             .map(|(i, v)| match v {
                                 // we want the field as an object, if it's not, we treat as null

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -653,8 +653,7 @@ impl Decoder {
         } else {
             projection
                 .iter()
-                .map(|name| self.schema.column_with_name(name))
-                .flatten()
+                .filter_map(|name| self.schema.column_with_name(name))
                 .map(|(_, field)| field.clone())
                 .collect()
         };

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -601,7 +601,7 @@ mod tests {
         let a = Int64Array::from(vec![1, 2, 3, 4, 5]);
 
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]);
-        assert!(!batch.is_ok());
+        assert!(batch.is_err());
     }
 
     #[test]
@@ -662,7 +662,7 @@ mod tests {
 
         let batch =
             RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]);
-        assert!(!batch.is_ok());
+        assert!(batch.is_err());
     }
 
     #[test]

--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -1769,14 +1769,13 @@ impl<'a> ArrayReaderBuilder {
                 // get the optional timezone information from arrow type
                 let timezone = arrow_type
                     .as_ref()
-                    .map(|data_type| {
+                    .and_then(|data_type| {
                         if let ArrowType::Timestamp(_, tz) = data_type {
                             tz.clone()
                         } else {
                             None
                         }
-                    })
-                    .flatten();
+                    });
                 let converter = Int96Converter::new(Int96ArrayConverter { timezone });
                 Ok(Box::new(ComplexObjectArrayReader::<
                     Int96Type,

--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -713,8 +713,8 @@ impl LevelInfo {
             DataType::List(_) | DataType::Map(_, _) => {
                 let offsets = unsafe { array.data().buffers()[0].typed_data::<i32>() };
                 let offsets = offsets
-                    .to_vec()
-                    .into_iter()
+                    .iter()
+                    .copied()
                     .skip(array.offset() + offset)
                     .take(len + 1)
                     .map(|v| v as i64)

--- a/parquet/src/util/cursor.rs
+++ b/parquet/src/util/cursor.rs
@@ -210,7 +210,7 @@ mod tests {
         let mut target = vec![];
         let cursor_res = cursor.read_to_end(&mut target);
         println!("{:?}", cursor_res);
-        assert!(!cursor_res.is_err(), "reading error");
+        assert!(cursor_res.is_ok(), "reading error");
         assert_eq!((end_included - start) as usize + 1, cursor_res.unwrap());
         assert_eq!((start..=end_included).collect::<Vec<_>>(), target);
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1362 .

# Rationale for this change
 Rust is updated to 1.59.0. Some new lints are added to cargo clippy.

# What changes are included in this PR?
run
```
cargo clippy --features test_common --features prettyprint --features=async --all-targets --workspace -- -D warnings
```
and fix all errors and warnings

# Are there any user-facing changes?
No


