### PR TITLE
Clarify release instructions about when to merge CHANGELOG update

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -71,9 +71,14 @@ Note that when reviewing the change log, rather than editing the
 `CHANGELOG.md`, it is preferred to update the issues and their labels
 (e.g. add `invalid` label to exclude them from release notes)
 
+Merge this PR to `master` prior to the next step.
+
 ## Prepare release candidate tarball
 
-(Note you need to be a committer to run these scripts as they upload to the apache svn distribution servers)
+After you have merged the updates to the `CHANGELOG` and version,
+create a release candidate using the following steps. Note you need to
+be a committer to run these scripts as they upload to the apache `svn`
+distribution servers.
 
 ### Create git tag for the release:
 


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/1304


# Rationale for this change
 
It was not 100% clear when releasing arrow when the CHANGELOG update PR should be merged.  See https://github.com/apache/arrow-rs/pull/1325#pullrequestreview-887945554


# What changes are included in this PR?

Make it clear the CHANGELOG PR should be merged prior to creating the release candidate

# Are there any user-facing changes?

No