### PR TITLE
Speed up the function `min_max_string`

### DIFF
--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -44,7 +44,7 @@ where
         None
     } else if null_count == 0 {
         // JUSTIFICATION
-        //  Benefit:  ~10% speedup
+        //  Benefit:  ~8% speedup
         //  Soundness: `i` is always within the array bounds
         (0..array.len())
             .map(|i| unsafe { array.value_unchecked(i) })

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -32,11 +32,12 @@ fn is_nan<T: ArrowNativeType + PartialOrd + Copy>(a: T) -> bool {
     !(a == a)
 }
 
-/// Helper macro to perform min/max of strings
-fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
-    array: &GenericStringArray<T>,
-    cmp: F,
-) -> Option<&str> {
+/// Helper function to perform min/max of strings
+fn min_max_string<T, F>(array: &GenericStringArray<T>, cmp: F) -> Option<&str>
+where
+    T: StringOffsetSizeTrait,
+    F: Fn(&str, &str) -> bool,
+{
     let null_count = array.null_count();
 
     if null_count == array.len() {

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -40,31 +40,13 @@ fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
     let null_count = array.null_count();
 
     if null_count == array.len() {
-        return None;
-    }
-    let data = array.data();
-    let mut n;
-    if null_count == 0 {
-        n = array.value(0);
-        for i in 1..data.len() {
-            let item = array.value(i);
-            if cmp(n, item) {
-                n = item;
-            }
-        }
+        None
     } else {
-        n = "";
-        let mut has_value = false;
-
-        for i in 0..data.len() {
-            let item = array.value(i);
-            if data.is_valid(i) && (!has_value || cmp(n, item)) {
-                has_value = true;
-                n = item;
-            }
-        }
+        array
+        .iter()
+        .flatten()
+        .reduce(|acc, item| {if cmp(acc, item) {item} else {acc}})
     }
-    Some(n)
 }
 
 /// Returns the minimum value in the array, according to the natural order.

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -41,11 +41,15 @@ fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
 
     if null_count == array.len() {
         None
+    } else if null_count == 0 {
+        (0..array.len())
+            .map(|i| array.value(i))
+            .reduce(|acc, item| if cmp(acc, item) { item } else { acc })
     } else {
         array
-        .iter()
-        .flatten()
-        .reduce(|acc, item| {if cmp(acc, item) {item} else {acc}})
+            .iter()
+            .flatten()
+            .reduce(|acc, item| if cmp(acc, item) { item } else { acc })
     }
 }
 

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -43,8 +43,11 @@ where
     if null_count == array.len() {
         None
     } else if null_count == 0 {
+        // JUSTIFICATION
+        //  Benefit:  ~10% speedup
+        //  Soundness: `i` is always within the array bounds
         (0..array.len())
-            .map(|i| array.value(i))
+            .map(|i| unsafe { array.value_unchecked(i) })
             .reduce(|acc, item| if cmp(acc, item) { item } else { acc })
     } else {
         array


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1373 .

# Rationale for this change
 1. Improve performance 
 2. clean up the code

# What changes are included in this PR?
1. Performance is improved when `null_count > 0`. See benchmark result.  
2. more functional styles and fewer mutable variables

## benchmark
```shell
min string 512          time:   [1.3687 us 1.3691 us 1.3696 us]                            
                        change: [-7.7279% -7.5833% -7.4242%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

min nulls string 512    time:   [1.6630 us 1.6647 us 1.6665 us]                                  
                        change: [-33.478% -33.362% -33.244%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

# Are there any user-facing changes?
No
