### PR TITLE
Introduce `ReadOptions` with builder API, for parquet filter row groups that satisfy all filters, and enable filter row groups by range.

### DIFF
--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -35,13 +35,8 @@ pub struct Bitmap {
 
 impl Bitmap {
     pub fn new(num_bits: usize) -> Self {
-        let num_bytes = num_bits / 8 + if num_bits % 8 > 0 { 1 } else { 0 };
-        let r = num_bytes % 64;
-        let len = if r == 0 {
-            num_bytes
-        } else {
-            num_bytes + 64 - r
-        };
+        let num_bytes = bit_util::ceil(num_bits, 8);
+        let len = bit_util::round_upto_multiple_of_64(num_bytes);
         Bitmap {
             bits: Buffer::from(&vec![0xFF; len]),
         }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -163,7 +163,7 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
                 }
             }
         }
-        
+
         self.metadata = ParquetMetaData::new(
             self.metadata.file_metadata().clone(),
             filtered_row_groups,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -150,7 +150,8 @@ impl ReadOptionsBuilder {
         self
     }
 
-    /// Add a range predicate on filtering row groups if their midpoints are within the range
+    /// Add a range predicate on filtering row groups if their midpoints are within
+    /// the Closed-Open range `[start..end)	{x | start <= x < end}`
     pub fn with_range(mut self, start: i64, end: i64) -> Self {
         assert!(start < end);
         let predicate = move |rg: &RowGroupMetaData, _: usize| {

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -151,7 +151,7 @@ impl ReadOptionsBuilder {
     }
 
     /// Add a range predicate on filtering row groups if their midpoints are within
-    /// the Closed-Open range `[start..end)	{x | start <= x < end}`
+    /// the Closed-Open range `[start..end) {x | start <= x < end}`
     pub fn with_range(mut self, start: i64, end: i64) -> Self {
         assert!(start < end);
         let predicate = move |rg: &RowGroupMetaData, _: usize| {


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #158.

# Rationale for this change
 
To support parallel parquet reading at row group level.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

One extra parameter while filtering row groups using row group metadata.

The midpoint and range comparison are from parquet-mr `ParquetInputSplit` semantic by selecting belonged row groups. 

# Are there any user-facing changes?

Yes.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
