### PR TITLE
Add note in contributing guideline about types of contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,17 @@
   under the License.
 -->
 
+## Introduction
+
+We welcome and encourage contributions of all kinds, such as:
+
+1. Tickets with issue reports of feature requests
+2. Documentation improvements
+3. Code (PR or PR Review)
+
+In addition to submitting new PRs, we have a healthy tradition of community members helping review each other's PRs. Doing so is a great way to help the community as well as get more familiar with Rust and the relevant codebases.
+
+
 ## Developer's guide to Arrow Rust
 
 ### Setting Up Your Build Environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,6 @@ We welcome and encourage contributions of all kinds, such as:
 
 In addition to submitting new PRs, we have a healthy tradition of community members helping review each other's PRs. Doing so is a great way to help the community as well as get more familiar with Rust and the relevant codebases.
 
-
 ## Developer's guide to Arrow Rust
 
 ### Setting Up Your Build Environment

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ and bug fixes and this plays a critical role in the release process.
 
 For design discussions we generally collaborate on Google documents and file a GitHub issue linking to the document.
 
+There is more information in the [contributing] guide.
+
 [rust]: https://www.rust-lang.org/
 [arrow-readme]: arrow/README.md
+[contributing]: CONTRIBUTING.md
 [parquet-readme]: parquet/README.md
 [flight-readme]: arrow-flight/README.md
 [datafusion-readme]: https://github.com/apache/arrow-datafusion/blob/master/README.md


### PR DESCRIPTION
As the community grows, I am trying to help it scale and not be bottlenecked on review by the maintainers. 

Ideally by the time one of the maintainers sees a PR it is more or less ready to go (though maybe that is wishful thinking)

Rendered version here: https://github.com/alamb/arrow-rs/blob/alamb/review_plea/CONTRIBUTING.md