### PR TITLE
fix: Fix grpc schema hack in flight integration test

### DIFF
--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -185,7 +185,8 @@ async fn consume_flight_location(
     let mut location = location;
     // The other Flight implementations use the `grpc+tcp` scheme, but the Rust http libs
     // don't recognize this as valid.
-    location.uri = location.uri.replace("grpc+tcp://", "grpc://");
+    // more details: https://github.com/apache/arrow-rs/issues/1398
+    location.uri = location.uri.replace("grpc+tcp://", "http://");
 
     let mut client = FlightServiceClient::connect(location.uri).await?;
     let resp = client.do_get(ticket).await?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1398

# Rationale for this change
 
 Certain flight integration tests are failing with rust

We think something about the gRPC library has changed recently to be more strict, but I never found a good way to verify this. 

# What changes are included in this PR?

Change some workaround code in the "scheme" passed to gRPC to use `http://` rather than`grpc://` https://github.com/apache/arrow-rs/issues/1398#issuecomment-1059610103 as suggested by @lidavidm ❤️  ❤️ 

# Are there any user-facing changes?
No this is a test only change