### PR TITLE
Add dictionary support for C data interface

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -79,6 +79,7 @@ _supported_pyarrow_types = [
             pa.field("c", pa.string()),
         ]
     ),
+    pa.dictionary(pa.int8(), pa.string()),
 ]
 
 _unsupported_pyarrow_types = [
@@ -121,14 +122,6 @@ def test_type_roundtrip(pyarrow_type):
 def test_type_roundtrip_raises(pyarrow_type):
     with pytest.raises(pa.ArrowException):
         rust.round_trip_type(pyarrow_type)
-
-
-def test_dictionary_type_roundtrip():
-    # the dictionary type conversion is incomplete
-    pyarrow_type = pa.dictionary(pa.int32(), pa.string())
-    ty = rust.round_trip_type(pyarrow_type)
-    assert ty == pa.int32()
-
 
 @pytest.mark.parametrize('pyarrow_type', _supported_pyarrow_types, ids=str)
 def test_field_roundtrip(pyarrow_type):
@@ -259,6 +252,16 @@ def test_decimal_python():
         None
     ]
     a = pa.array(data, pa.decimal128(6, 2))
+    b = rust.round_trip_array(a)
+    assert a == b
+    del a
+    del b
+
+def test_dictionary_python():
+    """
+    Python -> Rust -> Python
+    """
+    a = pa.array(["a", "b", "a"], type=pa.dictionary(pa.int8(), pa.string()))
     b = rust.round_trip_array(a)
     assert a == b
     del a

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -261,7 +261,7 @@ def test_dictionary_python():
     """
     Python -> Rust -> Python
     """
-    a = pa.array(["a", "b", "a"], type=pa.dictionary(pa.int8(), pa.string()))
+    a = pa.array(["a", None, "b", None, "a"], type=pa.dictionary(pa.int8(), pa.string()))
     b = rust.round_trip_array(a)
     assert a == b
     del a

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -131,8 +131,19 @@ mod tests {
 
     #[test]
     fn test_dictionary() -> Result<()> {
-        let values = StringArray::from(vec!["foo", "bar", "zoo"]);
-        let keys = Int32Array::from(vec![0, 1, 2, 2, 1, 0, 1, 2, 1, 2]);
+        let values = StringArray::from(vec![Some("foo"), Some("bar"), None]);
+        let keys = Int32Array::from(vec![
+            Some(0),
+            Some(1),
+            None,
+            Some(1),
+            Some(1),
+            None,
+            Some(1),
+            Some(2),
+            Some(1),
+            None,
+        ]);
         let array = DictionaryArray::try_new(&keys, &values)?;
 
         let data = array.data();

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -45,6 +45,7 @@ impl TryFrom<ArrayData> for ffi::ArrowArray {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::{DictionaryArray, Int32Array, StringArray};
     use crate::error::Result;
     use crate::{
         array::{
@@ -124,6 +125,16 @@ mod tests {
                 Arc::new(UInt32Array::from(vec![42, 28, 19, 31])),
             ),
         ]);
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_dictionary() -> Result<()> {
+        let values = StringArray::from(vec!["foo", "bar", "zoo"]);
+        let keys = Int32Array::from(vec![0, 1, 2, 2, 1, 0, 1, 2, 1, 2]);
+        let array = DictionaryArray::try_new(&keys, &values)?;
+
         let data = array.data();
         test_round_trip(data)
     }

--- a/arrow/src/datatypes/ffi.rs
+++ b/arrow/src/datatypes/ffi.rs
@@ -28,7 +28,7 @@ impl TryFrom<&FFI_ArrowSchema> for DataType {
 
     /// See [CDataInterface docs](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings)
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self> {
-        let dtype = match c_schema.format() {
+        let mut dtype = match c_schema.format() {
             "n" => DataType::Null,
             "b" => DataType::Boolean,
             "c" => DataType::Int8,
@@ -134,6 +134,12 @@ impl TryFrom<&FFI_ArrowSchema> for DataType {
                 }
             }
         };
+
+        if let Some(dict_schema) = c_schema.dictionary() {
+            let value_type = Self::try_from(dict_schema)?;
+            dtype = DataType::Dictionary(Box::new(dtype), Box::new(value_type));
+        }
+
         Ok(dtype)
     }
 }
@@ -169,49 +175,7 @@ impl TryFrom<&DataType> for FFI_ArrowSchema {
 
     /// See [CDataInterface docs](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings)
     fn try_from(dtype: &DataType) -> Result<Self> {
-        let format = match dtype {
-            DataType::Null => "n".to_string(),
-            DataType::Boolean => "b".to_string(),
-            DataType::Int8 => "c".to_string(),
-            DataType::UInt8 => "C".to_string(),
-            DataType::Int16 => "s".to_string(),
-            DataType::UInt16 => "S".to_string(),
-            DataType::Int32 => "i".to_string(),
-            DataType::UInt32 => "I".to_string(),
-            DataType::Int64 => "l".to_string(),
-            DataType::UInt64 => "L".to_string(),
-            DataType::Float16 => "e".to_string(),
-            DataType::Float32 => "f".to_string(),
-            DataType::Float64 => "g".to_string(),
-            DataType::Binary => "z".to_string(),
-            DataType::LargeBinary => "Z".to_string(),
-            DataType::Utf8 => "u".to_string(),
-            DataType::LargeUtf8 => "U".to_string(),
-            DataType::Decimal(precision, scale) => format!("d:{},{}", precision, scale),
-            DataType::Date32 => "tdD".to_string(),
-            DataType::Date64 => "tdm".to_string(),
-            DataType::Time32(TimeUnit::Second) => "tts".to_string(),
-            DataType::Time32(TimeUnit::Millisecond) => "ttm".to_string(),
-            DataType::Time64(TimeUnit::Microsecond) => "ttu".to_string(),
-            DataType::Time64(TimeUnit::Nanosecond) => "ttn".to_string(),
-            DataType::Timestamp(TimeUnit::Second, None) => "tss:".to_string(),
-            DataType::Timestamp(TimeUnit::Millisecond, None) => "tsm:".to_string(),
-            DataType::Timestamp(TimeUnit::Microsecond, None) => "tsu:".to_string(),
-            DataType::Timestamp(TimeUnit::Nanosecond, None) => "tsn:".to_string(),
-            DataType::Timestamp(TimeUnit::Second, Some(tz)) => format!("tss:{}", tz),
-            DataType::Timestamp(TimeUnit::Millisecond, Some(tz)) => format!("tsm:{}", tz),
-            DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => format!("tsu:{}", tz),
-            DataType::Timestamp(TimeUnit::Nanosecond, Some(tz)) => format!("tsn:{}", tz),
-            DataType::List(_) => "+l".to_string(),
-            DataType::LargeList(_) => "+L".to_string(),
-            DataType::Struct(_) => "+s".to_string(),
-            other => {
-                return Err(ArrowError::CDataInterface(format!(
-                    "The datatype \"{:?}\" is still not supported in Rust implementation",
-                    other
-                )))
-            }
-        };
+        let format = get_format_string(dtype)?;
         // allocate and hold the children
         let children = match dtype {
             DataType::List(child) | DataType::LargeList(child) => {
@@ -223,7 +187,57 @@ impl TryFrom<&DataType> for FFI_ArrowSchema {
                 .collect::<Result<Vec<_>>>()?,
             _ => vec![],
         };
-        FFI_ArrowSchema::try_new(&format, children)
+        let dictionary = if let DataType::Dictionary(_, value_data_type) = dtype {
+            Some(Self::try_from(value_data_type.as_ref())?)
+        } else {
+            None
+        };
+        FFI_ArrowSchema::try_new(&format, children, dictionary)
+    }
+}
+
+fn get_format_string(dtype: &DataType) -> Result<String> {
+    match dtype {
+        DataType::Null => Ok("n".to_string()),
+        DataType::Boolean => Ok("b".to_string()),
+        DataType::Int8 => Ok("c".to_string()),
+        DataType::UInt8 => Ok("C".to_string()),
+        DataType::Int16 => Ok("s".to_string()),
+        DataType::UInt16 => Ok("S".to_string()),
+        DataType::Int32 => Ok("i".to_string()),
+        DataType::UInt32 => Ok("I".to_string()),
+        DataType::Int64 => Ok("l".to_string()),
+        DataType::UInt64 => Ok("L".to_string()),
+        DataType::Float16 => Ok("e".to_string()),
+        DataType::Float32 => Ok("f".to_string()),
+        DataType::Float64 => Ok("g".to_string()),
+        DataType::Binary => Ok("z".to_string()),
+        DataType::LargeBinary => Ok("Z".to_string()),
+        DataType::Utf8 => Ok("u".to_string()),
+        DataType::LargeUtf8 => Ok("U".to_string()),
+        DataType::Decimal(precision, scale) => Ok(format!("d:{},{}", precision, scale)),
+        DataType::Date32 => Ok("tdD".to_string()),
+        DataType::Date64 => Ok("tdm".to_string()),
+        DataType::Time32(TimeUnit::Second) => Ok("tts".to_string()),
+        DataType::Time32(TimeUnit::Millisecond) => Ok("ttm".to_string()),
+        DataType::Time64(TimeUnit::Microsecond) => Ok("ttu".to_string()),
+        DataType::Time64(TimeUnit::Nanosecond) => Ok("ttn".to_string()),
+        DataType::Timestamp(TimeUnit::Second, None) => Ok("tss:".to_string()),
+        DataType::Timestamp(TimeUnit::Millisecond, None) => Ok("tsm:".to_string()),
+        DataType::Timestamp(TimeUnit::Microsecond, None) => Ok("tsu:".to_string()),
+        DataType::Timestamp(TimeUnit::Nanosecond, None) => Ok("tsn:".to_string()),
+        DataType::Timestamp(TimeUnit::Second, Some(tz)) => Ok(format!("tss:{}", tz)),
+        DataType::Timestamp(TimeUnit::Millisecond, Some(tz)) => Ok(format!("tsm:{}", tz)),
+        DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => Ok(format!("tsu:{}", tz)),
+        DataType::Timestamp(TimeUnit::Nanosecond, Some(tz)) => Ok(format!("tsn:{}", tz)),
+        DataType::List(_) => Ok("+l".to_string()),
+        DataType::LargeList(_) => Ok("+L".to_string()),
+        DataType::Struct(_) => Ok("+s".to_string()),
+        DataType::Dictionary(key_data_type, _) => get_format_string(key_data_type),
+        other => Err(ArrowError::CDataInterface(format!(
+            "The datatype \"{:?}\" is still not supported in Rust implementation",
+            other
+        ))),
     }
 }
 

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -122,6 +122,7 @@ pub struct FFI_ArrowSchema {
 
 struct SchemaPrivateData {
     children: Box<[*mut FFI_ArrowSchema]>,
+    dictionary: *mut FFI_ArrowSchema,
 }
 
 // callback used to drop [FFI_ArrowSchema] when it is exported.
@@ -141,6 +142,10 @@ unsafe extern "C" fn release_schema(schema: *mut FFI_ArrowSchema) {
         for child in private_data.children.iter() {
             drop(Box::from_raw(*child))
         }
+        if !private_data.dictionary.is_null() {
+            drop(Box::from_raw(private_data.dictionary));
+        }
+
         drop(private_data);
     }
 
@@ -150,7 +155,11 @@ unsafe extern "C" fn release_schema(schema: *mut FFI_ArrowSchema) {
 impl FFI_ArrowSchema {
     /// create a new [`FFI_ArrowSchema`]. This fails if the fields'
     /// [`DataType`] is not supported.
-    pub fn try_new(format: &str, children: Vec<FFI_ArrowSchema>) -> Result<Self> {
+    pub fn try_new(
+        format: &str,
+        children: Vec<FFI_ArrowSchema>,
+        dictionary: Option<FFI_ArrowSchema>,
+    ) -> Result<Self> {
         let mut this = Self::empty();
 
         let children_ptr = children
@@ -163,12 +172,19 @@ impl FFI_ArrowSchema {
         this.release = Some(release_schema);
         this.n_children = children_ptr.len() as i64;
 
+        let dictionary_ptr = dictionary
+            .map(|d| Box::into_raw(Box::new(d)))
+            .unwrap_or(std::ptr::null_mut());
+
         let mut private_data = Box::new(SchemaPrivateData {
             children: children_ptr,
+            dictionary: dictionary_ptr,
         });
 
         // intentionally set from private_data (see https://github.com/apache/arrow-rs/issues/580)
         this.children = private_data.children.as_mut_ptr();
+
+        this.dictionary = dictionary_ptr;
 
         this.private_data = Box::into_raw(private_data) as *mut c_void;
 
@@ -232,6 +248,10 @@ impl FFI_ArrowSchema {
 
     pub fn nullable(&self) -> bool {
         (self.flags / 2) & 1 == 1
+    }
+
+    pub fn dictionary(&self) -> Option<&Self> {
+        unsafe { self.dictionary.as_ref() }
     }
 }
 
@@ -356,6 +376,9 @@ unsafe extern "C" fn release_array(array: *mut FFI_ArrowArray) {
     for child in private.children.iter() {
         let _ = Box::from_raw(*child);
     }
+    if !private.dictionary.is_null() {
+        let _ = Box::from_raw(private.dictionary);
+    }
 
     array.release = None;
 }
@@ -365,6 +388,7 @@ struct ArrayPrivateData {
     buffers: Vec<Option<Buffer>>,
     buffers_ptr: Box<[*const c_void]>,
     children: Box<[*mut FFI_ArrowArray]>,
+    dictionary: *mut FFI_ArrowArray,
 }
 
 impl FFI_ArrowArray {
@@ -389,8 +413,16 @@ impl FFI_ArrowArray {
             })
             .collect::<Box<[_]>>();
 
-        let children = data
-            .child_data()
+        let empty = vec![];
+        let (child_data, dictionary) = match data.data_type() {
+            DataType::Dictionary(_, _) => (
+                empty.as_slice(),
+                Box::into_raw(Box::new(FFI_ArrowArray::new(&data.child_data()[0]))),
+            ),
+            _ => (data.child_data(), std::ptr::null_mut()),
+        };
+
+        let children = child_data
             .iter()
             .map(|child| Box::into_raw(Box::new(FFI_ArrowArray::new(child))))
             .collect::<Box<_>>();
@@ -402,6 +434,7 @@ impl FFI_ArrowArray {
             buffers,
             buffers_ptr,
             children,
+            dictionary,
         });
 
         Self {
@@ -412,7 +445,7 @@ impl FFI_ArrowArray {
             n_children,
             buffers: private_data.buffers_ptr.as_mut_ptr(),
             children: private_data.children.as_mut_ptr(),
-            dictionary: std::ptr::null_mut(),
+            dictionary,
             release: Some(release_array),
             private_data: Box::into_raw(private_data) as *mut c_void,
         }
@@ -508,13 +541,19 @@ pub trait ArrowArrayRef {
         let buffers = self.buffers()?;
         let null_bit_buffer = self.null_bit_buffer();
 
-        let child_data = (0..self.array().n_children as usize)
+        let mut child_data: Vec<ArrayData> = (0..self.array().n_children as usize)
             .map(|i| {
                 let child = self.child(i);
                 child.to_data()
             })
             .map(|d| d.unwrap())
             .collect();
+
+        if let Some(d) = self.dictionary() {
+            // For dictionary type there should only be a single child, so we don't need to worry if
+            // there are other children added above.
+            child_data.push(d.to_data()?);
+        }
 
         // Should FFI be checking validity?
         Ok(unsafe {
@@ -555,10 +594,14 @@ pub trait ArrowArrayRef {
     // for variable-sized buffers, such as the second buffer of a stringArray, we need
     // to fetch offset buffer's len to build the second buffer.
     fn buffer_len(&self, i: usize) -> Result<usize> {
-        // Inner type is not important for buffer length.
-        let data_type = &self.data_type()?;
+        // Special handling for dictionary type as we only care about the key type in the case.
+        let data_type = match &self.data_type()? {
+            DataType::Dictionary(key_data_type, _) => key_data_type.as_ref().clone(),
+            dt => dt.clone(),
+        };
 
-        Ok(match (data_type, i) {
+        // Inner type is not important for buffer length.
+        Ok(match (&data_type, i) {
             (DataType::Utf8, 1)
             | (DataType::LargeUtf8, 1)
             | (DataType::Binary, 1)
@@ -566,7 +609,7 @@ pub trait ArrowArrayRef {
             | (DataType::List(_), 1)
             | (DataType::LargeList(_), 1) => {
                 // the len of the offset buffer (buffer 1) equals length + 1
-                let bits = bit_width(data_type, i)?;
+                let bits = bit_width(&data_type, i)?;
                 debug_assert_eq!(bits % 8, 0);
                 (self.array().length as usize + 1) * (bits / 8)
             }
@@ -598,7 +641,7 @@ pub trait ArrowArrayRef {
             }
             // buffer len of primitive types
             _ => {
-                let bits = bit_width(data_type, i)?;
+                let bits = bit_width(&data_type, i)?;
                 bit_util::ceil(self.array().length as usize * bits, 8)
             }
         })
@@ -622,6 +665,21 @@ pub trait ArrowArrayRef {
     fn array(&self) -> &FFI_ArrowArray;
     fn schema(&self) -> &FFI_ArrowSchema;
     fn data_type(&self) -> Result<DataType>;
+    fn dictionary(&self) -> Option<ArrowArrayChild> {
+        unsafe {
+            assert!(!(self.array().dictionary.is_null() ^ self.schema().dictionary.is_null()),
+                    "Dictionary should both be set or not set in FFI_ArrowArray and FFI_ArrowSchema");
+            if !self.array().dictionary.is_null() {
+                Some(ArrowArrayChild::from_raw(
+                    &*self.array().dictionary,
+                    &*self.schema().dictionary,
+                    self.owner().clone(),
+                ))
+            } else {
+                None
+            }
+        }
+    }
 }
 
 #[allow(rustdoc::private_intra_doc_links)]
@@ -763,12 +821,12 @@ mod tests {
     use super::*;
     use crate::array::{
         make_array, Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
-        GenericBinaryArray, GenericListArray, GenericStringArray, Int32Array,
-        OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
+        DictionaryArray, GenericBinaryArray, GenericListArray, GenericStringArray,
+        Int32Array, OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
         TimestampMillisecondArray,
     };
     use crate::compute::kernels;
-    use crate::datatypes::Field;
+    use crate::datatypes::{Field, Int8Type};
     use std::convert::TryFrom;
 
     #[test]
@@ -1071,6 +1129,35 @@ mod tests {
                 Some(2)
             ])
         );
+
+        // (drop/release)
+        Ok(())
+    }
+
+    #[test]
+    fn test_dictionary() -> Result<()> {
+        // create an array natively
+        let values = vec!["a", "aaa", "aaa"];
+        let dict_array: DictionaryArray<Int8Type> = values.into_iter().collect();
+
+        // export it
+        let array = ArrowArray::try_from(dict_array.data().clone())?;
+
+        // (simulate consumer) import it
+        let data = ArrayData::try_from(array)?;
+        let array = make_array(data);
+
+        // perform some operation
+        let array = kernels::concat::concat(&[array.as_ref(), array.as_ref()]).unwrap();
+        let actual = array
+            .as_any()
+            .downcast_ref::<DictionaryArray<Int8Type>>()
+            .unwrap();
+
+        // verify
+        let new_values = vec!["a", "aaa", "aaa", "a", "aaa", "aaa"];
+        let expected: DictionaryArray<Int8Type> = new_values.into_iter().collect();
+        assert_eq!(actual, &expected);
 
         // (drop/release)
         Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1397.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently the Rust implementation of [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html) doesn't support dictionary type yet, which is necessary if we want to pass data between Rust and other languages such as Java/C++.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added dictionary support in Rust FFI.
- Added roundtrip tests within Rust (i.e., Rust -> Rust -> Rust)
- Added roundtrip tests between Python and Rust

I kept the `DictionaryArray` untouched so the dictionary (i.e., values) is still stored as the only child of the `ArrayData` it is associated to.

# Are there any user-facing changes?

Yes, now we can use C data interface with dictionary type. There is one API change on `ArrowSchema.try_new`:
```rust
    pub fn try_new(
        format: &str,
        children: Vec<FFI_ArrowSchema>,
        dictionary: Option<FFI_ArrowSchema>,
    ) -> Result<Self>
```

This PR added one parameter `dictionary`.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
