### PR TITLE
Set `default-features = false` for `zstd` in the parquet crate to support `wasm32-unknown-unknown`

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -37,7 +37,7 @@ snap = { version = "1.0", optional = true }
 brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
-zstd = { version = "0.10", optional = true }
+zstd = { version = "0.11", optional = true, default-features = false }
 chrono = { version = "0.4", default-features = false }
 num = "0.4"
 num-bigint = "0.4"

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -37,7 +37,7 @@ snap = { version = "1.0", optional = true }
 brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
-zstd = { version = "0.11", optional = true, default-features = false }
+zstd = { version = "0.11.1", optional = true, default-features = false }
 chrono = { version = "0.4", default-features = false }
 num = "0.4"
 num-bigint = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

Relevant to #180 but does not fully close it, as LZ4 still does not build on `wasm32-unknown-unknown`.

# Rationale for this change
 
- zstd has released [version 0.11.1](https://github.com/gyscos/zstd-rs/commit/ed00cb511212831d2befd48c2b2150429c85ec98) with Web Assembly (`wasm32-unknown-unknown`) support https://github.com/gyscos/zstd-rs/pull/139.
- This builds for `wasm32-unknown-unknown` only with `default-features = false`

# What changes are included in this PR?

Add `default-features = false` to the zstd dependency.

# Are there any user-facing changes?

None