### PR TITLE
Fix DeltaBitPack MiniBlock Bit Width Padding

### DIFF
--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -433,7 +433,6 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     initialized: bool,
 
     // Header info
-
     /// The number of values in each block
     block_size: usize,
     /// The number of values that remain to be read in the current page
@@ -444,7 +443,6 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     values_per_mini_block: usize,
 
     // Per block info
-
     /// The minimum delta in the block
     min_delta: T::T,
     /// The byte offset of the end of the current block
@@ -639,6 +637,7 @@ where
             self.last_value = value;
             buffer[0] = value;
             read += 1;
+            self.values_left -= 1;
         }
 
         while read != to_read {
@@ -668,9 +667,9 @@ where
 
             read += batch_read;
             self.mini_block_remaining -= batch_read;
+            self.values_left -= batch_read;
         }
 
-        self.values_left -= to_read;
         Ok(to_read)
     }
 

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -433,6 +433,7 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     initialized: bool,
 
     // Header info
+
     /// The number of values in each block
     block_size: usize,
     /// The number of values that remain to be read in the current page
@@ -443,6 +444,7 @@ pub struct DeltaBitPackDecoder<T: DataType> {
     values_per_mini_block: usize,
 
     // Per block info
+
     /// The minimum delta in the block
     min_delta: T::T,
     /// The byte offset of the end of the current block

--- a/parquet/src/encodings/encoding.rs
+++ b/parquet/src/encodings/encoding.rs
@@ -617,7 +617,11 @@ impl<T: DataType> DeltaBitPackEncoder<T> {
             self.values_in_block -= n;
         }
 
-        assert_eq!(self.values_in_block, 0);
+        assert_eq!(
+            self.values_in_block, 0,
+            "Expected 0 values in block, found {}",
+            self.values_in_block
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1416 
Closes #1417

# Rationale for this change
 
Fixes https://github.com/apache/arrow-datafusion/issues/1976

# What changes are included in this PR?

Makes DeltaBitPackEncoder padding deterministic, and makes DeltaBitPackDecoder resilient to non-zero padding

# Are there any user-facing changes?

Output that was previously somewhat non-deterministic, is now deterministic.