### PR TITLE
Fix possibly unaligned writes in MutableBuffer

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -303,8 +303,11 @@ impl MutableBuffer {
         let additional = len * std::mem::size_of::<T>();
         self.reserve(additional);
         unsafe {
-            let dst = self.data.as_ptr().add(self.len);
+            // this assumes that `[ToByteSlice]` can be copied directly
+            // without calling `to_byte_slice` for each element,
+            // which is correct for all ArrowNativeType implementations.
             let src = items.as_ptr() as *const u8;
+            let dst = self.data.as_ptr().add(self.len);
             std::ptr::copy_nonoverlapping(src, dst, additional)
         }
         self.len += additional;


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1410.

# Rationale for this change

Changes the `push`, `push_unchecked` and `extend_from_iter` functions so that data is transfered using `copy_nonoverlapping` which works for unaligned destinations. LLVM will most likely transform this again into a single unaligned write. This also makes these methods actually use the `ToByteSlice` trait. In `extend_from_slice`, which this PR did not change, the trait is more used like a marker trait because the whole slice is copied without going through the trait methods. This is probably fine since it's supposed to be an internal trait that is only implemented for `ArrowNativeType`.

The `from_trusted_len_iter` did not have a problem with alignment because the buffer is created inside the method, but for consistency I also changed them to use `to_byte_slice` and `copy_nonoverlapping`.

All newly added tests were previously failing when running under miri.
 
