### PR TITLE
remove redundant if/clamp_min/abs

### DIFF
--- a/arrow/src/compute/kernels/window.rs
+++ b/arrow/src/compute/kernels/window.rs
@@ -24,7 +24,6 @@ use crate::{
     compute::concat,
 };
 use num::abs;
-use num::traits::clamp_min;
 
 /// Shifts array by defined number of items (to left or right)
 /// A positive value for `offset` shifts the array to the right
@@ -64,18 +63,21 @@ pub fn shift(array: &dyn Array, offset: i64) -> Result<ArrayRef> {
     } else if offset == i64::MIN || abs(offset) >= value_len {
         Ok(new_null_array(array.data_type(), array.len()))
     } else {
-        let slice_offset = clamp_min(-offset, 0) as usize;
-        let length = array.len() - abs(offset) as usize;
-        let slice = array.slice(slice_offset, length);
-
-        // Generate array with remaining `null` items
-        let nulls = abs(offset) as usize;
-        let null_arr = new_null_array(array.data_type(), nulls);
-
         // Concatenate both arrays, add nulls after if shift > 0 else before
         if offset > 0 {
+            let length = array.len() - offset as usize;
+            let slice = array.slice(0, length);
+
+            // Generate array with remaining `null` items
+            let null_arr = new_null_array(array.data_type(), offset as usize);
             concat(&[null_arr.as_ref(), slice.as_ref()])
         } else {
+            let offset = -offset as usize;
+            let length = array.len() - offset;
+            let slice = array.slice(offset, length);
+
+            // Generate array with remaining `null` items
+            let null_arr = new_null_array(array.data_type(), offset);
             concat(&[slice.as_ref(), null_arr.as_ref()])
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1427.

# Rationale for this change
 
None

# What changes are included in this PR?

There are some redundant code for control flow

`if` is control flow will break the cpu pipeline, we should reduce the useless `if`.
`bbs()` should remove, and replace with code in the if
`clamp_min` is useless

# Are there any user-facing changes?
None

