### PR TITLE
Replace Arc with Box in ArrowArray for FFI structs

### DIFF
--- a/arrow/src/array/array.rs
+++ b/arrow/src/array/array.rs
@@ -629,7 +629,9 @@ pub unsafe fn make_array_from_raw(
     schema: *const ffi::FFI_ArrowSchema,
 ) -> Result<ArrayRef> {
     let array = ffi::ArrowArray::try_from_raw(array, schema)?;
-    let data = ArrayData::try_from(array)?;
+    let data = ArrayData::try_from(&array)?;
+    // Avoid dropping the `Box` pointers and trigger the `release` mechanism.
+    let _ = ffi::ArrowArray::into_raw(array);
     Ok(make_array(data))
 }
 // Helper function for printing potentially long arrays.

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -27,19 +27,11 @@ use crate::{
 
 use super::ArrayData;
 
-impl TryFrom<ffi::ArrowArray> for ArrayData {
+impl TryFrom<&ffi::ArrowArray> for ArrayData {
     type Error = ArrowError;
 
-    fn try_from(value: ffi::ArrowArray) -> Result<Self> {
-        let array = value.to_data();
-        // FFI_ArrowArray and FFI_ArowSchema are Box pointer in ArrowArray.
-        // Once we obtain the data from it, we don't want it to call release.
-        let (ffi_array, ffi_schema) = ffi::ArrowArray::into_raw(value);
-        unsafe {
-            (*(ffi_array as *mut ffi::FFI_ArrowArray)).release = None;
-            (*(ffi_schema as *mut ffi::FFI_ArrowSchema)).release = None;
-        }
-        array
+    fn try_from(value: &ffi::ArrowArray) -> Result<Self> {
+        value.to_data()
     }
 }
 

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -68,7 +68,7 @@ mod tests {
         // simulate an external consumer by being the consumer
         let d1 = unsafe { ArrowArray::try_from_raw(array, schema) }?;
 
-        let result = &ArrayData::try_from(d1)?;
+        let result = &ArrayData::try_from(&d1)?;
 
         assert_eq!(result, expected);
         Ok(())

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -25,7 +25,6 @@ use crate::util::bit_chunk_iterator::{BitChunks, UnalignedBitChunk};
 use crate::{
     bytes::{Bytes, Deallocation},
     datatypes::ArrowNativeType,
-    ffi,
 };
 
 use super::ops::bitwise_unary_op_helper;
@@ -95,9 +94,8 @@ impl Buffer {
     pub unsafe fn from_unowned(
         ptr: NonNull<u8>,
         len: usize,
-        data: Arc<ffi::FFI_ArrowArray>,
     ) -> Self {
-        Buffer::build_with_arguments(ptr, len, Deallocation::Foreign(data))
+        Buffer::build_with_arguments(ptr, len, Deallocation::Foreign)
     }
 
     /// Auxiliary method to create a new Buffer

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -90,10 +90,7 @@ impl Buffer {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// bytes and that the foreign deallocator frees the region.
-    pub unsafe fn from_unowned(
-        ptr: NonNull<u8>,
-        len: usize,
-    ) -> Self {
+    pub unsafe fn from_unowned(ptr: NonNull<u8>, len: usize) -> Self {
         Buffer::build_with_arguments(ptr, len, Deallocation::Foreign)
     }
 

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -85,7 +85,6 @@ impl Buffer {
     ///
     /// * `ptr` - Pointer to raw parts
     /// * `len` - Length of raw parts in **bytes**
-    /// * `data` - An [ffi::FFI_ArrowArray] with the data
     ///
     /// # Safety
     ///

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -116,7 +116,7 @@ pub struct FFI_ArrowSchema {
     n_children: i64,
     children: *mut *mut FFI_ArrowSchema,
     dictionary: *mut FFI_ArrowSchema,
-    pub(crate) release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowSchema)>,
+    release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowSchema)>,
     private_data: *mut c_void,
 }
 
@@ -326,7 +326,7 @@ pub struct FFI_ArrowArray {
     pub(crate) buffers: *mut *const c_void,
     children: *mut *mut FFI_ArrowArray,
     dictionary: *mut FFI_ArrowArray,
-    pub(crate) release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowArray)>,
+    release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowArray)>,
     // When exported, this MUST contain everything that is owned by this array.
     // for example, any buffer pointed to in `buffers` must be here, as well
     // as the `buffers` pointer itself.

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -538,13 +538,12 @@ pub trait ArrowArrayRef {
 
                 let len = self.buffer_len(index)?;
 
-                unsafe { create_buffer(self.array(), index, len) }
-                    .ok_or_else(|| {
-                        ArrowError::CDataInterface(format!(
-                            "The external buffer at position {} is null.",
-                            index - 1
-                        ))
-                    })
+                unsafe { create_buffer(self.array(), index, len) }.ok_or_else(|| {
+                    ArrowError::CDataInterface(format!(
+                        "The external buffer at position {} is null.",
+                        index - 1
+                    ))
+                })
             })
             .collect()
     }

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -479,7 +479,7 @@ unsafe fn create_buffer(
 }
 
 fn create_child<'a>(
-    owner: Arc<&'a FFI_ArrowArray>,
+    owner: &'a FFI_ArrowArray,
     array: &'a FFI_ArrowArray,
     schema: &'a FFI_ArrowSchema,
     index: usize,
@@ -614,7 +614,7 @@ pub trait ArrowArrayRef {
     }
 
     fn child(&self, index: usize) -> ArrowArrayChild {
-        create_child(self.owner().clone(), self.array(), self.schema(), index)
+        create_child(&self.owner(), self.array(), self.schema(), index)
     }
 
     fn owner(&self) -> Arc<&FFI_ArrowArray>;
@@ -653,7 +653,7 @@ pub struct ArrowArray {
 pub struct ArrowArrayChild<'a> {
     array: &'a FFI_ArrowArray,
     schema: &'a FFI_ArrowSchema,
-    owner: Arc<&'a FFI_ArrowArray>,
+    owner: &'a FFI_ArrowArray,
 }
 
 impl ArrowArrayRef for ArrowArray {
@@ -690,7 +690,7 @@ impl<'a> ArrowArrayRef for ArrowArrayChild<'a> {
     }
 
     fn owner(&self) -> Arc<&FFI_ArrowArray> {
-        Arc::new(self.owner.as_ref())
+        Arc::new(self.owner)
     }
 }
 
@@ -745,7 +745,7 @@ impl<'a> ArrowArrayChild<'a> {
     fn from_raw(
         array: &'a FFI_ArrowArray,
         schema: &'a FFI_ArrowSchema,
-        owner: Arc<&'a FFI_ArrowArray>,
+        owner: &'a FFI_ArrowArray,
     ) -> Self {
         Self {
             array,
@@ -777,7 +777,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -804,7 +804,7 @@ mod tests {
         let array = ArrowArray::try_from(original_array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -827,7 +827,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -899,7 +899,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // downcast
@@ -939,7 +939,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -984,7 +984,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -1010,7 +1010,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -1046,7 +1046,7 @@ mod tests {
         let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -673,7 +673,7 @@ pub trait ArrowArrayRef {
                 Some(ArrowArrayChild::from_raw(
                     &*self.array().dictionary,
                     &*self.schema().dictionary,
-                    self.owner().clone(),
+                    &self.owner(),
                 ))
             } else {
                 None
@@ -1142,7 +1142,7 @@ mod tests {
         let array = ArrowArray::try_from(dict_array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = ArrayData::try_from(array)?;
+        let data = ArrayData::try_from(&array)?;
         let array = make_array(data);
 
         // perform some operation

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -116,7 +116,7 @@ pub struct FFI_ArrowSchema {
     n_children: i64,
     children: *mut *mut FFI_ArrowSchema,
     dictionary: *mut FFI_ArrowSchema,
-    release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowSchema)>,
+    pub(crate) release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowSchema)>,
     private_data: *mut c_void,
 }
 
@@ -326,7 +326,7 @@ pub struct FFI_ArrowArray {
     pub(crate) buffers: *mut *const c_void,
     children: *mut *mut FFI_ArrowArray,
     dictionary: *mut FFI_ArrowArray,
-    release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowArray)>,
+    pub(crate) release: Option<unsafe extern "C" fn(arg1: *mut FFI_ArrowArray)>,
     // When exported, this MUST contain everything that is owned by this array.
     // for example, any buffer pointed to in `buffers` must be here, as well
     // as the `buffers` pointer itself.

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -126,7 +126,7 @@ impl PyArrowConvert for ArrayData {
 
         let ffi_array =
             unsafe { ffi::ArrowArray::try_from_raw(array_pointer, schema_pointer)? };
-        let data = ArrayData::try_from(ffi_array)?;
+        let data = ArrayData::try_from(&ffi_array)?;
 
         Ok(data)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1425.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Remove `Clone` from `FFI_ArrowArray` and `FFI_ArrowSchema`
* Change `array` and `schema` in `ArrowArray` from `Arc` to `Box` type

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

`TryFrom<ffi::ArrowArray> for ArrayData` is changed to `TryFrom<&ffi::ArrowArray> for ArrayData`.

```rust
pub unsafe fn from_unowned(
    ptr: NonNull<u8>,
    len: usize,
    data: Arc<ffi::FFI_ArrowArray>,
) -> Self
```

is changed to

```rust
pub unsafe fn from_unowned(
    ptr: NonNull<u8>,
    len: usize,
) -> Self
```

`fn owner(&self) -> &Arc<FFI_ArrowArray>;` in `trait ArrowArrayRef` is changed to `fn owner(&self) -> Arc<&FFI_ArrowArray>;`.