### PR TITLE
Improve performance of DictionaryArray::try_new() 

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -114,7 +114,7 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
 
         let array = unsafe { data.build_unchecked() };
 
-        array.validate_dictionary_offest()?;
+        array.validate_dictionary_offset()?;
 
         Ok(array.into())
     }

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -113,6 +113,8 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
             _ => data = data.null_count(0),
         }
 
+        // Safety: `validate` ensures key type is correct, and
+        //  `validate_dictionary_offset` ensures all offsets are within range
         let array = unsafe { data.build_unchecked() };
 
         array.validate()?;

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -112,7 +112,11 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
             _ => data = data.null_count(0),
         }
 
-        Ok(data.build()?.into())
+        let array = unsafe { data.build_unchecked() };
+
+        array.validate_dictionary_offest()?;
+
+        Ok(array.into())
     }
 
     /// Return an array view of the keys of this dictionary as a PrimitiveArray.

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Dictionary values must be integer, but was Float32")]
+    #[should_panic(expected = "Dictionary key type must be integer, but was Float32")]
     fn test_try_wrong_dictionary_key_type() {
         let values: StringArray = [Some("foo"), Some("bar")].into_iter().collect();
         let keys: Float32Array = [Some(0_f32), None, Some(3_f32)].into_iter().collect();

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -949,7 +949,7 @@ impl ArrayData {
             )));
         }
 
-        self.validate_dictionary_offest()?;
+        self.validate_dictionary_offset()?;
 
         // validate all children recursively
         self.child_data
@@ -967,7 +967,7 @@ impl ArrayData {
         Ok(())
     }
 
-    pub fn validate_dictionary_offest(&self) -> Result<()> {
+    pub fn validate_dictionary_offset(&self) -> Result<()> {
         match &self.data_type {
             DataType::Utf8 => self.validate_utf8::<i32>(),
             DataType::LargeUtf8 => self.validate_utf8::<i64>(),

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -693,7 +693,7 @@ impl ArrayData {
                 // At the moment, constructing a DictionaryArray will also check this
                 if !DataType::is_dictionary_key_type(key_type) {
                     return Err(ArrowError::InvalidArgumentError(format!(
-                        "Dictionary values must be integer, but was {}",
+                        "Dictionary key type must be integer, but was {}",
                         key_type
                     )));
                 }
@@ -1736,7 +1736,7 @@ mod tests {
 
     // Test creating a dictionary with a non integer type
     #[test]
-    #[should_panic(expected = "Dictionary values must be integer, but was Utf8")]
+    #[should_panic(expected = "Dictionary key type must be integer, but was Utf8")]
     fn test_non_int_dictionary() {
         let i32_buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
         let data_type =


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1313.

# What changes are included in this PR?

extract the dictionary validation logic out of `ArrayData::validate_full` into a separate function. 

`DictionaryArray::try_new`  use the `ArrayDataBuilder::build_unchecked` and afterwards call the new function which only validates that the keys are in bounds.

# Are there any user-facing changes?

None
