### PR TITLE
Add Full UnionArray validation

### DIFF
--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1127,9 +1127,9 @@ impl ArrayData {
     /// Returns an iterator over validated (i, type_id) function for
     /// each element i in the `UnionArray`, returning Err if the
     /// type_id is
-    fn for_each_valid_type_id<'a>(
-        &'a self,
-    ) -> impl Iterator<Item = Result<(usize, usize)>> + 'a {
+    fn for_each_valid_type_id(
+        &self,
+    ) -> impl Iterator<Item = Result<(usize, usize)>> + '_ {
         assert!(matches!(self.data_type(), DataType::Union(_, _)));
         let buffer = &self.buffers[0];
         let required_len = self.len + self.offset;

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -981,15 +981,13 @@ impl ArrayData {
                 let child = &self.child_data[0];
                 self.validate_offsets_full::<i64>(child.len + child.offset)
             }
-            DataType::Union(_, _) => {
+            DataType::Union(_, mode) => {
                 match mode {
                     UnionMode::Sparse => {
                         // typeids should all be valid
-                        self.validate_offsets_full::<i8>(self.child_data.len())?;
+                        self.validate_offsets_full::<i8>(self.child_data.len())
                     }
-                    UnionMode::Dense => {
-                        self.validate_dense_union_full()?;
-                    }
+                    UnionMode::Dense => self.validate_dense_union_full(),
                 }
             }
             DataType::Dictionary(key_type, _value_type) => {

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1124,9 +1124,9 @@ impl ArrayData {
         )
     }
 
-    /// Returns an iterator over validated (i, type_id) function for
-    /// each element i in the `UnionArray`, returning Err if the
-    /// type_id is
+    /// Returns an iterator over validated Result<(i, type_id)> for
+    /// each element i in the `UnionArray`, returning an Err if the
+    /// type_id is invalid
     fn for_each_valid_type_id(
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize)>> + '_ {
@@ -1162,7 +1162,7 @@ impl ArrayData {
     fn validate_sparse_union_full(&self) -> Result<()> {
         self.for_each_valid_type_id().try_for_each(|r| {
             // No additional validation is needed other than the
-            // type_id is within range, which is done during the iterator
+            // type_id is within range, which is done by the iterator
             r?;
             Ok(())
         })

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -2700,7 +2700,7 @@ mod tests {
     fn test_validate_dense_union_non_increasing_offset() {
         let type_ids = vec![1i8, 0i8, 0i8, 1i8];
         // This is ok because the offsets of the different children are increasing
-        // even though the offset of child 1 is decreasing:
+        // even though the offsets overall are decreasing:
         // type_id 0: 0, 0
         // type_id 1: 0, 1
         let offsets = vec![0i32, 0i32, 1i32, 0i32];


### PR DESCRIPTION
~Draft (need to write tests and file a ticket)~

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1486

# Rationale for this change

While reviewing https://github.com/apache/arrow-rs/pull/1412, I remembered to check the validation code for UnionArray and it turns out it was not implemented yet.

Since I had the [union layout](https://arrow.apache.org/docs/format/Columnar.html#union-layout) already loaded in my head, I figured I would pound out this PR:  

# What changes are included in this PR?
Validate all Union array data in `validate_full`

# Are there any user-facing changes?
More data validation. The APIs are all the same