### PR TITLE
Rewrite doc of `GenericListArray`

### DIFF
--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -49,7 +49,10 @@ impl OffsetSizeTrait for i64 {
     }
 }
 
-/// Generic struct for a primitive Array
+/// Generic struct for a variable-size list array.
+///
+/// Columnar format in Apache Arrow:
+/// <https://arrow.apache.org/docs/format/Columnar.html#variable-size-list-layout>
 ///
 /// For non generic lists, you may wish to consider using [`ListArray`] or [`LargeListArray`]`
 pub struct GenericListArray<OffsetSize> {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

Closes #1424.

# Rationale for this change
 1. Correct the definition of `GenericListArray`: (a struct for variable-size list array, not for primitive array)
 2. Add link to Arrow memory layout. In this way, users and developers can quickly review the Apache Arrow standard.

# Are there any user-facing changes?
Doc is updated
