### PR TITLE
Less async ParquetRecordBatchStream

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -47,7 +47,7 @@ clap = { version = "3", optional = true, features = ["derive", "env"] }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 rand = "0.8"
 futures = { version = "0.3", optional = true }
-tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "fs", "rt", "io-util"] }
+tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "sync"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -131,7 +131,7 @@ pub struct SerializedFileReader<R: ChunkReader> {
 /// For the predicates that are added to the builder,
 /// they will be chained using 'AND' to filter the row groups.
 pub struct ReadOptionsBuilder {
-    predicates: Vec<Box<dyn FnMut(&RowGroupMetaData, usize) -> bool>>,
+    predicates: Vec<Box<dyn FnMut(&RowGroupMetaData, usize) -> bool + Send>>,
 }
 
 impl ReadOptionsBuilder {
@@ -144,7 +144,7 @@ impl ReadOptionsBuilder {
     /// Filter only row groups that match the predicate criteria
     pub fn with_predicate(
         mut self,
-        predicate: Box<dyn FnMut(&RowGroupMetaData, usize) -> bool>,
+        predicate: Box<dyn FnMut(&RowGroupMetaData, usize) -> bool + Send>,
     ) -> Self {
         self.predicates.push(predicate);
         self
@@ -175,7 +175,7 @@ impl ReadOptionsBuilder {
 /// Currently, only predicates on row group metadata are supported.
 /// All predicates will be chained using 'AND' to filter the row groups.
 pub struct ReadOptions {
-    predicates: Vec<Box<dyn FnMut(&RowGroupMetaData, usize) -> bool>>,
+    predicates: Vec<Box<dyn FnMut(&RowGroupMetaData, usize) -> bool + Send>>,
 }
 
 impl<R: 'static + ChunkReader> SerializedFileReader<R> {


### PR DESCRIPTION
**This is a POC, and not something I intend for merge**

# Which issue does this PR close?

Relates to #TBD.

# Rationale for this change
 
See ticket

# What changes are included in this PR?

Changes `ParquetRecordBatchStream` to use `spawn_blocking` and `ChunkReader` instead of the tokio async IO traits

# Are there any user-facing changes?

Yes, to an unstable feature
