### PR TITLE
Fix reading/writing nested null arrays (#1480) (#1036) (#1399)

### DIFF
--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -225,11 +225,10 @@ where
 
     /// Reads at most `batch_size` records into array.
     fn next_batch(&mut self, batch_size: usize) -> Result<ArrayRef> {
-        let records_read =
-            read_records(&mut self.record_reader, self.pages.as_mut(), batch_size)?;
+        read_records(&mut self.record_reader, self.pages.as_mut(), batch_size)?;
 
         // convert to arrays
-        let array = arrow::array::NullArray::new(records_read);
+        let array = arrow::array::NullArray::new(self.record_reader.num_values());
 
         // save definition and repetition buffers
         self.def_levels_buffer = self.record_reader.consume_def_levels()?;
@@ -887,7 +886,7 @@ fn remove_indices(
                 Ok(Arc::new(StructArray::from((new_columns, valid.finish()))))
             }
         }
-        ArrowType::Null => Ok(Arc::new(NullArray::new(arr.len()))),
+        ArrowType::Null => Ok(Arc::new(NullArray::new(arr.len() - indices.len()))),
         _ => Err(ParquetError::General(format!(
             "ListArray of type List({:?}) is not supported by array_reader",
             item_type

--- a/parquet/src/arrow/levels.rs
+++ b/parquet/src/arrow/levels.rs
@@ -200,9 +200,8 @@ impl LevelInfo {
                 );
 
                 match child_array.data_type() {
-                    // TODO: The behaviour of a <list<null>> is untested
-                    DataType::Null => vec![list_level],
-                    DataType::Boolean
+                    DataType::Null
+                    | DataType::Boolean
                     | DataType::Int8
                     | DataType::Int16
                     | DataType::Int32
@@ -677,8 +676,9 @@ impl LevelInfo {
         len: usize,
     ) -> (Vec<i64>, Vec<bool>) {
         match array.data_type() {
-            DataType::Null
-            | DataType::Boolean
+            // A NullArray is entirely nulls, despite not containing a null buffer
+            DataType::Null => ((0..=(len as i64)).collect(), vec![false; len]),
+            DataType::Boolean
             | DataType::Int8
             | DataType::Int16
             | DataType::Int32


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1480 
Closes #1036 
Closes #1399

# Rationale for this change

See tickets

# What changes are included in this PR?

Fixes various bugs in handling of null arrays

# Are there any user-facing changes?

Previous incorrect behaviour is now fixed