### PR TITLE
Decouple buffer deallocation from ffi and allow creating buffers from rust vec

### DIFF
--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -2603,21 +2603,21 @@ mod tests {
         let mut bitmap = vec![0b1110_u8];
 
         let strings_buffer = unsafe {
-            Buffer::from_foreign(
+            Buffer::from_custom_allocation(
                 NonNull::new_unchecked(strings.as_mut_ptr()),
                 strings.len(),
                 Arc::new(strings),
             )
         };
         let offsets_buffer = unsafe {
-            Buffer::from_foreign(
+            Buffer::from_custom_allocation(
                 NonNull::new_unchecked(offsets.as_mut_ptr() as *mut u8),
                 offsets.len() * std::mem::size_of::<i32>(),
                 Arc::new(offsets),
             )
         };
         let null_buffer = unsafe {
-            Buffer::from_foreign(
+            Buffer::from_custom_allocation(
                 NonNull::new_unchecked(bitmap.as_mut_ptr()),
                 bitmap.len(),
                 Arc::new(bitmap),

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1459,10 +1459,11 @@ impl ArrayDataBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ptr::NonNull;
 
     use crate::array::{
-        Array, BooleanBuilder, Int32Array, Int32Builder, Int64Array, StringArray,
-        StructBuilder, UInt64Array,
+        make_array, Array, BooleanBuilder, Int32Array, Int32Builder, Int64Array,
+        StringArray, StructBuilder, UInt64Array,
     };
     use crate::buffer::Buffer;
     use crate::datatypes::Field;
@@ -2593,5 +2594,53 @@ mod tests {
         let cloned = crate::array::make_array(cloned_data);
 
         assert_eq!(&struct_array_slice, &cloned);
+    }
+
+    #[test]
+    fn test_string_data_from_foreign() {
+        let mut strings = "foobarfoobar".to_owned();
+        let mut offsets = vec![0_i32, 0, 3, 6, 12];
+        let mut bitmap = vec![0b1110_u8];
+
+        let strings_buffer = unsafe {
+            Buffer::from_foreign(
+                NonNull::new_unchecked(strings.as_mut_ptr()),
+                strings.len(),
+                Arc::new(strings),
+            )
+        };
+        let offsets_buffer = unsafe {
+            Buffer::from_foreign(
+                NonNull::new_unchecked(offsets.as_mut_ptr() as *mut u8),
+                offsets.len() * std::mem::size_of::<i32>(),
+                Arc::new(offsets),
+            )
+        };
+        let null_buffer = unsafe {
+            Buffer::from_foreign(
+                NonNull::new_unchecked(bitmap.as_mut_ptr()),
+                bitmap.len(),
+                Arc::new(bitmap),
+            )
+        };
+
+        let data = ArrayData::try_new(
+            DataType::Utf8,
+            4,
+            None,
+            Some(null_buffer),
+            0,
+            vec![offsets_buffer, strings_buffer],
+            vec![],
+        )
+        .unwrap();
+
+        let array = make_array(data);
+        let array = array.as_any().downcast_ref::<StringArray>().unwrap();
+
+        let expected =
+            StringArray::from(vec![None, Some("foo"), Some("bar"), Some("foobar")]);
+
+        assert_eq!(array, &expected);
     }
 }

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -21,12 +21,9 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 use std::{convert::AsRef, usize};
 
-use crate::bytes::Allocation;
+use crate::alloc::{Allocation, Deallocation};
 use crate::util::bit_chunk_iterator::{BitChunks, UnalignedBitChunk};
-use crate::{
-    bytes::{Bytes, Deallocation},
-    datatypes::ArrowNativeType,
-};
+use crate::{bytes::Bytes, datatypes::ArrowNativeType};
 
 use super::ops::bitwise_unary_op_helper;
 use super::MutableBuffer;
@@ -86,7 +83,7 @@ impl Buffer {
     ///
     /// * `ptr` - Pointer to raw parts
     /// * `len` - Length of raw parts in **bytes**
-    /// * `owner` - A [bytes::Owner] which is responsible for freeing that data
+    /// * `owner` - A [crate::alloc::Allocation] which is responsible for freeing that data
     ///
     /// # Safety
     ///

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -342,6 +342,7 @@ impl<T: ArrowNativeType> FromIterator<T> for Buffer {
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{RefUnwindSafe, UnwindSafe};
     use std::thread;
 
     use super::*;
@@ -553,6 +554,12 @@ mod tests {
             4,
             Buffer::from(&[0b01101101, 0b10101010]).count_set_bits_offset(7, 9)
         );
+    }
+
+    #[test]
+    fn test_unwind_safe() {
+        fn assert_unwind_safe<T: RefUnwindSafe + UnwindSafe>() {}
+        assert_unwind_safe::<Buffer>()
     }
 
     #[test]

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -84,7 +84,7 @@ impl Buffer {
     ///
     /// * `ptr` - Pointer to raw parts
     /// * `len` - Length of raw parts in **bytes**
-    /// * `data` - An [ffi::FFI_ArrowArray] with the data
+    /// * `data` - An [crate::ffi::FFI_ArrowArray] with the data
     ///
     /// # Safety
     ///

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use super::Buffer;
+use crate::alloc::Deallocation;
 use crate::{
     alloc,
-    bytes::{Bytes, Deallocation},
+    bytes::Bytes,
     datatypes::{ArrowNativeType, ToByteSlice},
     util::bit_util,
 };

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -267,7 +267,7 @@ impl MutableBuffer {
     #[inline]
     pub(super) fn into_buffer(self) -> Buffer {
         let bytes = unsafe {
-            Bytes::new(self.data, self.len, Deallocation::Native(self.capacity))
+            Bytes::new(self.data, self.len, Deallocation::Arrow(self.capacity))
         };
         std::mem::forget(self);
         Buffer::from_bytes(bytes)

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -20,18 +20,25 @@
 //! Note that this is a low-level functionality of this crate.
 
 use core::slice;
+use std::panic::RefUnwindSafe;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use std::{fmt::Debug, fmt::Formatter};
 
-use crate::{alloc, ffi};
+use crate::alloc;
+
+/// The owner of an allocation, that is not natively allocated.
+/// The trait implementation is responsible for dropping the allocations once no more references exist.
+pub trait Allocation: RefUnwindSafe {}
+
+impl<T: RefUnwindSafe> Allocation for T {}
 
 /// Mode of deallocating memory regions
 pub enum Deallocation {
     /// Native deallocation, using Rust deallocator with Arrow-specific memory alignment
     Native(usize),
     /// Foreign interface, via a callback
-    Foreign(Arc<ffi::FFI_ArrowArray>),
+    Foreign(Arc<dyn Allocation>),
 }
 
 impl Debug for Deallocation {

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -20,39 +20,11 @@
 //! Note that this is a low-level functionality of this crate.
 
 use core::slice;
-use std::panic::RefUnwindSafe;
 use std::ptr::NonNull;
-use std::sync::Arc;
 use std::{fmt::Debug, fmt::Formatter};
 
 use crate::alloc;
-
-/// The owner of an allocation, that is not natively allocated.
-/// The trait implementation is responsible for dropping the allocations once no more references exist.
-pub trait Allocation: RefUnwindSafe {}
-
-impl<T: RefUnwindSafe> Allocation for T {}
-
-/// Mode of deallocating memory regions
-pub enum Deallocation {
-    /// Native deallocation, using Rust deallocator with Arrow-specific memory alignment
-    Native(usize),
-    /// Foreign interface, via a callback
-    Foreign(Arc<dyn Allocation>),
-}
-
-impl Debug for Deallocation {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match self {
-            Deallocation::Native(capacity) => {
-                write!(f, "Deallocation::Native {{ capacity: {} }}", capacity)
-            }
-            Deallocation::Foreign(_) => {
-                write!(f, "Deallocation::Foreign {{ capacity: unknown }}")
-            }
-        }
-    }
-}
+use crate::alloc::Deallocation;
 
 /// A continuous, fixed-size, immutable memory region that knows how to de-allocate itself.
 /// This structs' API is inspired by the `bytes::Bytes`, but it is not limited to using rust's

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -32,8 +32,9 @@ use crate::alloc::Deallocation;
 ///
 /// In the most common case, this buffer is allocated using [`allocate_aligned`](crate::alloc::allocate_aligned)
 /// and deallocated accordingly [`free_aligned`](crate::alloc::free_aligned).
-/// When the region is allocated by an foreign allocator, [Deallocation::Foreign], this calls the
-/// foreign deallocator to deallocate the region when it is no longer needed.
+///
+/// When the region is allocated by a different allocator, [Deallocation::Custom], this calls the
+/// custom deallocator to deallocate the region when it is no longer needed.
 pub struct Bytes {
     /// The raw pointer to be beginning of the region
     ptr: NonNull<u8>,

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -538,7 +538,7 @@ unsafe fn create_buffer(
     assert!(index < array.n_buffers as usize);
     let ptr = *buffers.add(index);
 
-    NonNull::new(ptr as *mut u8).map(|ptr| Buffer::from_unowned(ptr, len, owner))
+    NonNull::new(ptr as *mut u8).map(|ptr| Buffer::from_foreign(ptr, len, owner))
 }
 
 fn create_child(

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -538,7 +538,8 @@ unsafe fn create_buffer(
     assert!(index < array.n_buffers as usize);
     let ptr = *buffers.add(index);
 
-    NonNull::new(ptr as *mut u8).map(|ptr| Buffer::from_foreign(ptr, len, owner))
+    NonNull::new(ptr as *mut u8)
+        .map(|ptr| Buffer::from_custom_allocation(ptr, len, owner))
 }
 
 fn create_child(


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1516


# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I'd like to process data that is coming from outside arrow using arrow compute kernels without copying the data.

The FFI api does not seem to support this use case at the moment. The only way I found to create an `FFI_ArrowArray` was with an already existing `ArrayData` struct. Creating `ArrayData` requires at least one `Buffer`, and creating a `Buffer` from foreign memory again needs an `FFI_ArrowArray`.

# What changes are included in this PR?

The owner of an allocation is tracked via a trait object instead of an `FFI_ArrowArray`. This allows zero-copy interoperability between arrow buffers and most collection types from rust stdlib or other crates. The most common example would be `Vec` or `String`, and it should also be possible to access arrow2 buffers this way.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The function `from_unowned` was marked as deprecated and delegates to a new function `from_custom_allocation`. The "unowned" part is abit misleading since the data is owned by the `FFI_ArrayArray`.

The other changes should be api compatible. The `bytes` module is `pub(crate)`, so moving the `Deallocation` enum should be fine.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
