### PR TITLE
Workaround nightly miri error in `try_from_trusted_len_iter`

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -538,8 +538,9 @@ impl MutableBuffer {
 
         let mut dst = buffer.data.as_ptr();
         for item in iterator {
+            let item = item?;
             // note how there is no reserve here (compared with `extend_from_iter`)
-            let src = item?.to_byte_slice().as_ptr();
+            let src = item.to_byte_slice().as_ptr();
             std::ptr::copy_nonoverlapping(src, dst, item_size);
             dst = dst.add(item_size);
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1496.

# Rationale for this change

I can't really explain why miri complained about this code, but the `Result` here is the only difference to several other usages of `to_byte_slice`. Extracting the result handling to a separate line seems to fix the issue.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
