### PR TITLE
Alternative implementation of nullif kernel by slicing nested buffers

### DIFF
--- a/arrow/src/array/array_map.rs
+++ b/arrow/src/array/array_map.rs
@@ -139,13 +139,6 @@ impl MapArray {
         let value_offsets = data.buffers()[0].as_ptr();
 
         let value_offsets = unsafe { RawPtrBox::<i32>::new(value_offsets) };
-        unsafe {
-            if (*value_offsets.as_ptr().offset(0)) != 0 {
-                return Err(ArrowError::InvalidArgumentError(String::from(
-                    "offsets do not start at zero",
-                )));
-            }
-        }
         Ok(Self {
             data,
             values,

--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -648,35 +648,11 @@ fn slice_buffers(
         },
         DataType::List(_) => {
             // safe because for List the first buffer is guaranteed to contain i32 offsets
-            let offsets = unsafe { &buffers[0].typed_data()[offset..] };
-            let first_offset = offsets[0] as usize;
-            let last_offset = offsets[len] as usize;
-            let nested_len = last_offset - first_offset;
-
-            // since we calculate a new offset buffer starting from 0 we also have to slice the child data
-            result_child_data = Some(
-                child_data
-                    .iter()
-                    .map(|d| d.slice(first_offset, nested_len))
-                    .collect(),
-            );
-            vec![offset_buffer_slice::<i32>(offsets, len)]
+            vec![buffers[0].slice(offset * size_of::<i32>())]
         }
         DataType::LargeList(_) => {
             // safe because for LargeList the first buffer is guaranteed to contain i64 offsets
-            let offsets = unsafe { &buffers[0].typed_data()[offset..] };
-            let first_offset = offsets[0] as usize;
-            let last_offset = offsets[len] as usize;
-            let nested_len = last_offset - first_offset;
-            // since we calculate a new offset buffer starting from 0 we also have to slice the child data
-
-            result_child_data = Some(
-                child_data
-                    .iter()
-                    .map(|d| d.slice(first_offset, nested_len))
-                    .collect(),
-            );
-            vec![offset_buffer_slice::<i64>(offsets, len)]
+            vec![buffers[0].slice(offset * size_of::<i64>())]
         }
         DataType::Binary | DataType::Utf8 => {
             // safe because for Binary/Utf8 the first buffer is guaranteed to contain i32 offsets

--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -1675,26 +1675,8 @@ mod tests {
         let result = nullif_alternative(&array_ref, &condition).unwrap();
         let result = result.as_any().downcast_ref::<StructArray>().unwrap();
 
-        let expected = StructArray::try_from(vec![
-            (
-                "a",
-                Arc::new(Int32Array::from(vec![Some(3), None, Some(5), Some(6)]))
-                    as ArrayRef,
-            ),
-            (
-                "b",
-                Arc::new(StringArray::from(vec![
-                    Some("dghi"),
-                    None,
-                    Some("lm"),
-                    Some("nop"),
-                ])),
-            ),
-        ])
-        .unwrap();
-
         // StructArray comparison does not seem to respect validity bitmap of the struct itself
-        // assert_eq!(result, &expected);
+        // so we need to compare the fields separately
 
         assert!(result.is_valid(0));
         assert!(!result.is_valid(1));

--- a/arrow/src/compute/util.rs
+++ b/arrow/src/compute/util.rs
@@ -36,25 +36,36 @@ pub(super) fn combine_option_bitmap(
     let left_offset_in_bits = left_data.offset();
     let right_offset_in_bits = right_data.offset();
 
-    let left = left_data.null_buffer();
-    let right = right_data.null_buffer();
+    let left_null_buffer = left_data.null_buffer();
+    let right_null_buffer = right_data.null_buffer();
 
-    match left {
-        None => match right {
-            None => Ok(None),
-            Some(r) => Ok(Some(r.bit_slice(right_offset_in_bits, len_in_bits))),
-        },
-        Some(l) => match right {
-            None => Ok(Some(l.bit_slice(left_offset_in_bits, len_in_bits))),
+    Ok(combine_option_buffers(
+        left_null_buffer,
+        left_offset_in_bits,
+        right_null_buffer,
+        right_offset_in_bits,
+        len_in_bits,
+    ))
+}
 
-            Some(r) => Ok(Some(buffer_bin_and(
-                l,
-                left_offset_in_bits,
-                r,
-                right_offset_in_bits,
-                len_in_bits,
-            ))),
-        },
+pub(super) fn combine_option_buffers(
+    left_null_buffer: Option<&Buffer>,
+    left_offset_in_bits: usize,
+    right_null_buffer: Option<&Buffer>,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
+) -> Option<Buffer> {
+    match (left_null_buffer, right_null_buffer) {
+        (None, None) => None,
+        (None, Some(r)) => Some(r.bit_slice(right_offset_in_bits, len_in_bits)),
+        (Some(l), None) => Some(l.bit_slice(left_offset_in_bits, len_in_bits)),
+        (Some(l), Some(r)) => Some(buffer_bin_and(
+            l,
+            left_offset_in_bits,
+            r,
+            right_offset_in_bits,
+            len_in_bits,
+        )),
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #510.

# Rationale for this change

This is an alternative implementation to #521 of the `nullif` kernel that works by slicing the buffers of the array depending on the data type. For most data types this can be done without copying data. The exceptions are boolean arrays (when the offset is not a multiple of 8) and list arrays because there are some assumptions that offsets start at zero.

There are several TODO still left in the code to verify the correct slicing logic for some data types. It also seems a bit strange that this slicing logic is only needed for a single kernel and I also don't like that we still need to copy for some data types.

A better design would require some larger refactorings of the current data model:

- Remove the `offset` from `ArrayData` so that all slicing has to be pushed down into buffers
- Add a `offset` field to `Bitmap` so that bitmaps can be sliced without copying
- Also use the `Bitmap` as the data holder for boolean arrays

# What changes are included in this PR?

I added the kernel as a separate function to make the diff easier to read, if we decide to merge this it should replace the existing `nullif` kernel.

The api changes since the `nullif` kernel now takes an `ArrayRef` instead of a `PrimitiveArray`.
