### PR TITLE
Clarify docs that SlicesIterator ignores null values

### DIFF
--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -62,7 +62,7 @@ macro_rules! downcast_dict_filter {
 }
 
 /// An iterator of `(usize, usize)` each representing an interval
-/// `[start, end]` whose slots of a [BooleanArray] are true. Each
+/// `[start, end)` whose slots of a [BooleanArray] are true. Each
 /// interval corresponds to a contiguous region of memory to be
 /// "taken" from an array to be filtered.
 ///

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -61,11 +61,16 @@ macro_rules! downcast_dict_filter {
     }};
 }
 
-/// An iterator of `(usize, usize)` each representing an interval `[start, end]` whose
-/// slots of a [BooleanArray] are true. Each interval corresponds to a contiguous region of memory
-/// to be "taken" from an array to be filtered.
+/// An iterator of `(usize, usize)` each representing an interval
+/// `[start, end]` whose slots of a [BooleanArray] are true. Each
+/// interval corresponds to a contiguous region of memory to be
+/// "taken" from an array to be filtered.
 ///
-/// This is only performant for filters that copy across long contiguous runs
+/// ## Notes:
+///
+/// 1. Ignores the validity bitmap (ignores nulls)
+///
+/// 2. Only performant for filters that copy across long contiguous runs
 #[derive(Debug)]
 pub struct SlicesIterator<'a> {
     iter: UnalignedBitChunkIterator<'a>,


### PR DESCRIPTION
# Which issue does this PR close?

N/A 

# Rationale for this change
 
There is a bug in datafusion that I think is due to a mistaken assumption that `SlicesIterator` would respect the null / validity mas: https://github.com/apache/arrow-datafusion/issues/2117 

# What changes are included in this PR?
Update docs of `SlicesIterator` to be clear that it ignores null masks

# Are there any user-facing changes?
better docs
