### PR TITLE
Implement `size_hint` and `ExactSizedIterator` for `DecimalArray`

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -25,6 +25,7 @@ use super::{
     array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData,
     FixedSizeListArray, GenericBinaryIter, GenericListArray, OffsetSizeTrait,
 };
+pub use crate::array::DecimalIter;
 use crate::buffer::Buffer;
 use crate::datatypes::{
     validate_decimal_precision, DECIMAL_DEFAULT_SCALE, DECIMAL_MAX_PRECISION,
@@ -982,54 +983,6 @@ impl From<DecimalArray> for ArrayData {
         array.data
     }
 }
-
-/// an iterator that returns Some(i128) or None, that can be used on a
-/// DecimalArray
-#[derive(Debug)]
-pub struct DecimalIter<'a> {
-    array: &'a DecimalArray,
-    current: usize,
-    current_end: usize,
-}
-
-impl<'a> DecimalIter<'a> {
-    pub fn new(array: &'a DecimalArray) -> Self {
-        Self {
-            array,
-            current: 0,
-            current_end: array.len(),
-        }
-    }
-}
-
-impl<'a> std::iter::Iterator for DecimalIter<'a> {
-    type Item = Option<i128>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current == self.current_end {
-            None
-        } else {
-            let old = self.current;
-            self.current += 1;
-            // TODO: Improve performance by avoiding bounds check here
-            // (by using adding a `value_unchecked, for example)
-            if self.array.is_null(old) {
-                Some(None)
-            } else {
-                Some(Some(self.array.value(old)))
-            }
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remain = self.current_end - self.current;
-        (remain, Some(remain))
-    }
-}
-
-/// iterator has known size.
-impl<'a> std::iter::ExactSizeIterator for DecimalIter<'a> {}
 
 impl<'a> IntoIterator for &'a DecimalArray {
     type Item = Option<i128>;

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1623,7 +1623,7 @@ mod tests {
     #[test]
     fn test_decimal_iter_sized() {
         let data = vec![Some(-100), None, Some(101)];
-        let array: DecimalArray = data.clone().into_iter().collect();
+        let array: DecimalArray = data.into_iter().collect();
         let mut iter = array.into_iter();
 
         // is exact sized

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1023,12 +1023,12 @@ impl<'a> std::iter::Iterator for DecimalIter<'a> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remain = self.array.len() - self.current;
+        let remain = self.current_end - self.current;
         (remain, Some(remain))
     }
 }
 
-/// iterator has have known size.
+/// iterator has known size.
 impl<'a> std::iter::ExactSizeIterator for DecimalIter<'a> {}
 
 impl<'a> IntoIterator for &'a DecimalArray {

--- a/arrow/src/array/iterator.rs
+++ b/arrow/src/array/iterator.rs
@@ -18,9 +18,9 @@
 use crate::datatypes::ArrowPrimitiveType;
 
 use super::{
-    Array, ArrayRef, BinaryOffsetSizeTrait, BooleanArray, GenericBinaryArray,
-    GenericListArray, GenericStringArray, OffsetSizeTrait, PrimitiveArray,
-    StringOffsetSizeTrait,
+    Array, ArrayRef, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
+    GenericBinaryArray, GenericListArray, GenericStringArray, OffsetSizeTrait,
+    PrimitiveArray, StringOffsetSizeTrait,
 };
 
 /// an iterator that returns Some(T) or None, that can be used on any PrimitiveArray
@@ -402,6 +402,54 @@ impl<'a, S: OffsetSizeTrait> std::iter::ExactSizeIterator
     for GenericListArrayIter<'a, S>
 {
 }
+
+/// an iterator that returns Some(i128) or None, that can be used on a
+/// DecimalArray
+#[derive(Debug)]
+pub struct DecimalIter<'a> {
+    array: &'a DecimalArray,
+    current: usize,
+    current_end: usize,
+}
+
+impl<'a> DecimalIter<'a> {
+    pub fn new(array: &'a DecimalArray) -> Self {
+        Self {
+            array,
+            current: 0,
+            current_end: array.len(),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for DecimalIter<'a> {
+    type Item = Option<i128>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.current_end {
+            None
+        } else {
+            let old = self.current;
+            self.current += 1;
+            // TODO: Improve performance by avoiding bounds check here
+            // (by using adding a `value_unchecked, for example)
+            if self.array.is_null(old) {
+                Some(None)
+            } else {
+                Some(Some(self.array.value(old)))
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remain = self.current_end - self.current;
+        (remain, Some(remain))
+    }
+}
+
+/// iterator has known size.
+impl<'a> std::iter::ExactSizeIterator for DecimalIter<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/arrow/src/array/iterator.rs
+++ b/arrow/src/array/iterator.rs
@@ -403,8 +403,8 @@ impl<'a, S: OffsetSizeTrait> std::iter::ExactSizeIterator
 {
 }
 
-/// an iterator that returns Some(i128) or None, that can be used on a
-/// DecimalArray
+/// an iterator that returns `Some(i128)` or `None`, that can be used on a
+/// [`DecimalArray`]
 #[derive(Debug)]
 pub struct DecimalIter<'a> {
     array: &'a DecimalArray,


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/1505

# Rationale for this change
 
I was doing some small cleanups in DataFusion https://github.com/apache/arrow-datafusion/pull/2107 and noticed that the DecimalArray iterators do not report their exact size. The exact size is used in several places for optimizations in Arrow


# What changes are included in this PR?
1. Implement size_hint and ExactSizedIterator for DecimalArray
2. Tests for same

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Can use DecimalArray::iter() in more situations
