### PR TITLE
Speed up the `substring` kernel by about 2x

### DIFF
--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -86,9 +86,10 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
             .iter()
             .zip(new_length.iter())
             .map(|(start, length)| {
-                (start.to_usize().unwrap(), length.to_usize().unwrap())
+                let start = start.to_usize().unwrap();
+                let length = length.to_usize().unwrap();
+                &data[start..start + length]
             })
-            .map(|(start, length)| &data[start..start + length])
             .for_each(|slice| new_values.extend_from_slice(slice));
         new_values
     };

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -35,6 +35,10 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
     let data = values.as_slice();
     let zero = OffsetSize::zero();
 
+    // calculate the start offset for each substring
+    // if `start` >= 0
+    // then, count from the start of each string
+    // else, count from the end of each string
     let new_starts: Vec<OffsetSize> = if start >= zero {
         offsets
             .windows(2)
@@ -47,6 +51,10 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
             .collect()
     };
 
+    // count the length of each substring
+    // if `length` is given
+    // then, use it
+    // else, length is `string[new_start..].len()`
     let new_length: Vec<OffsetSize> = if let Some(length) = length {
         offsets[1..]
             .iter()
@@ -70,6 +78,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
         }))
         .collect();
 
+    // concatenate substrings into a buffer
     let new_values = {
         let mut new_values =
             MutableBuffer::new(new_offsets.last().unwrap().to_usize().unwrap());

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -51,7 +51,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
         } else {
             Box::new(|start: OffsetSize, end: OffsetSize| end - start)
         };
-    
+
     // start and end offsets for each substring
     let mut new_starts_ends: Vec<(OffsetSize, OffsetSize)> =
         Vec::with_capacity(array.len());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1511.

# Rationale for this change
 Improve the performance and do some clean-up work.

# What changes are included in this PR?
1. calculate `new_offsets` first to estimate the memory needed for buffer
2. clean up the code: remove redundant comparisons.

# Benchmark
chip: Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz
```
substring               time:   [19.806 ms 19.824 ms 19.844 ms]                      
                        change: [-44.909% -44.829% -44.743%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
```
About 2X speed-up

# Are there any user-facing changes?
No.

