### PR TITLE
Add a diagram to `take` kernel documentation

### DIFF
--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -53,6 +53,21 @@ macro_rules! downcast_dict_take {
 
 /// Take elements by index from [Array], creating a new [Array] from those indexes.
 ///
+/// ```text
+/// ┌─────────────────┐      ┌─────────┐                              ┌─────────────────┐
+/// │        A        │      │    0    │                              │        A        │
+/// ├─────────────────┤      ├─────────┤                              ├─────────────────┤
+/// │        D        │      │    2    │                              │        B        │
+/// ├─────────────────┤      ├─────────┤   take(values, indicies)     ├─────────────────┤
+/// │        B        │      │    3    │ ─────────────────────────▶   │        C        │
+/// ├─────────────────┤      ├─────────┤                              ├─────────────────┤
+/// │        C        │      │    1    │                              │        D        │
+/// ├─────────────────┤      └─────────┘                              └─────────────────┘
+/// │        E        │
+/// └─────────────────┘
+///    values array            indicies array                              result
+/// ```
+///
 /// # Errors
 /// This function errors whenever:
 /// * An index cannot be casted to `usize` (typically 32 bit architectures)


### PR DESCRIPTION
# Which issue does this PR close?

NA

# Rationale for this change
 
I made a diagram for https://github.com/apache/arrow-rs/issues/1523 and figured I would put it in the docs as well

# What changes are included in this PR?

add some ascii art to the documentation

# Are there any user-facing changes?

docs