### PR TITLE
fix clippy errors in 1.60

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -295,6 +295,7 @@ impl Drop for FFI_ArrowSchema {
 
 // returns the number of bits that buffer `i` (in the C data interface) is expected to have.
 // This is set by the Arrow specification
+#[allow(clippy::manual_bits)]
 fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
     Ok(match (data_type, i) {
         // the null buffer is bit sized

--- a/parquet/src/arrow/schema.rs
+++ b/parquet/src/arrow/schema.rs
@@ -662,6 +662,7 @@ impl ParquetTypeConverter<'_> {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_int32(&self) -> Result<DataType> {
         match (
             self.schema.get_basic_info().logical_type(),
@@ -707,6 +708,7 @@ impl ParquetTypeConverter<'_> {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_int64(&self) -> Result<DataType> {
         match (
             self.schema.get_basic_info().logical_type(),
@@ -758,6 +760,7 @@ impl ParquetTypeConverter<'_> {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_fixed_len_byte_array(&self) -> Result<DataType> {
         match (
             self.schema.get_basic_info().logical_type(),
@@ -796,6 +799,7 @@ impl ParquetTypeConverter<'_> {
         )
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_byte_array(&self) -> Result<DataType> {
         match (self.schema.get_basic_info().logical_type(), self.schema.get_basic_info().converted_type()) {
             (Some(LogicalType::STRING(_)), _) => Ok(DataType::Utf8),


### PR DESCRIPTION
# Rationale
Rust 1.60 is released 🎉 

Clippy has added some new lints which were failing on CI

# Changes
"Fix" lints (by telling clippy to ignore them) to get CI clean
