### PR TITLE
Do not merge! Rename the `substring` function and mark it as `unsafe`

### DIFF
--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -22,11 +22,14 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::compute::kernels::substring::substring;
+use arrow::compute::kernels::substring::substring_bytes_unchecked;
 use arrow::util::bench_util::*;
 
 fn bench_substring(arr: &StringArray, start: i64, length: usize) {
-    substring(criterion::black_box(arr), start, &Some(length as u64)).unwrap();
+    unsafe {
+        substring_bytes_unchecked(criterion::black_box(arr), start, &Some(length as u64))
+            .unwrap()
+    };
 }
 
 fn add_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1541.

# What changes are included in this PR?
1. Rename the current `substring` function as `substring_bytes_unchecked`.
2. Mark the function as `unsafe`

# Are there any user-facing changes?
Yes! API of `pub substring` function has been changed.
