### PR TITLE
Improve JSON reader documentation

### DIFF
--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -555,8 +555,11 @@ where
     generate_schema(field_types)
 }
 
-/// JSON values to Arrow record batch decoder. Decoder's next_batch method takes a JSON Value
-/// iterator as input and outputs Arrow record batch.
+/// JSON values to Arrow record batch decoder.
+///
+/// A [Decoder] decodes arbitrary streams of [serde_json::Value]s and
+/// converts them to [RecordBatch]es. To decode JSON formatted files,
+/// see [Reader].
 ///
 /// # Examples
 /// ```
@@ -635,8 +638,9 @@ impl DecoderOptions {
 }
 
 impl Decoder {
-    /// Create a new JSON decoder from any value that implements the `Iterator<Item=Result<Value>>`
-    /// trait.
+    /// Create a new JSON decoder from some value that implements an
+    /// iterator over [serde_json::Value]s (aka implements the
+    /// `Iterator<Item=Result<Value>>` trait).
     pub fn new(schema: SchemaRef, options: DecoderOptions) -> Self {
         Self { schema, options }
     }
@@ -664,7 +668,10 @@ impl Decoder {
         }
     }
 
-    /// Read the next batch of records
+    /// Read the next batch of [serde_json::Value] records from the
+    /// interator into a [RecordBatch].
+    ///
+    /// Returns `None` if the input iterator is exhausted.
     pub fn next_batch<I>(&self, value_iter: &mut I) -> Result<Option<RecordBatch>>
     where
         I: Iterator<Item = Result<Value>>,


### PR DESCRIPTION
# Which issue does this PR close?

re #1538 

# Rationale for this change
 
I found @tustvold 's comment helpful https://github.com/apache/arrow-rs/pull/1539#pullrequestreview-939990412 and it wasn't 100% clear to me previously why there was a split between `Decoder` and `Reader`. While it was fresh on my mind, I tried to update the doc strings to encode this knowledge for the future

# What changes are included in this PR?

Improve doc comments

# Are there any user-facing changes?

Better (hopefully) doc strings