### PR TITLE
Support FixedSizeBinary and FixedSizeList for the C data interface

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -61,9 +61,11 @@ _supported_pyarrow_types = [
     pa.decimal128(19, 4),
     pa.string(),
     pa.binary(),
+    pa.binary(10),
     pa.large_string(),
     pa.large_binary(),
     pa.list_(pa.int32()),
+    pa.list_(pa.int32(), 2),
     pa.large_list(pa.uint16()),
     pa.struct(
         [
@@ -85,8 +87,6 @@ _supported_pyarrow_types = [
 _unsupported_pyarrow_types = [
     pa.decimal256(76, 38),
     pa.duration("s"),
-    pa.binary(10),
-    pa.list_(pa.int32(), 2),
     pa.map_(pa.string(), pa.int32()),
     pa.union(
         [pa.field("a", pa.binary(10)), pa.field("b", pa.string())],
@@ -190,6 +190,29 @@ def test_time32_python():
     del b
     del expected
 
+def test_binary_array():
+    """
+    Python -> Rust -> Python
+    """
+    a = pa.array(["a", None, "bb", "ccc"], pa.binary())
+    b = rust.round_trip_array(a)
+    b.validate(full=True)
+    assert a.to_pylist() == b.to_pylist()
+    assert a.type == b.type
+    del a
+    del b
+
+def test_fixed_len_binary_array():
+    """
+    Python -> Rust -> Python
+    """
+    a = pa.array(["aaa", None, "bbb", "ccc"], pa.binary(3))
+    b = rust.round_trip_array(a)
+    b.validate(full=True)
+    assert a.to_pylist() == b.to_pylist()
+    assert a.type == b.type
+    del a
+    del b
 
 def test_list_array():
     """
@@ -203,6 +226,17 @@ def test_list_array():
     del a
     del b
 
+def test_fixed_len_list_array():
+    """
+    Python -> Rust -> Python
+    """
+    a = pa.array([[1, 2], None, [3, 4], [5, 6]], pa.list_(pa.int64(), 2))
+    b = rust.round_trip_array(a)
+    b.validate(full=True)
+    assert a.to_pylist() == b.to_pylist()
+    assert a.type == b.type
+    del a
+    del b
 
 def test_timestamp_python():
     """

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -45,12 +45,14 @@ impl TryFrom<ArrayData> for ffi::ArrowArray {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{DictionaryArray, Int32Array, StringArray};
+    use crate::array::{DictionaryArray, FixedSizeListArray, Int32Array, StringArray};
+    use crate::buffer::Buffer;
     use crate::error::Result;
+    use crate::util::bit_util;
     use crate::{
         array::{
-            Array, ArrayData, BooleanArray, Int64Array, StructArray, UInt32Array,
-            UInt64Array,
+            Array, ArrayData, BooleanArray, FixedSizeBinaryArray, Int64Array,
+            StructArray, UInt32Array, UInt64Array,
         },
         datatypes::{DataType, Field},
         ffi::ArrowArray,
@@ -145,6 +147,114 @@ mod tests {
             None,
         ]);
         let array = DictionaryArray::try_new(&keys, &values)?;
+
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_fixed_size_binary() -> Result<()> {
+        let values = vec![vec![10, 10, 10], vec![20, 20, 20], vec![30, 30, 30]];
+        let array = FixedSizeBinaryArray::try_from_iter(values.into_iter())?;
+
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_fixed_size_binary_with_nulls() -> Result<()> {
+        let values = vec![
+            None,
+            Some(vec![10, 10, 10]),
+            None,
+            Some(vec![20, 20, 20]),
+            Some(vec![30, 30, 30]),
+            None,
+        ];
+        let array = FixedSizeBinaryArray::try_from_sparse_iter(values.into_iter())?;
+
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_fixed_size_list() -> Result<()> {
+        let v: Vec<i64> = (0..9).into_iter().collect();
+        let value_data = ArrayData::builder(DataType::Int64)
+            .len(9)
+            .add_buffer(Buffer::from_slice_ref(&v))
+            .build()?;
+        let list_data_type =
+            DataType::FixedSizeList(Box::new(Field::new("f", DataType::Int64, false)), 3);
+        let list_data = ArrayData::builder(list_data_type)
+            .len(3)
+            .add_child_data(value_data)
+            .build()?;
+        let array = FixedSizeListArray::from(list_data);
+
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_fixed_size_list_with_nulls() -> Result<()> {
+        // 0100 0110
+        let mut validity_bits: [u8; 1] = [0; 1];
+        bit_util::set_bit(&mut validity_bits, 1);
+        bit_util::set_bit(&mut validity_bits, 2);
+        bit_util::set_bit(&mut validity_bits, 6);
+
+        let v: Vec<i16> = (0..16).into_iter().collect();
+        let value_data = ArrayData::builder(DataType::Int16)
+            .len(16)
+            .add_buffer(Buffer::from_slice_ref(&v))
+            .build()?;
+        let list_data_type =
+            DataType::FixedSizeList(Box::new(Field::new("f", DataType::Int16, false)), 2);
+        let list_data = ArrayData::builder(list_data_type)
+            .len(8)
+            .null_bit_buffer(Buffer::from(validity_bits))
+            .add_child_data(value_data)
+            .build()?;
+        let array = FixedSizeListArray::from(list_data);
+
+        let data = array.data();
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_fixed_size_list_nested() -> Result<()> {
+        let v: Vec<i32> = (0..16).into_iter().collect();
+        let value_data = ArrayData::builder(DataType::Int32)
+            .len(16)
+            .add_buffer(Buffer::from_slice_ref(&v))
+            .build()?;
+
+        let offsets: Vec<i32> = vec![0, 2, 4, 6, 8, 10, 12, 14, 16];
+        let value_offsets = Buffer::from_slice_ref(&offsets);
+        let inner_list_data_type =
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
+        let inner_list_data = ArrayData::builder(inner_list_data_type.clone())
+            .len(8)
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
+            .build()?;
+
+        // 0000 0100
+        let mut validity_bits: [u8; 1] = [0; 1];
+        bit_util::set_bit(&mut validity_bits, 2);
+
+        let list_data_type = DataType::FixedSizeList(
+            Box::new(Field::new("f", inner_list_data_type, false)),
+            2,
+        );
+        let list_data = ArrayData::builder(list_data_type)
+            .len(4)
+            .null_bit_buffer(Buffer::from(validity_bits))
+            .add_child_data(inner_list_data)
+            .build()?;
+
+        let array = FixedSizeListArray::from(list_data);
 
         let data = array.data();
         test_round_trip(data)

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -333,6 +333,17 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
                 data_type, i
             )))
         }
+        (DataType::FixedSizeBinary(num_bytes), 1) => size_of::<u8>() * (*num_bytes as usize) * 8,
+        (DataType::FixedSizeList(f, num_elems), 1) => {
+            let child_bit_width = bit_width(f.data_type(), 1)?;
+            child_bit_width * (*num_elems as usize)
+        },
+        (DataType::FixedSizeBinary(_), _) | (DataType::FixedSizeList(_, _), _) => {
+            return Err(ArrowError::CDataInterface(format!(
+                "The datatype \"{:?}\" expects 2 buffers, but requested {}. Please verify that the C data interface is correctly implemented.",
+                data_type, i
+            )))
+        },
         // Variable-sized binaries: have two buffers.
         // "small": first buffer is i32, second is in bytes
         (DataType::Utf8, 1) | (DataType::Binary, 1) | (DataType::List(_), 1) => size_of::<i32>() * 8,
@@ -862,9 +873,10 @@ mod tests {
     use super::*;
     use crate::array::{
         export_array_into_raw, make_array, Array, ArrayData, BinaryOffsetSizeTrait,
-        BooleanArray, DecimalArray, DictionaryArray, GenericBinaryArray,
-        GenericListArray, GenericStringArray, Int32Array, OffsetSizeTrait,
-        StringOffsetSizeTrait, Time32MillisecondArray, TimestampMillisecondArray,
+        BooleanArray, DecimalArray, DictionaryArray, FixedSizeBinaryArray,
+        FixedSizeListArray, GenericBinaryArray, GenericListArray, GenericStringArray,
+        Int32Array, OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
+        TimestampMillisecondArray,
     };
     use crate::compute::kernels;
     use crate::datatypes::{Field, Int8Type};
@@ -1170,6 +1182,117 @@ mod tests {
                 Some(2)
             ])
         );
+
+        // (drop/release)
+        Ok(())
+    }
+
+    #[test]
+    fn test_fixed_size_binary_array() -> Result<()> {
+        let values = vec![
+            None,
+            Some(vec![10, 10, 10]),
+            None,
+            Some(vec![20, 20, 20]),
+            Some(vec![30, 30, 30]),
+            None,
+        ];
+        let array = FixedSizeBinaryArray::try_from_sparse_iter(values.into_iter())?;
+
+        // export it
+        let array = ArrowArray::try_from(array.data().clone())?;
+
+        // (simulate consumer) import it
+        let data = ArrayData::try_from(array)?;
+        let array = make_array(data);
+
+        // perform some operation
+        let array = kernels::concat::concat(&[array.as_ref(), array.as_ref()]).unwrap();
+        let array = array
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+
+        // verify
+        assert_eq!(
+            array,
+            &FixedSizeBinaryArray::try_from_sparse_iter(
+                vec![
+                    None,
+                    Some(vec![10, 10, 10]),
+                    None,
+                    Some(vec![20, 20, 20]),
+                    Some(vec![30, 30, 30]),
+                    None,
+                    None,
+                    Some(vec![10, 10, 10]),
+                    None,
+                    Some(vec![20, 20, 20]),
+                    Some(vec![30, 30, 30]),
+                    None,
+                ]
+                .into_iter()
+            )?
+        );
+
+        // (drop/release)
+        Ok(())
+    }
+
+    #[test]
+    fn test_fixed_size_list_array() -> Result<()> {
+        // 0000 0100
+        let mut validity_bits: [u8; 1] = [0; 1];
+        bit_util::set_bit(&mut validity_bits, 2);
+
+        let v: Vec<i32> = (0..9).into_iter().collect();
+        let value_data = ArrayData::builder(DataType::Int32)
+            .len(9)
+            .add_buffer(Buffer::from_slice_ref(&v))
+            .build()?;
+
+        let list_data_type =
+            DataType::FixedSizeList(Box::new(Field::new("f", DataType::Int32, false)), 3);
+        let list_data = ArrayData::builder(list_data_type.clone())
+            .len(3)
+            .null_bit_buffer(Buffer::from(validity_bits))
+            .add_child_data(value_data)
+            .build()?;
+
+        // export it
+        let array = ArrowArray::try_from(list_data)?;
+
+        // (simulate consumer) import it
+        let data = ArrayData::try_from(array)?;
+        let array = make_array(data);
+
+        // perform some operation
+        let array = kernels::concat::concat(&[array.as_ref(), array.as_ref()]).unwrap();
+        let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+
+        // 0010 0100
+        let mut expected_validity_bits: [u8; 1] = [0; 1];
+        bit_util::set_bit(&mut expected_validity_bits, 2);
+        bit_util::set_bit(&mut expected_validity_bits, 5);
+
+        let mut w = vec![];
+        w.extend_from_slice(&v);
+        w.extend_from_slice(&v);
+
+        let expected_value_data = ArrayData::builder(DataType::Int32)
+            .len(18)
+            .add_buffer(Buffer::from_slice_ref(&w))
+            .build()?;
+
+        let expected_list_data = ArrayData::builder(list_data_type)
+            .len(6)
+            .null_bit_buffer(Buffer::from(expected_validity_bits))
+            .add_child_data(expected_value_data)
+            .build()?;
+        let expected_array = FixedSizeListArray::from(expected_list_data);
+
+        // verify
+        assert_eq!(array, &expected_array);
 
         // (drop/release)
         Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1553.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently the C data interface doesn't support `FixedSizeBinary` and `FixedSizeList` yet with the following error message:

```
CDataInterface("The datatype \"FixedSizeBinary(9)\" is still not supported in Rust implementation
```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds support for `FixedSizeBinary` and `FixedSizeList` in the Rust C data interface.

# Are there any user-facing changes?

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes now `FixedSizeBinary` and `FixedSizeList` are supported. No API breakage.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->