### PR TITLE
Replace &Option<T>  with Option<&T>

### DIFF
--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -70,7 +70,7 @@ fn substring(array: ArrayData, start: i64) -> PyResult<ArrayData> {
     let array = ArrayRef::from(array);
 
     // substring
-    let array = kernels::substring::substring(array.as_ref(), start, &None)?;
+    let array = kernels::substring::substring(array.as_ref(), start, None)?;
 
     Ok(array.data().to_owned())
 }

--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -26,7 +26,7 @@ use arrow::compute::kernels::substring::substring;
 use arrow::util::bench_util::*;
 
 fn bench_substring(arr: &StringArray, start: i64, length: usize) {
-    substring(criterion::black_box(arr), start, &Some(length as u64)).unwrap();
+    substring(criterion::black_box(arr), start,Some(length as u64).as_ref()).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -26,7 +26,12 @@ use arrow::compute::kernels::substring::substring;
 use arrow::util::bench_util::*;
 
 fn bench_substring(arr: &StringArray, start: i64, length: usize) {
-    substring(criterion::black_box(arr), start,Some(length as u64).as_ref()).unwrap();
+    substring(
+        criterion::black_box(arr),
+        start,
+        Some(length as u64).as_ref(),
+    )
+    .unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(1, struct_data.null_count());
         assert_eq!(
             // 00001011
-            &Some(Bitmap::from(Buffer::from(&[11_u8]))),
+            Some(&Bitmap::from(Buffer::from(&[11_u8]))),
             struct_data.null_bitmap()
         );
 

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -3561,7 +3561,7 @@ mod tests {
         assert_eq!(4, struct_data.len());
         assert_eq!(1, struct_data.null_count());
         assert_eq!(
-            &Some(Bitmap::from(Buffer::from(&[11_u8]))),
+            Some(&Bitmap::from(Buffer::from(&[11_u8]))),
             struct_data.null_bitmap()
         );
 
@@ -3675,7 +3675,7 @@ mod tests {
         assert_eq!(3, map_data.len());
         assert_eq!(1, map_data.null_count());
         assert_eq!(
-            &Some(Bitmap::from(Buffer::from(&[5_u8]))),
+            Some(&Bitmap::from(Buffer::from(&[5_u8]))),
             map_data.null_bitmap()
         );
 

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -398,8 +398,8 @@ impl ArrayData {
 
     /// Returns a reference to the null bitmap of this array data
     #[inline]
-    pub const fn null_bitmap(&self) -> &Option<Bitmap> {
-        &self.null_bitmap
+    pub const fn null_bitmap(&self) -> Option<&Bitmap> {
+        self.null_bitmap.as_ref()
     }
 
     /// Returns a reference to the null buffer of this array data.
@@ -500,7 +500,7 @@ impl ArrayData {
                     .iter()
                     .map(|data| data.slice(offset, length))
                     .collect(),
-                null_bitmap: self.null_bitmap().clone(),
+                null_bitmap: self.null_bitmap().cloned(),
             };
 
             new_data

--- a/arrow/src/array/equal/utils.rs
+++ b/arrow/src/array/equal/utils.rs
@@ -132,7 +132,7 @@ pub(super) fn child_logical_null_buffer(
             let ceil = bit_util::ceil(parent_len, 8);
             Bitmap::from(Buffer::from(vec![0b11111111; ceil]))
         });
-    let self_null_bitmap = child_data.null_bitmap().clone().unwrap_or_else(|| {
+    let self_null_bitmap = child_data.null_bitmap().cloned().unwrap_or_else(|| {
         let ceil = bit_util::ceil(child_data.len(), 8);
         Bitmap::from(Buffer::from(vec![0b11111111; ceil]))
     });

--- a/arrow/src/compute/kernels/boolean.rs
+++ b/arrow/src/compute/kernels/boolean.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let expected = BooleanArray::from(vec![false, false, false, false]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1023,7 +1023,7 @@ mod tests {
         let expected = BooleanArray::from(vec![false, false, false, false]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1035,7 +1035,7 @@ mod tests {
         let expected = BooleanArray::from(vec![true, true, true, true]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1048,7 +1048,7 @@ mod tests {
         let expected = BooleanArray::from(vec![true, true, true, true]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1060,7 +1060,7 @@ mod tests {
         let expected = BooleanArray::from(vec![false, true, false, true]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1091,7 +1091,7 @@ mod tests {
         let expected = BooleanArray::from(vec![false, true, false, true]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1103,7 +1103,7 @@ mod tests {
         let expected = BooleanArray::from(vec![true, false, true, false]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]
@@ -1134,7 +1134,7 @@ mod tests {
         let expected = BooleanArray::from(vec![true, false, true, false]);
 
         assert_eq!(expected, res);
-        assert_eq!(&None, res.data_ref().null_bitmap());
+        assert_eq!(None, res.data_ref().null_bitmap());
     }
 
     #[test]

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1244,7 +1244,11 @@ where
             to_type,
             array.len(),
             Some(array.null_count()),
-            array.data().null_bitmap().cloned().map(|bitmap| bitmap.bits),
+            array
+                .data()
+                .null_bitmap()
+                .cloned()
+                .map(|bitmap| bitmap.bits),
             array.data().offset(),
             array.data().buffers().to_vec(),
             vec![],

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1244,7 +1244,7 @@ where
             to_type,
             array.len(),
             Some(array.null_count()),
-            array.data().null_bitmap().clone().map(|bitmap| bitmap.bits),
+            array.data().null_bitmap().cloned().map(|bitmap| bitmap.bits),
             array.data().offset(),
             array.data().buffers().to_vec(),
             vec![],
@@ -1730,7 +1730,7 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
                     cast_keys
                         .data()
                         .null_bitmap()
-                        .clone()
+                        .cloned()
                         .map(|bitmap| bitmap.bits),
                     cast_keys.data().offset(),
                     cast_keys.data().buffers().to_vec(),
@@ -1948,7 +1948,7 @@ fn cast_primitive_to_list<OffsetSize: OffsetSizeTrait + NumCast>(
             cast_array
                 .data()
                 .null_bitmap()
-                .clone()
+                .cloned()
                 .map(|bitmap| bitmap.bits),
             0,
             vec![offsets.into()],
@@ -1976,7 +1976,7 @@ fn cast_list_inner<OffsetSize: OffsetSizeTrait>(
             to_type.clone(),
             array.len(),
             Some(data.null_count()),
-            data.null_bitmap().clone().map(|bitmap| bitmap.bits),
+            data.null_bitmap().cloned().map(|bitmap| bitmap.bits),
             array.offset(),
             // reuse offset buffer
             data.buffers().to_vec(),

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -509,7 +509,7 @@ impl<R: Read> Iterator for Reader<R> {
             &self.batch_records[..read_records],
             self.schema.fields(),
             Some(self.schema.metadata.clone()),
-            &self.projection,
+            self.projection.as_ref(),
             self.line_number,
             format,
         );
@@ -526,12 +526,12 @@ fn parse(
     rows: &[StringRecord],
     fields: &[Field],
     metadata: Option<std::collections::HashMap<String, String>>,
-    projection: &Option<Vec<usize>>,
+    projection: Option<&Vec<usize>>,
     line_number: usize,
     datetime_format: Option<&str>,
 ) -> Result<RecordBatch> {
     let projection: Vec<usize> = match projection {
-        Some(ref v) => v.clone(),
+        Some(v) => v.clone(),
         None => fields.iter().enumerate().map(|(i, _)| i).collect(),
     };
 

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -221,7 +221,7 @@ impl<W: Write> Writer<W> {
                         .to_string()
                 }
                 DataType::Timestamp(time_unit, time_zone) => {
-                    self.handle_timestamp(time_unit, time_zone, row_index, col)?
+                    self.handle_timestamp(time_unit, time_zone.as_ref(), row_index, col)?
                 }
                 DataType::Decimal(..) => make_string_from_decimal(col, row_index)?,
                 t => {
@@ -242,7 +242,7 @@ impl<W: Write> Writer<W> {
     fn handle_timestamp(
         &self,
         time_unit: &TimeUnit,
-        _time_zone: &Option<String>,
+        _time_zone: Option<&String>,
         row_index: usize,
         col: &ArrayRef,
     ) -> Result<String> {
@@ -280,7 +280,7 @@ impl<W: Write> Writer<W> {
     fn handle_timestamp(
         &self,
         time_unit: &TimeUnit,
-        time_zone: &Option<String>,
+        time_zone: Option<&String>,
         row_index: usize,
         col: &ArrayRef,
     ) -> Result<String> {

--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -91,8 +91,8 @@ impl Field {
 
     /// Returns the immutable reference to the `Field`'s optional custom metadata.
     #[inline]
-    pub const fn metadata(&self) -> &Option<BTreeMap<String, String>> {
-        &self.metadata
+    pub const fn metadata(&self) -> Option<&BTreeMap<String, String>> {
+        self.metadata.as_ref()
     }
 
     /// Returns an immutable reference to the `Field`'s name.

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -1276,7 +1276,7 @@ mod tests {
         assert!(f1.try_merge(&f2).is_ok());
         assert!(f1.metadata().is_some());
         assert_eq!(
-            f1.metadata().clone().unwrap(),
+            f1.metadata().cloned().unwrap(),
             [
                 ("foo".to_string(), "bar".to_string()),
                 ("foo2".to_string(), "bar2".to_string())
@@ -1297,7 +1297,7 @@ mod tests {
         assert!(f1.try_merge(&f2).is_ok());
         assert!(f1.metadata().is_some());
         assert_eq!(
-            f1.metadata().clone().unwrap(),
+            f1.metadata().cloned().unwrap(),
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -376,9 +376,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
     ) -> Result<usize> {
-        self.write_batch_internal(
-            values, def_levels, rep_levels, None, None, None, None,
-        )
+        self.write_batch_internal(values, def_levels, rep_levels, None, None, None, None)
     }
 
     /// Writer may optionally provide pre-calculated statistics for this batch, in which case we do

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -270,8 +270,8 @@ impl<T: DataType> ColumnWriterImpl<T> {
         values: &[T::T],
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
-        min: &Option<T::T>,
-        max: &Option<T::T>,
+        min: Option<&T::T>,
+        max: Option<&T::T>,
         null_count: Option<u64>,
         distinct_count: Option<u64>,
     ) -> Result<usize> {
@@ -377,7 +377,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         rep_levels: Option<&[i16]>,
     ) -> Result<usize> {
         self.write_batch_internal(
-            values, def_levels, rep_levels, &None, &None, None, None,
+            values, def_levels, rep_levels, None, None, None, None,
         )
     }
 
@@ -389,8 +389,8 @@ impl<T: DataType> ColumnWriterImpl<T> {
         values: &[T::T],
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
-        min: &Option<T::T>,
-        max: &Option<T::T>,
+        min: Option<&T::T>,
+        max: Option<&T::T>,
         nulls_count: Option<u64>,
         distinct_count: Option<u64>,
     ) -> Result<usize> {
@@ -1487,8 +1487,8 @@ mod tests {
                 &[1, 2, 3, 4],
                 None,
                 None,
-                &Some(-17),
-                &Some(9000),
+                Some(&-17),
+                Some(&9000),
                 Some(21),
                 Some(55),
             )

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -139,8 +139,8 @@ impl FileMetaData {
     /// ```shell
     /// parquet-mr version 1.8.0 (build 0fda28af84b9746396014ad6a415b90592a98b3b)
     /// ```
-    pub fn created_by(&self) -> &Option<String> {
-        &self.created_by
+    pub fn created_by(&self) -> Option<&String> {
+        self.created_by.as_ref()
     }
 
     /// Returns key_value_metadata of this file.

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -139,8 +139,8 @@ impl FileMetaData {
     /// ```shell
     /// parquet-mr version 1.8.0 (build 0fda28af84b9746396014ad6a415b90592a98b3b)
     /// ```
-    pub fn created_by(&self) -> Option<&String> {
-        self.created_by.as_ref()
+    pub fn created_by(&self) -> Option<&str> {
+        self.created_by.as_deref()
     }
 
     /// Returns key_value_metadata of this file.

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -145,8 +145,8 @@ impl WriterProperties {
     }
 
     /// Returns `key_value_metadata` KeyValue pairs.
-    pub fn key_value_metadata(&self) -> &Option<Vec<KeyValue>> {
-        &self.key_value_metadata
+    pub fn key_value_metadata(&self) -> Option<&Vec<KeyValue>> {
+        self.key_value_metadata.as_ref()
     }
 
     /// Returns encoding for a data page, when dictionary encoding is enabled.
@@ -523,7 +523,7 @@ mod tests {
         assert_eq!(props.max_row_group_size(), DEFAULT_MAX_ROW_GROUP_SIZE);
         assert_eq!(props.writer_version(), DEFAULT_WRITER_VERSION);
         assert_eq!(props.created_by(), DEFAULT_CREATED_BY);
-        assert_eq!(props.key_value_metadata(), &None);
+        assert_eq!(props.key_value_metadata(), None);
         assert_eq!(props.encoding(&ColumnPath::from("col")), None);
         assert_eq!(
             props.compression(&ColumnPath::from("col")),
@@ -631,7 +631,7 @@ mod tests {
         assert_eq!(props.created_by(), "default");
         assert_eq!(
             props.key_value_metadata(),
-            &Some(vec![KeyValue::new("key".to_string(), "value".to_string(),)])
+            Some(&vec![KeyValue::new("key".to_string(), "value".to_string(),)])
         );
 
         assert_eq!(

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -631,7 +631,9 @@ mod tests {
         assert_eq!(props.created_by(), "default");
         assert_eq!(
             props.key_value_metadata(),
-            Some(&vec![KeyValue::new("key".to_string(), "value".to_string(),)])
+            Some(&vec![
+                KeyValue::new("key".to_string(), "value".to_string(),)
+            ])
         );
 
         assert_eq!(

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -605,7 +605,7 @@ mod tests {
         let file_metadata = metadata.file_metadata();
         assert!(file_metadata.created_by().is_some());
         assert_eq!(
-      file_metadata.created_by().as_ref().unwrap(),
+      file_metadata.created_by().unwrap(),
       "impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)"
     );
         assert!(file_metadata.key_value_metadata().is_none());
@@ -695,7 +695,7 @@ mod tests {
         let file_metadata = metadata.file_metadata();
         assert!(file_metadata.created_by().is_some());
         assert_eq!(
-            file_metadata.created_by().as_ref().unwrap(),
+            file_metadata.created_by().unwrap(),
             "parquet-mr version 1.8.1 (build 4aba4dae7bb0d4edbcf7923ae1339f28fd3f7fcf)"
         );
         assert!(file_metadata.key_value_metadata().is_some());

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -188,7 +188,7 @@ impl<W: ParquetWriter> SerializedFileWriter<W> {
                 .iter()
                 .map(|v| v.to_thrift())
                 .collect(),
-            key_value_metadata: self.props.key_value_metadata().to_owned(),
+            key_value_metadata: self.props.key_value_metadata().cloned(),
             created_by: Some(self.props.created_by().to_owned()),
             column_orders: None,
             encryption_algorithm: None,

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -231,7 +231,7 @@ fn print_timeunit(unit: &TimeUnit) -> &str {
 
 #[inline]
 fn print_logical_and_converted(
-    logical_type: &Option<LogicalType>,
+    logical_type: Option<&LogicalType>,
     converted_type: ConvertedType,
     precision: i32,
     scale: i32,
@@ -315,7 +315,7 @@ impl<'a> Printer<'a> {
                 // Also print logical type if it is available
                 // If there is a logical type, do not print converted type
                 let logical_type_str = print_logical_and_converted(
-                    &basic_info.logical_type(),
+                    basic_info.logical_type().as_ref(),
                     basic_info.converted_type(),
                     precision,
                     scale,
@@ -347,7 +347,7 @@ impl<'a> Printer<'a> {
                     let r = basic_info.repetition();
                     write!(self.output, "{} group {} ", r, basic_info.name());
                     let logical_str = print_logical_and_converted(
-                        &basic_info.logical_type(),
+                        basic_info.logical_type().as_ref(),
                         basic_info.converted_type(),
                         0,
                         0,


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1556 .

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Not needing to associate a lifetime with a None type.
# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
**arrow::array::ArrayData**
`null_bitmap()` returns `Option<&Bitmap>` rather than `&Option<Bitmap>`

**arrow::compute::kernels::substring**
`substring()` takes `Option<&u64>` as an argument rather than `&Option<u64>`

**arrow::datatypes::Field** 
`metadata()` returns `Option<&BTreeMap<String, String>>` ...

**parquet::column::writer::ColumnWriterImpl**
`write_batch_with_statistics()` now takes `Option<&T::T>` for both `min` and `max` arguments

**parquet::file::metadata::FileMetaData** 
`created_by()` returns `Option<&String>` ...

**parquet::file::properties::WriterProperties** 
`key_value_metadata()` returns `Option<&Vec<KeyValue>>` ...



<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
