### PR TITLE
Use littleendian arrow files for `projection_should_work`

### DIFF
--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -1108,15 +1108,13 @@ mod tests {
     }
 
     #[test]
-    // https://github.com/apache/arrow-rs/issues/1548
-    #[cfg(not(feature = "force_validate"))]
     fn projection_should_work() {
         // complementary to the previous test
         let testdata = crate::util::test_util::arrow_test_data();
         let paths = vec![
             "generated_interval",
             "generated_datetime",
-            // "generated_map", Err: Last offset 872415232 of Utf8 is larger than values length 52 (https://github.com/apache/arrow-rs/issues/859)
+            "generated_map",
             "generated_nested",
             "generated_null_trivial",
             "generated_null",
@@ -1125,8 +1123,11 @@ mod tests {
             "generated_primitive",
         ];
         paths.iter().for_each(|path| {
+            // We must use littleendian files here.
+            // The offsets are not translated for big-endian files
+            // https://github.com/apache/arrow-rs/issues/859
             let file = File::open(format!(
-                "{}/arrow-ipc-stream/integration/1.0.0-bigendian/{}.arrow_file",
+                "{}/arrow-ipc-stream/integration/1.0.0-littleendian/{}.arrow_file",
                 testdata, path
             ))
             .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1548.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently by enabling `force_validate`, the test `projection_should_work` fails.
```
cargo test --features=force_validate -p arrow
```

```
---- ipc::reader::tests::projection_should_work stdout ----
thread 'ipc::reader::tests::projection_should_work' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidArgumentError("Last offset 251658240 of List(Field { name: \"item\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }) is larger than values length 15")', arrow/src/array/data.rs:301:34
```

It is because the arrow files used in the test is bigendian, but currently the IPC reader doesn't translate big endian offsets (#859). As that's a known issue, I change the test to use littleendian arrow files, and add a comment there to explain the reason.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
