### PR TITLE
Use `Option<T>` rather than `Option<&T>` for copy types in substring kernel

### DIFF
--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -26,12 +26,7 @@ use arrow::compute::kernels::substring::substring;
 use arrow::util::bench_util::*;
 
 fn bench_substring(arr: &StringArray, start: i64, length: usize) {
-    substring(
-        criterion::black_box(arr),
-        start,
-        Some(length as u64).as_ref(),
-    )
-    .unwrap();
+    substring(criterion::black_box(arr), start, Some(length as u64)).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1556.

# Rationale for this change
 
Suggested by @jhorstmann on https://github.com/apache/arrow-rs/pull/1571#discussion_r851723463

# What changes are included in this PR?

Changes `Option<&T>` to `Option<T>` where `T: Clone`

# Are there any user-facing changes?

Yes, this changes the signature of the substring kernel

FYI @tfeda 
