### PR TITLE
Add utf-8 validation checking for `substring`

### DIFF
--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -25,8 +25,8 @@ use arrow::array::*;
 use arrow::compute::kernels::substring::substring;
 use arrow::util::bench_util::*;
 
-fn bench_substring(arr: &StringArray, start: i64, length: usize) {
-    substring(criterion::black_box(arr), start, Some(length as u64)).unwrap();
+fn bench_substring(arr: &StringArray, start: i64, length: Option<u64>) {
+    substring(criterion::black_box(arr), start, length).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -34,10 +34,13 @@ fn add_benchmark(c: &mut Criterion) {
     let str_len = 1000;
 
     let arr_string = create_string_array_with_len::<i32>(size, 0.0, str_len);
-    let start = 1;
 
-    c.bench_function("substring", |b| {
-        b.iter(|| bench_substring(&arr_string, start, str_len - 1))
+    c.bench_function("substring (start = 0, length = None)", |b| {
+        b.iter(|| bench_substring(&arr_string, 0, None))
+    });
+
+    c.bench_function("substring (start = 1, length = str_len - 1)", |b| {
+        b.iter(|| bench_substring(&arr_string, 1, Some((str_len - 1) as u64)))
     });
 }
 

--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -39,10 +39,10 @@ fn add_benchmark(c: &mut Criterion) {
     let str_len = 1000;
 
     let arr_string = create_string_array_with_len::<i32>(size, 0.0, str_len);
-    let start = 0;
+    let start = 1;
 
     c.bench_function("substring", |b| {
-        b.iter(|| bench_substring(&arr_string, start, str_len))
+        b.iter(|| bench_substring(&arr_string, start, str_len - 1))
     });
 }
 

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -144,12 +144,14 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
 ///
 /// # Error
 /// - The function errors when the passed array is not a \[Large\]String array.
-/// - The function errors when you try to create a substring in the middle of a multibyte character.
+/// - The function errors if the offset of a substring in the input array is at invalid char boundary.
+/// 
+/// ## Example of trying to get an invalid utf-8 substring
 /// ```
 /// # use arrow::array::StringArray;
 /// # use arrow::compute::kernels::substring::substring;
 /// let array = StringArray::from(vec![Some("E=mc²")]);
-/// let error = substring(&array, -1, None).unwrap_err().to_string();
+/// let error = substring(&array, 0, Some(&5)).unwrap_err().to_string();
 /// assert!(error.contains("invalid utf-8 boundary"));
 /// ```
 pub fn substring(

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -39,6 +39,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
     // Check if `offset` is at a valid char boundary.
     // If yes, return `offset`, else return error
     let check_char_boundary = {
+        // Safety: a StringArray must contain valid UTF8 data
         let data_str = unsafe { std::str::from_utf8_unchecked(data) };
         |offset: OffsetSize| {
             let offset_usize = offset.to_usize().unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1575 

# What changes are included in this PR?

1. Check if the offsets of substrings are at valid utf-8 char boundary.
2. Add another substring benchmark.

# Are there any user-facing changes?
No.

# Benchmark
```
substring (start = 0, length = None)                                                                            
                        time:   [19.795 ms 19.810 ms 19.828 ms]
                        change: [-1.4682% -1.3201% -1.1834%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

substring (start = 1, length = str_len - 1)                                                                            
                        time:   [21.777 ms 21.798 ms 21.820 ms]
                        change: [+9.0489% +9.2069% +9.3504%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
```

We only check the char boundary validation when `start != 0` or `length != None`.