### PR TITLE
Derive `Clone` and `PartialEq` for json `DecoderOptions`

### DIFF
--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -590,13 +590,14 @@ pub struct Decoder {
     options: DecoderOptions,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
+/// Options for JSON decoding
 pub struct DecoderOptions {
     /// Batch size (number of records to load each time), defaults to 1024 records
     batch_size: usize,
     /// Optional projection for which columns to load (case-sensitive names)
     projection: Option<Vec<String>>,
-    /// optional HashMap of column names to its format string
+    /// optional HashMap of column name to its format string
     format_strings: Option<HashMap<String, String>>,
 }
 
@@ -3321,5 +3322,14 @@ mod tests {
         assert_eq!(12, sum_num_rows);
         assert_eq!(3, num_batches);
         assert_eq!(100000000000011, sum_a);
+    }
+
+
+    #[test]
+    fn test_options_clone() {
+        // ensure options have appropriate derivation
+        let options = DecoderOptions::new().with_batch_size(64);
+        let cloned = options.clone();
+        assert_eq!(options, cloned);
     }
 }

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -3324,7 +3324,6 @@ mod tests {
         assert_eq!(100000000000011, sum_a);
     }
 
-
     #[test]
     fn test_options_clone() {
         // ensure options have appropriate derivation


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/1580

# Rationale for this change
 
see ticket

# What changes are included in this PR?

derive `Clone` and `PartialEq`, test

# Are there any user-facing changes?
yes
