### PR TITLE
Add support for nested list arrays from parquet to arrow arrays (#993)

### DIFF
--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -717,13 +717,7 @@ impl ArrayReader for StructArrayReader {
             .children
             .iter_mut()
             .map(|reader| reader.next_batch(batch_size))
-            .try_fold(
-                Vec::new(),
-                |mut result, child_array| -> Result<Vec<ArrayRef>> {
-                    result.push(child_array?);
-                    Ok(result)
-                },
-            )?;
+            .collect::<Result<Vec<_>>>()?;
 
         // check that array child data has same size
         let children_array_len =

--- a/parquet/src/arrow/array_reader.rs
+++ b/parquet/src/arrow/array_reader.rs
@@ -1532,7 +1532,7 @@ mod tests {
             ArrowType::Int32,
             array_1.clone(),
             Some(vec![0, 1, 2, 3, 1]),
-            Some(vec![1, 1, 1, 1, 1]),
+            Some(vec![0, 1, 1, 1, 1]),
         );
 
         let array_2 = Arc::new(PrimitiveArray::<ArrowInt32>::from(vec![5, 4, 3, 2, 1]));
@@ -1540,7 +1540,7 @@ mod tests {
             ArrowType::Int32,
             array_2.clone(),
             Some(vec![0, 1, 3, 1, 2]),
-            Some(vec![1, 1, 1, 1, 1]),
+            Some(vec![0, 1, 1, 1, 1]),
         );
 
         let struct_type = ArrowType::Struct(vec![
@@ -1570,7 +1570,7 @@ mod tests {
             struct_array_reader.get_def_levels()
         );
         assert_eq!(
-            Some(vec![1, 1, 1, 1, 1].as_slice()),
+            Some(vec![0, 1, 1, 1, 1].as_slice()),
             struct_array_reader.get_rep_levels()
         );
     }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -192,10 +192,10 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
         list_offsets.push(OffsetSize::from_usize(cur_offset).unwrap());
 
         let child_data = if skipped == 0 {
-            // No empty lists - can reuse original array
+            // No filtered values - can reuse original array
             next_batch_array.data().clone()
         } else {
-            // One or more empty lists - must build new array
+            // One or more filtered values - must build new array
             if let Some(start) = filter_start.take() {
                 child_data_builder.extend(0, start, cur_offset + skipped)
             }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -164,7 +164,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
                         // Fully defined value
 
                         // Record current offset if it is None
-                        filter_start.get_or_insert_with(|| cur_offset + skipped);
+                        filter_start.get_or_insert(cur_offset + skipped);
 
                         cur_offset += 1;
 

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -102,6 +102,12 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
             ));
         }
 
+        if !rep_levels.is_empty() && rep_levels[0] != 0 {
+            // This implies either the source data was invalid, or the leaf column
+            // reader did not correctly delimit semantic records
+            return Err(general_err!("first repetition level of batch must be 0"));
+        }
+
         // A non-nullable list has a single definition level indicating if the list is empty
         //
         // A nullable list has two definition levels associated with it:

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -35,11 +35,11 @@ pub struct ListArrayReader<OffsetSize: OffsetSizeTrait> {
     item_reader: Box<dyn ArrayReader>,
     data_type: ArrowType,
     item_type: ArrowType,
-    // The definition level at which this list is not null
+    /// The definition level at which this list is not null
     def_level: i16,
-    // The repetition level that corresponds to a new value in this array
+    /// The repetition level that corresponds to a new value in this array
     rep_level: i16,
-    // If this list is nullable
+    /// If this list is nullable
     nullable: bool,
     _marker: PhantomData<OffsetSize>,
 }

--- a/parquet/src/arrow/array_reader/test_util.rs
+++ b/parquet/src/arrow/array_reader/test_util.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::ArrayRef;
+use arrow::array::{Array, ArrayRef};
 use arrow::datatypes::DataType as ArrowType;
 use std::any::Any;
 use std::sync::Arc;
@@ -111,6 +111,16 @@ impl InMemoryArrayReader {
         def_levels: Option<Vec<i16>>,
         rep_levels: Option<Vec<i16>>,
     ) -> Self {
+        assert!(def_levels
+            .as_ref()
+            .map(|d| d.len() == array.len())
+            .unwrap_or(true));
+
+        assert!(rep_levels
+            .as_ref()
+            .map(|r| r.len() == array.len())
+            .unwrap_or(true));
+
         Self {
             data_type,
             array,

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -27,7 +27,7 @@ pub trait TypeVisitor<R, C> {
 
     /// Default implementation when visiting a list.
     ///
-    /// It checks list type definition and calls [`visit_list_with_item`] with extracted
+    /// It checks list type definition and calls [`Self::visit_list_with_item`] with extracted
     /// item type.
     ///
     /// To fully understand this algorithm, please refer to
@@ -35,7 +35,7 @@ pub trait TypeVisitor<R, C> {
     ///
     /// For example, a standard list type looks like:
     ///
-    /// ```ignore
+    /// ```text
     /// required/optional group my_list (LIST) {
     //    repeated group list {
     //      required/optional binary element (UTF8);
@@ -43,7 +43,7 @@ pub trait TypeVisitor<R, C> {
     //  }
     /// ```
     ///
-    /// In such a case, [`visit_list_with_item`] will be called with `my_list` as the list
+    /// In such a case, [`Self::visit_list_with_item`] will be called with `my_list` as the list
     /// type, and `element` as the `item_type`
     ///
     fn visit_list(&mut self, list_type: TypePtr, context: C) -> Result<R> {

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -27,17 +27,30 @@ pub trait TypeVisitor<R, C> {
 
     /// Default implementation when visiting a list.
     ///
-    /// It checks list type definition and calls `visit_list_with_item` with extracted
+    /// It checks list type definition and calls [`visit_list_with_item`] with extracted
     /// item type.
     ///
     /// To fully understand this algorithm, please refer to
     /// [parquet doc](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md).
+    ///
+    /// For example, a standard list type looks like:
+    ///
+    /// ```ignore
+    /// required/optional group my_list (LIST) {
+    //    repeated group list {
+    //      required/optional binary element (UTF8);
+    //    }
+    //  }
+    /// ```
+    ///
+    /// In such a case, [`visit_list_with_item`] will be called with `my_list` as the list
+    /// type, and `element` as the `item_type`
+    ///
     fn visit_list(&mut self, list_type: TypePtr, context: C) -> Result<R> {
         match list_type.as_ref() {
-            Type::PrimitiveType { .. } => panic!(
-                "{:?} is a list type and can't be processed as primitive.",
-                list_type
-            ),
+            Type::PrimitiveType { .. } => {
+                panic!("{:?} is a list type and must be a group type", list_type)
+            }
             Type::GroupType {
                 basic_info: _,
                 fields,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #993.

Closes #720 

# Rationale for this change
 
Adds support for reading nested lists from parquet.

# What changes are included in this PR?

Reworks the ListArrayReader to handle nested repetition levels.

Some drive by cleanup of ArrayReaderBuilder to error on encountering non-spec-compliant data

# Are there any user-facing changes?

No
