### PR TITLE
Fix Null Mask Handling in ArrayData And UnionArray

### DIFF
--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -61,7 +61,6 @@ use std::any::Any;
 ///     type_id_buffer,
 ///     Some(value_offsets_buffer),
 ///     children,
-///     None,
 /// ).unwrap();
 ///
 /// let value = array.value(0).as_any().downcast_ref::<Int32Array>().unwrap().value(0);
@@ -94,7 +93,6 @@ use std::any::Any;
 ///     type_id_buffer,
 ///     None,
 ///     children,
-///     None,
 /// ).unwrap();
 ///
 /// let value = array.value(0).as_any().downcast_ref::<Int32Array>().unwrap().value(0);

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -140,7 +140,6 @@ impl UnionArray {
         type_ids: Buffer,
         value_offsets: Option<Buffer>,
         child_arrays: Vec<(Field, ArrayRef)>,
-        bitmap_data: Option<Buffer>,
     ) -> Self {
         let (field_types, field_values): (Vec<_>, Vec<_>) =
             child_arrays.into_iter().unzip();
@@ -152,13 +151,11 @@ impl UnionArray {
             UnionMode::Sparse
         };
 
-        let mut builder = ArrayData::builder(DataType::Union(field_types, mode))
+        let builder = ArrayData::builder(DataType::Union(field_types, mode))
             .add_buffer(type_ids)
             .child_data(field_values.into_iter().map(|a| a.data().clone()).collect())
             .len(len);
-        if let Some(bitmap) = bitmap_data {
-            builder = builder.null_bit_buffer(bitmap)
-        }
+
         let data = match value_offsets {
             Some(b) => builder.add_buffer(b).build_unchecked(),
             None => builder.build_unchecked(),
@@ -171,7 +168,6 @@ impl UnionArray {
         type_ids: Buffer,
         value_offsets: Option<Buffer>,
         child_arrays: Vec<(Field, ArrayRef)>,
-        bitmap: Option<Buffer>,
     ) -> Result<Self> {
         if let Some(b) = &value_offsets {
             if ((type_ids.len()) * 4) != b.len() {
@@ -216,7 +212,7 @@ impl UnionArray {
         // Unsafe Justification: arguments were validated above (and
         // re-revalidated as part of data().validate() below)
         let new_self =
-            unsafe { Self::new_unchecked(type_ids, value_offsets, child_arrays, bitmap) };
+            unsafe { Self::new_unchecked(type_ids, value_offsets, child_arrays) };
         new_self.data().validate()?;
 
         Ok(new_self)
@@ -512,7 +508,7 @@ mod tests {
         builder.append::<Int32Type>("a", 1).unwrap();
         builder.append::<Int64Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 10).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         let union = builder.build().unwrap();
 
@@ -522,29 +518,29 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(1_i32, value);
                 }
                 1 => {
                     let slot = slot.as_any().downcast_ref::<Int64Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(3_i64, value);
                 }
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(10_i32, value);
                 }
-                3 => assert!(union.is_null(i)),
+                3 => assert!(slot.is_null(0)),
                 4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
@@ -560,7 +556,7 @@ mod tests {
         builder.append::<Int32Type>("a", 1).unwrap();
         builder.append::<Int64Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 10).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         let union = builder.build().unwrap();
 
@@ -573,15 +569,15 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(10_i32, value);
                 }
-                1 => assert!(new_union.is_null(i)),
+                1 => assert!(slot.is_null(0)),
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
@@ -614,13 +610,9 @@ mod tests {
                 Arc::new(float_array),
             ),
         ];
-        let array = UnionArray::try_new(
-            type_id_buffer,
-            Some(value_offsets_buffer),
-            children,
-            None,
-        )
-        .unwrap();
+        let array =
+            UnionArray::try_new(type_id_buffer, Some(value_offsets_buffer), children)
+                .unwrap();
 
         // Check type ids
         assert_eq!(Buffer::from_slice_ref(&type_ids), array.data().buffers()[0]);
@@ -800,7 +792,7 @@ mod tests {
     fn test_sparse_mixed_with_nulls() {
         let mut builder = UnionBuilder::new_sparse(5);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Float64Type>("c", 3.0).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         let union = builder.build().unwrap();
@@ -824,22 +816,22 @@ mod tests {
             match i {
                 0 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(1_i32, value);
                 }
-                1 => assert!(union.is_null(i)),
+                1 => assert!(slot.is_null(0)),
                 2 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(value, 3_f64);
                 }
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);
@@ -853,9 +845,9 @@ mod tests {
     fn test_sparse_mixed_with_nulls_and_offset() {
         let mut builder = UnionBuilder::new_sparse(5);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Float64Type>("c", 3.0).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Float64Type>("c").unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         let union = builder.build().unwrap();
 
@@ -866,18 +858,18 @@ mod tests {
         for i in 0..new_union.len() {
             let slot = new_union.value(i);
             match i {
-                0 => assert!(new_union.is_null(i)),
+                0 => assert!(slot.is_null(0)),
                 1 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
-                    assert!(!new_union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(value, 3_f64);
                 }
-                2 => assert!(new_union.is_null(i)),
+                2 => assert!(slot.is_null(0)),
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
-                    assert!(!new_union.is_null(i));
+                    assert!(!slot.is_null(0));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);
@@ -885,5 +877,13 @@ mod tests {
                 _ => unreachable!(),
             }
         }
+    }
+
+    #[test]
+    fn test_type_check() {
+        let mut builder = UnionBuilder::new_sparse(2);
+        builder.append::<Float32Type>("a", 1.0).unwrap();
+        let err = builder.append::<Int32Type>("a", 1).unwrap_err().to_string();
+        assert!(err.contains("Attempt to write col \"a\" with type Int32 doesn't match existing type Float32"), "{}", err);
     }
 }

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -1895,22 +1895,18 @@ struct FieldData {
     ///  The number of array slots represented by the buffer
     slots: usize,
     /// A builder for the bitmap if required (for Sparse Unions)
-    bitmap_builder: Option<BooleanBufferBuilder>,
+    bitmap_builder: BooleanBufferBuilder,
 }
 
 impl FieldData {
     /// Creates a new `FieldData`.
-    fn new(
-        type_id: i8,
-        data_type: DataType,
-        bitmap_builder: Option<BooleanBufferBuilder>,
-    ) -> Self {
+    fn new(type_id: i8, data_type: DataType) -> Self {
         Self {
             type_id,
             data_type,
             values_buffer: Some(MutableBuffer::new(1)),
             slots: 0,
-            bitmap_builder,
+            bitmap_builder: BooleanBufferBuilder::new(1),
         }
     }
 
@@ -1931,28 +1927,26 @@ impl FieldData {
         self.values_buffer = Some(mutable_buffer);
 
         self.slots += 1;
-        if let Some(b) = &mut self.bitmap_builder {
-            b.append(true)
-        };
+        self.bitmap_builder.append(true);
         Ok(())
     }
 
     /// Appends a null to this `FieldData`.
     #[allow(clippy::unnecessary_wraps)]
     fn append_null<T: ArrowPrimitiveType>(&mut self) -> Result<()> {
-        if let Some(b) = &mut self.bitmap_builder {
-            let values_buffer = self
-                .values_buffer
-                .take()
-                .expect("Values buffer was never created");
-            let mut builder: BufferBuilder<T::Native> =
-                mutable_buffer_to_builder(values_buffer, self.slots);
-            builder.advance(1);
-            let mutable_buffer = builder_to_mutable_buffer(builder);
-            self.values_buffer = Some(mutable_buffer);
-            self.slots += 1;
-            b.append(false);
-        };
+        let values_buffer = self
+            .values_buffer
+            .take()
+            .expect("Values buffer was never created");
+
+        let mut builder: BufferBuilder<T::Native> =
+            mutable_buffer_to_builder(values_buffer, self.slots);
+
+        builder.advance(1);
+        let mutable_buffer = builder_to_mutable_buffer(builder);
+        self.values_buffer = Some(mutable_buffer);
+        self.slots += 1;
+        self.bitmap_builder.append(false);
         Ok(())
     }
 
@@ -2047,8 +2041,6 @@ pub struct UnionBuilder {
     type_id_builder: Int8BufferBuilder,
     /// Builder to keep track of offsets (`None` for sparse unions)
     value_offset_builder: Option<Int32BufferBuilder>,
-    /// Optional builder for null slots
-    bitmap_builder: Option<BooleanBufferBuilder>,
 }
 
 impl UnionBuilder {
@@ -2059,7 +2051,6 @@ impl UnionBuilder {
             fields: HashMap::default(),
             type_id_builder: Int8BufferBuilder::new(capacity),
             value_offset_builder: Some(Int32BufferBuilder::new(capacity)),
-            bitmap_builder: None,
         }
     }
 
@@ -2070,39 +2061,13 @@ impl UnionBuilder {
             fields: HashMap::default(),
             type_id_builder: Int8BufferBuilder::new(capacity),
             value_offset_builder: None,
-            bitmap_builder: None,
         }
     }
 
     /// Appends a null to this builder.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
-        if self.bitmap_builder.is_none() {
-            let mut builder = BooleanBufferBuilder::new(self.len + 1);
-            for _ in 0..self.len {
-                builder.append(true);
-            }
-            self.bitmap_builder = Some(builder)
-        }
-        self.bitmap_builder
-            .as_mut()
-            .expect("Cannot be None")
-            .append(false);
-
-        self.type_id_builder.append(i8::default());
-
-        match &mut self.value_offset_builder {
-            // Handle dense union
-            Some(value_offset_builder) => value_offset_builder.append(i32::default()),
-            // Handle sparse union
-            None => {
-                for (_, fd) in self.fields.iter_mut() {
-                    fd.append_null_dynamic()?;
-                }
-            }
-        };
-        self.len += 1;
-        Ok(())
+    pub fn append_null<T: ArrowPrimitiveType>(&mut self, type_name: &str) -> Result<()> {
+        self.append_option::<T>(type_name, None)
     }
 
     /// Appends a value to this builder.
@@ -2112,21 +2077,27 @@ impl UnionBuilder {
         type_name: &str,
         v: T::Native,
     ) -> Result<()> {
+        self.append_option::<T>(type_name, Some(v))
+    }
+
+    fn append_option<T: ArrowPrimitiveType>(
+        &mut self,
+        type_name: &str,
+        v: Option<T::Native>,
+    ) -> Result<()> {
         let type_name = type_name.to_string();
 
         let mut field_data = match self.fields.remove(&type_name) {
-            Some(data) => data,
-            None => match self.value_offset_builder {
-                Some(_) => {
-                    // For Dense Union, we don't build bitmap in individual field
-                    FieldData::new(self.fields.len() as i8, T::DATA_TYPE, None)
+            Some(data) => {
+                if data.data_type != T::DATA_TYPE {
+                    return Err(ArrowError::InvalidArgumentError(format!("Attempt to write col \"{}\" with type {} doesn't match existing type {}", type_name, T::DATA_TYPE, data.data_type)));
                 }
+                data
+            }
+            None => match self.value_offset_builder {
+                Some(_) => FieldData::new(self.fields.len() as i8, T::DATA_TYPE),
                 None => {
-                    let mut fd = FieldData::new(
-                        self.fields.len() as i8,
-                        T::DATA_TYPE,
-                        Some(BooleanBufferBuilder::new(1)),
-                    );
+                    let mut fd = FieldData::new(self.fields.len() as i8, T::DATA_TYPE);
                     for _ in 0..self.len {
                         fd.append_null::<T>()?;
                     }
@@ -2143,20 +2114,19 @@ impl UnionBuilder {
             }
             // Sparse Union
             None => {
-                for (name, fd) in self.fields.iter_mut() {
-                    if name != &type_name {
-                        fd.append_null_dynamic()?;
-                    }
+                for (_, fd) in self.fields.iter_mut() {
+                    // Append to all bar the FieldData currently being appended to
+                    fd.append_null_dynamic()?;
                 }
             }
         }
-        field_data.append_to_values_buffer::<T>(v)?;
-        self.fields.insert(type_name, field_data);
 
-        // Update the bitmap builder if it exists
-        if let Some(b) = &mut self.bitmap_builder {
-            b.append(true);
+        match v {
+            Some(v) => field_data.append_to_values_buffer::<T>(v)?,
+            None => field_data.append_null::<T>()?,
         }
+
+        self.fields.insert(type_name, field_data);
         self.len += 1;
         Ok(())
     }
@@ -2173,7 +2143,7 @@ impl UnionBuilder {
                 data_type,
                 values_buffer,
                 slots,
-                bitmap_builder,
+                mut bitmap_builder,
             },
         ) in self.fields.into_iter()
         {
@@ -2182,16 +2152,10 @@ impl UnionBuilder {
                 .into();
             let arr_data_builder = ArrayDataBuilder::new(data_type.clone())
                 .add_buffer(buffer)
-                .len(slots);
+                .len(slots)
+                .null_bit_buffer(bitmap_builder.finish());
             //                .build();
-            let arr_data_ref = unsafe {
-                match bitmap_builder {
-                    Some(mut bb) => arr_data_builder
-                        .null_bit_buffer(bb.finish())
-                        .build_unchecked(),
-                    None => arr_data_builder.build_unchecked(),
-                }
-            };
+            let arr_data_ref = unsafe { arr_data_builder.build_unchecked() };
             let array_ref = make_array(arr_data_ref);
             children.push((type_id, (Field::new(&name, data_type, false), array_ref)))
         }
@@ -2201,9 +2165,8 @@ impl UnionBuilder {
                 .expect("This will never be None as type ids are always i8 values.")
         });
         let children: Vec<_> = children.into_iter().map(|(_, b)| b).collect();
-        let bitmap = self.bitmap_builder.map(|mut b| b.finish());
 
-        UnionArray::try_new(type_id_buffer, value_offsets_buffer, children, bitmap)
+        UnionArray::try_new(type_id_buffer, value_offsets_buffer, children)
     }
 }
 

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -1894,7 +1894,7 @@ struct FieldData {
     values_buffer: Option<MutableBuffer>,
     ///  The number of array slots represented by the buffer
     slots: usize,
-    /// A builder for the bitmap if required (for Sparse Unions)
+    /// A builder for the null bitmap
     bitmap_builder: BooleanBufferBuilder,
 }
 
@@ -2154,7 +2154,7 @@ impl UnionBuilder {
                 .add_buffer(buffer)
                 .len(slots)
                 .null_bit_buffer(bitmap_builder.finish());
-            //                .build();
+
             let arr_data_ref = unsafe { arr_data_builder.build_unchecked() };
             let array_ref = make_array(arr_data_ref);
             children.push((type_id, (Field::new(&name, data_type, false), array_ref)))

--- a/arrow/src/array/equal/boolean.rs
+++ b/arrow/src/array/equal/boolean.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::array::{data::count_nulls, ArrayData};
-use crate::buffer::Buffer;
 use crate::util::bit_util::get_bit;
 
 use super::utils::{equal_bits, equal_len};
@@ -24,8 +23,6 @@ use super::utils::{equal_bits, equal_len};
 pub(super) fn boolean_equal(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     mut lhs_start: usize,
     mut rhs_start: usize,
     mut len: usize,
@@ -33,8 +30,8 @@ pub(super) fn boolean_equal(
     let lhs_values = lhs.buffers()[0].as_slice();
     let rhs_values = rhs.buffers()[0].as_slice();
 
-    let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
-    let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
+    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
+    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
 
     if lhs_null_count == 0 && rhs_null_count == 0 {
         // Optimize performance for starting offset at u8 boundary.
@@ -73,8 +70,8 @@ pub(super) fn boolean_equal(
         )
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
+        let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
 
         let lhs_start = lhs.offset() + lhs_start;
         let rhs_start = rhs.offset() + rhs_start;

--- a/arrow/src/array/equal/decimal.rs
+++ b/arrow/src/array/equal/decimal.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::array::{data::count_nulls, ArrayData};
-use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::util::bit_util::get_bit;
 
@@ -25,8 +24,6 @@ use super::utils::equal_len;
 pub(super) fn decimal_equal(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
@@ -39,8 +36,8 @@ pub(super) fn decimal_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
-    let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
+    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
+    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
 
     if lhs_null_count == 0 && rhs_null_count == 0 {
         equal_len(
@@ -52,8 +49,8 @@ pub(super) fn decimal_equal(
         )
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
+        let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
         // with nulls, we need to compare item by item whenever it is not null
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;

--- a/arrow/src/array/equal/fixed_binary.rs
+++ b/arrow/src/array/equal/fixed_binary.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::array::{data::count_nulls, ArrayData};
-use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::util::bit_util::get_bit;
 
@@ -25,8 +24,6 @@ use super::utils::equal_len;
 pub(super) fn fixed_binary_equal(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
@@ -39,8 +36,8 @@ pub(super) fn fixed_binary_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
-    let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
+    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
+    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
 
     if lhs_null_count == 0 && rhs_null_count == 0 {
         equal_len(
@@ -52,8 +49,8 @@ pub(super) fn fixed_binary_equal(
         )
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
+        let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
         // with nulls, we need to compare item by item whenever it is not null
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -282,8 +282,7 @@ fn equal_range(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    utils::base_equal(lhs, rhs)
-        && utils::equal_nulls(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
+    utils::equal_nulls(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
         && equal_values(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
 }
 

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -25,10 +25,7 @@ use super::{
     GenericStringArray, MapArray, NullArray, OffsetSizeTrait, PrimitiveArray,
     StringOffsetSizeTrait, StructArray,
 };
-use crate::{
-    buffer::Buffer,
-    datatypes::{ArrowPrimitiveType, DataType, IntervalUnit},
-};
+use crate::datatypes::{ArrowPrimitiveType, DataType, IntervalUnit};
 use half::f16;
 
 mod boolean;
@@ -144,146 +141,99 @@ impl PartialEq for StructArray {
 }
 
 /// Compares the values of two [ArrayData] starting at `lhs_start` and `rhs_start` respectively
-/// for `len` slots. The null buffers `lhs_nulls` and `rhs_nulls` inherit parent nullability.
-///
-/// If an array is a child of a struct or list, the array's nulls have to be merged with the parent.
-/// This then affects the null count of the array, thus the merged nulls are passed separately
-/// as `lhs_nulls` and `rhs_nulls` variables to functions.
-/// The nulls are merged with a bitwise AND, and null counts are recomputed where necessary.
+/// for `len` slots.
 #[inline]
 fn equal_values(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
 ) -> bool {
     match lhs.data_type() {
         DataType::Null => null_equal(lhs, rhs, lhs_start, rhs_start, len),
-        DataType::Boolean => {
-            boolean_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
-        DataType::UInt8 => primitive_equal::<u8>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::UInt16 => primitive_equal::<u16>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::UInt32 => primitive_equal::<u32>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::UInt64 => primitive_equal::<u64>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Int8 => primitive_equal::<i8>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Int16 => primitive_equal::<i16>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Int32 => primitive_equal::<i32>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Int64 => primitive_equal::<i64>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Float32 => primitive_equal::<f32>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Float64 => primitive_equal::<f64>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
+        DataType::Boolean => boolean_equal(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::UInt8 => primitive_equal::<u8>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::UInt16 => primitive_equal::<u16>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::UInt32 => primitive_equal::<u32>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::UInt64 => primitive_equal::<u64>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Int8 => primitive_equal::<i8>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Int16 => primitive_equal::<i16>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Int32 => primitive_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Int64 => primitive_equal::<i64>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Float32 => primitive_equal::<f32>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Float64 => primitive_equal::<f64>(lhs, rhs, lhs_start, rhs_start, len),
         DataType::Date32
         | DataType::Time32(_)
-        | DataType::Interval(IntervalUnit::YearMonth) => primitive_equal::<i32>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            primitive_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len)
+        }
         DataType::Date64
         | DataType::Interval(IntervalUnit::DayTime)
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
-        | DataType::Duration(_) => primitive_equal::<i64>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Interval(IntervalUnit::MonthDayNano) => primitive_equal::<i128>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Utf8 | DataType::Binary => variable_sized_equal::<i32>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::LargeUtf8 | DataType::LargeBinary => variable_sized_equal::<i64>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
+        | DataType::Duration(_) => {
+            primitive_equal::<i64>(lhs, rhs, lhs_start, rhs_start, len)
+        }
+        DataType::Interval(IntervalUnit::MonthDayNano) => {
+            primitive_equal::<i128>(lhs, rhs, lhs_start, rhs_start, len)
+        }
+        DataType::Utf8 | DataType::Binary => {
+            variable_sized_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len)
+        }
+        DataType::LargeUtf8 | DataType::LargeBinary => {
+            variable_sized_equal::<i64>(lhs, rhs, lhs_start, rhs_start, len)
+        }
         DataType::FixedSizeBinary(_) => {
-            fixed_binary_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
+            fixed_binary_equal(lhs, rhs, lhs_start, rhs_start, len)
         }
-        DataType::Decimal(_, _) => {
-            decimal_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
-        DataType::List(_) => {
-            list_equal::<i32>(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
-        DataType::LargeList(_) => {
-            list_equal::<i64>(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
+        DataType::Decimal(_, _) => decimal_equal(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::List(_) => list_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::LargeList(_) => list_equal::<i64>(lhs, rhs, lhs_start, rhs_start, len),
         DataType::FixedSizeList(_, _) => {
-            fixed_list_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
+            fixed_list_equal(lhs, rhs, lhs_start, rhs_start, len)
         }
-        DataType::Struct(_) => {
-            struct_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
-        DataType::Union(_, _) => {
-            union_equal(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
+        DataType::Struct(_) => struct_equal(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Union(_, _) => union_equal(lhs, rhs, lhs_start, rhs_start, len),
         DataType::Dictionary(data_type, _) => match data_type.as_ref() {
-            DataType::Int8 => dictionary_equal::<i8>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::Int16 => dictionary_equal::<i16>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::Int32 => dictionary_equal::<i32>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::Int64 => dictionary_equal::<i64>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::UInt8 => dictionary_equal::<u8>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::UInt16 => dictionary_equal::<u16>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::UInt32 => dictionary_equal::<u32>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
-            DataType::UInt64 => dictionary_equal::<u64>(
-                lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-            ),
+            DataType::Int8 => dictionary_equal::<i8>(lhs, rhs, lhs_start, rhs_start, len),
+            DataType::Int16 => {
+                dictionary_equal::<i16>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::Int32 => {
+                dictionary_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::Int64 => {
+                dictionary_equal::<i64>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::UInt8 => {
+                dictionary_equal::<u8>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::UInt16 => {
+                dictionary_equal::<u16>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::UInt32 => {
+                dictionary_equal::<u32>(lhs, rhs, lhs_start, rhs_start, len)
+            }
+            DataType::UInt64 => {
+                dictionary_equal::<u64>(lhs, rhs, lhs_start, rhs_start, len)
+            }
             _ => unreachable!(),
         },
-        DataType::Float16 => primitive_equal::<f16>(
-            lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
-        ),
-        DataType::Map(_, _) => {
-            list_equal::<i32>(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        }
+        DataType::Float16 => primitive_equal::<f16>(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Map(_, _) => list_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len),
     }
 }
 
 fn equal_range(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    utils::equal_nulls(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
-        && equal_values(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
+    utils::equal_nulls(lhs, rhs, lhs_start, rhs_start, len)
+        && equal_values(lhs, rhs, lhs_start, rhs_start, len)
 }
 
 /// Logically compares two [ArrayData].
@@ -299,12 +249,10 @@ fn equal_range(
 /// This function may panic whenever any of the [ArrayData] does not follow the Arrow specification.
 /// (e.g. wrong number of buffers, buffer `len` does not correspond to the declared `len`)
 pub fn equal(lhs: &ArrayData, rhs: &ArrayData) -> bool {
-    let lhs_nulls = lhs.null_buffer();
-    let rhs_nulls = rhs.null_buffer();
     utils::base_equal(lhs, rhs)
         && lhs.null_count() == rhs.null_count()
-        && utils::equal_nulls(lhs, rhs, lhs_nulls, rhs_nulls, 0, 0, lhs.len())
-        && equal_values(lhs, rhs, lhs_nulls, rhs_nulls, 0, 0, lhs.len())
+        && utils::equal_nulls(lhs, rhs, 0, 0, lhs.len())
+        && equal_values(lhs, rhs, 0, 0, lhs.len())
 }
 
 #[cfg(test)]
@@ -492,6 +440,13 @@ mod tests {
                 vec![None, Some(2), None, Some(3)],
                 (1, 2),
                 true,
+            ),
+            (
+                vec![Some(1), Some(2), None, Some(0)],
+                (2, 2),
+                vec![Some(4), Some(5), Some(0), None],
+                (2, 2),
+                false,
             ),
         ];
 
@@ -989,6 +944,11 @@ mod tests {
             None,
         ]);
         test_equal(&a, &b, false);
+
+        let b = create_fixed_size_list_array(&[None, Some(&[4, 5, 6]), None, None]);
+
+        test_equal(&a.slice(2, 4), &b, true);
+        test_equal(&a.slice(3, 3), &b.slice(1, 3), true);
     }
 
     #[test]
@@ -1358,7 +1318,7 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union1 = builder.build().unwrap();
@@ -1368,7 +1328,7 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union2 = builder.build().unwrap();
@@ -1388,8 +1348,8 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("c").unwrap();
+        builder.append_null::<Int32Type>("b").unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union4 = builder.build().unwrap();
 
@@ -1405,7 +1365,7 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union1 = builder.build().unwrap();
@@ -1415,7 +1375,7 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union2 = builder.build().unwrap();
@@ -1435,8 +1395,8 @@ mod tests {
         builder.append::<Int32Type>("b", 2).unwrap();
         builder.append::<Int32Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
-        builder.append_null().unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
+        builder.append_null::<Int32Type>("a").unwrap();
         builder.append::<Int32Type>("b", 7).unwrap();
         let union4 = builder.build().unwrap();
 

--- a/arrow/src/array/equal/primitive.rs
+++ b/arrow/src/array/equal/primitive.rs
@@ -18,7 +18,6 @@
 use std::mem::size_of;
 
 use crate::array::{data::count_nulls, ArrayData};
-use crate::buffer::Buffer;
 use crate::util::bit_util::get_bit;
 
 use super::utils::equal_len;
@@ -26,8 +25,6 @@ use super::utils::equal_len;
 pub(super) fn primitive_equal<T>(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
@@ -36,8 +33,8 @@ pub(super) fn primitive_equal<T>(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * byte_width..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * byte_width..];
 
-    let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
-    let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
+    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
+    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
 
     if lhs_null_count == 0 && rhs_null_count == 0 {
         // without nulls, we just need to compare slices
@@ -50,8 +47,8 @@ pub(super) fn primitive_equal<T>(
         )
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
+        let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
         // with nulls, we need to compare item by item whenever it is not null
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;

--- a/arrow/src/array/equal/structure.rs
+++ b/arrow/src/array/equal/structure.rs
@@ -61,9 +61,11 @@ pub(super) fn struct_equal(
             let lhs_is_null = !get_bit(lhs_null_bytes, lhs_pos + lhs.offset());
             let rhs_is_null = !get_bit(rhs_null_bytes, rhs_pos + rhs.offset());
 
-            lhs_is_null
-                || (lhs_is_null == rhs_is_null)
-                    && equal_child_values(lhs, rhs, lhs_pos, rhs_pos, 1)
+            if lhs_is_null != rhs_is_null {
+                return false;
+            }
+
+            lhs_is_null || equal_child_values(lhs, rhs, lhs_pos, rhs_pos, 1)
         })
     }
 }

--- a/arrow/src/array/equal/structure.rs
+++ b/arrow/src/array/equal/structure.rs
@@ -15,24 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    array::data::count_nulls, array::ArrayData, buffer::Buffer, util::bit_util::get_bit,
-};
+use crate::{array::data::count_nulls, array::ArrayData, util::bit_util::get_bit};
 
-use super::{equal_range, utils::child_logical_null_buffer};
+use super::equal_range;
 
 /// Compares the values of two [ArrayData] starting at `lhs_start` and `rhs_start` respectively
-/// for `len` slots. The null buffers `lhs_nulls` and `rhs_nulls` inherit parent nullability.
-///
-/// If an array is a child of a struct or list, the array's nulls have to be merged with the parent.
-/// This then affects the null count of the array, thus the merged nulls are passed separately
-/// as `lhs_nulls` and `rhs_nulls` variables to functions.
-/// The nulls are merged with a bitwise AND, and null counts are recomputed where necessary.
-fn equal_values(
+/// for `len` slots.
+fn equal_child_values(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
@@ -41,39 +32,27 @@ fn equal_values(
         .iter()
         .zip(rhs.child_data())
         .all(|(lhs_values, rhs_values)| {
-            // merge the null data
-            let lhs_merged_nulls = child_logical_null_buffer(lhs, lhs_nulls, lhs_values);
-            let rhs_merged_nulls = child_logical_null_buffer(rhs, rhs_nulls, rhs_values);
-            equal_range(
-                lhs_values,
-                rhs_values,
-                lhs_merged_nulls.as_ref(),
-                rhs_merged_nulls.as_ref(),
-                lhs_start,
-                rhs_start,
-                len,
-            )
+            equal_range(lhs_values, rhs_values, lhs_start, rhs_start, len)
         })
 }
 
 pub(super) fn struct_equal(
     lhs: &ArrayData,
     rhs: &ArrayData,
-    lhs_nulls: Option<&Buffer>,
-    rhs_nulls: Option<&Buffer>,
     lhs_start: usize,
     rhs_start: usize,
     len: usize,
 ) -> bool {
     // we have to recalculate null counts from the null buffers
-    let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
-    let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
+    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
+    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+
     if lhs_null_count == 0 && rhs_null_count == 0 {
-        equal_values(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
+        equal_child_values(lhs, rhs, lhs_start, rhs_start, len)
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
+        let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
         // with nulls, we need to compare item by item whenever it is not null
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;
@@ -84,7 +63,7 @@ pub(super) fn struct_equal(
 
             lhs_is_null
                 || (lhs_is_null == rhs_is_null)
-                    && equal_values(lhs, rhs, lhs_nulls, rhs_nulls, lhs_pos, rhs_pos, 1)
+                    && equal_child_values(lhs, rhs, lhs_pos, rhs_pos, 1)
         })
     }
 }

--- a/arrow/src/array/transform/union.rs
+++ b/arrow/src/array/transform/union.rs
@@ -48,17 +48,13 @@ pub(super) fn build_extend_dense(array: &ArrayData) -> Extend {
                 .buffer1
                 .extend_from_slice(&type_ids[start..start + len]);
 
-            // extends offsets
-            mutable
-                .buffer2
-                .extend_from_slice(&offsets[start..start + len]);
-
             (start..start + len).for_each(|i| {
                 let type_id = type_ids[i] as usize;
                 let src_offset = offsets[i] as usize;
                 let child_data = &mut mutable.child_data[type_id];
                 let dst_offset = child_data.len();
 
+                // Extend offsets
                 mutable.buffer2.push(dst_offset as i32);
                 mutable.child_data[type_id].extend(index, src_offset, src_offset + 1)
             })

--- a/arrow/src/array/transform/union.rs
+++ b/arrow/src/array/transform/union.rs
@@ -22,140 +22,54 @@ use super::{Extend, _MutableArrayData};
 pub(super) fn build_extend_sparse(array: &ArrayData) -> Extend {
     let type_ids = array.buffer::<i8>(0);
 
-    if array.null_count() == 0 {
-        Box::new(
-            move |mutable: &mut _MutableArrayData,
-                  index: usize,
-                  start: usize,
-                  len: usize| {
-                // extends type_ids
-                mutable
-                    .buffer1
-                    .extend_from_slice(&type_ids[start..start + len]);
+    Box::new(
+        move |mutable: &mut _MutableArrayData, index: usize, start: usize, len: usize| {
+            // extends type_ids
+            mutable
+                .buffer1
+                .extend_from_slice(&type_ids[start..start + len]);
 
-                mutable
-                    .child_data
-                    .iter_mut()
-                    .for_each(|child| child.extend(index, start, start + len))
-            },
-        )
-    } else {
-        Box::new(
-            move |mutable: &mut _MutableArrayData,
-                  index: usize,
-                  start: usize,
-                  len: usize| {
-                // extends type_ids
-                mutable
-                    .buffer1
-                    .extend_from_slice(&type_ids[start..start + len]);
-
-                (start..start + len).for_each(|i| {
-                    if array.is_valid(i) {
-                        mutable
-                            .child_data
-                            .iter_mut()
-                            .for_each(|child| child.extend(index, i, i + 1))
-                    } else {
-                        mutable
-                            .child_data
-                            .iter_mut()
-                            .for_each(|child| child.extend_nulls(1))
-                    }
-                })
-            },
-        )
-    }
+            mutable
+                .child_data
+                .iter_mut()
+                .for_each(|child| child.extend(index, start, start + len))
+        },
+    )
 }
 
 pub(super) fn build_extend_dense(array: &ArrayData) -> Extend {
     let type_ids = array.buffer::<i8>(0);
     let offsets = array.buffer::<i32>(1);
 
-    if array.null_count() == 0 {
-        Box::new(
-            move |mutable: &mut _MutableArrayData,
-                  index: usize,
-                  start: usize,
-                  len: usize| {
-                // extends type_ids
-                mutable
-                    .buffer1
-                    .extend_from_slice(&type_ids[start..start + len]);
-                // extends offsets
-                mutable
-                    .buffer2
-                    .extend_from_slice(&offsets[start..start + len]);
-
-                (start..start + len).for_each(|i| {
-                    let type_id = type_ids[i] as usize;
-                    let offset_start = offsets[start] as usize;
-
-                    mutable.child_data[type_id].extend(
-                        index,
-                        offset_start,
-                        offset_start + 1,
-                    )
-                })
-            },
-        )
-    } else {
-        Box::new(
-            move |mutable: &mut _MutableArrayData,
-                  index: usize,
-                  start: usize,
-                  len: usize| {
-                // extends type_ids
-                mutable
-                    .buffer1
-                    .extend_from_slice(&type_ids[start..start + len]);
-                // extends offsets
-                mutable
-                    .buffer2
-                    .extend_from_slice(&offsets[start..start + len]);
-
-                (start..start + len).for_each(|i| {
-                    let type_id = type_ids[i] as usize;
-                    let offset_start = offsets[start] as usize;
-
-                    if array.is_valid(i) {
-                        mutable.child_data[type_id].extend(
-                            index,
-                            offset_start,
-                            offset_start + 1,
-                        )
-                    } else {
-                        mutable.child_data[type_id].extend_nulls(1)
-                    }
-                })
-            },
-        )
-    }
-}
-
-pub(super) fn extend_nulls_dense(mutable: &mut _MutableArrayData, len: usize) {
-    let mut count: usize = 0;
-    let num = len / mutable.child_data.len();
-    mutable
-        .child_data
-        .iter_mut()
-        .enumerate()
-        .for_each(|(idx, child)| {
-            let n = if count + num > len { len - count } else { num };
-            count += n;
+    Box::new(
+        move |mutable: &mut _MutableArrayData, index: usize, start: usize, len: usize| {
+            // extends type_ids
             mutable
                 .buffer1
-                .extend_from_slice(vec![idx as i8; n].as_slice());
+                .extend_from_slice(&type_ids[start..start + len]);
+
+            // extends offsets
             mutable
                 .buffer2
-                .extend_from_slice(vec![child.len() as i32; n].as_slice());
-            child.extend_nulls(n)
-        })
+                .extend_from_slice(&offsets[start..start + len]);
+
+            (start..start + len).for_each(|i| {
+                let type_id = type_ids[i] as usize;
+                let src_offset = offsets[i] as usize;
+                let child_data = &mut mutable.child_data[type_id];
+                let dst_offset = child_data.len();
+
+                mutable.buffer2.push(dst_offset as i32);
+                mutable.child_data[type_id].extend(index, src_offset, src_offset + 1)
+            })
+        },
+    )
 }
 
-pub(super) fn extend_nulls_sparse(mutable: &mut _MutableArrayData, len: usize) {
-    mutable
-        .child_data
-        .iter_mut()
-        .for_each(|child| child.extend_nulls(len))
+pub(super) fn extend_nulls_dense(_mutable: &mut _MutableArrayData, _len: usize) {
+    panic!("cannot call extend_nulls on UnionArray as cannot infer type");
+}
+
+pub(super) fn extend_nulls_sparse(_mutable: &mut _MutableArrayData, _len: usize) {
+    panic!("cannot call extend_nulls on UnionArray as cannot infer type");
 }

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -190,11 +190,10 @@ fn create_array(
 
             let len = union_node.length() as usize;
 
-            let null_buffer: Buffer = read_buffer(&buffers[buffer_index], data);
             let type_ids: Buffer =
-                read_buffer(&buffers[buffer_index + 1], data)[..len].into();
+                read_buffer(&buffers[buffer_index], data)[..len].into();
 
-            buffer_index += 2;
+            buffer_index += 1;
 
             let value_offsets = match mode {
                 UnionMode::Dense => {
@@ -224,13 +223,7 @@ fn create_array(
                 children.push((field.clone(), triple.0));
             }
 
-            let array = UnionArray::try_new(
-                type_ids,
-                value_offsets,
-                children,
-                Some(null_buffer),
-            )?;
-
+            let array = UnionArray::try_new(type_ids, value_offsets, children)?;
             Arc::new(array)
         }
         Null => {
@@ -1359,7 +1352,7 @@ mod tests {
 
     fn check_union_with_builder(mut builder: UnionBuilder) {
         builder.append::<datatypes::Int32Type>("a", 1).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null::<datatypes::Int32Type>("a").unwrap();
         builder.append::<datatypes::Float64Type>("c", 3.0).unwrap();
         builder.append::<datatypes::Int32Type>("a", 4).unwrap();
         builder.append::<datatypes::Int64Type>("d", 11).unwrap();

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -811,7 +811,11 @@ fn write_array_data(
     let mut offset = offset;
     nodes.push(ipc::FieldNode::new(num_rows as i64, null_count as i64));
     // NullArray does not have any buffers, thus the null buffer is not generated
-    if array_data.data_type() != &DataType::Null {
+    // UnionArray does not have a validity buffer
+    if !matches!(
+        array_data.data_type(),
+        DataType::Null | DataType::Union(_, _)
+    ) {
         // write null buffer if exists
         let null_buffer = match array_data.null_buffer() {
             None => {
@@ -1273,8 +1277,7 @@ mod tests {
         let offsets = Buffer::from_slice_ref(&[0_i32, 1, 2]);
 
         let union =
-            UnionArray::try_new(types, Some(offsets), vec![(dctfield, array)], None)
-                .unwrap();
+            UnionArray::try_new(types, Some(offsets), vec![(dctfield, array)]).unwrap();
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "union",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1599 
Closes #1598 
Closes #1596
Closes #1590 
Closes #1591
Closes #626

# Rationale for this change
 
See tickets, unfortunately these changes all ended up interacting with each other and so I've lumped them into a single PR.

# What changes are included in this PR?

## ArrayData Equality

The currently ArrayData equality code attempts to construct a logical bitmask, that propogates the nullability of the parent down to its children. Certain arrays, however, may have a different number of children than their parent, e.g. dense union array or list arrays. This requires recomputing the mask to factor this in. In some cases, this was computing a mask that took account of the offset of the child, but in others it was not. I also don't think any of the codepaths took account for if the child also contained an offset.

Taking a step back, none of the codepaths are actually comparing runs of nulls, instead they fall back to iterating per value if the array contains nulls. For example,

```
 // get a ref of the null buffer bytes, to use in testing for nullness
let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
(0..len).all(|i| {
    let lhs_pos = lhs_start + i;
    let rhs_pos = rhs_start + i;

    let lhs_is_null = !get_bit(lhs_null_bytes, lhs_pos + lhs.offset());
    let rhs_is_null = !get_bit(rhs_null_bytes, rhs_pos + rhs.offset());

    lhs_is_null
        || (lhs_is_null == rhs_is_null)
            && equal_range(
                lhs_values,
                rhs_values,
                lhs_keys[lhs_pos].to_usize().unwrap(),
                rhs_keys[rhs_pos].to_usize().unwrap(),
                1,
            )
})
```

As a result we don't actually need this complexity, and by removing it we avoid ambiguity about what offset the null mask has, what the null mask is, etc...

## UnionArray Nullability

Whilst working on this I realised that UnionArray's don't actually have a parent validity mask, as this change would have implications for the equality logic I lumped it into this PR.

# Are there any user-facing changes?

Array equality should be more correct, and UnionArrays slightly less broken
