### PR TITLE
Don't access and validate offset buffer in ListArray::from(ArrayData)

### DIFF
--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -531,10 +531,10 @@ mod tests {
         // Construct a list array from the above two
         let list_data_type =
             DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(0)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build()
             .unwrap();
 

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -521,12 +521,12 @@ mod tests {
         // Construct an empty value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(0)
-            .add_buffer(Buffer::from_iter(std::iter::empty::<i32>()))
+            .add_buffer(Buffer::from([]))
             .build()
             .unwrap();
 
         // Construct an empty offset buffer
-        let value_offsets = Buffer::from_iter(std::iter::empty::<i32>());
+        let value_offsets = Buffer::from([]);
 
         // Construct a list array from the above two
         let list_data_type =


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1601.

# Rationale for this change

All required validation should already be done as part of the ArrayData creation. 

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
