### PR TITLE
Parquet: schema validation should allow scale == precision for decimal type

### DIFF
--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -467,13 +467,13 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             return Err(general_err!("Invalid DECIMAL scale: {}", self.scale));
         }
 
-        if self.scale >= self.precision {
+        if self.scale > self.precision {
             return Err(general_err!(
-            "Invalid DECIMAL: scale ({}) cannot be greater than or equal to precision \
+                "Invalid DECIMAL: scale ({}) cannot be greater than precision \
              ({})",
-            self.scale,
-            self.precision
-        ));
+                self.scale,
+                self.precision
+            ));
         }
 
         // Check precision and scale based on physical type limitations.
@@ -1345,9 +1345,18 @@ mod tests {
         if let Err(e) = result {
             assert_eq!(
                 format!("{}", e),
-                "Parquet error: Invalid DECIMAL: scale (2) cannot be greater than or equal to precision (1)"
+                "Parquet error: Invalid DECIMAL: scale (2) cannot be greater than precision (1)"
             );
         }
+
+        // It is OK if precision == scale
+        result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
+            .with_repetition(Repetition::REQUIRED)
+            .with_converted_type(ConvertedType::DECIMAL)
+            .with_precision(1)
+            .with_scale(1)
+            .build();
+        assert!(result.is_ok());
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)


### PR DESCRIPTION

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1606.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

For decimal type, it is a valid case for scale to be equal to precision. However currently the `PrimitiveTypeBuilder` will return error in such case.

```rust
        if self.scale >= self.precision {
            return Err(general_err!(
            "Invalid DECIMAL: scale ({}) cannot be greater than or equal to precision \
             ({})",
            self.scale,
            self.precision
        ));
```

It seems the Parquet [logical type specification for decimal type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal) is also incorrect on this:

> If not specified, the scale is 0. Scale must be zero or a positive integer **less than** the precision. Precision is required and must be a non-zero positive integer. A precision too large for the underlying type (see below) is an error.

Both [Java](https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/schema/Types.java#L618) and [C++](https://github.com/apache/arrow/blob/master/cpp/src/parquet/types.cc#L976) implementation allows scale to be equal to precision.

# What changes are included in this PR?

Fix the schema validation and allow the case when scale is equal to precision. Added a test for this.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

- Yes, the behavior is fixed after the PR, where users can now construct decimal logical type where scale is equal to precision, such as `Decimal(5, 5)`.
- There is no API change introduced.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
