### PR TITLE
Add `substring` support for binary

### DIFF
--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -246,6 +246,7 @@ pub fn substring(array: &dyn Array, start: i64, length: Option<u64>) -> Result<A
 mod tests {
     use super::*;
 
+    #[allow(clippy::type_complexity)]
     fn with_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<Option<&[u8]>>, i64, Option<u64>, Vec<Option<&[u8]>>)> = vec![
             // identity
@@ -314,6 +315,7 @@ mod tests {
         with_nulls_generic_binary::<i64>()
     }
 
+    #[allow(clippy::type_complexity)]
     fn without_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<&[u8]>, i64, Option<u64>, Vec<&[u8]>)> = vec![
             // increase start

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -312,8 +312,7 @@ mod tests {
         with_nulls_generic_string::<i64>()
     }
 
-    fn without_nulls<T: 'static + Array + PartialEq + From<Vec<Option<&'static str>>>>(
-    ) -> Result<()> {
+    fn without_nulls_generic_string<O: StringOffsetSizeTrait>() -> Result<()> {
         let cases = vec![
             // increase start
             (
@@ -369,11 +368,14 @@ mod tests {
 
         cases.into_iter().try_for_each::<_, Result<()>>(
             |(array, start, length, expected)| {
-                let array = StringArray::from(array);
+                let array = GenericStringArray::<O>::from(array);
                 let result = substring(&array, start, length)?;
                 assert_eq!(array.len(), result.len());
-                let result = result.as_any().downcast_ref::<StringArray>().unwrap();
-                let expected = StringArray::from(expected);
+                let result = result
+                    .as_any()
+                    .downcast_ref::<GenericStringArray<O>>()
+                    .unwrap();
+                let expected = GenericStringArray::<O>::from(expected);
                 assert_eq!(&expected, result,);
                 Ok(())
             },
@@ -384,12 +386,12 @@ mod tests {
 
     #[test]
     fn without_nulls_string() -> Result<()> {
-        without_nulls::<StringArray>()
+        without_nulls_generic_string::<i32>()
     }
 
     #[test]
     fn without_nulls_large_string() -> Result<()> {
-        without_nulls::<LargeStringArray>()
+        without_nulls_generic_string::<i64>()
     }
 
     #[test]

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines kernel to extract a substring of a \[Large\]StringArray
+//! Defines kernel to extract a substring of an Array
+//! Supported array types: \[Large\]StringArray, \[Large\]BinaryArray
 
 use crate::buffer::MutableBuffer;
 use crate::{array::*, buffer::Buffer};
@@ -85,6 +86,7 @@ fn binary_substring<OffsetSize: BinaryOffsetSizeTrait>(
     Ok(make_array(data))
 }
 
+/// substring by byte
 fn utf8_substring<OffsetSize: StringOffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     start: OffsetSize,
@@ -188,8 +190,8 @@ fn utf8_substring<OffsetSize: StringOffsetSizeTrait>(
 /// ```
 ///
 /// # Error
-/// - The function errors when the passed array is not a \[Large\]String array.
-/// - The function errors if the offset of a substring in the input array is at invalid char boundary.
+/// - The function errors when the passed array is not a \[Large\]String array or \[Large\]Binary array.
+/// - The function errors if the offset of a substring in the input array is at invalid char boundary (only for \[Large\]String array).
 ///
 /// ## Example of trying to get an invalid utf-8 format substring
 /// ```


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1593 .

# Rationale for this change


# What changes are included in this PR?
1. Add substring support for (Large)BinaryArray
2. Add some tests
3. fix a bug in the test of string array
4. update doc

# Are there any user-facing changes?
Update some docs

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
