### PR TITLE
Improve docs and examples links on main readme

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -19,13 +19,14 @@
 
 # Apache Arrow Official Native Rust Implementation
 
-[![Crates.io](https://img.shields.io/crates/v/arrow.svg)](https://crates.io/crates/arrow)
+[crates.io](https://img.shields.io/crates/v/arrow.svg)(https://crates.io/crates/arrow)
+[docs.rs](https://img.shields.io/docsrs/arrow.svg)(https://docs.rs/arrow/latest/arrow/)
 
-This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation.
+This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation. More information can be found on [crates.io](https://crates.io/crates/arrow), [docs.rs](https://docs.rs/arrow/latest/arrow/) and [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples).
 
 ## Rust Version Compatibility
 
-This crate is tested with the latest stable version of Rust. We do not currently test against other, older versions of the Rust compiler.
+This crate is tested with the latest stable version of Rust. We do not currently test against other, older versions.
 
 ## Versioning / Releases
 

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -19,8 +19,8 @@
 
 # Apache Arrow Official Native Rust Implementation
 
-[crates.io](https://img.shields.io/crates/v/arrow.svg)(https://crates.io/crates/arrow)
-[docs.rs](https://img.shields.io/docsrs/arrow.svg)(https://docs.rs/arrow/latest/arrow/)
+[![crates.io](https://img.shields.io/crates/v/arrow.svg)](https://crates.io/crates/arrow)
+[![docs.rs](https://img.shields.io/docsrs/arrow.svg)](https://docs.rs/arrow/latest/arrow/)
 
 This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation. More information can be found on [crates.io](https://crates.io/crates/arrow), [docs.rs](https://docs.rs/arrow/latest/arrow/) and [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples).
 

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -22,7 +22,7 @@
 [![crates.io](https://img.shields.io/crates/v/arrow.svg)](https://crates.io/crates/arrow)
 [![docs.rs](https://img.shields.io/docsrs/arrow.svg)](https://docs.rs/arrow/latest/arrow/)
 
-This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation. More information can be found on [crates.io](https://crates.io/crates/arrow), [docs.rs](https://docs.rs/arrow/latest/arrow/) and [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples).
+This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation. Additional details can be found on [crates.io](https://crates.io/crates/arrow), [docs.rs](https://docs.rs/arrow/latest/arrow/) and [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples).
 
 ## Rust Version Compatibility
 


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/1613


# Rationale for this change
 
Make it easier to find crates.io, docs.rs and examples from the main arrow crate readme

# What changes are included in this PR?

See rendered version https://github.com/alamb/arrow-rs/tree/alamb/main_readme/arrow
