### PR TITLE
Minor: Clarify docs on `UnionBuilder::append_null`

### DIFF
--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -2064,7 +2064,13 @@ impl UnionBuilder {
         }
     }
 
-    /// Appends a null to this builder.
+    /// Appends a null to this builder, encoding the null in the array
+    /// of the `type_name` child / field.
+    ///
+    /// Since `UnionArray` encodes nulls as an entry in its children
+    /// (it doesn't have a validity bitmap itself), and where the null
+    /// is part of the final array, appending a NULL requires
+    /// specifying which field (child) to use.
     #[inline]
     pub fn append_null<T: ArrowPrimitiveType>(&mut self, type_name: &str) -> Result<()> {
         self.append_option::<T>(type_name, None)


### PR DESCRIPTION
Follow on to https://github.com/apache/arrow-rs/pull/1589

# Rationale for this change
Encode the non obvious (to me) rationale for having to specify child / field name in `UnionBuilder::append_null`. See comment from @tustvold  https://github.com/apache/arrow-rs/pull/1589#discussion_r860772343

# What changes are included in this PR?
Update doc strings

# Are there any user-facing changes?
Docs