### PR TITLE
Nit: use the standard function `div_ceil` 

### DIFF
--- a/arrow/src/util/bit_util.rs
+++ b/arrow/src/util/bit_util.rs
@@ -17,6 +17,7 @@
 
 //! Utils for working with bits
 
+use num::Integer;
 #[cfg(feature = "simd")]
 use packed_simd::u8x64;
 
@@ -99,12 +100,9 @@ pub unsafe fn unset_bit_raw(data: *mut u8, i: usize) {
 /// Returns the ceil of `value`/`divisor`
 #[inline]
 pub fn ceil(value: usize, divisor: usize) -> usize {
-    let (quot, rem) = (value / divisor, value % divisor);
-    if rem > 0 && divisor > 0 {
-        quot + 1
-    } else {
-        quot
-    }
+    // Rewrite as `value.div_ceil(&divisor)` after
+    // https://github.com/rust-lang/rust/issues/88581 is merged.
+    Integer::div_ceil(&value, &divisor)
 }
 
 /// Performs SIMD bitwise binary operations.


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?
None. It is just a small change.

# What changes are included in this PR?
We should use the standard function `div_ceil` instead of implementing our own.

# Are there any user-facing changes?
None

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
