### PR TITLE
do not assume footer exists, fixes issue #1335

### DIFF
--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -651,43 +651,48 @@ impl<R: Read + Seek> FileReader<R> {
 
         // Create an array of optional dictionary value arrays, one per field.
         let mut dictionaries_by_field = vec![None; schema.all_fields().len()];
-        for block in footer.dictionaries().unwrap() {
-            // read length from end of offset
-            let mut message_size: [u8; 4] = [0; 4];
-            reader.seek(SeekFrom::Start(block.offset() as u64))?;
-            reader.read_exact(&mut message_size)?;
-            if message_size == CONTINUATION_MARKER {
-                reader.read_exact(&mut message_size)?;
+        match footer.dictionaries() {
+            Some(dictionaries) => { 
+                for block in dictionaries {
+                    // read length from end of offset
+                    let mut message_size: [u8; 4] = [0; 4];
+                    reader.seek(SeekFrom::Start(block.offset() as u64))?;
+                    reader.read_exact(&mut message_size)?;
+                    if message_size == CONTINUATION_MARKER {
+                        reader.read_exact(&mut message_size)?;
+                    }
+                    let footer_len = i32::from_le_bytes(message_size);
+                    let mut block_data = vec![0; footer_len as usize];
+
+                    reader.read_exact(&mut block_data)?;
+
+                    let message = ipc::root_as_message(&block_data[..]).map_err(|err| {
+                        ArrowError::IoError(format!("Unable to get root as message: {:?}", err))
+                    })?;
+
+                    match message.header_type() {
+                        ipc::MessageHeader::DictionaryBatch => {
+                            let batch = message.header_as_dictionary_batch().unwrap();
+
+                            // read the block that makes up the dictionary batch into a buffer
+                            let mut buf = vec![0; block.bodyLength() as usize];
+                            reader.seek(SeekFrom::Start(
+                                block.offset() as u64 + block.metaDataLength() as u64,
+                            ))?;
+                            reader.read_exact(&mut buf)?;
+
+                            read_dictionary(&buf, batch, &schema, &mut dictionaries_by_field)?;
+                        }
+                        t => {
+                            return Err(ArrowError::IoError(format!(
+                                "Expecting DictionaryBatch in dictionary blocks, found {:?}.",
+                                t
+                            )));
+                        }
+                    }
+                }
             }
-            let footer_len = i32::from_le_bytes(message_size);
-            let mut block_data = vec![0; footer_len as usize];
-
-            reader.read_exact(&mut block_data)?;
-
-            let message = ipc::root_as_message(&block_data[..]).map_err(|err| {
-                ArrowError::IoError(format!("Unable to get root as message: {:?}", err))
-            })?;
-
-            match message.header_type() {
-                ipc::MessageHeader::DictionaryBatch => {
-                    let batch = message.header_as_dictionary_batch().unwrap();
-
-                    // read the block that makes up the dictionary batch into a buffer
-                    let mut buf = vec![0; block.bodyLength() as usize];
-                    reader.seek(SeekFrom::Start(
-                        block.offset() as u64 + block.metaDataLength() as u64,
-                    ))?;
-                    reader.read_exact(&mut buf)?;
-
-                    read_dictionary(&buf, batch, &schema, &mut dictionaries_by_field)?;
-                }
-                t => {
-                    return Err(ArrowError::IoError(format!(
-                        "Expecting DictionaryBatch in dictionary blocks, found {:?}.",
-                        t
-                    )));
-                }
-            };
+            _ => (), 
         }
         let projection = match projection {
             Some(projection_indices) => {


### PR DESCRIPTION

This is my first Rust PR, please let me know if I could do this in a more idiomatic way!

# Which issue does this PR close?

Closes #1335, on the `arrow-rs` side at least, Julia's Arrow.jl also writes mismatched versions (apache/arrow-julia#320).

# What changes are included in this PR?

IPC reader no longer assumes footer exists.

# Are there any user-facing changes?

No.


