### PR TITLE
Add `substring` support for `FixedSizeBinaryArray`

### DIFF
--- a/arrow/benches/string_kernels.rs
+++ b/arrow/benches/string_kernels.rs
@@ -25,22 +25,27 @@ use arrow::array::*;
 use arrow::compute::kernels::substring::substring;
 use arrow::util::bench_util::*;
 
-fn bench_substring(arr: &StringArray, start: i64, length: Option<u64>) {
+fn bench_substring(arr: &dyn Array, start: i64, length: Option<u64>) {
     substring(criterion::black_box(arr), start, length).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
-    let str_len = 1000;
+    let val_len = 1000;
 
-    let arr_string = create_string_array_with_len::<i32>(size, 0.0, str_len);
+    let arr_string = create_string_array_with_len::<i32>(size, 0.0, val_len);
+    let arr_fsb = create_fsb_array(size, 0.0, val_len);
 
-    c.bench_function("substring (start = 0, length = None)", |b| {
+    c.bench_function("substring utf8 (start = 0, length = None)", |b| {
         b.iter(|| bench_substring(&arr_string, 0, None))
     });
 
-    c.bench_function("substring (start = 1, length = str_len - 1)", |b| {
-        b.iter(|| bench_substring(&arr_string, 1, Some((str_len - 1) as u64)))
+    c.bench_function("substring utf8 (start = 1, length = str_len - 1)", |b| {
+        b.iter(|| bench_substring(&arr_string, 1, Some((val_len - 1) as u64)))
+    });
+
+    c.bench_function("substring fixed size binary array", |b| {
+        b.iter(|| bench_substring(&arr_fsb, 1, Some((val_len - 1) as u64)))
     });
 }
 

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -90,7 +90,7 @@ fn fixed_size_binary_substring(
     array: &FixedSizeBinaryArray,
     old_len: i32,
     start: i32,
-    length: Option<i32>
+    length: Option<i32>,
 ) -> Result<ArrayRef> {
     let new_start = if start >= 0 {
         start.min(old_len)
@@ -101,7 +101,7 @@ fn fixed_size_binary_substring(
         Some(len) => len.min(old_len - new_start),
         None => old_len - new_start,
     };
-    
+
     // build value buffer
     let num_of_elements = array.len();
     let values = array.value_data();
@@ -110,11 +110,12 @@ fn fixed_size_binary_substring(
     (0..num_of_elements)
         .map(|idx| {
             let offset = array.value_offset(idx);
-            ((offset + new_start) as usize, (offset + new_start + new_len) as usize)
+            (
+                (offset + new_start) as usize,
+                (offset + new_start + new_len) as usize,
+            )
         })
-        .for_each(|(start, end)| {
-            new_values.extend_from_slice(&data[start..end])
-        });
+        .for_each(|(start, end)| new_values.extend_from_slice(&data[start..end]));
 
     let array_data = unsafe {
         ArrayData::new_unchecked(
@@ -123,7 +124,7 @@ fn fixed_size_binary_substring(
             None,
             array.data_ref().null_buffer().cloned(),
             0,
-            vec![ new_values.into()],
+            vec![new_values.into()],
             vec![],
         )
     };
@@ -268,9 +269,9 @@ pub fn substring(array: &dyn Array, start: i64, length: Option<u64>) -> Result<A
             array
                 .as_any()
                 .downcast_ref::<FixedSizeBinaryArray>()
-                .expect("a fixed size binary is expected"), 
+                .expect("a fixed size binary is expected"),
             *old_len,
-            start as i32, 
+            start as i32,
             length.map(|e| e as i32),
         ),
         DataType::LargeUtf8 => utf8_substring(

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -792,7 +792,7 @@ mod tests {
             .downcast_ref::<FixedSizeBinaryArray>()
             .unwrap();
         let expected = FixedSizeBinaryArray::try_from_sparse_iter(
-            vec![None, Some("rrow")].into_iter(),
+            vec![None, Some(b"rrow")].into_iter(),
         )
         .unwrap();
         assert_eq!(result, &expected);

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -509,6 +509,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::type_complexity)]
     fn with_nulls_fixed_size_binary() -> Result<()> {
         let cases: Vec<(Vec<Option<&[u8]>>, i64, Option<u64>, Vec<Option<&[u8]>>)> = vec![
             // all-nulls array is always identical
@@ -636,6 +637,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::type_complexity)]
     fn without_nulls_fixed_size_binary() -> Result<()> {
         let cases: Vec<(Vec<&[u8]>, i64, Option<u64>, Vec<&[u8]>)> = vec![
             // empty array is always identical

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -92,8 +92,6 @@ fn fixed_size_binary_substring(
     start: i32,
     length: Option<i32>
 ) -> Result<ArrayRef> {
-    let null_bit_buffer = array.data_ref().null_buffer().cloned();
-    
     let new_start = if start >= 0 {
         start.min(old_len)
     } else {
@@ -123,7 +121,7 @@ fn fixed_size_binary_substring(
             DataType::FixedSizeBinary(new_len),
             num_of_elements,
             None,
-            null_bit_buffer,
+            array.data_ref().null_buffer().cloned(),
             0,
             vec![ new_values.into()],
             vec![],

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -304,6 +304,8 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn with_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<Option<&[u8]>>, i64, Option<u64>, Vec<Option<&[u8]>>)> = vec![
+            // all-nulls array is always identical
+            (vec![None, None, None], -1, Some(1), vec![None, None, None]),
             // identity
             (
                 vec![Some(b"hello"), None, Some(&[0xf8, 0xf9, 0xff, 0xfa])],
@@ -373,6 +375,8 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn without_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<&[u8]>, i64, Option<u64>, Vec<&[u8]>)> = vec![
+            // empty array is always identical
+            (vec![b"", b"", b""], 2, Some(1), vec![b"", b"", b""]),
             // increase start
             (
                 vec![b"hello", b"", &[0xf8, 0xf9, 0xff, 0xfa]],
@@ -765,6 +769,8 @@ mod tests {
 
     fn with_nulls_generic_string<O: StringOffsetSizeTrait>() -> Result<()> {
         let cases = vec![
+            // all-nulls array is always identical
+            (vec![None, None, None], 0, None, vec![None, None, None]),
             // identity
             (
                 vec![Some("hello"), None, Some("word")],
@@ -833,6 +839,8 @@ mod tests {
 
     fn without_nulls_generic_string<O: StringOffsetSizeTrait>() -> Result<()> {
         let cases = vec![
+            // empty array is always identical
+            (vec!["", "", ""], 0, None, vec!["", "", ""]),
             // increase start
             (
                 vec!["hello", "", "word"],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1618.

# What changes are included in this PR?
1. make the `substring` kernel support `FixedSizeBinaryArray`
2. add more test cases for binary and utf8
3. add benchmark for `FixedSizeBinaryArray`

# Are there any user-facing changes?
Rename some benchmarks.

# Bench Result
```
substring utf8 (start = 0, length = None)                                                                            
                        time:   [19.811 ms 19.843 ms 19.883 ms]

substring utf8 (start = 1, length = str_len - 1)                                                                            
                        time:   [21.270 ms 21.284 ms 21.299 ms]


substring fixed size binary array                                                                            
                        time:   [19.717 ms 19.753 ms 19.798 ms]
```
