### PR TITLE
Remove `StringOffsetTrait` and `BinaryOffsetTrait`

### DIFF
--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -27,31 +27,25 @@ use crate::buffer::Buffer;
 use crate::util::bit_util;
 use crate::{buffer::MutableBuffer, datatypes::DataType};
 
-/// Like [`OffsetSizeTrait`], but specialized for Strings.
-/// This allow us to expose a constant datatype for the [`GenericStringArray`].
-pub trait StringOffsetSizeTrait: OffsetSizeTrait {
-    const DATA_TYPE: DataType;
-}
-
-impl StringOffsetSizeTrait for i32 {
-    const DATA_TYPE: DataType = DataType::Utf8;
-}
-
-impl StringOffsetSizeTrait for i64 {
-    const DATA_TYPE: DataType = DataType::LargeUtf8;
-}
-
 /// Generic struct for \[Large\]StringArray
 ///
 /// See [`StringArray`] and [`LargeStringArray`] for storing
 /// specific string data.
-pub struct GenericStringArray<OffsetSize: StringOffsetSizeTrait> {
+pub struct GenericStringArray<OffsetSize: OffsetSizeTrait> {
     data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,
     value_data: RawPtrBox<u8>,
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
+    pub fn get_data_type() -> DataType {
+        if OffsetSize::is_large() {
+            DataType::LargeUtf8
+        } else {
+            DataType::Utf8
+        }
+    }
+
     /// Returns the length for the element at index `i`.
     #[inline]
     pub fn value_length(&self, i: usize) -> OffsetSize {
@@ -134,7 +128,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
             "StringArray can only be created from List<u8> arrays, mismatched data types."
         );
 
-        let mut builder = ArrayData::builder(OffsetSize::DATA_TYPE)
+        let mut builder = ArrayData::builder(Self::get_data_type())
             .len(v.len())
             .add_buffer(v.data().buffers()[0].clone())
             .add_buffer(v.data().child_data()[0].buffers()[0].clone());
@@ -174,7 +168,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         assert!(!offsets.is_empty()); // wrote at least one
         let actual_len = (offsets.len() / std::mem::size_of::<OffsetSize>()) - 1;
 
-        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
+        let array_data = ArrayData::builder(Self::get_data_type())
             .len(actual_len)
             .add_buffer(offsets.into())
             .add_buffer(values.into());
@@ -202,7 +196,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
     }
 }
 
-impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<&'a Option<Ptr>>
+impl<'a, Ptr, OffsetSize: OffsetSizeTrait> FromIterator<&'a Option<Ptr>>
     for GenericStringArray<OffsetSize>
 where
     Ptr: AsRef<str> + 'a,
@@ -216,7 +210,7 @@ where
     }
 }
 
-impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Option<Ptr>>
+impl<'a, Ptr, OffsetSize: OffsetSizeTrait> FromIterator<Option<Ptr>>
     for GenericStringArray<OffsetSize>
 where
     Ptr: AsRef<str>,
@@ -251,7 +245,7 @@ where
 
         // calculate actual data_len, which may be different from the iterator's upper bound
         let data_len = (offsets.len() / offset_size) - 1;
-        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
+        let array_data = ArrayData::builder(Self::get_data_type())
             .len(data_len)
             .add_buffer(offsets.into())
             .add_buffer(values.into())
@@ -261,7 +255,7 @@ where
     }
 }
 
-impl<'a, T: StringOffsetSizeTrait> IntoIterator for &'a GenericStringArray<T> {
+impl<'a, T: OffsetSizeTrait> IntoIterator for &'a GenericStringArray<T> {
     type Item = Option<&'a str>;
     type IntoIter = GenericStringIter<'a, T>;
 
@@ -270,14 +264,14 @@ impl<'a, T: StringOffsetSizeTrait> IntoIterator for &'a GenericStringArray<T> {
     }
 }
 
-impl<'a, T: StringOffsetSizeTrait> GenericStringArray<T> {
+impl<'a, T: OffsetSizeTrait> GenericStringArray<T> {
     /// constructs a new iterator
     pub fn iter(&'a self) -> GenericStringIter<'a, T> {
         GenericStringIter::<'a, T>::new(self)
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> fmt::Debug for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericStringArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let prefix = if OffsetSize::is_large() { "Large" } else { "" };
 
@@ -289,7 +283,7 @@ impl<OffsetSize: StringOffsetSizeTrait> fmt::Debug for GenericStringArray<Offset
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> Array for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> Array for GenericStringArray<OffsetSize> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -299,13 +293,11 @@ impl<OffsetSize: StringOffsetSizeTrait> Array for GenericStringArray<OffsetSize>
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> From<ArrayData>
-    for GenericStringArray<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> From<ArrayData> for GenericStringArray<OffsetSize> {
     fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.data_type(),
-            &<OffsetSize as StringOffsetSizeTrait>::DATA_TYPE,
+            &Self::get_data_type(),
             "[Large]StringArray expects Datatype::[Large]Utf8"
         );
         assert_eq!(
@@ -323,7 +315,7 @@ impl<OffsetSize: StringOffsetSizeTrait> From<ArrayData>
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> From<Vec<Option<&str>>>
+impl<OffsetSize: OffsetSizeTrait> From<Vec<Option<&str>>>
     for GenericStringArray<OffsetSize>
 {
     fn from(v: Vec<Option<&str>>) -> Self {
@@ -331,17 +323,13 @@ impl<OffsetSize: StringOffsetSizeTrait> From<Vec<Option<&str>>>
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> From<Vec<&str>>
-    for GenericStringArray<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> From<Vec<&str>> for GenericStringArray<OffsetSize> {
     fn from(v: Vec<&str>) -> Self {
         Self::from_iter_values(v)
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> From<Vec<String>>
-    for GenericStringArray<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> From<Vec<String>> for GenericStringArray<OffsetSize> {
     fn from(v: Vec<String>) -> Self {
         Self::from_iter_values(v)
     }
@@ -371,7 +359,7 @@ pub type StringArray = GenericStringArray<i32>;
 /// ```
 pub type LargeStringArray = GenericStringArray<i64>;
 
-impl<T: StringOffsetSizeTrait> From<GenericListArray<T>> for GenericStringArray<T> {
+impl<T: OffsetSizeTrait> From<GenericListArray<T>> for GenericStringArray<T> {
     fn from(v: GenericListArray<T>) -> Self {
         GenericStringArray::<T>::from_list(v)
     }

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -1165,9 +1165,7 @@ pub struct DecimalBuilder {
     scale: usize,
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> ArrayBuilder
-    for GenericBinaryBuilder<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> ArrayBuilder for GenericBinaryBuilder<OffsetSize> {
     /// Returns the builder as a non-mutable `Any` reference.
     fn as_any(&self) -> &dyn Any {
         self
@@ -1296,7 +1294,7 @@ impl ArrayBuilder for DecimalBuilder {
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
     /// Creates a new `GenericBinaryBuilder`, `capacity` is the number of bytes in the values
     /// array
     pub fn new(capacity: usize) -> Self {

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -1199,9 +1199,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> ArrayBuilder
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> ArrayBuilder
-    for GenericStringBuilder<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> ArrayBuilder for GenericStringBuilder<OffsetSize> {
     /// Returns the builder as a non-mutable `Any` reference.
     fn as_any(&self) -> &dyn Any {
         self
@@ -1347,7 +1345,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> GenericStringBuilder<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> GenericStringBuilder<OffsetSize> {
     /// Creates a new `StringBuilder`,
     /// `capacity` is the number of bytes of string data to pre-allocate space for in this builder
     pub fn new(capacity: usize) -> Self {

--- a/arrow/src/array/cast.rs
+++ b/arrow/src/array/cast.rs
@@ -63,7 +63,7 @@ pub fn as_large_list_array(arr: &dyn Array) -> &LargeListArray {
 
 #[doc = "Force downcast ArrayRef to GenericBinaryArray"]
 #[inline]
-pub fn as_generic_binary_array<S: BinaryOffsetSizeTrait>(
+pub fn as_generic_binary_array<S: OffsetSizeTrait>(
     arr: &dyn Array,
 ) -> &GenericBinaryArray<S> {
     arr.as_any()

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -20,10 +20,9 @@
 //! depend on dynamic casting of `Array`.
 
 use super::{
-    Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray, DictionaryArray,
-    FixedSizeBinaryArray, FixedSizeListArray, GenericBinaryArray, GenericListArray,
-    GenericStringArray, MapArray, NullArray, OffsetSizeTrait, PrimitiveArray,
-    StructArray,
+    Array, ArrayData, BooleanArray, DecimalArray, DictionaryArray, FixedSizeBinaryArray,
+    FixedSizeListArray, GenericBinaryArray, GenericListArray, GenericStringArray,
+    MapArray, NullArray, OffsetSizeTrait, PrimitiveArray, StructArray,
 };
 use crate::datatypes::{ArrowPrimitiveType, DataType, IntervalUnit};
 use half::f16;
@@ -98,7 +97,7 @@ impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericBinaryArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
         equal(self.data(), other.data())
     }
@@ -261,10 +260,10 @@ mod tests {
     use std::sync::Arc;
 
     use crate::array::{
-        array::Array, ArrayData, ArrayDataBuilder, ArrayRef, BinaryOffsetSizeTrait,
-        BooleanArray, FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray,
-        Int32Builder, ListBuilder, NullArray, PrimitiveBuilder, StringArray,
-        StringDictionaryBuilder, StructArray, UnionBuilder,
+        array::Array, ArrayData, ArrayDataBuilder, ArrayRef, BooleanArray,
+        FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray, Int32Builder,
+        ListBuilder, NullArray, PrimitiveBuilder, StringArray, StringDictionaryBuilder,
+        StructArray, UnionBuilder,
     };
     use crate::array::{GenericStringArray, Int32Array};
     use crate::buffer::Buffer;
@@ -528,7 +527,7 @@ mod tests {
         test_generic_string_equal::<i64>()
     }
 
-    fn test_generic_binary_equal<OffsetSize: BinaryOffsetSizeTrait>() {
+    fn test_generic_binary_equal<OffsetSize: OffsetSizeTrait>() {
         let cases = binary_cases();
 
         for (lhs, rhs, expected) in cases {

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -23,7 +23,7 @@ use super::{
     Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray, DictionaryArray,
     FixedSizeBinaryArray, FixedSizeListArray, GenericBinaryArray, GenericListArray,
     GenericStringArray, MapArray, NullArray, OffsetSizeTrait, PrimitiveArray,
-    StringOffsetSizeTrait, StructArray,
+    StructArray,
 };
 use crate::datatypes::{ArrowPrimitiveType, DataType, IntervalUnit};
 use half::f16;
@@ -92,7 +92,7 @@ impl PartialEq for BooleanArray {
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
         equal(self.data(), other.data())
     }
@@ -264,7 +264,7 @@ mod tests {
         array::Array, ArrayData, ArrayDataBuilder, ArrayRef, BinaryOffsetSizeTrait,
         BooleanArray, FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray,
         Int32Builder, ListBuilder, NullArray, PrimitiveBuilder, StringArray,
-        StringDictionaryBuilder, StringOffsetSizeTrait, StructArray, UnionBuilder,
+        StringDictionaryBuilder, StructArray, UnionBuilder,
     };
     use crate::array::{GenericStringArray, Int32Array};
     use crate::buffer::Buffer;
@@ -506,7 +506,7 @@ mod tests {
         ]
     }
 
-    fn test_generic_string_equal<OffsetSize: StringOffsetSizeTrait>() {
+    fn test_generic_string_equal<OffsetSize: OffsetSizeTrait>() {
         let cases = binary_cases();
 
         for (lhs, rhs, expected) in cases {

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -251,7 +251,7 @@ impl PartialEq<MapArray> for Value {
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> JsonEqual for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> JsonEqual for GenericBinaryArray<OffsetSize> {
     fn equals_json(&self, json: &[&Value]) -> bool {
         if self.len() != json.len() {
             return false;
@@ -271,9 +271,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> JsonEqual for GenericBinaryArray<OffsetS
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq<Value>
-    for GenericBinaryArray<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> PartialEq<Value> for GenericBinaryArray<OffsetSize> {
     fn eq(&self, json: &Value) -> bool {
         match json {
             Value::Array(json_array) => self.equals_json_values(json_array),
@@ -282,9 +280,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq<Value>
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq<GenericBinaryArray<OffsetSize>>
-    for Value
-{
+impl<OffsetSize: OffsetSizeTrait> PartialEq<GenericBinaryArray<OffsetSize>> for Value {
     fn eq(&self, arrow: &GenericBinaryArray<OffsetSize>) -> bool {
         match self {
             Value::Array(json_array) => arrow.equals_json_values(json_array),

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -293,7 +293,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq<GenericBinaryArray<OffsetSize>
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> JsonEqual for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> JsonEqual for GenericStringArray<OffsetSize> {
     fn equals_json(&self, json: &[&Value]) -> bool {
         if self.len() != json.len() {
             return false;
@@ -307,9 +307,7 @@ impl<OffsetSize: StringOffsetSizeTrait> JsonEqual for GenericStringArray<OffsetS
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> PartialEq<Value>
-    for GenericStringArray<OffsetSize>
-{
+impl<OffsetSize: OffsetSizeTrait> PartialEq<Value> for GenericStringArray<OffsetSize> {
     fn eq(&self, json: &Value) -> bool {
         match json {
             Value::Array(json_array) => self.equals_json_values(json_array),
@@ -318,9 +316,7 @@ impl<OffsetSize: StringOffsetSizeTrait> PartialEq<Value>
     }
 }
 
-impl<OffsetSize: StringOffsetSizeTrait> PartialEq<GenericStringArray<OffsetSize>>
-    for Value
-{
+impl<OffsetSize: OffsetSizeTrait> PartialEq<GenericStringArray<OffsetSize>> for Value {
     fn eq(&self, arrow: &GenericStringArray<OffsetSize>) -> bool {
         match self {
             Value::Array(json_array) => arrow.equals_json_values(json_array),

--- a/arrow/src/array/iterator.rs
+++ b/arrow/src/array/iterator.rs
@@ -18,9 +18,8 @@
 use crate::datatypes::ArrowPrimitiveType;
 
 use super::{
-    Array, ArrayRef, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
-    GenericBinaryArray, GenericListArray, GenericStringArray, OffsetSizeTrait,
-    PrimitiveArray,
+    Array, ArrayRef, BooleanArray, DecimalArray, GenericBinaryArray, GenericListArray,
+    GenericStringArray, OffsetSizeTrait, PrimitiveArray,
 };
 
 /// an iterator that returns Some(T) or None, that can be used on any PrimitiveArray
@@ -246,14 +245,14 @@ impl<'a, T: OffsetSizeTrait> std::iter::ExactSizeIterator for GenericStringIter<
 #[derive(Debug)]
 pub struct GenericBinaryIter<'a, T>
 where
-    T: BinaryOffsetSizeTrait,
+    T: OffsetSizeTrait,
 {
     array: &'a GenericBinaryArray<T>,
     current: usize,
     current_end: usize,
 }
 
-impl<'a, T: BinaryOffsetSizeTrait> GenericBinaryIter<'a, T> {
+impl<'a, T: OffsetSizeTrait> GenericBinaryIter<'a, T> {
     /// create a new iterator
     pub fn new(array: &'a GenericBinaryArray<T>) -> Self {
         GenericBinaryIter::<T> {
@@ -264,7 +263,7 @@ impl<'a, T: BinaryOffsetSizeTrait> GenericBinaryIter<'a, T> {
     }
 }
 
-impl<'a, T: BinaryOffsetSizeTrait> std::iter::Iterator for GenericBinaryIter<'a, T> {
+impl<'a, T: OffsetSizeTrait> std::iter::Iterator for GenericBinaryIter<'a, T> {
     type Item = Option<&'a [u8]>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -293,9 +292,7 @@ impl<'a, T: BinaryOffsetSizeTrait> std::iter::Iterator for GenericBinaryIter<'a,
     }
 }
 
-impl<'a, T: BinaryOffsetSizeTrait> std::iter::DoubleEndedIterator
-    for GenericBinaryIter<'a, T>
-{
+impl<'a, T: OffsetSizeTrait> std::iter::DoubleEndedIterator for GenericBinaryIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.current_end == self.current {
             None
@@ -316,10 +313,7 @@ impl<'a, T: BinaryOffsetSizeTrait> std::iter::DoubleEndedIterator
 }
 
 /// all arrays have known size.
-impl<'a, T: BinaryOffsetSizeTrait> std::iter::ExactSizeIterator
-    for GenericBinaryIter<'a, T>
-{
-}
+impl<'a, T: OffsetSizeTrait> std::iter::ExactSizeIterator for GenericBinaryIter<'a, T> {}
 
 #[derive(Debug)]
 pub struct GenericListArrayIter<'a, S>

--- a/arrow/src/array/iterator.rs
+++ b/arrow/src/array/iterator.rs
@@ -20,7 +20,7 @@ use crate::datatypes::ArrowPrimitiveType;
 use super::{
     Array, ArrayRef, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
     GenericBinaryArray, GenericListArray, GenericStringArray, OffsetSizeTrait,
-    PrimitiveArray, StringOffsetSizeTrait,
+    PrimitiveArray,
 };
 
 /// an iterator that returns Some(T) or None, that can be used on any PrimitiveArray
@@ -172,14 +172,14 @@ impl<'a> std::iter::ExactSizeIterator for BooleanIter<'a> {}
 #[derive(Debug)]
 pub struct GenericStringIter<'a, T>
 where
-    T: StringOffsetSizeTrait,
+    T: OffsetSizeTrait,
 {
     array: &'a GenericStringArray<T>,
     current: usize,
     current_end: usize,
 }
 
-impl<'a, T: StringOffsetSizeTrait> GenericStringIter<'a, T> {
+impl<'a, T: OffsetSizeTrait> GenericStringIter<'a, T> {
     /// create a new iterator
     pub fn new(array: &'a GenericStringArray<T>) -> Self {
         GenericStringIter::<T> {
@@ -190,7 +190,7 @@ impl<'a, T: StringOffsetSizeTrait> GenericStringIter<'a, T> {
     }
 }
 
-impl<'a, T: StringOffsetSizeTrait> std::iter::Iterator for GenericStringIter<'a, T> {
+impl<'a, T: OffsetSizeTrait> std::iter::Iterator for GenericStringIter<'a, T> {
     type Item = Option<&'a str>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -219,9 +219,7 @@ impl<'a, T: StringOffsetSizeTrait> std::iter::Iterator for GenericStringIter<'a,
     }
 }
 
-impl<'a, T: StringOffsetSizeTrait> std::iter::DoubleEndedIterator
-    for GenericStringIter<'a, T>
-{
+impl<'a, T: OffsetSizeTrait> std::iter::DoubleEndedIterator for GenericStringIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.current_end == self.current {
             None
@@ -242,10 +240,7 @@ impl<'a, T: StringOffsetSizeTrait> std::iter::DoubleEndedIterator
 }
 
 /// all arrays have known size.
-impl<'a, T: StringOffsetSizeTrait> std::iter::ExactSizeIterator
-    for GenericStringIter<'a, T>
-{
-}
+impl<'a, T: OffsetSizeTrait> std::iter::ExactSizeIterator for GenericStringIter<'a, T> {}
 
 /// an iterator that returns `Some(&[u8])` or `None`, for binary arrays
 #[derive(Debug)]

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -391,7 +391,6 @@ pub type DurationMillisecondArray = PrimitiveArray<DurationMillisecondType>;
 pub type DurationMicrosecondArray = PrimitiveArray<DurationMicrosecondType>;
 pub type DurationNanosecondArray = PrimitiveArray<DurationNanosecondType>;
 
-pub use self::array_binary::BinaryOffsetSizeTrait;
 pub use self::array_binary::GenericBinaryArray;
 pub use self::array_list::GenericListArray;
 pub use self::array_list::OffsetSizeTrait;

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -396,7 +396,6 @@ pub use self::array_binary::GenericBinaryArray;
 pub use self::array_list::GenericListArray;
 pub use self::array_list::OffsetSizeTrait;
 pub use self::array_string::GenericStringArray;
-pub use self::array_string::StringOffsetSizeTrait;
 
 // --------------------- Array Builder ---------------------
 

--- a/arrow/src/array/ord.rs
+++ b/arrow/src/array/ord.rs
@@ -72,7 +72,7 @@ where
 
 fn compare_string<T>(left: &dyn Array, right: &dyn Array) -> DynComparator
 where
-    T: StringOffsetSizeTrait,
+    T: OffsetSizeTrait,
 {
     let left: StringArray = StringArray::from(left.data().clone());
     let right: StringArray = StringArray::from(right.data().clone());

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -17,9 +17,8 @@
 
 use super::{
     data::{into_buffers, new_buffers},
-    ArrayData, ArrayDataBuilder,
+    ArrayData, ArrayDataBuilder, OffsetSizeTrait,
 };
-use crate::array::StringOffsetSizeTrait;
 use crate::{
     buffer::MutableBuffer,
     datatypes::DataType,
@@ -333,7 +332,7 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
     })
 }
 
-fn preallocate_offset_and_binary_buffer<Offset: StringOffsetSizeTrait>(
+fn preallocate_offset_and_binary_buffer<Offset: OffsetSizeTrait>(
     capacity: usize,
     binary_size: usize,
 ) -> [MutableBuffer; 2] {

--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -21,7 +21,7 @@ use multiversion::multiversion;
 use std::ops::Add;
 
 use crate::array::{
-    Array, BooleanArray, GenericStringArray, PrimitiveArray, StringOffsetSizeTrait,
+    Array, BooleanArray, GenericStringArray, OffsetSizeTrait, PrimitiveArray,
 };
 use crate::datatypes::{ArrowNativeType, ArrowNumericType};
 
@@ -35,7 +35,7 @@ fn is_nan<T: ArrowNativeType + PartialOrd + Copy>(a: T) -> bool {
 /// Helper function to perform min/max of strings
 fn min_max_string<T, F>(array: &GenericStringArray<T>, cmp: F) -> Option<&str>
 where
-    T: StringOffsetSizeTrait,
+    T: OffsetSizeTrait,
     F: Fn(&str, &str) -> bool,
 {
     let null_count = array.null_count();
@@ -80,16 +80,12 @@ where
 }
 
 /// Returns the maximum value in the string array, according to the natural order.
-pub fn max_string<T: StringOffsetSizeTrait>(
-    array: &GenericStringArray<T>,
-) -> Option<&str> {
+pub fn max_string<T: OffsetSizeTrait>(array: &GenericStringArray<T>) -> Option<&str> {
     min_max_string(array, |a, b| a < b)
 }
 
 /// Returns the minimum value in the string array, according to the natural order.
-pub fn min_string<T: StringOffsetSizeTrait>(
-    array: &GenericStringArray<T>,
-) -> Option<&str> {
+pub fn min_string<T: OffsetSizeTrait>(array: &GenericStringArray<T>) -> Option<&str> {
     min_max_string(array, |a, b| a > b)
 }
 

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1345,7 +1345,7 @@ fn cast_timestamp_to_string<T, OffsetSize>(array: &ArrayRef) -> Result<ArrayRef>
 where
     T: ArrowTemporalType + ArrowNumericType,
     i64: From<<T as ArrowPrimitiveType>::Native>,
-    OffsetSize: StringOffsetSizeTrait,
+    OffsetSize: OffsetSizeTrait,
 {
     let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
@@ -1363,7 +1363,7 @@ where
 }
 
 /// Cast date32 types to Utf8/LargeUtf8
-fn cast_date32_to_string<OffsetSize: StringOffsetSizeTrait>(
+fn cast_date32_to_string<OffsetSize: OffsetSizeTrait>(
     array: &ArrayRef,
 ) -> Result<ArrayRef> {
     let array = array.as_any().downcast_ref::<Date32Array>().unwrap();
@@ -1382,7 +1382,7 @@ fn cast_date32_to_string<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Cast date64 types to Utf8/LargeUtf8
-fn cast_date64_to_string<OffsetSize: StringOffsetSizeTrait>(
+fn cast_date64_to_string<OffsetSize: OffsetSizeTrait>(
     array: &ArrayRef,
 ) -> Result<ArrayRef> {
     let array = array.as_any().downcast_ref::<Date64Array>().unwrap();
@@ -1405,7 +1405,7 @@ fn cast_numeric_to_string<FROM, OffsetSize>(array: &ArrayRef) -> Result<ArrayRef
 where
     FROM: ArrowNumericType,
     FROM::Native: lexical_core::ToLexical,
-    OffsetSize: StringOffsetSizeTrait,
+    OffsetSize: OffsetSizeTrait,
 {
     Ok(Arc::new(numeric_to_string_cast::<FROM, OffsetSize>(
         array
@@ -1421,7 +1421,7 @@ fn numeric_to_string_cast<T, OffsetSize>(
 where
     T: ArrowPrimitiveType + ArrowNumericType,
     T::Native: lexical_core::ToLexical,
-    OffsetSize: StringOffsetSizeTrait,
+    OffsetSize: OffsetSizeTrait,
 {
     from.iter()
         .map(|maybe_value| maybe_value.map(lexical_to_string))
@@ -1429,7 +1429,7 @@ where
 }
 
 /// Cast numeric types to Utf8
-fn cast_string_to_numeric<T, Offset: StringOffsetSizeTrait>(
+fn cast_string_to_numeric<T, Offset: OffsetSizeTrait>(
     from: &ArrayRef,
     cast_options: &CastOptions,
 ) -> Result<ArrayRef>
@@ -1445,7 +1445,7 @@ where
     )?))
 }
 
-fn string_to_numeric_cast<T, Offset: StringOffsetSizeTrait>(
+fn string_to_numeric_cast<T, Offset: OffsetSizeTrait>(
     from: &GenericStringArray<Offset>,
     cast_options: &CastOptions,
 ) -> Result<PrimitiveArray<T>>
@@ -1494,7 +1494,7 @@ where
 }
 
 /// Casts generic string arrays to Date32Array
-fn cast_string_to_date32<Offset: StringOffsetSizeTrait>(
+fn cast_string_to_date32<Offset: OffsetSizeTrait>(
     array: &dyn Array,
     cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
@@ -1556,7 +1556,7 @@ fn cast_string_to_date32<Offset: StringOffsetSizeTrait>(
 }
 
 /// Casts generic string arrays to Date64Array
-fn cast_string_to_date64<Offset: StringOffsetSizeTrait>(
+fn cast_string_to_date64<Offset: OffsetSizeTrait>(
     array: &dyn Array,
     cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
@@ -1617,7 +1617,7 @@ fn cast_string_to_date64<Offset: StringOffsetSizeTrait>(
 }
 
 /// Casts generic string arrays to TimeStampNanosecondArray
-fn cast_string_to_timestamp_ns<Offset: StringOffsetSizeTrait>(
+fn cast_string_to_timestamp_ns<Offset: OffsetSizeTrait>(
     array: &dyn Array,
     cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
@@ -2047,8 +2047,8 @@ fn cast_list_inner<OffsetSize: OffsetSizeTrait>(
 /// a `Utf8` array it will return an Error.
 fn cast_str_container<OffsetSizeFrom, OffsetSizeTo>(array: &dyn Array) -> Result<ArrayRef>
 where
-    OffsetSizeFrom: StringOffsetSizeTrait + ToPrimitive,
-    OffsetSizeTo: StringOffsetSizeTrait + NumCast + ArrowNativeType,
+    OffsetSizeFrom: OffsetSizeTrait + ToPrimitive,
+    OffsetSizeTo: OffsetSizeTrait + NumCast + ArrowNativeType,
 {
     let str_array = array
         .as_any()

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -811,7 +811,7 @@ pub fn neq_bool_scalar(left: &BooleanArray, right: bool) -> Result<BooleanArray>
 }
 
 /// Perform `left == right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn eq_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -819,7 +819,7 @@ pub fn eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left == right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar
-pub fn eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn eq_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -827,7 +827,7 @@ pub fn eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left != right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn neq_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn neq_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -835,7 +835,7 @@ pub fn neq_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left != right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar.
-pub fn neq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn neq_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -843,7 +843,7 @@ pub fn neq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left < right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn lt_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn lt_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -851,7 +851,7 @@ pub fn lt_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left < right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar.
-pub fn lt_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn lt_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -859,7 +859,7 @@ pub fn lt_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left <= right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn lt_eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn lt_eq_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -867,7 +867,7 @@ pub fn lt_eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left <= right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar.
-pub fn lt_eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn lt_eq_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -875,7 +875,7 @@ pub fn lt_eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left > right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn gt_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn gt_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -883,7 +883,7 @@ pub fn gt_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left > right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar.
-pub fn gt_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn gt_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -891,7 +891,7 @@ pub fn gt_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left >= right` operation on [`BinaryArray`] / [`LargeBinaryArray`].
-pub fn gt_eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn gt_eq_binary<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &GenericBinaryArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -899,7 +899,7 @@ pub fn gt_eq_binary<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left >= right` operation on [`BinaryArray`] / [`LargeBinaryArray`] and a scalar.
-pub fn gt_eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
+pub fn gt_eq_binary_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericBinaryArray<OffsetSize>,
     right: &[u8],
 ) -> Result<BooleanArray> {
@@ -2295,7 +2295,7 @@ where
 
 /// Perform the given operation on two `DictionaryArray`s which value type is
 /// `DataType::Binary` or `DataType::LargeBinary`.
-pub fn cmp_dict_binary<K, OffsetSize: BinaryOffsetSizeTrait, F>(
+pub fn cmp_dict_binary<K, OffsetSize: OffsetSizeTrait, F>(
     left: &DictionaryArray<K>,
     right: &DictionaryArray<K>,
     op: F,

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -246,7 +246,7 @@ fn regex_like<OffsetSize, F>(
     op: F,
 ) -> Result<BooleanArray>
 where
-    OffsetSize: StringOffsetSizeTrait,
+    OffsetSize: OffsetSizeTrait,
     F: Fn(&str) -> Result<Regex>,
 {
     let mut map = HashMap::new();
@@ -312,7 +312,7 @@ where
 /// let result = like_utf8(&strings, &patterns).unwrap();
 /// assert_eq!(result, BooleanArray::from(vec![true, false, false, true]));
 /// ```
-pub fn like_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn like_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -330,7 +330,7 @@ pub fn like_utf8<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`like_utf8`] for more details.
-pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn like_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -398,7 +398,7 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`].
 ///
 /// See the documentation on [`like_utf8`] for more details.
-pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn nlike_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -416,7 +416,7 @@ pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`like_utf8`] for more details.
-pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn nlike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -471,7 +471,7 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`].
 ///
 /// See the documentation on [`like_utf8`] for more details.
-pub fn ilike_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn ilike_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -489,7 +489,7 @@ pub fn ilike_utf8<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`like_utf8`] for more details.
-pub fn ilike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn ilike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -555,7 +555,7 @@ pub fn ilike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 /// special search modes, such as case insensitive and multi-line mode.
 /// See the documentation [here](https://docs.rs/regex/1.5.4/regex/#grouping-and-flags)
 /// for more information.
-pub fn regexp_is_match_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn regexp_is_match_utf8<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     regex_array: &GenericStringArray<OffsetSize>,
     flags_array: Option<&GenericStringArray<OffsetSize>>,
@@ -639,7 +639,7 @@ pub fn regexp_is_match_utf8<OffsetSize: StringOffsetSizeTrait>(
 /// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`regexp_is_match_utf8`] for more details.
-pub fn regexp_is_match_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn regexp_is_match_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     regex: &str,
     flag: Option<&str>,
@@ -682,7 +682,7 @@ pub fn regexp_is_match_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left == right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn eq_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -690,7 +690,7 @@ pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left == right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn eq_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -907,7 +907,7 @@ pub fn gt_eq_binary_scalar<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// Perform `left != right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn neq_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -915,7 +915,7 @@ pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left != right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn neq_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -923,7 +923,7 @@ pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left < right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn lt_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -931,7 +931,7 @@ pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left < right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn lt_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -939,7 +939,7 @@ pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left <= right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn lt_eq_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -947,7 +947,7 @@ pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left <= right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn lt_eq_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -955,7 +955,7 @@ pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left > right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn gt_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -963,7 +963,7 @@ pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left > right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn gt_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -971,7 +971,7 @@ pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left >= right` operation on [`StringArray`] / [`LargeStringArray`].
-pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
+pub fn gt_eq_utf8<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
 ) -> Result<BooleanArray> {
@@ -979,7 +979,7 @@ pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
 }
 
 /// Perform `left >= right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
-pub fn gt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
+pub fn gt_eq_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
 ) -> Result<BooleanArray> {
@@ -2281,7 +2281,7 @@ where
 
 /// Perform the given operation on two `DictionaryArray`s which value type is
 /// `DataType::Utf8` or `DataType::LargeUtf8`.
-pub fn cmp_dict_utf8<K, OffsetSize: StringOffsetSizeTrait, F>(
+pub fn cmp_dict_utf8<K, OffsetSize: OffsetSizeTrait, F>(
     left: &DictionaryArray<K>,
     right: &DictionaryArray<K>,
     op: F,
@@ -2661,7 +2661,7 @@ pub fn contains_utf8<OffsetSize>(
     right: &ListArray,
 ) -> Result<BooleanArray>
 where
-    OffsetSize: StringOffsetSizeTrait,
+    OffsetSize: OffsetSizeTrait,
 {
     let left_len = left.len();
     if left_len != right.len() {

--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -34,9 +34,7 @@ use crate::array::*;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
 
-fn compute_str_values_length<Offset: StringOffsetSizeTrait>(
-    arrays: &[&ArrayData],
-) -> usize {
+fn compute_str_values_length<Offset: OffsetSizeTrait>(arrays: &[&ArrayData]) -> usize {
     arrays
         .iter()
         .map(|&data| {

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -743,7 +743,7 @@ struct FilterString<'a, OffsetSize> {
 
 impl<'a, OffsetSize> FilterString<'a, OffsetSize>
 where
-    OffsetSize: Zero + AddAssign + StringOffsetSizeTrait,
+    OffsetSize: Zero + AddAssign + OffsetSizeTrait,
 {
     fn new(capacity: usize, array: &'a GenericStringArray<OffsetSize>) -> Self {
         let num_offsets_bytes = (capacity + 1) * std::mem::size_of::<OffsetSize>();
@@ -815,7 +815,7 @@ fn filter_string<OffsetSize>(
     predicate: &FilterPredicate,
 ) -> GenericStringArray<OffsetSize>
 where
-    OffsetSize: Zero + AddAssign + StringOffsetSizeTrait,
+    OffsetSize: Zero + AddAssign + OffsetSizeTrait,
 {
     let data = array.data();
     assert_eq!(data.buffers().len(), 2);

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -84,9 +84,9 @@ where
 
 fn length_string<O, T>(array: &dyn Array) -> ArrayRef
 where
-    O: StringOffsetSizeTrait,
+    O: OffsetSizeTrait,
     T: ArrowPrimitiveType,
-    T::Native: StringOffsetSizeTrait,
+    T::Native: OffsetSizeTrait,
 {
     let array = array
         .as_any()
@@ -111,9 +111,9 @@ where
 
 fn bit_length_string<O, T>(array: &dyn Array) -> ArrayRef
 where
-    O: StringOffsetSizeTrait,
+    O: OffsetSizeTrait,
     T: ArrowPrimitiveType,
-    T::Native: StringOffsetSizeTrait,
+    T::Native: OffsetSizeTrait,
 {
     let array = array
         .as_any()

--- a/arrow/src/compute/kernels/length.rs
+++ b/arrow/src/compute/kernels/length.rs
@@ -71,9 +71,9 @@ where
 
 fn length_binary<O, T>(array: &dyn Array) -> ArrayRef
 where
-    O: BinaryOffsetSizeTrait,
+    O: OffsetSizeTrait,
     T: ArrowPrimitiveType,
-    T::Native: BinaryOffsetSizeTrait,
+    T::Native: OffsetSizeTrait,
 {
     let array = array
         .as_any()
@@ -97,9 +97,9 @@ where
 
 fn bit_length_binary<O, T>(array: &dyn Array) -> ArrayRef
 where
-    O: BinaryOffsetSizeTrait,
+    O: OffsetSizeTrait,
     T: ArrowPrimitiveType,
-    T::Native: BinaryOffsetSizeTrait,
+    T::Native: OffsetSizeTrait,
 {
     let array = array
         .as_any()

--- a/arrow/src/compute/kernels/regexp.rs
+++ b/arrow/src/compute/kernels/regexp.rs
@@ -19,8 +19,7 @@
 //! expression of a \[Large\]StringArray
 
 use crate::array::{
-    ArrayRef, GenericStringArray, GenericStringBuilder, ListBuilder,
-    StringOffsetSizeTrait,
+    ArrayRef, GenericStringArray, GenericStringBuilder, ListBuilder, OffsetSizeTrait,
 };
 use crate::error::{ArrowError, Result};
 use std::collections::HashMap;
@@ -30,7 +29,7 @@ use std::sync::Arc;
 use regex::Regex;
 
 /// Extract all groups matched by a regular expression for a given String array.
-pub fn regexp_match<OffsetSize: StringOffsetSizeTrait>(
+pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     regex_array: &GenericStringArray<OffsetSize>,
     flags_array: Option<&GenericStringArray<OffsetSize>>,

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -779,7 +779,7 @@ fn sort_binary<S>(
     limit: Option<usize>,
 ) -> UInt32Array
 where
-    S: BinaryOffsetSizeTrait,
+    S: OffsetSizeTrait,
 {
     let mut valids: Vec<(u32, &[u8])> = values
         .as_any()
@@ -1343,7 +1343,7 @@ mod tests {
         }
 
         // Generic size binary array
-        fn make_generic_binary_array<S: BinaryOffsetSizeTrait>(
+        fn make_generic_binary_array<S: OffsetSizeTrait>(
             data: &[Option<Vec<u8>>],
         ) -> Arc<GenericBinaryArray<S>> {
             Arc::new(GenericBinaryArray::<S>::from_opt_vec(

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -614,7 +614,7 @@ fn insert_valid_values<T>(result_slice: &mut [u32], offset: usize, valids: &[(u3
 }
 
 /// Sort strings
-fn sort_string<Offset: StringOffsetSizeTrait>(
+fn sort_string<Offset: OffsetSizeTrait>(
     values: &ArrayRef,
     value_indices: Vec<u32>,
     null_indices: Vec<u32>,

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -87,7 +87,7 @@ fn binary_substring<OffsetSize: BinaryOffsetSizeTrait>(
 }
 
 /// substring by byte
-fn utf8_substring<OffsetSize: StringOffsetSizeTrait>(
+fn utf8_substring<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     start: OffsetSize,
     length: Option<OffsetSize>,
@@ -154,7 +154,7 @@ fn utf8_substring<OffsetSize: StringOffsetSizeTrait>(
 
     let data = unsafe {
         ArrayData::new_unchecked(
-            <OffsetSize as StringOffsetSizeTrait>::DATA_TYPE,
+            GenericStringArray::<OffsetSize>::get_data_type(),
             array.len(),
             None,
             null_bit_buffer,
@@ -453,7 +453,7 @@ mod tests {
         without_nulls_generic_binary::<i64>()
     }
 
-    fn with_nulls_generic_string<O: StringOffsetSizeTrait>() -> Result<()> {
+    fn with_nulls_generic_string<O: OffsetSizeTrait>() -> Result<()> {
         let cases = vec![
             // identity
             (
@@ -521,7 +521,7 @@ mod tests {
         with_nulls_generic_string::<i64>()
     }
 
-    fn without_nulls_generic_string<O: StringOffsetSizeTrait>() -> Result<()> {
+    fn without_nulls_generic_string<O: OffsetSizeTrait>() -> Result<()> {
         let cases = vec![
             // increase start
             (

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use std::cmp::Ordering;
 
-fn binary_substring<OffsetSize: BinaryOffsetSizeTrait>(
+fn binary_substring<OffsetSize: OffsetSizeTrait>(
     array: &GenericBinaryArray<OffsetSize>,
     start: OffsetSize,
     length: Option<OffsetSize>,
@@ -74,7 +74,7 @@ fn binary_substring<OffsetSize: BinaryOffsetSizeTrait>(
 
     let data = unsafe {
         ArrayData::new_unchecked(
-            <OffsetSize as BinaryOffsetSizeTrait>::DATA_TYPE,
+            GenericBinaryArray::<OffsetSize>::get_data_type(),
             array.len(),
             None,
             null_bit_buffer,
@@ -247,7 +247,7 @@ mod tests {
     use super::*;
 
     #[allow(clippy::type_complexity)]
-    fn with_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
+    fn with_nulls_generic_binary<O: OffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<Option<&[u8]>>, i64, Option<u64>, Vec<Option<&[u8]>>)> = vec![
             // identity
             (
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn without_nulls_generic_binary<O: BinaryOffsetSizeTrait>() -> Result<()> {
+    fn without_nulls_generic_binary<O: OffsetSizeTrait>() -> Result<()> {
         let cases: Vec<(Vec<&[u8]>, i64, Option<u64>, Vec<&[u8]>)> = vec![
             // increase start
             (

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -679,7 +679,7 @@ fn take_string<OffsetSize, IndexType>(
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericStringArray<OffsetSize>>
 where
-    OffsetSize: Zero + AddAssign + StringOffsetSizeTrait,
+    OffsetSize: Zero + AddAssign + OffsetSizeTrait,
     IndexType: ArrowNumericType,
     IndexType::Native: ToPrimitive,
 {
@@ -778,7 +778,7 @@ where
     }
 
     let mut array_data =
-        ArrayData::builder(<OffsetSize as StringOffsetSizeTrait>::DATA_TYPE)
+        ArrayData::builder(GenericStringArray::<OffsetSize>::get_data_type())
             .len(data_len)
             .add_buffer(offsets_buffer.into())
             .add_buffer(values.into());

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -889,7 +889,7 @@ fn take_binary<IndexType, OffsetType>(
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericBinaryArray<OffsetType>>
 where
-    OffsetType: BinaryOffsetSizeTrait,
+    OffsetType: OffsetSizeTrait,
     IndexType: ArrowNumericType,
     IndexType::Native: ToPrimitive,
 {

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -875,8 +875,7 @@ mod tests {
         export_array_into_raw, make_array, Array, ArrayData, BinaryOffsetSizeTrait,
         BooleanArray, DecimalArray, DictionaryArray, FixedSizeBinaryArray,
         FixedSizeListArray, GenericBinaryArray, GenericListArray, GenericStringArray,
-        Int32Array, OffsetSizeTrait, StringOffsetSizeTrait, Time32MillisecondArray,
-        TimestampMillisecondArray,
+        Int32Array, OffsetSizeTrait, Time32MillisecondArray, TimestampMillisecondArray,
     };
     use crate::compute::kernels;
     use crate::datatypes::{Field, Int8Type};
@@ -932,7 +931,7 @@ mod tests {
     }
     // case with nulls is tested in the docs, through the example on this module.
 
-    fn test_generic_string<Offset: StringOffsetSizeTrait>() -> Result<()> {
+    fn test_generic_string<Offset: OffsetSizeTrait>() -> Result<()> {
         // create an array natively
         let array =
             GenericStringArray::<Offset>::from(vec![Some("a"), None, Some("aaa")]);

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -872,10 +872,10 @@ impl<'a> ArrowArrayChild<'a> {
 mod tests {
     use super::*;
     use crate::array::{
-        export_array_into_raw, make_array, Array, ArrayData, BinaryOffsetSizeTrait,
-        BooleanArray, DecimalArray, DictionaryArray, FixedSizeBinaryArray,
-        FixedSizeListArray, GenericBinaryArray, GenericListArray, GenericStringArray,
-        Int32Array, OffsetSizeTrait, Time32MillisecondArray, TimestampMillisecondArray,
+        export_array_into_raw, make_array, Array, ArrayData, BooleanArray, DecimalArray,
+        DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray, GenericBinaryArray,
+        GenericListArray, GenericStringArray, Int32Array, OffsetSizeTrait,
+        Time32MillisecondArray, TimestampMillisecondArray,
     };
     use crate::compute::kernels;
     use crate::datatypes::{Field, Int8Type};
@@ -1043,7 +1043,7 @@ mod tests {
         test_generic_list::<i64>()
     }
 
-    fn test_generic_binary<Offset: BinaryOffsetSizeTrait>() -> Result<()> {
+    fn test_generic_binary<Offset: OffsetSizeTrait>() -> Result<()> {
         // create an array natively
         let array: Vec<Option<&[u8]>> = vec![Some(b"a"), None, Some(b"aaa")];
         let array = GenericBinaryArray::<Offset>::from(array);

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -143,7 +143,7 @@ pub fn create_string_dict_array<K: ArrowDictionaryKeyType>(
 }
 
 /// Creates an random (but fixed-seeded) binary array of a given size and null density
-pub fn create_binary_array<Offset: BinaryOffsetSizeTrait>(
+pub fn create_binary_array<Offset: OffsetSizeTrait>(
     size: usize,
     null_density: f32,
 ) -> GenericBinaryArray<Offset> {

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -91,7 +91,7 @@ where
 }
 
 /// Creates an random (but fixed-seeded) array of a given size and null density
-pub fn create_string_array<Offset: StringOffsetSizeTrait>(
+pub fn create_string_array<Offset: OffsetSizeTrait>(
     size: usize,
     null_density: f32,
 ) -> GenericStringArray<Offset> {
@@ -99,7 +99,7 @@ pub fn create_string_array<Offset: StringOffsetSizeTrait>(
 }
 
 /// Creates a random (but fixed-seeded) array of a given size, null density and length
-pub fn create_string_array_with_len<Offset: StringOffsetSizeTrait>(
+pub fn create_string_array_with_len<Offset: OffsetSizeTrait>(
     size: usize,
     null_density: f32,
     str_len: usize,


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1644.

# Rationale for this change

# What changes are included in this PR?

1. Remove `StringOffsetTrait` and `BinaryOffsetTrait`
2. Add `get_data_type` function for `StringArray` and `BinaryArray` (unfortunately, this function cannot be `const` because `OffsetSizeTrait::is_large` is not `const`)

# Are there any user-facing changes?
Yes. Delete 2 public traits.
