### PR TITLE
Replace `fn is_large` with `const IS_LARGE`

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -44,8 +44,11 @@ pub struct GenericBinaryArray<OffsetSize: OffsetSizeTrait> {
 }
 
 impl<OffsetSize: OffsetSizeTrait> GenericBinaryArray<OffsetSize> {
+    /// Get the data type of the array.
+    // Declare this function as `pub const fn` after
+    // https://github.com/rust-lang/rust/issues/93706 is merged.
     pub fn get_data_type() -> DataType {
-        if OffsetSize::is_large() {
+        if OffsetSize::IS_LARGE {
             DataType::LargeBinary
         } else {
             DataType::Binary
@@ -226,7 +229,7 @@ impl<'a, T: OffsetSizeTrait> GenericBinaryArray<T> {
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericBinaryArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let prefix = if OffsetSize::is_large() { "Large" } else { "" };
+        let prefix = if OffsetSize::IS_LARGE { "Large" } else { "" };
 
         write!(f, "{}BinaryArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -32,21 +32,15 @@ use crate::{
 
 /// trait declaring an offset size, relevant for i32 vs i64 array types.
 pub trait OffsetSizeTrait: ArrowNativeType + Num + Ord + std::ops::AddAssign {
-    fn is_large() -> bool;
+    const IS_LARGE: bool;
 }
 
 impl OffsetSizeTrait for i32 {
-    #[inline]
-    fn is_large() -> bool {
-        false
-    }
+    const IS_LARGE: bool = false;
 }
 
 impl OffsetSizeTrait for i64 {
-    #[inline]
-    fn is_large() -> bool {
-        true
-    }
+    const IS_LARGE: bool = true;
 }
 
 /// Generic struct for a variable-size list array.
@@ -118,7 +112,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
 
     #[inline]
     fn get_type(data_type: &DataType) -> Option<&DataType> {
-        match (OffsetSize::is_large(), data_type) {
+        match (OffsetSize::IS_LARGE, data_type) {
             (true, DataType::LargeList(child)) | (false, DataType::List(child)) => {
                 Some(child.data_type())
             }
@@ -175,7 +169,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
             .collect();
 
         let field = Box::new(Field::new("item", T::DATA_TYPE, true));
-        let data_type = if OffsetSize::is_large() {
+        let data_type = if OffsetSize::IS_LARGE {
             DataType::LargeList(field)
         } else {
             DataType::List(field)
@@ -255,7 +249,7 @@ impl<OffsetSize: 'static + OffsetSizeTrait> Array for GenericListArray<OffsetSiz
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericListArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let prefix = if OffsetSize::is_large() { "Large" } else { "" };
+        let prefix = if OffsetSize::IS_LARGE { "Large" } else { "" };
 
         write!(f, "{}ListArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -38,8 +38,11 @@ pub struct GenericStringArray<OffsetSize: OffsetSizeTrait> {
 }
 
 impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
+    /// Get the data type of the array.
+    // Declare this function as `pub const fn` after
+    // https://github.com/rust-lang/rust/issues/93706 is merged.
     pub fn get_data_type() -> DataType {
-        if OffsetSize::is_large() {
+        if OffsetSize::IS_LARGE {
             DataType::LargeUtf8
         } else {
             DataType::Utf8
@@ -273,7 +276,7 @@ impl<'a, T: OffsetSizeTrait> GenericStringArray<T> {
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericStringArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let prefix = if OffsetSize::is_large() { "Large" } else { "" };
+        let prefix = if OffsetSize::IS_LARGE { "Large" } else { "" };
 
         write!(f, "{}StringArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {

--- a/arrow/src/array/builder.rs
+++ b/arrow/src/array/builder.rs
@@ -983,7 +983,7 @@ where
             values_data.data_type().clone(),
             true, // TODO: find a consistent way of getting this
         ));
-        let data_type = if OffsetSize::is_large() {
+        let data_type = if OffsetSize::IS_LARGE {
             DataType::LargeList(field)
         } else {
             DataType::List(field)

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -339,7 +339,7 @@ fn preallocate_offset_and_binary_buffer<Offset: OffsetSizeTrait>(
     // offsets
     let mut buffer = MutableBuffer::new((1 + capacity) * mem::size_of::<Offset>());
     // safety: `unsafe` code assumes that this buffer is initialized with one element
-    if Offset::is_large() {
+    if Offset::IS_LARGE {
         buffer.push(0i64);
     } else {
         buffer.push(0i32)

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -237,7 +237,7 @@ where
         let validate_utf8 = col.converted_type() == ConvertedType::UTF8;
 
         let value_type =
-            match (V::is_large(), col.converted_type() == ConvertedType::UTF8) {
+            match (V::IS_LARGE, col.converted_type() == ConvertedType::UTF8) {
                 (true, true) => ArrowType::LargeUtf8,
                 (true, false) => ArrowType::LargeBinary,
                 (false, true) => ArrowType::Utf8,


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1658 .

# What changes are included in this PR?
Replace `fn is_large` with `const IS_LARGE`.

Unfortunately, we still can't declare `BinaryArray::get_data_type` as `const fn`. Please look at the docs.

# Are there any user-facing changes?
Yes. `fn is_large` is deleted
