### PR TITLE
Add dictionary array support for substring function

### DIFF
--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -53,7 +53,8 @@ use std::sync::Arc;
 /// ```
 ///
 /// # Error
-/// - The function errors when the passed array is not a \[Large\]String array or \[Large\]Binary array.
+/// - The function errors when the passed array is not a \[Large\]String array, \[Large\]Binary
+///   array, or DictionaryArray with \[Large\]String or \[Large\]Binary as its value type.
 /// - The function errors if the offset of a substring in the input array is at invalid char boundary (only for \[Large\]String array).
 ///
 /// ## Example of trying to get an invalid utf-8 format substring

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -74,7 +74,8 @@ pub fn substring(array: &dyn Array, start: i64, length: Option<u64>) -> Result<A
                             .as_any()
                             .downcast_ref::<DictionaryArray<$gt>>()
                             .unwrap_or_else(|| {
-                                panic!("Expect 'DictionaryArray<$gt>' but got {:?}", array)
+                                panic!("Expect 'DictionaryArray<{}>' but got array of data type {:?}",
+                                       stringify!($gt), array.data_type())
                             });
                         let values = substring(dict.values(), start, length)?;
                         let result = DictionaryArray::try_new(dict.keys(), &values)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1656.

# Rationale for this change
 
Currently the `substring` kernel only support "plain" arrays but not dictionary encoded ones. With dictionary array, the compute could be much more efficient since it only needs to be done on the dictionary values.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds the support of dictionary array for `substring` kernel.

# Are there any user-facing changes?

No