### PR TITLE
Speed up the offsets checking

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -175,3 +175,7 @@ harness = false
 [[bench]]
 name = "string_kernels"
 harness = false
+
+[[bench]]
+name = "array_data_validate"
+harness = false

--- a/arrow/benches/array_data_validate.rs
+++ b/arrow/benches/array_data_validate.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+extern crate arrow;
+
+use arrow::{array::*, buffer::Buffer, datatypes::DataType};
+
+fn create_binary_array_data(length: i32) -> ArrayData {
+    let value_buffer = Buffer::from_iter(0_i32..length);
+    let offsets_buffer = Buffer::from_iter(0_i32..length + 1);
+    ArrayData::try_new(
+        DataType::Binary,
+        length as usize,
+        None,
+        None,
+        0,
+        vec![offsets_buffer, value_buffer],
+        vec![],
+    )
+    .unwrap()
+}
+
+fn array_slice_benchmark(c: &mut Criterion) {
+    c.bench_function("validate_binary_array_data 20000", |b| {
+        b.iter(|| create_binary_array_data(20000))
+    });
+}
+
+criterion_group!(benches, array_slice_benchmark);
+criterion_main!(benches);

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1033,15 +1033,15 @@ impl ArrayData {
     }
 
     /// Calls the `validate(item_index, range)` function for each of
-    /// the ranges specified in the arrow offset buffer of type
+    /// the ranges specified in the arrow offsets buffer of type
     /// `T`. Also validates that each offset is smaller than
-    /// `max_offset`
+    /// `offset_limit`
     ///
-    /// For example, the offset buffer contained `[1, 2, 4]`, this
+    /// For example, the offsets buffer contained `[1, 2, 4]`, this
     /// function would call `validate([1,2])`, and `validate([2,4])`
     fn validate_each_offset<T, V>(
         &self,
-        offset_buffer: &Buffer,
+        offsets_buffer: &Buffer,
         offset_limit: usize,
         validate: V,
     ) -> Result<()>
@@ -1049,7 +1049,7 @@ impl ArrayData {
         T: ArrowNativeType + std::convert::TryInto<usize> + num::Num + std::fmt::Display,
         V: Fn(usize, Range<usize>) -> Result<()>,
     {
-        let offsets = self.typed_offsets::<T>(offset_buffer)?
+        let offsets = self.typed_offsets::<T>(offsets_buffer)?
             .iter()
             .enumerate()
             .map(|(i, x)| {
@@ -1059,7 +1059,7 @@ impl ArrayData {
                         "Offset invariant failure: Could not convert offset {} to usize at position {}",
                         x, i))}
                     );
-                // check if the offset exceed the limit
+                // check if the offset exceeds the limit
                 match r {
                     Ok(n) if n <= offset_limit => Ok(n),
                     Ok(_) => Err(ArrowError::InvalidArgumentError(format!(

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1089,7 +1089,7 @@ impl ArrayData {
                     Err(err) => Some(Err(err)),
                 }
             })
-            .skip(1)// the first element is meaningless
+            .skip(1) // the first element is meaningless
             .try_for_each(|res: Result<(usize, Range<usize>)>| {
                 let (item_index, range) = res?;
                 validate(item_index-1, range)

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -726,7 +726,9 @@ impl ArrayData {
     /// Returns a reference to the data in `buffer` as a typed slice
     /// (typically `&[i32]` or `&[i64]`) after validating. The
     /// returned slice is guaranteed to have at least `self.len + 1`
-    /// entries
+    /// entries.
+    ///
+    /// For an empty array, the `buffer` can also be empty`.
     fn typed_offsets<'a, T: ArrowNativeType + num::Num + std::fmt::Display>(
         &'a self,
         buffer: &'a Buffer,
@@ -1036,6 +1038,9 @@ impl ArrayData {
     /// the ranges specified in the arrow offsets buffer of type
     /// `T`. Also validates that each offset is smaller than
     /// `offset_limit`
+    ///
+    /// For an empty array, the offsets buffer can either be empty
+    /// or contain a single `0`.
     ///
     /// For example, the offsets buffer contained `[1, 2, 4]`, this
     /// function would call `validate([1,2])`, and `validate([2,4])`

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1084,7 +1084,7 @@ impl ArrayData {
                     }
                     Ok((i, end)) => Some(Err(ArrowError::InvalidArgumentError(format!(
                         "Offset invariant failure: non-monotonic offset at slot {}: {} > {}",
-                        i-1, start, end))
+                        i - 1, start, end))
                     )),
                     Err(err) => Some(Err(err)),
                 }

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1808,6 +1808,90 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_utf8_array_with_empty_offsets_buffer() {
+        let data_buffer = Buffer::from(&[]);
+        let offsets_buffer = Buffer::from(&[]);
+        ArrayData::try_new(
+            DataType::Utf8,
+            0,
+            None,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_empty_utf8_array_with_single_zero_offset() {
+        let data_buffer = Buffer::from(&[]);
+        let offsets_buffer = Buffer::from_slice_ref(&[0i32]);
+        ArrayData::try_new(
+            DataType::Utf8,
+            0,
+            None,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "First offset 1 of Utf8 is larger than values length 0")]
+    fn test_empty_utf8_array_with_invalid_offset() {
+        let data_buffer = Buffer::from(&[]);
+        let offsets_buffer = Buffer::from_slice_ref(&[1i32]);
+        ArrayData::try_new(
+            DataType::Utf8,
+            0,
+            None,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_empty_utf8_array_with_non_zero_offset() {
+        let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+        let offsets_buffer = Buffer::from_slice_ref(&[0i32, 2, 6, 0]);
+        ArrayData::try_new(
+            DataType::Utf8,
+            0,
+            None,
+            None,
+            3,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Offsets buffer size (bytes): 4 isn't large enough for LargeUtf8. Length 0 needs 1"
+    )]
+    fn test_empty_large_utf8_array_with_wrong_type_offsets() {
+        let data_buffer = Buffer::from(&[]);
+        let offsets_buffer = Buffer::from_slice_ref(&[0i32]);
+        ArrayData::try_new(
+            DataType::LargeUtf8,
+            0,
+            None,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+    }
+
+    #[test]
     #[should_panic(
         expected = "Offsets buffer size (bytes): 8 isn't large enough for Utf8. Length 2 needs 3"
     )]

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -728,7 +728,7 @@ impl ArrayData {
     /// returned slice is guaranteed to have at least `self.len + 1`
     /// entries.
     ///
-    /// For an empty array, the `buffer` can also be empty`.
+    /// For an empty array, the `buffer` can also be empty.
     fn typed_offsets<'a, T: ArrowNativeType + num::Num + std::fmt::Display>(
         &'a self,
         buffer: &'a Buffer,


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1675.
Re #1620.

# Rationale for this change
Originally, in each iteration, we fully check `start_offset` and `end_offset`, which means that all elements (except the first and the last) in the `offsets_buffer` are checked twice. This is somewhat wasteful.

# What changes are included in this PR?
1. Hoist some checking outside the `window` iteration.
2. Update some error messages.
3. Add docs and tests for empty binary-like array. (As Arrow tends to be ambiguous in this case. I keep the current implementation. We can change it in the future, or in #1620).
4. Add a benchmark for offsets checking.

# Are there any user-facing changes?
No.

# Benchmark result
```
Gnuplot not found, using plotters backend
validate_binary_array_data 20000                                                                             
                        time:   [35.595 us 35.650 us 35.712 us]
                        change: [-17.373% -17.034% -16.724%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```