### PR TITLE
fix bench command line options

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -35,6 +35,7 @@ rust-version = "1.57"
 [lib]
 name = "arrow"
 path = "src/lib.rs"
+bench = false
 
 [dependencies]
 serde = { version = "1.0" }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -89,3 +89,6 @@ harness = false
 name = "arrow_reader"
 required-features = ["test_common", "experimental"]
 harness = false
+
+[lib]
+bench = false


### PR DESCRIPTION
I working for https://github.com/apache/arrow-rs/issues/1660

fix to criterion bench not accepts options

```
error: Unrecognized option: 'save-baseline'
error: bench failed
```
https://github.com/bheisler/criterion.rs/issues/193#issuecomment-415740713

# Which issue does this PR close?

None

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

not working `cargo bench -- --save-baseline tag` and `cargo bench -- --baseline tag`.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
add `bench = false` to Cargo.toml `[lib]`

