### PR TITLE
Add gRPC service reflection support to arrow flight

### DIFF
--- a/arrow-flight/build.rs
+++ b/arrow-flight/build.rs
@@ -19,10 +19,12 @@ use std::{
     env,
     fs::OpenOptions,
     io::{Read, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto_descriptor.bin");
+
     // override the build location, in order to check in the changes to proto files
     env::set_var("OUT_DIR", "src");
 
@@ -37,6 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let proto_path = Path::new("../format/Flight.proto");
 
         tonic_build::configure()
+            .file_descriptor_set_path(&descriptor_path)
             // protoc in unbuntu builder needs this option
             .protoc_arg("--experimental_allow_proto3_optional")
             .compile(&[proto_path], &[proto_dir])?;
@@ -69,6 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let proto_path = Path::new("../format/FlightSql.proto");
 
         tonic_build::configure()
+            .file_descriptor_set_path(&descriptor_path)
             // protoc in unbuntu builder needs this option
             .protoc_arg("--experimental_allow_proto3_optional")
             .compile(&[proto_path], &[proto_dir])?;

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -229,7 +229,7 @@ pub mod flight_service_client {
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
-        T::ResponseBody: Default + Body<Data = Bytes> + Send + 'static,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
@@ -242,6 +242,7 @@ pub mod flight_service_client {
         ) -> FlightServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
                 Response = http::Response<


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1706

# Rationale for this change
We like to use the gRPC service reflection, via  `grpcurl --plaintext localhost:8082 list`, to list gRPC services in IOx

We have a flight based service that does not appear in the service list (see https://github.com/influxdata/influxdb_iox/issues/4543)

I think this is because the arrow-flight library doesn't create the appropriate descriptors, but I am not sure

# What changes are included in this PR?

Try to generate the appropriate service descriptor

# Are there any user-facing changes?
Can now use reflection (if using https://crates.io/crates/tonic-reflection)