### PR TITLE
Fix docs.rs build

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -63,7 +63,6 @@ arrow = { path = "../arrow", version = "13.0.0", default-features = false, featu
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -121,7 +121,6 @@ pub mod arrow_writer;
 mod bit_util;
 
 #[cfg(feature = "async")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "async")))]
 pub mod async_reader;
 
 experimental_mod!(converter);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1695

# Rationale for this change
 
I broke docs.rs build by merging https://github.com/apache/arrow-rs/pull/1349 without testing it first (shame on me!)

# What changes are included in this PR?

Fix the build by removing unneeded part of 1349

I tested this by temporarily publishing an ancient version of parquet to crates.io from this branch https://github.com/alamb/arrow-rs/tree/alamb/test_crates_publish and verifying the docs built correctly

You can see the results here:
* https://crates.io/crates/parquet/0.18.1
* https://docs.rs/parquet/0.18.1/parquet/

# Are there any user-facing changes?
Docs will work correctly when published on crates.io

cc @HaoYang670 @viirya @tustvold 