### PR TITLE
Minor: Refine `OffsetSizeTrait` to extend `num::Integer` 

### DIFF
--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -18,7 +18,7 @@
 use std::any::Any;
 use std::fmt;
 
-use num::Num;
+use num::Integer;
 
 use super::{
     array::print_long_array, make_array, raw_pointer::RawPtrBox, Array, ArrayData,
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// trait declaring an offset size, relevant for i32 vs i64 array types.
-pub trait OffsetSizeTrait: ArrowNativeType + Num + Ord + std::ops::AddAssign {
+pub trait OffsetSizeTrait: ArrowNativeType + std::ops::AddAssign + Integer {
     const IS_LARGE: bool;
 }
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?
None.

# Rationale for this change
Offsets are always integers, so `OffsetSizeTrait` should be a superset of `Interger`.

# What changes are included in this PR?
Add `Integer`, remove `Num` and `Ord`.

# Are there any user-facing changes?
No.