### PR TITLE
Fix: Null buffer accounts for `offset` in `substring` kernel.

### DIFF
--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -561,9 +561,12 @@ mod tests {
 
     fn generic_binary_with_non_zero_offset<O: OffsetSizeTrait>() -> Result<()> {
         let values = 0_u8..15;
-        let one = O::one();
-        let five = one + one + one + one + one;
-        let offsets = &[O::zero(), five, five + five, five + five + five];
+        let offsets = &[
+            O::zero(),
+            O::from_usize(5).unwrap(),
+            O::from_usize(10).unwrap(),
+            O::from_usize(15).unwrap(),
+        ];
         // set the first and third element to be valid
         let bitmap = [0b101_u8];
 
@@ -1040,9 +1043,12 @@ mod tests {
 
     fn generic_string_with_non_zero_offset<O: OffsetSizeTrait>() -> Result<()> {
         let values = "hellotherearrow";
-        let one = O::one();
-        let five = one + one + one + one + one;
-        let offsets = &[O::zero(), five, five + five, five + five + five];
+        let offsets = &[
+            O::zero(),
+            O::from_usize(5).unwrap(),
+            O::from_usize(10).unwrap(),
+            O::from_usize(15).unwrap(),
+        ];
         // set the first and third element to be valid
         let bitmap = [0b101_u8];
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1639.

# Rationale for this change
 The null buffer was not aligned with the `offset` of array.

# What changes are included in this PR?
Use `bit_slice` to align the null buffer.
Add tests to test the alignment.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
