### PR TITLE
Remove `null_count` from `ArrayData::try_new()`

### DIFF
--- a/arrow/benches/array_data_validate.rs
+++ b/arrow/benches/array_data_validate.rs
@@ -30,7 +30,6 @@ fn create_binary_array_data(length: i32) -> ArrayData {
         DataType::Binary,
         length as usize,
         None,
-        None,
         0,
         vec![offsets_buffer, value_buffer],
         vec![],

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -1252,7 +1252,6 @@ mod tests {
             DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
             8,
             None,
-            None,
             0,
             vec![list_value_offsets],
             vec![expected_int_array.data().clone()],
@@ -1333,7 +1332,6 @@ mod tests {
         let expected_list_data = ArrayData::try_new(
             DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
             12,
-            None,
             Some(Buffer::from(&[0b11011011, 0b1110])),
             0,
             vec![list_value_offsets],
@@ -1484,7 +1482,6 @@ mod tests {
                 false,
             ),
             12,
-            None,
             Some(Buffer::from(&[0b11011011, 0b1110])),
             0,
             vec![map_offsets],
@@ -1556,7 +1553,6 @@ mod tests {
         let expected_list_data = ArrayData::try_new(
             DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
             6,
-            None,
             None,
             0,
             vec![list_value_offsets],

--- a/arrow/src/compute/util.rs
+++ b/arrow/src/compute/util.rs
@@ -190,7 +190,6 @@ pub(super) mod tests {
             ArrayData::try_new(
                 DataType::UInt8,
                 len,
-                None,
                 null_bit_buffer,
                 offset,
                 vec![buffer],


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #911.

# Rationale for this change
Avoid the inconsistency of between `ArrayData::null_count` and `ArrayData::null_nit_buffer`.

(Sadly, we could not do any simplification in `ArrayData::validate`.)


# Are there any user-facing changes?
The API of `ArrayData::try_new()`
