### PR TITLE
Fix BitReader::get_batch zero extension (#1708)

### DIFF
--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -584,10 +584,10 @@ impl BitReader {
                 in_ptr = unsafe { unpack32(in_ptr, out_ptr, num_bits) };
                 self.byte_offset += 4 * num_bits;
 
-                for (batch, out) in batch.iter_mut().zip(out_buf) {
+                for out in out_buf {
                     // Zero-allocate buffer
                     let mut out_bytes = T::Buffer::default();
-                    let in_bytes = out.to_ne_bytes();
+                    let in_bytes = out.to_le_bytes();
 
                     {
                         let out_bytes = out_bytes.as_mut();
@@ -595,10 +595,9 @@ impl BitReader {
                         (&mut out_bytes[..len]).copy_from_slice(&in_bytes[..len]);
                     }
 
-                    *batch = T::from_ne_bytes(out_bytes);
+                    batch[i] = T::from_le_bytes(out_bytes);
+                    i += 1;
                 }
-
-                i += 32;
             }
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1708.

# Rationale for this change

`unpack32` as used by `BitReader::get_batch` always decodes to an array of 32, 32-bit integers. If the type being read is a different size it will read to a temporary buffer and then either truncate or zero-extend the data.

An oversight meant that instead of zero-extending, it would just set up to the first 4 bytes, and leave any remaining bytes alone.

In practice this didn't matter as we were only using this for decoding 16-bit levels, however, with #1284 the DeltaBitPackDecoder was changed to also use this method. As this does get used with 64-bit types, buffer reuse could easily lead to garbage data on decode.

# What changes are included in this PR?

Fixes `BitReader::get_batch` to correctly zero-extend, and reduces the use of unsafe in the process.

# Are there any user-facing changes?

No
