### PR TITLE
Pin nightly version to bypass packed_simd build error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly]
+        rust: [nightly-2022-05-23]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -355,7 +355,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly]
+        rust: [nightly-2022-05-23]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -400,7 +400,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly]
+        rust: [nightly-2022-05-23]
     container:
       image: ${{ matrix.arch }}/rust
       env:


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1734.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There is building error on `packed_simd` with latest `nightly`.  Before `packed_simd` publishes new release, our CI will be blocked by the errors. This is to unblock PRs.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
