### PR TITLE
Rename `string_concat` to `concat_elements_utf8`

### DIFF
--- a/arrow/src/compute/kernels/concat_elements.rs
+++ b/arrow/src/compute/kernels/concat_elements.rs
@@ -33,7 +33,7 @@ use crate::error::{ArrowError, Result};
 /// ```
 ///
 /// An error will be returned if `left` and `right` have different lengths
-pub fn concat_elements_string<Offset: OffsetSizeTrait>(
+pub fn concat_elements_utf8<Offset: OffsetSizeTrait>(
     left: &GenericStringArray<Offset>,
     right: &GenericStringArray<Offset>,
 ) -> Result<GenericStringArray<Offset>> {
@@ -101,7 +101,7 @@ mod tests {
             .into_iter()
             .collect::<StringArray>();
 
-        let output = concat_elements_string(&left, &right).unwrap();
+        let output = concat_elements_utf8(&left, &right).unwrap();
 
         let expected = [None, Some("baryyy"), None]
             .into_iter()
@@ -119,7 +119,7 @@ mod tests {
             .into_iter()
             .collect::<StringArray>();
 
-        let output = concat_elements_string(&left, &right).unwrap();
+        let output = concat_elements_utf8(&left, &right).unwrap();
 
         let expected = [Some("foobaz"), Some(""), Some("bar")]
             .into_iter()
@@ -133,7 +133,7 @@ mod tests {
         let left = StringArray::from(vec!["foo", "bar"]);
         let right = StringArray::from(vec!["bar", "baz"]);
 
-        let output = concat_elements_string(&left, &right).unwrap();
+        let output = concat_elements_utf8(&left, &right).unwrap();
 
         let expected = StringArray::from(vec!["foobar", "barbaz"]);
 
@@ -145,7 +145,7 @@ mod tests {
         let left = StringArray::from(vec!["foo", "bar"]);
         let right = StringArray::from(vec!["baz"]);
 
-        let output = concat_elements_string(&left, &right);
+        let output = concat_elements_utf8(&left, &right);
 
         assert!(output.is_err());
     }
@@ -157,7 +157,7 @@ mod tests {
 
         let left_slice = left.slice(0, 3);
         let right_slice = right.slice(1, 3);
-        let output = concat_elements_string(
+        let output = concat_elements_utf8(
             left_slice
                 .as_any()
                 .downcast_ref::<GenericStringArray<i32>>()
@@ -178,7 +178,7 @@ mod tests {
         let left_slice = left.slice(2, 2);
         let right_slice = right.slice(1, 2);
 
-        let output = concat_elements_string(
+        let output = concat_elements_utf8(
             left_slice
                 .as_any()
                 .downcast_ref::<GenericStringArray<i32>>()

--- a/arrow/src/compute/kernels/concat_elements.rs
+++ b/arrow/src/compute/kernels/concat_elements.rs
@@ -19,9 +19,10 @@ use crate::array::*;
 use crate::compute::util::combine_option_bitmap;
 use crate::error::{ArrowError, Result};
 
-/// Returns the elementwise concatenation of `StringArray`.
+/// Returns the elementwise concatenation of a [`StringArray`].
 ///
-/// An index of the resulting `StringArray` is null if any of `StringArray` are null at that location.
+/// An index of the resulting [`StringArray`] is null if any of
+/// `StringArray` are null at that location.
 ///
 /// ```text
 /// e.g:
@@ -31,8 +32,8 @@ use crate::error::{ArrowError, Result};
 ///   ["a", "b"] + [None, "c"] = [None, "bc"]
 /// ```
 ///
-/// Attention: `left` and `right` must have the same length.
-pub fn string_concat<Offset: OffsetSizeTrait>(
+/// An error will be returned if `left` and `right` have different lengths
+pub fn concat_elements_string<Offset: OffsetSizeTrait>(
     left: &GenericStringArray<Offset>,
     right: &GenericStringArray<Offset>,
 ) -> Result<GenericStringArray<Offset>> {
@@ -100,7 +101,7 @@ mod tests {
             .into_iter()
             .collect::<StringArray>();
 
-        let output = string_concat(&left, &right).unwrap();
+        let output = concat_elements_string(&left, &right).unwrap();
 
         let expected = [None, Some("baryyy"), None]
             .into_iter()
@@ -118,7 +119,7 @@ mod tests {
             .into_iter()
             .collect::<StringArray>();
 
-        let output = string_concat(&left, &right).unwrap();
+        let output = concat_elements_string(&left, &right).unwrap();
 
         let expected = [Some("foobaz"), Some(""), Some("bar")]
             .into_iter()
@@ -132,7 +133,7 @@ mod tests {
         let left = StringArray::from(vec!["foo", "bar"]);
         let right = StringArray::from(vec!["bar", "baz"]);
 
-        let output = string_concat(&left, &right).unwrap();
+        let output = concat_elements_string(&left, &right).unwrap();
 
         let expected = StringArray::from(vec!["foobar", "barbaz"]);
 
@@ -144,7 +145,7 @@ mod tests {
         let left = StringArray::from(vec!["foo", "bar"]);
         let right = StringArray::from(vec!["baz"]);
 
-        let output = string_concat(&left, &right);
+        let output = concat_elements_string(&left, &right);
 
         assert!(output.is_err());
     }
@@ -156,7 +157,7 @@ mod tests {
 
         let left_slice = left.slice(0, 3);
         let right_slice = right.slice(1, 3);
-        let output = string_concat(
+        let output = concat_elements_string(
             left_slice
                 .as_any()
                 .downcast_ref::<GenericStringArray<i32>>()
@@ -177,7 +178,7 @@ mod tests {
         let left_slice = left.slice(2, 2);
         let right_slice = right.slice(1, 2);
 
-        let output = string_concat(
+        let output = concat_elements_string(
             left_slice
                 .as_any()
                 .downcast_ref::<GenericStringArray<i32>>()


### PR DESCRIPTION
# Which issue does this PR close?
re https://github.com/apache/arrow-rs/issues/1747


# Rationale for this change
 
Per suggestion from @tustvold  here https://github.com/apache/arrow-rs/pull/1752#issuecomment-1138724644

The idea is to have a naming scheme that is consistent with other kernels such as `eq_utf8` 

It also allows us to add a `concat_elements_dyn` to work with dynamic array types, which I will track in a moment

# What changes are included in this PR?
Rename `string_concat` to `concat_elements_utf8`


# Are there any user-facing changes?
No, code is not yet released

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
