### PR TITLE
Improve ParquetFileArrowReader UX

### DIFF
--- a/parquet/src/arrow/arrow_reader.rs
+++ b/parquet/src/arrow/arrow_reader.rs
@@ -32,6 +32,7 @@ use crate::arrow::ProjectionMask;
 use crate::errors::Result;
 use crate::file::metadata::{KeyValue, ParquetMetaData};
 use crate::file::reader::FileReader;
+use crate::schema::types::SchemaDescriptor;
 
 /// Arrow reader api.
 /// With this api, user can get arrow schema from parquet file, and read parquet data
@@ -164,8 +165,19 @@ impl ParquetFileArrowReader {
     }
 
     /// Expose the reader metadata
+    #[deprecated = "use metadata() instead"]
     pub fn get_metadata(&mut self) -> ParquetMetaData {
         self.file_reader.metadata().clone()
+    }
+
+    /// Returns the parquet metadata
+    pub fn metadata(&self) -> &ParquetMetaData {
+        self.file_reader.metadata()
+    }
+
+    /// Returns the parquet schema
+    pub fn parquet_schema(&self) -> &SchemaDescriptor {
+        self.file_reader.metadata().file_metadata().schema_descr()
     }
 
     /// Returns the key value metadata, returns `None` if [`ArrowReaderOptions::skip_arrow_metadata`]


### PR DESCRIPTION
# Which issue does this PR close?

Follow on from #1716

# Rationale for this change
 
As pointed out by @alamb https://github.com/influxdata/influxdb_iox/pull/4743/files/5fccaab1f94f7e5b8b69ab35ea11c151cb1b8a2d#r885642739 the UX of getting the parquet schema from a ParquetFileArrowReader is not great.

# What changes are included in this PR?

Adds a parquet_schema member function that returns the schema.

It also deprecates the get_metadata function, as it doesn't need a mutable reference nor to return a clone, and replaces it with a `metadata` function that is consistent with the equivalent method on FileReader.

# Are there any user-facing changes?

A function is deprecated