### PR TITLE
Access metadata of flushed row groups on write (#1691)

### DIFF
--- a/parquet/src/arrow/arrow_writer.rs
+++ b/parquet/src/arrow/arrow_writer.rs
@@ -36,6 +36,7 @@ use super::schema::{
 use crate::arrow::levels::calculate_array_levels;
 use crate::column::writer::ColumnWriter;
 use crate::errors::{ParquetError, Result};
+use crate::file::metadata::RowGroupMetaDataPtr;
 use crate::file::properties::WriterProperties;
 use crate::file::writer::{SerializedColumnWriter, SerializedRowGroupWriter};
 use crate::{data_type::*, file::writer::SerializedFileWriter};
@@ -93,6 +94,11 @@ impl<W: Write> ArrowWriter<W> {
             arrow_schema,
             max_row_group_size,
         })
+    }
+
+    /// Returns metadata for any flushed row groups
+    pub fn flushed_row_groups(&self) -> &[RowGroupMetaDataPtr] {
+        self.writer.flushed_row_groups()
     }
 
     /// Enqueues the provided `RecordBatch` to be written

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -217,7 +217,7 @@ impl FileMetaData {
 pub type RowGroupMetaDataPtr = Arc<RowGroupMetaData>;
 
 /// Metadata for a row group.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RowGroupMetaData {
     columns: Vec<ColumnChunkMetaData>,
     num_rows: i64,

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -153,6 +153,11 @@ impl<W: Write> SerializedFileWriter<W> {
         Ok(row_group_writer)
     }
 
+    /// Returns metadata for any flushed row groups
+    pub fn flushed_row_groups(&self) -> &[RowGroupMetaDataPtr] {
+        &self.row_groups
+    }
+
     /// Closes and finalises file writer, returning the file metadata.
     ///
     /// All row groups must be appended before this method is called.

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1004,7 +1004,7 @@ mod tests {
         );
         let mut rows: i64 = 0;
 
-        for subset in &data {
+        for (idx, subset) in data.iter().enumerate() {
             let mut row_group_writer = file_writer.next_row_group().unwrap();
             if let Some(mut writer) = row_group_writer.next_column().unwrap() {
                 rows += writer
@@ -1013,7 +1013,10 @@ mod tests {
                     .unwrap() as i64;
                 writer.close().unwrap();
             }
-            row_group_writer.close().unwrap();
+            let last_group = row_group_writer.close().unwrap();
+            let flushed = file_writer.flushed_row_groups();
+            assert_eq!(flushed.len(), idx + 1);
+            assert_eq!(flushed[idx].as_ref(), last_group.as_ref());
         }
         file_writer.close().unwrap();
 

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -838,6 +838,7 @@ impl ColumnDescriptor {
 
 /// A schema descriptor. This encapsulates the top-level schemas for all the columns,
 /// as well as all descriptors for all the primitive columns.
+#[derive(PartialEq)]
 pub struct SchemaDescriptor {
     // The top-level schema (the "message" type).
     // This must be a `GroupType` where each field is a root column type in the schema.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1691

@pacman82 please let me know if this provides the necessary functionality

# Rationale for this change
 
Provides information on data that has already been written, to allow for adaptive writing policies

# What changes are included in this PR?

Adds the ability to fetch metadata about flushed row groups

# Are there any user-facing changes?

No
