### PR TITLE
csv::infer_file_schema remove redundant ref

### DIFF
--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -120,7 +120,7 @@ pub struct ReaderOptions {
 /// Return inferred schema and number of records used for inference. This function does not change
 /// reader cursor offset.
 pub fn infer_file_schema<R: Read + Seek>(
-    reader: &mut R,
+    reader: R,
     delimiter: u8,
     max_read_records: Option<usize>,
     has_header: bool,
@@ -136,7 +136,7 @@ pub fn infer_file_schema<R: Read + Seek>(
 }
 
 fn infer_file_schema_with_csv_options<R: Read + Seek>(
-    reader: &mut R,
+    mut reader: R,
     roptoins: ReaderOptions,
 ) -> Result<(Schema, usize)> {
     let saved_offset = reader.seek(SeekFrom::Current(0))?;
@@ -155,7 +155,7 @@ fn infer_file_schema_with_csv_options<R: Read + Seek>(
 ///
 /// Return infered schema and number of records used for inference.
 pub fn infer_reader_schema<R: Read>(
-    reader: &mut R,
+    reader: R,
     delimiter: u8,
     max_read_records: Option<usize>,
     has_header: bool,
@@ -170,7 +170,7 @@ pub fn infer_reader_schema<R: Read>(
 }
 
 fn infer_reader_schema_with_csv_options<R: Read>(
-    reader: &mut R,
+    reader: R,
     roptions: ReaderOptions,
 ) -> Result<(Schema, usize)> {
     let mut csv_reader = Reader::build_csv_reader(

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -137,11 +137,12 @@ pub fn infer_file_schema<R: Read + Seek>(
 
 fn infer_file_schema_with_csv_options<R: Read + Seek>(
     mut reader: R,
-    roptoins: ReaderOptions,
+    roptions: ReaderOptions,
 ) -> Result<(Schema, usize)> {
     let saved_offset = reader.seek(SeekFrom::Current(0))?;
 
-    let (schema, records_count) = infer_reader_schema_with_csv_options(reader, roptoins)?;
+    let (schema, records_count) =
+        infer_reader_schema_with_csv_options(&mut reader, roptions)?;
     // return the reader seek back to the start
     reader.seek(SeekFrom::Start(saved_offset))?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
The `std::io::Read/Write/Seek` traits have blanket implementations for `&mut T` - see [here](https://doc.rust-lang.org/std/io/trait.Read.html#impl-Read-13) and so there is no reason to force callers to pass in an `&mut`. In fact it makes for worse ergonomics as it prevents passing in an owned type

# What changes are included in this PR?

Removes unnecessary `&mut`

# Are there any user-facing changes?

No
