### PR TITLE
Fix typos in the Memory and Buffers section of the docs home

### DIFF
--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -72,8 +72,8 @@
 //!
 //! Data in [`Array`](array::Array) is stored in [`ArrayData`](array::ArrayData), that in turn
 //! is a collection of other [`ArrayData`](array::ArrayData) and [`Buffers`](buffer::Buffer).
-//! [`Buffers`](buffer::Buffer) is the central struct that array implementations use keep allocated memory and pointers.
-//! The [`MutableBuffer`](buffer::MutableBuffer) is the mutable counter-part of[`Buffer`](buffer::Buffer).
+//! [`Buffers`](buffer::Buffer) is the central struct that array implementations use to keep allocated memory and pointers.
+//! The [`MutableBuffer`](buffer::MutableBuffer) is the mutable counter-part of [`Buffer`](buffer::Buffer).
 //! These are the lowest abstractions of this crate, and are used throughout the crate to
 //! efficiently allocate, write, read and deallocate memory.
 //!


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
Just fixing couple of minor typos in https://docs.rs/arrow/latest/arrow/index.html#memory-and-buffers

# Are there any user-facing changes?

No
