### PR TITLE
Further seal the `OffsetSizeTrait`

### DIFF
--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -47,7 +47,7 @@ impl OffsetSizeTrait for i64 {
 }
 
 mod private {
-    /// Prevent users from implementing the [`OffsetSizeTrait`].
+    /// Prevent users from implementing the [`super::OffsetSizeTrait`].
     pub trait Sealed {}
     impl Sealed for i32 {}
     impl Sealed for i64 {}

--- a/arrow/src/array/array_list.rs
+++ b/arrow/src/array/array_list.rs
@@ -30,8 +30,11 @@ use crate::{
     error::ArrowError,
 };
 
-/// trait declaring an offset size, relevant for i32 vs i64 array types.
-pub trait OffsetSizeTrait: ArrowNativeType + std::ops::AddAssign + Integer {
+/// [`OffsetSizeTrait`] describes types that can be used as offsets.
+/// This trait is sealed and cannot be implemented for types except [`i32`] and [`i64`].
+pub trait OffsetSizeTrait:
+    ArrowNativeType + std::ops::AddAssign + Integer + private::Sealed
+{
     const IS_LARGE: bool;
 }
 
@@ -41,6 +44,13 @@ impl OffsetSizeTrait for i32 {
 
 impl OffsetSizeTrait for i64 {
     const IS_LARGE: bool = true;
+}
+
+mod private {
+    /// Prevent users from implementing the [`OffsetSizeTrait`].
+    pub trait Sealed {}
+    impl Sealed for i32 {}
+    impl Sealed for i64 {}
 }
 
 /// Generic struct for a variable-size list array.


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

This is a follow-up PR of #1819.

# Rationale for this change
 `OffsetSizeTrait` should only be implemented for `i32` and `i64`

# What changes are included in this PR?
1. seal the `OffsetSizeTrait`
2. update docs

# Are there any user-facing changes?
Yes.

## verify

```rust
impl OffsetSizeTrait for u32 {
    const IS_LARGE: bool = false;
}
```
gives compile error
```
error[E0277]: the trait bound `u32: array_list::private::Sealed` is not satisfied
  --> arrow/src/array/array_list.rs:49:6
   |
49 | impl OffsetSizeTrait for u32 {
   |      ^^^^^^^^^^^^^^^ the trait `array_list::private::Sealed` is not implemented for `u32`
   |
   = help: the following implementations were found:
             <i32 as array_list::private::Sealed>
             <i64 as array_list::private::Sealed>
note: required by a bound in `array_list::OffsetSizeTrait`
  --> arrow/src/array/array_list.rs:36:55
   |
35 | pub trait OffsetSizeTrait:
   |           --------------- required by a bound in this
36 |     ArrowNativeType + std::ops::AddAssign + Integer + private::Sealed
   |                                                       ^^^^^^^^^^^^^^^ required by this bound in `array_list::OffsetSizeTrait`
```
, which is good!
