### PR TITLE
Update MIRI pin

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -26,20 +26,15 @@ jobs:
   miri-checks:
     name: MIRI
     runs-on: ubuntu-latest
-    strategy:
-      # Consult https://rust-lang.github.io/rustup-components-history/ to see compatible versions
-      matrix:
-        arch: [ amd64 ]
-        rust: [ nightly-2022-06-08 ]
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt clippy miri
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
       - name: Run Miri Checks
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -27,9 +27,10 @@ jobs:
     name: MIRI
     runs-on: ubuntu-latest
     strategy:
+      # Consult https://rust-lang.github.io/rustup-components-history/ to see compatible versions
       matrix:
-        arch: [amd64]
-        rust: [nightly-2022-01-17]
+        arch: [ amd64 ]
+        rust: [ nightly-2022-06-08 ]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
The git history does not really indicate why this was pinned, so lets unpin and see what breaks. This is currently blocking #1822 

# What changes are included in this PR?

Unpins miri version used in CI

# Are there any user-facing changes?

No
