### PR TITLE
Improve comparison of struct fields

### DIFF
--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -62,7 +62,7 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef> {
 
     if arrays
         .iter()
-        .any(|array| array.data_type() != arrays[0].data_type())
+        .any(|array| !array.data_type().equals_datatype(arrays[0].data_type()))
     {
         return Err(ArrowError::InvalidArgumentError(
             "It is not possible to concatenate arrays of different data types."

--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -62,7 +62,7 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef> {
 
     if arrays
         .iter()
-        .any(|array| !array.data_type().compatible_datatype(arrays[0].data_type()))
+        .any(|array| array.data_type() != arrays[0].data_type())
     {
         return Err(ArrowError::InvalidArgumentError(
             "It is not possible to concatenate arrays of different data types."

--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -62,7 +62,7 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef> {
 
     if arrays
         .iter()
-        .any(|array| !array.data_type().equals_datatype(arrays[0].data_type()))
+        .any(|array| !array.data_type().compatible_datatype(arrays[0].data_type()))
     {
         return Err(ArrowError::InvalidArgumentError(
             "It is not possible to concatenate arrays of different data types."

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -675,19 +675,19 @@ impl DataType {
             (DataType::List(a), DataType::List(b))
             | (DataType::LargeList(a), DataType::LargeList(b)) => {
                 a.is_nullable() == b.is_nullable()
-                    && a.data_type().equals_datatype(b.data_type())
+                    && a.data_type().compatible_datatype(b.data_type())
             }
             (DataType::FixedSizeList(a, a_size), DataType::FixedSizeList(b, b_size)) => {
                 a_size == b_size
                     && a.is_nullable() == b.is_nullable()
-                    && a.data_type().equals_datatype(b.data_type())
+                    && a.data_type().compatible_datatype(b.data_type())
             }
             (DataType::Struct(a), DataType::Struct(b)) => {
                 a.iter()
                     .all(|a| match b.iter().find(|f| f.name().eq(a.name())) {
                         Some(b) => {
                             a.is_nullable() == b.is_nullable()
-                                && a.data_type().equals_datatype(b.data_type())
+                                && a.data_type().compatible_datatype(b.data_type())
                         }
                         None => a.is_nullable(),
                     })
@@ -695,7 +695,7 @@ impl DataType {
                         .all(|b| match a.iter().find(|f| f.name().eq(b.name())) {
                             Some(a) => {
                                 a.is_nullable() == b.is_nullable()
-                                    && a.data_type().equals_datatype(b.data_type())
+                                    && a.data_type().compatible_datatype(b.data_type())
                             }
                             None => b.is_nullable(),
                         })


### PR DESCRIPTION
Currently if the order of fields in struct is different, it will fail.
This fix will lookup fields, ignoring the field order and length and
fail if not nullable.

Array data type comparison will use the equals_datatype instead of
comparing enums.

This fix work towards closing of https://github.com/apache/arrow-datafusion/issues/2326.

@alamb 
