### PR TITLE
MINOR: Remove version check from `test_command_help`

### DIFF
--- a/parquet/src/bin/parquet-fromcsv-help.txt
+++ b/parquet/src/bin/parquet-fromcsv-help.txt
@@ -1,4 +1,3 @@
-parquet 15.0.0
 Apache Arrow <dev@arrow.apache.org>
 Binary to convert csv to Parquet
 

--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -403,6 +403,7 @@ mod tests {
         let mut buffer_vec = Vec::new();
         let mut buffer = std::io::Cursor::new(&mut buffer_vec);
         cmd.write_long_help(&mut buffer).unwrap();
+        // Remove Parquet version string from the help text
         let mut actual = String::from_utf8(buffer_vec).unwrap();
         let pos = actual.find('\n').unwrap() + 1;
         actual = actual[pos..].to_string();

--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -403,7 +403,9 @@ mod tests {
         let mut buffer_vec = Vec::new();
         let mut buffer = std::io::Cursor::new(&mut buffer_vec);
         cmd.write_long_help(&mut buffer).unwrap();
-        let actual = String::from_utf8(buffer_vec).unwrap();
+        let mut actual = String::from_utf8(buffer_vec).unwrap();
+        let pos = actual.find('\n').unwrap() + 1;
+        actual = actual[pos..].to_string();
         assert_eq!(
             expected, actual,
             "help text not match. please update to \n---\n{}\n---\n",


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

It causes test failure in CI after version upgrading:

```
---- tests::test_command_help stdout ----
thread 'tests::test_command_help' panicked at 'assertion failed: `(left == right)`
  left: `"parquet 15.0.0
  ...
   right: `"parquet 16.0.0
```

Seems not necessary to have a version there and ask for updating the file each time.



# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
