### PR TITLE
Add vec-inspired APIs to BufferBuilder (#1850)

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -30,7 +30,11 @@ use std::ptr::NonNull;
 /// along cache lines and in multiple of 64 bytes.
 /// Use [MutableBuffer::push] to insert an item, [MutableBuffer::extend_from_slice]
 /// to insert many items, and `into` to convert it to [`Buffer`].
+///
+/// For a safe, strongly typed API consider using [`crate::array::BufferBuilder`]
+///
 /// # Example
+///
 /// ```
 /// # use arrow::buffer::{Buffer, MutableBuffer};
 /// let mut buffer = MutableBuffer::new(0);
@@ -150,6 +154,17 @@ impl MutableBuffer {
             self.data = ptr;
             self.capacity = new_capacity;
         }
+    }
+
+    /// Truncates this buffer to `len` bytes
+    ///
+    /// If `len` is greater than the buffer's current length, this has no effect
+    #[inline(always)]
+    pub fn truncate(&mut self, len: usize) {
+        if len > self.len {
+            return;
+        }
+        self.len = len;
     }
 
     /// Resizes the buffer, either truncating its contents (with no change in capacity), or


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1850

# Rationale for this change
 
This adds vec-inspired APIs to BufferBuilder, which will allow removing a non-trivial amount of custom code from the parquet reader, and opens up some interesting future possibilities (e.g. #1851)

# What changes are included in this PR?

Adds vec-inspired APIs to BufferBuidler

# Are there any user-facing changes?

No
