### PR TITLE
 Faster StringDictionaryBuilder (~60% faster) (#1851) 

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -38,6 +38,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
+ahash = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
@@ -45,6 +46,7 @@ indexmap = { version = "1.9", default-features = false, features = ["std"] }
 rand = { version = "0.8", default-features = false, features =  ["std", "std_rng"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.0", default-features = false }
+hashbrown = { version = "0.12", default-features = false }
 csv_crate = { version = "1.1", default-features = false, optional = true, package="csv" }
 regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
 lazy_static = { version = "1.4", default-features = false }

--- a/arrow/benches/string_dictionary_builder.rs
+++ b/arrow/benches/string_dictionary_builder.rs
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{Int32Builder, StringBuilder, StringDictionaryBuilder};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{thread_rng, Rng};
+
+/// Note: this is best effort, not all keys are necessarily present or unique
+fn build_strings(dict_size: usize, total_size: usize, key_len: usize) -> Vec<String> {
+    let mut rng = thread_rng();
+    let values: Vec<String> = (0..dict_size)
+        .map(|_| (0..key_len).map(|_| rng.gen::<char>()).collect())
+        .collect();
+
+    (0..total_size)
+        .map(|_| values[rng.gen_range(0..dict_size)].clone())
+        .collect()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_dictionary_builder");
+
+    let mut do_bench = |dict_size: usize, total_size: usize, key_len: usize| {
+        group.bench_function(
+            format!(
+                "(dict_size:{}, len:{}, key_len: {})",
+                dict_size, total_size, key_len
+            ),
+            |b| {
+                let strings = build_strings(dict_size, total_size, key_len);
+                b.iter(|| {
+                    let keys = Int32Builder::new(strings.len());
+                    let values = StringBuilder::new((key_len + 1) * dict_size);
+                    let mut builder = StringDictionaryBuilder::new(keys, values);
+
+                    for val in &strings {
+                        builder.append(val).unwrap();
+                    }
+
+                    builder.finish();
+                })
+            },
+        );
+    };
+
+    do_bench(20, 1000, 5);
+    do_bench(100, 1000, 5);
+    do_bench(100, 1000, 10);
+    do_bench(100, 10000, 10);
+    do_bench(100, 10000, 100);
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow/src/array/builder/generic_list_builder.rs
+++ b/arrow/src/array/builder/generic_list_builder.rs
@@ -107,6 +107,11 @@ where
         &mut self.values_builder
     }
 
+    /// Returns the child array builder as an immutable reference
+    pub fn values_ref(&self) -> &T {
+        &self.values_builder
+    }
+
     /// Finish the current variable-length list array slot
     #[inline]
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
@@ -151,6 +156,11 @@ where
         let array_data = unsafe { array_data.build_unchecked() };
 
         GenericListArray::<OffsetSize>::from(array_data)
+    }
+
+    /// Returns the current offsets buffer as a slice
+    pub fn offsets_slice(&self) -> &[OffsetSize] {
+        self.offsets_builder.as_slice()
     }
 }
 

--- a/arrow/src/array/builder/generic_string_builder.rs
+++ b/arrow/src/array/builder/generic_string_builder.rs
@@ -87,6 +87,16 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringBuilder<OffsetSize> {
     pub fn finish(&mut self) -> GenericStringArray<OffsetSize> {
         GenericStringArray::<OffsetSize>::from(self.builder.finish())
     }
+
+    /// Returns the current values buffer as a slice
+    pub fn values_slice(&self) -> &[u8] {
+        self.builder.values_ref().values_slice()
+    }
+
+    /// Returns the current offsets buffer as a slice
+    pub fn offsets_slice(&self) -> &[OffsetSize] {
+        self.builder.offsets_slice()
+    }
 }
 
 impl<OffsetSize: OffsetSizeTrait> ArrayBuilder for GenericStringBuilder<OffsetSize> {

--- a/arrow/src/array/builder/primitive_builder.rs
+++ b/arrow/src/array/builder/primitive_builder.rs
@@ -230,6 +230,11 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         b.append_n(self.values_builder.len(), true);
         self.bitmap_builder = Some(b);
     }
+
+    /// Returns the current values buffer as a slice
+    pub fn values_slice(&self) -> &[T::Native] {
+        self.values_builder.as_slice()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1851
Relates to #1843

# Rationale for this change
 
StringDictionaryBuilder can be made significantly faster

# What changes are included in this PR?

There are two major changes in this PR

* Switch to ahash
* Avoid caching string keys in HashMap

The first is ~40% uplift regardless of data shape, the latter adds a further performance improvement ranging from ~10-20% depending on the dictionary size.

```
string_dictionary_builder/(dict_size:20, len:1000, key_len: 5)                                                                             
                        time:   [15.148 us 15.179 us 15.213 us]
                        change: [-49.937% -49.607% -49.183%] (p = 0.00 < 0.05)
                        Performance has improved.
string_dictionary_builder/(dict_size:100, len:1000, key_len: 5)                                                                             
                        time:   [15.334 us 15.372 us 15.408 us]
                        change: [-60.780% -60.676% -60.577%] (p = 0.00 < 0.05)
                        Performance has improved.
string_dictionary_builder/(dict_size:100, len:1000, key_len: 10)                                                                             
                        time:   [14.638 us 14.653 us 14.668 us]
                        change: [-66.763% -66.716% -66.673%] (p = 0.00 < 0.05)
                        Performance has improved.
string_dictionary_builder/(dict_size:100, len:10000, key_len: 10)                                                                            
                        time:   [131.08 us 131.15 us 131.23 us]
                        change: [-61.008% -60.966% -60.922%] (p = 0.00 < 0.05)
                        Performance has improved.
string_dictionary_builder/(dict_size:100, len:10000, key_len: 100)                                                                            
                        time:   [379.73 us 379.89 us 380.06 us]
                        change: [-61.999% -61.946% -61.887%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# Are there any user-facing changes?

No