### PR TITLE
Exclude some long-running tests when running under miri

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -19,8 +19,6 @@ run_miri() {
 # If MIRI fails, automatically retry
 # Seems like miri is occasionally killed by the github runner
 # https://github.com/apache/arrow-rs/issues/879
-for i in `seq 1 5`; do
-    echo "Starting Arrow MIRI run..."
-    run_miri && break
-    echo "foo" > /tmp/data.txt
-done
+echo "Starting Arrow MIRI run..."
+run_miri
+echo "Miri finished with exit code $?"

--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -8,6 +8,7 @@
 
 # stacked borrows checking uses too much memory to run successfully in github actions
 # re-enable if the CI is migrated to something more powerful (https://github.com/apache/arrow-rs/issues/1833)
+# see also https://github.com/rust-lang/miri/issues/1367
 export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
 cargo miri setup
 cargo clean

--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -6,19 +6,12 @@
 # rustup default nightly
 
 
-export MIRIFLAGS="-Zmiri-disable-isolation"
+# stacked borrows checking uses too much memory to run successfully in github actions
+# re-enable if the CI is migrated to something more powerful (https://github.com/apache/arrow-rs/issues/1833)
+export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
 cargo miri setup
 cargo clean
 
-run_miri() {
-    # Currently only the arrow crate is tested with miri
-    # IO related tests and some unsupported tests are skipped
-    cargo miri test -p arrow -- --skip csv --skip ipc --skip json
-}
-
-# If MIRI fails, automatically retry
-# Seems like miri is occasionally killed by the github runner
-# https://github.com/apache/arrow-rs/issues/879
 echo "Starting Arrow MIRI run..."
-run_miri
+cargo miri test -p arrow -- --skip csv --skip ipc --skip json
 echo "Miri finished with exit code $?"

--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -436,6 +436,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_dense_i32_large() {
         let mut builder = UnionBuilder::new_dense(1024);
 

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -1332,6 +1332,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fuzz_test_slices_iterator() {
         let mut rng = thread_rng();
 
@@ -1401,6 +1402,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fuzz_filter() {
         let mut rng = thread_rng();
 

--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -611,6 +611,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fuzz_unaligned_bit_chunk_iterator() {
         let mut rng = thread_rng();
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1862.

# Rationale for this change

Stacked borrow checking uses a lot of cpu and memory resources. Disabling it should make CI much more reliable.
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?



<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
