### PR TITLE
Fixes #1874 - Upgrade `regex` dependency to 1.5.6

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -46,7 +46,7 @@ rand = { version = "0.8", optional = true }
 num = "0.4"
 half = "1.8"
 csv_crate = { version = "1.1", optional = true, package="csv" }
-regex = "1.3"
+regex = "1.5.6"
 lazy_static = "1.4"
 packed_simd = { version = "0.3", optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }


### PR DESCRIPTION

# Which issue does this PR close?

Closes #1874.

# Rationale for this change

Use newer version of `regex` dependency which does not have (known) vulnerabilities.

# What changes are included in this PR?

Upgrade a dependency.

# Are there any user-facing changes?

No.
