### PR TITLE
Fix memory leak in ffi test

### DIFF
--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -74,6 +74,11 @@ mod tests {
         let result = &ArrayData::try_from(d1)?;
 
         assert_eq!(result, expected);
+
+        unsafe {
+            Arc::from_raw(array);
+            Arc::from_raw(schema);
+        }
         Ok(())
     }
 

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -79,6 +79,8 @@
 //! unsafe {
 //!     Box::from_raw(out_array_ptr);
 //!     Box::from_raw(out_schema_ptr);
+//!     Arc::from_raw(array_ptr);
+//!     Arc::from_raw(schema_ptr);
 //! }
 //!
 //! Ok(())

--- a/arrow/src/ffi_stream.rs
+++ b/arrow/src/ffi_stream.rs
@@ -500,6 +500,8 @@ mod tests {
         }
 
         assert_eq!(produced_batches, vec![batch.clone(), batch]);
+
+        unsafe { Arc::from_raw(stream_ptr) };
         Ok(())
     }
 
@@ -529,6 +531,8 @@ mod tests {
         }
 
         assert_eq!(produced_batches, vec![batch.clone(), batch]);
+
+        unsafe { Arc::from_raw(stream_ptr) };
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1872.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

A few raw Arc pointers were not converted back to Arc structs so leading to leaks.

Verified by `cargo +nightly miri test -p arrow -- --skip csv --skip ipc --skip json --skip util --skip compute --skip array --skip buffer --skip datatypes --skip bitmap --skip record_batch --skip tensor`

```
running 15 tests                 
test ffi::tests::test_binary ... ok                                                   
test ffi::tests::test_bool ... ok                                                     
test ffi::tests::test_decimal_round_trip ... ok       
test ffi::tests::test_dictionary ... ok
test ffi::tests::test_duration ... ok
test ffi::tests::test_large_binary ... ok
test ffi::tests::test_large_list ... ok
test ffi::tests::test_large_string ... ok                                             
test ffi::tests::test_list ... ok                                                     
test ffi::tests::test_round_trip ... ok                                               
test ffi::tests::test_string ... ok
test ffi::tests::test_time32 ... ok                                                   
test ffi::tests::test_timestamp ... ok
test ffi_stream::tests::test_stream_round_trip_export ... ok
test ffi_stream::tests::test_stream_round_trip_import ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 1162 filtered out

   Doc-tests arrow

running 8 tests
test src/ffi_stream.rs - ffi_stream (line 27) ... ignored
test src/lib.rs - (line 69) ... ok
test src/lib.rs - (line 43) ... ok
test src/lib.rs - (line 28) ... ok
test src/lib.rs - (line 90) ... ok
test src/lib.rs - (line 126) ... ok
test src/lib.rs - (line 167) ... ok
test src/ffi.rs - ffi (line 27) ... ok

test result: ok. 7 passed; 0 failed; 1 ignored; 0 measured; 147 filtered out; finished in 1.03s
```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
