### PR TITLE
Issue #1876: Explicitly declare the used features for each dependency in arrow-flight

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -27,14 +27,14 @@ repository = "https://github.com/apache/arrow-rs"
 license = "Apache-2.0"
 
 [dependencies]
-arrow = { path = "../arrow", version = "16.0.0" }
-base64 = "0.13"
-tonic = "0.7"
-bytes = "1"
-prost = "0.10"
-prost-types = { version = "0.10.0", optional = true }
-prost-derive = "0.10"
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+arrow = { path = "../arrow", version = "16.0.0", default-features = false, features = ["ipc"] }
+base64 = { version = "0.13", default-features = false }
+tonic = { version = "0.7", default-features = false, features = ["transport", "codegen", "prost"] }
+bytes = { version = "1", default-features = false }
+prost = { version = "0.10", default-features = false }
+prost-types = { version = "0.10.0", default-features = false, optional = true }
+prost-derive = { version = "0.10", default-features = false }
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [features]
@@ -44,10 +44,10 @@ flight-sql-experimental = ["prost-types"]
 [dev-dependencies]
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = { version = "0.7", default-features = false, features = ["transport", "prost"] }
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
-proc-macro2 = ">1.0.30"
+proc-macro2 = { version = ">1.0.30", default-features = false }
 
 [[example]]
 name = "flight_sql_server"


### PR DESCRIPTION
# Which issue does this PR close?

This is the second PR for https://github.com/apache/arrow-rs/issues/1876.
It changes just arrow-flight/Cargo.toml.
The PR does not upgrade the dependencies!

Previous PRs:
* https://github.com/apache/arrow-rs/pull/1877 - module `arrow `

# Rationale for this change
 
Reduce the disk and CPU usage at build time.

# What changes are included in this PR?

N/A

# Are there any user-facing changes?

N/A
<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
