### PR TITLE
Issue #1876: Explicitly declare the used features for each dependency in parquet

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -30,37 +30,36 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-parquet-format = "4.0.0"
-bytes = "1.1"
-byteorder = "1"
-thrift = "0.13"
-snap = { version = "1.0", optional = true }
-brotli = { version = "3.3", optional = true }
-flate2 = { version = "1.0", optional = true }
-lz4 = { version = "1.23", optional = true }
+parquet-format = { version = "4.0.0", default-features = false }
+bytes = { version = "1.1", default-features = false, features = ["std"] }
+byteorder = { version = "1", default-features = false }
+thrift = { version = "0.13", default-features = false }
+snap = { version = "1.0", default-features = false, optional = true }
+brotli = { version = "3.3", default-features = false, features = ["std"], optional = true }
+flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
+lz4 = { version = "1.23", default-features = false, optional = true }
 zstd = { version = "0.11.1", optional = true, default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-num = "0.4"
-num-bigint = "0.4"
+num = { version = "0.4", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 arrow = { path = "../arrow", version = "16.0.0", optional = true, default-features = false, features = ["ipc"] }
-base64 = { version = "0.13", optional = true }
-clap = { version = "~3.1", optional = true, features = ["derive", "env"] }
-serde_json = { version = "1.0", optional = true }
-rand = "0.8"
-futures = { version = "0.3", optional = true }
+base64 = { version = "0.13", default-features = false, features = ["std"], optional = true }
+clap = { version = "~3.1", default-features = false, features = ["std", "derive", "env"], optional = true }
+serde_json = { version = "1.0", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false }
+futures = { version = "0.3", default-features = false, features = ["std" ], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "fs", "rt", "io-util"] }
 
 [dev-dependencies]
-base64 = "0.13"
-criterion = "0.3"
-rand = "0.8"
-snap = "1.0"
-tempfile = "3.0"
-brotli = "3.3"
-flate2 = "1.0"
-lz4 = "1.23"
-zstd = "0.11"
-serde_json = { version = "1.0", features = ["preserve_order"] }
+base64 = { version = "0.13", default-features = false, features = ["std"] }
+criterion = { version = "0.3", default-features = false }
+snap = { version = "1.0", default-features = false }
+tempfile = { version = "3.0", default-features = false }
+brotli = { version = "3.3", default-features = false, features = [ "std" ] }
+flate2 = { version = "1.0", default-features = false, features = [ "rust_backend" ] }
+lz4 = { version = "1.23", default-features = false }
+zstd = { version = "0.11", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
 arrow = { path = "../arrow", version = "16.0.0", default-features = false, features = ["ipc", "test_utils", "prettyprint"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Which issue does this PR close?

This is the third PR for https://github.com/apache/arrow-rs/issues/1876.
It changes just parquet/Cargo.toml.
The PR does not upgrade the dependencies!

Previous PRs:

* https://github.com/apache/arrow-rs/pull/1877 - module arrow
* https://github.com/apache/arrow-rs/pull/1880 - module arrow-flight

# Rationale for this change
 
Reduce the disk and CPU usage at build time.

# What changes are included in this PR?

N/A

# Are there any user-facing changes?

N/A
<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
