### PR TITLE
Feature add weekday temporal kernel

### DIFF
--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -480,15 +480,15 @@ mod tests {
 
     #[test]
     fn test_temporal_array_date64_weekday() {
-        //1514764800000 -> 2018-01-01
-        //1550636625000 -> 2019-02-20
+        //1514764800000 -> 2018-01-01 (Monday)
+        //1550636625000 -> 2019-02-20 (Wednesday)
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
         let b = weekday(&a).unwrap();
-        assert_eq!(1, b.value(0));
+        assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
-        assert_eq!(3, b.value(2));
+        assert_eq!(2, b.value(2));
     }
 
     #[test]

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -480,6 +480,19 @@ mod tests {
     }
 
     #[test]
+    fn test_temporal_array_date64_weekday() {
+        //1514764800000 -> 2018-01-01
+        //1550636625000 -> 2019-02-20
+        let a: PrimitiveArray<Date64Type> =
+            vec![Some(1514764800000), None, Some(1550636625000)].into();
+
+        let b = weekday(&a).unwrap();
+        assert_eq!(1, b.value(1));
+        assert!(!b.is_valid(1));
+        assert_eq!(3, b.value(2));
+    }
+
+    #[test]
     fn test_temporal_array_date64_day() {
         //1514764800000 -> 2018-01-01
         //1550636625000 -> 2019-02-20

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -239,7 +239,6 @@ where
     Ok(b.finish())
 }
 
-
 /// Extracts the day of a given temporal array as an array of integers
 pub fn day<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -486,7 +486,7 @@ mod tests {
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
         let b = weekday(&a).unwrap();
-        assert_eq!(1, b.value(1));
+        assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(3, b.value(2));
     }


### PR DESCRIPTION
This feature will add the temporal kernel for weekday (day of week). When added, DOW support can be add to datafusion.