### PR TITLE
Minor: Add examples to docstring for `weekday`

### DIFF
--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -267,7 +267,10 @@ where
     Ok(b.finish())
 }
 
-/// Extracts the day of week of a given temporal array as an array of integers
+/// Extracts the day of week of a given temporal array as an array of
+/// integers.
+///
+/// Monday is encoded as `0`, Tuesday as `1`, etc.
 pub fn weekday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where
     T: ArrowTemporalType + ArrowNumericType,


### PR DESCRIPTION
Minor follow on to https://github.com/apache/arrow-rs/pull/1891 from @nl5887 -- add an example in the docstring of `weekday` kernel