### PR TITLE
Issue #1876: Explicitly declare the used features for each dependency in parquet

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -46,7 +46,7 @@ arrow = { path = "../arrow", version = "16.0.0", optional = true, default-featur
 base64 = { version = "0.13", default-features = false, features = ["std"], optional = true }
 clap = { version = "~3.1", default-features = false, features = ["std", "derive", "env"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 futures = { version = "0.3", default-features = false, features = ["std" ], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "fs", "rt", "io-util"] }
 


### PR DESCRIPTION
Declare that parquet module uses rand's std and std_rng features

# Which issue does this PR close?

This is the third PR for https://github.com/apache/arrow-rs/issues/1876.
It changes just parquet/Cargo.toml.
The PR does not upgrade the dependencies!

# Rationale for this change

This is a follow-up of https://github.com/apache/arrow-rs/pull/1881.
The build fails when building **only** `parquet` module:
```bash
$ cd parquet
$ cargo +nightly build --all-features
```

# What changes are included in this PR?

Add `"std"` and `"std_rng"` features for `rand` dependency

# Are there any user-facing changes?

No