### PR TITLE
Issue #1876: Explicitly declare the used features for each dependency in integration_testing

### DIFF
--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -31,16 +31,16 @@ rust-version = "1.57"
 logging = ["tracing-subscriber"]
 
 [dependencies]
-arrow = { path = "../arrow" }
-arrow-flight = { path = "../arrow-flight" }
-async-trait = "0.1.41"
-clap = { version = "~3.1", features = ["derive", "env"] }
-futures = "0.3"
-hex = "0.4"
-prost = "0.10"
-serde = { version = "1.0", features = ["rc"] }
-serde_derive = "1.0"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-tonic = "0.7"
-tracing-subscriber = { version = "0.3.1", optional = true }
+arrow = { path = "../arrow", default-features = false, features = [ "test_utils" ] }
+arrow-flight = { path = "../arrow-flight", default-features = false }
+async-trait = { version = "0.1.41", default-features = false }
+clap = { version = "~3.1", default-features = false, features = ["std", "derive"] }
+futures = { version = "0.3", default-features = false }
+hex = { version = "0.4", default-features = false }
+prost = { version = "0.10", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["rc"] }
+serde_derive = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
+tokio = { version = "1.0", default-features = false }
+tonic = { version = "0.7", default-features = false }
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt"], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1876.
This is the last PR for https://github.com/apache/arrow-rs/issues/1876.
It changes just integration_testing/Cargo.toml.
The PR does **not** upgrade the dependencies!

# Rationale for this change
 
Reduce the disk and CPU usage at build time.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
