### PR TITLE
Refine the `bit_util` of Parquet.

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -468,7 +468,7 @@ fn parse_v1_level(
             Ok((i32_size + data_size, buf.range(i32_size, data_size)))
         }
         Encoding::BIT_PACKED => {
-            let bit_width = num_required_bits(max_level as u64) as u8;
+            let bit_width = num_required_bits(max_level as u64);
             let num_bytes = ceil(
                 (num_buffered_values as usize * bit_width as usize) as i64,
                 8,

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -27,7 +27,7 @@ use crate::column::reader::decoder::{
 use crate::data_type::*;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
-use crate::util::bit_util::ceil;
+use crate::util::bit_util::{ceil, num_required_bits};
 use crate::util::memory::ByteBufferPtr;
 
 pub(crate) mod decoder;
@@ -468,7 +468,7 @@ fn parse_v1_level(
             Ok((i32_size + data_size, buf.range(i32_size, data_size)))
         }
         Encoding::BIT_PACKED => {
-            let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
+            let bit_width = num_required_bits(max_level as u64) as u8;
             let num_bytes = ceil(
                 (num_buffered_values as usize * bit_width as usize) as i64,
                 8,

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -26,8 +26,10 @@ use crate::encodings::{
 };
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
-use crate::util::bit_util::num_required_bits;
-use crate::util::{bit_util::BitReader, memory::ByteBufferPtr};
+use crate::util::{
+    bit_util::{num_required_bits, BitReader},
+    memory::ByteBufferPtr,
+};
 
 /// A slice of levels buffer data that is written to by a [`ColumnLevelDecoder`]
 pub trait LevelsBufferSlice {
@@ -239,7 +241,7 @@ impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
     type Slice = [i16];
 
     fn new(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
-        let bit_width = num_required_bits(max_level as u64) as u8;
+        let bit_width = num_required_bits(max_level as u64);
         match encoding {
             Encoding::RLE => {
                 let mut decoder = RleDecoder::new(bit_width);

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -26,6 +26,7 @@ use crate::encodings::{
 };
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
+use crate::util::bit_util::num_required_bits;
 use crate::util::{bit_util::BitReader, memory::ByteBufferPtr};
 
 /// A slice of levels buffer data that is written to by a [`ColumnLevelDecoder`]
@@ -238,7 +239,7 @@ impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
     type Slice = [i16];
 
     fn new(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
-        let bit_width = crate::util::bit_util::log2(max_level as u64 + 1) as u8;
+        let bit_width = num_required_bits(max_level as u64) as u8;
         match encoding {
             Encoding::RLE => {
                 let mut decoder = RleDecoder::new(bit_width);

--- a/parquet/src/encodings/encoding.rs
+++ b/parquet/src/encodings/encoding.rs
@@ -307,12 +307,10 @@ impl<T: DataType> DictEncoder<T> {
     #[inline]
     fn bit_width(&self) -> u8 {
         let num_entries = self.uniques.len();
-        if num_entries == 0 {
-            0
-        } else if num_entries == 1 {
-            1
+        if num_entries <= 1 {
+            num_entries as u8
         } else {
-            num_required_bits(num_entries as u64 - 1) as u8
+            num_required_bits(num_entries as u64 - 1)
         }
     }
 
@@ -589,7 +587,7 @@ impl<T: DataType> DeltaBitPackEncoder<T> {
             }
 
             // Compute bit width to store (max_delta - min_delta)
-            let bit_width = num_required_bits(self.subtract_u64(max_delta, min_delta));
+            let bit_width = num_required_bits(self.subtract_u64(max_delta, min_delta)) as usize;
             self.bit_writer.write_at(offset + i, bit_width as u8);
 
             // Encode values in current mini block using min_delta and bit_width

--- a/parquet/src/encodings/encoding.rs
+++ b/parquet/src/encodings/encoding.rs
@@ -26,7 +26,7 @@ use crate::encodings::rle::RleEncoder;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 use crate::util::{
-    bit_util::{self, log2, num_required_bits, BitWriter},
+    bit_util::{self, num_required_bits, BitWriter},
     hash_util,
     memory::ByteBufferPtr,
 };
@@ -312,7 +312,7 @@ impl<T: DataType> DictEncoder<T> {
         } else if num_entries == 1 {
             1
         } else {
-            log2(num_entries as u64) as u8
+            num_required_bits(num_entries as u64 - 1) as u8
         }
     }
 

--- a/parquet/src/encodings/levels.rs
+++ b/parquet/src/encodings/levels.rs
@@ -22,8 +22,9 @@ use super::rle::{RleDecoder, RleEncoder};
 use crate::basic::Encoding;
 use crate::data_type::AsBytes;
 use crate::errors::{ParquetError, Result};
+use crate::util::bit_util::num_required_bits;
 use crate::util::{
-    bit_util::{ceil, log2, BitReader, BitWriter},
+    bit_util::{ceil, BitReader, BitWriter},
     memory::ByteBufferPtr,
 };
 
@@ -36,7 +37,7 @@ pub fn max_buffer_size(
     max_level: i16,
     num_buffered_values: usize,
 ) -> usize {
-    let bit_width = log2(max_level as u64 + 1) as u8;
+    let bit_width = num_required_bits(max_level as u64) as u8;
     match encoding {
         Encoding::RLE => {
             RleEncoder::max_buffer_size(bit_width, num_buffered_values)
@@ -66,7 +67,7 @@ impl LevelEncoder {
     ///
     /// Panics, if encoding is not supported.
     pub fn v1(encoding: Encoding, max_level: i16, byte_buffer: Vec<u8>) -> Self {
-        let bit_width = log2(max_level as u64 + 1) as u8;
+        let bit_width = num_required_bits(max_level as u64) as u8;
         match encoding {
             Encoding::RLE => LevelEncoder::Rle(RleEncoder::new_from_buf(
                 bit_width,
@@ -89,7 +90,7 @@ impl LevelEncoder {
     /// Creates new level encoder based on RLE encoding. Used to encode Data Page v2
     /// repetition and definition levels.
     pub fn v2(max_level: i16, byte_buffer: Vec<u8>) -> Self {
-        let bit_width = log2(max_level as u64 + 1) as u8;
+        let bit_width = num_required_bits(max_level as u64) as u8;
         LevelEncoder::RleV2(RleEncoder::new_from_buf(bit_width, byte_buffer, 0))
     }
 
@@ -163,7 +164,7 @@ impl LevelDecoder {
     ///
     /// Panics if encoding is not supported
     pub fn v1(encoding: Encoding, max_level: i16) -> Self {
-        let bit_width = log2(max_level as u64 + 1) as u8;
+        let bit_width = num_required_bits(max_level as u64) as u8;
         match encoding {
             Encoding::RLE => LevelDecoder::Rle(None, RleDecoder::new(bit_width)),
             Encoding::BIT_PACKED => {
@@ -178,7 +179,7 @@ impl LevelDecoder {
     ///
     /// To set data for this decoder, use `set_data_range` method.
     pub fn v2(max_level: i16) -> Self {
-        let bit_width = log2(max_level as u64 + 1) as u8;
+        let bit_width = num_required_bits(max_level as u64) as u8;
         LevelDecoder::RleV2(None, RleDecoder::new(bit_width))
     }
 

--- a/parquet/src/encodings/levels.rs
+++ b/parquet/src/encodings/levels.rs
@@ -22,9 +22,8 @@ use super::rle::{RleDecoder, RleEncoder};
 use crate::basic::Encoding;
 use crate::data_type::AsBytes;
 use crate::errors::{ParquetError, Result};
-use crate::util::bit_util::num_required_bits;
 use crate::util::{
-    bit_util::{ceil, BitReader, BitWriter},
+    bit_util::{ceil, num_required_bits, BitReader, BitWriter},
     memory::ByteBufferPtr,
 };
 
@@ -37,7 +36,7 @@ pub fn max_buffer_size(
     max_level: i16,
     num_buffered_values: usize,
 ) -> usize {
-    let bit_width = num_required_bits(max_level as u64) as u8;
+    let bit_width = num_required_bits(max_level as u64);
     match encoding {
         Encoding::RLE => {
             RleEncoder::max_buffer_size(bit_width, num_buffered_values)
@@ -67,7 +66,7 @@ impl LevelEncoder {
     ///
     /// Panics, if encoding is not supported.
     pub fn v1(encoding: Encoding, max_level: i16, byte_buffer: Vec<u8>) -> Self {
-        let bit_width = num_required_bits(max_level as u64) as u8;
+        let bit_width = num_required_bits(max_level as u64);
         match encoding {
             Encoding::RLE => LevelEncoder::Rle(RleEncoder::new_from_buf(
                 bit_width,
@@ -90,7 +89,7 @@ impl LevelEncoder {
     /// Creates new level encoder based on RLE encoding. Used to encode Data Page v2
     /// repetition and definition levels.
     pub fn v2(max_level: i16, byte_buffer: Vec<u8>) -> Self {
-        let bit_width = num_required_bits(max_level as u64) as u8;
+        let bit_width = num_required_bits(max_level as u64);
         LevelEncoder::RleV2(RleEncoder::new_from_buf(bit_width, byte_buffer, 0))
     }
 
@@ -164,7 +163,7 @@ impl LevelDecoder {
     ///
     /// Panics if encoding is not supported
     pub fn v1(encoding: Encoding, max_level: i16) -> Self {
-        let bit_width = num_required_bits(max_level as u64) as u8;
+        let bit_width = num_required_bits(max_level as u64);
         match encoding {
             Encoding::RLE => LevelDecoder::Rle(None, RleDecoder::new(bit_width)),
             Encoding::BIT_PACKED => {
@@ -179,7 +178,7 @@ impl LevelDecoder {
     ///
     /// To set data for this decoder, use `set_data_range` method.
     pub fn v2(max_level: i16) -> Self {
-        let bit_width = num_required_bits(max_level as u64) as u8;
+        let bit_width = num_required_bits(max_level as u64);
         LevelDecoder::RleV2(None, RleDecoder::new(bit_width))
     }
 

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -870,7 +870,7 @@ mod tests {
             }
             let bit_width = bit_util::num_required_bits(values.len() as u64);
             assert!(bit_width < 64);
-            test_round_trip(&values[..], bit_width as u8);
+            test_round_trip(&values[..], bit_width);
         }
     }
 }

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -136,7 +136,7 @@ where
 /// Returns the ceil of value/divisor.
 ///
 /// This function should be removed after
-/// https://github.com/rust-lang/rust/issues/88581 is closed.
+/// [`int_roundings`](https://github.com/rust-lang/rust/issues/88581) is stable.
 #[inline]
 pub fn ceil(value: i64, divisor: i64) -> i64 {
     num::Integer::div_ceil(&value, &divisor)

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -164,8 +164,8 @@ pub fn unset_array_bit(bits: &mut [u8], i: usize) {
 
 /// Returns the minimum number of bits needed to represent the value 'x'
 #[inline]
-pub fn num_required_bits(x: u64) -> usize {
-    64 - x.leading_zeros() as usize
+pub fn num_required_bits(x: u64) -> u8 {
+    64 - x.leading_zeros() as u8
 }
 
 static BIT_MASK: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
@@ -829,6 +829,7 @@ mod tests {
         assert_eq!(num_required_bits(10), 4);
         assert_eq!(num_required_bits(12), 4);
         assert_eq!(num_required_bits(16), 5);
+        assert_eq!(num_required_bits(u64::MAX), 64);
     }
 
     #[test]

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -141,17 +141,8 @@ pub fn ceil(value: i64, divisor: i64) -> i64 {
 
 /// Returns ceil(log2(x))
 #[inline]
-pub fn log2(mut x: u64) -> i32 {
-    if x == 1 {
-        return 0;
-    }
-    x -= 1;
-    let mut result = 0;
-    while x > 0 {
-        x >>= 1;
-        result += 1;
-    }
-    result
+pub fn log2(x: u64) -> i32 {
+    num_required_bits(x - 1) as i32
 }
 
 /// Returns the `num_bits` least-significant bits of `v`
@@ -180,12 +171,7 @@ pub fn unset_array_bit(bits: &mut [u8], i: usize) {
 /// Returns the minimum number of bits needed to represent the value 'x'
 #[inline]
 pub fn num_required_bits(x: u64) -> usize {
-    for i in (0..64).rev() {
-        if x & (1u64 << i) != 0 {
-            return i + 1;
-        }
-    }
-    0
+    64 - x.leading_zeros() as usize
 }
 
 static BIT_MASK: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -139,12 +139,6 @@ pub fn ceil(value: i64, divisor: i64) -> i64 {
     value / divisor + ((value % divisor != 0) as i64)
 }
 
-/// Returns ceil(log2(x))
-#[inline]
-pub fn log2(x: u64) -> i32 {
-    num_required_bits(x - 1) as i32
-}
-
 /// Returns the `num_bits` least-significant bits of `v`
 #[inline]
 pub fn trailing_bits(v: u64, num_bits: usize) -> u64 {
@@ -862,20 +856,6 @@ mod tests {
         assert!(!get_bit(&[0b01001001, 0b01010010], 13));
         assert!(get_bit(&[0b01001001, 0b01010010], 14));
         assert!(!get_bit(&[0b01001001, 0b01010010], 15));
-    }
-
-    #[test]
-    fn test_log2() {
-        assert_eq!(log2(1), 0);
-        assert_eq!(log2(2), 1);
-        assert_eq!(log2(3), 2);
-        assert_eq!(log2(4), 2);
-        assert_eq!(log2(5), 3);
-        assert_eq!(log2(5), 3);
-        assert_eq!(log2(6), 3);
-        assert_eq!(log2(7), 3);
-        assert_eq!(log2(8), 3);
-        assert_eq!(log2(9), 4);
     }
 
     #[test]

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -133,23 +133,23 @@ where
     memcpy(&source.as_bytes()[..num_bytes], target)
 }
 
-/// Returns the ceil of value/divisor
+/// Returns the ceil of value/divisor.
+///
+/// This function should be removed after
+/// https://github.com/rust-lang/rust/issues/88581 is closed.
 #[inline]
 pub fn ceil(value: i64, divisor: i64) -> i64 {
-    value / divisor + ((value % divisor != 0) as i64)
+    num::Integer::div_ceil(&value, &divisor)
 }
 
 /// Returns the `num_bits` least-significant bits of `v`
 #[inline]
 pub fn trailing_bits(v: u64, num_bits: usize) -> u64 {
-    if num_bits == 0 {
-        return 0;
-    }
     if num_bits >= 64 {
-        return v;
+        v
+    } else {
+        v & ((1<<num_bits) - 1)
     }
-    let n = 64 - num_bits;
-    (v << n) >> n
 }
 
 #[inline]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1901 .

# What changes are included in this PR?
1. Remove the function `log2`, because:
- The ceiling of `log2 (n)` == `num_required_bits(n - 1)`
- `log2` is unsafe, which panics when the input number is zero.
2. Change the return type of `num_required_bits` to u8
3. Use the std function `div_ceil`
4. optimize `trailing_bits`

# Are there any user-facing changes?
Yes.
