### PR TITLE
minor: clarify docstring on `DictionaryArray::lookup_key`

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -128,7 +128,11 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
         &self.keys
     }
 
-    /// Returns the lookup key by doing reverse dictionary lookup
+    /// If `value` is present in `values` (aka the dictionary),
+    /// returns the coresponding key (index into the `values`
+    /// array). Otherwise returns `None`.
+    ///
+    /// Panics if `values` is not a [`StringArray`].
     pub fn lookup_key(&self, value: &str) -> Option<K::Native> {
         let rd_buf: &StringArray =
             self.values.as_any().downcast_ref::<StringArray>().unwrap();

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -129,7 +129,7 @@ impl<'a, K: ArrowPrimitiveType> DictionaryArray<K> {
     }
 
     /// If `value` is present in `values` (aka the dictionary),
-    /// returns the coresponding key (index into the `values`
+    /// returns the corresponding key (index into the `values`
     /// array). Otherwise returns `None`.
     ///
     /// Panics if `values` is not a [`StringArray`].


### PR DESCRIPTION
While working on something else I found another docstring I think could be improved

