### PR TITLE
Require Send+Sync bounds for Allocation trait

### DIFF
--- a/arrow/src/alloc/mod.rs
+++ b/arrow/src/alloc/mod.rs
@@ -127,9 +127,9 @@ pub unsafe fn reallocate<T: NativeType>(
 
 /// The owner of an allocation.
 /// The trait implementation is responsible for dropping the allocations once no more references exist.
-pub trait Allocation: RefUnwindSafe {}
+pub trait Allocation: RefUnwindSafe + Send + Sync {}
 
-impl<T: RefUnwindSafe> Allocation for T {}
+impl<T: RefUnwindSafe + Send + Sync> Allocation for T {}
 
 /// Mode of deallocating memory regions
 pub(crate) enum Deallocation {

--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -257,11 +257,6 @@ impl std::ops::Deref for Buffer {
     }
 }
 
-unsafe impl Sync for Buffer {}
-// false positive, see https://github.com/apache/arrow-rs/pull/1169
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl Send for Buffer {}
-
 impl From<MutableBuffer> for Buffer {
     #[inline]
     fn from(buffer: MutableBuffer) -> Self {

--- a/arrow/src/bytes.rs
+++ b/arrow/src/bytes.rs
@@ -101,6 +101,11 @@ impl Bytes {
     }
 }
 
+// Deallocation is Send + Sync, repeating the bound here makes that refactoring safe
+// The only field that is not automatically Send+Sync then is the NonNull ptr
+unsafe impl Send for Bytes where Deallocation: Send {}
+unsafe impl Sync for Bytes where Deallocation: Sync {}
+
 impl Drop for Bytes {
     #[inline]
     fn drop(&mut self) {

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -409,6 +409,9 @@ impl Drop for FFI_ArrowArray {
     }
 }
 
+unsafe impl Send for FFI_ArrowArray {}
+unsafe impl Sync for FFI_ArrowArray {}
+
 // callback used to drop [FFI_ArrowArray] when it is exported
 unsafe extern "C" fn release_array(array: *mut FFI_ArrowArray) {
     if array.is_null() {


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1944.

# Rationale for this change

`Send + Sync` were previously implemented for `Buffer` which probably was not sound in case the underlying `Allocation` was not also `Send + Sync`.



 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

 - `Allocation` trait requires `Send + Sync`
 - `Bytes` implements `Send + Sync` which should be fine since it only contains a `NonNull` pointer in addition to the allocation
 - `Buffer` is then automatically `Send + Sync`
 - `FFI_ArrowArray` now has to implement `Send + Sync`. This requirement was previously hidden by the unsafe impl on `Buffer`, even before the introduction of the `Allocation` abstraction in #1494 
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

This could be a breaking change for users of the `Allocation` trait, but those usages would have been unsound before.