### PR TITLE
Set is_adjusted_to_utc if any timezone set (#1932)

### DIFF
--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -53,7 +53,7 @@ fn apply_hint(parquet: DataType, hint: DataType) -> DataType {
         (DataType::Date32, DataType::Date64) => hint,
 
         // Determine timezone
-        (DataType::Timestamp(p, None), DataType::Timestamp(h, Some(_))) if p == h => hint,
+        (DataType::Timestamp(p, _), DataType::Timestamp(h, Some(_))) if p == h => hint,
 
         // Determine offset size
         (DataType::Utf8, DataType::LargeUtf8) => hint,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1932

# Rationale for this change
 
As pointed out by @jorgecarleitao https://github.com/apache/arrow-rs/pull/1937#issuecomment-1167941057 we can always set is_adjusted_to_utc if any timezone is set

# What changes are included in this PR?

Copies the docstring from arrow schema.fbs into DataType to clarify the potentially unexpected semantics of Timestamp.

Sets is_adjusted_to_utc if any timezone is set

# Are there any user-facing changes?

No
