### PR TITLE
Unpin clap (#1867)

### DIFF
--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -34,7 +34,7 @@ logging = ["tracing-subscriber"]
 arrow = { path = "../arrow", default-features = false, features = [ "test_utils" ] }
 arrow-flight = { path = "../arrow-flight", default-features = false }
 async-trait = { version = "0.1.41", default-features = false }
-clap = { version = "~3.1", default-features = false, features = ["std", "derive"] }
+clap = { version = "3", default-features = false, features = ["std", "derive"] }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false }
 prost = { version = "0.10", default-features = false }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -44,7 +44,7 @@ num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 arrow = { path = "../arrow", version = "17.0.0", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", default-features = false, features = ["std"], optional = true }
-clap = { version = "~3.1", default-features = false, features = ["std", "derive", "env"], optional = true }
+clap = { version = "3", default-features = false, features = ["std", "derive", "env"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 futures = { version = "0.3", default-features = false, features = ["std" ], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1867

# Rationale for this change
 
Originally pinned by #1868 to workaround upstream shenanigans. The changes have since been backed out of the upstream - https://github.com/clap-rs/clap/pull/3830 and so we can unpin clap

# What changes are included in this PR?

Unpins clap

# Are there any user-facing changes?

No
