### PR TITLE
Remove indexmap

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -40,8 +40,7 @@ bench = false
 [dependencies]
 serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", default-features = false }
-serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
-indexmap = { version = "1.9", default-features = false, features = ["std"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
 rand = { version = "0.8", default-features = false, features =  ["std", "std_rng"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.0", default-features = false }

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -40,7 +40,7 @@ hex = { version = "0.4", default-features = false }
 prost = { version = "0.10", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["rc"] }
 serde_derive = { version = "1.0", default-features = false }
-serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false }
 tonic = { version = "0.7", default-features = false }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt"], optional = true }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -45,7 +45,7 @@ num-bigint = { version = "0.4", default-features = false }
 arrow = { path = "../arrow", version = "17.0.0", optional = true, default-features = false, features = ["ipc"] }
 base64 = { version = "0.13", default-features = false, features = ["std"], optional = true }
 clap = { version = "3", default-features = false, features = ["std", "derive", "env"], optional = true }
-serde_json = { version = "1.0", default-features = false, optional = true }
+serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 futures = { version = "0.3", default-features = false, features = ["std" ], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "fs", "rt", "io-util"] }
@@ -59,7 +59,7 @@ brotli = { version = "3.3", default-features = false, features = [ "std" ] }
 flate2 = { version = "1.0", default-features = false, features = [ "rust_backend" ] }
 lz4 = { version = "1.23", default-features = false }
 zstd = { version = "0.11", default-features = false }
-serde_json = { version = "1.0", default-features = false, features = ["preserve_order"] }
+serde_json = { version = "1.0", default-features = false, features = [ "std" ] }
 arrow = { path = "../arrow", version = "17.0.0", default-features = false, features = ["ipc", "test_utils", "prettyprint"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1882.

# Rationale for this change
 
See #1882 

# What changes are included in this PR?

Removes the `indexmap` dependency to evaluate the impact on tests

# Are there any user-facing changes?

Yes, `arrow::json::reader::ReaderBuilder::with_format_strings` used to incorrectly take an `IndexMap` aliased as `HashMap`, it and other related decoder options now take a `HashMap`

_____

Note that there are other crates that depend on `indexmap`.

These are:

* clap - `integration-testing`, in `parquet` as an optional feature for binaries
* h2 - `arrow-flight` (dependency of `tonic`)
* petgraph - `arrow-flight` `arrow-flight` (dependency of `tonic-build`)
* tower - `arrow-flight` (dependency of `tonic`)

So if we can find a suitable resolution to the JSON writer, we could remove `indexmap` from the `arrow` crate.

I've also noticed that our write behaviour changes if we don't `preserve_order` on serde-json, which could be a blocker.


