### PR TITLE
Fix the behavior of `from_fixed_size_list` when offset > 0

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -848,7 +848,7 @@ impl DecimalArray {
         let child_offset = child_data.offset();
         let builder = ArrayData::builder(DataType::Decimal(precision, scale))
             .len(v.len())
-            .add_buffer(v.data_ref().child_data()[0].buffers()[0].slice(child_offset))
+            .add_buffer(child_data.buffers()[0].slice(child_offset))
             .null_bit_buffer(v.data_ref().null_buffer().cloned())
             .offset(list_offset);
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1958 .

# Rationale for this change
 Consider the impact of the offset of the list array (also the offset of the child array) when building decimal array.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
