### PR TITLE
Declare the value_length of decimal array as a `const`

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -785,15 +785,15 @@ impl DecimalArray {
             let pos = self.value_offset_at(offset);
             std::slice::from_raw_parts(
                 self.value_data.as_ptr().offset(pos as isize),
-                (self.value_offset_at(offset + 1) - pos) as usize,
+                Self::VALUE_LENGTH as usize,
             )
         };
-        let as_array = raw_val.try_into();
-        let integer = match as_array {
-            Ok(v) if raw_val.len() == 16 => i128::from_le_bytes(v),
-            _ => panic!("DecimalArray elements are not 128bit integers."),
-        };
-        Decimal128::new_from_i128(self.precision, self.scale, integer)
+        let as_array = raw_val.try_into().unwrap();
+        Decimal128::new_from_i128(
+            self.precision,
+            self.scale,
+            i128::from_le_bytes(as_array),
+        )
     }
 
     /// Returns the offset for the element at index `i`.

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -772,10 +772,11 @@ pub struct DecimalArray {
     value_data: RawPtrBox<u8>,
     precision: usize,
     scale: usize,
-    length: i32,
 }
 
 impl DecimalArray {
+    const VALUE_LENGTH: i32 = 16;
+
     /// Returns the element at index `i`.
     pub fn value(&self, i: usize) -> Decimal128 {
         assert!(i < self.data.len(), "DecimalArray out of bounds access");
@@ -807,8 +808,8 @@ impl DecimalArray {
     ///
     /// All elements have the same length as the array is a fixed size.
     #[inline]
-    pub fn value_length(&self) -> i32 {
-        self.length
+    pub const fn value_length(&self) -> i32 {
+        Self::VALUE_LENGTH
     }
 
     /// Returns a clone of the value data buffer
@@ -818,7 +819,7 @@ impl DecimalArray {
 
     #[inline]
     fn value_offset_at(&self, i: usize) -> i32 {
-        self.length * i as i32
+        Self::VALUE_LENGTH * i as i32
     }
 
     #[inline]
@@ -956,13 +957,11 @@ impl From<ArrayData> for DecimalArray {
             DataType::Decimal(precision, scale) => (*precision, *scale),
             _ => panic!("Expected data type to be Decimal"),
         };
-        let length = 16;
         Self {
             data,
             value_data: unsafe { RawPtrBox::new(values) },
             precision,
             scale,
-            length,
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1967.

# Rationale for this change
The value length of Decimal128 is always 16 bytes, so declare it as a constant.

# Are there any user-facing changes?
Yes.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
