### PR TITLE
Enable serialized_reader read specific Page by passing row ranges.

### DIFF
--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -552,7 +552,7 @@ impl PageReader for InMemoryColumnChunkReader {
         Ok(None)
     }
 
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
         Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -205,7 +205,7 @@ pub trait PageReader: Iterator<Item = Result<Page>> + Send {
 
     /// Gets metadata about the next page, returns an error if no
     /// column index information
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>>;
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>>;
 
     /// Skips reading the next page, returns an error if no
     /// column index information

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -1792,6 +1792,7 @@ mod tests {
             7,
             Compression::UNCOMPRESSED,
             Type::INT32,
+            i64::MIN,
         )
         .unwrap();
 
@@ -1975,6 +1976,7 @@ mod tests {
                 data.len() as i64,
                 Compression::UNCOMPRESSED,
                 Int32Type::get_physical_type(),
+                i64::MIN,
             )
             .unwrap(),
         );
@@ -2358,6 +2360,7 @@ mod tests {
                 column_metadata.num_values(),
                 column_metadata.compression(),
                 T::get_physical_type(),
+                i64::MIN,
             )
             .unwrap(),
         );

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -228,7 +228,7 @@ pub struct RowGroupMetaData {
     num_rows: i64,
     total_byte_size: i64,
     schema_descr: SchemaDescPtr,
-    // Todo add filter result -> row range
+    page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
 impl RowGroupMetaData {
@@ -267,6 +267,11 @@ impl RowGroupMetaData {
         self.columns.iter().map(|c| c.total_compressed_size).sum()
     }
 
+    /// Returns reference of page offset index.
+    pub fn page_offset_index(&self) -> &Option<Vec<Vec<PageLocation>>> {
+        &self.page_offset_index
+    }
+
     /// Returns reference to a schema descriptor.
     pub fn schema_descr(&self) -> &SchemaDescriptor {
         self.schema_descr.as_ref()
@@ -275,6 +280,11 @@ impl RowGroupMetaData {
     /// Returns reference counted clone of schema descriptor.
     pub fn schema_descr_ptr(&self) -> SchemaDescPtr {
         self.schema_descr.clone()
+    }
+
+    /// Sets page offset index for this row group.
+    pub fn set_page_offset(&mut self, page_offset: Vec<Vec<PageLocation>>) {
+        self.page_offset_index = Some(page_offset);
     }
 
     /// Method to convert from Thrift.
@@ -295,6 +305,7 @@ impl RowGroupMetaData {
             num_rows,
             total_byte_size,
             schema_descr,
+            page_offset_index: None,
         })
     }
 
@@ -318,6 +329,7 @@ pub struct RowGroupMetaDataBuilder {
     schema_descr: SchemaDescPtr,
     num_rows: i64,
     total_byte_size: i64,
+    page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
 impl RowGroupMetaDataBuilder {
@@ -328,6 +340,7 @@ impl RowGroupMetaDataBuilder {
             schema_descr,
             num_rows: 0,
             total_byte_size: 0,
+            page_offset_index: None,
         }
     }
 
@@ -349,6 +362,12 @@ impl RowGroupMetaDataBuilder {
         self
     }
 
+    /// Sets page offset index for this row group.
+    pub fn set_page_offset(mut self, page_offset: Vec<Vec<PageLocation>>) -> Self {
+        self.page_offset_index = Some(page_offset);
+        self
+    }
+
     /// Builds row group metadata.
     pub fn build(self) -> Result<RowGroupMetaData> {
         if self.schema_descr.num_columns() != self.columns.len() {
@@ -364,6 +383,7 @@ impl RowGroupMetaDataBuilder {
             num_rows: self.num_rows,
             total_byte_size: self.total_byte_size,
             schema_descr: self.schema_descr,
+            page_offset_index: self.page_offset_index,
         })
     }
 }

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1052,6 +1052,7 @@ mod tests {
                 total_num_values,
                 codec,
                 physical_type,
+                i64::MIN,
             )
             .unwrap();
 

--- a/parquet/src/util/page_util.rs
+++ b/parquet/src/util/page_util.rs
@@ -15,18 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod io;
-pub mod memory;
-#[macro_use]
-pub mod bit_util;
-mod bit_packing;
-pub mod cursor;
-pub mod hash_util;
-#[cfg(any(test, feature = "test_common"))]
-pub(crate) mod test_common;
-pub(crate)mod page_util;
+use crate::errors::Result;
+use parquet_format::PageLocation;
 
-#[cfg(any(test, feature = "test_common"))]
-pub use self::test_common::page_util::{
-    DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
-};
+pub(crate) fn calculate_row_count(indexes: &[PageLocation], page_num: usize, total_row_count: i64) -> Result<usize> {
+    if page_num == indexes.len() - 1 {
+        Ok((total_row_count - indexes[page_num].first_row_index + 1) as usize)
+    } else {
+        Ok((indexes[page_num + 1].first_row_index - indexes[page_num].first_row_index) as usize)
+    }
+}

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -173,7 +173,7 @@ impl<P: Iterator<Item = Page> + Send> PageReader for InMemoryPageReader<P> {
         Ok(self.page_iter.next())
     }
 
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #1976.

# Rationale for this change
 Part support #1792 
if we want to use page index get row ranges , first use `SerializedFileReader` get pageIndex info, then use this index get 
 row_ranges like below:
``` rust
        //filter `x < 11`
        let filter =
            |page: &PageIndex<i32>| page.max.as_ref().map(|&x| x < 11).unwrap_or(false);

        let mask = index.indexes.iter().map(filter).collect::<Vec<_>>();

        let row_ranges = compute_row_ranges(&mask, locations, total_rows).unwrap();
```
Finally we can pass the `row_ranges` to new API  to read parquet file(datafusion use this way but without `row_ranges`)
```
fn get_record_reader_by_columns_and_row_ranges(
        &mut self,
        mask: ProjectionMask,
        row_ranges: &RowRanges,
        batch_size: usize,
    ) -> Result<ParquetRecordBatchReader> {
```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

One example: if we read  col1, col2  and apply filter get the result we need read `row_ranges[20, 80]`,
_For col1:_ 
  we need all data from page1, page2, page3. 
_For col2:_
 after this PR, we will **filter**  page2 and keep page0, page1
     as for page1: need all data
     as for page0: we need part of its row_range(need row align **TODO**)
```
 * rows   col1   col2   col3
 *      ┌──────┬──────┬──────┐
 *   0  │  p0  │      │      │
 *      ╞══════╡  p0  │  p0  │
 *  20  │ p1(X)│------│------│
 *      ╞══════╪══════╡      │
 *  40  │ p2(X)│      │------│
 *      ╞══════╡ p1(X)╞══════╡
 *  60  │ p3(X)│      │------│
 *      ╞══════╪══════╡      │
 *  80  │  p4  │      │  p1  │
 *      ╞══════╡  p2  │      │
 * 100  │  p5  │      │      │
 *      └──────┴──────┴──────┘
 * 
```

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
