### PR TITLE
Remove PrimitiveBuilder::finish_dict (#1978)

### DIFF
--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -166,6 +166,17 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     ) -> impl Iterator<Item = Option<T::Native>> + 'a {
         indexes.map(|opt_index| opt_index.map(|index| self.value_unchecked(index)))
     }
+
+    /// Returns the backing [`ArrayData`] of this [`PrimitiveArray`]
+    pub fn into_data(self) -> ArrayData {
+        self.into()
+    }
+}
+
+impl<T: ArrowPrimitiveType> From<PrimitiveArray<T>> for ArrayData {
+    fn from(a: PrimitiveArray<T>) -> Self {
+        a.data
+    }
 }
 
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -195,6 +195,11 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
     ) -> impl Iterator<Item = Option<&str>> + 'a {
         indexes.map(|opt_index| opt_index.map(|index| self.value_unchecked(index)))
     }
+
+    /// Returns the backing [`ArrayData`] of this [`GenericStringArray`]
+    pub fn into_data(self) -> ArrayData {
+        self.into()
+    }
 }
 
 impl<'a, Ptr, OffsetSize: OffsetSizeTrait> FromIterator<&'a Option<Ptr>>
@@ -333,6 +338,12 @@ impl<OffsetSize: OffsetSizeTrait> From<Vec<&str>> for GenericStringArray<OffsetS
 impl<OffsetSize: OffsetSizeTrait> From<Vec<String>> for GenericStringArray<OffsetSize> {
     fn from(v: Vec<String>) -> Self {
         Self::from_iter_values(v)
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait> From<GenericStringArray<OffsetSize>> for ArrayData {
+    fn from(a: GenericStringArray<OffsetSize>) -> Self {
+        a.data
     }
 }
 

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -1217,6 +1217,11 @@ impl ArrayData {
             .zip(other.child_data.iter())
             .all(|(a, b)| a.ptr_eq(b))
     }
+
+    /// Converts this [`ArrayData`] into an [`ArrayDataBuilder`]
+    pub fn into_builder(self) -> ArrayDataBuilder {
+        self.into()
+    }
 }
 
 /// Return the expected [`DataTypeLayout`] Arrays of this data
@@ -1408,6 +1413,10 @@ impl ArrayDataBuilder {
         }
     }
 
+    pub fn data_type(self, data_type: DataType) -> Self {
+        Self { data_type, ..self }
+    }
+
     #[inline]
     #[allow(clippy::len_without_is_empty)]
     pub const fn len(mut self, n: usize) -> Self {
@@ -1479,6 +1488,22 @@ impl ArrayDataBuilder {
             self.buffers,
             self.child_data,
         )
+    }
+}
+
+impl From<ArrayData> for ArrayDataBuilder {
+    fn from(d: ArrayData) -> Self {
+        // TODO: Store Bitmap on ArrayData (#1799)
+        let null_bit_buffer = d.null_buffer().cloned();
+        Self {
+            null_bit_buffer,
+            data_type: d.data_type,
+            len: d.len,
+            null_count: Some(d.null_count),
+            offset: d.offset,
+            buffers: d.buffers,
+            child_data: d.child_data,
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1978 
Part of #1979 

# Rationale for this change
 
The finish_dict method has always struck me as a little bit strange, and it is definitely not safe. This PR just removes it

# What changes are included in this PR?

Starts the process of #1979 and uses this to remove the need for `PrimitiveBuilder::finish_dict`

# Are there any user-facing changes?

Yes, this removes an API
