### PR TITLE
Stub out Skip Records API (#1792)

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -122,6 +122,10 @@ impl<I: OffsetSizeTrait + ScalarValue> ArrayReader for ByteArrayReader<I> {
         Ok(buffer.into_array(null_buffer, self.data_type.clone()))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        self.record_reader.skip_records(num_records)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels_buffer
             .as_ref()
@@ -209,6 +213,10 @@ impl<I: OffsetSizeTrait + ScalarValue> ColumnValueDecoder
             .ok_or_else(|| general_err!("no decoder set"))?;
 
         decoder.read(out, range.end - range.start, self.dict.as_ref())
+    }
+
+    fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
+        todo!()
     }
 }
 

--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -216,7 +216,7 @@ impl<I: OffsetSizeTrait + ScalarValue> ColumnValueDecoder
     }
 
     fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -184,6 +184,10 @@ where
         Ok(array)
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        self.record_reader.skip_records(num_records)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels_buffer
             .as_ref()
@@ -370,6 +374,10 @@ where
                 }
             }
         }
+    }
+
+    fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
+        todo!()
     }
 }
 

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -377,7 +377,7 @@ where
     }
 
     fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 

--- a/parquet/src/arrow/array_reader/complex_object_array.rs
+++ b/parquet/src/arrow/array_reader/complex_object_array.rs
@@ -163,6 +163,13 @@ where
         Ok(array)
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        match self.column_reader.as_mut() {
+            Some(reader) => reader.skip_records(num_records),
+            None => Ok(0),
+        }
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels_buffer.as_deref()
     }

--- a/parquet/src/arrow/array_reader/empty_array.rs
+++ b/parquet/src/arrow/array_reader/empty_array.rs
@@ -65,6 +65,12 @@ impl ArrayReader for EmptyArrayReader {
         Ok(Arc::new(StructArray::from(data)))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        let skipped = self.remaining_rows.min(num_records);
+        self.remaining_rows -= skipped;
+        Ok(skipped)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         None
     }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -231,6 +231,10 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
         Ok(Arc::new(result_array))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        self.item_reader.skip_records(num_records)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.item_reader.get_def_levels()
     }

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -149,6 +149,19 @@ impl ArrayReader for MapArrayReader {
         Ok(Arc::new(MapArray::from(array_data)))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        let key_skipped = self.key_reader.skip_records(num_records)?;
+        let value_skipped = self.value_reader.skip_records(num_records)?;
+        if key_skipped != value_skipped {
+            return Err(general_err!(
+                "MapArrayReader out of sync, skipped {} keys and {} values",
+                key_skipped,
+                value_skipped
+            ));
+        }
+        Ok(key_skipped)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         // Children definition levels should describe the same parent structure,
         // so return key_reader only

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -64,6 +64,9 @@ pub trait ArrayReader: Send {
     /// Reads at most `batch_size` records into an arrow array and return it.
     fn next_batch(&mut self, batch_size: usize) -> Result<ArrayRef>;
 
+    /// Skips over `num_records` records, returning the number of rows skipped
+    fn skip_records(&mut self, num_records: usize) -> Result<usize>;
+
     /// If this array has a non-zero definition level, i.e. has a nullable parent
     /// array, returns the definition levels of data from the last call of `next_batch`
     ///

--- a/parquet/src/arrow/array_reader/null_array.rs
+++ b/parquet/src/arrow/array_reader/null_array.rs
@@ -96,6 +96,10 @@ where
         Ok(Arc::new(array))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        self.record_reader.skip_records(num_records)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels_buffer.as_ref().map(|buf| buf.typed_data())
     }

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -233,6 +233,10 @@ where
         Ok(array)
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        self.record_reader.skip_records(num_records)
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels_buffer.as_ref().map(|buf| buf.typed_data())
     }

--- a/parquet/src/arrow/array_reader/test_util.rs
+++ b/parquet/src/arrow/array_reader/test_util.rs
@@ -170,6 +170,11 @@ impl ArrayReader for InMemoryArrayReader {
         Ok(self.array.slice(self.last_idx, read))
     }
 
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        let array = self.next_batch(num_records)?;
+        Ok(array.len())
+    }
+
     fn get_def_levels(&self) -> Option<&[i16]> {
         self.def_levels
             .as_ref()

--- a/parquet/src/arrow/arrow_reader.rs
+++ b/parquet/src/arrow/arrow_reader.rs
@@ -127,7 +127,7 @@ impl ArrowReaderOptions {
 
     /// Scan rows from the parquet file according to the provided `selection`
     ///
-    /// TODO: Make public once row selection fully implemented
+    /// TODO: Make public once row selection fully implemented (#1792)
     pub(crate) fn with_row_selection(
         self,
         selection: impl Into<Vec<RowSelection>>,
@@ -348,7 +348,7 @@ impl ParquetRecordBatchReader {
     /// a time from [`ArrayReader`] based on the configured `selection`. If `selection` is `None`
     /// all rows will be returned
     ///
-    /// TODO: Make public once row selection fully implemented
+    /// TODO: Make public once row selection fully implemented (#1792)
     pub(crate) fn new(
         batch_size: usize,
         array_reader: Box<dyn ArrayReader>,

--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -97,7 +97,7 @@ use crate::arrow::arrow_reader::ParquetRecordBatchReader;
 use crate::arrow::schema::parquet_to_arrow_schema;
 use crate::arrow::ProjectionMask;
 use crate::basic::Compression;
-use crate::column::page::{Page, PageIterator, PageReader};
+use crate::column::page::{Page, PageIterator, PageMetadata, PageReader};
 use crate::compression::{create_codec, Codec};
 use crate::errors::{ParquetError, Result};
 use crate::file::footer::{decode_footer, decode_metadata};
@@ -550,6 +550,14 @@ impl PageReader for InMemoryColumnChunkReader {
 
         // We are at the end of this column chunk and no more page left. Return None.
         Ok(None)
+    }
+
+    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+        todo!()
+    }
+
+    fn skip_next_page(&mut self) -> Result<()> {
+        todo!()
     }
 }
 

--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -553,11 +553,11 @@ impl PageReader for InMemoryColumnChunkReader {
     }
 
     fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 
     fn skip_next_page(&mut self) -> Result<()> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -25,7 +25,7 @@ use crate::arrow::buffer::bit_util::count_set_bits;
 use crate::arrow::record_reader::buffer::BufferQueue;
 use crate::basic::Encoding;
 use crate::column::reader::decoder::{
-    ColumnLevelDecoder, ColumnLevelDecoderImpl, LevelsBufferSlice,
+    ColumnLevelDecoder, ColumnLevelDecoderImpl, DefinitionLevelDecoder, LevelsBufferSlice,
 };
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
@@ -146,7 +146,7 @@ impl LevelsBufferSlice for DefinitionLevelBuffer {
     }
 }
 
-pub struct DefinitionLevelDecoder {
+pub struct DefinitionLevelBufferDecoder {
     max_level: i16,
     encoding: Encoding,
     data: Option<ByteBufferPtr>,
@@ -154,7 +154,7 @@ pub struct DefinitionLevelDecoder {
     packed_decoder: Option<PackedDecoder>,
 }
 
-impl ColumnLevelDecoder for DefinitionLevelDecoder {
+impl ColumnLevelDecoder for DefinitionLevelBufferDecoder {
     type Slice = DefinitionLevelBuffer;
 
     fn new(max_level: i16, encoding: Encoding, data: ByteBufferPtr) -> Self {
@@ -220,6 +220,16 @@ impl ColumnLevelDecoder for DefinitionLevelDecoder {
                 decoder.read(nulls, range.end - range.start)
             }
         }
+    }
+}
+
+impl DefinitionLevelDecoder for DefinitionLevelBufferDecoder {
+    fn skip_def_levels(
+        &mut self,
+        _num_levels: usize,
+        _max_def_level: i16,
+    ) -> Result<(usize, usize)> {
+        todo!()
     }
 }
 

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -229,7 +229,7 @@ impl DefinitionLevelDecoder for DefinitionLevelBufferDecoder {
         _num_levels: usize,
         _max_def_level: i16,
     ) -> Result<(usize, usize)> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -220,7 +220,7 @@ where
         self.consume_bitmap();
         self.reset();
 
-        let remaining = buffered_records - num_records;
+        let remaining = num_records - buffered_records;
 
         if remaining == 0 {
             return Ok(buffered_records);

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -22,7 +22,7 @@ use arrow::buffer::Buffer;
 
 use crate::arrow::record_reader::{
     buffer::{BufferQueue, ScalarBuffer, ValuesBuffer},
-    definition_levels::{DefinitionLevelBuffer, DefinitionLevelDecoder},
+    definition_levels::{DefinitionLevelBuffer, DefinitionLevelBufferDecoder},
 };
 use crate::column::{
     page::PageReader,
@@ -56,8 +56,9 @@ pub struct GenericRecordReader<V, CV> {
     records: V,
     def_levels: Option<DefinitionLevelBuffer>,
     rep_levels: Option<ScalarBuffer<i16>>,
-    column_reader:
-        Option<GenericColumnReader<ColumnLevelDecoderImpl, DefinitionLevelDecoder, CV>>,
+    column_reader: Option<
+        GenericColumnReader<ColumnLevelDecoderImpl, DefinitionLevelBufferDecoder, CV>,
+    >,
 
     /// Number of records accumulated in records
     num_records: usize,
@@ -200,6 +201,37 @@ where
         }
 
         Ok(records_read)
+    }
+
+    /// Try to skip the next `num_records` rows
+    ///
+    /// # Returns
+    ///
+    /// Number of records skipped
+    pub fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        // First need to clear the buffer
+        let (buffered_records, buffered_values) = self.count_records(num_records);
+        self.num_records += buffered_records;
+        self.num_values += buffered_values;
+
+        self.consume_def_levels();
+        self.consume_rep_levels();
+        self.consume_record_data();
+        self.consume_bitmap();
+        self.reset();
+
+        let remaining = buffered_records - num_records;
+
+        if remaining == 0 {
+            return Ok(buffered_records);
+        }
+
+        let skipped = match self.column_reader.as_mut() {
+            Some(column_reader) => column_reader.skip_records(remaining)?,
+            None => 0,
+        };
+
+        Ok(skipped + buffered_records)
     }
 
     /// Returns number of records stored in buffer.

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -187,12 +187,29 @@ impl PageWriteSpec {
     }
 }
 
+/// Contains metadata for a page
+pub struct PageMetadata {
+    /// The number of rows in this page
+    pub num_rows: usize,
+
+    /// Returns true if the page is a dictionary page
+    pub is_dict: bool,
+}
+
 /// API for reading pages from a column chunk.
 /// This offers a iterator like API to get the next page.
 pub trait PageReader: Iterator<Item = Result<Page>> + Send {
     /// Gets the next page in the column chunk associated with this reader.
     /// Returns `None` if there are no pages left.
     fn get_next_page(&mut self) -> Result<Option<Page>>;
+
+    /// Gets metadata about the next page, returns an error if no
+    /// column index information
+    fn peek_next_page(&self) -> Result<Option<PageMetadata>>;
+
+    /// Skips reading the next page, returns an error if no
+    /// column index information
+    fn skip_next_page(&mut self) -> Result<()>;
 }
 
 /// API for writing pages in a column chunk.

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -251,7 +251,7 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     }
 
     fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 
@@ -301,12 +301,12 @@ impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
         _num_levels: usize,
         _max_def_level: i16,
     ) -> Result<(usize, usize)> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 
 impl RepetitionLevelDecoder for ColumnLevelDecoderImpl {
     fn skip_rep_levels(&mut self, _num_records: usize) -> Result<(usize, usize)> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -81,6 +81,25 @@ pub trait ColumnLevelDecoder {
     fn read(&mut self, out: &mut Self::Slice, range: Range<usize>) -> Result<usize>;
 }
 
+pub trait RepetitionLevelDecoder: ColumnLevelDecoder {
+    /// Skips over repetition level corresponding to `num_records` records, where a record
+    /// is delimited by a repetition level of 0
+    ///
+    /// Returns the number of records skipped, and the number of levels skipped
+    fn skip_rep_levels(&mut self, num_records: usize) -> Result<(usize, usize)>;
+}
+
+pub trait DefinitionLevelDecoder: ColumnLevelDecoder {
+    /// Skips over `num_levels` definition levels
+    ///
+    /// Returns the number of values skipped, and the number of levels skipped
+    fn skip_def_levels(
+        &mut self,
+        num_levels: usize,
+        max_def_level: i16,
+    ) -> Result<(usize, usize)>;
+}
+
 /// Decodes value data to a [`ValuesBufferSlice`]
 pub trait ColumnValueDecoder {
     type Slice: ValuesBufferSlice + ?Sized;
@@ -126,6 +145,11 @@ pub trait ColumnValueDecoder {
     /// Implementations may panic if `range` overlaps with already written data
     ///
     fn read(&mut self, out: &mut Self::Slice, range: Range<usize>) -> Result<usize>;
+
+    /// Skips over `num_values` values
+    ///
+    /// Returns the number of values skipped
+    fn skip_values(&mut self, num_values: usize) -> Result<usize>;
 }
 
 /// An implementation of [`ColumnValueDecoder`] for `[T::T]`
@@ -225,6 +249,10 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
 
         current_decoder.get(&mut out[range])
     }
+
+    fn skip_values(&mut self, _num_values: usize) -> Result<usize> {
+        todo!()
+    }
 }
 
 /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
@@ -264,5 +292,21 @@ impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
             }
             LevelDecoderInner::Rle(reader) => reader.get_batch(&mut out[range]),
         }
+    }
+}
+
+impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
+    fn skip_def_levels(
+        &mut self,
+        _num_levels: usize,
+        _max_def_level: i16,
+    ) -> Result<(usize, usize)> {
+        todo!()
+    }
+}
+
+impl RepetitionLevelDecoder for ColumnLevelDecoderImpl {
+    fn skip_rep_levels(&mut self, _num_records: usize) -> Result<(usize, usize)> {
+        todo!()
     }
 }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -557,11 +557,11 @@ impl<T: Read + Send> PageReader for SerializedPageReader<T> {
     }
 
     fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 
     fn skip_next_page(&mut self) -> Result<()> {
-        todo!()
+        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 }
 

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -25,7 +25,7 @@ use parquet_format::{PageHeader, PageType};
 use thrift::protocol::TCompactInputProtocol;
 
 use crate::basic::{Compression, Encoding, Type};
-use crate::column::page::{Page, PageReader};
+use crate::column::page::{Page, PageMetadata, PageReader};
 use crate::compression::{create_codec, Codec};
 use crate::errors::{ParquetError, Result};
 use crate::file::page_index::index_reader;
@@ -554,6 +554,14 @@ impl<T: Read + Send> PageReader for SerializedPageReader<T> {
 
         // We are at the end of this column chunk and no more page left. Return None.
         Ok(None)
+    }
+
+    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+        todo!()
+    }
+
+    fn skip_next_page(&mut self) -> Result<()> {
+        todo!()
     }
 }
 

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::basic::Encoding;
-use crate::column::page::PageReader;
+use crate::column::page::{PageMetadata, PageReader};
 use crate::column::page::{Page, PageIterator};
 use crate::data_type::DataType;
 use crate::encodings::encoding::{get_encoder, DictEncoder, Encoder};
@@ -171,6 +171,14 @@ impl<P: Iterator<Item = Page>> InMemoryPageReader<P> {
 impl<P: Iterator<Item = Page> + Send> PageReader for InMemoryPageReader<P> {
     fn get_next_page(&mut self) -> Result<Option<Page>> {
         Ok(self.page_iter.next())
+    }
+
+    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+        unimplemented!()
+    }
+
+    fn skip_next_page(&mut self) -> Result<()> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1792

# Rationale for this change
 
Stubs out an API for providing skip records functionality within parquet. I think this will work to support #1792, #1191 and potentially other functionality down the line.

Let me know what you think @Ted-Jiang @sunchao 

# What changes are included in this PR?

Stubs out APIs for adding row skipping logic to the parquet implementation

# Are there any user-facing changes?

No :tada:
