### PR TITLE
Fix parquet test_common feature flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,6 +107,7 @@ jobs:
           cargo check -p parquet
           cargo check -p parquet --no-default-features
           cargo check -p parquet --no-default-features --features arrow
+          cargo check -p parquet --all-features
       - name: Test compilation of parquet targets with different feature combinations
         run: |
           cargo check -p parquet --all-targets

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -72,7 +72,7 @@ arrow = ["dep:arrow", "base64"]
 # Enable CLI tools
 cli = ["serde_json", "base64", "clap","arrow/csv"]
 # Enable internal testing APIs
-test_common = []
+test_common = ["arrow/test_utils"]
 # Experimental, unstable functionality primarily used for testing
 experimental = []
 # Enable async APIs


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
Without this running

```
cargo check -p parquet --features test_common
```

Would result in

```
error[E0433]: failed to resolve: could not find `test_util` in `util`
  --> parquet/src/util/test_common/file_util.rs:23:41
   |
23 |         PathBuf::from_str(&arrow::util::test_util::parquet_test_data()).unwrap();
   |                                         ^^^^^^^^^ could not find `test_util` in `util`
```

# What changes are included in this PR?

Enables the `arrow/test_util` feature if the parquet `test_common` feature is enabled

# Are there any user-facing changes?

No
