### PR TITLE
Don't generate empty google.protobuf.rs

### DIFF
--- a/arrow-flight/build.rs
+++ b/arrow-flight/build.rs
@@ -88,6 +88,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         file.write_all(buffer.as_bytes())?;
     }
 
+    // Prost currently generates an empty file, this was fixed but then reverted
+    // https://github.com/tokio-rs/prost/pull/639
+    let google_protobuf_rs = Path::new("src/sql/google.protobuf.rs");
+    if google_protobuf_rs.exists() {
+        std::fs::remove_file(google_protobuf_rs).unwrap();
+    }
+
     // As the proto file is checked in, the build should not fail if the file is not found
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
Since https://github.com/tokio-rs/prost/pull/639 was reverted, prost generates some empty files. Lets explicitly make sure this file is expunged.

# What changes are included in this PR?

Automatically deletes the empty file if it is created

# Are there any user-facing changes?

No
