### PR TITLE
Add page index reader test for all types and support empty index.

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -55,8 +55,10 @@ use crate::schema::types::{
 pub struct ParquetMetaData {
     file_metadata: FileMetaData,
     row_groups: Vec<RowGroupMetaData>,
-    page_indexes: Option<Vec<Index>>,
-    offset_indexes: Option<Vec<Vec<PageLocation>>>,
+    /// Page index for all pages in each column chunk
+    page_indexes: Option<Vec<Vec<Index>>>,
+    /// Offset index for all pages in each column chunk
+    offset_indexes: Option<Vec<Vec<Vec<PageLocation>>>>,
 }
 
 impl ParquetMetaData {
@@ -74,8 +76,8 @@ impl ParquetMetaData {
     pub fn new_with_page_index(
         file_metadata: FileMetaData,
         row_groups: Vec<RowGroupMetaData>,
-        page_indexes: Option<Vec<Index>>,
-        offset_indexes: Option<Vec<Vec<PageLocation>>>,
+        page_indexes: Option<Vec<Vec<Index>>>,
+        offset_indexes: Option<Vec<Vec<Vec<PageLocation>>>>,
     ) -> Self {
         ParquetMetaData {
             file_metadata,
@@ -107,12 +109,12 @@ impl ParquetMetaData {
     }
 
     /// Returns page indexes in this file.
-    pub fn page_indexes(&self) -> Option<&Vec<Index>> {
+    pub fn page_indexes(&self) -> Option<&Vec<Vec<Index>>> {
         self.page_indexes.as_ref()
     }
 
     /// Returns offset indexes in this file.
-    pub fn offset_indexes(&self) -> Option<&Vec<Vec<PageLocation>>> {
+    pub fn offset_indexes(&self) -> Option<&Vec<Vec<Vec<PageLocation>>>> {
         self.offset_indexes.as_ref()
     }
 }

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -59,7 +59,7 @@ pub enum Index {
     /// Sometimes reading page index from parquet file
     /// will only return pageLocations without min_max index,
     /// `None` represents this lack of index information
-    EMPTY_ARRAY,
+    None,
 }
 
 /// An index of a column of [`Type`] physical representation

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -56,7 +56,7 @@ pub enum Index {
     DOUBLE(NativeIndex<f64>),
     BYTE_ARRAY(ByteArrayIndex),
     FIXED_LEN_BYTE_ARRAY(ByteArrayIndex),
-    EMPTY_ARRAY(),
+    EMPTY_ARRAY,
 }
 
 /// An index of a column of [`Type`] physical representation

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -56,6 +56,9 @@ pub enum Index {
     DOUBLE(NativeIndex<f64>),
     BYTE_ARRAY(ByteArrayIndex),
     FIXED_LEN_BYTE_ARRAY(ByteArrayIndex),
+    /// Sometimes reading page index from parquet file
+    /// will only return pageLocations without min_max index,
+    /// Use `EMPTY_ARRAY` representing None will be more convenient.
     EMPTY_ARRAY,
 }
 

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -58,7 +58,7 @@ pub enum Index {
     FIXED_LEN_BYTE_ARRAY(ByteArrayIndex),
     /// Sometimes reading page index from parquet file
     /// will only return pageLocations without min_max index,
-    /// Use `EMPTY_ARRAY` representing None will be more convenient.
+    /// `None` represents this lack of index information
     EMPTY_ARRAY,
 }
 

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -56,6 +56,7 @@ pub enum Index {
     DOUBLE(NativeIndex<f64>),
     BYTE_ARRAY(ByteArrayIndex),
     FIXED_LEN_BYTE_ARRAY(ByteArrayIndex),
+    EMPTY_ARRAY(),
 }
 
 /// An index of a column of [`Type`] physical representation

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -101,13 +101,7 @@ fn get_index_offset_and_lengths(
         .iter()
         .map(|x| x.column_index_length())
         .map(|maybe_length| {
-            let index_length = maybe_length.ok_or_else(|| {
-                ParquetError::General(
-                    "The column_index_length must exist if offset_index_offset exists"
-                        .to_string(),
-                )
-            })?;
-
+            let index_length = maybe_length.unwrap_or(0);
             Ok(index_length.try_into().unwrap())
         })
         .collect::<Result<Vec<_>, ParquetError>>()?;
@@ -143,6 +137,9 @@ fn deserialize_column_index(
     data: &[u8],
     column_type: Type,
 ) -> Result<Index, ParquetError> {
+    if data.is_empty() {
+        return Ok(Index::EMPTY_ARRAY());
+    }
     let mut d = Cursor::new(data);
     let mut prot = TCompactInputProtocol::new(&mut d);
 

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -138,7 +138,7 @@ fn deserialize_column_index(
     column_type: Type,
 ) -> Result<Index, ParquetError> {
     if data.is_empty() {
-        return Ok(Index::EMPTY_ARRAY);
+        return Ok(Index::None);
     }
     let mut d = Cursor::new(data);
     let mut prot = TCompactInputProtocol::new(&mut d);

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -138,7 +138,7 @@ fn deserialize_column_index(
     column_type: Type,
 ) -> Result<Index, ParquetError> {
     if data.is_empty() {
-        return Ok(Index::EMPTY_ARRAY());
+        return Ok(Index::EMPTY_ARRAY);
     }
     let mut d = Cursor::new(data);
     let mut prot = TCompactInputProtocol::new(&mut d);

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -571,7 +571,6 @@ mod tests {
     use crate::schema::parser::parse_message_type;
     use crate::util::bit_util::from_le_slice;
     use crate::util::test_common::{get_test_file, get_test_path};
-    use arrow::datatypes::ToByteSlice;
     use parquet_format::BoundaryOrder;
     use std::sync::Arc;
 
@@ -1138,16 +1137,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 0),
                 BoundaryOrder::Unordered,
             );
             assert_eq!(row_group_offset_indexes[0].len(), 325);
@@ -1166,16 +1156,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 2),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[2].len(), 325);
@@ -1187,16 +1168,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 3),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[3].len(), 325);
@@ -1208,16 +1180,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 4),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[4].len(), 325);
@@ -1226,12 +1189,10 @@ mod tests {
         };
         //col6->bigint_col: INT64 UNCOMPRESSED DO:0 FPO:152326 SZ:71598/71598/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 90, num_nulls: 0]
         if let Index::INT64(index) = &page_indexes[0][5] {
-            //Todo row_group_metadata.column(0).statistics().unwrap().min_bytes() only return 4 bytes
             check_native_page_index(
                 index,
                 528,
-                0_i64.to_byte_slice(),
-                100_i64.to_byte_slice(),
+                get_row_group_min_max_bytes(row_group_metadata, 5),
                 BoundaryOrder::Unordered,
             );
             assert_eq!(row_group_offset_indexes[5].len(), 528);
@@ -1243,16 +1204,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 6),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[6].len(), 325);
@@ -1264,8 +1216,7 @@ mod tests {
             check_native_page_index(
                 index,
                 528,
-                0_i64.to_byte_slice(),
-                100_i64.to_byte_slice(),
+                get_row_group_min_max_bytes(row_group_metadata, 7),
                 BoundaryOrder::Unordered,
             );
             assert_eq!(row_group_offset_indexes[7].len(), 528);
@@ -1277,16 +1228,7 @@ mod tests {
             check_bytes_page_index(
                 index,
                 974,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 8),
                 BoundaryOrder::Unordered,
             );
             assert_eq!(row_group_offset_indexes[8].len(), 974);
@@ -1298,16 +1240,7 @@ mod tests {
             check_bytes_page_index(
                 index,
                 352,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 9),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[9].len(), 352);
@@ -1315,6 +1248,7 @@ mod tests {
             unreachable!()
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
+        //Notice: min_max values for each page for this col not exits.
         if let Index::EMPTY_ARRAY() = &page_indexes[0][10] {
             assert_eq!(row_group_offset_indexes[10].len(), 974);
         } else {
@@ -1325,16 +1259,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 11),
                 BoundaryOrder::Ascending,
             );
             assert_eq!(row_group_offset_indexes[11].len(), 325);
@@ -1346,16 +1271,7 @@ mod tests {
             check_native_page_index(
                 index,
                 325,
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .min_bytes(),
-                row_group_metadata
-                    .column(0)
-                    .statistics()
-                    .unwrap()
-                    .max_bytes(),
+                get_row_group_min_max_bytes(row_group_metadata, 12),
                 BoundaryOrder::Unordered,
             );
             assert_eq!(row_group_offset_indexes[12].len(), 325);
@@ -1367,30 +1283,36 @@ mod tests {
     fn check_native_page_index<T: ParquetValueType>(
         row_group_index: &NativeIndex<T>,
         page_size: usize,
-        min_value: &[u8],
-        max_value: &[u8],
+        min_max: (&[u8], &[u8]),
         boundary_order: BoundaryOrder,
     ) {
         assert_eq!(row_group_index.indexes.len(), page_size);
         assert_eq!(row_group_index.boundary_order, boundary_order);
         row_group_index.indexes.iter().all(|x| {
-            x.min.as_ref().unwrap() >= &from_le_slice::<T>(min_value)
-                && x.max.as_ref().unwrap() <= &from_le_slice::<T>(max_value)
+            x.min.as_ref().unwrap() >= &from_le_slice::<T>(min_max.0)
+                && x.max.as_ref().unwrap() <= &from_le_slice::<T>(min_max.1)
         });
     }
 
     fn check_bytes_page_index(
         row_group_index: &ByteArrayIndex,
         page_size: usize,
-        min_value: &[u8],
-        max_value: &[u8],
+        min_max: (&[u8], &[u8]),
         boundary_order: BoundaryOrder,
     ) {
         assert_eq!(row_group_index.indexes.len(), page_size);
         assert_eq!(row_group_index.boundary_order, boundary_order);
         row_group_index.indexes.iter().all(|x| {
-            x.min.as_ref().unwrap().as_slice() >= min_value
-                && x.max.as_ref().unwrap().as_slice() <= max_value
+            x.min.as_ref().unwrap().as_slice() >= min_max.0
+                && x.max.as_ref().unwrap().as_slice() <= min_max.1
         });
+    }
+
+    fn get_row_group_min_max_bytes(
+        r: &RowGroupMetaData,
+        col_num: usize,
+    ) -> (&[u8], &[u8]) {
+        let statistics = r.column(col_num).statistics().unwrap();
+        (statistics.min_bytes(), statistics.max_bytes())
     }
 }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1249,7 +1249,7 @@ mod tests {
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
         //Notice: min_max values for each page for this col not exits.
-        if let Index::EMPTY_ARRAY() = &page_indexes[0][10] {
+        if let Index::EMPTY_ARRAY = &page_indexes[0][10] {
             assert_eq!(row_group_offset_indexes[10].len(), 974);
         } else {
             unreachable!()

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1249,7 +1249,7 @@ mod tests {
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
         //Notice: min_max values for each page for this col not exits.
-        if let Index::EMPTY_ARRAY = &page_indexes[0][10] {
+        if let Index::None = &page_indexes[0][10] {
             assert_eq!(row_group_offset_indexes[10].len(), 974);
         } else {
             unreachable!()


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/2010.

# Rationale for this change
 
After https://github.com/apache/parquet-testing/pull/25 merged, there will be standard page index test file in parquet-testing.All types support page index in parquet-format has add test in this pr.

Another change:
I found there is a situation one col has pageLocation but without min_max index(😂 i missed it). So add EMPTY_ARRAY in enum Index.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
