### PR TITLE
Add builder style APIs For `Field`: `with_name`, `with_data_type` and `with_nullable`

### DIFF
--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -26,9 +26,10 @@ use crate::error::{ArrowError, Result};
 
 use super::DataType;
 
-/// Contains the meta-data for a single relative type.
+/// Describes a single column in a [`Schema`](super::Schema).
 ///
-/// The `Schema` object is an ordered collection of `Field` objects.
+/// A [`Schema`](super::Schema) is an ordered collection of
+/// [`Field`] objects.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Field {
     name: String,
@@ -95,7 +96,7 @@ impl Field {
         }
     }
 
-    /// Creates a new field
+    /// Creates a new field that has additional dictionary information
     pub fn new_dict(
         name: &str,
         data_type: DataType,
@@ -144,19 +145,62 @@ impl Field {
         &self.name
     }
 
-    /// Returns an immutable reference to the `Field`'s  data-type.
+    /// Set the name of the [`Field`].
+    ///
+    /// ```
+    /// # use arrow::datatypes::*;
+    /// let field = Field::new("c1", DataType::Int64, false)
+    ///    .with_name("c2");
+    ///
+    /// assert_eq!(field.name(), "c2");
+    /// ```
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Returns an immutable reference to the [`Field`]'s  [`DataType`].
     #[inline]
     pub const fn data_type(&self) -> &DataType {
         &self.data_type
     }
 
-    /// Indicates whether this `Field` supports null values.
+    /// Set [`DataType`] of the [`Field`]
+    ///
+    /// ```
+    /// # use arrow::datatypes::*;
+    /// let field = Field::new("c1", DataType::Int64, false)
+    ///    .with_data_type(DataType::Utf8);
+    ///
+    /// assert_eq!(field.data_type(), &DataType::Utf8);
+    /// ```
+    pub fn with_data_type(mut self, data_type: DataType) -> Self {
+        self.data_type = data_type;
+        self
+    }
+
+    /// Indicates whether this [`Field`] supports null values.
     #[inline]
     pub const fn is_nullable(&self) -> bool {
         self.nullable
     }
 
-    /// Returns a (flattened) vector containing all fields contained within this field (including it self)
+    /// Set `nullable` of the [`Field`]
+    ///
+    /// ```
+    /// # use arrow::datatypes::*;
+    /// let field = Field::new("c1", DataType::Int64, false)
+    ///    .with_nullable(true);
+    ///
+    /// assert_eq!(field.is_nullable(), true);
+    /// ```
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = nullable;
+        self
+    }
+
+    /// Returns a (flattened) [`Vec`] containing all child [`Field`]s
+    /// within `self` contained within this field (including `self`)
     pub(crate) fn fields(&self) -> Vec<&Field> {
         let mut collected_fields = vec![self];
         collected_fields.append(&mut self._fields(&self.data_type));
@@ -491,14 +535,16 @@ impl Field {
         }
     }
 
-    /// Merge field into self if it is compatible. Struct will be merged recursively.
-    /// NOTE: `self` may be updated to unexpected state in case of merge failure.
+    /// Merge this field into self if it is compatible.
+    ///
+    /// Struct fields are merged recursively.
+    ///
+    /// NOTE: `self` may be updated to a partial / unexpected state in case of merge failure.
     ///
     /// Example:
     ///
     /// ```
-    /// use arrow::datatypes::*;
-    ///
+    /// # use arrow::datatypes::*;
     /// let mut field = Field::new("c1", DataType::Int64, false);
     /// assert!(field.try_merge(&Field::new("c1", DataType::Int64, true)).is_ok());
     /// assert!(field.is_nullable());

--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -145,7 +145,7 @@ impl Field {
         &self.name
     }
 
-    /// Set the name of the [`Field`].
+    /// Set the name of the [`Field`] and returns self.
     ///
     /// ```
     /// # use arrow::datatypes::*;
@@ -165,7 +165,7 @@ impl Field {
         &self.data_type
     }
 
-    /// Set [`DataType`] of the [`Field`]
+    /// Set [`DataType`] of the [`Field`] and returns self.
     ///
     /// ```
     /// # use arrow::datatypes::*;
@@ -185,7 +185,7 @@ impl Field {
         self.nullable
     }
 
-    /// Set `nullable` of the [`Field`]
+    /// Set `nullable` of the [`Field`] and returns self.
     ///
     /// ```
     /// # use arrow::datatypes::*;


### PR DESCRIPTION

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1934


# Rationale for this change
 

The lack of such an API caused me consternation in https://github.com/apache/arrow-datafusion/pull/2803 and https://github.com/influxdata/influxdb_iox/pull/5021

Basically I want to be able to change a field's nullability like

```rust
let new_field = old_field.clone().with_nullable(false);
```

But instead I have to do something like

```rust
 // make a copy of the field, but allow it to be nullable
 Field::new(f.name(), f.data_type().clone(), true)
   .with_metadata(f.metadata().cloned())
```

# What changes are included in this PR?
1. Add `Field::with_name`
1. Add `Field::with_data_type`
1. Add `Field::with_nullability`
2. Add examples (which also serve as tests)
3. Update  additional documentation


# Are there any user-facing changes?

yes, new APIs and better docs