### PR TITLE
Consistent case in Index enumeration

### DIFF
--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -48,6 +48,10 @@ impl<T> PageIndex<T> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Index {
+    /// Sometimes reading page index from parquet file
+    /// will only return pageLocations without min_max index,
+    /// `NONE` represents this lack of index information
+    NONE,
     BOOLEAN(BooleanIndex),
     INT32(NativeIndex<i32>),
     INT64(NativeIndex<i64>),
@@ -56,10 +60,6 @@ pub enum Index {
     DOUBLE(NativeIndex<f64>),
     BYTE_ARRAY(ByteArrayIndex),
     FIXED_LEN_BYTE_ARRAY(ByteArrayIndex),
-    /// Sometimes reading page index from parquet file
-    /// will only return pageLocations without min_max index,
-    /// `None` represents this lack of index information
-    None,
 }
 
 /// An index of a column of [`Type`] physical representation

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -138,7 +138,7 @@ fn deserialize_column_index(
     column_type: Type,
 ) -> Result<Index, ParquetError> {
     if data.is_empty() {
-        return Ok(Index::None);
+        return Ok(Index::NONE);
     }
     let mut d = Cursor::new(data);
     let mut prot = TCompactInputProtocol::new(&mut d);

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1257,7 +1257,7 @@ mod tests {
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
         //Notice: min_max values for each page for this col not exits.
-        if let Index::None = &page_indexes[0][10] {
+        if let Index::NONE = &page_indexes[0][10] {
             assert_eq!(row_group_offset_indexes[10].len(), 974);
         } else {
             unreachable!()


### PR DESCRIPTION
Follow up to #2012, makes the capitalization consistent 