### PR TITLE
Add support for adding intervals to dates

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -51,7 +51,7 @@ csv_crate = { version = "1.1", default-features = false, optional = true, packag
 regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
 lazy_static = { version = "1.4", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = {version = "0.6", default-features = false, optional = true}
 chronoutil = "0.2.3"
 flatbuffers = { version = "2.1.2", default-features = false, features = ["thiserror"], optional = true }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -53,7 +53,6 @@ lazy_static = { version = "1.4", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = {version = "0.6", default-features = false, optional = true}
-chronoutil = "0.2.3"
 flatbuffers = { version = "2.1.2", default-features = false, features = ["thiserror"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 comfy-table = { version = "6.0", optional = true, default-features = false }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -53,6 +53,7 @@ lazy_static = { version = "1.4", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = {version = "0.6", default-features = false, optional = true}
+chronoutil = "0.2.3"
 flatbuffers = { version = "2.1.2", default-features = false, features = ["thiserror"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 comfy-table = { version = "6.0", optional = true, default-features = false }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -51,7 +51,7 @@ csv_crate = { version = "1.1", default-features = false, optional = true, packag
 regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
 lazy_static = { version = "1.4", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = {version = "0.6", default-features = false, optional = true}
 flatbuffers = { version = "2.1.2", default-features = false, features = ["thiserror"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["std"] }

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::new(1, 2)]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1141,7 +1141,7 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::new(1, 2)]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1156,7 +1156,7 @@ mod tests {
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b =
-            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::new(1, 2, 3)]);
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(1, 2, 3)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1170,7 +1170,7 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::new(1, 2)]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
@@ -1184,7 +1184,7 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::new(1, 2)]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
@@ -1199,7 +1199,7 @@ mod tests {
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b =
-            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::new(1, 2, 3)]);
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(1, 2, 3)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -783,9 +783,9 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                 .as_any()
                 .downcast_ref::<PrimitiveArray<Date32Type>>()
                 .ok_or_else(|| {
-                    ArrowError::CastError(format!(
-                        "Left array cannot be cast to Date32Type",
-                    ))
+                    ArrowError::CastError(
+                        "Left array cannot be cast to Date32Type".to_string(),
+                    )
                 })?;
             match right.data_type() {
                 DataType::Interval(IntervalUnit::YearMonth) => {
@@ -793,11 +793,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalYearMonthType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalYearMonthType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date32Type::add_year_months(a, b))?;
+                    let res = math_op(l, r, Date32Type::add_year_months)?;
                     return Ok(Arc::new(res));
                 }
                 DataType::Interval(IntervalUnit::DayTime) => {
@@ -805,11 +806,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalDayTimeType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalDayTimeType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date32Type::add_day_time(a, b))?;
+                    let res = math_op(l, r, Date32Type::add_day_time)?;
                     return Ok(Arc::new(res));
                 }
                 DataType::Interval(IntervalUnit::MonthDayNano) => {
@@ -817,11 +819,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalMonthDayNanoType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalMonthDayNanoType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date32Type::add_month_day_nano(a, b))?;
+                    let res = math_op(l, r, Date32Type::add_month_day_nano)?;
                     return Ok(Arc::new(res));
                 }
                 t => Err(ArrowError::CastError(format!(
@@ -835,9 +838,9 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                 .as_any()
                 .downcast_ref::<PrimitiveArray<Date64Type>>()
                 .ok_or_else(|| {
-                    ArrowError::CastError(format!(
-                        "Left array cannot be cast to Date64Type",
-                    ))
+                    ArrowError::CastError(
+                        "Left array cannot be cast to Date64Type".to_string(),
+                    )
                 })?;
             match right.data_type() {
                 DataType::Interval(IntervalUnit::YearMonth) => {
@@ -845,11 +848,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalYearMonthType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalYearMonthType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date64Type::add_year_months(a, b))?;
+                    let res = math_op(l, r, Date64Type::add_year_months)?;
                     return Ok(Arc::new(res));
                 }
                 DataType::Interval(IntervalUnit::DayTime) => {
@@ -857,11 +861,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalDayTimeType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalDayTimeType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date64Type::add_day_time(a, b))?;
+                    let res = math_op(l, r, Date64Type::add_day_time)?;
                     return Ok(Arc::new(res));
                 }
                 DataType::Interval(IntervalUnit::MonthDayNano) => {
@@ -869,11 +874,12 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                         .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
                         .ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "Right array cannot be cast to IntervalMonthDayNanoType",
-                            ))
+                            ArrowError::CastError(
+                                "Right array cannot be cast to IntervalMonthDayNanoType"
+                                    .to_string(),
+                            )
                         })?;
-                    let res = math_op(l, r, |a, b| Date64Type::add_month_day_nano(a, b))?;
+                    let res = math_op(l, r, Date64Type::add_month_day_nano)?;
                     return Ok(Arc::new(res));
                 }
                 t => Err(ArrowError::CastError(format!(

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::new(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1141,7 +1141,7 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::new(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1155,9 +1155,8 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
-            1, 2, 3,
-        )]);
+        let b =
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::new(1, 2, 3)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1171,7 +1170,7 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::new(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
@@ -1185,7 +1184,7 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::new(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
@@ -1199,9 +1198,8 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
-            1, 2, 3,
-        )]);
+        let b =
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::new(1, 2, 3)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -34,7 +34,10 @@ use crate::compute::kernels::arity::unary;
 use crate::compute::unary_dyn;
 use crate::compute::util::combine_option_bitmap;
 use crate::datatypes;
-use crate::datatypes::{ArrowNumericType, DataType, Date32Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit, IntervalYearMonthType};
+use crate::datatypes::{
+    ArrowNumericType, DataType, Date32Type, Date64Type, IntervalDayTimeType,
+    IntervalMonthDayNanoType, IntervalUnit, IntervalYearMonthType,
+};
 use crate::datatypes::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
     UInt32Type, UInt64Type, UInt8Type,
@@ -776,45 +779,103 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
             typed_dict_math_op!(left, right, |a, b| a + b, math_op_dict)
         }
         DataType::Date32 => {
-            let l = left.as_any()
+            let l = left
+                .as_any()
                 .downcast_ref::<PrimitiveArray<Date32Type>>()
-                .ok_or_else(|| {ArrowError::CastError(format!(
-                    "Left array cannot be cast to Date32Type",
-                ))})?;
+                .ok_or_else(|| {
+                    ArrowError::CastError(format!(
+                        "Left array cannot be cast to Date32Type",
+                    ))
+                })?;
             match right.data_type() {
                 DataType::Interval(IntervalUnit::YearMonth) => {
-                    let r = right.as_any()
-                            .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
-                            .ok_or_else(|| {ArrowError::CastError(format!(
-                        "Right array cannot be cast to IntervalYearMonthType",
-                    ))})?;
-                    let res = math_op(l, r, |a, b| {
-                        Date32Type::add_year_months(a, b)
-                    })?;
+                    let r = right
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalYearMonthType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date32Type::add_year_months(a, b))?;
                     return Ok(Arc::new(res));
-                },
+                }
                 DataType::Interval(IntervalUnit::DayTime) => {
-                    let r = right.as_any()
+                    let r = right
+                        .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
-                        .ok_or_else(|| {ArrowError::CastError(format!(
-                            "Right array cannot be cast to IntervalDayTimeType",
-                        ))})?;
-                    let res = math_op(l, r, |a, b| {
-                        Date32Type::add_day_time(a, b)
-                    })?;
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalDayTimeType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date32Type::add_day_time(a, b))?;
                     return Ok(Arc::new(res));
-                },
+                }
                 DataType::Interval(IntervalUnit::MonthDayNano) => {
-                    let r = right.as_any()
+                    let r = right
+                        .as_any()
                         .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
-                        .ok_or_else(|| {ArrowError::CastError(format!(
-                            "Right array cannot be cast to IntervalMonthDayNanoType",
-                        ))})?;
-                    let res = math_op(l, r, |a, b| {
-                        Date32Type::add_month_day_nano(a, b)
-                    })?;
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalMonthDayNanoType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date32Type::add_month_day_nano(a, b))?;
                     return Ok(Arc::new(res));
-                },
+                }
+                t => Err(ArrowError::CastError(format!(
+                    "Cannot perform arithmetic operation on arrays of type {}",
+                    t
+                ))),
+            }
+        }
+        DataType::Date64 => {
+            let l = left
+                .as_any()
+                .downcast_ref::<PrimitiveArray<Date64Type>>()
+                .ok_or_else(|| {
+                    ArrowError::CastError(format!(
+                        "Left array cannot be cast to Date64Type",
+                    ))
+                })?;
+            match right.data_type() {
+                DataType::Interval(IntervalUnit::YearMonth) => {
+                    let r = right
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalYearMonthType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date64Type::add_year_months(a, b))?;
+                    return Ok(Arc::new(res));
+                }
+                DataType::Interval(IntervalUnit::DayTime) => {
+                    let r = right
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalDayTimeType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date64Type::add_day_time(a, b))?;
+                    return Ok(Arc::new(res));
+                }
+                DataType::Interval(IntervalUnit::MonthDayNano) => {
+                    let r = right
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
+                        .ok_or_else(|| {
+                            ArrowError::CastError(format!(
+                                "Right array cannot be cast to IntervalMonthDayNanoType",
+                            ))
+                        })?;
+                    let res = math_op(l, r, |a, b| Date64Type::add_month_day_nano(a, b))?;
+                    return Ok(Arc::new(res));
+                }
                 t => Err(ArrowError::CastError(format!(
                     "Cannot perform arithmetic operation on arrays of type {}",
                     t
@@ -1100,10 +1161,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveDate;
     use super::*;
     use crate::array::Int32Array;
     use crate::datatypes::Date64Type;
+    use chrono::NaiveDate;
 
     #[test]
     fn test_primitive_array_add() {
@@ -1119,56 +1180,90 @@ mod tests {
 
     #[test]
     fn test_date32_month_add() {
-        let a = Date32Array::from(vec![Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 1)]);
+        let a = Date32Array::from(vec![Date32Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
-        assert_eq!(c.value(0), Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+        assert_eq!(
+            c.value(0),
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 03, 01))
+        );
     }
 
     #[test]
     fn test_date32_day_time_add() {
-        let a = Date32Array::from(vec![Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 1)]);
+        let a = Date32Array::from(vec![Date32Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
-        assert_eq!(c.value(0), Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 01, 02)));
+        assert_eq!(
+            c.value(0),
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 02))
+        );
     }
 
     #[test]
     fn test_date32_month_day_nano_add() {
-        let a = Date32Array::from(vec![Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(1, 1, 1)]);
+        let a = Date32Array::from(vec![Date32Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
+            1, 2, 3,
+        )]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
-        assert_eq!(c.value(0), Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+        assert_eq!(
+            c.value(0),
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 02, 03))
+        );
     }
 
     #[test]
     fn test_date64_month_add() {
-        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 1)]);
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
-        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+        assert_eq!(
+            c.value(0),
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 03, 01))
+        );
     }
 
     #[test]
     fn test_date64_day_time_add() {
-        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 1)]);
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
-        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 01, 02)));
+        assert_eq!(
+            c.value(0),
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 02))
+        );
     }
 
     #[test]
     fn test_date64_month_day_nano_add() {
-        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
-        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(1, 1, 1)]);
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(
+            NaiveDate::from_ymd(2000, 01, 01),
+        )]);
+        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
+            1, 2, 3,
+        )]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
-        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+        assert_eq!(
+            c.value(0),
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 02, 03))
+        );
     }
 
     #[test]

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -779,53 +779,22 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
             typed_dict_math_op!(left, right, |a, b| a + b, math_op_dict)
         }
         DataType::Date32 => {
-            let l = left
-                .as_any()
-                .downcast_ref::<PrimitiveArray<Date32Type>>()
-                .ok_or_else(|| {
-                    ArrowError::CastError(
-                        "Left array cannot be cast to Date32Type".to_string(),
-                    )
-                })?;
+            let l = as_primitive_array::<Date32Type>(left);
             match right.data_type() {
                 DataType::Interval(IntervalUnit::YearMonth) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalYearMonthType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalYearMonthType>(right);
                     let res = math_op(l, r, Date32Type::add_year_months)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 DataType::Interval(IntervalUnit::DayTime) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalDayTimeType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalDayTimeType>(right);
                     let res = math_op(l, r, Date32Type::add_day_time)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 DataType::Interval(IntervalUnit::MonthDayNano) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalMonthDayNanoType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalMonthDayNanoType>(right);
                     let res = math_op(l, r, Date32Type::add_month_day_nano)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 t => Err(ArrowError::CastError(format!(
                     "Cannot perform arithmetic operation on arrays of type {}",
@@ -834,53 +803,22 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
             }
         }
         DataType::Date64 => {
-            let l = left
-                .as_any()
-                .downcast_ref::<PrimitiveArray<Date64Type>>()
-                .ok_or_else(|| {
-                    ArrowError::CastError(
-                        "Left array cannot be cast to Date64Type".to_string(),
-                    )
-                })?;
+            let l = as_primitive_array::<Date64Type>(left);
             match right.data_type() {
                 DataType::Interval(IntervalUnit::YearMonth) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalYearMonthType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalYearMonthType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalYearMonthType>(right);
                     let res = math_op(l, r, Date64Type::add_year_months)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 DataType::Interval(IntervalUnit::DayTime) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalDayTimeType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalDayTimeType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalDayTimeType>(right);
                     let res = math_op(l, r, Date64Type::add_day_time)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 DataType::Interval(IntervalUnit::MonthDayNano) => {
-                    let r = right
-                        .as_any()
-                        .downcast_ref::<PrimitiveArray<IntervalMonthDayNanoType>>()
-                        .ok_or_else(|| {
-                            ArrowError::CastError(
-                                "Right array cannot be cast to IntervalMonthDayNanoType"
-                                    .to_string(),
-                            )
-                        })?;
+                    let r = as_primitive_array::<IntervalMonthDayNanoType>(right);
                     let res = math_op(l, r, Date64Type::add_month_day_nano)?;
-                    return Ok(Arc::new(res));
+                    Ok(Arc::new(res))
                 }
                 t => Err(ArrowError::CastError(format!(
                     "Cannot perform arithmetic operation on arrays of type {}",
@@ -1187,35 +1125,35 @@ mod tests {
     #[test]
     fn test_date32_month_add() {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 03, 01))
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 3, 1))
         );
     }
 
     #[test]
     fn test_date32_day_time_add() {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 02))
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 1, 2))
         );
     }
 
     #[test]
     fn test_date32_month_day_nano_add() {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
             1, 2, 3,
@@ -1224,42 +1162,42 @@ mod tests {
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 02, 03))
+            Date32Type::from_naive_date(NaiveDate::from_ymd(2000, 2, 3))
         );
     }
 
     #[test]
     fn test_date64_month_add() {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 03, 01))
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 3, 1))
         );
     }
 
     #[test]
     fn test_date64_day_time_add() {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 02))
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 1, 2))
         );
     }
 
     #[test]
     fn test_date64_month_day_nano_add() {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
-            NaiveDate::from_ymd(2000, 01, 01),
+            NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(
             1, 2, 3,
@@ -1268,7 +1206,7 @@ mod tests {
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
             c.value(0),
-            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 02, 03))
+            Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 2, 3))
         );
     }
 

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1103,6 +1103,7 @@ mod tests {
     use chrono::NaiveDate;
     use super::*;
     use crate::array::Int32Array;
+    use crate::datatypes::Date64Type;
 
     #[test]
     fn test_primitive_array_add() {
@@ -1141,6 +1142,33 @@ mod tests {
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(c.value(0), Date32Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+    }
+
+    #[test]
+    fn test_date64_month_add() {
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
+        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::from(1, 1)]);
+        let c = add_dyn(&a, &b).unwrap();
+        let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
+        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
+    }
+
+    #[test]
+    fn test_date64_day_time_add() {
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
+        let b = IntervalDayTimeArray::from(vec![IntervalDayTimeType::from(1, 1)]);
+        let c = add_dyn(&a, &b).unwrap();
+        let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
+        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 01, 02)));
+    }
+
+    #[test]
+    fn test_date64_month_day_nano_add() {
+        let a = Date64Array::from(vec![Date64Type::from_naive_date(NaiveDate::from_ymd(2000, 01, 01))]);
+        let b = IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::from(1, 1, 1)]);
+        let c = add_dyn(&a, &b).unwrap();
+        let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
+        assert_eq!(c.value(0), Date64Type::from_naive_date(NaiveDate::from_ymd(2001, 02, 01)));
     }
 
     #[test]

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -796,9 +796,9 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                     let res = math_op(l, r, Date32Type::add_month_day_nano)?;
                     Ok(Arc::new(res))
                 }
-                t => Err(ArrowError::CastError(format!(
-                    "Cannot perform arithmetic operation on arrays of type {}",
-                    t
+                _ => Err(ArrowError::CastError(format!(
+                    "Cannot perform arithmetic operation between array of type {} and array of type {}",
+                    left.data_type(), right.data_type()
                 ))),
             }
         }
@@ -820,9 +820,9 @@ pub fn add_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef> {
                     let res = math_op(l, r, Date64Type::add_month_day_nano)?;
                     Ok(Arc::new(res))
                 }
-                t => Err(ArrowError::CastError(format!(
-                    "Cannot perform arithmetic operation on arrays of type {}",
-                    t
+                _ => Err(ArrowError::CastError(format!(
+                    "Cannot perform arithmetic operation between array of type {} and array of type {}",
+                    left.data_type(), right.data_type()
                 ))),
             }
         }

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1127,7 +1127,8 @@ mod tests {
         let a = Date32Array::from(vec![Date32Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
+        let b =
+            IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1156,7 +1157,9 @@ mod tests {
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b =
-            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(1, 2, 3)]);
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(
+                1, 2, 3,
+            )]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(
@@ -1170,7 +1173,8 @@ mod tests {
         let a = Date64Array::from(vec![Date64Type::from_naive_date(
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
-        let b = IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
+        let b =
+            IntervalYearMonthArray::from(vec![IntervalYearMonthType::make_value(1, 2)]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(
@@ -1199,7 +1203,9 @@ mod tests {
             NaiveDate::from_ymd(2000, 1, 1),
         )]);
         let b =
-            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(1, 2, 3)]);
+            IntervalMonthDayNanoArray::from(vec![IntervalMonthDayNanoType::make_value(
+                1, 2, 3,
+            )]);
         let c = add_dyn(&a, &b).unwrap();
         let c = c.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(

--- a/arrow/src/datatypes/delta.rs
+++ b/arrow/src/datatypes/delta.rs
@@ -1,0 +1,182 @@
+// MIT License
+//
+// Copyright (c) 2020-2022 Oliver Margetts
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Copied from chronoutil crate
+
+//! Contains utility functions for shifting Date objects.
+use chrono::Datelike;
+
+/// Returns true if the year is a leap-year, as naively defined in the Gregorian calendar.
+#[inline]
+pub(crate) fn is_leap_year(year: i32) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+// If the day lies within the month, this function has no effect. Otherwise, it shifts
+// day backwards to the final day of the month.
+// XXX: No attempt is made to handle days outside the 1-31 range.
+#[inline]
+fn normalise_day(year: i32, month: u32, day: u32) -> u32 {
+    if day <= 28 {
+        day
+    } else if month == 2 {
+        28 + is_leap_year(year) as u32
+    } else if day == 31 && (month == 4 || month == 6 || month == 9 || month == 11) {
+        30
+    } else {
+        day
+    }
+}
+
+/// Shift a date by the given number of months.
+/// Ambiguous month-ends are shifted backwards as necessary.
+pub(crate) fn shift_months<D: Datelike>(date: D, months: i32) -> D {
+    let mut year = date.year() + (date.month() as i32 + months) / 12;
+    let mut month = (date.month() as i32 + months) % 12;
+    let mut day = date.day();
+
+    if month < 1 {
+        year -= 1;
+        month += 12;
+    }
+
+    day = normalise_day(year, month as u32, day);
+
+    // This is slow but guaranteed to succeed (short of interger overflow)
+    if day <= 28 {
+        date.with_day(day)
+            .unwrap()
+            .with_month(month as u32)
+            .unwrap()
+            .with_year(year)
+            .unwrap()
+    } else {
+        date.with_day(1)
+            .unwrap()
+            .with_month(month as u32)
+            .unwrap()
+            .with_year(year)
+            .unwrap()
+            .with_day(day)
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use chrono::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+
+    use super::*;
+
+    #[test]
+    fn test_leap_year_cases() {
+        let _leap_years: Vec<i32> = vec![
+            1904, 1908, 1912, 1916, 1920, 1924, 1928, 1932, 1936, 1940, 1944, 1948, 1952,
+            1956, 1960, 1964, 1968, 1972, 1976, 1980, 1984, 1988, 1992, 1996, 2000, 2004,
+            2008, 2012, 2016, 2020,
+        ];
+        let leap_years_1900_to_2020: HashSet<i32> = _leap_years.into_iter().collect();
+
+        for year in 1900..2021 {
+            assert_eq!(is_leap_year(year), leap_years_1900_to_2020.contains(&year))
+        }
+    }
+
+    #[test]
+    fn test_shift_months() {
+        let base = NaiveDate::from_ymd(2020, 1, 31);
+
+        assert_eq!(shift_months(base, 0), NaiveDate::from_ymd(2020, 1, 31));
+        assert_eq!(shift_months(base, 1), NaiveDate::from_ymd(2020, 2, 29));
+        assert_eq!(shift_months(base, 2), NaiveDate::from_ymd(2020, 3, 31));
+        assert_eq!(shift_months(base, 3), NaiveDate::from_ymd(2020, 4, 30));
+        assert_eq!(shift_months(base, 4), NaiveDate::from_ymd(2020, 5, 31));
+        assert_eq!(shift_months(base, 5), NaiveDate::from_ymd(2020, 6, 30));
+        assert_eq!(shift_months(base, 6), NaiveDate::from_ymd(2020, 7, 31));
+        assert_eq!(shift_months(base, 7), NaiveDate::from_ymd(2020, 8, 31));
+        assert_eq!(shift_months(base, 8), NaiveDate::from_ymd(2020, 9, 30));
+        assert_eq!(shift_months(base, 9), NaiveDate::from_ymd(2020, 10, 31));
+        assert_eq!(shift_months(base, 10), NaiveDate::from_ymd(2020, 11, 30));
+        assert_eq!(shift_months(base, 11), NaiveDate::from_ymd(2020, 12, 31));
+        assert_eq!(shift_months(base, 12), NaiveDate::from_ymd(2021, 1, 31));
+        assert_eq!(shift_months(base, 13), NaiveDate::from_ymd(2021, 2, 28));
+
+        assert_eq!(shift_months(base, -1), NaiveDate::from_ymd(2019, 12, 31));
+        assert_eq!(shift_months(base, -2), NaiveDate::from_ymd(2019, 11, 30));
+        assert_eq!(shift_months(base, -3), NaiveDate::from_ymd(2019, 10, 31));
+        assert_eq!(shift_months(base, -4), NaiveDate::from_ymd(2019, 9, 30));
+        assert_eq!(shift_months(base, -5), NaiveDate::from_ymd(2019, 8, 31));
+        assert_eq!(shift_months(base, -6), NaiveDate::from_ymd(2019, 7, 31));
+        assert_eq!(shift_months(base, -7), NaiveDate::from_ymd(2019, 6, 30));
+        assert_eq!(shift_months(base, -8), NaiveDate::from_ymd(2019, 5, 31));
+        assert_eq!(shift_months(base, -9), NaiveDate::from_ymd(2019, 4, 30));
+        assert_eq!(shift_months(base, -10), NaiveDate::from_ymd(2019, 3, 31));
+        assert_eq!(shift_months(base, -11), NaiveDate::from_ymd(2019, 2, 28));
+        assert_eq!(shift_months(base, -12), NaiveDate::from_ymd(2019, 1, 31));
+        assert_eq!(shift_months(base, -13), NaiveDate::from_ymd(2018, 12, 31));
+
+        assert_eq!(shift_months(base, 1265), NaiveDate::from_ymd(2125, 6, 30));
+    }
+
+    #[test]
+    fn test_shift_months_with_overflow() {
+        let base = NaiveDate::from_ymd(2020, 12, 31);
+
+        assert_eq!(shift_months(base, 0), base);
+        assert_eq!(shift_months(base, 1), NaiveDate::from_ymd(2021, 1, 31));
+        assert_eq!(shift_months(base, 2), NaiveDate::from_ymd(2021, 2, 28));
+        assert_eq!(shift_months(base, 12), NaiveDate::from_ymd(2021, 12, 31));
+        assert_eq!(shift_months(base, 18), NaiveDate::from_ymd(2022, 6, 30));
+
+        assert_eq!(shift_months(base, -1), NaiveDate::from_ymd(2020, 11, 30));
+        assert_eq!(shift_months(base, -2), NaiveDate::from_ymd(2020, 10, 31));
+        assert_eq!(shift_months(base, -10), NaiveDate::from_ymd(2020, 2, 29));
+        assert_eq!(shift_months(base, -12), NaiveDate::from_ymd(2019, 12, 31));
+        assert_eq!(shift_months(base, -18), NaiveDate::from_ymd(2019, 6, 30));
+    }
+
+    #[test]
+    fn test_shift_months_datetime() {
+        let date = NaiveDate::from_ymd(2020, 1, 31);
+        let o_clock = NaiveTime::from_hms(1, 2, 3);
+
+        let base = NaiveDateTime::new(date, o_clock);
+
+        assert_eq!(
+            shift_months(base, 0).date(),
+            NaiveDate::from_ymd(2020, 1, 31)
+        );
+        assert_eq!(
+            shift_months(base, 1).date(),
+            NaiveDate::from_ymd(2020, 2, 29)
+        );
+        assert_eq!(
+            shift_months(base, 2).date(),
+            NaiveDate::from_ymd(2020, 3, 31)
+        );
+        assert_eq!(shift_months(base, 0).time(), o_clock);
+        assert_eq!(shift_months(base, 1).time(), o_clock);
+        assert_eq!(shift_months(base, 2).time(), o_clock);
+    }
+}

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -36,7 +36,9 @@ mod types;
 pub use types::*;
 mod datatype;
 pub use datatype::*;
+mod delta;
 mod ffi;
+
 pub use ffi::*;
 
 /// A reference-counted reference to a [`Schema`](crate::datatypes::Schema).

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -291,4 +291,37 @@ impl Date64Type {
         let epoch = NaiveDate::from_ymd(1970, 1, 1);
         d.sub(epoch).num_milliseconds() as <Date64Type as ArrowPrimitiveType>::Native
     }
+
+    pub fn add_year_months(
+        date: <Date64Type as ArrowPrimitiveType>::Native,
+        delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native
+    ) -> <Date64Type as ArrowPrimitiveType>::Native {
+        let prior = Date64Type::to_naive_date(date);
+        let months = IntervalYearMonthType::to_months(delta);
+        let posterior = shift_months(prior, months);
+        Date64Type::from_naive_date(posterior)
+    }
+
+    pub fn add_day_time(
+        date: <Date64Type as ArrowPrimitiveType>::Native,
+        delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native
+    ) -> <Date64Type as ArrowPrimitiveType>::Native {
+        let (days, ms) = IntervalDayTimeType::to_parts(delta);
+        let res = Date64Type::to_naive_date(date);
+        let res = res.add(Duration::days(days as i64));
+        let res = res.add(Duration::milliseconds(ms as i64));
+        Date64Type::from_naive_date(res)
+    }
+
+    pub fn add_month_day_nano(
+        date: <Date64Type as ArrowPrimitiveType>::Native,
+        delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
+    ) -> <Date64Type as ArrowPrimitiveType>::Native {
+        let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(delta);
+        let res = Date64Type::to_naive_date(date);
+        let res = shift_months(res, months);
+        let res = res.add(Duration::days(days as i64));
+        let res = res.add(Duration::nanoseconds(nanos));
+        Date64Type::from_naive_date(res)
+    }
 }

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -196,13 +196,13 @@ impl ArrowTimestampType for TimestampNanosecondType {
 }
 
 impl IntervalYearMonthType {
-    /// Creates a IntervalYearMonthType
+    /// Creates a IntervalYearMonthType::Native
     ///
     /// # Arguments
     ///
     /// * `years` - The number of years (+/-) represented in this interval
     /// * `months` - The number of months (+/-) represented in this interval
-    pub fn new(
+    pub fn make_value(
         years: i32,
         months: i32,
     ) -> <IntervalYearMonthType as ArrowPrimitiveType>::Native {
@@ -222,13 +222,13 @@ impl IntervalYearMonthType {
 }
 
 impl IntervalDayTimeType {
-    /// Creates a IntervalDayTimeType
+    /// Creates a IntervalDayTimeType::Native
     ///
     /// # Arguments
     ///
     /// * `days` - The number of days (+/-) represented in this interval
     /// * `millis` - The number of milliseconds (+/-) represented in this interval
-    pub fn new(
+    pub fn make_value(
         days: i32,
         millis: i32,
     ) -> <IntervalDayTimeType as ArrowPrimitiveType>::Native {
@@ -252,14 +252,14 @@ impl IntervalDayTimeType {
 }
 
 impl IntervalMonthDayNanoType {
-    /// Creates a IntervalMonthDayNanoType
+    /// Creates a IntervalMonthDayNanoType::Native
     ///
     /// # Arguments
     ///
     /// * `months` - The number of months (+/-) represented in this interval
     /// * `days` - The number of days (+/-) represented in this interval
     /// * `nanos` - The number of nanoseconds (+/-) represented in this interval
-    pub fn new(
+    pub fn make_value(
         months: i32,
         days: i32,
         nanos: i64,

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::{Add, Sub};
+use super::{ArrowPrimitiveType, DataType, IntervalUnit, TimeUnit};
 use chrono::{Duration, NaiveDate};
 use chronoutil::shift_months;
-use super::{ArrowPrimitiveType, DataType, IntervalUnit, TimeUnit};
 use half::f16;
+use std::ops::{Add, Sub};
 
 // BooleanType is special: its bit-width is not the size of the primitive type, and its `index`
 // operation assumes bit-packing.
@@ -196,7 +196,10 @@ impl ArrowTimestampType for TimestampNanosecondType {
 }
 
 impl IntervalYearMonthType {
-    pub fn from(years: i32, months: i32) -> <IntervalYearMonthType as ArrowPrimitiveType>::Native {
+    pub fn from(
+        years: i32,
+        months: i32,
+    ) -> <IntervalYearMonthType as ArrowPrimitiveType>::Native {
         years * 12 + months
     }
 
@@ -206,13 +209,18 @@ impl IntervalYearMonthType {
 }
 
 impl IntervalDayTimeType {
-    pub fn from(days: i32, millis: i32) -> <IntervalDayTimeType as ArrowPrimitiveType>::Native {
+    pub fn from(
+        days: i32,
+        millis: i32,
+    ) -> <IntervalDayTimeType as ArrowPrimitiveType>::Native {
         let m = millis as u64 & u32::MAX as u64;
         let d = (days as u64 & u32::MAX as u64) << 32;
         (m | d) as <IntervalDayTimeType as ArrowPrimitiveType>::Native
     }
 
-    pub fn to_parts(i: <IntervalDayTimeType as ArrowPrimitiveType>::Native) -> (i32, i32) {
+    pub fn to_parts(
+        i: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
+    ) -> (i32, i32) {
         let days = (i >> 32) as i32;
         let ms = i as i32;
         (days, ms)
@@ -220,21 +228,26 @@ impl IntervalDayTimeType {
 }
 
 impl IntervalMonthDayNanoType {
-    pub fn from(months: i32, days: i32, nanos: i64) -> <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native {
+    pub fn from(
+        months: i32,
+        days: i32,
+        nanos: i64,
+    ) -> <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native {
         let m = months as u128 & u32::MAX as u128;
         let d = (days as u128 & u32::MAX as u128) << 32;
         let n = (nanos as u128) << 64;
         (m | d | n) as <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
     }
 
-    pub fn to_parts(i: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native) -> (i32, i32, i64) {
+    pub fn to_parts(
+        i: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
+    ) -> (i32, i32, i64) {
         let nanos = (i >> 64) as i64;
         let days = (i >> 32) as i32;
         let months = i as i32;
         (months, days, nanos)
     }
 }
-
 
 impl Date32Type {
     pub fn to_naive_date(i: <Date32Type as ArrowPrimitiveType>::Native) -> NaiveDate {
@@ -249,7 +262,7 @@ impl Date32Type {
 
     pub fn add_year_months(
         date: <Date32Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native
+        delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native,
     ) -> <Date32Type as ArrowPrimitiveType>::Native {
         let prior = Date32Type::to_naive_date(date);
         let months = IntervalYearMonthType::to_months(delta);
@@ -259,7 +272,7 @@ impl Date32Type {
 
     pub fn add_day_time(
         date: <Date32Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native
+        delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
     ) -> <Date32Type as ArrowPrimitiveType>::Native {
         let (days, ms) = IntervalDayTimeType::to_parts(delta);
         let res = Date32Type::to_naive_date(date);
@@ -270,7 +283,7 @@ impl Date32Type {
 
     pub fn add_month_day_nano(
         date: <Date32Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
+        delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
     ) -> <Date32Type as ArrowPrimitiveType>::Native {
         let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(delta);
         let res = Date32Type::to_naive_date(date);
@@ -294,7 +307,7 @@ impl Date64Type {
 
     pub fn add_year_months(
         date: <Date64Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native
+        delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native,
     ) -> <Date64Type as ArrowPrimitiveType>::Native {
         let prior = Date64Type::to_naive_date(date);
         let months = IntervalYearMonthType::to_months(delta);
@@ -304,7 +317,7 @@ impl Date64Type {
 
     pub fn add_day_time(
         date: <Date64Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native
+        delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
     ) -> <Date64Type as ArrowPrimitiveType>::Native {
         let (days, ms) = IntervalDayTimeType::to_parts(delta);
         let res = Date64Type::to_naive_date(date);
@@ -315,7 +328,7 @@ impl Date64Type {
 
     pub fn add_month_day_nano(
         date: <Date64Type as ArrowPrimitiveType>::Native,
-        delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
+        delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
     ) -> <Date64Type as ArrowPrimitiveType>::Native {
         let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(delta);
         let res = Date64Type::to_naive_date(date);

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use super::{ArrowPrimitiveType, DataType, IntervalUnit, TimeUnit};
+use crate::datatypes::delta::shift_months;
 use chrono::{Duration, NaiveDate};
-use chronoutil::shift_months;
 use half::f16;
 use std::ops::{Add, Sub};
 
@@ -196,7 +196,13 @@ impl ArrowTimestampType for TimestampNanosecondType {
 }
 
 impl IntervalYearMonthType {
-    pub fn from(
+    /// Creates a IntervalYearMonthType
+    ///
+    /// # Arguments
+    ///
+    /// * `years` - The number of years (+/-) represented in this interval
+    /// * `months` - The number of months (+/-) represented in this interval
+    pub fn new(
         years: i32,
         months: i32,
     ) -> <IntervalYearMonthType as ArrowPrimitiveType>::Native {
@@ -209,7 +215,13 @@ impl IntervalYearMonthType {
 }
 
 impl IntervalDayTimeType {
-    pub fn from(
+    /// Creates a IntervalDayTimeType
+    ///
+    /// # Arguments
+    ///
+    /// * `days` - The number of days (+/-) represented in this interval
+    /// * `millis` - The number of milliseconds (+/-) represented in this interval
+    pub fn new(
         days: i32,
         millis: i32,
     ) -> <IntervalDayTimeType as ArrowPrimitiveType>::Native {
@@ -228,7 +240,14 @@ impl IntervalDayTimeType {
 }
 
 impl IntervalMonthDayNanoType {
-    pub fn from(
+    /// Creates a IntervalMonthDayNanoType
+    ///
+    /// # Arguments
+    ///
+    /// * `months` - The number of months (+/-) represented in this interval
+    /// * `days` - The number of days (+/-) represented in this interval
+    /// * `nanos` - The number of nanoseconds (+/-) represented in this interval
+    pub fn new(
         months: i32,
         days: i32,
         nanos: i64,

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -209,6 +209,13 @@ impl IntervalYearMonthType {
         years * 12 + months
     }
 
+    /// Turns a IntervalYearMonthType type into an i32 of months.
+    ///
+    /// This operation is technically a no-op, it is included for comprehensiveness.
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The IntervalYearMonthType::Native to convert
     pub fn to_months(i: <IntervalYearMonthType as ArrowPrimitiveType>::Native) -> i32 {
         i
     }
@@ -230,6 +237,11 @@ impl IntervalDayTimeType {
         (m | d) as <IntervalDayTimeType as ArrowPrimitiveType>::Native
     }
 
+    /// Turns a IntervalDayTimeType into a tuple of (days, milliseconds)
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The IntervalDayTimeType to convert
     pub fn to_parts(
         i: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
     ) -> (i32, i32) {
@@ -258,6 +270,11 @@ impl IntervalMonthDayNanoType {
         (m | d | n) as <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
     }
 
+    /// Turns a IntervalMonthDayNanoType into a tuple of (months, days, nanos)
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The IntervalMonthDayNanoType to convert
     pub fn to_parts(
         i: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
     ) -> (i32, i32, i64) {
@@ -269,16 +286,32 @@ impl IntervalMonthDayNanoType {
 }
 
 impl Date32Type {
+    /// Converts an arrow Date32Type into a chrono::NaiveDate
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The Date32Type to convert
     pub fn to_naive_date(i: <Date32Type as ArrowPrimitiveType>::Native) -> NaiveDate {
         let epoch = NaiveDate::from_ymd(1970, 1, 1);
         epoch.add(Duration::days(i as i64))
     }
 
+    /// Converts a chrono::NaiveDate into an arrow Date32Type
+    ///
+    /// # Arguments
+    ///
+    /// * `d` - The NaiveDate to convert
     pub fn from_naive_date(d: NaiveDate) -> <Date32Type as ArrowPrimitiveType>::Native {
         let epoch = NaiveDate::from_ymd(1970, 1, 1);
         d.sub(epoch).num_days() as <Date32Type as ArrowPrimitiveType>::Native
     }
 
+    /// Adds the given IntervalYearMonthType to an arrow Date32Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_year_months(
         date: <Date32Type as ArrowPrimitiveType>::Native,
         delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native,
@@ -289,6 +322,12 @@ impl Date32Type {
         Date32Type::from_naive_date(posterior)
     }
 
+    /// Adds the given IntervalDayTimeType to an arrow Date32Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_day_time(
         date: <Date32Type as ArrowPrimitiveType>::Native,
         delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
@@ -300,6 +339,12 @@ impl Date32Type {
         Date32Type::from_naive_date(res)
     }
 
+    /// Adds the given IntervalMonthDayNanoType to an arrow Date32Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_month_day_nano(
         date: <Date32Type as ArrowPrimitiveType>::Native,
         delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
@@ -314,16 +359,32 @@ impl Date32Type {
 }
 
 impl Date64Type {
+    /// Converts an arrow Date64Type into a chrono::NaiveDate
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The Date64Type to convert
     pub fn to_naive_date(i: <Date64Type as ArrowPrimitiveType>::Native) -> NaiveDate {
         let epoch = NaiveDate::from_ymd(1970, 1, 1);
         epoch.add(Duration::milliseconds(i as i64))
     }
 
+    /// Converts a chrono::NaiveDate into an arrow Date64Type
+    ///
+    /// # Arguments
+    ///
+    /// * `d` - The NaiveDate to convert
     pub fn from_naive_date(d: NaiveDate) -> <Date64Type as ArrowPrimitiveType>::Native {
         let epoch = NaiveDate::from_ymd(1970, 1, 1);
         d.sub(epoch).num_milliseconds() as <Date64Type as ArrowPrimitiveType>::Native
     }
 
+    /// Adds the given IntervalYearMonthType to an arrow Date64Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_year_months(
         date: <Date64Type as ArrowPrimitiveType>::Native,
         delta: <IntervalYearMonthType as ArrowPrimitiveType>::Native,
@@ -334,6 +395,12 @@ impl Date64Type {
         Date64Type::from_naive_date(posterior)
     }
 
+    /// Adds the given IntervalDayTimeType to an arrow Date64Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_day_time(
         date: <Date64Type as ArrowPrimitiveType>::Native,
         delta: <IntervalDayTimeType as ArrowPrimitiveType>::Native,
@@ -345,6 +412,12 @@ impl Date64Type {
         Date64Type::from_naive_date(res)
     }
 
+    /// Adds the given IntervalMonthDayNanoType to an arrow Date64Type
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - The date on which to perform the operation
+    /// * `delta` - The interval to add
     pub fn add_month_day_nano(
         date: <Date64Type as ArrowPrimitiveType>::Native,
         delta: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,


### PR DESCRIPTION
Re #527.

# Rationale for this change
 
Support for adding scalar intervals to scalar dates was added in datafusion, but in order to support adding columns to columns, we need to move that logic down into an arrow kernel.

# What changes are included in this PR?

- Support for adding interval types to date types
- A change to `add_dyn` to allow it to accept lambda functions with two differing parameter types

# Are there any user-facing changes?

Adding intervals to dates should work now.
