### PR TITLE
Implement FromIterator for Builders

### DIFF
--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -222,38 +222,7 @@ impl<'a> BooleanArray {
 
 impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let (_, data_len) = iter.size_hint();
-        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
-
-        let num_bytes = bit_util::ceil(data_len, 8);
-        let mut null_buf = MutableBuffer::from_len_zeroed(num_bytes);
-        let mut val_buf = MutableBuffer::from_len_zeroed(num_bytes);
-
-        let data = val_buf.as_slice_mut();
-
-        let null_slice = null_buf.as_slice_mut();
-        iter.enumerate().for_each(|(i, item)| {
-            if let Some(a) = item.borrow() {
-                bit_util::set_bit(null_slice, i);
-                if *a {
-                    bit_util::set_bit(data, i);
-                }
-            }
-        });
-
-        let data = unsafe {
-            ArrayData::new_unchecked(
-                DataType::Boolean,
-                data_len,
-                None,
-                Some(null_buf.into()),
-                0,
-                vec![val_buf.into()],
-                vec![],
-            )
-        };
-        BooleanArray::from(data)
+        iter.into_iter().collect::<BooleanBuilder>().finish()
     }
 }
 

--- a/arrow/src/array/builder/boolean_buffer_builder.rs
+++ b/arrow/src/array/builder/boolean_buffer_builder.rs
@@ -35,6 +35,11 @@ impl BooleanBufferBuilder {
         Self { buffer, len: 0 }
     }
 
+    pub fn new_null(len: usize) -> Self {
+        let buffer = MutableBuffer::new_null(len);
+        Self { buffer, len }
+    }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.len

--- a/arrow/src/array/builder/boolean_buffer_builder.rs
+++ b/arrow/src/array/builder/boolean_buffer_builder.rs
@@ -35,11 +35,6 @@ impl BooleanBufferBuilder {
         Self { buffer, len: 0 }
     }
 
-    pub fn new_null(len: usize) -> Self {
-        let buffer = MutableBuffer::new_null(len);
-        Self { buffer, len }
-    }
-
     #[inline]
     pub fn len(&self) -> usize {
         self.len

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -193,10 +193,11 @@ impl ArrayBuilder for BooleanBuilder {
 impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanBuilder {
     fn from_iter<T: IntoIterator<Item = Ptr>>(iter: T) -> Self {
         let iter = iter.into_iter();
-        let (data_len, _) = iter.size_hint();
+        let (lower, upper) = iter.size_hint();
+        let size_hint = upper.unwrap_or(lower);
 
-        let mut bitmap_builder = BooleanBufferBuilder::new(data_len);
-        let mut values_builder = BooleanBufferBuilder::new(data_len);
+        let mut bitmap_builder = BooleanBufferBuilder::new(size_hint);
+        let mut values_builder = BooleanBufferBuilder::new(size_hint);
 
         iter.for_each(|item| {
             if let Some(a) = item.borrow() {

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -191,7 +191,7 @@ impl ArrayBuilder for BooleanBuilder {
 }
 
 impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanBuilder {
-    fn from_iter<T: IntoIterator<Item = Ptr>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -196,23 +196,21 @@ impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanBuilder {
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut bitmap_builder = BooleanBufferBuilder::new(size_hint);
-        let mut values_builder = BooleanBufferBuilder::new(size_hint);
+        let mut builder = BooleanBuilder::new(size_hint);
 
         iter.for_each(|item| {
             if let Some(a) = item.borrow() {
-                bitmap_builder.append(true);
-                values_builder.append(*a);
+                builder
+                    .append_value(*a)
+                    .expect("Unable to append a value to a boolean array builder.");
             } else {
-                bitmap_builder.append(false);
-                values_builder.append(false);
+                builder
+                    .append_null()
+                    .expect("Unable to append a null value to a boolean array builder.");
             }
         });
 
-        BooleanBuilder {
-            values_builder,
-            bitmap_builder,
-        }
+        builder
     }
 }
 

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -193,18 +193,18 @@ impl ArrayBuilder for BooleanBuilder {
 impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanBuilder {
     fn from_iter<T: IntoIterator<Item = Ptr>>(iter: T) -> Self {
         let iter = iter.into_iter();
-        let (_, data_len) = iter.size_hint();
-        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
+        let (data_len, _) = iter.size_hint();
 
-        let mut bitmap_builder = BooleanBufferBuilder::new_null(data_len);
-        let mut values_builder = BooleanBufferBuilder::new_null(data_len);
+        let mut bitmap_builder = BooleanBufferBuilder::new(data_len);
+        let mut values_builder = BooleanBufferBuilder::new(data_len);
 
-        iter.enumerate().for_each(|(i, item)| {
+        iter.for_each(|item| {
             if let Some(a) = item.borrow() {
-                bitmap_builder.set_bit(i, true);
-                if *a {
-                    values_builder.set_bit(i, true);
-                }
+                bitmap_builder.append(true);
+                values_builder.append(*a);
+            } else {
+                bitmap_builder.append(false);
+                values_builder.append(false);
             }
         });
 

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -176,30 +176,22 @@ impl<Ptr: Borrow<Option<i128>>> FromIterator<Ptr> for DecimalBuilder {
         let size_hint = upper.unwrap_or(lower);
         let fixed_len = 16_usize;
 
-        let mut builder = FixedSizeListBuilder::with_capacity(
-            UInt8Builder::new(size_hint),
-            fixed_len as i32,
-            size_hint,
-        );
+        let mut builder =
+            DecimalBuilder::new(size_hint * fixed_len, DECIMAL_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
 
         iter.for_each(|item| {
             if let Some(a) = item.borrow() {
-                let values = Self::from_i128_to_fixed_size_bytes(*a, fixed_len)
-                    .expect("Conversion should be possible.");
-                builder.values().append_slice(&values).unwrap();
-                builder.append(true).unwrap();
+                builder
+                    .append_value(*a)
+                    .expect("Unable to append a value to a decimal array builder.");
             } else {
-                builder.values().append_nulls(fixed_len).unwrap();
-                builder.append(false).unwrap();
+                builder
+                    .append_null()
+                    .expect("Unable to append a null value to a decimal array builder.");
             }
         });
 
-        DecimalBuilder {
-            builder,
-            precision: DECIMAL_MAX_PRECISION,
-            scale: DECIMAL_DEFAULT_SCALE,
-            value_validation: true,
-        }
+        builder
     }
 }
 

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -176,8 +176,11 @@ impl<Ptr: Borrow<Option<i128>>> FromIterator<Ptr> for DecimalBuilder {
         let size_hint = upper.unwrap_or(lower);
         let fixed_len = 16_usize;
 
-        let mut builder =
-            DecimalBuilder::new(size_hint * fixed_len, DECIMAL_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
+        let mut builder = DecimalBuilder::new(
+            size_hint * fixed_len,
+            DECIMAL_MAX_PRECISION,
+            DECIMAL_DEFAULT_SCALE,
+        );
 
         iter.for_each(|item| {
             if let Some(a) = item.borrow() {

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -170,7 +170,7 @@ impl ArrayBuilder for DecimalBuilder {
 }
 
 impl<Ptr: Borrow<Option<i128>>> FromIterator<Ptr> for DecimalBuilder {
-    fn from_iter<T: IntoIterator<Item = Ptr>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -186,10 +186,7 @@ impl<Ptr: Borrow<Option<i128>>> FromIterator<Ptr> for DecimalBuilder {
             if let Some(a) = item.borrow() {
                 let values = Self::from_i128_to_fixed_size_bytes(*a, fixed_len)
                     .expect("Conversion should be possible.");
-                builder
-                    .values()
-                    .append_values(&values, &[true; 16])
-                    .unwrap();
+                builder.values().append_slice(&values).unwrap();
                 builder.append(true).unwrap();
             } else {
                 builder.values().append_nulls(fixed_len).unwrap();

--- a/arrow/src/array/builder/fixed_size_list_builder.rs
+++ b/arrow/src/array/builder/fixed_size_list_builder.rs
@@ -60,21 +60,6 @@ impl<T: ArrayBuilder> ArrayBuilder for FixedSizeListBuilder<T>
 where
     T: 'static,
 {
-    /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.bitmap_builder.len()
@@ -88,6 +73,21 @@ where
     /// Builds the array and reset this builder.
     fn finish(&mut self) -> ArrayRef {
         Arc::new(self.finish())
+    }
+
+    /// Returns the builder as a non-mutable `Any` reference.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Returns the builder as a mutable `Any` reference.
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
+        self
     }
 }
 

--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -120,19 +120,21 @@ where
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut builder =
-            GenericListBuilder::with_capacity(UInt8Builder::new(size_hint), size_hint);
+        let mut builder = GenericBinaryBuilder::new(size_hint);
 
         iter.for_each(|item| {
             if let Some(a) = item {
-                builder.values().append_slice(a.as_ref()).unwrap();
-                builder.append(true).unwrap();
+                builder
+                    .append_value(a.as_ref())
+                    .expect("Unable to append a value to a binary array builder.");
             } else {
-                builder.append(false).unwrap();
+                builder
+                    .append_null()
+                    .expect("Unable to append a null value to a binary array builder.");
             }
         });
 
-        GenericBinaryBuilder { builder }
+        builder
     }
 }
 

--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -115,15 +115,13 @@ impl<Ptr, OffsetSize: OffsetSizeTrait> FromIterator<Option<Ptr>>
 where
     Ptr: AsRef<[u8]>,
 {
-    fn from_iter<T: IntoIterator<Item = Option<Ptr>>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut builder = GenericListBuilder::with_capacity(
-            UInt8Builder::new(size_hint),
-            size_hint,
-        );
+        let mut builder =
+            GenericListBuilder::with_capacity(UInt8Builder::new(size_hint), size_hint);
 
         iter.for_each(|item| {
             if let Some(a) = item {

--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -39,6 +39,16 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
         }
     }
 
+    /// Creates a new `GenericBinaryBuilder`,
+    /// `data_capacity` is the number of bytes of string data to pre-allocate space for in this builder
+    /// `item_capacity` is the number of items to pre-allocate space for in this builder
+    pub fn with_capacity(item_capacity: usize, data_capacity: usize) -> Self {
+        let values_builder = UInt8Builder::new(data_capacity);
+        Self {
+            builder: GenericListBuilder::with_capacity(values_builder, item_capacity),
+        }
+    }
+
     /// Appends a single byte value into the builder's values array.
     ///
     /// Note, when appending individual byte values you must call `append` to delimit each
@@ -120,7 +130,7 @@ where
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut builder = GenericBinaryBuilder::new(size_hint);
+        let mut builder = GenericBinaryBuilder::with_capacity(size_hint, 0);
 
         iter.for_each(|item| {
             if let Some(a) = item {

--- a/arrow/src/array/builder/generic_list_builder.rs
+++ b/arrow/src/array/builder/generic_list_builder.rs
@@ -61,21 +61,6 @@ impl<OffsetSize: OffsetSizeTrait, T: ArrayBuilder> ArrayBuilder
 where
     T: 'static,
 {
-    /// Returns the builder as a non-mutable `Any` reference.
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    /// Returns the builder as a mutable `Any` reference.
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    /// Returns the boxed builder as a box of `Any`.
-    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.bitmap_builder.len()
@@ -89,6 +74,21 @@ where
     /// Builds the array and reset this builder.
     fn finish(&mut self) -> ArrayRef {
         Arc::new(self.finish())
+    }
+
+    /// Returns the builder as a non-mutable `Any` reference.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Returns the builder as a mutable `Any` reference.
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn into_box_any(self: Box<Self>) -> Box<dyn Any> {
+        self
     }
 }
 

--- a/arrow/src/array/builder/generic_string_builder.rs
+++ b/arrow/src/array/builder/generic_string_builder.rs
@@ -142,22 +142,21 @@ where
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut builder =
-            GenericListBuilder::with_capacity(UInt8Builder::new(size_hint), size_hint);
+        let mut builder = GenericStringBuilder::new(size_hint);
 
         iter.for_each(|item| {
             if let Some(a) = item {
                 builder
-                    .values()
-                    .append_slice(a.as_ref().as_bytes())
-                    .unwrap();
-                builder.append(true).unwrap();
+                    .append_value(a.as_ref())
+                    .expect("Unable to append a value to a string array builder.");
             } else {
-                builder.append(false).unwrap();
+                builder
+                    .append_null()
+                    .expect("Unable to append a null value to a string array builder.");
             }
         });
 
-        GenericStringBuilder { builder }
+        builder
     }
 }
 

--- a/arrow/src/array/builder/generic_string_builder.rs
+++ b/arrow/src/array/builder/generic_string_builder.rs
@@ -29,7 +29,7 @@ pub struct GenericStringBuilder<OffsetSize: OffsetSizeTrait> {
 }
 
 impl<OffsetSize: OffsetSizeTrait> GenericStringBuilder<OffsetSize> {
-    /// Creates a new `StringBuilder`,
+    /// Creates a new `GenericStringBuilder`,
     /// `capacity` is the number of bytes of string data to pre-allocate space for in this builder
     pub fn new(capacity: usize) -> Self {
         let values_builder = UInt8Builder::new(capacity);
@@ -38,7 +38,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringBuilder<OffsetSize> {
         }
     }
 
-    /// Creates a new `StringBuilder`,
+    /// Creates a new `GenericStringBuilder`,
     /// `data_capacity` is the number of bytes of string data to pre-allocate space for in this builder
     /// `item_capacity` is the number of items to pre-allocate space for in this builder
     pub fn with_capacity(item_capacity: usize, data_capacity: usize) -> Self {
@@ -142,7 +142,7 @@ where
         let (lower, upper) = iter.size_hint();
         let size_hint = upper.unwrap_or(lower);
 
-        let mut builder = GenericStringBuilder::new(size_hint);
+        let mut builder = GenericStringBuilder::with_capacity(size_hint, 0);
 
         iter.for_each(|item| {
             if let Some(a) = item {

--- a/arrow/src/array/builder/string_dictionary_builder.rs
+++ b/arrow/src/array/builder/string_dictionary_builder.rs
@@ -284,11 +284,11 @@ impl<'a, T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'a
             if let Some(a) = item {
                 builder
                     .append(a)
-                    .expect("Unable to append a value to a dictionary array.");
+                    .expect("Unable to append a value to a dictionary array builder.");
             } else {
-                builder
-                    .append_null()
-                    .expect("Unable to append a null value to a dictionary array.");
+                builder.append_null().expect(
+                    "Unable to append a null value to a dictionary array builder.",
+                );
             }
         });
 

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -391,7 +391,7 @@ unsafe fn reallocate(
 
 impl<A: ArrowNativeType> Extend<A> for MutableBuffer {
     #[inline]
-    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = A>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         self.extend_from_iter(iterator)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1841

# Rationale for this change

1. it allows us to create builder from iterators
2. helps us to avoid wiring `FromIterator` for specific array types and utilize builder implementation for the same
 
# What changes are included in this PR?

It adds `FromIterator` to builder types and make specific array types to use corresponding builder type. 

Note: it doesn't add new `FromIterator` implementation but "moves" existing implementation to builder types. I haven't added new tests for this and relied upon existing tests since specific types will call this implementations. Let me know if we want to add tests this change. (cc @tustvold @alamb)

# Are there any user-facing changes?

N/A