### PR TITLE
Support peek_next_page() and skip_next_page in serialized_reader.

### DIFF
--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -552,7 +552,7 @@ impl PageReader for InMemoryColumnChunkReader {
         Ok(None)
     }
 
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
         Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
     }
 

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -205,7 +205,7 @@ pub trait PageReader: Iterator<Item = Result<Page>> + Send {
 
     /// Gets metadata about the next page, returns an error if no
     /// column index information
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>>;
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>>;
 
     /// Skips reading the next page, returns an error if no
     /// column index information

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -1792,7 +1792,6 @@ mod tests {
             7,
             Compression::UNCOMPRESSED,
             Type::INT32,
-            i64::MIN,
         )
         .unwrap();
 
@@ -1976,7 +1975,6 @@ mod tests {
                 data.len() as i64,
                 Compression::UNCOMPRESSED,
                 Int32Type::get_physical_type(),
-                i64::MIN,
             )
             .unwrap(),
         );
@@ -2360,7 +2358,6 @@ mod tests {
                 column_metadata.num_values(),
                 column_metadata.compression(),
                 T::get_physical_type(),
-                i64::MIN,
             )
             .unwrap(),
         );

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -1792,6 +1792,7 @@ mod tests {
             7,
             Compression::UNCOMPRESSED,
             Type::INT32,
+            i64::MIN,
         )
         .unwrap();
 
@@ -1975,6 +1976,7 @@ mod tests {
                 data.len() as i64,
                 Compression::UNCOMPRESSED,
                 Int32Type::get_physical_type(),
+                i64::MIN,
             )
             .unwrap(),
         );
@@ -2358,6 +2360,7 @@ mod tests {
                 column_metadata.num_values(),
                 column_metadata.compression(),
                 T::get_physical_type(),
+                i64::MIN,
             )
             .unwrap(),
         );

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -267,7 +267,7 @@ impl RowGroupMetaData {
         self.columns.iter().map(|c| c.total_compressed_size).sum()
     }
 
-    /// Returns reference of page offset index.
+    /// Returns reference of page offset index of all column in this row group.
     pub fn page_offset_index(&self) -> &Option<Vec<Vec<PageLocation>>> {
         &self.page_offset_index
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -228,7 +228,7 @@ pub struct RowGroupMetaData {
     num_rows: i64,
     total_byte_size: i64,
     schema_descr: SchemaDescPtr,
-    // Todo add filter result -> row range
+    page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
 impl RowGroupMetaData {
@@ -267,6 +267,11 @@ impl RowGroupMetaData {
         self.columns.iter().map(|c| c.total_compressed_size).sum()
     }
 
+    /// Returns reference of page offset index.
+    pub fn page_offset_index(&self) -> &Option<Vec<Vec<PageLocation>>> {
+        &self.page_offset_index
+    }
+
     /// Returns reference to a schema descriptor.
     pub fn schema_descr(&self) -> &SchemaDescriptor {
         self.schema_descr.as_ref()
@@ -275,6 +280,11 @@ impl RowGroupMetaData {
     /// Returns reference counted clone of schema descriptor.
     pub fn schema_descr_ptr(&self) -> SchemaDescPtr {
         self.schema_descr.clone()
+    }
+
+    /// Sets page offset index for this row group.
+    pub fn set_page_offset(&mut self, page_offset: Vec<Vec<PageLocation>>) {
+        self.page_offset_index = Some(page_offset);
     }
 
     /// Method to convert from Thrift.
@@ -295,6 +305,7 @@ impl RowGroupMetaData {
             num_rows,
             total_byte_size,
             schema_descr,
+            page_offset_index: None,
         })
     }
 
@@ -318,6 +329,7 @@ pub struct RowGroupMetaDataBuilder {
     schema_descr: SchemaDescPtr,
     num_rows: i64,
     total_byte_size: i64,
+    page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
 impl RowGroupMetaDataBuilder {
@@ -328,6 +340,7 @@ impl RowGroupMetaDataBuilder {
             schema_descr,
             num_rows: 0,
             total_byte_size: 0,
+            page_offset_index: None,
         }
     }
 
@@ -349,6 +362,12 @@ impl RowGroupMetaDataBuilder {
         self
     }
 
+    /// Sets page offset index for this row group.
+    pub fn set_page_offset(mut self, page_offset: Vec<Vec<PageLocation>>) -> Self {
+        self.page_offset_index = Some(page_offset);
+        self
+    }
+
     /// Builds row group metadata.
     pub fn build(self) -> Result<RowGroupMetaData> {
         if self.schema_descr.num_columns() != self.columns.len() {
@@ -364,6 +383,7 @@ impl RowGroupMetaDataBuilder {
             num_rows: self.num_rows,
             total_byte_size: self.total_byte_size,
             schema_descr: self.schema_descr,
+            page_offset_index: self.page_offset_index,
         })
     }
 }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -34,11 +34,11 @@ use crate::file::{footer, metadata::*, reader::*, statistics};
 use crate::record::reader::RowIter;
 use crate::record::Row;
 use crate::schema::types::Type as SchemaType;
+use crate::util::page_util::{calculate_row_count, get_pages_readable_slices};
 use crate::util::{io::TryClone, memory::ByteBufferPtr};
 
 // export `SliceableCursor` and `FileSource` publically so clients can
 // re-use the logic in their own ParquetFileWriter wrappers
-use crate::util::page_util::{calculate_row_count, get_pages_readable_slices};
 #[allow(deprecated)]
 pub use crate::util::{cursor::SliceableCursor, io::FileSource};
 
@@ -513,18 +513,6 @@ pub struct SerializedPageReader<T: Read> {
 
     // Column chunk type.
     physical_type: Type,
-    // //Page offset index.
-    // page_offset_index: Option<Vec<PageLocation>>,
-    //
-    // // The number of data pages we have seen so far,
-    // // include the skipped page.
-    // seen_num_data_pages: usize,
-    //
-    // // A flag to check whether a dictionary page should read first
-    // has_dictionary_page_to_read: bool,
-    //
-    // // A list of readable slice in 'SerializedPageReader' for skipping page with offset index.
-    // page_bufs: VecDeque<T>,
 }
 
 impl<T: Read> SerializedPageReader<T> {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1052,7 +1052,6 @@ mod tests {
                 total_num_values,
                 codec,
                 physical_type,
-                i64::MIN,
             )
             .unwrap();
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1052,6 +1052,7 @@ mod tests {
                 total_num_values,
                 codec,
                 physical_type,
+                i64::MIN,
             )
             .unwrap();
 

--- a/parquet/src/util/page_util.rs
+++ b/parquet/src/util/page_util.rs
@@ -33,7 +33,7 @@ pub(crate) fn calculate_row_count(indexes: &[PageLocation], page_num: usize, tot
 
 /// Use column chunk's offset index to get each page serially readable slice
 /// and a flag indicates whether having one dictionary page in this column chunk.
-pub(crate) fn get_pages_readable_slices<T: Read + Send, R: ChunkReader + ChunkReader<T=T>>(col_chunk_offset_index: &[PageLocation], col_start: u64, chunk_reader: Arc<R>) -> Result<(VecDeque<T>, bool)> {
+pub(crate) fn get_pages_readable_slices<T: Read + Send, R: ChunkReader<T=T>>(col_chunk_offset_index: &[PageLocation], col_start: u64, chunk_reader: Arc<R>) -> Result<(VecDeque<T>, bool)> {
     let first_data_page_offset = col_chunk_offset_index[0].offset as u64;
     let has_dictionary_page = first_data_page_offset != col_start;
     let mut page_readers = VecDeque::with_capacity(col_chunk_offset_index.len() + 1);

--- a/parquet/src/util/page_util.rs
+++ b/parquet/src/util/page_util.rs
@@ -15,13 +15,40 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::VecDeque;
+use std::io::Read;
+use std::sync::Arc;
 use crate::errors::Result;
 use parquet_format::PageLocation;
+use crate::file::reader::ChunkReader;
 
+/// Use column chunk's offset index to get the `page_num` page row count.
 pub(crate) fn calculate_row_count(indexes: &[PageLocation], page_num: usize, total_row_count: i64) -> Result<usize> {
     if page_num == indexes.len() - 1 {
         Ok((total_row_count - indexes[page_num].first_row_index + 1) as usize)
     } else {
         Ok((indexes[page_num + 1].first_row_index - indexes[page_num].first_row_index) as usize)
     }
+}
+
+/// Use column chunk's offset index to get each page serially readable slice
+/// and a flag indicates whether having one dictionary page in this column chunk.
+pub(crate) fn get_pages_readable_slices<T: Read + Send, R: ChunkReader + ChunkReader<T=T>>(col_chunk_offset_index: &[PageLocation], col_start: u64, chunk_reader: Arc<R>) -> Result<(VecDeque<T>, bool)> {
+    let first_data_page_offset = col_chunk_offset_index[0].offset as u64;
+    let has_dictionary_page = first_data_page_offset != col_start;
+    let mut page_readers = VecDeque::with_capacity(col_chunk_offset_index.len() + 1);
+
+    if has_dictionary_page {
+        let length = (first_data_page_offset - col_start) as usize;
+        let reader: T = chunk_reader.get_read(col_start, length)?;
+        page_readers.push_back(reader);
+    }
+
+    for index in col_chunk_offset_index {
+        let start = index.offset as u64;
+        let length = index.compressed_page_size as usize;
+        let reader: T = chunk_reader.get_read(start, length)?;
+        page_readers.push_back(reader)
+    }
+    Ok((page_readers, has_dictionary_page))
 }

--- a/parquet/src/util/page_util.rs
+++ b/parquet/src/util/page_util.rs
@@ -15,18 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod io;
-pub mod memory;
-#[macro_use]
-pub mod bit_util;
-mod bit_packing;
-pub mod cursor;
-pub mod hash_util;
-#[cfg(any(test, feature = "test_common"))]
-pub(crate) mod test_common;
-pub(crate)mod page_util;
+use crate::errors::Result;
+use parquet_format::PageLocation;
 
-#[cfg(any(test, feature = "test_common"))]
-pub use self::test_common::page_util::{
-    DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
-};
+pub(crate) fn calculate_row_count(indexes: &[PageLocation], page_num: usize, total_row_count: i64) -> Result<usize> {
+    if page_num == indexes.len() - 1 {
+        Ok((total_row_count - indexes[page_num].first_row_index + 1) as usize)
+    } else {
+        Ok((indexes[page_num + 1].first_row_index - indexes[page_num].first_row_index) as usize)
+    }
+}

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -173,7 +173,7 @@ impl<P: Iterator<Item = Page> + Send> PageReader for InMemoryPageReader<P> {
         Ok(self.page_iter.next())
     }
 
-    fn peek_next_page(&self) -> Result<Option<PageMetadata>> {
+    fn peek_next_page(&mut self) -> Result<Option<PageMetadata>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #2043.

# Rationale for this change

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?



<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
