### PR TITLE
Remove null count from write_batch_with_statistics

### DIFF
--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -292,7 +292,6 @@ impl<'a, T: DataType> ColumnWriterImpl<'a, T> {
         rep_levels: Option<&[i16]>,
         min: Option<&T::T>,
         max: Option<&T::T>,
-        null_count: Option<u64>,
         distinct_count: Option<u64>,
     ) -> Result<usize> {
         // We check for DataPage limits only after we have inserted the values. If a user
@@ -346,10 +345,6 @@ impl<'a, T: DataType> ColumnWriterImpl<'a, T> {
             self.column_distinct_count = None;
         }
 
-        if let Some(nulls) = null_count {
-            self.num_column_nulls += nulls;
-        }
-
         let mut values_offset = 0;
         let mut levels_offset = 0;
         for _ in 0..num_batches {
@@ -389,7 +384,7 @@ impl<'a, T: DataType> ColumnWriterImpl<'a, T> {
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
     ) -> Result<usize> {
-        self.write_batch_internal(values, def_levels, rep_levels, None, None, None, None)
+        self.write_batch_internal(values, def_levels, rep_levels, None, None, None)
     }
 
     /// Writer may optionally provide pre-calculated statistics for use when computing
@@ -406,7 +401,6 @@ impl<'a, T: DataType> ColumnWriterImpl<'a, T> {
         rep_levels: Option<&[i16]>,
         min: Option<&T::T>,
         max: Option<&T::T>,
-        nulls_count: Option<u64>,
         distinct_count: Option<u64>,
     ) -> Result<usize> {
         self.write_batch_internal(
@@ -415,7 +409,6 @@ impl<'a, T: DataType> ColumnWriterImpl<'a, T> {
             rep_levels,
             min,
             max,
-            nulls_count,
             distinct_count,
         )
     }
@@ -1726,7 +1719,6 @@ mod tests {
                 None,
                 Some(&-17),
                 Some(&9000),
-                Some(21),
                 Some(55),
             )
             .unwrap();
@@ -1774,7 +1766,6 @@ mod tests {
                 None,
                 Some(&5),
                 Some(&7),
-                Some(0),
                 Some(3),
             )
             .unwrap();

--- a/parquet/src/column/writer.rs
+++ b/parquet/src/column/writer.rs
@@ -1737,7 +1737,7 @@ mod tests {
         assert_eq!(metadata.dictionary_page_offset(), Some(0));
         if let Some(stats) = metadata.statistics() {
             assert!(stats.has_min_max_set());
-            assert_eq!(stats.null_count(), 21);
+            assert_eq!(stats.null_count(), 0);
             assert_eq!(stats.distinct_count().unwrap_or(0), 55);
             if let Statistics::Int32(stats) = stats {
                 assert_eq!(stats.min(), &-17);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2046

# Rationale for this change
 
We must compute null counts regardless, and so there is no advantage to providing a pre-computed null count

# What changes are included in this PR?

Removes null count from write_batch_with_statistics

# Are there any user-facing changes?

Yes
