### PR TITLE
feat(compute): Support week0 (PostgreSQL behaviour) for temporal

### DIFF
--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -120,6 +120,7 @@ trait ChronoDateExt {
     /// Returns a value in range `0..=3` indicating the quarter (zero-based) this date falls into
     fn quarter0(&self) -> u32;
 
+    /// Returns the day of week; Sunday is encoded as `0`, Monday as `1`, etc.
     fn weekday0(&self) -> i32;
 }
 

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -120,8 +120,11 @@ trait ChronoDateExt {
     /// Returns a value in range `0..=3` indicating the quarter (zero-based) this date falls into
     fn quarter0(&self) -> u32;
 
+    /// Returns the day of week; Monday is encoded as `0`, Tuesday as `1`, etc.
+    fn num_days_from_monday(&self) -> i32;
+
     /// Returns the day of week; Sunday is encoded as `0`, Monday as `1`, etc.
-    fn weekday0(&self) -> i32;
+    fn num_days_from_sunday(&self) -> i32;
 }
 
 impl<T: Datelike> ChronoDateExt for T {
@@ -133,7 +136,11 @@ impl<T: Datelike> ChronoDateExt for T {
         self.month0() / 3
     }
 
-    fn weekday0(&self) -> i32 {
+    fn num_days_from_monday(&self) -> i32 {
+        self.weekday().num_days_from_monday() as i32
+    }
+
+    fn num_days_from_sunday(&self) -> i32 {
         self.weekday().num_days_from_sunday() as i32
     }
 }
@@ -277,14 +284,19 @@ where
     let mut b = Int32Builder::new(array.len());
     match array.data_type() {
         &DataType::Date32 | &DataType::Date64 | &DataType::Timestamp(_, None) => {
-            extract_component_from_array!(array, b, weekday, value_as_datetime)
+            extract_component_from_array!(
+                array,
+                b,
+                num_days_from_monday,
+                value_as_datetime
+            )
         }
         &DataType::Timestamp(_, Some(ref tz)) => {
             let mut scratch = Parsed::new();
             extract_component_from_array!(
                 array,
                 b,
-                weekday,
+                num_days_from_monday,
                 value_as_datetime_with_tz,
                 tz,
                 scratch
@@ -308,14 +320,19 @@ where
     let mut b = Int32Builder::new(array.len());
     match array.data_type() {
         &DataType::Date32 | &DataType::Date64 | &DataType::Timestamp(_, None) => {
-            extract_component_from_array!(array, b, weekday0, value_as_datetime)
+            extract_component_from_array!(
+                array,
+                b,
+                num_days_from_sunday,
+                value_as_datetime
+            )
         }
         &DataType::Timestamp(_, Some(ref tz)) => {
             let mut scratch = Parsed::new();
             extract_component_from_array!(
                 array,
                 b,
-                weekday0,
+                num_days_from_sunday,
                 value_as_datetime_with_tz,
                 tz,
                 scratch

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -297,7 +297,7 @@ where
 }
 
 /// Extracts the day of week of a given temporal array as an array of
-/// integers.
+/// integers, starting at Sunday. This is different than [`weekday`] which starts at Monday.
 ///
 /// Sunday is encoded as `0`, Monday as `1`, etc.
 pub fn weekday0<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>


### PR DESCRIPTION
# Rationale for this change
 
DataFusion uses temporal to operate with date like structures. I want to implement `EXTRACT(DOW from NOW())`.

# What changes are included in this PR?

Implementation of `temporal::dow`

# Are there any user-facing changes?

No

Thanks
