### PR TITLE
Use `read_volatile` in `BitChunkIterator.next`

### DIFF
--- a/arrow/src/util/bit_chunk_iterator.rs
+++ b/arrow/src/util/bit_chunk_iterator.rs
@@ -333,7 +333,7 @@ impl Iterator for BitChunkIterator<'_> {
             // the constructor ensures that bit_offset is in 0..8
             // that means we need to read at most one additional byte to fill in the high bits
             let next = unsafe {
-                std::ptr::read_unaligned(raw_data.add(index + 1) as *const u8) as u64
+                std::ptr::read_volatile(raw_data.add(index + 1) as *const u8) as u64
             };
 
             (current >> bit_offset) | (next << (64 - bit_offset))


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2060.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->


```
boolean_append_packed   time:   [19.721 us 19.777 us 19.835 us]                                   
                        change: [-12.491% -10.883% -9.3860%] (p = 0.00 < 0.05)                                                                                                                                                         
                        Performance has improved.                                                                  
Found 6 outliers among 100 measurements (6.00%)                                                                                                                                                                                        
  3 (3.00%) high mild                                                                                                                                                                                                                  
  3 (3.00%) high severe                                                                                                                                                                                                                
```

The benchmark is somehow fluctuating. But mostly I see `read_volatile` is faster.


Both `read_volatile` and `read_unaligned` do a bitwise copy of T. But `read_unaligned` internally creates a `MaybeUninit` and copy data into the temporary `MaybeUninit`. Then it checks if the value is initialized and returns the value. `read_volatile` just simply loads the value from the given address.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
