### PR TITLE
Improve performance of filter_dict

### DIFF
--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -159,7 +159,7 @@ impl<K: ArrowPrimitiveType> DictionaryArray<K> {
     /// # Safety
     ///
     /// The input keys, values and data must form a valid DictionaryArray,
-    /// or undefined behavior can results.
+    /// or undefined behavior can occur.
     pub(crate) unsafe fn try_new_unchecked(
         keys: PrimitiveArray<K>,
         values: ArrayRef,

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -151,6 +151,28 @@ impl<K: ArrowPrimitiveType> DictionaryArray<K> {
         Ok(array.into())
     }
 
+    /// Create a new DictionaryArray directly from specified keys
+    /// (indexes into the dictionary) and values (dictionary)
+    /// array, and the corresponding ArrayData. This is used internally
+    /// for the usage like filter kernel.
+    ///
+    /// # Safety
+    ///
+    /// The input keys, values and data must form a valid DictionaryArray,
+    /// or undefined behavior can results.
+    pub(crate) unsafe fn try_new_unchecked(
+        keys: PrimitiveArray<K>,
+        values: ArrayRef,
+        data: ArrayData,
+    ) -> Self {
+        Self {
+            data,
+            keys,
+            values,
+            is_ordered: false,
+        }
+    }
+
     /// Return an array view of the keys of this dictionary as a PrimitiveArray.
     pub fn keys(&self) -> &PrimitiveArray<K> {
         &self.keys

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -786,7 +786,13 @@ where
         )
     };
 
-    DictionaryArray::<T>::from(data)
+    unsafe {
+        DictionaryArray::<T>::try_new_unchecked(
+            filtered_keys,
+            array.values().clone(),
+            data,
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2062.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

```
filter context string dictionary (kept 1/2)                                                                                                                                                                                            
                        time:   [21.995 us 22.197 us 22.408 us]                                                                                                                                                                        
                        change: [-2.3630% -1.2909% -0.2122%] (p = 0.02 < 0.05)                                                                                                                                                         
                        Change within noise threshold.                                                                                                                                                                                 
Found 8 outliers among 100 measurements (8.00%)                                                                                                                                                                                        
  8 (8.00%) high mild                                                                                                                                                                                                                  
                                                                                                                                                                                                                                       
filter context string dictionary high selectivity (kept 1023/1024)                                                                                                                                                                     
                        time:   [10.567 us 10.650 us 10.735 us]                                                                                                                                                                        
                        change: [-3.2419% -2.2248% -1.2276%] (p = 0.00 < 0.05)
                        Performance has improved.

filter context string dictionary low selectivity (kept 1/1024)                                                                              
                        time:   [910.91 ns 917.49 ns 924.83 ns]
                        change: [-23.778% -22.819% -21.986%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

filter context string dictionary w NULLs (kept 1/2)                                                                             
                        time:   [53.386 us 53.870 us 54.349 us]
                        change: [-5.8932% -4.8921% -3.8850%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

filter context string dictionary w NULLs high selectivity (kept 1023/1024)                                                                              
                        time:   [20.187 us 20.381 us 20.576 us]
                        change: [-2.2931% -1.2510% -0.2547%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

filter context string dictionary w NULLs low selectivity (kept 1/1024)                                                                              
                        time:   [1.2670 us 1.2742 us 1.2816 us]
                        change: [-24.367% -23.820% -23.263%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
