### PR TITLE
Support nullable indices in boolean take kernel and some optimizations

### DIFF
--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1457,6 +1457,29 @@ mod tests {
     }
 
     #[test]
+    fn test_take_bool_nullable_index() {
+        // indices where the masked invalid elements would be out of bounds
+        let index_data = ArrayData::try_new(
+            DataType::Int32,
+            6,
+            Some(Buffer::from_iter(vec![
+                false, true, false, true, false, true,
+            ])),
+            0,
+            vec![Buffer::from_iter(vec![99, 0, 999, 1, 9999, 2])],
+            vec![],
+        )
+        .unwrap();
+        let index = UInt32Array::from(index_data);
+        test_take_boolean_arrays(
+            vec![Some(true), None, Some(false)],
+            &index,
+            None,
+            vec![None, Some(true), None, None, None, Some(false)],
+        );
+    }
+
+    #[test]
     fn test_take_bool_with_offset() {
         let index =
             UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(2), None]);


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2057.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

 - Use the `PrimitiveIter` to iterate over indices, which makes it easier to handle nullable indices.
 - Split up the kernel into separate logic for taking the values and the validity bitmap. This reduces branching in the inner loop and thus increases the performance.

# Are there any user-facing changes?

no

# Benchmark results compared to master

```
Gnuplot not found, using plotters backend
take bool 512           time:   [1.3921 us 1.3927 us 1.3933 us]                           
                        change: [+3.7963% +3.9074% +3.9940%] (p = 0.00 < 0.05)
                        Performance has regressed.

take bool 1024          time:   [3.6781 us 3.8022 us 3.9126 us]                            
                        change: [-33.173% -31.574% -30.047%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool 4096          time:   [10.833 us 10.878 us 10.924 us]                            
                        change: [-67.171% -67.042% -66.917%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool nulls 512     time:   [1.4058 us 1.4067 us 1.4077 us]                                 
                        change: [+4.1519% +4.3855% +4.6259%] (p = 0.00 < 0.05)
                        Performance has regressed.

take bool nulls 1024    time:   [2.5999 us 2.6011 us 2.6027 us]                                  
                        change: [-31.505% -31.418% -31.333%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool nulls 4096    time:   [9.7339 us 9.7377 us 9.7420 us]                                  
                        change: [-54.586% -54.558% -54.531%] (p = 0.00 < 0.05)
                        Performance has improved.
```

There is a small regression for very small inputs, which will probably be alleviated by #1857. Larger inputs see a big improvement.