### PR TITLE
Rename `weekday` and `weekday0` kernels to to `num_days_from_monday` and `days_since_sunday`

### DIFF
--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -276,7 +276,9 @@ where
 /// integers.
 ///
 /// Monday is encoded as `0`, Tuesday as `1`, etc.
-pub fn weekday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
+///
+/// See also [`num_days_from_sunday`] which starts at Sunday.
+pub fn num_days_from_monday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where
     T: ArrowTemporalType + ArrowNumericType,
     i64: std::convert::From<T::Native>,
@@ -309,10 +311,12 @@ where
 }
 
 /// Extracts the day of week of a given temporal array as an array of
-/// integers, starting at Sunday. This is different than [`weekday`] which starts at Monday.
+/// integers, starting at Sunday.
 ///
 /// Sunday is encoded as `0`, Monday as `1`, etc.
-pub fn weekday0<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
+///
+/// See also [`num_days_from_monday`] which starts at Monday.
+pub fn num_days_from_sunday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where
     T: ArrowTemporalType + ArrowNumericType,
     i64: std::convert::From<T::Native>,
@@ -632,7 +636,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = weekday(&a).unwrap();
+        let b = num_days_from_monday(&a).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2, b.value(2));
@@ -651,7 +655,7 @@ mod tests {
         ]
         .into();
 
-        let b = weekday0(&a).unwrap();
+        let b = num_days_from_sunday(&a).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(1, b.value(2));


### PR DESCRIPTION

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/2065

# Rationale for this change
 

Depending on the usecase sometimes one wants the days of week to start from Sunday or Monday. Dates :shrug:

@ovr added the `weekday0` kernel in https://github.com/apache/arrow-rs/pull/2052

But now the names are `weekday` and `weekday0` which I think might be confusing to the average reader


# What changes are included in this PR?

Rename the kernels to follow the  chrono naming scheme `num_days_from_sunday` and `num_days_from_monday`

https://docs.rs/chrono/0.4.19/chrono/enum.Weekday.html#method.num_days_from_sunday
https://docs.rs/chrono/0.4.19/chrono/enum.Weekday.html#method.num_days_from_monday

# Are there any user-facing changes?
Yes, name of the `compute::kernels::temporal::weekday` (which is present in arrow 18) is renamed to `compute::kernels::temporal::num_days_since_monday`