### PR TITLE
Improve performance of set_bits by using copy_from_slice instead of setting individual bytes

### DIFF
--- a/arrow/src/util/bit_mask.rs
+++ b/arrow/src/util/bit_mask.rs
@@ -42,10 +42,9 @@ pub fn set_bits(
     let chunks = BitChunks::new(data, offset_read + bits_to_align, len - bits_to_align);
     chunks.iter().for_each(|chunk| {
         null_count += chunk.count_zeros();
-        chunk.to_le_bytes().iter().for_each(|b| {
-            write_data[write_byte_index] = *b;
-            write_byte_index += 1;
-        })
+        write_data[write_byte_index..write_byte_index + 8]
+            .copy_from_slice(&chunk.to_le_bytes());
+        write_byte_index += 8;
     });
 
     // Set individual bits both to align write_data to a byte offset and the remainder bits not covered by the bit chunk iterator


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2060.

# Rationale for this change
 
Using `copy_from_slice` here reduces the number of bounds checks to one per chunk instead of one per byte.

Performance of `boolean_append_packed` improves by about 40% on my laptop.

```
$ RUSTFLAGS="-Ctarget-cpu=skylake" perf record cargo bench --bench boolean_append_packed
boolean_append_packed   time:   [11.634 us 11.712 us 11.802 us]                                   
                        change: [-41.447% -40.956% -40.476%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Further improvements should be possible by asserting the bounds once on function entry and then using unsafe `ptr::copy_non_overlapping` in the main loop and `get_bit_raw`/`set_bit_raw` for the non-aligned parts.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No