### PR TITLE
Enable rebase merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,7 +29,7 @@ github:
   enabled_merge_buttons:
     squash: true
     merge: false
-    rebase: false
+    rebase: true
   features:
     issues: true
   protected_branches:


### PR DESCRIPTION
This will allow preserving PR commit history, which in certain situations (e.g. #2081) can be desirable.

The alternative would be to perform the rebase merge locally and push to master, but this feels less hacky