### PR TITLE
Handle offset consistently for StructArray (#1750)

### DIFF
--- a/arrow/src/array/array_struct.rs
+++ b/arrow/src/array/array_struct.rs
@@ -111,7 +111,7 @@ impl From<ArrayData> for StructArray {
         let boxed_fields = data
             .child_data()
             .iter()
-            .map(|cd| make_array(cd.clone()))
+            .map(|cd| make_array(cd.slice(data.offset(), data.len())))
             .collect();
 
         Self { data, boxed_fields }

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -493,36 +493,15 @@ impl ArrayData {
     pub fn slice(&self, offset: usize, length: usize) -> ArrayData {
         assert!((offset + length) <= self.len());
 
-        if let DataType::Struct(_) = self.data_type() {
-            // Slice into children
-            let new_offset = self.offset + offset;
-            let new_data = ArrayData {
-                data_type: self.data_type().clone(),
-                len: length,
-                null_count: count_nulls(self.null_buffer(), new_offset, length),
-                offset: new_offset,
-                buffers: self.buffers.clone(),
-                // Slice child data, to propagate offsets down to them
-                child_data: self
-                    .child_data()
-                    .iter()
-                    .map(|data| data.slice(offset, length))
-                    .collect(),
-                null_bitmap: self.null_bitmap().cloned(),
-            };
+        let mut new_data = self.clone();
 
-            new_data
-        } else {
-            let mut new_data = self.clone();
+        new_data.len = length;
+        new_data.offset = offset + self.offset;
 
-            new_data.len = length;
-            new_data.offset = offset + self.offset;
+        new_data.null_count =
+            count_nulls(new_data.null_buffer(), new_data.offset, new_data.len);
 
-            new_data.null_count =
-                count_nulls(new_data.null_buffer(), new_data.offset, new_data.len);
-
-            new_data
-        }
+        new_data
     }
 
     /// Returns the `buffer` as a slice of type `T` starting at self.offset

--- a/arrow/src/array/equal/structure.rs
+++ b/arrow/src/array/equal/structure.rs
@@ -32,7 +32,13 @@ fn equal_child_values(
         .iter()
         .zip(rhs.child_data())
         .all(|(lhs_values, rhs_values)| {
-            equal_range(lhs_values, rhs_values, lhs_start, rhs_start, len)
+            equal_range(
+                lhs_values,
+                rhs_values,
+                lhs_start + lhs.offset(),
+                rhs_start + rhs.offset(),
+                len,
+            )
         })
 }
 

--- a/arrow/src/array/transform/structure.rs
+++ b/arrow/src/array/transform/structure.rs
@@ -20,16 +20,16 @@ use crate::array::ArrayData;
 use super::{Extend, _MutableArrayData};
 
 pub(super) fn build_extend(array: &ArrayData) -> Extend {
+    let offset = array.offset();
     if array.null_count() == 0 {
         Box::new(
             move |mutable: &mut _MutableArrayData,
                   index: usize,
                   start: usize,
                   len: usize| {
-                mutable
-                    .child_data
-                    .iter_mut()
-                    .for_each(|child| child.extend(index, start, start + len))
+                mutable.child_data.iter_mut().for_each(|child| {
+                    child.extend(index, offset + start, offset + start + len)
+                })
             },
         )
     } else {
@@ -40,10 +40,9 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                   len: usize| {
                 (start..start + len).for_each(|i| {
                     if array.is_valid(i) {
-                        mutable
-                            .child_data
-                            .iter_mut()
-                            .for_each(|child| child.extend(index, i, i + 1))
+                        mutable.child_data.iter_mut().for_each(|child| {
+                            child.extend(index, offset + i, offset + i + 1)
+                        })
                     } else {
                         mutable
                             .child_data


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1750

# Rationale for this change
 
The special casing of StructArray is inconsistent with how offsets are handled for all other types. This makes an already very confusing parameter, even more confusing.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Removes the special-casing of StructArray in ArrayData::slice, instead handling it within the Array implementation as is done for all other array types. Longer term we may want to revisit the offset field, #1799, but until then we should be consistent.

# Are there any user-facing changes?

Sort of, whilst extremely unlikely any code is actually doing this, it was possible to manually construct an ArrayData for a StructArray with a non-zero offset. This previously would not behave correctly (as it wasn't entirely clear what the correct semantics even where).
