### PR TITLE
Remove doc hidden from GenericColumnReader

### DIFF
--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -45,7 +45,6 @@ pub(crate) const MIN_BATCH_SIZE: usize = 1024;
 pub type RecordReader<T> =
     GenericRecordReader<ScalarBuffer<<T as DataType>::T>, ColumnValueDecoderImpl<T>>;
 
-#[doc(hidden)]
 /// A generic stateful column reader that delimits semantic records
 ///
 /// This type is hidden from the docs, and relies on private traits with no

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -108,7 +108,6 @@ pub type ColumnReaderImpl<T> = GenericColumnReader<
     decoder::ColumnValueDecoderImpl<T>,
 >;
 
-#[doc(hidden)]
 /// Reads data for a given column chunk, using the provided decoders:
 ///
 /// - R: [`ColumnLevelDecoder`] used to decode repetition levels

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -110,9 +110,9 @@ pub type ColumnReaderImpl<T> = GenericColumnReader<
 
 /// Reads data for a given column chunk, using the provided decoders:
 ///
-/// - R: [`ColumnLevelDecoder`] used to decode repetition levels
-/// - D: [`ColumnLevelDecoder`] used to decode definition levels
-/// - V: [`ColumnValueDecoder`] used to decode value data
+/// - R: `ColumnLevelDecoder` used to decode repetition levels
+/// - D: `ColumnLevelDecoder` used to decode definition levels
+/// - V: `ColumnValueDecoder` used to decode value data
 pub struct GenericColumnReader<R, D, V> {
     descr: ColumnDescPtr,
 


### PR DESCRIPTION
Currently the lack of docs makes it hard to determine how to use `ColumnReaderImpl` - see [here](https://docs.rs/parquet/latest/parquet/column/reader/type.ColumnReaderImpl.html).

The decision was initially made to hide these docs to allow us to evolve the API, however, I think it makes sense to unhide this API because:

* It should be relatively static now
* As ColumnLevelDecoderImpl, etc... are still private, this change does not impact our ability to make breaking changes to them
* We are making more frequent breaking releases than we were at the time this change was made
