### PR TITLE
Return reference from UnionArray::child (#2035)

### DIFF
--- a/arrow/src/array/array_union.rs
+++ b/arrow/src/array/array_union.rs
@@ -231,10 +231,10 @@ impl UnionArray {
     ///
     /// Panics if the `type_id` provided is less than zero or greater than the number of types
     /// in the `Union`.
-    pub fn child(&self, type_id: i8) -> ArrayRef {
+    pub fn child(&self, type_id: i8) -> &ArrayRef {
         assert!(0 <= type_id);
         assert!((type_id as usize) < self.boxed_fields.len());
-        self.boxed_fields[type_id as usize].clone()
+        &self.boxed_fields[type_id as usize]
     }
 
     /// Returns the `type_id` for the array slot at `index`.

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -226,7 +226,7 @@ impl IpcDataGenerator {
             }
             DataType::Union(fields, _, _) => {
                 let union = as_union_array(column);
-                for (field, ref column) in fields
+                for (field, column) in fields
                     .iter()
                     .enumerate()
                     .map(|(n, f)| (f, union.child(n as i8)))

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -434,7 +434,7 @@ fn union_to_string(
     let name = fields.get(field_idx).unwrap().name();
 
     let value = array_value_to_string(
-        &list.child(type_id),
+        list.child(type_id),
         match mode {
             UnionMode::Dense => list.value_offset(row) as usize,
             UnionMode::Sparse => row,


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2035

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See #2035

# What changes are included in this PR?

Changes UnionArray::child to return a reference

# Are there any user-facing changes?

Yes
