### PR TITLE
Make builder append methods infallible where possible

### DIFF
--- a/arrow/benches/builder.rs
+++ b/arrow/benches/builder.rs
@@ -43,7 +43,7 @@ fn bench_primitive(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = Int64Builder::new(64);
             for _ in 0..NUM_BATCHES {
-                let _ = black_box(builder.append_slice(&data[..]));
+                black_box(builder.append_slice(&data[..]));
             }
             black_box(builder.finish());
         })
@@ -57,7 +57,7 @@ fn bench_primitive_nulls(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = UInt8Builder::new(64);
             for _ in 0..NUM_BATCHES * BATCH_SIZE {
-                let _ = black_box(builder.append_null());
+                black_box(builder.append_null());
             }
             black_box(builder.finish());
         })

--- a/arrow/benches/builder.rs
+++ b/arrow/benches/builder.rs
@@ -43,7 +43,7 @@ fn bench_primitive(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = Int64Builder::new(64);
             for _ in 0..NUM_BATCHES {
-                black_box(builder.append_slice(&data[..]));
+                builder.append_slice(&data[..]);
             }
             black_box(builder.finish());
         })
@@ -57,7 +57,7 @@ fn bench_primitive_nulls(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = UInt8Builder::new(64);
             for _ in 0..NUM_BATCHES * BATCH_SIZE {
-                black_box(builder.append_null());
+                builder.append_null();
             }
             black_box(builder.finish());
         })
@@ -80,7 +80,7 @@ fn bench_bool(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = BooleanBuilder::new(64);
             for _ in 0..NUM_BATCHES {
-                let _ = black_box(builder.append_slice(&data[..]));
+                builder.append_slice(&data[..]);
             }
             black_box(builder.finish());
         })
@@ -98,7 +98,7 @@ fn bench_string(c: &mut Criterion) {
         b.iter(|| {
             let mut builder = StringBuilder::new(64);
             for _ in 0..NUM_BATCHES * BATCH_SIZE {
-                let _ = black_box(builder.append_value(SAMPLE_STRING));
+                builder.append_value(SAMPLE_STRING);
             }
             black_box(builder.finish());
         })

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -49,12 +49,12 @@ fn build_utf8_date_array(size: usize, with_nulls: bool) -> ArrayRef {
 
     for _ in 0..size {
         if with_nulls && rng.gen::<f32>() > 0.8 {
-            builder.append_null().unwrap();
+            builder.append_null();
         } else {
             let string = NaiveDate::from_num_days_from_ce(rng.sample(range))
                 .format("%Y-%m-%d")
                 .to_string();
-            builder.append_value(&string).unwrap();
+            builder.append_value(&string);
         }
     }
     Arc::new(builder.finish())
@@ -70,12 +70,12 @@ fn build_utf8_date_time_array(size: usize, with_nulls: bool) -> ArrayRef {
 
     for _ in 0..size {
         if with_nulls && rng.gen::<f32>() > 0.8 {
-            builder.append_null().unwrap();
+            builder.append_null();
         } else {
             let string = NaiveDateTime::from_timestamp(rng.sample(range), 0)
                 .format("%Y-%m-%dT%H:%M:%S")
                 .to_string();
-            builder.append_value(&string).unwrap();
+            builder.append_value(&string);
         }
     }
     Arc::new(builder.finish())

--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -33,10 +33,10 @@ fn create_random_index(size: usize, null_density: f32) -> UInt32Array {
     let mut builder = UInt32Builder::new(size);
     for _ in 0..size {
         if rng.gen::<f32>() < null_density {
-            builder.append_null().unwrap()
+            builder.append_null();
         } else {
             let value = rng.gen_range::<u32, _>(0u32..size as u32);
-            builder.append_value(value).unwrap();
+            builder.append_value(value);
         }
     }
     builder.finish()

--- a/arrow/examples/builders.rs
+++ b/arrow/examples/builders.rs
@@ -37,19 +37,17 @@ fn main() {
     let mut primitive_array_builder = Int32Builder::new(100);
 
     // Append an individual primitive value
-    primitive_array_builder.append_value(55).unwrap();
+    primitive_array_builder.append_value(55);
 
     // Append a null value
-    primitive_array_builder.append_null().unwrap();
+    primitive_array_builder.append_null();
 
     // Append a slice of primitive values
-    primitive_array_builder.append_slice(&[39, 89, 12]).unwrap();
+    primitive_array_builder.append_slice(&[39, 89, 12]);
 
     // Append lots of values
-    primitive_array_builder.append_null().unwrap();
-    primitive_array_builder
-        .append_slice(&(25..50).collect::<Vec<i32>>())
-        .unwrap();
+    primitive_array_builder.append_null();
+    primitive_array_builder.append_slice(&(25..50).collect::<Vec<i32>>());
 
     // Build the `PrimitiveArray`
     let primitive_array = primitive_array_builder.finish();

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -276,9 +276,9 @@ mod tests {
     #[test]
     fn test_boolean_with_null_fmt_debug() {
         let mut builder = BooleanArray::builder(3);
-        builder.append_value(true).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(false).unwrap();
+        builder.append_value(true);
+        builder.append_null();
+        builder.append_value(false);
         let arr = builder.finish();
         assert_eq!(
             "BooleanArray\n[\n  true,\n  null,\n  false,\n]",

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -319,9 +319,7 @@ impl<'a, T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'a
                     .append(i)
                     .expect("Unable to append a value to a dictionary array.");
             } else {
-                builder
-                    .append_null()
-                    .expect("Unable to append a null value to a dictionary array.");
+                builder.append_null();
             }
         });
 
@@ -463,7 +461,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<UInt32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(12345678).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(22345678).unwrap();
         let array = builder.finish();
         assert_eq!(

--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -937,9 +937,9 @@ mod tests {
     #[test]
     fn test_int32_with_null_fmt_debug() {
         let mut builder = Int32Array::builder(3);
-        builder.append_slice(&[0, 1]).unwrap();
-        builder.append_null().unwrap();
-        builder.append_slice(&[3, 4]).unwrap();
+        builder.append_slice(&[0, 1]);
+        builder.append_null();
+        builder.append_slice(&[3, 4]);
         let arr = builder.finish();
         assert_eq!(
             "PrimitiveArray<Int32>\n[\n  0,\n  1,\n  null,\n  3,\n  4,\n]",

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -446,15 +446,12 @@ mod tests {
         let string_builder = StringBuilder::new(3);
         let mut list_of_string_builder = ListBuilder::new(string_builder);
 
-        list_of_string_builder.values().append_value("foo").unwrap();
-        list_of_string_builder.values().append_value("bar").unwrap();
-        list_of_string_builder.append(true).unwrap();
+        list_of_string_builder.values().append_value("foo");
+        list_of_string_builder.values().append_value("bar");
+        list_of_string_builder.append(true);
 
-        list_of_string_builder
-            .values()
-            .append_value("foobar")
-            .unwrap();
-        list_of_string_builder.append(true).unwrap();
+        list_of_string_builder.values().append_value("foobar");
+        list_of_string_builder.append(true);
         let list_of_strings = list_of_string_builder.finish();
 
         assert_eq!(list_of_strings.len(), 2);

--- a/arrow/src/array/builder/buffer_builder.rs
+++ b/arrow/src/array/builder/buffer_builder.rs
@@ -362,7 +362,6 @@ mod tests {
     use crate::array::Int32BufferBuilder;
     use crate::array::Int8Builder;
     use crate::array::UInt8BufferBuilder;
-    use crate::error::Result;
 
     #[test]
     fn test_builder_i32_empty() {
@@ -457,17 +456,17 @@ mod tests {
     }
 
     #[test]
-    fn test_append_values() -> Result<()> {
+    fn test_append_values() {
         let mut a = Int8Builder::new(0);
-        a.append_value(1)?;
-        a.append_null()?;
-        a.append_value(-2)?;
+        a.append_value(1);
+        a.append_null();
+        a.append_value(-2);
         assert_eq!(a.len(), 3);
 
         // append values
         let values = &[1, 2, 3, 4];
         let is_valid = &[true, true, false, true];
-        a.append_values(values, is_valid)?;
+        a.append_values(values, is_valid);
 
         assert_eq!(a.len(), 7);
         let array = a.finish();
@@ -478,7 +477,5 @@ mod tests {
         assert_eq!(array.value(4), 2);
         assert!(array.is_null(5));
         assert_eq!(array.value(6), 4);
-
-        Ok(())
     }
 }

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -108,7 +108,7 @@ impl DecimalBuilder {
 
     /// Append a null value to the array.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.builder.append_null()
     }
 
@@ -167,6 +167,8 @@ impl Decimal256Builder {
     }
 
     /// Appends a [`Decimal256`] number into the builder.
+    ///
+    /// Returns an error if `value` has different precision, scale or length in bytes than this builder
     #[inline]
     pub fn append_value(&mut self, value: &Decimal256) -> Result<()> {
         if self.precision != value.precision() || self.scale != value.scale() {
@@ -187,7 +189,7 @@ impl Decimal256Builder {
 
     /// Append a null value to the array.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.builder.append_null()
     }
 
@@ -215,7 +217,7 @@ mod tests {
         let mut builder = DecimalBuilder::new(30, 38, 6);
 
         builder.append_value(8_887_000_000_i128).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(-8_887_000_000_i128).unwrap();
         let decimal_array: DecimalArray = builder.finish();
 
@@ -233,7 +235,7 @@ mod tests {
         builder
             .append_value(Decimal128::new_from_i128(30, 38, 8_887_000_000_i128))
             .unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder
             .append_value(Decimal128::new_from_i128(30, 38, -8_887_000_000_i128))
             .unwrap();
@@ -255,7 +257,7 @@ mod tests {
         let value = Decimal256::try_new_from_bytes(40, 6, bytes.as_slice()).unwrap();
         builder.append_value(&value).unwrap();
 
-        builder.append_null().unwrap();
+        builder.append_null();
 
         bytes = vec![255; 32];
         let value = Decimal256::try_new_from_bytes(40, 6, bytes.as_slice()).unwrap();

--- a/arrow/src/array/builder/fixed_size_binary_builder.rs
+++ b/arrow/src/array/builder/fixed_size_binary_builder.rs
@@ -71,11 +71,10 @@ impl FixedSizeBinaryBuilder {
 
     /// Append a null value to the array.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.values_builder
             .append_slice(&vec![0u8; self.value_length as usize][..]);
         self.bitmap_builder.append(false);
-        Ok(())
     }
 
     /// Builds the [`FixedSizeBinaryArray`] and reset this builder.
@@ -137,7 +136,7 @@ mod tests {
 
         //  [b"hello", null, "arrow"]
         builder.append_value(b"hello").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(b"arrow").unwrap();
         let array: FixedSizeBinaryArray = builder.finish();
 
@@ -153,7 +152,7 @@ mod tests {
         let mut builder = FixedSizeBinaryBuilder::new(0, 0);
 
         builder.append_value(b"").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(b"").unwrap();
         assert!(!builder.is_empty());
 

--- a/arrow/src/array/builder/fixed_size_list_builder.rs
+++ b/arrow/src/array/builder/fixed_size_list_builder.rs
@@ -23,7 +23,6 @@ use crate::array::ArrayRef;
 use crate::array::FixedSizeListArray;
 use crate::datatypes::DataType;
 use crate::datatypes::Field;
-use crate::error::Result;
 
 use super::ArrayBuilder;
 use super::BooleanBufferBuilder;
@@ -109,9 +108,8 @@ where
 
     /// Finish the current fixed-length list array slot
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+    pub fn append(&mut self, is_valid: bool) {
         self.bitmap_builder.append(is_valid);
-        Ok(())
     }
 
     /// Builds the [`FixedSizeListBuilder`] and reset this builder.
@@ -162,22 +160,22 @@ mod tests {
         let mut builder = FixedSizeListBuilder::new(values_builder, 3);
 
         //  [[0, 1, 2], null, [3, null, 5], [6, 7, null]]
-        builder.values().append_value(0).unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_null().unwrap();
-        builder.values().append_null().unwrap();
-        builder.values().append_null().unwrap();
-        builder.append(false).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.values().append_null().unwrap();
-        builder.values().append_value(5).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_value(6).unwrap();
-        builder.values().append_value(7).unwrap();
-        builder.values().append_null().unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_value(0);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.append(true);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.append(false);
+        builder.values().append_value(3);
+        builder.values().append_null();
+        builder.values().append_value(5);
+        builder.append(true);
+        builder.values().append_value(6);
+        builder.values().append_value(7);
+        builder.values().append_null();
+        builder.append(true);
         let list_array = builder.finish();
 
         assert_eq!(DataType::Int32, list_array.value_type());
@@ -202,17 +200,17 @@ mod tests {
         let values_builder = Int32Array::builder(5);
         let mut builder = FixedSizeListBuilder::new(values_builder, 3);
 
-        builder.values().append_slice(&[1, 2, 3]).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_slice(&[4, 5, 6]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5, 6]);
+        builder.append(true);
 
         let mut arr = builder.finish();
         assert_eq!(2, arr.len());
         assert_eq!(0, builder.len());
 
-        builder.values().append_slice(&[7, 8, 9]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[7, 8, 9]);
+        builder.append(true);
         arr = builder.finish();
         assert_eq!(1, arr.len());
         assert_eq!(0, builder.len());
@@ -226,12 +224,12 @@ mod tests {
         let values_builder = Int32Array::builder(5);
         let mut builder = FixedSizeListBuilder::new(values_builder, 3);
 
-        builder.values().append_slice(&[1, 2, 3]).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_slice(&[4, 5, 6]).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_slice(&[7, 8, 9, 10]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5, 6]);
+        builder.append(true);
+        builder.values().append_slice(&[7, 8, 9, 10]);
+        builder.append(true);
 
         builder.finish();
     }

--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -19,7 +19,6 @@ use crate::array::{
     ArrayBuilder, ArrayRef, GenericBinaryArray, GenericListBuilder, OffsetSizeTrait,
     UInt8Builder,
 };
-use crate::error::Result;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -44,9 +43,8 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
     /// Note, when appending individual byte values you must call `append` to delimit each
     /// distinct list value.
     #[inline]
-    pub fn append_byte(&mut self, value: u8) -> Result<()> {
-        self.builder.values().append_value(value)?;
-        Ok(())
+    pub fn append_byte(&mut self, value: u8) {
+        self.builder.values().append_value(value);
     }
 
     /// Appends a byte slice into the builder.
@@ -54,21 +52,20 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
     /// Automatically calls the `append` method to delimit the slice appended in as a
     /// distinct array element.
     #[inline]
-    pub fn append_value(&mut self, value: impl AsRef<[u8]>) -> Result<()> {
-        self.builder.values().append_slice(value.as_ref())?;
-        self.builder.append(true)?;
-        Ok(())
+    pub fn append_value(&mut self, value: impl AsRef<[u8]>) {
+        self.builder.values().append_slice(value.as_ref());
+        self.builder.append(true);
     }
 
     /// Finish the current variable-length list array slot.
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+    pub fn append(&mut self, is_valid: bool) {
         self.builder.append(is_valid)
     }
 
     /// Append a null value to the array.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.append(false)
     }
 
@@ -119,19 +116,19 @@ mod tests {
     fn test_binary_array_builder() {
         let mut builder = BinaryBuilder::new(20);
 
-        builder.append_byte(b'h').unwrap();
-        builder.append_byte(b'e').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'o').unwrap();
-        builder.append(true).unwrap();
-        builder.append(true).unwrap();
-        builder.append_byte(b'w').unwrap();
-        builder.append_byte(b'o').unwrap();
-        builder.append_byte(b'r').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'd').unwrap();
-        builder.append(true).unwrap();
+        builder.append_byte(b'h');
+        builder.append_byte(b'e');
+        builder.append_byte(b'l');
+        builder.append_byte(b'l');
+        builder.append_byte(b'o');
+        builder.append(true);
+        builder.append(true);
+        builder.append_byte(b'w');
+        builder.append_byte(b'o');
+        builder.append_byte(b'r');
+        builder.append_byte(b'l');
+        builder.append_byte(b'd');
+        builder.append(true);
 
         let binary_array = builder.finish();
 
@@ -148,19 +145,19 @@ mod tests {
     fn test_large_binary_array_builder() {
         let mut builder = LargeBinaryBuilder::new(20);
 
-        builder.append_byte(b'h').unwrap();
-        builder.append_byte(b'e').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'o').unwrap();
-        builder.append(true).unwrap();
-        builder.append(true).unwrap();
-        builder.append_byte(b'w').unwrap();
-        builder.append_byte(b'o').unwrap();
-        builder.append_byte(b'r').unwrap();
-        builder.append_byte(b'l').unwrap();
-        builder.append_byte(b'd').unwrap();
-        builder.append(true).unwrap();
+        builder.append_byte(b'h');
+        builder.append_byte(b'e');
+        builder.append_byte(b'l');
+        builder.append_byte(b'l');
+        builder.append_byte(b'o');
+        builder.append(true);
+        builder.append(true);
+        builder.append_byte(b'w');
+        builder.append_byte(b'o');
+        builder.append_byte(b'r');
+        builder.append_byte(b'l');
+        builder.append_byte(b'd');
+        builder.append(true);
 
         let binary_array = builder.finish();
 

--- a/arrow/src/array/builder/generic_list_builder.rs
+++ b/arrow/src/array/builder/generic_list_builder.rs
@@ -24,7 +24,6 @@ use crate::array::GenericListArray;
 use crate::array::OffsetSizeTrait;
 use crate::datatypes::DataType;
 use crate::datatypes::Field;
-use crate::error::Result;
 
 use super::{ArrayBuilder, BooleanBufferBuilder, BufferBuilder};
 
@@ -111,11 +110,10 @@ where
 
     /// Finish the current variable-length list array slot
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+    pub fn append(&mut self, is_valid: bool) {
         self.offsets_builder
             .append(OffsetSize::from_usize(self.values_builder.len()).unwrap());
         self.bitmap_builder.append(is_valid);
-        Ok(())
     }
 
     /// Builds the [`GenericListArray`] and reset this builder.
@@ -171,17 +169,17 @@ mod tests {
         let mut builder = GenericListBuilder::<O, _>::new(values_builder);
 
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        builder.values().append_value(0).unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.values().append_value(4).unwrap();
-        builder.values().append_value(5).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_value(6).unwrap();
-        builder.values().append_value(7).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_value(0);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.append(true);
+        builder.values().append_value(3);
+        builder.values().append_value(4);
+        builder.values().append_value(5);
+        builder.append(true);
+        builder.values().append_value(6);
+        builder.values().append_value(7);
+        builder.append(true);
         let list_array = builder.finish();
 
         let values = list_array.values().data().buffers()[0].clone();
@@ -216,18 +214,19 @@ mod tests {
         let mut builder = GenericListBuilder::<O, _>::new(values_builder);
 
         //  [[0, 1, 2], null, [3, null, 5], [6, 7]]
-        builder.values().append_value(0).unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.append(true).unwrap();
-        builder.append(false).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.values().append_null().unwrap();
-        builder.values().append_value(5).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_value(6).unwrap();
-        builder.values().append_value(7).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_value(0);
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.append(true);
+        builder.append(false);
+        builder.values().append_value(3);
+        builder.values().append_null();
+        builder.values().append_value(5);
+        builder.append(true);
+        builder.values().append_value(6);
+        builder.values().append_value(7);
+        builder.append(true);
+
         let list_array = builder.finish();
 
         assert_eq!(DataType::Int32, list_array.value_type());
@@ -252,17 +251,17 @@ mod tests {
         let values_builder = Int32Array::builder(5);
         let mut builder = ListBuilder::new(values_builder);
 
-        builder.values().append_slice(&[1, 2, 3]).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_slice(&[4, 5, 6]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5, 6]);
+        builder.append(true);
 
         let mut arr = builder.finish();
         assert_eq!(2, arr.len());
         assert!(builder.is_empty());
 
-        builder.values().append_slice(&[7, 8, 9]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[7, 8, 9]);
+        builder.append(true);
         arr = builder.finish();
         assert_eq!(1, arr.len());
         assert!(builder.is_empty());
@@ -275,29 +274,29 @@ mod tests {
         let mut builder = ListBuilder::new(values_builder);
 
         //  [[[1, 2], [3, 4]], [[5, 6, 7], null, [8]], null, [[9, 10]]]
-        builder.values().values().append_value(1).unwrap();
-        builder.values().values().append_value(2).unwrap();
-        builder.values().append(true).unwrap();
-        builder.values().values().append_value(3).unwrap();
-        builder.values().values().append_value(4).unwrap();
-        builder.values().append(true).unwrap();
-        builder.append(true).unwrap();
+        builder.values().values().append_value(1);
+        builder.values().values().append_value(2);
+        builder.values().append(true);
+        builder.values().values().append_value(3);
+        builder.values().values().append_value(4);
+        builder.values().append(true);
+        builder.append(true);
 
-        builder.values().values().append_value(5).unwrap();
-        builder.values().values().append_value(6).unwrap();
-        builder.values().values().append_value(7).unwrap();
-        builder.values().append(true).unwrap();
-        builder.values().append(false).unwrap();
-        builder.values().values().append_value(8).unwrap();
-        builder.values().append(true).unwrap();
-        builder.append(true).unwrap();
+        builder.values().values().append_value(5);
+        builder.values().values().append_value(6);
+        builder.values().values().append_value(7);
+        builder.values().append(true);
+        builder.values().append(false);
+        builder.values().values().append_value(8);
+        builder.values().append(true);
+        builder.append(true);
 
-        builder.append(false).unwrap();
+        builder.append(false);
 
-        builder.values().values().append_value(9).unwrap();
-        builder.values().values().append_value(10).unwrap();
-        builder.values().append(true).unwrap();
-        builder.append(true).unwrap();
+        builder.values().values().append_value(9);
+        builder.values().values().append_value(10);
+        builder.values().append(true);
+        builder.append(true);
 
         let list_array = builder.finish();
 

--- a/arrow/src/array/builder/generic_string_builder.rs
+++ b/arrow/src/array/builder/generic_string_builder.rs
@@ -19,7 +19,6 @@ use crate::array::{
     ArrayBuilder, ArrayRef, GenericListBuilder, GenericStringArray, OffsetSizeTrait,
     UInt8Builder,
 };
-use crate::error::Result;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -53,34 +52,32 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringBuilder<OffsetSize> {
     /// Automatically calls the `append` method to delimit the string appended in as a
     /// distinct array element.
     #[inline]
-    pub fn append_value(&mut self, value: impl AsRef<str>) -> Result<()> {
+    pub fn append_value(&mut self, value: impl AsRef<str>) {
         self.builder
             .values()
-            .append_slice(value.as_ref().as_bytes())?;
-        self.builder.append(true)?;
-        Ok(())
+            .append_slice(value.as_ref().as_bytes());
+        self.builder.append(true);
     }
 
     /// Finish the current variable-length list array slot.
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+    pub fn append(&mut self, is_valid: bool) {
         self.builder.append(is_valid)
     }
 
     /// Append a null value to the array.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.append(false)
     }
 
     /// Append an `Option` value to the array.
     #[inline]
-    pub fn append_option(&mut self, value: Option<impl AsRef<str>>) -> Result<()> {
+    pub fn append_option(&mut self, value: Option<impl AsRef<str>>) {
         match value {
-            None => self.append_null()?,
-            Some(v) => self.append_value(v)?,
+            None => self.append_null(),
+            Some(v) => self.append_value(v),
         };
-        Ok(())
     }
 
     /// Builds the `StringArray` and reset this builder.
@@ -141,9 +138,9 @@ mod tests {
     fn test_string_array_builder() {
         let mut builder = StringBuilder::new(20);
 
-        builder.append_value("hello").unwrap();
-        builder.append(true).unwrap();
-        builder.append_value("world").unwrap();
+        builder.append_value("hello");
+        builder.append(true);
+        builder.append_value("world");
 
         let string_array = builder.finish();
 
@@ -160,14 +157,14 @@ mod tests {
     fn test_string_array_builder_finish() {
         let mut builder = StringBuilder::new(10);
 
-        builder.append_value("hello").unwrap();
-        builder.append_value("world").unwrap();
+        builder.append_value("hello");
+        builder.append_value("world");
 
         let mut arr = builder.finish();
         assert_eq!(2, arr.len());
         assert_eq!(0, builder.len());
 
-        builder.append_value("arrow").unwrap();
+        builder.append_value("arrow");
         arr = builder.finish();
         assert_eq!(1, arr.len());
         assert_eq!(0, builder.len());
@@ -178,9 +175,9 @@ mod tests {
         let mut builder = StringBuilder::new(20);
 
         let var = "hello".to_owned();
-        builder.append_value(&var).unwrap();
-        builder.append(true).unwrap();
-        builder.append_value("world").unwrap();
+        builder.append_value(&var);
+        builder.append(true);
+        builder.append_value("world");
 
         let string_array = builder.finish();
 
@@ -196,10 +193,10 @@ mod tests {
     #[test]
     fn test_string_array_builder_append_option() {
         let mut builder = StringBuilder::new(20);
-        builder.append_option(Some("hello")).unwrap();
-        builder.append_option(None::<&str>).unwrap();
-        builder.append_option(None::<String>).unwrap();
-        builder.append_option(Some("world")).unwrap();
+        builder.append_option(Some("hello"));
+        builder.append_option(None::<&str>);
+        builder.append_option(None::<String>);
+        builder.append_option(Some("world"));
 
         let string_array = builder.finish();
 

--- a/arrow/src/array/builder/map_builder.rs
+++ b/arrow/src/array/builder/map_builder.rs
@@ -25,7 +25,6 @@ use crate::array::MapArray;
 use crate::array::StructArray;
 use crate::datatypes::DataType;
 use crate::datatypes::Field;
-use crate::error::{ArrowError, Result};
 
 use super::{ArrayBuilder, BooleanBufferBuilder, BufferBuilder};
 
@@ -96,18 +95,14 @@ impl<K: ArrayBuilder, V: ArrayBuilder> MapBuilder<K, V> {
 
     /// Finish the current map array slot
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
-        if self.key_builder.len() != self.value_builder.len() {
-            return Err(ArrowError::InvalidArgumentError(format!(
+    pub fn append(&mut self, is_valid: bool) {
+        assert_eq!(self.key_builder.len(), self.value_builder.len(),
                 "Cannot append to a map builder when its keys and values have unequal lengths of {} and {}",
                 self.key_builder.len(),
-                self.value_builder.len()
-            )));
-        }
+                self.value_builder.len());
         self.offsets_builder.append(self.key_builder.len() as i32);
         self.bitmap_builder.append(is_valid);
         self.len += 1;
-        Ok(())
     }
 
     pub fn finish(&mut self) -> MapArray {
@@ -209,20 +204,20 @@ mod tests {
         let mut builder = MapBuilder::new(None, string_builder, int_builder);
 
         let string_builder = builder.keys();
-        string_builder.append_value("joe").unwrap();
-        string_builder.append_null().unwrap();
-        string_builder.append_null().unwrap();
-        string_builder.append_value("mark").unwrap();
+        string_builder.append_value("joe");
+        string_builder.append_null();
+        string_builder.append_null();
+        string_builder.append_value("mark");
 
         let int_builder = builder.values();
-        int_builder.append_value(1).unwrap();
-        int_builder.append_value(2).unwrap();
-        int_builder.append_null().unwrap();
-        int_builder.append_value(4).unwrap();
+        int_builder.append_value(1);
+        int_builder.append_value(2);
+        int_builder.append_null();
+        int_builder.append_value(4);
 
-        builder.append(true).unwrap();
-        builder.append(false).unwrap();
-        builder.append(true).unwrap();
+        builder.append(true);
+        builder.append(false);
+        builder.append(true);
 
         let arr = builder.finish();
 

--- a/arrow/src/array/builder/mod.rs
+++ b/arrow/src/array/builder/mod.rs
@@ -81,17 +81,17 @@ pub use union_builder::UnionBuilder;
 ///     .as_any_mut()
 ///     .downcast_mut::<Float64Builder>()
 ///     .unwrap()
-///     .append_value(3.14)?;
+///     .append_value(3.14);
 /// data_builders[1]
 ///     .as_any_mut()
 ///     .downcast_mut::<Int64Builder>()
 ///     .unwrap()
-///     .append_value(-1)?;
+///     .append_value(-1);
 /// data_builders[2]
 ///     .as_any_mut()
 ///     .downcast_mut::<StringBuilder>()
 ///     .unwrap()
-///     .append_value("🍎")?;
+///     .append_value("🍎");
 ///
 /// // Finish
 /// let array_refs: Vec<ArrayRef> = data_builders

--- a/arrow/src/array/builder/primitive_dictionary_builder.rs
+++ b/arrow/src/array/builder/primitive_dictionary_builder.rs
@@ -43,7 +43,7 @@ use super::PrimitiveBuilder;
 ///  let value_builder = PrimitiveBuilder::<UInt32Type>::new(2);
 ///  let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
 ///  builder.append(12345678).unwrap();
-///  builder.append_null().unwrap();
+///  builder.append_null();
 ///  builder.append(22345678).unwrap();
 ///  let array = builder.finish();
 ///
@@ -140,21 +140,21 @@ where
     pub fn append(&mut self, value: V::Native) -> Result<K::Native> {
         if let Some(&key) = self.map.get(value.to_byte_slice()) {
             // Append existing value.
-            self.keys_builder.append_value(key)?;
+            self.keys_builder.append_value(key);
             Ok(key)
         } else {
             // Append new value.
             let key = K::Native::from_usize(self.values_builder.len())
                 .ok_or(ArrowError::DictionaryKeyOverflowError)?;
-            self.values_builder.append_value(value)?;
-            self.keys_builder.append_value(key as K::Native)?;
+            self.values_builder.append_value(value);
+            self.keys_builder.append_value(key as K::Native);
             self.map.insert(value.to_byte_slice().into(), key);
             Ok(key)
         }
     }
 
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.keys_builder.append_null()
     }
 
@@ -193,7 +193,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<UInt32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(12345678).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(22345678).unwrap();
         let array = builder.finish();
 

--- a/arrow/src/array/builder/struct_builder.rs
+++ b/arrow/src/array/builder/struct_builder.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use crate::array::*;
 use crate::datatypes::DataType;
 use crate::datatypes::Field;
-use crate::error::Result;
 
 /// Array builder for Struct types.
 ///
@@ -201,15 +200,14 @@ impl StructBuilder {
     /// Appends an element (either null or non-null) to the struct. The actual elements
     /// should be appended for each child sub-array in a consistent way.
     #[inline]
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+    pub fn append(&mut self, is_valid: bool) {
         self.bitmap_builder.append(is_valid);
         self.len += 1;
-        Ok(())
     }
 
     /// Appends a null element to the struct.
     #[inline]
-    pub fn append_null(&mut self) -> Result<()> {
+    pub fn append_null(&mut self) {
         self.append(false)
     }
 
@@ -263,23 +261,23 @@ mod tests {
         let string_builder = builder
             .field_builder::<StringBuilder>(0)
             .expect("builder at field 0 should be string builder");
-        string_builder.append_value("joe").unwrap();
-        string_builder.append_null().unwrap();
-        string_builder.append_null().unwrap();
-        string_builder.append_value("mark").unwrap();
+        string_builder.append_value("joe");
+        string_builder.append_null();
+        string_builder.append_null();
+        string_builder.append_value("mark");
 
         let int_builder = builder
             .field_builder::<Int32Builder>(1)
             .expect("builder at field 1 should be int builder");
-        int_builder.append_value(1).unwrap();
-        int_builder.append_value(2).unwrap();
-        int_builder.append_null().unwrap();
-        int_builder.append_value(4).unwrap();
+        int_builder.append_value(1);
+        int_builder.append_value(2);
+        int_builder.append_null();
+        int_builder.append_value(4);
 
-        builder.append(true).unwrap();
-        builder.append(true).unwrap();
-        builder.append_null().unwrap();
-        builder.append(true).unwrap();
+        builder.append(true);
+        builder.append(true);
+        builder.append_null();
+        builder.append(true);
 
         let arr = builder.finish();
 
@@ -326,19 +324,17 @@ mod tests {
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-            .unwrap();
+            .append_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
             .append_slice(&[
                 false, true, false, true, false, true, false, true, false, true,
-            ])
-            .unwrap();
+            ]);
 
         // Append slot values - all are valid.
         for _ in 0..10 {
-            assert!(builder.append(true).is_ok())
+            builder.append(true);
         }
 
         assert_eq!(10, builder.len());
@@ -351,17 +347,15 @@ mod tests {
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_slice(&[1, 3, 5, 7, 9])
-            .unwrap();
+            .append_slice(&[1, 3, 5, 7, 9]);
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_slice(&[false, true, false, true, false])
-            .unwrap();
+            .append_slice(&[false, true, false, true, false]);
 
         // Append slot values - all are valid.
         for _ in 0..5 {
-            assert!(builder.append(true).is_ok())
+            builder.append(true);
         }
 
         assert_eq!(5, builder.len());

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -2619,66 +2619,56 @@ mod tests {
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_option(Some(10))
-            .unwrap();
+            .append_option(Some(10));
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_option(Some(true))
-            .unwrap();
-        builder.append(true).unwrap();
+            .append_option(Some(true));
+        builder.append(true);
 
         // struct[1] = null
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_option(None)
-            .unwrap();
+            .append_option(None);
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_option(None)
-            .unwrap();
-        builder.append(false).unwrap();
+            .append_option(None);
+        builder.append(false);
 
         // struct[2] = { a: null, b: false }
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_option(None)
-            .unwrap();
+            .append_option(None);
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_option(Some(false))
-            .unwrap();
-        builder.append(true).unwrap();
+            .append_option(Some(false));
+        builder.append(true);
 
         // struct[3] = { a: 21, b: null }
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_option(Some(21))
-            .unwrap();
+            .append_option(Some(21));
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_option(None)
-            .unwrap();
-        builder.append(true).unwrap();
+            .append_option(None);
+        builder.append(true);
 
         // struct[4] = { a: 18, b: false }
         builder
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_option(Some(18))
-            .unwrap();
+            .append_option(Some(18));
         builder
             .field_builder::<BooleanBuilder>(1)
             .unwrap()
-            .append_option(Some(false))
-            .unwrap();
-        builder.append(true).unwrap();
+            .append_option(Some(false));
+        builder.append(true);
 
         let struct_array = builder.finish();
         let struct_array_slice = struct_array.slice(1, 3);
@@ -2776,9 +2766,8 @@ mod tests {
         .unwrap();
         fixed_size_builder
             .values()
-            .append_slice(value_as_bytes.as_slice())
-            .unwrap();
-        fixed_size_builder.append(true).unwrap();
+            .append_slice(value_as_bytes.as_slice());
+        fixed_size_builder.append(true);
         let fixed_size_array = fixed_size_builder.finish();
 
         // Build ArrayData for Decimal

--- a/arrow/src/array/equal/list.rs
+++ b/arrow/src/array/equal/list.rs
@@ -161,21 +161,21 @@ mod tests {
     fn list_array_non_zero_nulls() {
         // Tests handling of list arrays with non-empty null ranges
         let mut builder = ListBuilder::new(Int64Builder::new(10));
-        builder.values().append_value(1).unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.append(true).unwrap();
-        builder.append(false).unwrap();
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.values().append_value(3);
+        builder.append(true);
+        builder.append(false);
         let array1 = builder.finish();
 
         let mut builder = ListBuilder::new(Int64Builder::new(10));
-        builder.values().append_value(1).unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_null().unwrap();
-        builder.values().append_null().unwrap();
-        builder.append(false).unwrap();
+        builder.values().append_value(1);
+        builder.values().append_value(2);
+        builder.values().append_value(3);
+        builder.append(true);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.append(false);
         let array2 = builder.finish();
 
         assert_eq!(array1, array2);

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -610,10 +610,10 @@ mod tests {
         let mut builder = ListBuilder::new(Int32Builder::new(10));
         for d in data.as_ref() {
             if let Some(v) = d {
-                builder.values().append_slice(v.as_ref()).unwrap();
-                builder.append(true).unwrap()
+                builder.values().append_slice(v.as_ref());
+                builder.append(true);
             } else {
-                builder.append(false).unwrap()
+                builder.append(false);
             }
         }
         builder.finish().into_data()
@@ -771,7 +771,7 @@ mod tests {
             if let Some(v) = d {
                 builder.append_value(v.as_ref()).unwrap();
             } else {
-                builder.append_null().unwrap();
+                builder.append_null();
             }
         }
         builder.finish().into_data()
@@ -932,13 +932,13 @@ mod tests {
 
         for d in data.as_ref() {
             if let Some(v) = d {
-                builder.values().append_slice(v.as_ref()).unwrap();
-                builder.append(true).unwrap()
+                builder.values().append_slice(v.as_ref());
+                builder.append(true);
             } else {
                 for _ in 0..builder.value_length() {
-                    builder.values().append_null().unwrap();
+                    builder.values().append_null();
                 }
-                builder.append(false).unwrap()
+                builder.append(false);
             }
         }
         builder.finish().into_data()
@@ -1247,7 +1247,7 @@ mod tests {
             if let Some(v) = key {
                 builder.append(v).unwrap();
             } else {
-                builder.append_null().unwrap()
+                builder.append_null()
             }
         }
         builder.finish().into_data()

--- a/arrow/src/array/equal_json.rs
+++ b/arrow/src/array/equal_json.rs
@@ -468,10 +468,10 @@ mod tests {
     ) -> Result<ListArray> {
         for d in data.as_ref() {
             if let Some(v) = d {
-                builder.values().append_slice(v.as_ref())?;
-                builder.append(true)?
+                builder.values().append_slice(v.as_ref());
+                builder.append(true);
             } else {
-                builder.append(false)?
+                builder.append(false);
             }
         }
         Ok(builder.finish())
@@ -484,13 +484,13 @@ mod tests {
     ) -> Result<FixedSizeListArray> {
         for d in data.as_ref() {
             if let Some(v) = d {
-                builder.values().append_slice(v.as_ref())?;
-                builder.append(true)?
+                builder.values().append_slice(v.as_ref());
+                builder.append(true);
             } else {
                 for _ in 0..builder.value_length() {
-                    builder.values().append_null()?;
+                    builder.values().append_null();
                 }
-                builder.append(false)?
+                builder.append(false);
             }
         }
         Ok(builder.finish())
@@ -766,12 +766,12 @@ mod tests {
     fn test_binary_json_equal() {
         // Test the equal case
         let mut builder = BinaryBuilder::new(6);
-        builder.append_value(b"hello").unwrap();
-        builder.append_null().unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(b"world").unwrap();
-        builder.append_null().unwrap();
-        builder.append_null().unwrap();
+        builder.append_value(b"hello");
+        builder.append_null();
+        builder.append_null();
+        builder.append_value(b"world");
+        builder.append_null();
+        builder.append_null();
         let arrow_array = builder.finish();
         let json_array: Value = serde_json::from_str(
             r#"
@@ -866,7 +866,7 @@ mod tests {
         // Test the equal case
         let mut builder = FixedSizeBinaryBuilder::new(15, 5);
         builder.append_value(b"hello").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(b"world").unwrap();
         let arrow_array: FixedSizeBinaryArray = builder.finish();
         let json_array: Value = serde_json::from_str(
@@ -884,7 +884,7 @@ mod tests {
 
         // Test unequal case
         builder.append_value(b"hello").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(b"world").unwrap();
         let arrow_array: FixedSizeBinaryArray = builder.finish();
         let json_array: Value = serde_json::from_str(

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -79,13 +79,13 @@
 //! let mut builder = Int16Array::builder(100);
 //!
 //! // Append a single primitive value
-//! builder.append_value(1).unwrap();
+//! builder.append_value(1);
 //!
 //! // Append a null value
-//! builder.append_null().unwrap();
+//! builder.append_null();
 //!
 //! // Append a slice of primitive values
-//! builder.append_slice(&[2, 3, 4]).unwrap();
+//! builder.append_slice(&[2, 3, 4]);
 //!
 //! // Build the array
 //! let array = builder.finish();

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -806,15 +806,15 @@ mod tests {
     }
 
     #[test]
-    fn test_list_null_offset() -> Result<()> {
+    fn test_list_null_offset() {
         let int_builder = Int64Builder::new(24);
         let mut builder = ListBuilder::<Int64Builder>::new(int_builder);
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[4, 5])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[6, 7, 8])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5]);
+        builder.append(true);
+        builder.values().append_slice(&[6, 7, 8]);
+        builder.append(true);
         let array = builder.finish();
         let arrays = vec![array.data()];
 
@@ -826,13 +826,11 @@ mod tests {
 
         let int_builder = Int64Builder::new(24);
         let mut builder = ListBuilder::<Int64Builder>::new(int_builder);
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
         let expected = builder.finish();
 
         assert_eq!(array, expected);
-
-        Ok(())
     }
 
     /// tests extending from a variable-sized (strings and binary) array w/ offset with nulls
@@ -974,7 +972,7 @@ mod tests {
             if let Some(v) = key {
                 builder.append(v).unwrap();
             } else {
-                builder.append_null().unwrap()
+                builder.append_null()
             }
         }
         builder.finish().into_data()
@@ -1176,24 +1174,24 @@ mod tests {
     }
 
     #[test]
-    fn test_list_append() -> Result<()> {
+    fn test_list_append() {
         let mut builder = ListBuilder::<Int64Builder>::new(Int64Builder::new(24));
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[4, 5])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[6, 7, 8])?;
-        builder.values().append_slice(&[9, 10, 11])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5]);
+        builder.append(true);
+        builder.values().append_slice(&[6, 7, 8]);
+        builder.values().append_slice(&[9, 10, 11]);
+        builder.append(true);
         let a = builder.finish();
 
         let a_builder = Int64Builder::new(24);
         let mut a_builder = ListBuilder::<Int64Builder>::new(a_builder);
-        a_builder.values().append_slice(&[12, 13])?;
-        a_builder.append(true)?;
-        a_builder.append(true)?;
-        a_builder.values().append_slice(&[14, 15])?;
-        a_builder.append(true)?;
+        a_builder.values().append_slice(&[12, 13]);
+        a_builder.append(true);
+        a_builder.append(true);
+        a_builder.values().append_slice(&[14, 15]);
+        a_builder.append(true);
         let b = a_builder.finish();
 
         let c = b.slice(1, 2);
@@ -1239,35 +1237,33 @@ mod tests {
         )
         .unwrap();
         assert_eq!(finished, expected_list_data);
-
-        Ok(())
     }
 
     #[test]
     fn test_list_nulls_append() -> Result<()> {
         let mut builder = ListBuilder::<Int64Builder>::new(Int64Builder::new(32));
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[4, 5])?;
-        builder.append(true)?;
-        builder.append(false)?;
-        builder.values().append_slice(&[6, 7, 8])?;
-        builder.values().append_null()?;
-        builder.values().append_null()?;
-        builder.values().append_slice(&[9, 10, 11])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5]);
+        builder.append(true);
+        builder.append(false);
+        builder.values().append_slice(&[6, 7, 8]);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.values().append_slice(&[9, 10, 11]);
+        builder.append(true);
         let a = builder.finish();
         let a = a.data();
 
         let mut builder = ListBuilder::<Int64Builder>::new(Int64Builder::new(32));
-        builder.values().append_slice(&[12, 13])?;
-        builder.append(true)?;
-        builder.append(false)?;
-        builder.append(true)?;
-        builder.values().append_null()?;
-        builder.values().append_null()?;
-        builder.values().append_slice(&[14, 15])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[12, 13]);
+        builder.append(true);
+        builder.append(false);
+        builder.append(true);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.values().append_slice(&[14, 15]);
+        builder.append(true);
         let b = builder.finish();
         let b = b.data();
         let c = b.slice(1, 2);
@@ -1325,24 +1321,24 @@ mod tests {
     }
 
     #[test]
-    fn test_list_append_with_capacities() -> Result<()> {
+    fn test_list_append_with_capacities() {
         let mut builder = ListBuilder::<Int64Builder>::new(Int64Builder::new(24));
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[4, 5])?;
-        builder.append(true)?;
-        builder.values().append_slice(&[6, 7, 8])?;
-        builder.values().append_slice(&[9, 10, 11])?;
-        builder.append(true)?;
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5]);
+        builder.append(true);
+        builder.values().append_slice(&[6, 7, 8]);
+        builder.values().append_slice(&[9, 10, 11]);
+        builder.append(true);
         let a = builder.finish();
 
         let a_builder = Int64Builder::new(24);
         let mut a_builder = ListBuilder::<Int64Builder>::new(a_builder);
-        a_builder.values().append_slice(&[12, 13])?;
-        a_builder.append(true)?;
-        a_builder.append(true)?;
-        a_builder.values().append_slice(&[14, 15, 16, 17])?;
-        a_builder.append(true)?;
+        a_builder.values().append_slice(&[12, 13]);
+        a_builder.append(true);
+        a_builder.append(true);
+        a_builder.values().append_slice(&[14, 15, 16, 17]);
+        a_builder.append(true);
         let b = a_builder.finish();
 
         let mutable = MutableArrayData::with_capacities(
@@ -1354,8 +1350,6 @@ mod tests {
         // capacities are rounded up to multiples of 64 by MutableBuffer
         assert_eq!(mutable.data.buffer1.capacity(), 64);
         assert_eq!(mutable.data.child_data[0].data.buffer1.capacity(), 192);
-
-        Ok(())
     }
 
     #[test]
@@ -1365,21 +1359,19 @@ mod tests {
             Int64Builder::new(32),
             Int64Builder::new(32),
         );
-        builder.keys().append_slice(&[1, 2, 3])?;
-        builder.values().append_slice(&[1, 2, 3])?;
-        builder.append(true)?;
-        builder.keys().append_slice(&[4, 5])?;
-        builder.values().append_slice(&[4, 5])?;
-        builder.append(true)?;
-        builder.append(false)?;
-        builder
-            .keys()
-            .append_slice(&[6, 7, 8, 100, 101, 9, 10, 11])?;
-        builder.values().append_slice(&[6, 7, 8])?;
-        builder.values().append_null()?;
-        builder.values().append_null()?;
-        builder.values().append_slice(&[9, 10, 11])?;
-        builder.append(true)?;
+        builder.keys().append_slice(&[1, 2, 3]);
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.keys().append_slice(&[4, 5]);
+        builder.values().append_slice(&[4, 5]);
+        builder.append(true);
+        builder.append(false);
+        builder.keys().append_slice(&[6, 7, 8, 100, 101, 9, 10, 11]);
+        builder.values().append_slice(&[6, 7, 8]);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.values().append_slice(&[9, 10, 11]);
+        builder.append(true);
 
         let a = builder.finish();
         let a = a.data();
@@ -1390,16 +1382,16 @@ mod tests {
             Int64Builder::new(32),
         );
 
-        builder.keys().append_slice(&[12, 13])?;
-        builder.values().append_slice(&[12, 13])?;
-        builder.append(true)?;
-        builder.append(false)?;
-        builder.append(true)?;
-        builder.keys().append_slice(&[100, 101, 14, 15])?;
-        builder.values().append_null()?;
-        builder.values().append_null()?;
-        builder.values().append_slice(&[14, 15])?;
-        builder.append(true)?;
+        builder.keys().append_slice(&[12, 13]);
+        builder.values().append_slice(&[12, 13]);
+        builder.append(true);
+        builder.append(false);
+        builder.append(true);
+        builder.keys().append_slice(&[100, 101, 14, 15]);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.values().append_slice(&[14, 15]);
+        builder.append(true);
 
         let b = builder.finish();
         let b = b.data();
@@ -1512,23 +1504,23 @@ mod tests {
     fn test_list_of_strings_append() -> Result<()> {
         // [["alpha", "beta", None]]
         let mut builder = ListBuilder::new(StringBuilder::new(32));
-        builder.values().append_value("Hello")?;
-        builder.values().append_value("Arrow")?;
-        builder.values().append_null()?;
-        builder.append(true)?;
+        builder.values().append_value("Hello");
+        builder.values().append_value("Arrow");
+        builder.values().append_null();
+        builder.append(true);
         let a = builder.finish();
 
         // [["alpha", "beta"], [None], ["gamma", "delta", None]]
         let mut builder = ListBuilder::new(StringBuilder::new(32));
-        builder.values().append_value("alpha")?;
-        builder.values().append_value("beta")?;
-        builder.append(true)?;
-        builder.values().append_null()?;
-        builder.append(true)?;
-        builder.values().append_value("gamma")?;
-        builder.values().append_value("delta")?;
-        builder.values().append_null()?;
-        builder.append(true)?;
+        builder.values().append_value("alpha");
+        builder.values().append_value("beta");
+        builder.append(true);
+        builder.values().append_null();
+        builder.append(true);
+        builder.values().append_value("gamma");
+        builder.values().append_value("delta");
+        builder.values().append_null();
+        builder.append(true);
         let b = builder.finish();
 
         let mut mutable = MutableArrayData::new(vec![a.data(), b.data()], false, 10);

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -1361,17 +1361,17 @@ mod tests {
         );
         builder.keys().append_slice(&[1, 2, 3]);
         builder.values().append_slice(&[1, 2, 3]);
-        builder.append(true);
+        builder.append(true).unwrap();
         builder.keys().append_slice(&[4, 5]);
         builder.values().append_slice(&[4, 5]);
-        builder.append(true);
-        builder.append(false);
+        builder.append(true).unwrap();
+        builder.append(false).unwrap();
         builder.keys().append_slice(&[6, 7, 8, 100, 101, 9, 10, 11]);
         builder.values().append_slice(&[6, 7, 8]);
         builder.values().append_null();
         builder.values().append_null();
         builder.values().append_slice(&[9, 10, 11]);
-        builder.append(true);
+        builder.append(true).unwrap();
 
         let a = builder.finish();
         let a = a.data();
@@ -1384,14 +1384,14 @@ mod tests {
 
         builder.keys().append_slice(&[12, 13]);
         builder.values().append_slice(&[12, 13]);
-        builder.append(true);
-        builder.append(false);
-        builder.append(true);
+        builder.append(true).unwrap();
+        builder.append(false).unwrap();
+        builder.append(true).unwrap();
         builder.keys().append_slice(&[100, 101, 14, 15]);
         builder.values().append_null();
         builder.values().append_null();
         builder.values().append_slice(&[14, 15]);
-        builder.append(true);
+        builder.append(true).unwrap();
 
         let b = builder.finish();
         let b = b.data();

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -377,7 +377,7 @@ impl MutableBuffer {
 
 /// # Safety
 /// `ptr` must be allocated for `old_capacity`.
-#[inline]
+#[cold]
 unsafe fn reallocate(
     ptr: NonNull<u8>,
     old_capacity: usize,

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1245,7 +1245,7 @@ mod tests {
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(10).unwrap();
         let b = builder.finish();
 
@@ -1274,7 +1274,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(5).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
         builder.append(9).unwrap();
@@ -1329,7 +1329,7 @@ mod tests {
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(10).unwrap();
         let b = builder.finish();
 
@@ -1358,7 +1358,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(5).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
         builder.append(9).unwrap();
@@ -1413,7 +1413,7 @@ mod tests {
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(10).unwrap();
         let b = builder.finish();
 
@@ -1457,7 +1457,7 @@ mod tests {
         builder.append(5).unwrap();
         builder.append(3).unwrap();
         builder.append(1).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(3).unwrap();
         let b = builder.finish();
 
@@ -1486,7 +1486,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(5).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
         builder.append(9).unwrap();
@@ -1672,7 +1672,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(5).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
         builder.append(9).unwrap();

--- a/arrow/src/compute/kernels/arity.rs
+++ b/arrow/src/compute/kernels/arity.rs
@@ -235,7 +235,7 @@ mod tests {
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(9).unwrap();
         let dictionary_array = builder.finish();
 
@@ -246,7 +246,7 @@ mod tests {
         builder.append(7).unwrap();
         builder.append(8).unwrap();
         builder.append(9).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(10).unwrap();
         let expected = builder.finish();
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -3680,17 +3680,17 @@ mod tests {
         let values_builder = StringBuilder::new(10);
         let mut builder = ListBuilder::new(values_builder);
 
-        builder.values().append_value("Lorem").unwrap();
-        builder.values().append_value("ipsum").unwrap();
-        builder.values().append_null().unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_value("sit").unwrap();
-        builder.values().append_value("amet").unwrap();
-        builder.values().append_value("Lorem").unwrap();
-        builder.append(true).unwrap();
-        builder.append(false).unwrap();
-        builder.values().append_value("ipsum").unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_value("Lorem");
+        builder.values().append_value("ipsum");
+        builder.values().append_null();
+        builder.append(true);
+        builder.values().append_value("sit");
+        builder.values().append_value("amet");
+        builder.values().append_value("Lorem");
+        builder.append(true);
+        builder.append(false);
+        builder.values().append_value("ipsum");
+        builder.append(true);
 
         //  [["Lorem", "ipsum", null], ["sit", "amet", "Lorem"], null, ["ipsum"]]
         // value_offsets = [0, 3, 6, 6]
@@ -4261,7 +4261,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(123).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = eq_dyn_scalar(&array, 123).unwrap();
@@ -4305,7 +4305,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(123).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = lt_dyn_scalar(&array, 123).unwrap();
@@ -4348,7 +4348,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(123).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = lt_eq_dyn_scalar(&array, 23).unwrap();
@@ -4392,7 +4392,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(123).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = gt_dyn_scalar(&array, 23).unwrap();
@@ -4436,7 +4436,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(22).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = gt_eq_dyn_scalar(&array, 23).unwrap();
@@ -4480,7 +4480,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<Int32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(22).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(23).unwrap();
         let array = builder.finish();
         let a_eq = neq_dyn_scalar(&array, 23).unwrap();
@@ -4624,7 +4624,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("abc").unwrap();
@@ -4652,7 +4652,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("abc").unwrap();
@@ -4681,7 +4681,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("xyz").unwrap();
@@ -4710,7 +4710,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("xyz").unwrap();
@@ -4740,7 +4740,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("xyz").unwrap();
@@ -4769,7 +4769,7 @@ mod tests {
         let value_builder = StringBuilder::new(100);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append("def").unwrap();
         builder.append("def").unwrap();
         builder.append("abc").unwrap();

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -1420,16 +1420,16 @@ mod tests {
         // [{"key1": 1}, {"key2": 2, "key3": 3}, null, {"key1": 1}
         builder.keys().append_value("key1");
         builder.values().append_value(1);
-        builder.append(true);
+        builder.append(true).unwrap();
         builder.keys().append_value("key2");
         builder.keys().append_value("key3");
         builder.values().append_value(2);
         builder.values().append_value(3);
-        builder.append(true);
-        builder.append(false);
+        builder.append(true).unwrap();
+        builder.append(false).unwrap();
         builder.keys().append_value("key1");
         builder.values().append_value(1);
-        builder.append(true);
+        builder.append(true).unwrap();
         let maparray = Arc::new(builder.finish()) as ArrayRef;
 
         let indices = vec![Some(true), Some(false), Some(false), Some(true)]
@@ -1441,10 +1441,10 @@ mod tests {
             MapBuilder::new(None, StringBuilder::new(8), Int64Builder::new(2));
         builder.keys().append_value("key1");
         builder.values().append_value(1);
-        builder.append(true);
+        builder.append(true).unwrap();
         builder.keys().append_value("key1");
         builder.values().append_value(1);
-        builder.append(true);
+        builder.append(true).unwrap();
         let expected = Arc::new(builder.finish()) as ArrayRef;
 
         assert_eq!(&expected, &got);

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -1040,10 +1040,10 @@ mod tests {
     fn test_filter_string_array_with_negated_boolean_array() {
         let a = StringArray::from(vec!["hello", " ", "world", "!"]);
         let mut bb = BooleanBuilder::new(2);
-        bb.append_value(false).unwrap();
-        bb.append_value(true).unwrap();
-        bb.append_value(false).unwrap();
-        bb.append_value(true).unwrap();
+        bb.append_value(false);
+        bb.append_value(true);
+        bb.append_value(false);
+        bb.append_value(true);
         let b = bb.finish();
         let b = crate::compute::not(&b).unwrap();
 
@@ -1418,18 +1418,18 @@ mod tests {
         let mut builder =
             MapBuilder::new(None, StringBuilder::new(16), Int64Builder::new(4));
         // [{"key1": 1}, {"key2": 2, "key3": 3}, null, {"key1": 1}
-        builder.keys().append_value("key1").unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.append(true).unwrap();
-        builder.keys().append_value("key2").unwrap();
-        builder.keys().append_value("key3").unwrap();
-        builder.values().append_value(2).unwrap();
-        builder.values().append_value(3).unwrap();
-        builder.append(true).unwrap();
-        builder.append(false).unwrap();
-        builder.keys().append_value("key1").unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.append(true).unwrap();
+        builder.keys().append_value("key1");
+        builder.values().append_value(1);
+        builder.append(true);
+        builder.keys().append_value("key2");
+        builder.keys().append_value("key3");
+        builder.values().append_value(2);
+        builder.values().append_value(3);
+        builder.append(true);
+        builder.append(false);
+        builder.keys().append_value("key1");
+        builder.values().append_value(1);
+        builder.append(true);
         let maparray = Arc::new(builder.finish()) as ArrayRef;
 
         let indices = vec![Some(true), Some(false), Some(false), Some(true)]
@@ -1439,12 +1439,12 @@ mod tests {
 
         let mut builder =
             MapBuilder::new(None, StringBuilder::new(8), Int64Builder::new(2));
-        builder.keys().append_value("key1").unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.append(true).unwrap();
-        builder.keys().append_value("key1").unwrap();
-        builder.values().append_value(1).unwrap();
-        builder.append(true).unwrap();
+        builder.keys().append_value("key1");
+        builder.values().append_value(1);
+        builder.append(true);
+        builder.keys().append_value("key1");
+        builder.values().append_value(1);
+        builder.append(true);
         let expected = Arc::new(builder.finish()) as ArrayRef;
 
         assert_eq!(&expected, &got);

--- a/arrow/src/compute/kernels/regexp.rs
+++ b/arrow/src/compute/kernels/regexp.rs
@@ -61,8 +61,8 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
                 // Required for Postgres compatibility:
                 // SELECT regexp_match('foobarbequebaz', ''); = {""}
                 (Some(_), Some(pattern)) if pattern == *"" => {
-                    list_builder.values().append_value("")?;
-                    list_builder.append(true)?;
+                    list_builder.values().append_value("");
+                    list_builder.append(true);
                 }
                 (Some(value), Some(pattern)) => {
                     let existing_pattern = patterns.get(&pattern);
@@ -82,14 +82,14 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
                     match re.captures(value) {
                         Some(caps) => {
                             for m in caps.iter().skip(1).flatten() {
-                                list_builder.values().append_value(m.as_str())?;
+                                list_builder.values().append_value(m.as_str());
                             }
-                            list_builder.append(true)?
+                            list_builder.append(true);
                         }
-                        None => list_builder.append(false)?,
+                        None => list_builder.append(false),
                     }
                 }
-                _ => list_builder.append(false)?,
+                _ => list_builder.append(false),
             }
             Ok(())
         })
@@ -103,7 +103,7 @@ mod tests {
     use crate::array::{ListArray, StringArray};
 
     #[test]
-    fn match_single_group() -> Result<()> {
+    fn match_single_group() {
         let values = vec![
             Some("abc-005-def"),
             Some("X-7-5"),
@@ -117,41 +117,39 @@ mod tests {
         pattern_values.push(r"(bar)(bequ1e)");
         pattern_values.push("");
         let pattern = StringArray::from(pattern_values);
-        let actual = regexp_match(&array, &pattern, None)?;
+        let actual = regexp_match(&array, &pattern, None).unwrap();
         let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new(0);
         let mut expected_builder = ListBuilder::new(elem_builder);
-        expected_builder.values().append_value("005")?;
-        expected_builder.append(true)?;
-        expected_builder.values().append_value("7")?;
-        expected_builder.append(true)?;
-        expected_builder.append(false)?;
-        expected_builder.append(false)?;
-        expected_builder.append(false)?;
-        expected_builder.values().append_value("")?;
-        expected_builder.append(true)?;
+        expected_builder.values().append_value("005");
+        expected_builder.append(true);
+        expected_builder.values().append_value("7");
+        expected_builder.append(true);
+        expected_builder.append(false);
+        expected_builder.append(false);
+        expected_builder.append(false);
+        expected_builder.values().append_value("");
+        expected_builder.append(true);
         let expected = expected_builder.finish();
         let result = actual.as_any().downcast_ref::<ListArray>().unwrap();
         assert_eq!(&expected, result);
-        Ok(())
     }
 
     #[test]
-    fn match_single_group_with_flags() -> Result<()> {
+    fn match_single_group_with_flags() {
         let values = vec![Some("abc-005-def"), Some("X-7-5"), Some("X545"), None];
         let array = StringArray::from(values);
         let pattern = StringArray::from(vec![r"x.*-(\d*)-.*"; 4]);
         let flags = StringArray::from(vec!["i"; 4]);
-        let actual = regexp_match(&array, &pattern, Some(&flags))?;
+        let actual = regexp_match(&array, &pattern, Some(&flags)).unwrap();
         let elem_builder: GenericStringBuilder<i32> = GenericStringBuilder::new(0);
         let mut expected_builder = ListBuilder::new(elem_builder);
-        expected_builder.append(false)?;
-        expected_builder.values().append_value("7")?;
-        expected_builder.append(true)?;
-        expected_builder.append(false)?;
-        expected_builder.append(false)?;
+        expected_builder.append(false);
+        expected_builder.values().append_value("7");
+        expected_builder.append(true);
+        expected_builder.append(false);
+        expected_builder.append(false);
         let expected = expected_builder.finish();
         let result = actual.as_any().downcast_ref::<ListArray>().unwrap();
         assert_eq!(&expected, result);
-        Ok(())
     }
 }

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1076,14 +1076,12 @@ mod tests {
             struct_builder
                 .field_builder::<BooleanBuilder>(0)
                 .unwrap()
-                .append_option(value.and_then(|v| v.0))
-                .unwrap();
+                .append_option(value.and_then(|v| v.0));
             struct_builder
                 .field_builder::<Int32Builder>(1)
                 .unwrap()
-                .append_option(value.and_then(|v| v.1))
-                .unwrap();
-            struct_builder.append(value.is_some()).unwrap();
+                .append_option(value.and_then(|v| v.1));
+            struct_builder.append(value.is_some());
         }
         struct_builder.finish()
     }
@@ -2033,7 +2031,7 @@ mod tests {
         dict_builder.append("foo").unwrap();
         dict_builder.append("bar").unwrap();
         dict_builder.append("").unwrap();
-        dict_builder.append_null().unwrap();
+        dict_builder.append_null();
         dict_builder.append("foo").unwrap();
         dict_builder.append("bar").unwrap();
         dict_builder.append("bar").unwrap();

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -31,11 +31,11 @@ macro_rules! extract_component_from_array {
     ($array:ident, $builder:ident, $extract_fn:ident, $using:ident) => {
         for i in 0..$array.len() {
             if $array.is_null(i) {
-                $builder.append_null()?;
+                $builder.append_null();
             } else {
                 match $array.$using(i) {
-                    Some(dt) => $builder.append_value(dt.$extract_fn() as i32)?,
-                    None => $builder.append_null()?,
+                    Some(dt) => $builder.append_value(dt.$extract_fn() as i32),
+                    None => $builder.append_null(),
                 }
             }
         }
@@ -43,13 +43,13 @@ macro_rules! extract_component_from_array {
     ($array:ident, $builder:ident, $extract_fn1:ident, $extract_fn2:ident, $using:ident) => {
         for i in 0..$array.len() {
             if $array.is_null(i) {
-                $builder.append_null()?;
+                $builder.append_null();
             } else {
                 match $array.$using(i) {
                     Some(dt) => {
-                        $builder.append_value(dt.$extract_fn1().$extract_fn2() as i32)?
+                        $builder.append_value(dt.$extract_fn1().$extract_fn2() as i32);
                     }
-                    None => $builder.append_null()?,
+                    None => $builder.append_null(),
                 }
             }
         }
@@ -72,7 +72,7 @@ macro_rules! extract_component_from_array {
 
             for i in 0..$array.len() {
                 if $array.is_null(i) {
-                    $builder.append_null()?;
+                    $builder.append_null();
                 } else {
                     match $array.value_as_datetime(i) {
                         Some(utc) => {
@@ -90,9 +90,9 @@ macro_rules! extract_component_from_array {
                             };
                             match $array.$using(i, fixed_offset) {
                                 Some(dt) => {
-                                    $builder.append_value(dt.$extract_fn() as i32)?
+                                    $builder.append_value(dt.$extract_fn() as i32);
                                 }
-                                None => $builder.append_null()?,
+                                None => $builder.append_null(),
                             }
                         }
                         err => return_compute_error_with!(

--- a/arrow/src/csv/reader.rs
+++ b/arrow/src/csv/reader.rs
@@ -704,12 +704,12 @@ fn build_decimal_array(
         match col_s {
             None => {
                 // No data for this row
-                decimal_builder.append_null()?;
+                decimal_builder.append_null();
             }
             Some(s) => {
                 if s.is_empty() {
                     // append null
-                    decimal_builder.append_null()?;
+                    decimal_builder.append_null();
                 } else {
                     let decimal_value: Result<i128> =
                         parse_decimal_with_parameter(s, precision, scale);

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -803,7 +803,7 @@ impl Decoder {
             }
             DataType::Dictionary(_, _) => {
                 let values_builder =
-                    self.build_string_dictionary_builder::<DT>(rows.len() * 5)?;
+                    self.build_string_dictionary_builder::<DT>(rows.len() * 5);
                 Box::new(ListBuilder::new(values_builder))
             }
             e => {
@@ -855,14 +855,14 @@ impl Decoder {
                             ))?;
                         for val in vals {
                             if let Some(v) = val {
-                                builder.values().append_value(&v)?
+                                builder.values().append_value(&v);
                             } else {
-                                builder.values().append_null()?
+                                builder.values().append_null();
                             };
                         }
 
                         // Append to the list
-                        builder.append(true)?;
+                        builder.append(true);
                     }
                     DataType::Dictionary(_, _) => {
                         let builder = builder.as_any_mut().downcast_mut::<ListBuilder<StringDictionaryBuilder<DT>>>().ok_or_else(||ArrowError::JsonError(
@@ -870,14 +870,14 @@ impl Decoder {
                         ))?;
                         for val in vals {
                             if let Some(v) = val {
-                                let _ = builder.values().append(&v)?;
+                                let _ = builder.values().append(&v);
                             } else {
-                                builder.values().append_null()?
+                                builder.values().append_null();
                             };
                         }
 
                         // Append to the list
-                        builder.append(true)?;
+                        builder.append(true);
                     }
                     e => {
                         return Err(ArrowError::JsonError(format!(
@@ -897,13 +897,13 @@ impl Decoder {
     fn build_string_dictionary_builder<T>(
         &self,
         row_len: usize,
-    ) -> Result<StringDictionaryBuilder<T>>
+    ) -> StringDictionaryBuilder<T>
     where
         T: ArrowPrimitiveType + ArrowDictionaryKeyType,
     {
         let key_builder = PrimitiveBuilder::<T>::new(row_len);
         let values_builder = StringBuilder::new(row_len * 5);
-        Ok(StringDictionaryBuilder::new(key_builder, values_builder))
+        StringDictionaryBuilder::new(key_builder, values_builder)
     }
 
     #[inline(always)]
@@ -954,12 +954,12 @@ impl Decoder {
         for row in rows {
             if let Some(value) = row.get(&col_name) {
                 if let Some(boolean) = value.as_bool() {
-                    builder.append_value(boolean)?
+                    builder.append_value(boolean);
                 } else {
-                    builder.append_null()?;
+                    builder.append_null();
                 }
             } else {
-                builder.append_null()?;
+                builder.append_null();
             }
         }
         Ok(Arc::new(builder.finish()))
@@ -1479,16 +1479,16 @@ impl Decoder {
         T: ArrowPrimitiveType + ArrowDictionaryKeyType,
     {
         let mut builder: StringDictionaryBuilder<T> =
-            self.build_string_dictionary_builder(rows.len())?;
+            self.build_string_dictionary_builder(rows.len());
         for row in rows {
             if let Some(value) = row.get(&col_name) {
                 if let Some(str_v) = value.as_str() {
                     builder.append(str_v).map(drop)?
                 } else {
-                    builder.append_null()?
+                    builder.append_null();
                 }
             } else {
-                builder.append_null()?
+                builder.append_null();
             }
         }
         Ok(Arc::new(builder.finish()) as ArrayRef)

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -247,7 +247,7 @@ mod tests {
         let mut builder = StringDictionaryBuilder::new(keys_builder, values_builder);
 
         builder.append("one")?;
-        builder.append_null()?;
+        builder.append_null();
         builder.append("three")?;
         let array = Arc::new(builder.finish());
 
@@ -284,12 +284,12 @@ mod tests {
         let keys_builder = Int32Array::builder(3);
         let mut builder = FixedSizeListBuilder::new(keys_builder, 3);
 
-        builder.values().append_slice(&[1, 2, 3]).unwrap();
-        builder.append(true).unwrap();
-        builder.values().append_slice(&[4, 5, 6]).unwrap();
-        builder.append(false).unwrap();
-        builder.values().append_slice(&[7, 8, 9]).unwrap();
-        builder.append(true).unwrap();
+        builder.values().append_slice(&[1, 2, 3]);
+        builder.append(true);
+        builder.values().append_slice(&[4, 5, 6]);
+        builder.append(false);
+        builder.values().append_slice(&[7, 8, 9]);
+        builder.append(true);
 
         let array = Arc::new(builder.finish());
 
@@ -321,7 +321,7 @@ mod tests {
         let mut builder = FixedSizeBinaryBuilder::new(3, 3);
 
         builder.append_value(&[1, 2, 3]).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(&[7, 8, 9]).unwrap();
 
         let array = Arc::new(builder.finish());
@@ -351,8 +351,8 @@ mod tests {
     macro_rules! check_datetime {
         ($ARRAYTYPE:ident, $VALUE:expr, $EXPECTED_RESULT:expr) => {
             let mut builder = $ARRAYTYPE::builder(10);
-            builder.append_value($VALUE).unwrap();
-            builder.append_null().unwrap();
+            builder.append_value($VALUE);
+            builder.append_null();
             let array = builder.finish();
 
             let schema = Arc::new(Schema::new(vec![Field::new(

--- a/integration-testing/src/lib.rs
+++ b/integration-testing/src/lib.rs
@@ -121,7 +121,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_bool().unwrap()),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -142,7 +142,7 @@ fn array_from_json(
                         ))
                     })? as i8),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -158,7 +158,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_i64().unwrap() as i16),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -177,7 +177,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_i64().unwrap() as i32),
                     _ => b.append_null(),
-                }?;
+                };
             }
             let array = Arc::new(b.finish()) as ArrayRef;
             arrow::compute::cast(&array, field.data_type())
@@ -238,7 +238,7 @@ fn array_from_json(
                         _ => panic!("Unable to parse {:?} as number", value),
                     }),
                     _ => b.append_null(),
-                }?;
+                };
             }
             let array = Arc::new(b.finish()) as ArrayRef;
             arrow::compute::cast(&array, field.data_type())
@@ -255,7 +255,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_u64().unwrap() as u8),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -271,7 +271,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_u64().unwrap() as u16),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -287,7 +287,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_u64().unwrap() as u32),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -309,7 +309,7 @@ fn array_from_json(
                             .expect("Unable to parse string as u64"),
                     ),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -352,7 +352,7 @@ fn array_from_json(
                         _ => panic!("Unable to parse {:?} as MonthDayNano", value),
                     }),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -368,7 +368,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_f64().unwrap() as f32),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -384,7 +384,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_f64().unwrap()),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -403,7 +403,7 @@ fn array_from_json(
                         b.append_value(&v)
                     }
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -422,7 +422,7 @@ fn array_from_json(
                         b.append_value(&v)
                     }
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -438,7 +438,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_str().unwrap()),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -454,7 +454,7 @@ fn array_from_json(
                 match is_valid {
                     1 => b.append_value(value.as_str().unwrap()),
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -470,10 +470,10 @@ fn array_from_json(
                 match is_valid {
                     1 => {
                         let v = hex::decode(value.as_str().unwrap()).unwrap();
-                        b.append_value(&v)
+                        b.append_value(&v)?
                     }
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }
@@ -605,9 +605,11 @@ fn array_from_json(
                 .zip(json_col.data.unwrap())
             {
                 match is_valid {
-                    1 => b.append_value(value.as_str().unwrap().parse::<i128>().unwrap()),
+                    1 => {
+                        b.append_value(value.as_str().unwrap().parse::<i128>().unwrap())?
+                    }
                     _ => b.append_null(),
-                }?;
+                };
             }
             Ok(Arc::new(b.finish()))
         }

--- a/parquet/src/arrow/arrow_reader.rs
+++ b/parquet/src/arrow/arrow_reader.rs
@@ -1551,7 +1551,7 @@ mod tests {
         for _ in 0..2 {
             let mut list_builder = ListBuilder::new(Int32Builder::new(batch_size));
             for _ in 0..(batch_size) {
-                list_builder.append(true).unwrap();
+                list_builder.append(true);
             }
             let batch = RecordBatch::try_new(
                 schema.clone(),

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -1200,52 +1200,47 @@ mod tests {
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_value(1)
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_value(1);
+        values.append(true);
+        list_builder.append(true);
 
         // []
-        list_builder.append(true).unwrap();
+        list_builder.append(true);
 
         // null
-        list_builder.append(false).unwrap();
+        list_builder.append(false);
 
         // [null, null]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(false).unwrap();
+            .append_null();
+        values.append(false);
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(false).unwrap();
-        list_builder.append(true).unwrap();
+            .append_null();
+        values.append(false);
+        list_builder.append(true);
 
         // [{a: null}]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_null();
+        values.append(true);
+        list_builder.append(true);
 
         // [{a: 2}]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_value(2)
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_value(2);
+        values.append(true);
+        list_builder.append(true);
 
         let array = Arc::new(list_builder.finish());
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1517,7 +1517,7 @@ mod tests {
     fn fixed_size_binary_single_column() {
         let mut builder = FixedSizeBinaryBuilder::new(16, 4);
         builder.append_value(b"0123").unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append_value(b"8910").unwrap();
         builder.append_value(b"1112").unwrap();
         let array = Arc::new(builder.finish());
@@ -1697,7 +1697,7 @@ mod tests {
         let value_builder = PrimitiveBuilder::<UInt32Type>::new(2);
         let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
         builder.append(12345678).unwrap();
-        builder.append_null().unwrap();
+        builder.append_null();
         builder.append(22345678).unwrap();
         builder.append(12345678).unwrap();
         let d = builder.finish();
@@ -1833,77 +1833,67 @@ mod tests {
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_value(1)
-            .unwrap();
+            .append_value(1);
         values
             .field_builder::<Int32Builder>(1)
             .unwrap()
-            .append_value(2)
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_value(2);
+        values.append(true);
+        list_builder.append(true);
 
         // []
-        list_builder.append(true).unwrap();
+        list_builder.append(true);
 
         // null
-        list_builder.append(false).unwrap();
+        list_builder.append(false);
 
         // [null, null]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
+            .append_null();
         values
             .field_builder::<Int32Builder>(1)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(false).unwrap();
+            .append_null();
+        values.append(false);
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
+            .append_null();
         values
             .field_builder::<Int32Builder>(1)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(false).unwrap();
-        list_builder.append(true).unwrap();
+            .append_null();
+        values.append(false);
+        list_builder.append(true);
 
         // [{a: null, b: 3}]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_null()
-            .unwrap();
+            .append_null();
         values
             .field_builder::<Int32Builder>(1)
             .unwrap()
-            .append_value(3)
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_value(3);
+        values.append(true);
+        list_builder.append(true);
 
         // [{a: 2, b: null}]
         let values = list_builder.values();
         values
             .field_builder::<Int32Builder>(0)
             .unwrap()
-            .append_value(2)
-            .unwrap();
+            .append_value(2);
         values
             .field_builder::<Int32Builder>(1)
             .unwrap()
-            .append_null()
-            .unwrap();
-        values.append(true).unwrap();
-        list_builder.append(true).unwrap();
+            .append_null();
+        values.append(true);
+        list_builder.append(true);
 
         let array = Arc::new(list_builder.finish());
 

--- a/parquet/src/arrow/buffer/converter.rs
+++ b/parquet/src/arrow/buffer/converter.rs
@@ -58,9 +58,9 @@ impl Converter<Vec<Option<FixedLenByteArray>>, FixedSizeBinaryArray>
         let mut builder = FixedSizeBinaryBuilder::new(source.len(), self.byte_width);
         for v in source {
             match v {
-                Some(array) => builder.append_value(array.data()),
+                Some(array) => builder.append_value(array.data())?,
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -117,7 +117,7 @@ impl Converter<Vec<Option<FixedLenByteArray>>, IntervalYearMonthArray>
                     array.data()[0..4].try_into().unwrap(),
                 )),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -142,7 +142,7 @@ impl Converter<Vec<Option<FixedLenByteArray>>, IntervalDayTimeArray>
                     array.data()[4..12].try_into().unwrap(),
                 )),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -179,7 +179,7 @@ impl Converter<Vec<Option<ByteArray>>, StringArray> for Utf8ArrayConverter {
             match v {
                 Some(array) => builder.append_value(array.as_utf8()?),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -200,7 +200,7 @@ impl Converter<Vec<Option<ByteArray>>, LargeStringArray> for LargeUtf8ArrayConve
             match v {
                 Some(array) => builder.append_value(array.as_utf8()?),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -216,7 +216,7 @@ impl Converter<Vec<Option<ByteArray>>, BinaryArray> for BinaryArrayConverter {
             match v {
                 Some(array) => builder.append_value(array.data()),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())
@@ -232,7 +232,7 @@ impl Converter<Vec<Option<ByteArray>>, LargeBinaryArray> for LargeBinaryArrayCon
             match v {
                 Some(array) => builder.append_value(array.data()),
                 None => builder.append_null(),
-            }?
+            }
         }
 
         Ok(builder.finish())


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2071.

# Rationale for this change

 Infallible methods are easier to use and less confusing when there are no actual error cases.

# What changes are included in this PR?

Nearly all append methods in builders are now infallible. The following builders still have fallible methods

 - FixedSizeBinaryBuilder when the given slice has the wrong length
 - StringDictionaryBuilder in case the key datatype would overflow
 - DecimalBuilder/Decimal256Builder in case the precision, scale or byte length does not match
 - MapBuilder when the key and values builders are in an inconsistent state of not having the same length

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, a lot of them

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
