### PR TITLE
Support skip_def_levels (only max_def_levels=1) for ColumnLevelDecoder

### DIFF
--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -455,10 +455,10 @@ mod tests {
 
         let mut skip_value = 0;
         let mut read_value = 0;
-        let mut read_data = vec![];
 
         loop {
-            let remaining = len - read_value - skip_value;
+            let offset = read_value + skip_value;
+            let remaining = len - offset;
             if remaining == 0 {
                 break;
             }
@@ -468,20 +468,15 @@ mod tests {
             } else if to_read > 0 {
                 let mut decoded = BooleanBufferBuilder::new(to_read);
                 read_value += decoder.read(&mut decoded, to_read).unwrap();
-                read_data.push(decoded.as_slice().to_vec());
+                for i in 0..to_read {
+                    //check each bit
+                    let read_bit = decoded.get_bit(i);
+                    let expect_bit = expected.get_bit(i + offset);
+                    assert_eq!(read_bit, expect_bit);
+                }
             }
         }
-
         assert_eq!(read_value + skip_value, len);
-
-        let expected = expected.as_slice();
-        for data in read_data.iter().enumerate() {
-            assert!(find_subsequence(expected, data.1).is_some());
-        }
-    }
-
-    fn find_subsequence(u1: &[u8], u2: &Vec<u8>) -> Option<usize> {
-        u1.windows(u2.len()).position(|window| window == u2)
     }
 
     #[test]

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -254,9 +254,7 @@ struct PackedDecoder {
 
 impl PackedDecoder {
     fn next_rle_block(&mut self) -> Result<()> {
-        let indicator_value = self
-            .decode_header()
-            .expect("decode_header fail in PackedDecoder");
+        let indicator_value = self.decode_header()?;
         if indicator_value & 1 == 1 {
             let len = (indicator_value >> 1) as usize;
             self.packed_count = len * 8;

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -481,7 +481,7 @@ mod tests {
                     decoder.read(&mut decoded, to_read_or_skip_level).unwrap();
                 read_level += read_level_num;
                 for i in 0..read_level_num {
-                    assert!(decoded.len() > 0);
+                    assert!(!decoded.is_empty());
                     //check each read bit
                     let read_bit = decoded.get_bit(i);
                     if read_bit {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2107 .

# Rationale for this change
 
This pr only support skip def_levels in `DefinitionLevelBufferDecoder`,
@tustvold Just make sure  all page with max_def_level = 1 and max_rep_level = 0,
will only use `DefinitionLevelBufferDecoder` decode def_level.

In another word, this will support the skip val in col like `OPTIONAL type R:0 D:1`



Added :
Seems it still use `ColumnLevelDecoderImpl` in some case facing `R:0 D:1`
when decoding some col`s def_level
# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
