### PR TITLE
Add get_byte_ranges method to AsyncFileReader trait

### DIFF
--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -87,7 +87,6 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::Stream;
-use futures::StreamExt;
 use parquet_format::PageType;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2110 

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In certain cases it is better from a performance perspective to fetch data in parallel such as reading from object storage. This adds a hook into the `AsyncFileReader` trait to allow upstream consumers of this API to do that. 

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `get_byte_ranges(&mut self, ranges: Vec<Range<usize>>)` method to `AsyncFileReader` trait with a default implementation that will fallback to calling `get_bytes` serially for the provided ranges. 

# Are there any user-facing changes?

No

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
