### PR TITLE
Simplify null mask preservation in parquet reader

### DIFF
--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -307,21 +307,19 @@ fn create_primitive_array_reader(
     use parquet::arrow::array_reader::PrimitiveArrayReader;
     match column_desc.physical_type() {
         Type::INT32 => {
-            let reader = PrimitiveArrayReader::<Int32Type>::new_with_options(
+            let reader = PrimitiveArrayReader::<Int32Type>::new(
                 Box::new(page_iterator),
                 column_desc,
                 None,
-                true,
             )
             .unwrap();
             Box::new(reader)
         }
         Type::INT64 => {
-            let reader = PrimitiveArrayReader::<Int64Type>::new_with_options(
+            let reader = PrimitiveArrayReader::<Int64Type>::new(
                 Box::new(page_iterator),
                 column_desc,
                 None,
-                true,
             )
             .unwrap();
             Box::new(reader)
@@ -335,7 +333,7 @@ fn create_string_byte_array_reader(
     column_desc: ColumnDescPtr,
 ) -> Box<dyn ArrayReader> {
     use parquet::arrow::array_reader::make_byte_array_reader;
-    make_byte_array_reader(Box::new(page_iterator), column_desc, None, true).unwrap()
+    make_byte_array_reader(Box::new(page_iterator), column_desc, None).unwrap()
 }
 
 fn create_string_byte_array_dictionary_reader(
@@ -350,7 +348,6 @@ fn create_string_byte_array_dictionary_reader(
         Box::new(page_iterator),
         column_desc,
         Some(arrow_type),
-        true,
     )
     .unwrap()
 }

--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -160,16 +160,14 @@ fn build_primitive_reader(
     ));
 
     let page_iterator = row_groups.column_chunks(col_idx)?;
-    let null_mask_only = field.def_level == 1 && field.nullable;
     let arrow_type = Some(field.arrow_type.clone());
 
     match physical_type {
         PhysicalType::BOOLEAN => Ok(Box::new(
-            PrimitiveArrayReader::<BoolType>::new_with_options(
+            PrimitiveArrayReader::<BoolType>::new(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             )?,
         )),
         PhysicalType::INT32 => {
@@ -180,21 +178,19 @@ fn build_primitive_reader(
                 )?))
             } else {
                 Ok(Box::new(
-                    PrimitiveArrayReader::<Int32Type>::new_with_options(
+                    PrimitiveArrayReader::<Int32Type>::new(
                         page_iterator,
                         column_desc,
                         arrow_type,
-                        null_mask_only,
                     )?,
                 ))
             }
         }
         PhysicalType::INT64 => Ok(Box::new(
-            PrimitiveArrayReader::<Int64Type>::new_with_options(
+            PrimitiveArrayReader::<Int64Type>::new(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             )?,
         )),
         PhysicalType::INT96 => {
@@ -218,19 +214,17 @@ fn build_primitive_reader(
             )?))
         }
         PhysicalType::FLOAT => Ok(Box::new(
-            PrimitiveArrayReader::<FloatType>::new_with_options(
+            PrimitiveArrayReader::<FloatType>::new(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             )?,
         )),
         PhysicalType::DOUBLE => Ok(Box::new(
-            PrimitiveArrayReader::<DoubleType>::new_with_options(
+            PrimitiveArrayReader::<DoubleType>::new(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             )?,
         )),
         PhysicalType::BYTE_ARRAY => match arrow_type {
@@ -238,13 +232,11 @@ fn build_primitive_reader(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             ),
             _ => make_byte_array_reader(
                 page_iterator,
                 column_desc,
                 arrow_type,
-                null_mask_only,
             ),
         },
         PhysicalType::FIXED_LEN_BYTE_ARRAY => match field.arrow_type {

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -59,17 +59,6 @@ where
         column_desc: ColumnDescPtr,
         arrow_type: Option<ArrowType>,
     ) -> Result<Self> {
-        Self::new_with_options(pages, column_desc, arrow_type, false)
-    }
-
-    /// Construct primitive array reader with ability to only compute null mask and not
-    /// buffer level data
-    pub fn new_with_options(
-        pages: Box<dyn PageIterator>,
-        column_desc: ColumnDescPtr,
-        arrow_type: Option<ArrowType>,
-        null_mask_only: bool,
-    ) -> Result<Self> {
         // Check if Arrow type is specified, else create it from Parquet type
         let data_type = match arrow_type {
             Some(t) => t,
@@ -78,8 +67,7 @@ where
                 .clone(),
         };
 
-        let record_reader =
-            RecordReader::<T>::new_with_options(column_desc.clone(), null_mask_only);
+        let record_reader = RecordReader::<T>::new(column_desc.clone());
 
         Ok(Self {
             data_type,

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -195,7 +195,6 @@ where
     ///
     /// `values` will be contiguously populated with the non-null values. Note that if the column
     /// is not required, this may be less than either `batch_size` or the number of levels read
-    #[inline]
     pub fn read_batch(
         &mut self,
         batch_size: usize,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #2107

# Rationale for this change
 
The original logic added in #1054 is very confusing as it determines whether to use a packed decoder, based on the type of `DefinitionLevelBuffer` passed to `DefinitionLevelBufferDecoder`. Not only is this confusing, but it creates a problem when skipping the first records in a column chunk, as the type of decoder is not known until data has been read :scream:

This largely dated from a time when `GenericRecordReader` was generic over the levels in addition to values. In the end I removed this prior to merge as it was unnecessary complexity.

# What changes are included in this PR?

Explicitly construct the decoders in `GenericRecordReader`, and passes them to `GenericColumnReader::new_with_decoders`. This allows adding an additional constructor parameter to `DefinitionLevelBufferDecoder` to instruct it whether to decode packed or not.

# Are there any user-facing changes?

No, all these traits are crate private