### PR TITLE
Update `GenericBinaryBuilder` to use buffer builders directly.

### DIFF
--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -36,11 +36,11 @@ pub struct GenericBinaryBuilder<OffsetSize: OffsetSizeTrait> {
 }
 
 impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
-    /// Creates a new `GenericBinaryBuilder`, `capacity` is the number of bytes in the values
-    /// array
+    /// Creates a new [`GenericBinaryBuilder`].
+    /// `capacity` is the number of bytes in the values array.
     pub fn new(capacity: usize) -> Self {
         let mut offsets_builder = BufferBuilder::<OffsetSize>::new(1024);
-        offsets_builder.append_n_zeroed(1);
+        offsets_builder.append(OffsetSize::zero());
         Self {
             value_builder: UInt8BufferBuilder::new(capacity),
             offsets_builder,
@@ -78,7 +78,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
             .add_buffer(self.value_builder.finish())
             .null_bit_buffer(Some(self.null_buffer_builder.finish()));
 
-        self.offsets_builder.append_n_zeroed(1);
+        self.offsets_builder.append(OffsetSize::zero());
         let array_data = unsafe { array_builder.build_unchecked() };
         GenericBinaryArray::<OffsetSize>::from(array_data)
     }
@@ -100,12 +100,12 @@ impl<OffsetSize: OffsetSizeTrait> ArrayBuilder for GenericBinaryBuilder<OffsetSi
         self
     }
 
-    /// Returns the number of array slots in the builder
+    /// Returns the number of binary slots in the builder
     fn len(&self) -> usize {
         self.null_buffer_builder.len()
     }
 
-    /// Returns whether the number of array slots is zero
+    /// Returns whether the number of binary slots is zero
     fn is_empty(&self) -> bool {
         self.null_buffer_builder.is_empty()
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2104.

# Rationale for this change
 Don't build binary array from list builder to avoid bugs and extra memory occupation.

# What changes are included in this PR?
1. Update the struct of `GenericBinaryBuilder`
2. Remove the method `append_byte` and `append`. (`append_value` and `append_null` can achieve all functionalities)
3. More tests to cover the all-null case and builder resetting.
4. Fix some docs

# Are there any user-facing changes?
Yes, remove 2 pub methods `append_byte` and `append`.

<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
