### PR TITLE
Fix logical merge conflict: `match` arms have incompatible types

### DIFF
--- a/integration-testing/src/lib.rs
+++ b/integration-testing/src/lib.rs
@@ -642,7 +642,7 @@ fn array_from_json(
                                 .unwrap();
                         b.append_value(&decimal)
                     }
-                    _ => b.append_null(),
+                    _ => Ok(b.append_null()),
                 }?;
             }
             Ok(Arc::new(b.finish()))


### PR DESCRIPTION
Fix build on master

I merged https://github.com/apache/arrow-rs/pull/2094 which had a logical conflict which results in a build failure on master such as https://github.com/apache/arrow-rs/runs/7455984487?check_suite_focus=true


```
   Compiling arrow-integration-testing v18.0.0 (/__w/arrow-rs/arrow-rs/integration-testing)
error[E0308]: `match` arms have incompatible types
   --> integration-testing/src/lib.rs:645:26
    |
628 | /                 match is_valid {
629 | |                     1 => {
630 | |                         let str = value.as_str().unwrap();
631 | |                         let integer = BigInt::parse_bytes(str.as_bytes(), 10).unwrap();
...   |
643 | |                         b.append_value(&decimal)
    | |                         ------------------------ this is found to be of type `std::result::Result<(), ArrowError>`
644 | |                     }
645 | |                     _ => b.append_null(),
    | |                          ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found `()`
646 | |                 }?;
    | |_________________- `match` arms have incompatible types
    |
    = note:   expected enum `std::result::Result<(), ArrowError>`
            found unit type `()`
```