### PR TITLE
Make MapFieldNames public (#2118)

### DIFF
--- a/arrow/src/array/builder/mod.rs
+++ b/arrow/src/array/builder/mod.rs
@@ -52,7 +52,7 @@ pub use fixed_size_list_builder::FixedSizeListBuilder;
 pub use generic_binary_builder::GenericBinaryBuilder;
 pub use generic_list_builder::GenericListBuilder;
 pub use generic_string_builder::GenericStringBuilder;
-pub use map_builder::MapBuilder;
+pub use map_builder::{MapBuilder, MapFieldNames};
 pub use primitive_builder::PrimitiveBuilder;
 pub use primitive_dictionary_builder::PrimitiveDictionaryBuilder;
 pub use string_dictionary_builder::StringDictionaryBuilder;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2118

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See ticket

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make MapFieldNames public so `MapBuilder` can be used 

# Are there any user-facing changes?

No