### PR TITLE
Run throttle test on mac

### DIFF
--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -314,8 +314,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // macos github runner is so slow it can't complete within WAIT_TIME*2
-    #[cfg(target_os = "linux")]
     async fn get_test() {
         let inner = InMemory::new();
         let store = ThrottledStore::new(inner, ThrottleConfig::default());
@@ -343,8 +341,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // macos github runner is so slow it can't complete within WAIT_TIME*2
-    #[cfg(target_os = "linux")]
     async fn list_test() {
         let inner = InMemory::new();
         let store = ThrottledStore::new(inner, ThrottleConfig::default());
@@ -370,8 +366,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // macos github runner is so slow it can't complete within WAIT_TIME*2
-    #[cfg(target_os = "linux")]
     async fn list_with_delimiter_test() {
         let inner = InMemory::new();
         let store = ThrottledStore::new(inner, ThrottleConfig::default());


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/pull/2142

As part of the new object store crate merge, I disabled some tests that failed consistently on the mac, but @viirya  had a better fix in https://github.com/apache/arrow-rs/pull/2142

# Rationale for this change
Restore test coverage for object_store 

# What changes are included in this PR?
Run tests on windows and mac


# Are there any user-facing changes?

no