### PR TITLE
Add object-store labels to PRs

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -26,3 +26,6 @@ parquet:
 
 parquet-derive:
   - parquet_derive/**/*
+
+object-store:
+  - object_store/**/*


### PR DESCRIPTION
# Which issue does this PR close?

re #2030 

# Rationale for this change
 
automatically assigning labels to PRs to assists in reviews and categorization

# What changes are included in this PR?

automatically add `object-store` label to PRs 

# Are there any user-facing changes?

no
