### PR TITLE
Run `object_store_integration`  tests

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -1,0 +1,96 @@
+---
+name: "object_store tests"
+
+on:
+  pull_request:
+
+jobs:
+  # This job functions as "proof of life" that things are working --no need to port
+  lint:
+    name: Lint (cargo fmt)
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup component add rustfmt
+      - name: Run
+        run: cargo fmt --all -- --check
+
+  # test the crate
+  linux-test:
+    name: Emulator Tests
+    runs-on: ubuntu-latest
+    services:
+      fake-gcs:
+        image: fsouza/fake-gcs-server
+        ports:
+          - 4443:4443
+      localstack:
+        image: localstack/localstack:0.14.4
+        ports:
+          - 4566:4566
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10002
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+        # https://github.com/rust-lang/cargo/issues/10280
+        CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        RUST_BACKTRACE: "1"
+        # Run integration tests
+        TEST_INTEGRATION: 1
+        AWS_DEFAULT_REGION: "us-east-1"
+        AWS_ACCESS_KEY_ID: test
+        AWS_SECRET_ACCESS_KEY: test
+        AWS_ENDPOINT: http://localstack:4566
+        AZURE_USE_EMULATOR: "1"
+        AZURITE_BLOB_STORAGE_URL: "http://azurite:10000"
+        AZURITE_QUEUE_STORAGE_URL: "http://azurite:10001"
+        GOOGLE_SERVICE_ACCOUNT: "/tmp/gcs.json"
+        GCP_ACCEPT_INVALID_CERTIFICATES: "true"
+        OBJECT_STORE_BUCKET: test-bucket
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure Fake GCS Server (GCP emulation)
+          # the magical connection string is from
+          # https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio#http-connection-strings
+        run: |
+          curl --insecure -v -X POST --data-binary '{"name":"test-bucket"}' -H "Content-Type: application/json" "https://fake-gcs:4443/storage/v1/b"
+          echo '{"gcs_base_url": "https://fake-gcs:4443", "disable_oauth": true, "client_email": "", "private_key": ""}' > "$GOOGLE_SERVICE_ACCOUNT"
+
+      - name: Setup LocalStack (AWS emulation)
+        run: |
+          cd /tmp
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          aws --endpoint-url=http://localstack:4566 s3 mb s3://test-bucket
+
+      - name: Configure Azurite (Azure emulation)
+          # the magical connection string is from
+          # https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio#http-connection-strings
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+          az storage container create -n test-bucket --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;'
+
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+
+      - name: Run tests
+        run: |
+          # run tests
+          cargo test --workspace --features=aws,azure,azure_test,gcp

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -1,8 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ---
 name: "object_store tests"
 
 on:
   pull_request:
+    paths:
+      # Only run when object store files or github workflows change
+      - object_store/**
+      -.github/**
 
 jobs:
   # This job functions as "proof of life" that things are working --no need to port

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -525,10 +525,12 @@ fn check_if_emulator_works() -> Result<()> {
 /// if present, otherwise falls back to default_url
 fn url_from_env(env_name: &str, default_url: &str) -> Result<Url> {
     let url = match std::env::var(env_name) {
-        Ok(env_value) => Url::parse(&env_value).context(UnableToParseEmulatorUrlSnafu {
-            env_name,
-            env_value,
-        })?,
+        Ok(env_value) => {
+            Url::parse(&env_value).context(UnableToParseEmulatorUrlSnafu {
+                env_name,
+                env_value,
+            })?
+        }
         Err(_) => Url::parse(default_url).expect("Failed to parse default URL"),
     };
     Ok(url)
@@ -554,12 +556,14 @@ pub fn new_azure(
         // Allow overriding defaults. Values taken from
         // from https://docs.rs/azure_storage/0.2.0/src/azure_storage/core/clients/storage_account_client.rs.html#129-141
         let http_client = azure_core::new_http_client();
-        let blob_storage_url = url_from_env("AZURITE_BLOB_STORAGE_URL", "http://127.0.0.1:10000")?;
+        let blob_storage_url =
+            url_from_env("AZURITE_BLOB_STORAGE_URL", "http://127.0.0.1:10000")?;
         let queue_storage_url =
             url_from_env("AZURITE_QUEUE_STORAGE_URL", "http://127.0.0.1:10001")?;
         let table_storage_url =
             url_from_env("AZURITE_TABLE_STORAGE_URL", "http://127.0.0.1:10002")?;
-        let filesystem_url = url_from_env("AZURITE_TABLE_STORAGE_URL", "http://127.0.0.1:10004")?;
+        let filesystem_url =
+            url_from_env("AZURITE_TABLE_STORAGE_URL", "http://127.0.0.1:10004")?;
 
         let storage_client = StorageAccountClient::new_emulator(
             http_client,
@@ -588,8 +592,6 @@ pub fn new_azure(
         // make url ending consistent between the emulator and remote storage account
         .trim_end_matches('/')
         .to_string();
-
-    println!("AAL using remote blob base URL: {}", blob_base_url);
 
     let container_name = container_name.into();
 

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -38,6 +38,8 @@ use futures::{
 use snafu::{ResultExt, Snafu};
 use std::collections::BTreeSet;
 use std::{convert::TryInto, sync::Arc};
+use tokio::io::AsyncWrite;
+use url::Url;
 
 /// A specialized `Error` for Azure object store-related errors
 #[derive(Debug, Snafu)]
@@ -158,6 +160,18 @@ enum Error {
         "Azurite (azure emulator) support not compiled in, please add `azure_test` feature"
     ))]
     NoEmulatorFeature,
+
+    #[snafu(display(
+        "Unable parse emulator url {}={}, Error: {}",
+        env_name,
+        env_value,
+        source
+    ))]
+    UnableToParseEmulatorUrl {
+        env_name: String,
+        env_value: String,
+        source: url::ParseError,
+    },
 }
 
 impl From<Error> for super::Error {
@@ -507,6 +521,19 @@ fn check_if_emulator_works() -> Result<()> {
     Err(Error::NoEmulatorFeature.into())
 }
 
+/// Parses the contents of the environment variable `env_name` as a URL
+/// if present, otherwise falls back to default_url
+fn url_from_env(env_name: &str, default_url: &str) -> Result<Url> {
+    let url = match std::env::var(env_name) {
+        Ok(env_value) => Url::parse(&env_value).context(UnableToParseEmulatorUrlSnafu {
+            env_name,
+            env_value,
+        })?,
+        Err(_) => Url::parse(default_url).expect("Failed to parse default URL"),
+    };
+    Ok(url)
+}
+
 /// Configure a connection to container with given name on Microsoft Azure
 /// Blob store.
 ///
@@ -524,7 +551,25 @@ pub fn new_azure(
 
     let (is_emulator, storage_account_client) = if use_emulator {
         check_if_emulator_works()?;
-        (true, StorageAccountClient::new_emulator_default())
+        // Allow overriding defaults. Values taken from
+        // from https://docs.rs/azure_storage/0.2.0/src/azure_storage/core/clients/storage_account_client.rs.html#129-141
+        let http_client = azure_core::new_http_client();
+        let blob_storage_url = url_from_env("AZURITE_BLOB_STORAGE_URL", "http://127.0.0.1:10000")?;
+        let queue_storage_url =
+            url_from_env("AZURITE_QUEUE_STORAGE_URL", "http://127.0.0.1:10001")?;
+        let table_storage_url =
+            url_from_env("AZURITE_TABLE_STORAGE_URL", "http://127.0.0.1:10002")?;
+        let filesystem_url = url_from_env("AZURITE_TABLE_STORAGE_URL", "http://127.0.0.1:10004")?;
+
+        let storage_client = StorageAccountClient::new_emulator(
+            http_client,
+            &blob_storage_url,
+            &table_storage_url,
+            &queue_storage_url,
+            &filesystem_url,
+        );
+
+        (true, storage_client)
     } else {
         (
             false,
@@ -543,6 +588,8 @@ pub fn new_azure(
         // make url ending consistent between the emulator and remote storage account
         .trim_end_matches('/')
         .to_string();
+
+    println!("AAL using remote blob base URL: {}", blob_base_url);
 
     let container_name = container_name.into();
 


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2030


# Rationale for this change
 
https://github.com/apache/arrow-rs/pull/2081 brought in the `object_store_rs` code, but did not include the test scripts for running object store tests against s3/azure/gcp simulators



# What changes are included in this PR?

Adds github action based tests for running object store integration tests
Adds scripts + small object store configuration changes required to run them

It is based on my PR https://github.com/influxdata/object_store_rs/pull/51 which I used to prototype the changes

I ported this using these commands:
```shell
$ git fetch git@github.com:alamb/object_store_rs.git alamb/test_gh_actions
$ git cherry-pick 25f4896
# and manually fixed some things
```

# Are there any user-facing changes?

Not really