### PR TITLE
Do not pretend to cache rust build artifacts, speed up CI by ~20%

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./dev/release/run-rat.sh .
 
   prettier:
-    name: Use prettier to check formatting of documents
+    name: Use prettier to check formatting of markdown documents
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,34 +24,9 @@ on:
 
 jobs:
 
-  # build the library, a compilation step used by multiple steps below
-  linux-build-lib:
-    name: Build Libraries on AMD64 Rust ${{ matrix.rust }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Build Workspace
-        run: |
-          cargo build
-
   # test the crate
   linux-test:
     name: Test Workspace on AMD64 Rust ${{ matrix.rust }}
-    needs: [ linux-build-lib ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -159,8 +134,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      # TODO: this won't cache anything, which is expensive. Setup this action
-      # with a OS-dependent path.
       - name: Setup Rust toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }} --no-self-update
@@ -176,7 +149,6 @@ jobs:
 
   clippy:
     name: Clippy
-    needs: [ linux-build-lib ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -264,12 +236,6 @@ jobs:
           path: /home/runner/.cargo
           # this key is not equal because the user is different than on a container (runner vs github)
           key: cargo-coverage-cache3-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/target
-          # this key is not equal because coverage uses different compilation flags.
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-coverage-cache3-${{ matrix.rust }}-
       - name: Run coverage
         run: |
           export CARGO_HOME="/home/runner/.cargo"
@@ -311,11 +277,6 @@ jobs:
         with:
           path: /github/home/.cargo
           key: cargo-wasm32-cache3-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home/target
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache3-${{ matrix.rust }}
       - name: Setup Rust toolchain for WASM
         run: |
           rustup toolchain install ${{ matrix.rust }}


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149


# Rationale for this change
 
Caching rust build artifacts (aka the contents of `target`)  is notoriously difficult (as the slightest change in various environments or dependencies often causes a significant recompile). 

However, the CI jobs spent a non trivial amount of time attempting to cache the artifacts unsuccessfully (as my measurements below will show). Until someone has some time to get the caching working properly, I propose we simply stop trying and save ourselves some time (and github worker rate-limit credits)

# What changes are included in this PR?

Remove the `linux-build-lib` job as it gates other jobs from starting but does not save any time

# Are there any user-facing changes?
Hopefully faster CI

Master PR before this change: https://github.com/apache/arrow-rs/pull/2144/checks
Rust run took:  *38m 44s*: https://github.com/apache/arrow-rs/actions/runs/2724270288/usage

This PR: https://github.com/apache/arrow-rs/pull/2150/checks
Rust run took: *30 m39s*: https://github.com/apache/arrow-rs/actions/runs/2724923930/usage