### PR TITLE
Break out docs CI job to its own github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
         rust: [ nightly ]
     container:
       image: ${{ matrix.arch }}/rust
+      env:
         RUSTDOCFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,17 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Docs
 
 on:
   # always trigger
   push:
-    paths:
-      # Only run when rust or github files are changed
-      - **/*.rs
-      - .github/**
   pull_request:
-    paths:
-      # Only run when rust or github files are changed
-      - **/*.rs
-      - .github/**
 
 jobs:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  # always trigger
+  push:
+    paths:
+      # Only run when rust or github files are changed
+      - **/*.rs
+      - .github/**
+  pull_request:
+    paths:
+      # Only run when rust or github files are changed
+      - **/*.rs
+      - .github/**
+
+jobs:
+
+  # test doc links still work
+  docs:
+    name: Rustdocs are clean
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ amd64 ]
+        rust: [ nightly ]
+    container:
+      image: ${{ matrix.arch }}/rust
+        RUSTDOCFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install python dev
+        run: |
+          apt update
+          apt install -y libpython3.9-dev
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: Run cargo doc
+        run: |
+          cargo doc --document-private-items --no-deps --workspace --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -327,34 +327,3 @@ jobs:
           cd arrow
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-unknown-unknown
           cargo build --no-default-features --features=csv,ipc,simd --target wasm32-wasi
-
-  # test doc links still work
-  docs:
-    name: Docs are clean on AMD64 Rust ${{ matrix.rust }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ nightly ]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-        RUSTDOCFLAGS: "-Dwarnings"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Install python dev
-        run: |
-          apt update
-          apt install -y libpython3.9-dev
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Run cargo doc
-        run: |
-          cargo doc --document-private-items --no-deps --workspace --all-features


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
Running all CI jobs on all PRs is wasteful; Breaking the workflows into multiple actions is a precursor to being more deliberate about what actions to run based on changes in this PR 

# What changes are included in this PR?
Break the `rustdoc` check into its own file, name it reasonably

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
