### PR TITLE
Only run integration tests when `arrow` changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,14 +17,21 @@
 
 name: Integration
 
+# Only run when arrow or github changes
 on:
   push:
+    paths:
+      - arrow/**
+      - .github/**
   pull_request:
+    paths:
+      - arrow/**
+      - .github/**
 
 jobs:
 
   integration:
-    name: Integration Test
+    name: Archery test With other arrows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Arrow
@@ -49,7 +56,7 @@ jobs:
 
   # test FFI against the C-Data interface exposed by pyarrow
   pyarrow-integration-test:
-    name: Test Pyarrow C Data Interface
+    name: Pyarrow C Data Interface
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
These actions test the integration of the `arrow` crate, yet they run on all PRs (including `parquet` changes and now also `object_store` changes) and they take significant time (32 minutes), often the longest test in the suite

# What changes are included in this PR?

1. Only run this integration if files in `arrow` or `.github` change
2. Rename test to be more specific

# Are there any user-facing changes?

no

# Testing:
* Positive (a change to `.github`, in this PR): https://github.com/apache/arrow-rs/runs/7483623018?check_suite_focus=true
* Postive (a change to `arrow`): I need to merge this PR to test
* Negative(a change to `parquet`): I need to merge this PR to test