### PR TITLE
Break parquet_derive and arrow_flight tests into their own workflows

### DIFF
--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+name: "Arrow Flight"
+
+on:
+  pull_request:
+
+jobs:
+  # test the crate
+  linux-test:
+    name: Test
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Tests with default features
+        run: |
+          cargo test -p arrow-flight
+      - name: Tests with all features
+        run: |
+          cargo test -p arrow-flight --all-features

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -25,7 +25,6 @@ jobs:
   # test the crate
   linux-test:
     name: Test
-    needs: [ linux-build-lib ]
     runs-on: ubuntu-latest
     container:
       image: amd64/rust

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -25,7 +25,6 @@ jobs:
   # test the crate
   linux-test:
     name: Test
-    needs: [ linux-build-lib ]
     runs-on: ubuntu-latest
     container:
       image: amd64/rust

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+name: "Parquet Derive"
+
+on:
+  pull_request:
+
+jobs:
+  # test the crate
+  linux-test:
+    name: Test
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Test crate
+        run: |
+          cargo test -p parquet_derive

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,9 +71,6 @@ jobs:
           cargo check -p arrow --all-targets
           cargo check -p arrow --no-default-features --all-targets
           cargo check -p arrow --no-default-features --all-targets --features test_utils
-      - name: Re-run tests on arrow-flight with all features
-        run: |
-          cargo test -p arrow-flight --all-features
       - name: Re-run tests on parquet crate with all features
         run: |
           cargo test -p parquet --all-features
@@ -88,9 +85,6 @@ jobs:
           cargo check -p parquet --all-targets
           cargo check -p parquet --no-default-features --all-targets
           cargo check -p parquet --no-default-features --features arrow --all-targets
-      - name: Test compilation of parquet_derive macro with different feature combinations
-        run: |
-          cargo check -p parquet_derive
 
   # test the --features "simd" of the arrow crate. This requires nightly.
   linux-test-simd:


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change

There is the broader issues described in  https://github.com/apache/arrow-rs/issues/2149 of making Arrow CI jobs more efficient by being more fine grained. 

In addition, the current `test` job both takes a long time and takes a lot of disk space -- see https://github.com/apache/arrow-rs/pull/2148#issuecomment-1194043930 for example. So reducing the number of checks done in a single job should reduce its chances of running out of disk space
 

# What changes are included in this PR?

Move `parquet_derive` and `arrow_flight` jobs into their own workflow

# Are there any user-facing changes?

Hopefully less CI failures due to out of disk space