### PR TITLE
Run actions on push to master, pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ name: Docs
 on:
   # always trigger
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,9 +20,8 @@ name: Integration
 # Only run when arrow or github changes
 on:
   push:
-    paths:
-      - arrow/**
-      - .github/**
+    branches:
+      - master
   pull_request:
     paths:
       - arrow/**

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -20,6 +20,8 @@ name: MIRI
 on:
   # always trigger
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -19,6 +19,9 @@
 name: "Object Store"
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     paths:
       # Only run when object store files or github workflows change

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,8 @@ name: Rust
 on:
   # always trigger
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
# Which issue does this PR close?

Re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
While wondering "why did we run out of github actions credits" (when my test jobs are waiting for a runner) I looked at the history of actions https://github.com/apache/arrow-rs/actions and saw several jobs were started *twice* 

![Screen Shot 2022-07-25 at 10 00 47 AM](https://user-images.githubusercontent.com/490673/180795752-261f7636-be68-47fe-8f70-b645dfaa2c08.png)

I have noticed the same thing on some of my own PRs but I have not found any recent examples. 



# What changes are included in this PR?

Change jobs to trigger on push to `master` only as well as PRs

# Are there any user-facing changes?

No