### PR TITLE
Remove another attempt to cache target directory in action.yaml

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -42,14 +42,6 @@ runs:
     - name: Generate lockfile
       shell: bash
       run: cargo fetch
-    - name: Cache Rust dependencies
-      uses: actions/cache@v3
-      with:
-        # these represent compiled steps of both dependencies and arrow
-        # and thus are specific for a particular OS, arch and rust version.
-        path: /github/home/target
-        key: ${{ runner.os }}-${{ runner.arch }}-target-cache3-${{ inputs.rust-version }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-target-cache3-${{ inputs.rust-version }}-
     - name: Install Build Dependencies
       shell: bash
       run: |


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change

I removed most of the ineffective "try to cache `target`" logic in  https://github.com/apache/arrow-rs/pull/2150 but I missed one

I noticed this while looking at the failure here: https://github.com/apache/arrow-rs/runs/7500811391?check_suite_focus=true

It basically runs out of disk space when trying to copy all of `target` into the cache (and it took 3m to do so)

![Screen Shot 2022-07-25 at 1 40 32 PM](https://user-images.githubusercontent.com/490673/180840419-83ef6400-c9d4-4e4f-baf8-a42d842678c8.png)


# What changes are included in this PR?

Remove attempt to cache target directory from common setup-builder action

# Are there any user-facing changes?

Hopefully less CI failures due to out of disk space