### PR TITLE
Let the `StringBuilder` use `BinaryBuilder`

### DIFF
--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -20,8 +20,8 @@ use std::fmt;
 use std::{any::Any, iter::FromIterator};
 
 use super::{
-    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, GenericBinaryArray, GenericListArray,
-    GenericStringIter, OffsetSizeTrait,
+    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData,
+    GenericBinaryArray, GenericListArray, GenericStringIter, OffsetSizeTrait,
 };
 use crate::array::array::ArrayAccessor;
 use crate::buffer::Buffer;
@@ -313,19 +313,23 @@ impl<'a, OffsetSize: OffsetSizeTrait> ArrayAccessor
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> From<GenericListArray<OffsetSize>> for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> From<GenericListArray<OffsetSize>>
+    for GenericStringArray<OffsetSize>
+{
     fn from(v: GenericListArray<OffsetSize>) -> Self {
         GenericStringArray::<OffsetSize>::from_list(v)
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> From<GenericBinaryArray<OffsetSize>> for GenericStringArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait> From<GenericBinaryArray<OffsetSize>>
+    for GenericStringArray<OffsetSize>
+{
     fn from(v: GenericBinaryArray<OffsetSize>) -> Self {
         let builder = v
             .into_data()
             .into_builder()
             .data_type(Self::get_data_type());
-        let data = unsafe {builder.build_unchecked()};
+        let data = unsafe { builder.build_unchecked() };
         Self::from(data)
     }
 }

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::{any::Any, iter::FromIterator};
 
 use super::{
-    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, GenericListArray,
+    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, GenericBinaryArray, GenericListArray,
     GenericStringIter, OffsetSizeTrait,
 };
 use crate::array::array::ArrayAccessor;
@@ -313,6 +313,23 @@ impl<'a, OffsetSize: OffsetSizeTrait> ArrayAccessor
     }
 }
 
+impl<OffsetSize: OffsetSizeTrait> From<GenericListArray<OffsetSize>> for GenericStringArray<OffsetSize> {
+    fn from(v: GenericListArray<OffsetSize>) -> Self {
+        GenericStringArray::<OffsetSize>::from_list(v)
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait> From<GenericBinaryArray<OffsetSize>> for GenericStringArray<OffsetSize> {
+    fn from(v: GenericBinaryArray<OffsetSize>) -> Self {
+        let builder = v
+            .into_data()
+            .into_builder()
+            .data_type(Self::get_data_type());
+        let data = unsafe {builder.build_unchecked()};
+        Self::from(data)
+    }
+}
+
 impl<OffsetSize: OffsetSizeTrait> From<ArrayData> for GenericStringArray<OffsetSize> {
     fn from(data: ArrayData) -> Self {
         assert_eq!(
@@ -384,12 +401,6 @@ pub type StringArray = GenericStringArray<i32>;
 /// assert_eq!(array.value(2), "bar");
 /// ```
 pub type LargeStringArray = GenericStringArray<i64>;
-
-impl<T: OffsetSizeTrait> From<GenericListArray<T>> for GenericStringArray<T> {
-    fn from(v: GenericListArray<T>) -> Self {
-        GenericStringArray::<T>::from_list(v)
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/arrow/src/array/builder/generic_binary_builder.rs
+++ b/arrow/src/array/builder/generic_binary_builder.rs
@@ -48,6 +48,19 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
         }
     }
 
+    /// Creates a new [`GenericBinaryBuilder`],
+    /// `item_capacity` is the number of items to pre-allocate space for in this builder
+    /// `data_capacity` is the number of bytes to pre-allocate space for in this builder
+    pub fn with_capacity(item_capacity: usize, data_capacity: usize) -> Self {
+        let mut offsets_builder = BufferBuilder::<OffsetSize>::new(item_capacity + 1);
+        offsets_builder.append(OffsetSize::zero());
+        Self {
+            value_builder: UInt8BufferBuilder::new(data_capacity),
+            offsets_builder,
+            null_buffer_builder: NullBufferBuilder::new(item_capacity),
+        }
+    }
+
     /// Appends a byte slice into the builder.
     #[inline]
     pub fn append_value(&mut self, value: impl AsRef<[u8]>) {
@@ -81,6 +94,16 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryBuilder<OffsetSize> {
         self.offsets_builder.append(OffsetSize::zero());
         let array_data = unsafe { array_builder.build_unchecked() };
         GenericBinaryArray::<OffsetSize>::from(array_data)
+    }
+
+    /// Returns the current values buffer as a slice
+    pub fn values_slice(&self) -> &[u8] {
+        self.value_builder.as_slice()
+    }
+
+    /// Returns the current offsets buffer as a slice
+    pub fn offsets_slice(&self) -> &[OffsetSize] {
+        self.offsets_builder.as_slice()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2156.

# Rationale for this change
Using less memory and faster.

## Benchmark
Tested on Intel Ubuntu
```
Benchmarking bench_primitive/bench_string: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
bench_primitive/bench_string                                                                             
                        time:   [1.7409 ms 1.7420 ms 1.7432 ms]
                        thrpt:  [3.6413 GiB/s 3.6440 GiB/s 3.6462 GiB/s]
                 change:
                        time:   [-7.9510% -7.7647% -7.5385%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1532% +8.4184% +8.6378%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```

# What changes are included in this PR?
1. Update the String Builder to use Binary Builder
2. Add some methods to Binary Builder because we use them in the String Builder.
3. Update tests.
4. Add from<binary_array> for string array.

# Are there any user-facing changes?
Delete the pub method `StringBuilder::append(bool)`.
