### PR TITLE
Change CI names to match crate names

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 # tests for arrow crate
-name: Arrow
+name: arrow
 
 on:
   # always trigger

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -16,7 +16,8 @@
 # under the License.
 
 ---
-name: "Arrow Flight"
+# tests for arrow_flight crate
+name: "arrow_flight"
 
 on:
   pull_request:

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -17,7 +17,7 @@
 
 ---
 # tests for arrow_flight crate
-name: "arrow_flight"
+name: arrow_flight
 
 on:
   pull_request:

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -16,7 +16,8 @@
 # under the License.
 
 ---
-name: "Object Store"
+# tests for object_store crate
+name: object_store
 
 on:
   push:

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -16,7 +16,8 @@
 # under the License.
 
 ---
-name: "Parquet Derive"
+# tests for parquet_derive crate
+name: parquet_derive
 
 on:
   pull_request:


### PR DESCRIPTION
# Which issue does this PR close?
RE https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
OCD making the names of the CI jobs easier to match with the code they test

# What changes are included in this PR?

Change CI names to match crates
