### PR TITLE
Break parquet CI into its own workflow, standardize step names 

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -169,4 +169,4 @@ jobs:
           rustup component add clippy
       - name: Run clippy
         run: |
-          cargo clippy -p arrow --features test_common --features prettyprint  --features=async --all-targets --workspace -- -D warnings
+          cargo clippy -p arrow --features test_common --features prettyprint  --features=async --all-targets -- -D warnings

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -45,10 +45,10 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Test default features
+      - name: Test
         run: |
           cargo test -p arrow
-      - name: Test all supported features
+      - name: Test --features=force_validate,prettyprint
         run: |
           cargo test -p arrow --features=force_validate,prettyprint
       - name: Run examples
@@ -61,7 +61,7 @@ jobs:
 
   # test compilaton features
   linux-features:
-    name: Feature Compatibility
+    name: Check Compilation
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -77,14 +77,23 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Test compilation with different features
+      - name: Check compilation
+        run: |
+          cargo check -p arrow
+      - name: Check compilation --no-default-features
         run: |
           cargo check -p arrow --no-default-features
+      - name: Check compilation --all-targets
+        run: |
           cargo check -p arrow --all-targets
+      - name: Check compilation --no-default-features --all-targets
+        run: |
           cargo check -p arrow --no-default-features --all-targets
+      - name: Check compilation --no-default-features --all-targets --features test_utils
+        run: |
           cargo check -p arrow --no-default-features --all-targets --features test_utils
 
-  # test the --features "simd" of the arrow crate. This requires nightly.
+  # test the --features "simd" of the arrow crate. This requires nightly Rust.
   linux-test-simd:
     name: Test SIMD on AMD64 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
@@ -102,12 +111,14 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: nightly
-      - name: Run tests
+      - name: Run tests --features "simd"
         run: |
           cargo test -p arrow --features "simd"
-      - name: Check compilation with simd features
+      - name: Check compilation --features "simd"
         run: |
           cargo check -p arrow --features simd
+      - name: Check compilation --features simd --all-targets
+        run: |
           cargo check -p arrow --features simd --all-targets
 
 

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -169,4 +169,4 @@ jobs:
           rustup component add clippy
       - name: Run clippy
         run: |
-          cargo clippy -p arrow --features test_common --features prettyprint  --features=async --all-targets -- -D warnings
+          cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils --all-targets -- -D warnings

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -40,9 +40,9 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Tests with default features
+      - name: Test
         run: |
           cargo test -p arrow-flight
-      - name: Tests with all features
+      - name: Test --all-features
         run: |
           cargo test -p arrow-flight --all-features

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -46,3 +46,21 @@ jobs:
       - name: Test --all-features
         run: |
           cargo test -p arrow-flight --all-features
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Setup Clippy
+        run: |
+          rustup component add clippy
+      - name: Run clippy
+        run: |
+          cargo clippy -p arrow-flight --all-features -- -D warnings

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -105,4 +105,7 @@ jobs:
           rustup component add clippy
       - name: Run clippy
         run: |
-          cargo clippy -p parquet --all-targets --all-features -- -D warnings
+          # Only run clippy for the library at this time,
+          # as there are clippy errors for other targets
+          cargo clippy -p parquet --all-features --lib -- -D warnings
+          #cargo clippy -p parquet --all-targets --all-features -- -D warnings

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -108,4 +108,5 @@ jobs:
           # Only run clippy for the library at this time,
           # as there are clippy errors for other targets
           cargo clippy -p parquet --all-features --lib -- -D warnings
+          # https://github.com/apache/arrow-rs/issues/1254
           #cargo clippy -p parquet --all-targets --all-features -- -D warnings

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+# tests for parquet crate
+name: "parquet"
+
+on:
+  pull_request:
+
+jobs:
+  # test the crate
+  linux-test:
+    name: Test
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Test
+        run: |
+          cargo test -p parquet
+      - name: Test --all-features
+        run: |
+          cargo test -p parquet --all-features
+
+
+  # test compilaton
+  linux-features:
+    name: Check Compilation
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check compilation
+        run: |
+          cargo check -p parquet
+      - name: Check compilation --no-default-features
+        run: |
+          cargo check -p parquet --no-default-features
+      - name: Check compilation --no-default-features --features arrow
+        run: |
+          cargo check -p parquet --no-default-features --features arrow
+      - name: Check compilation --no-default-features --all-features
+        run: |
+          cargo check -p parquet --all-features
+      - name: Check compilation --all-targets
+        run: |
+          cargo check -p parquet --all-targets
+      - name: Check compilation --no-default-features --all-targets
+        run: |
+          cargo check -p parquet --no-default-features --all-targets
+      - name: Check compilation --no-default-features --features-arrow --all-targets
+        run: |
+          cargo check -p parquet --no-default-features --features arrow --all-targets
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Setup Clippy
+        run: |
+          rustup component add clippy
+      - name: Run clippy
+        run: |
+          cargo clippy -p parquet --all-targets --all-features -- -D warnings

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -43,3 +43,21 @@ jobs:
       - name: Test
         run: |
           cargo test -p parquet_derive
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Setup Clippy
+        run: |
+          rustup component add clippy
+      - name: Run clippy
+        run: |
+          cargo clippy -p parquet_derive --all-features -- -D warnings

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -40,6 +40,6 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Test crate
+      - name: Test
         run: |
           cargo test -p parquet_derive

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,34 +81,6 @@ jobs:
           export RUSTFLAGS="-C debuginfo=0"
           cargo test
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Setup Clippy
-        run: |
-          rustup component add clippy
-      - name: Run clippy
-        run: |
-          cargo clippy --features test_common --features prettyprint  --features=async --all-targets --workspace -- -D warnings
-
   check_benches:
     name: Check Benchmarks (but don't run them)
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,19 +55,6 @@ jobs:
           # run tests on all workspace members with default feature list
           cargo test
       - name: Re-run tests on parquet crate with all features
-        run: |
-          cargo test -p parquet --all-features
-      - name: Test compilation of parquet library crate with different feature combinations
-        run: |
-          cargo check -p parquet
-          cargo check -p parquet --no-default-features
-          cargo check -p parquet --no-default-features --features arrow
-          cargo check -p parquet --all-features
-      - name: Test compilation of parquet targets with different feature combinations
-        run: |
-          cargo check -p parquet --all-targets
-          cargo check -p parquet --no-default-features --all-targets
-          cargo check -p parquet --no-default-features --features arrow --all-targets
 
 
   windows-and-macos:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,37 +26,6 @@ on:
 
 jobs:
 
-  # test the crate
-  linux-test:
-    name: Test Workspace on AMD64 Rust ${{ matrix.rust }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-        ARROW_TEST_DATA: /__w/arrow-rs/arrow-rs/testing/data
-        PARQUET_TEST_DATA: /__w/arrow-rs/arrow-rs/parquet-testing/data
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Run tests
-        run: |
-          # run tests on all workspace members with default feature list
-          cargo test
-      - name: Re-run tests on parquet crate with all features
-
-
   windows-and-macos:
     name: Test on ${{ matrix.os }} Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -182,6 +182,10 @@ impl RleEncoder {
         self.bit_writer.bytes_written()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.bit_writer.bytes_written() == 0
+    }
+
     #[inline]
     pub fn consume(mut self) -> Result<Vec<u8>> {
         self.flush()?;


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
Having the CI checks broken up by crate is a prerequisite for more specific triggering them

# What changes are included in this PR?

1. Break parquet CI into its own workflow
2. Standardize testing names
3. Run clippy on each target (remove overall workspace run)
3. Run tests for each target (remove overall workspace run)

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
