### PR TITLE
object_store: update azure dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,9 @@ resolver = "2"
 # how it is compiled within the workspace, causing the whole workspace to be compiled from scratch
 # this way, this is a stand-alone package that compiles independently of the others.
 exclude = ["arrow-pyarrow-integration-testing"]
+
+# TEMP: pin to upstream azure crate until 0.3 is released
+[patch.crates-io]
+azure_core = {  git = "https://github.com/Azure/azure-sdk-for-rust.git", branch="main" }
+azure_storage = {  git = "https://github.com/Azure/azure-sdk-for-rust.git", branch="main" }
+azure_storage_blobs= {  git = "https://github.com/Azure/azure-sdk-for-rust.git", branch="main" }

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -35,9 +35,9 @@ all-features = true
 [dependencies] # In alphabetical order
 async-trait = "0.1.53"
 # Microsoft Azure Blob storage integration
-azure_core = { version = "0.2", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
-azure_storage = { version = "0.2", optional = true, default-features = false, features = ["account"] }
-azure_storage_blobs = { version = "0.2", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
+azure_core = { version = "0.3", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
+azure_storage = { version = "0.3", optional = true, default-features = false, features = ["account"] }
+azure_storage_blobs = { version = "0.3", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # Google Cloud Storage integration


### PR DESCRIPTION
Draft until new upstream ms azure sdk is updated

# Which issue does this PR close?

re https://github.com/influxdata/object_store_rs/pull/36
See also https://github.com/apache/arrow-rs/issues/2176 which may obviate it

# Rationale for this change

 Ports https://github.com/influxdata/object_store_rs/pull/36

cc @roeap 

I did so with these commands

```shell
git checkout -b alamb/test_update_azure
git fetch git@github.com:roeap/object_store_rs.git azure-dependencies
git cherry-pick 7bf6630d7cfe7c8e02cc4cd44d985e1de2711c3c
# manually resolved conflicts  in Cargo.toml
```

# What changes are included in this PR?

Ported https://github.com/influxdata/object_store_rs/pull/36 to this repo

# Are there any user-facing changes?

not sure