### PR TITLE
Use BitChunks in equal_bits

### DIFF
--- a/arrow/benches/equal.rs
+++ b/arrow/benches/equal.rs
@@ -51,6 +51,9 @@ fn add_benchmark(c: &mut Criterion) {
 
     let arr_a = create_boolean_array(513, 0.0, 0.5);
     c.bench_function("equal_bool_513", |b| b.iter(|| bench_equal(&arr_a)));
+
+    let arr_a = create_boolean_array(1024, 0.0, 0.5);
+    c.bench_function("equal_bool_1024", |b| b.iter(|| bench_equal(&arr_a)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/arrow/benches/equal.rs
+++ b/arrow/benches/equal.rs
@@ -51,9 +51,6 @@ fn add_benchmark(c: &mut Criterion) {
 
     let arr_a = create_boolean_array(513, 0.0, 0.5);
     c.bench_function("equal_bool_513", |b| b.iter(|| bench_equal(&arr_a)));
-
-    let arr_a = create_boolean_array(1024, 0.0, 0.5);
-    c.bench_function("equal_bool_1024", |b| b.iter(|| bench_equal(&arr_a)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -23,6 +23,7 @@ use crate::datatypes::{
     UnionMode,
 };
 use crate::error::{ArrowError, Result};
+use crate::util::bit_iterator::BitSliceIterator;
 use crate::{bitmap::Bitmap, datatypes::ArrowNativeType};
 use crate::{
     buffer::{Buffer, MutableBuffer},
@@ -36,6 +37,21 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use super::equal::equal;
+
+#[inline]
+pub(crate) fn contains_nulls(
+    null_bit_buffer: Option<&Buffer>,
+    offset: usize,
+    len: usize,
+) -> bool {
+    match null_bit_buffer {
+        Some(buffer) => match BitSliceIterator::new(buffer, offset, len).next() {
+            Some((start, end)) => start != 0 || end != len,
+            None => false,
+        },
+        None => false, // No null buffer
+    }
+}
 
 #[inline]
 pub(crate) fn count_nulls(

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -47,7 +47,7 @@ pub(crate) fn contains_nulls(
     match null_bit_buffer {
         Some(buffer) => match BitSliceIterator::new(buffer, offset, len).next() {
             Some((start, end)) => start != 0 || end != len,
-            None => false,
+            None => len != 0, // No non-null values
         },
         None => false, // No null buffer
     }
@@ -2880,5 +2880,15 @@ mod tests {
 
         let err = data.validate_values().unwrap_err();
         assert_eq!(err.to_string(), "Invalid argument error: Offset invariant failure: offset at position 1 out of bounds: 3 > 2");
+    }
+
+    #[test]
+    fn test_contains_nulls() {
+        let buffer: Buffer = MutableBuffer::from_iter([false, false, false, true, true, false]).into();
+
+        assert!(contains_nulls(Some(&buffer), 0, 6));
+        assert!(contains_nulls(Some(&buffer), 0, 3));
+        assert!(!contains_nulls(Some(&buffer), 3, 2));
+        assert!(!contains_nulls(Some(&buffer), 0, 0));
     }
 }

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -2884,7 +2884,8 @@ mod tests {
 
     #[test]
     fn test_contains_nulls() {
-        let buffer: Buffer = MutableBuffer::from_iter([false, false, false, true, true, false]).into();
+        let buffer: Buffer =
+            MutableBuffer::from_iter([false, false, false, true, true, false]).into();
 
         assert!(contains_nulls(Some(&buffer), 0, 6));
         assert!(contains_nulls(Some(&buffer), 0, 3));

--- a/arrow/src/array/equal/boolean.rs
+++ b/arrow/src/array/equal/boolean.rs
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::util::bit_util::get_bit;
 
 use super::utils::{equal_bits, equal_len};
 
+/// Returns true if the value data for the arrays is equal, assuming the null masks have
+/// already been checked for equality
 pub(super) fn boolean_equal(
     lhs: &ArrayData,
     rhs: &ArrayData,
@@ -30,10 +32,9 @@ pub(super) fn boolean_equal(
     let lhs_values = lhs.buffers()[0].as_slice();
     let rhs_values = rhs.buffers()[0].as_slice();
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let contains_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !contains_nulls {
         // Optimize performance for starting offset at u8 boundary.
         if lhs_start % 8 == 0
             && rhs_start % 8 == 0
@@ -75,7 +76,6 @@ pub(super) fn boolean_equal(
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
         let lhs_null_bytes = lhs.null_buffer().as_ref().unwrap().as_slice();
-        let rhs_null_bytes = rhs.null_buffer().as_ref().unwrap().as_slice();
 
         let lhs_start = lhs.offset() + lhs_start;
         let rhs_start = rhs.offset() + rhs_start;
@@ -84,11 +84,8 @@ pub(super) fn boolean_equal(
             let lhs_pos = lhs_start + i;
             let rhs_pos = rhs_start + i;
             let lhs_is_null = !get_bit(lhs_null_bytes, lhs_pos);
-            let rhs_is_null = !get_bit(rhs_null_bytes, rhs_pos);
-            let lhs_is_true = get_bit(lhs_values, lhs_pos);
-            let rhs_is_true = get_bit(rhs_values, rhs_pos);
 
-            lhs_is_null == rhs_is_null && (lhs_is_null || (lhs_is_true == rhs_is_true))
+            lhs_is_null || get_bit(lhs_values, lhs_pos) == get_bit(rhs_values, rhs_pos)
         })
     }
 }
@@ -108,5 +105,14 @@ mod tests {
 
         let slice = array.slice(8, 24);
         assert_eq!(slice.data(), slice.data());
+    }
+
+    #[test]
+    fn test_sliced_nullable_boolean_array() {
+        let a = BooleanArray::from(vec![None; 32]);
+        let b = BooleanArray::from(vec![true; 32]);
+        let slice_a = a.slice(1, 12);
+        let slice_b = b.slice(1, 12);
+        assert_ne!(slice_a.data(), slice_b.data());
     }
 }

--- a/arrow/src/array/equal/boolean.rs
+++ b/arrow/src/array/equal/boolean.rs
@@ -85,10 +85,10 @@ pub(super) fn boolean_equal(
             let rhs_pos = rhs_start + i;
             let lhs_is_null = !get_bit(lhs_null_bytes, lhs_pos);
             let rhs_is_null = !get_bit(rhs_null_bytes, rhs_pos);
+            let lhs_is_true = get_bit(lhs_values, lhs_pos);
+            let rhs_is_true = get_bit(rhs_values, rhs_pos);
 
-            lhs_is_null
-                || (lhs_is_null == rhs_is_null)
-                    && equal_bits(lhs_values, rhs_values, lhs_pos, rhs_pos, 1)
+            lhs_is_null == rhs_is_null && (lhs_is_null || (lhs_is_true == rhs_is_true))
         })
     }
 }

--- a/arrow/src/array/equal/boolean.rs
+++ b/arrow/src/array/equal/boolean.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::array::{data::contains_nulls, ArrayData};
+use crate::util::bit_iterator::BitIndexIterator;
 use crate::util::bit_util::get_bit;
 
 use super::utils::{equal_bits, equal_len};
@@ -80,12 +81,10 @@ pub(super) fn boolean_equal(
         let lhs_start = lhs.offset() + lhs_start;
         let rhs_start = rhs.offset() + rhs_start;
 
-        (0..len).all(|i| {
+        BitIndexIterator::new(lhs_null_bytes, lhs_start, len).all(|i| {
             let lhs_pos = lhs_start + i;
             let rhs_pos = rhs_start + i;
-            let lhs_is_null = !get_bit(lhs_null_bytes, lhs_pos);
-
-            lhs_is_null || get_bit(lhs_values, lhs_pos) == get_bit(rhs_values, rhs_pos)
+            get_bit(lhs_values, lhs_pos) == get_bit(rhs_values, rhs_pos)
         })
     }
 }

--- a/arrow/src/array/equal/utils.rs
+++ b/arrow/src/array/equal/utils.rs
@@ -17,7 +17,7 @@
 
 use crate::array::{data::count_nulls, ArrayData};
 use crate::datatypes::DataType;
-use crate::util::bit_util;
+use crate::util::bit_chunk_iterator::BitChunks;
 
 // whether bits along the positions are equal
 // `lhs_start`, `rhs_start` and `len` are _measured in bits_.
@@ -29,10 +29,16 @@ pub(super) fn equal_bits(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    (0..len).all(|i| {
-        bit_util::get_bit(lhs_values, lhs_start + i)
-            == bit_util::get_bit(rhs_values, rhs_start + i)
-    })
+    let lhs = BitChunks::new(lhs_values, lhs_start, len);
+    let rhs = BitChunks::new(rhs_values, rhs_start, len);
+
+    for (a, b) in lhs.iter().zip(rhs.iter()) {
+        if a != b {
+            return false;
+        }
+    }
+
+    lhs.remainder_bits() == rhs.remainder_bits()
 }
 
 #[inline]


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2186 
Part of #2188 

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
```
equal_512               time:   [33.149 ns 33.153 ns 33.157 ns]                       
                        change: [-2.0324% -1.9669% -1.9098%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

equal_nulls_512         time:   [948.52 ns 948.88 ns 949.33 ns]                             
                        change: [-45.807% -45.682% -45.573%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe

equal_string_512        time:   [46.418 ns 46.430 ns 46.442 ns]                              
                        change: [-1.5368% -1.4796% -1.4286%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild

equal_string_nulls_512  time:   [4.1180 us 4.1189 us 4.1199 us]                                    
                        change: [-19.389% -19.355% -19.320%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

equal_bool_512          time:   [15.277 ns 15.286 ns 15.295 ns]                            
                        change: [-23.554% -23.428% -23.320%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild

equal_bool_513          time:   [23.229 ns 23.249 ns 23.268 ns]                            
                        change: [+4.4352% +4.6082% +4.7715%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild

```

Technically equal_bool_513 has regressed, but this is a fraction of a nanosecond so I think is unlikely to be all that meaningful in practice, and the significant millisecond improvements elsewhere are justification for this change

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
