### PR TITLE
Ignore broken symlinks for LocalFileSystem object store

### DIFF
--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -990,8 +990,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(target_os = "linux")]
-    // macos has some magic in its root '/.VolumeIcon.icns"' which causes this test to fail
     async fn test_list_root() {
         let integration = LocalFileSystem::new();
         let result = integration.list_with_delimiter(None).await;


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2174.

# Rationale for this change
 


 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`convert_walkdir_result` now ignores broken symlinks.

Resolution follows suggestions in:
* https://github.com/influxdata/object_store_rs/issues/49#issuecomment-1182687242
* https://doc.rust-lang.org/std/path/struct.Path.html#see-also-5

# What changes are included in this PR?

`convert_walkdir_result` now tests if a `DirEntry` is a symlink and if it is broken or not, function ignores broken symlinks (return `Ok(None)`.



# Are there any user-facing changes?

No.
