### PR TITLE
Ignore symlinks under LocalFileSystem root (#2174)

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -66,7 +66,6 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 parking_lot = { version = "0.12" }
 # Filesystem integration
 url = "2.2"
-walkdir = "2"
 
 [features]
 azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest"]

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -239,7 +239,6 @@ impl Config {
         )?)
     }
 
-
     /// List the contents of a directory, adding any files and directories to
     /// `files` and `dirs` respectively, and then returning them
     ///
@@ -250,7 +249,7 @@ impl Config {
         mut files: Vec<ObjectMeta>,
         mut dirs: Vec<PathBuf>,
     ) -> Result<(Vec<ObjectMeta>, Vec<PathBuf>)> {
-        let config = self.clone();
+        let config = Arc::clone(self);
         maybe_spawn_blocking(move || {
             let read_dir = match std::fs::read_dir(&dir) {
                 Ok(read_dir) => read_dir,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2174
Closes #2206 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The LocalFileSystem relies on canonicalizing filesystem paths to a URL in order to assign them a consistent key. This logic breaks down when encountering symlinks, as not only can files have multiple paths, but these paths may be outside the prefix of the LocalFileSystem itself. The simplest solution is to just not support them

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Explicitly ignore any symlinks encountered, which also allows dropping the walkdir dependency as we no longer need protection against filesystem loops caused by soft links. Hard link loops are impossible to handle, with most OSes preventing them.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

Symlinks will no longer be followed by LocalFileSystem