### PR TITLE
Run parquet CI jobs on push to master

### DIFF
--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -20,6 +20,10 @@
 name: "parquet"
 
 on:
+  # always trigger
+  push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149 where we are breaking up CI into smaller pieces that can be run more targeted


# Rationale for this change

in https://github.com/apache/arrow-rs/pull/2190 I forgot to trigger the parquet checks on merge to master


# What changes are included in this PR?

trigger parquet checks on merge to master (to ensure master is always clean)

# Are there any user-facing changes?