### PR TITLE
parquet: export json api with `serde_json` feature name

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -70,7 +70,9 @@ default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 # Enable arrow reader/writer APIs
 arrow = ["dep:arrow", "base64"]
 # Enable CLI tools
-cli = ["serde_json", "base64", "clap", "arrow/csv"]
+cli = ["json", "base64", "clap", "arrow/csv"]
+# Enable JSON APIs
+json = ["serde_json"]
 # Enable internal testing APIs
 test_common = ["arrow/test_utils"]
 # Experimental, unstable functionality primarily used for testing

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -27,7 +27,7 @@ use crate::data_type::{ByteArray, Decimal, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 
-#[cfg(any(feature = "serde_json", test))]
+#[cfg(any(feature = "json", test))]
 use serde_json::Value;
 
 /// Macro as a shortcut to generate 'not yet implemented' panic error.
@@ -79,7 +79,7 @@ impl Row {
         }
     }
 
-    #[cfg(any(feature = "serde_json", test))]
+    #[cfg(any(feature = "json", test))]
     pub fn to_json_value(&self) -> Value {
         Value::Object(
             self.fields
@@ -667,7 +667,7 @@ impl Field {
         }
     }
 
-    #[cfg(any(feature = "serde_json", test))]
+    #[cfg(any(feature = "json", test))]
     pub fn to_json_value(&self) -> Value {
         match &self {
             Field::Null => Value::Null,

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -27,7 +27,7 @@ use crate::data_type::{ByteArray, Decimal, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 
-#[cfg(any(feature = "cli", test))]
+#[cfg(any(feature = "serde_json", test))]
 use serde_json::Value;
 
 /// Macro as a shortcut to generate 'not yet implemented' panic error.
@@ -79,7 +79,7 @@ impl Row {
         }
     }
 
-    #[cfg(any(feature = "cli", test))]
+    #[cfg(any(feature = "serde_json", test))]
     pub fn to_json_value(&self) -> Value {
         Value::Object(
             self.fields
@@ -667,7 +667,7 @@ impl Field {
         }
     }
 
-    #[cfg(any(feature = "cli", test))]
+    #[cfg(any(feature = "serde_json", test))]
     pub fn to_json_value(&self) -> Value {
         match &self {
             Field::Null => Value::Null,
@@ -1685,7 +1685,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "cli", test))]
     fn test_to_json_value() {
         assert_eq!(Field::Null.to_json_value(), Value::Null);
         assert_eq!(Field::Bool(true).to_json_value(), Value::Bool(true));


### PR DESCRIPTION
# Rationale for this change
 
I'm trying to read parquet file without `arrow` dependency, for the sake of smaller binary size. However, `parquet::record::Row#to_json_value` is gated with `cli` feature flag, which introduces other unnecessary crates. 

# What changes are included in this PR?

Replace `feature = cli` with `feature = serde_json`.

# Are there any user-facing changes?

No. `serde_json` is already covered by `cli`.
