### PR TITLE
Update `FlightSqlService` trait to proxy handshake

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -15,10 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::pin::Pin;
+use futures::Stream;
 use arrow_flight::sql::{ActionCreatePreparedStatementResult, SqlInfo};
-use arrow_flight::FlightData;
+use arrow_flight::{FlightData, HandshakeRequest, HandshakeResponse};
 use tonic::transport::Server;
-use tonic::{Response, Status, Streaming};
+use tonic::{Request, Response, Status, Streaming};
 
 use arrow_flight::{
     flight_service_server::FlightService,
@@ -41,6 +43,46 @@ pub struct FlightSqlServiceImpl {}
 #[tonic::async_trait]
 impl FlightSqlService for FlightSqlServiceImpl {
     type FlightService = FlightSqlServiceImpl;
+
+    async fn do_handshake(
+        &self,
+        request: Request<Streaming<HandshakeRequest>>
+    ) -> Result<
+        Response<Pin<Box<dyn Stream<Item=Result<HandshakeResponse, Status>> + Send>>>,
+        Status
+    > {
+        let basic = "Basic ";
+        let authorization = request.metadata().get("authorization")
+            .ok_or(Status::invalid_argument("authorization field not present"))?
+            .to_str()
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        if !authorization.starts_with(basic) {
+            Err(Status::invalid_argument(format!("Auth type not implemented: {}", authorization)))?;
+        }
+        let base64 = &authorization[basic.len()..];
+        let bytes = base64::decode(base64)
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        let str = String::from_utf8(bytes)
+            .map_err(|_| Status::invalid_argument("authorization not parsable"))?;
+        let parts: Vec<_> = str.split(":").collect();
+        if parts.len() != 2 {
+            Err(Status::invalid_argument(format!("Invalid authorization header")))?;
+        }
+        let user = parts[0];
+        let pass = parts[1];
+        if user != "admin" || pass != "password" {
+            Err(Status::unauthenticated("Invalid credentials!"))?
+        }
+        let result = HandshakeResponse {
+            protocol_version: 0,
+            payload: "random_uuid_token".as_bytes().to_vec()
+        };
+        let result = Ok(result);
+        let output = futures::stream::iter(vec![result]);
+        return Ok(Response::new(Box::pin(output)));
+
+    }
+
     // get_flight_info
     async fn get_flight_info_statement(
         &self,

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -48,7 +48,7 @@ pub trait FlightSqlService:
     type FlightService: FlightService;
 
     /// Accept authentication and return a token
-    /// https://arrow.apache.org/docs/format/Flight.html#authentication
+    /// <https://arrow.apache.org/docs/format/Flight.html#authentication>
     async fn do_handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -56,7 +56,9 @@ pub trait FlightSqlService:
         Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
         Status,
     > {
-        Err(Status::unimplemented("Handshake has no default implementation"))
+        Err(Status::unimplemented(
+            "Handshake has no default implementation",
+        ))
     }
 
     /// Get a FlightInfo for executing a SQL query.

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -47,6 +47,13 @@ pub trait FlightSqlService:
     /// When impl FlightSqlService, you can always set FlightService to Self
     type FlightService: FlightService;
 
+    /// Accept authentication and return a token
+    /// https://arrow.apache.org/docs/format/Flight.html#authentication
+    async fn do_handshake(
+        &self,
+        request: Request<Streaming<HandshakeRequest>>,
+    ) -> Result<Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>, Status>;
+
     /// Get a FlightInfo for executing a SQL query.
     async fn get_flight_info_statement(
         &self,
@@ -256,9 +263,10 @@ where
 
     async fn handshake(
         &self,
-        _request: Request<Streaming<HandshakeRequest>>,
+        request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        Err(Status::unimplemented("Not yet implemented"))
+        let res = self.do_handshake(request).await?;
+        Ok(res)
     }
 
     async fn list_flights(

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -52,7 +52,10 @@ pub trait FlightSqlService:
     async fn do_handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,
-    ) -> Result<Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>, Status>;
+    ) -> Result<
+        Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
+        Status,
+    >;
 
     /// Get a FlightInfo for executing a SQL query.
     async fn get_flight_info_statement(

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -51,11 +51,13 @@ pub trait FlightSqlService:
     /// <https://arrow.apache.org/docs/format/Flight.html#authentication>
     async fn do_handshake(
         &self,
-        request: Request<Streaming<HandshakeRequest>>,
+        _request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<
         Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
         Status,
-    >;
+    > {
+        Err(Status::unimplemented("Handshake has no default implementation"))
+    }
 
     /// Get a FlightInfo for executing a SQL query.
     async fn get_flight_info_statement(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2210.

# Rationale for this change
 
Apache Arrow Ballista now supports FlightSQL, and can run simple statements like `select 1;`, however due to its architecture, tables need to be registered before any substantive queries can be run. Unfortunately, tables have to be registered on a context, or else the next query will have no idea that they were registered. The native Ballista protocol uses a [custom field](https://github.com/apache/arrow-ballista/blob/6bd0f6a58d0a7bdaf75af2c2485d56d5a812bea3/ballista/rust/core/proto/ballista.proto#L668) to implement this behavior, but for FlightSQL, we should use its [native method](https://arrow.apache.org/docs/format/Flight.html#authentication). However the existing FlightSqlService trait forces this [to return](https://github.com/apache/arrow-rs/blob/bc493d92c2a032a95d92dab81642f05182f20d81/arrow-flight/src/sql/server.rs#L261) an unimplemented Err.

# What changes are included in this PR?

Proxying of the `handshake()` method

# Are there any user-facing changes?

~~Other implementers of `FlightSqlService` will have to implement the method (they can just return `NotImplemented` as that was the previous behavior).~~
