### PR TITLE
remove redundant CI benchmark check, cleanups

### DIFF
--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Check compilation --all-targets --no-default-features
         run: |
           cargo check -p parquet --all-targets --no-default-features
-      - name: Check compilation  --all-targets --no-default-features --features-arrow
+      - name: Check compilation  --all-targets --no-default-features --features arrow
         run: |
           cargo check -p parquet --all-targets --no-default-features --features arrow
       - name: Check compilation  --all-targets --all-features

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -73,25 +73,16 @@ jobs:
           rust-version: stable
       - name: Check compilation
         run: |
-          cargo check -p parquet
-      - name: Check compilation --no-default-features
-        run: |
-          cargo check -p parquet --no-default-features
-      - name: Check compilation --no-default-features --features arrow
-        run: |
-          cargo check -p parquet --no-default-features --features arrow
-      - name: Check compilation --no-default-features --all-features
-        run: |
-          cargo check -p parquet --all-features
-      - name: Check compilation --all-targets
-        run: |
           cargo check -p parquet --all-targets
       - name: Check compilation --no-default-features --all-targets
         run: |
           cargo check -p parquet --no-default-features --all-targets
-      - name: Check compilation --no-default-features --features-arrow --all-targets
+      - name: Check compilation --no-default-features --features arrow --all-targets
         run: |
           cargo check -p parquet --no-default-features --features arrow --all-targets
+      - name: Check compilation --all-features --all-targets
+        run: |
+          cargo check -p parquet --all-features --all-targets
 
   clippy:
     name: Clippy

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -76,18 +76,41 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+
+        # Run different tests for the library on its own as well as
+        # all targets to ensure that it still works in the absence of
+        # features that might be enabled by dev-dependencies of other
+        # targets.
+        #
+        # This for each of (library and all-targets), check
+        # 1. compiles with default features
+        # 1. compiles with no default features
+        # 3. compiles with just arrow feature
+        # 3. compiles with all features
       - name: Check compilation
         run: |
+          cargo check -p parquet
+      - name: Check compilation --no-default-features
+        run: |
+          cargo check -p parquet --no-default-features
+      - name: Check compilation --no-default-features --features arrow
+        run: |
+          cargo check -p parquet --no-default-features --features arrow
+      - name: Check compilation --no-default-features --all-features
+        run: |
+          cargo check -p parquet --all-features
+      - name: Check compilation --all-targets
+        run: |
           cargo check -p parquet --all-targets
-      - name: Check compilation --no-default-features --all-targets
+      - name: Check compilation --all-targets --no-default-features
         run: |
-          cargo check -p parquet --no-default-features --all-targets
-      - name: Check compilation --no-default-features --features arrow --all-targets
+          cargo check -p parquet --all-targets --no-default-features
+      - name: Check compilation  --all-targets --no-default-features --features-arrow
         run: |
-          cargo check -p parquet --no-default-features --features arrow --all-targets
-      - name: Check compilation --all-features --all-targets
+          cargo check -p parquet --all-targets --no-default-features --features arrow
+      - name: Check compilation  --all-targets --all-features
         run: |
-          cargo check -p parquet --all-features --all-targets
+          cargo check -p parquet --all-targets --all-features
 
   clippy:
     name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,36 +44,9 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          export ARROW_TEST_DATA=$(pwd)/testing/data
-          export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
           # do not produce debug symbols to keep memory usage down
           export RUSTFLAGS="-C debuginfo=0"
           cargo test
-
-  check_benches:
-    name: Check Benchmarks (but don't run them)
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
-        with:
-          rust-version: ${{ matrix.rust }}
-      - name: Check benchmarks
-        run: |
-          cargo check --benches --workspace --features test_common,prettyprint,async,experimental
 
   lint:
     name: Lint (cargo fmt)
@@ -109,16 +82,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/.cargo
-          # this key is not equal because the user is different than on a container (runner vs github)
           key: cargo-coverage-cache3-
       - name: Run coverage
         run: |
-          export CARGO_HOME="/home/runner/.cargo"
-          export CARGO_TARGET_DIR="/home/runner/target"
-
-          export ARROW_TEST_DATA=$(pwd)/testing/data
-          export PARQUET_TEST_DATA=$(pwd)/parquet-testing/data
-
           rustup toolchain install stable
           rustup default stable
           cargo install --version 0.18.2 cargo-tarpaulin

--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -692,4 +692,3 @@ fn add_benches(c: &mut Criterion) {
 
 criterion_group!(benches, add_benches);
 criterion_main!(benches);
-

--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -692,3 +692,4 @@ fn add_benches(c: &mut Criterion) {
 
 criterion_group!(benches, add_benches);
 criterion_main!(benches);
+


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
Clean up CI so we don't have to deal with jobs that are not adding value

# What changes are included in this PR?
1. Remove redundeant benchmark check job (it is already covered by other jobs -- I will comment inline)
2. Remove unecessary environment variables from win/mac jobs
3. Removes redundant compile checks in parquet crate

# Are there any user-facing changes?

No