### PR TITLE
Deliberately  trigger CI workflows based on what files were changed

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,25 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+The CI is structured so most tests are run in specific workflows:
+`arrow.yml` for `arrow`, `parquet.yml` for `parquet` and so on.
+
+The basic idea is to run all tests on pushes to master (to ensure we
+keep master green) but run only the individual workflows on PRs that
+change files that could affect them.

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -19,8 +19,17 @@
 # tests for arrow_flight crate
 name: arrow_flight
 
+
+# trigger for all PRs that touch certain files and changes to master
 on:
+  push:
+    branches:
+      - master
   pull_request:
+    paths:
+      - arrow/**
+      - arrow-flight/**
+      - .github/**
 
 jobs:
   # test the crate

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Attempt to cancel stale workflow runs to save github actions runner time
 name: Cancel stale runs
 
 on:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,9 +17,11 @@
 
 name: Dev
 
+# trigger for all PRs and changes to master
 on:
-  # always trigger
   push:
+    branches:
+      - master
   pull_request:
 
 env:

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -17,6 +17,7 @@
 
 name: Dev PR
 
+# Trigger whenever a PR is changed (title as well as new / changed commits)
 on:
   pull_request_target:
     types:

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -42,9 +42,3 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/workflows/dev_pr/labeler.yml
           sync-labels: true
-
-      #- name: Checks if PR needs rebase
-      #  uses: eps1lon/actions-label-merge-conflict@releases/2.x
-      #  with:
-      #    dirtyLabel: "needs-rebase"
-      #    repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,8 @@
 
 name: Docs
 
+# trigger for all PRs and changes to master
 on:
-  # always trigger
   push:
     branches:
       - master

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@
 
 name: Integration
 
-# Only run when arrow or github changes
+# trigger for all PRs that touch certain files and changes to master
 on:
   push:
     branches:
@@ -25,6 +25,8 @@ on:
   pull_request:
     paths:
       - arrow/**
+      - arrow-pyarrow-integration-testing/**
+      - integration-testing/**
       - .github/**
 
 jobs:

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -17,12 +17,15 @@
 
 name: MIRI
 
+# trigger for all PRs that touch certain files and changes to master
 on:
-  # always trigger
   push:
     branches:
       - master
   pull_request:
+    paths:
+      - arrow/**
+      - .github/**
 
 jobs:
   miri-checks:

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -16,16 +16,16 @@
 # under the License.
 
 ---
-# tests for object_store crate
+# CI for `object_store` crate
 name: object_store
 
+# trigger for all PRs that touch certain files and changes to master
 on:
   push:
     branches:
       - master
   pull_request:
     paths:
-      # Only run when object store files or github workflows change
       - object_store/**
       - .github/**
 

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 ---
-# CI for `object_store` crate
+# tests for `object_store` crate
 name: object_store
 
 # trigger for all PRs that touch certain files and changes to master

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -19,12 +19,17 @@
 # tests for parquet crate
 name: "parquet"
 
+
+# trigger for all PRs that touch certain files and changes to master
 on:
-  # always trigger
   push:
     branches:
       - master
   pull_request:
+    paths:
+      - arrow/**
+      - parquet/**
+      - .github/**
 
 jobs:
   # test the crate

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -19,8 +19,18 @@
 # tests for parquet_derive crate
 name: parquet_derive
 
+
+# trigger for all PRs that touch certain files and changes to master
 on:
+  push:
+    branches:
+      - master
   pull_request:
+    paths:
+      - parquet/**
+      - parquet_derive/**
+      - parquet_derive_test/**
+      - .github/**
 
 jobs:
   # test the crate

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# tests for workspace wide
 name: Rust
 
+# trigger for all PRs and changes to master
 on:
-  # always trigger
   push:
     branches:
       - master
@@ -26,6 +27,8 @@ on:
 
 jobs:
 
+  # Check workspace wide compile and test with default features for
+  # mac and windows
   windows-and-macos:
     name: Test on ${{ matrix.os }} Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
@@ -75,6 +78,7 @@ jobs:
         run: |
           cargo check --benches --workspace --features test_common,prettyprint,async,experimental
 
+  # Run cargo fmt for all crates
   lint:
     name: Lint (cargo fmt)
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/2149

This is the final part of the CI workflow I have planned under the aegis of that https://github.com/apache/arrow-rs/issues/2149 😓 


# Rationale for this change

Right now we run almost all CI checks for all PRs even those that make no code changes (changes to README, etc) or changes to some other crate (e.g. change in `arrow-flight` can't affect `parquet` yet we run all the parquet checks anyways)

This increases PR times in two ways: 1 more checks need to complete and 2.  we consume many github action builder minutes on useless tests, which increases the time spent waiting for a builder on the queue. 

Of course, there is a real possibility that this change may miss running a CI check that causes master to fail -- but I think the improved PR speed and test specificity will make up for any such mishaps. We can also always go back to running all the tests on all PRs

# What changes are included in this PR?

The basic idea is to run all tests on pushes to master (to keep master green) but only run the individual workflows on PRs that change files that could affect them.


# Are there any user-facing changes?
No