### PR TITLE
Add append_option support to decimal builders

### DIFF
--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -117,6 +117,18 @@ impl Decimal128Builder {
         self.builder.append_null()
     }
 
+    /// Appends an `Option<T>` into the builder.
+    #[inline]
+    pub fn append_option(&mut self, value: Option<impl Into<i128>>) -> Result<()> {
+        match value {
+            None => {
+                self.append_null();
+                Ok(())
+            },
+            Some(value) => self.append_value(value),
+        }
+    }
+
     /// Builds the `Decimal128Array` and reset this builder.
     pub fn finish(&mut self) -> Decimal128Array {
         Decimal128Array::from_fixed_size_binary_array(
@@ -219,6 +231,18 @@ impl Decimal256Builder {
         self.builder.append_null()
     }
 
+    /// Appends an `Option<T>` into the builder.
+    #[inline]
+    pub fn append_option(&mut self, value: Option<&Decimal256>) -> Result<()> {
+        match value {
+            None => {
+                self.append_null();
+                Ok(())
+            },
+            Some(value) => self.append_value(value),
+        }
+    }
+
     /// Builds the [`Decimal256Array`] and reset this builder.
     pub fn finish(&mut self) -> Decimal256Array {
         Decimal256Array::from_fixed_size_binary_array(
@@ -246,11 +270,13 @@ mod tests {
         builder.append_value(8_887_000_000_i128).unwrap();
         builder.append_null();
         builder.append_value(-8_887_000_000_i128).unwrap();
+        builder.append_option(None::<i128>).unwrap();
+        builder.append_option(Some(8_887_000_000_i128)).unwrap();
         let decimal_array: Decimal128Array = builder.finish();
 
         assert_eq!(&DataType::Decimal(38, 6), decimal_array.data_type());
-        assert_eq!(3, decimal_array.len());
-        assert_eq!(1, decimal_array.null_count());
+        assert_eq!(5, decimal_array.len());
+        assert_eq!(2, decimal_array.null_count());
         assert_eq!(32, decimal_array.value_offset(2));
         assert_eq!(16, decimal_array.value_length());
     }
@@ -296,11 +322,14 @@ mod tests {
         let value = Decimal256::try_new_from_bytes(40, 6, bytes.as_slice()).unwrap();
         builder.append_value(&value).unwrap();
 
+        builder.append_option(None::<&Decimal256>).unwrap();
+        builder.append_option(Some(&value)).unwrap();
+
         let decimal_array: Decimal256Array = builder.finish();
 
         assert_eq!(&DataType::Decimal256(40, 6), decimal_array.data_type());
-        assert_eq!(4, decimal_array.len());
-        assert_eq!(1, decimal_array.null_count());
+        assert_eq!(6, decimal_array.len());
+        assert_eq!(2, decimal_array.null_count());
         assert_eq!(64, decimal_array.value_offset(2));
         assert_eq!(32, decimal_array.value_length());
 

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -124,7 +124,7 @@ impl Decimal128Builder {
             None => {
                 self.append_null();
                 Ok(())
-            },
+            }
             Some(value) => self.append_value(value),
         }
     }
@@ -238,7 +238,7 @@ impl Decimal256Builder {
             None => {
                 self.append_null();
                 Ok(())
-            },
+            }
             Some(value) => self.append_value(value),
         }
     }

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -117,7 +117,7 @@ impl Decimal128Builder {
         self.builder.append_null()
     }
 
-    /// Appends an `Option<T>` into the builder.
+    /// Appends an `Option<impl Into<i128>>` into the builder.
     #[inline]
     pub fn append_option(&mut self, value: Option<impl Into<i128>>) -> Result<()> {
         match value {
@@ -231,7 +231,7 @@ impl Decimal256Builder {
         self.builder.append_null()
     }
 
-    /// Appends an `Option<T>` into the builder.
+    /// Appends an `Option<&Decimal256>` into the builder.
     #[inline]
     pub fn append_option(&mut self, value: Option<&Decimal256>) -> Result<()> {
         match value {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2224

# Rationale for this change

Most of the other builders support append_option which is quite useful for optional fields.  

# What changes are included in this PR?

Support for append_option in `Decimal128Builder` and `Decimal256Builder`.

# Are there any user-facing changes?

One new public method on `Decimal128Builder` and `Decimal256Builder`.