### PR TITLE
Only trigger `arrow` CI on changes to arrow

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -24,6 +24,9 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - arrow/**
+      - .github/**
 
 jobs:
 


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2149

# Rationale for this change
 
We should only trigger arrow tests if there were changes to arrow (as it does not depend on any other crates in this workspace)

Somehow I missed this in https://github.com/apache/arrow-rs/pull/2213

I noticed this when I saw the `arrow` jobs run on https://github.com/apache/arrow-rs/pull/2204

# What changes are included in this PR?

Only trigger `arrow` CI jobs when there are changes to `arrow` (or `.github`)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
