### PR TITLE
Update `IntervalMonthDayNanoType::make_value()` to conform to specifications

### DIFF
--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -232,6 +232,16 @@ impl IntervalDayTimeType {
         days: i32,
         millis: i32,
     ) -> <IntervalDayTimeType as ArrowPrimitiveType>::Native {
+        /*
+        https://github.com/apache/arrow/blob/02c8598d264c839a5b5cf3109bfd406f3b8a6ba5/cpp/src/arrow/type.h#L1433
+        struct DayMilliseconds {
+            int32_t days = 0;
+            int32_t milliseconds = 0;
+        64      56      48      40      32      24      16      8       0
+        +-------+-------+-------+-------+-------+-------+-------+-------+
+        |             days              |         milliseconds          |
+        +-------+-------+-------+-------+-------+-------+-------+-------+
+        */
         let m = millis as u64 & u32::MAX as u64;
         let d = (days as u64 & u32::MAX as u64) << 32;
         (m | d) as <IntervalDayTimeType as ArrowPrimitiveType>::Native
@@ -264,9 +274,20 @@ impl IntervalMonthDayNanoType {
         days: i32,
         nanos: i64,
     ) -> <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native {
-        let m = months as u128 & u32::MAX as u128;
-        let d = (days as u128 & u32::MAX as u128) << 32;
-        let n = (nanos as u128) << 64;
+        /*
+        https://github.com/apache/arrow/blob/02c8598d264c839a5b5cf3109bfd406f3b8a6ba5/cpp/src/arrow/type.h#L1475
+        struct MonthDayNanos {
+            int32_t months;
+            int32_t days;
+            int64_t nanoseconds;
+        128     112     96      80      64      48      32      16      0
+        +-------+-------+-------+-------+-------+-------+-------+-------+
+        |     months    |      days     |             nanos             |
+        +-------+-------+-------+-------+-------+-------+-------+-------+
+        */
+        let m = (months as u128 & u32::MAX as u128) << 96;
+        let d = (days as u128 & u32::MAX as u128) << 64;
+        let n = nanos as u128;
         (m | d | n) as <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native
     }
 
@@ -278,9 +299,9 @@ impl IntervalMonthDayNanoType {
     pub fn to_parts(
         i: <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native,
     ) -> (i32, i32, i64) {
-        let nanos = (i >> 64) as i64;
-        let days = (i >> 32) as i32;
-        let months = i as i32;
+        let months = (i >> 96) as i32;
+        let days = (i >> 64) as i32;
+        let nanos = i as i64;
         (months, days, nanos)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2234.

# Rationale for this change
 
Fix bug that will cause users to generate incorrect interval values.

# What changes are included in this PR?

Revised implementation of `IntervalMonthDayNanoType::make_value()` and better inline documentation.

# Are there any user-facing changes?

Erroneous durations will be fixed.
