### PR TITLE
Make `Schema::fields` and `Schema::metadata` `pub` (public)

### DIFF
--- a/arrow/src/datatypes/schema.rs
+++ b/arrow/src/datatypes/schema.rs
@@ -33,11 +33,11 @@ use super::Field;
 /// memory layout.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Schema {
-    pub(crate) fields: Vec<Field>,
+    pub fields: Vec<Field>,
     /// A map of key-value pairs containing additional meta data.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
-    pub(crate) metadata: HashMap<String, String>,
+    pub metadata: HashMap<String, String>,
 }
 
 impl Schema {

--- a/arrow/tests/schema.rs
+++ b/arrow/tests/schema.rs
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, Field, Schema};
+use std::collections::HashMap;
+/// The tests in this file ensure a `Schema` can be manipulated
+/// outside of the arrow crate
+
+#[test]
+fn schema_destructure() {
+    let meta = [("foo".to_string(), "baz".to_string())]
+        .into_iter()
+        .collect::<HashMap<String, String>>();
+
+    let field = Field::new("c1", DataType::Utf8, false);
+    let schema = Schema::new(vec![field]).with_metadata(meta);
+
+    // Destructuring a Schema allows rewriting fields and metadata
+    // without copying
+    //
+    // Model this usecase below:
+
+    let Schema {
+        mut fields,
+        metadata,
+    } = schema;
+    fields.push(Field::new("c2", DataType::Utf8, false));
+
+    let new_schema = Schema::new(fields).with_metadata(metadata);
+
+    assert_eq!(new_schema.fields().len(), 2);
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1091

(I will file a follow on ticket to make the metadata type handling uniform between `Schema` and `Field`)

# Rationale for this change
 
Whenever working with `Schema` (e.g. project, etc) I often find myself having to `clone()` `fields` and `metadat` which is:
1. Inefficient (often we are copying when we already have an owned Schema)
2. Akward (and easy to forget to copy metadata)

This most recently happened to me on this PR like https://github.com/apache/arrow-datafusion/pull/2985

@jorgecarleitao  and I discussed various options on https://github.com/apache/arrow-rs/issues/1091 and he suggested that that making members of `Schema` `pub` would be good as he astutely observed that

> there is no invariant betweem them [members of Schema] , so there is nothing that users can break by accessing individual members.

# What changes are included in this PR?
1. Make `Schema` fields pub
2. Add a test outside the crate to use that

# Are there any user-facing changes?
Fields are pub 🎉 

# Alternates considered
I also considered making a function like the following to allow destructuring the `Schema`

```rust
impl Schema {
  // Consume self and return the consitutuent parts
  pub fn into_parts(self) -> (Vec<Field>, HashMap<String, String>)) {
    (self.fields, self.metadata
  }
}
```

And this would satisfy my usecase and I am happy to do this instead if reviewers prefer. 

After I reread  https://github.com/apache/arrow-rs/issues/1091 I decided I would propose the 'make things pub' first and see what I reaction I got. 

cc @nevi-me @seddonm1 @tustvold @HaoYang670 @andygrove @viirya 