### PR TITLE
Fix escaped like wildcards in `like_utf8` / `nlike_utf8` kernels

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -49,6 +49,7 @@ half = { version = "2.0", default-features = false }
 hashbrown = { version = "0.12", default-features = false }
 csv_crate = { version = "1.1", default-features = false, optional = true, package="csv" }
 regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
+regex-syntax = { version = "0.6.27", default-features = false, features = ["unicode"] }
 lazy_static = { version = "1.4", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -320,7 +320,6 @@ fn replace_like_wildcards(pattern: &str) -> Result<String> {
                     result.push('\\');
                     result.push('\\');
                 }
-
             }
         } else if regex_syntax::is_meta_character(c) {
             result.push('\\');
@@ -370,7 +369,9 @@ pub fn nlike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
         for i in 0..left.len() {
             result.append(left.value(i) != right);
         }
-    } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
+    } else if right.ends_with('%')
+        && !right.ends_with("\\%")
+        && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use ends_with
         for i in 0..left.len() {
@@ -443,7 +444,9 @@ pub fn ilike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
         for i in 0..left.len() {
             result.append(left.value(i) == right);
         }
-    } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
+    } else if right.ends_with('%')
+        && !right.ends_with("\\%")
+        && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use ends_with
         for i in 0..left.len() {
@@ -524,7 +527,9 @@ pub fn nilike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
         for i in 0..left.len() {
             result.append(left.value(i) != right);
         }
-    } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
+    } else if right.ends_with('%')
+        && !right.ends_with("\\%")
+        && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use ends_with
         for i in 0..left.len() {

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -304,23 +304,18 @@ fn replace_like_wildcards(text: &str) -> Result<String> {
     let mut chars_iter = text.chars().peekable();
     while let Some(c) = chars_iter.next() {
         if c == '\\' {
-            let next = chars_iter.peek().copied();
+            let next = chars_iter.peek();
             match next {
-                Some(next) => {
-                    if is_like_pattern(next) {
-                        result.push(next);
-                        // Skipping the next char as it is already appended
-                        chars_iter.next();
-                    } else {
-                        result.push('\\');
-                        result.push('\\');
-                    }
+                Some(next) if is_like_pattern(*next) => {
+                    result.push(*next);
+                    // Skipping the next char as it is already appended
+                    chars_iter.next();
                 }
-                None => {
+                _ => {
                     result.push('\\');
                     result.push('\\');
-                    return Ok(result);
                 }
+
             }
         } else if regex_syntax::is_meta_character(c) {
             result.push('\\');


### PR DESCRIPTION
# Which issue does this PR close?

Closes #415

# Rationale for this change
 
It is explained in the Issues linked above.

# What changes are included in this PR?

Added a new function that replaces the like wildcards '%' and '_' for the regex counterparts before executing them. It also takes into account that the wildcards can be escaped, in that case, it does remove the escape characters and leaves the wildcards so that they are matched against the raw character.

This is implemented iterating over all the characters of the pattern to figure out when it needs to be transformed or not.

# Are there any user-facing changes?
N/A