### PR TITLE
Remove fallibility from RLEEncoder (#2226)

### DIFF
--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -408,12 +408,12 @@ mod tests {
         let mut encoder = RleEncoder::new(1, 1024);
         for _ in 0..len {
             let bool = rng.gen_bool(0.8);
-            assert!(encoder.put(bool as u64).unwrap());
+            encoder.put(bool as u64);
             expected.append(bool);
         }
         assert_eq!(expected.len(), len);
 
-        let encoded = encoder.consume().unwrap();
+        let encoded = encoder.consume();
         let mut decoder = PackedDecoder::new();
         decoder.set_data(Encoding::RLE, ByteBufferPtr::new(encoded));
 
@@ -444,7 +444,7 @@ mod tests {
         let mut total_value = 0;
         for _ in 0..len {
             let bool = rng.gen_bool(0.8);
-            assert!(encoder.put(bool as u64).unwrap());
+            encoder.put(bool as u64);
             expected.append(bool);
             if bool {
                 total_value += 1;
@@ -452,7 +452,7 @@ mod tests {
         }
         assert_eq!(expected.len(), len);
 
-        let encoded = encoder.consume().unwrap();
+        let encoded = encoder.consume();
         let mut decoder = PackedDecoder::new();
         decoder.set_data(Encoding::RLE, ByteBufferPtr::new(encoded));
 

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -630,7 +630,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                             Encoding::RLE,
                             &self.rep_levels_sink[..],
                             max_rep_level,
-                        )?[..],
+                        )[..],
                     );
                 }
 
@@ -640,7 +640,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                             Encoding::RLE,
                             &self.def_levels_sink[..],
                             max_def_level,
-                        )?[..],
+                        )[..],
                     );
                 }
 
@@ -671,14 +671,14 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
                 if max_rep_level > 0 {
                     let levels =
-                        self.encode_levels_v2(&self.rep_levels_sink[..], max_rep_level)?;
+                        self.encode_levels_v2(&self.rep_levels_sink[..], max_rep_level);
                     rep_levels_byte_len = levels.len();
                     buffer.extend_from_slice(&levels[..]);
                 }
 
                 if max_def_level > 0 {
                     let levels =
-                        self.encode_levels_v2(&self.def_levels_sink[..], max_def_level)?;
+                        self.encode_levels_v2(&self.def_levels_sink[..], max_def_level);
                     def_levels_byte_len = levels.len();
                     buffer.extend_from_slice(&levels[..]);
                 }
@@ -794,18 +794,18 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         encoding: Encoding,
         levels: &[i16],
         max_level: i16,
-    ) -> Result<Vec<u8>> {
+    ) -> Vec<u8> {
         let mut encoder = LevelEncoder::v1(encoding, max_level, levels.len());
-        encoder.put(levels)?;
+        encoder.put(levels);
         encoder.consume()
     }
 
     /// Encodes definition or repetition levels for Data Page v2.
     /// Encoding is always RLE.
     #[inline]
-    fn encode_levels_v2(&self, levels: &[i16], max_level: i16) -> Result<Vec<u8>> {
+    fn encode_levels_v2(&self, levels: &[i16], max_level: i16) -> Vec<u8> {
         let mut encoder = LevelEncoder::v2(max_level, levels.len());
-        encoder.put(levels)?;
+        encoder.put(levels);
         encoder.consume()
     }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -23,7 +23,7 @@ use crate::data_type::private::ParquetValueType;
 use crate::data_type::DataType;
 use crate::encodings::encoding::{Encoder, PlainEncoder};
 use crate::encodings::rle::RleEncoder;
-use crate::errors::{ParquetError, Result};
+use crate::errors::Result;
 use crate::schema::types::ColumnDescPtr;
 use crate::util::bit_util::num_required_bits;
 use crate::util::interner::{Interner, Storage};
@@ -132,12 +132,10 @@ impl<T: DataType> DictEncoder<T> {
         // Write bit width in the first byte
         let mut encoder = RleEncoder::new_from_buf(self.bit_width(), buffer);
         for index in &self.indices {
-            if !encoder.put(*index as u64)? {
-                return Err(general_err!("Encoder doesn't have enough space"));
-            }
+            encoder.put(*index as u64)
         }
         self.indices.clear();
-        Ok(ByteBufferPtr::new(encoder.consume()?))
+        Ok(ByteBufferPtr::new(encoder.consume()))
     }
 
     fn put_one(&mut self, value: &T::T) {

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -195,9 +195,7 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
 
         for value in values {
             let value = value.as_u64()?;
-            if !rle_encoder.put(value)? {
-                return Err(general_err!("RLE buffer is full"));
-            }
+            rle_encoder.put(value)
         }
         Ok(())
     }
@@ -227,7 +225,7 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
             .expect("RLE value encoder is not initialized");
 
         // Flush all encoder buffers and raw values
-        let mut buf = rle_encoder.consume()?;
+        let mut buf = rle_encoder.consume();
         assert!(buf.len() > 4, "should have had padding inserted");
 
         // Note that buf does not have any offset, all data is encoded bytes

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -75,8 +75,8 @@ impl DataPageBuilderImpl {
             return 0;
         }
         let mut level_encoder = LevelEncoder::v1(Encoding::RLE, max_level, levels.len());
-        level_encoder.put(levels).expect("put() should be OK");
-        let encoded_levels = level_encoder.consume().expect("consume() should be OK");
+        level_encoder.put(levels);
+        let encoded_levels = level_encoder.consume();
         // Actual encoded bytes (without length offset)
         let encoded_bytes = &encoded_levels[mem::size_of::<i32>()..];
         if self.datapage_v2 {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2226

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Follow on to #2226 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

RLEEncoder is no longer fallible and so we can simplify its interface

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

No, the encoding module is experimental
