### PR TITLE
Use initial capacity for interner hashmap

### DIFF
--- a/parquet/src/util/interner.rs
+++ b/parquet/src/util/interner.rs
@@ -20,6 +20,8 @@ use hashbrown::hash_map::RawEntryMut;
 use hashbrown::HashMap;
 use std::hash::Hash;
 
+const DEFAULT_DEDUP_CAPACITY: usize = 4096;
+
 /// Storage trait for [`Interner`]
 pub trait Storage {
     type Key: Copy;
@@ -53,7 +55,7 @@ impl<S: Storage> Interner<S> {
     pub fn new(storage: S) -> Self {
         Self {
             state: Default::default(),
-            dedup: Default::default(),
+            dedup: HashMap::with_capacity_and_hasher(DEFAULT_DEDUP_CAPACITY, ()),
             storage,
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?


Closes #2273 2273

# Rationale for this change
 
 This saves rehashing / reshuffling the hashmap when there are quite some distinct values.
  
This is quite a bit faster:

```
 Benchmarking write_batch primitive/4096 values primitive:
                        time:   [1.0495 ms 1.0520 ms 1.0550 ms]
                        thrpt:  [167.22 MiB/s 167.70 MiB/s 168.09 MiB/s]
                 change:
                        time:   [-24.025% -22.929% -21.823%] (p = 0.00 < 0.05)
                        thrpt:  [+27.916% +29.751% +31.622%]
                        Performance has improved.
Benchmarking write_batch primitive/4096 values primitive non-null:     
                        time:   [826.87 µs 827.46 µs 828.10 µs]
                        thrpt:  [208.91 MiB/s 209.07 MiB/s 209.22 MiB/s]
                 change:
                        time:   [-36.274% -36.156% -36.056%] (p = 0.00 < 0.05)
                        thrpt:  [+56.388% +56.633% +56.922%]
                        Performance has improved.
```

# What changes are included in this PR?

Adds an initial capacity for the hashmap.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
