### PR TITLE
Clean up string casts and improve performance

### DIFF
--- a/arrow/src/temporal_conversions.rs
+++ b/arrow/src/temporal_conversions.rs
@@ -20,13 +20,18 @@
 use chrono::{Duration, NaiveDateTime, NaiveTime};
 
 /// Number of seconds in a day
-const SECONDS_IN_DAY: i64 = 86_400;
+pub(crate) const SECONDS_IN_DAY: i64 = 86_400;
 /// Number of milliseconds in a second
-const MILLISECONDS: i64 = 1_000;
+pub(crate) const MILLISECONDS: i64 = 1_000;
 /// Number of microseconds in a second
-const MICROSECONDS: i64 = 1_000_000;
+pub(crate) const MICROSECONDS: i64 = 1_000_000;
 /// Number of nanoseconds in a second
-const NANOSECONDS: i64 = 1_000_000_000;
+pub(crate) const NANOSECONDS: i64 = 1_000_000_000;
+
+/// Number of milliseconds in a day
+pub(crate) const MILLISECONDS_IN_DAY: i64 = SECONDS_IN_DAY * MILLISECONDS;
+/// Number of days between 0001-01-01 and 1970-01-01
+pub(crate) const EPOCH_DAYS_FROM_CE: i32 = 719_163;
 
 /// converts a `i32` representing a `date32` to [`NaiveDateTime`]
 #[inline]


### PR DESCRIPTION
~Draft until https://github.com/apache/arrow-rs/pull/2283 is merged~

# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/2285

# Rationale for this change
 
Here are some cleanups I suggested to @stuartcarnie  of while reviewing https://github.com/apache/arrow-rs/pull/2251 
 -- https://github.com/apache/arrow-rs/pull/2251#discussion_r934909397. Turns out not only did I give a bad suggestion (🤦 ), he was following the existing pattern in this file.

Since I was already working on this, I figured I would finish up the change so that new kernels don't get the same copy/paste code.

I think this both makes the code easier to read (it is less verbose) and it should improve performance by removing bounds checks (and unnecessary `String` construction and allocation)

# What changes are included in this PR?

1. Use `Iterator`s rather than `value()` and `is_null` and remove several `to_string()` calls
2. Move duplicated constants into `temporal_conversion.rs`

# Are there any user-facing changes?

No (maybe faster cast kernels)