### PR TITLE
Fix fmt + Mac CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,35 +95,37 @@ jobs:
       - name: Run
         run: cargo fmt --all -- --check
 
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    # Note runs outside of a container
-    # otherwise we get this error:
-    # Failed to run tests: ASLR disable failed: EPERM: Operation not permitted
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install stable
-          rustup default stable
-      - name: Install protobuf compiler
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/.cargo
-          key: cargo-coverage-cache3-
-      - name: Run coverage
-        run: |
-          rustup toolchain install stable
-          rustup default stable
-          cargo install --version 0.18.2 cargo-tarpaulin
-          cargo tarpaulin --all --out Xml
-      - name: Report coverage
-        continue-on-error: true
-        run: bash <(curl -s https://codecov.io/bash)
+  # Commented out while fixed in https://github.com/apache/arrow-rs/issues/2279
+  #
+  # coverage:
+  #   name: Coverage
+  #   runs-on: ubuntu-latest
+  #   # Note runs outside of a container
+  #   # otherwise we get this error:
+  #   # Failed to run tests: ASLR disable failed: EPERM: Operation not permitted
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - name: Setup Rust toolchain
+  #       run: |
+  #         rustup toolchain install stable
+  #         rustup default stable
+  #     - name: Install protobuf compiler
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y protobuf-compiler
+  #     - name: Cache Cargo
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: /home/runner/.cargo
+  #         key: cargo-coverage-cache3-
+  #     - name: Run coverage
+  #       run: |
+  #         rustup toolchain install stable
+  #         rustup default stable
+  #         cargo install --version 0.18.2 cargo-tarpaulin
+  #         cargo tarpaulin --all --out Xml
+  #     - name: Report coverage
+  #       continue-on-error: true
+  #       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,32 +28,55 @@ on:
 jobs:
 
   # Check workspace wide compile and test with default features for
-  # mac and windows
-  windows-and-macos:
-    name: Test on ${{ matrix.os }} Rust ${{ matrix.rust }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ windows-latest, macos-latest ]
-        rust: [ stable ]
+  # mac
+  macos:
+    name: Test on Mac
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install protoc with brew
+        run: |
+          brew install protobuf
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - name: Run tests
         shell: bash
         run: |
           # do not produce debug symbols to keep memory usage down
           export RUSTFLAGS="-C debuginfo=0"
           cargo test
+
+  # Commented out while fixed in https://github.com/apache/arrow-rs/issues/2279
+  #
+  # # Check workspace wide compile and test with default features for
+  # # windows
+  # windows:
+  #   name: Test on Windows
+  #   runs-on: windows-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - name: Install protoc with NuGet
+  #       run: |
+  #         nuget.exe install Google.Protobuf -Version 3.21.4 -OutputDirectory d:\\proto
+  #         nuget.exe install Grpc.Tools -Version 2.47.0 -OutputDirectory d:\\proto
+  #     - name: Setup Rust toolchain
+  #       run: |
+  #         rustup toolchain install stable --no-self-update
+  #         rustup default stable
+  #     - name: Run tests
+  #       shell: bash
+  #       run: |
+  #         # do not produce debug symbols to keep memory usage down
+  #         export RUSTFLAGS="-C debuginfo=0"
+  #         # This is where protoc is installed
+  #         export PATH=$PATH:/d/proto/Grpc.Tools.2.47.0/tools/windows_x86
+  #         cargo test
 
 
   # Run cargo fmt for all crates
@@ -75,27 +98,20 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64 ]
-        rust: [ stable ]
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Setup Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: ./.github/actions/setup-builder
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/.cargo
-          key: cargo-coverage-cache3-
+          rust-version: stable
       - name: Run coverage
         run: |
           rustup toolchain install stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,20 +98,26 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    container:
-      image: amd64/rust
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
+    # Note runs outside of a container
+    # otherwise we get this error:
+    # Failed to run tests: ASLR disable failed: EPERM: Operation not permitted
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-builder
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Cache Cargo
+        uses: actions/cache@v3
         with:
-          rust-version: stable
+          path: /home/runner/.cargo
+          key: cargo-coverage-cache3-
       - name: Run coverage
         run: |
           rustup toolchain install stable


### PR DESCRIPTION
# Which issue does this PR close?

Relates to https://github.com/apache/arrow-rs/issues/2279

# Rationale for this change
 
The `windows`, `Mac`, `fmt` and `codecov` CI checks are broken currently

# What changes are included in this PR?
Fix `Mac`, and `fmt` CI checks 

I am still working on Windows and Coverage (see my flailing attempts at https://github.com/apache/arrow-rs/pull/2280) but I think it is important to restore the CI checks sooner rather than later



# Are there any user-facing changes?

No
