### PR TITLE
feat: roundtrip field metadata in FFI

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -139,6 +139,14 @@ def test_field_roundtrip(pyarrow_type):
         assert field == pyarrow_field
 
 
+def test_field_metadata_roundtrip():
+    metadata = {"hello": "World! 😊", "x": "2"}
+    pyarrow_field = pa.field("test", pa.int32(), metadata=metadata)
+    field = rust.round_trip_field(pyarrow_field)
+    assert field == pyarrow_field
+    assert field.metadata == pyarrow_field.metadata
+
+
 def test_schema_roundtrip():
     pyarrow_fields = zip(string.ascii_lowercase, _supported_pyarrow_types)
     pyarrow_schema = pa.schema(pyarrow_fields)

--- a/arrow/src/datatypes/ffi.rs
+++ b/arrow/src/datatypes/ffi.rs
@@ -176,7 +176,9 @@ impl TryFrom<&FFI_ArrowSchema> for Field {
 
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self> {
         let dtype = DataType::try_from(c_schema)?;
-        let field = Field::new(c_schema.name(), dtype, c_schema.nullable());
+        let mut field = Field::new(c_schema.name(), dtype, c_schema.nullable());
+        field.set_metadata(c_schema.metadata());
+
         Ok(field)
     }
 }
@@ -302,7 +304,8 @@ impl TryFrom<&Field> for FFI_ArrowSchema {
 
         FFI_ArrowSchema::try_from(field.data_type())?
             .with_name(field.name())?
-            .with_flags(flags)
+            .with_flags(flags)?
+            .with_metadata(field.metadata())
     }
 }
 


### PR DESCRIPTION
This is a **very** rough draft.

# Which issue does this PR close?

Closes #478.

# Rationale for this change
 
It would be nice for field metadata to roundtrip between PyArrow and Rust layers.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes. Fields passed through FFI will no longer lose their metadata.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
