### PR TITLE
Speedup take_boolean / take_bits for non-null indices (~4 - 5x speedup)

### DIFF
--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -614,23 +614,41 @@ where
     let mut output_buffer = MutableBuffer::new_null(len);
     let output_slice = output_buffer.as_slice_mut();
 
-    indices
-        .iter()
-        .enumerate()
-        .try_for_each::<_, Result<()>>(|(i, index)| {
-            if let Some(index) = index {
-                let index = ToPrimitive::to_usize(&index).ok_or_else(|| {
+    let indices_has_nulls = indices.null_count() > 0;
+
+    if indices_has_nulls {
+        indices
+            .iter()
+            .enumerate()
+            .try_for_each::<_, Result<()>>(|(i, index)| {
+                if let Some(index) = index {
+                    let index = ToPrimitive::to_usize(&index).ok_or_else(|| {
+                        ArrowError::ComputeError("Cast to usize failed".to_string())
+                    })?;
+
+                    if bit_util::get_bit(values_slice, values_offset + index) {
+                        bit_util::set_bit(output_slice, i);
+                    }
+                }
+
+                Ok(())
+            })?;
+    } else {
+        indices
+            .values()
+            .iter()
+            .enumerate()
+            .try_for_each::<_, Result<()>>(|(i, index)| {
+                let index = ToPrimitive::to_usize(index).ok_or_else(|| {
                     ArrowError::ComputeError("Cast to usize failed".to_string())
                 })?;
 
                 if bit_util::get_bit(values_slice, values_offset + index) {
                     bit_util::set_bit(output_slice, i);
                 }
-            }
-
-            Ok(())
-        })?;
-
+                Ok(())
+            })?;
+    }
     Ok(output_buffer.into())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2306 

# Rationale for this change
 Speedup for (common) case of non-null indices array:
 
 ```
Benchmarking take bool 512: Collecting 100 samples in estimated 5.0003 s (6.8M i                                                                                take bool 512           time:   [733.01 ns 733.90 ns 735.34 ns]
                        change: [-76.500% -76.428% -76.358%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

Benchmarking take bool 1024: Collecting 100 samples in estimated 5.0004 s (3.9M                                                                                 take bool 1024          time:   [1.2751 µs 1.2767 µs 1.2786 µs]
                        change: [-79.428% -79.373% -79.309%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
