### PR TITLE
fix: IPC writer should truncate string array with all empty string

### DIFF
--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -1851,12 +1851,10 @@ mod tests {
     #[test]
     fn truncate_ipc_string_array_with_all_empty_string() {
         fn create_batch() -> RecordBatch {
-            let schema = Schema::new(vec![
-                Field::new("a", DataType::Utf8, true),
-            ]);
-            let a = StringArray::from(vec![Some(""), Some(""), Some(""), Some(""), Some("")]);
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])
-                .unwrap()
+            let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
+            let a =
+                StringArray::from(vec![Some(""), Some(""), Some(""), Some(""), Some("")]);
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap()
         }
 
         let record_batch = create_batch();

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -1861,8 +1861,6 @@ mod tests {
         let record_batch_slice = record_batch.slice(0, 1);
         let deserialized_batch = deserialize(serialize(&record_batch_slice));
 
-        // dbg!(serialize(&record_batch).len());
-        // dbg!(serialize(&record_batch_slice).len());
         assert!(serialize(&record_batch).len() > serialize(&record_batch_slice).len());
         assert_eq!(record_batch_slice, deserialized_batch);
     }

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -888,8 +888,8 @@ fn get_buffer_element_width(spec: &BufferSpec) -> usize {
 #[inline]
 fn get_value_offset_byte_width(data_type: &DataType) -> usize {
     match data_type {
-        DataType::Binary | DataType::Utf8 => 8,
-        DataType::LargeBinary | DataType::LargeUtf8 => 16,
+        DataType::Binary | DataType::Utf8 => 4,
+        DataType::LargeBinary | DataType::LargeUtf8 => 8,
         _ => unreachable!(),
     }
 }

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -884,6 +884,16 @@ fn get_buffer_element_width(spec: &BufferSpec) -> usize {
     }
 }
 
+/// Returns byte width for binary value_offset buffer spec.
+#[inline]
+fn get_value_offset_byte_width(data_type: &DataType) -> usize {
+    match data_type {
+        DataType::Binary | DataType::Utf8 => 8,
+        DataType::LargeBinary | DataType::LargeUtf8 => 16,
+        _ => unreachable!(),
+    }
+}
+
 /// Returns the number of total bytes in base binary arrays.
 fn get_binary_buffer_len(array_data: &ArrayData) -> usize {
     if array_data.is_empty() {
@@ -1005,13 +1015,16 @@ fn write_array_data(
         data_type,
         DataType::Binary | DataType::LargeBinary | DataType::Utf8 | DataType::LargeUtf8
     ) {
-        let total_bytes = get_binary_buffer_len(array_data);
-        let value_buffer = &array_data.buffers()[1];
+        let offset_buffer = &array_data.buffers()[0];
+        let value_offset_byte_width = get_value_offset_byte_width(data_type);
+        let min_length = array_data.len() * value_offset_byte_width;
         if buffer_need_truncate(
             array_data.offset(),
-            value_buffer,
-            &BufferSpec::VariableWidth,
-            total_bytes,
+            offset_buffer,
+            &BufferSpec::FixedWidth {
+                byte_width: value_offset_byte_width,
+            },
+            min_length,
         ) {
             // Rebase offsets and truncate values
             let (new_offsets, byte_offset) =
@@ -1029,6 +1042,8 @@ fn write_array_data(
 
             offset = write_buffer(new_offsets.as_slice(), buffers, arrow_data, offset);
 
+            let total_bytes = get_binary_buffer_len(array_data);
+            let value_buffer = &array_data.buffers()[1];
             let buffer_length = min(total_bytes, value_buffer.len() - byte_offset);
             let buffer_slice =
                 &value_buffer.as_slice()[byte_offset..(byte_offset + buffer_length)];
@@ -1830,6 +1845,27 @@ mod tests {
         assert!(structs.column(0).is_valid(1));
         assert!(structs.column(1).is_valid(0));
         assert!(structs.column(1).is_null(1));
+        assert_eq!(record_batch_slice, deserialized_batch);
+    }
+
+    #[test]
+    fn truncate_ipc_string_array_with_all_empty_string() {
+        fn create_batch() -> RecordBatch {
+            let schema = Schema::new(vec![
+                Field::new("a", DataType::Utf8, true),
+            ]);
+            let a = StringArray::from(vec![Some(""), Some(""), Some(""), Some(""), Some("")]);
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])
+                .unwrap()
+        }
+
+        let record_batch = create_batch();
+        let record_batch_slice = record_batch.slice(0, 1);
+        let deserialized_batch = deserialize(serialize(&record_batch_slice));
+
+        // dbg!(serialize(&record_batch).len());
+        // dbg!(serialize(&record_batch_slice).len());
+        assert!(serialize(&record_batch).len() > serialize(&record_batch_slice).len());
         assert_eq!(record_batch_slice, deserialized_batch);
     }
 }

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -1017,7 +1017,7 @@ fn write_array_data(
     ) {
         let offset_buffer = &array_data.buffers()[0];
         let value_offset_byte_width = get_value_offset_byte_width(data_type);
-        let min_length = array_data.len() * value_offset_byte_width;
+        let min_length = (array_data.len() + 1) * value_offset_byte_width;
         if buffer_need_truncate(
             array_data.offset(),
             offset_buffer,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/2312#issue-1327990182

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
fixed ipc truncation bug

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
