### PR TITLE
Increase DeltaBitPackEncoder miniblock size to 64 for 64-bit integers  (#2282)

### DIFF
--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -241,7 +241,6 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
 
 const MAX_PAGE_HEADER_WRITER_SIZE: usize = 32;
 const MAX_BIT_WRITER_SIZE: usize = 10 * 1024 * 1024;
-const DEFAULT_BLOCK_SIZE: usize = 128;
 const DEFAULT_NUM_MINI_BLOCKS: usize = 4;
 
 /// Delta bit packed encoder.
@@ -284,11 +283,18 @@ pub struct DeltaBitPackEncoder<T: DataType> {
 impl<T: DataType> DeltaBitPackEncoder<T> {
     /// Creates new delta bit packed encoder.
     pub fn new() -> Self {
-        let block_size = DEFAULT_BLOCK_SIZE;
-        let num_mini_blocks = DEFAULT_NUM_MINI_BLOCKS;
-        let mini_block_size = block_size / num_mini_blocks;
-        assert_eq!(mini_block_size % 8, 0);
         Self::assert_supported_type();
+
+        // Size miniblocks so that they can be efficiently decoded
+        let mini_block_size = match T::T::PHYSICAL_TYPE {
+            Type::INT32 => 32,
+            Type::INT64 => 64,
+            _ => unreachable!(),
+        };
+
+        let num_mini_blocks = DEFAULT_NUM_MINI_BLOCKS;
+        let block_size = mini_block_size * num_mini_blocks;
+        assert_eq!(block_size % 128, 0);
 
         DeltaBitPackEncoder {
             page_header_writer: BitWriter::new(MAX_PAGE_HEADER_WRITER_SIZE),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Part of #2282

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Following #2278 we can efficiently decode blocks of 64x 64-bit integers, however, the defaults of DeltaBitPackEncoder configure 32-wide miniblocks. #2282 tracks allowing users to configure this, but in the short term we should choose a more optimal default.

```
arrow_array_reader/Int64Array/binary packed, mandatory, no NULLs                                                                             
                        time:   [25.295 us 25.307 us 25.322 us]
                        change: [-59.630% -59.504% -59.394%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
arrow_array_reader/Int64Array/binary packed, optional, no NULLs                                                                             
                        time:   [41.864 us 41.871 us 41.878 us]
                        change: [-47.152% -47.076% -46.954%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
arrow_array_reader/Int64Array/binary packed, optional, half NULLs                                                                             
                        time:   [46.301 us 46.324 us 46.345 us]
                        change: [-26.069% -25.818% -25.590%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changes to using a miniblock size of 64 for 64-bit integers

# Are there any user-facing changes?

There should be no breaking user-facing changes, although this may change the way their data is encoded.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
