### PR TITLE
Add more const evaluation for `GenericBinaryArray` and `GenericListArray`: add `PREFIX` and data type constructor

### DIFF
--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -236,7 +236,7 @@ impl<'a, T: OffsetSizeTrait> GenericBinaryArray<T> {
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericBinaryArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let prefix = if OffsetSize::IS_LARGE { "Large" } else { "" };
+        let prefix = OffsetSize::PREFIX;
 
         write!(f, "{}BinaryArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {
@@ -608,11 +608,9 @@ mod tests {
             .unwrap();
         let binary_array1 = GenericBinaryArray::<O>::from(array_data1);
 
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt8, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt8, false),
+        ));
 
         let array_data2 = ArrayData::builder(data_type)
             .len(3)
@@ -660,11 +658,9 @@ mod tests {
 
         let offsets = [0, 5, 8, 15].map(|n| O::from_usize(n).unwrap());
         let null_buffer = Buffer::from_slice_ref(&[0b101]);
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt8, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt8, false),
+        ));
 
         // [None, Some(b"Parquet")]
         let array_data = ArrayData::builder(data_type)
@@ -707,11 +703,9 @@ mod tests {
             .unwrap();
 
         let offsets = [0, 5, 10].map(|n| O::from_usize(n).unwrap());
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt8, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt8, false),
+        ));
 
         // [None, Some(b"Parquet")]
         let array_data = ArrayData::builder(data_type)

--- a/arrow/src/array/array_string.rs
+++ b/arrow/src/array/array_string.rs
@@ -294,7 +294,7 @@ impl<'a, T: OffsetSizeTrait> GenericStringArray<T> {
 
 impl<OffsetSize: OffsetSizeTrait> fmt::Debug for GenericStringArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let prefix = if OffsetSize::IS_LARGE { "Large" } else { "" };
+        let prefix = OffsetSize::PREFIX;
 
         write!(f, "{}StringArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {
@@ -707,11 +707,9 @@ mod tests {
 
         let offsets = [0, 5, 8, 15].map(|n| O::from_usize(n).unwrap());
         let null_buffer = Buffer::from_slice_ref(&[0b101]);
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt8, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt8, false),
+        ));
 
         // [None, Some("Parquet")]
         let array_data = ArrayData::builder(data_type)
@@ -754,11 +752,9 @@ mod tests {
             .unwrap();
 
         let offsets = [0, 5, 10].map(|n| O::from_usize(n).unwrap());
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt8, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt8, false),
+        ));
 
         // [None, Some(b"Parquet")]
         let array_data = ArrayData::builder(data_type)
@@ -792,11 +788,9 @@ mod tests {
             .unwrap();
 
         let offsets = [0, 2, 3].map(|n| O::from_usize(n).unwrap());
-        let data_type = if O::IS_LARGE {
-            DataType::LargeList
-        } else {
-            DataType::List
-        }(Box::new(Field::new("item", DataType::UInt16, false)));
+        let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::UInt16, false),
+        ));
 
         let array_data = ArrayData::builder(data_type)
             .len(2)

--- a/arrow/src/array/builder/generic_list_builder.rs
+++ b/arrow/src/array/builder/generic_list_builder.rs
@@ -22,7 +22,6 @@ use crate::array::ArrayData;
 use crate::array::ArrayRef;
 use crate::array::GenericListArray;
 use crate::array::OffsetSizeTrait;
-use crate::datatypes::DataType;
 use crate::datatypes::Field;
 
 use super::{ArrayBuilder, BufferBuilder, NullBufferBuilder};
@@ -135,11 +134,7 @@ where
             values_data.data_type().clone(),
             true, // TODO: find a consistent way of getting this
         ));
-        let data_type = if OffsetSize::IS_LARGE {
-            DataType::LargeList(field)
-        } else {
-            DataType::List(field)
-        };
+        let data_type = GenericListArray::<OffsetSize>::DATA_TYPE_CONSTRUCTOR(field);
         let array_data_builder = ArrayData::builder(data_type)
             .len(len)
             .add_buffer(offset_buffer)
@@ -163,6 +158,7 @@ mod tests {
     use crate::array::builder::ListBuilder;
     use crate::array::{Array, Int32Array, Int32Builder};
     use crate::buffer::Buffer;
+    use crate::datatypes::DataType;
 
     fn _test_generic_list_array_builder<O: OffsetSizeTrait>() {
         let values_builder = Int32Builder::new(10);

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -313,11 +313,7 @@ fn preallocate_offset_and_binary_buffer<Offset: OffsetSizeTrait>(
     // offsets
     let mut buffer = MutableBuffer::new((1 + capacity) * mem::size_of::<Offset>());
     // safety: `unsafe` code assumes that this buffer is initialized with one element
-    if Offset::IS_LARGE {
-        buffer.push(0i64);
-    } else {
-        buffer.push(0i32)
-    }
+    buffer.push(Offset::zero());
 
     [
         buffer,

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -1034,12 +1034,9 @@ mod tests {
             .collect::<Buffer>();
 
         // Construct a list array from the above two
-        let list_data_type = match std::mem::size_of::<Offset>() {
-            4 => DataType::List(Box::new(Field::new("item", DataType::Int32, false))),
-            _ => {
-                DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)))
-            }
-        };
+        let list_data_type = GenericListArray::<Offset>::DATA_TYPE_CONSTRUCTOR(Box::new(
+            Field::new("item", DataType::Int32, false),
+        ));
 
         let list_data = ArrayData::builder(list_data_type)
             .len(3)

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -268,10 +268,7 @@ mod tests {
         item_nullable: bool,
     ) -> ArrowType {
         let field = Box::new(Field::new("item", data_type, item_nullable));
-        match OffsetSize::IS_LARGE {
-            true => ArrowType::LargeList(field),
-            false => ArrowType::List(field),
-        }
+        GenericListArray::<OffsetSize>::DATA_TYPE_CONSTRUCTOR(field)
     }
 
     fn downcast<OffsetSize: OffsetSizeTrait>(


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2311 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
More constant evaluation is better.
Less repeated code is better.

# What changes are included in this PR?
1. Add data type constructor for list array
2. Add const field `PREFIX` for OffsetSizeTrait

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
