### PR TITLE
Make skip_records in complex_object_array can skip cross row groups

### DIFF
--- a/parquet/src/arrow/array_reader/complex_object_array.rs
+++ b/parquet/src/arrow/array_reader/complex_object_array.rs
@@ -206,8 +206,7 @@ where
                 .column_reader
                 .as_mut()
                 .unwrap()
-                .skip_records(remain_to_skip)
-                .unwrap();
+                .skip_records(remain_to_skip)?;
             num_read += skip;
             //  skip < remain_to_skip means end of row group
             //  self.next_column_reader() == false means end of file

--- a/parquet/src/arrow/array_reader/complex_object_array.rs
+++ b/parquet/src/arrow/array_reader/complex_object_array.rs
@@ -197,19 +197,25 @@ where
     }
 
     fn skip_records(&mut self, num_records: usize) -> Result<usize> {
-        match self.column_reader.as_mut() {
-            Some(reader) => reader.skip_records(num_records),
-            None => {
-                if self.next_column_reader()? {
-                    self.column_reader
-                        .as_mut()
-                        .unwrap()
-                        .skip_records(num_records)
-                } else {
-                    Ok(0)
-                }
+        let mut num_read = 0;
+        while (self.column_reader.is_some() || self.next_column_reader()?)
+            && num_read < num_records
+        {
+            let remain_to_skip = num_records - num_read;
+            let skip = self
+                .column_reader
+                .as_mut()
+                .unwrap()
+                .skip_records(remain_to_skip)
+                .unwrap();
+            num_read += skip;
+            //  skip < remain_to_skip means end of row group
+            //  self.next_column_reader() == false means end of file
+            if skip < remain_to_skip && !self.next_column_reader()? {
+                break;
             }
         }
+        Ok(num_read)
     }
 
     fn get_def_levels(&self) -> Option<&[i16]> {


### PR DESCRIPTION
# Which issue does this PR close?


Closes #2331  #2316.

# Rationale for this change
 
doing fuzz test for reading `FIXED_LEN_BYTE_ARRAY`
Facing one row group one page with 20 rows, but need skip 60 rows.
For now, this case returns 20 as `skip_record` cause below assert fail.
https://github.com/apache/arrow-rs/blob/2683b06cbc213327b464f6458385877c9a7666b0/parquet/src/arrow/arrow_reader.rs#L299-L308


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
