### PR TITLE
MINOR: make capitalization of CI job names consistent

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 # Attempt to cancel stale workflow runs to save github actions runner time
-name: Cancel stale runs
+name: cancel
 
 on:
   workflow_run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Coverage
+name: coverage
 
 # Trigger only on pushes to master, not pull requests
 on:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Dev
+name: dev
 
 # trigger for all PRs and changes to master
 on:
@@ -43,7 +43,7 @@ jobs:
         run: ./dev/release/run-rat.sh .
 
   prettier:
-    name: Use prettier to check formatting of markdown documents
+    name: Markdown format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Dev PR
+name: dev_pr
 
 # Trigger whenever a PR is changed (title as well as new / changed commits)
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Docs
+name: docs
 
 # trigger for all PRs and changes to master
 on:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Integration
+name: integration
 
 # trigger for all PRs that touch certain files and changes to master
 on:

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: MIRI
+name: miri
 
 # trigger for all PRs that touch certain files and changes to master
 on:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# tests for workspace wide
-name: Rust
+# workspace wide tests
+name: rust
 
 # trigger for all PRs and changes to master
 on:


### PR DESCRIPTION
# Which issue does this PR close?

re #2149 

# Rationale for this change
 
The inconsistent capitalization of CI jobs bothers me when I am verifying that the correct CI ran:
<img width="859" alt="Screen Shot 2022-08-05 at 8 09 28 AM" src="https://user-images.githubusercontent.com/490673/183074708-7c781397-0e2d-41b9-a767-b7d0347cb437.png">

# What changes are included in this PR?
make workflow names match the files they are defined in

# Are there any user-facing changes?
no