### PR TITLE
Fix cargo publish ( can't find `dynamic_types` example at `examples/dynamic_types.rs` or `examples/dynamic_types/main.rs`)

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -92,6 +92,7 @@ tempfile = { version = "3", default-features = false }
 [[example]]
 name = "dynamic_types"
 required-features = ["prettyprint"]
+path="./examples/dynamic_types.rs"
 
 [[bench]]
 name = "aggregate_kernels"


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/2172

# Rationale for this change
 
When the release verification script tried to publish the 'arrow' crate, it got the following error:

```
+ pushd arrow
/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi/apache-arrow-rs-20.0.0/arrow /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi/apache-arrow-rs-20.0.0 /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi
+ cargo publish --dry-run
    Updating crates.io index
   Packaging arrow v20.0.0 (/private/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi/apache-arrow-rs-20.0.0/arrow)
   Verifying arrow v20.0.0 (/private/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi/apache-arrow-rs-20.0.0/arrow)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/private/var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi/apache-arrow-rs-20.0.0/target/package/arrow-20.0.0/Cargo.toml`

Caused by:
  can't find `dynamic_types` example at `examples/dynamic_types.rs` or `examples/dynamic_types/main.rs`. Please specify example.path if you want to use a non-default path.
+ cleanup
+ '[' no = yes ']'
+ echo 'Failed to verify release candidate. See /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi for details.'
Failed to verify release candidate. See /var/folders/s3/h5hgj43j0bv83shtmz_t_w400000gn/T/arrow-20.0.0.XXXXX.dVwsseAi for details.

```

I can reproduce it locally too

```
alamb@MacBook-Pro-8 arrow % cargo publish --dry-run
cargo publish --dry-run
    Updating crates.io index
   Packaging arrow v20.0.0 (/Users/alamb/Software/arrow-rs/arrow)
   Verifying arrow v20.0.0 (/Users/alamb/Software/arrow-rs/arrow)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Software/arrow-rs/target/package/arrow-20.0.0/Cargo.toml`

Caused by:
  can't find `dynamic_types` example at `examples/dynamic_types.rs` or `examples/dynamic_types/main.rs`. Please specify example.path if you want to use a non-default path.
```

I don't really know what Cargo is complaining about:

```shell
$ ls examples/dynamic_types.rs
examples/dynamic_types.rs
```

🤷 

Looks like the change came in from @tustvold 's change on #2299

# What changes are included in this PR?

Add a `path` attribute as suggested by Cargo



# Are there any user-facing changes?

no
