### PR TITLE
Relax path validation (#2355)

### DIFF
--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -126,7 +126,6 @@ pub enum Error {
 /// Path::parse("..").unwrap_err();
 /// Path::parse("/foo//").unwrap_err();
 /// Path::parse("😀").unwrap_err();
-/// Path::parse("%Q").unwrap_err();
 /// ```
 ///
 /// [RFC 1738]: https://www.ietf.org/rfc/rfc1738.txt

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use std::borrow::Cow;
 
 use crate::path::DELIMITER_BYTE;
@@ -23,11 +23,15 @@ use snafu::Snafu;
 
 /// Error returned by [`PathPart::parse`]
 #[derive(Debug, Snafu)]
-#[snafu(display("Invalid path segment - got \"{}\" expected: \"{}\"", actual, expected))]
+#[snafu(display(
+    "Encountered illegal character sequence \"{}\" whilst parsing path segment \"{}\"",
+    illegal,
+    segment
+))]
 #[allow(missing_copy_implementations)]
 pub struct InvalidPart {
-    actual: String,
-    expected: String,
+    segment: String,
+    illegal: String,
 }
 
 /// The PathPart type exists to validate the directory/file names that form part
@@ -43,19 +47,37 @@ pub struct PathPart<'a> {
 impl<'a> PathPart<'a> {
     /// Parse the provided path segment as a [`PathPart`] returning an error if invalid
     pub fn parse(segment: &'a str) -> Result<Self, InvalidPart> {
-        let decoded: Cow<'a, [u8]> = percent_decode(segment.as_bytes()).into();
-        let part = PathPart::from(decoded.as_ref());
-        if segment != part.as_ref() {
+        if segment == "." || segment == ".." {
             return Err(InvalidPart {
-                actual: segment.to_string(),
-                expected: part.raw.to_string(),
+                segment: segment.to_string(),
+                illegal: segment.to_string(),
             });
+        }
+
+        for (idx, char) in segment.char_indices() {
+            // A percent character is always valid, even if not
+            // followed by a valid 2-digit hex code
+            // https://url.spec.whatwg.org/#percent-encoded-bytes
+            if char == '%' {
+                continue;
+            }
+
+            if !char.is_ascii() || should_percent_encode(segment.as_bytes()[idx]) {
+                return Err(InvalidPart {
+                    segment: segment.to_string(),
+                    illegal: char.to_string(),
+                });
+            }
         }
 
         Ok(Self {
             raw: segment.into(),
         })
     }
+}
+
+fn should_percent_encode(c: u8) -> bool {
+    percent_encode(&[c], INVALID).next().unwrap().len() != 1
 }
 
 /// Characters we want to encode.
@@ -144,5 +166,19 @@ mod tests {
     fn path_part_cant_be_two_dots() {
         let part: PathPart<'_> = "..".into();
         assert_eq!(part.raw, "%2E%2E");
+    }
+
+    #[test]
+    fn path_part_parse() {
+        PathPart::parse("foo").unwrap();
+        PathPart::parse("foo/bar").unwrap_err();
+
+        // Test percent-encoded path
+        PathPart::parse("foo%2Fbar").unwrap();
+        PathPart::parse("L%3ABC.parquet").unwrap();
+
+        // Test path containing bad escape sequence
+        PathPart::parse("%Z").unwrap();
+        PathPart::parse("%%").unwrap();
     }
 }

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -54,18 +54,19 @@ impl<'a> PathPart<'a> {
             });
         }
 
-        for (idx, char) in segment.char_indices() {
+        for (idx, b) in segment.as_bytes().iter().cloned().enumerate() {
             // A percent character is always valid, even if not
             // followed by a valid 2-digit hex code
             // https://url.spec.whatwg.org/#percent-encoded-bytes
-            if char == '%' {
+            if b == b'%' {
                 continue;
             }
 
-            if !char.is_ascii() || should_percent_encode(segment.as_bytes()[idx]) {
+            if !b.is_ascii() || should_percent_encode(b) {
                 return Err(InvalidPart {
                     segment: segment.to_string(),
-                    illegal: char.to_string(),
+                    // This is correct as only single byte characters up to this point
+                    illegal: segment.chars().nth(idx).unwrap().to_string(),
                 });
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2355
Closes #2349 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See tickets

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This relaxes the validation in `PathPart::parse` to be less conservative about what constitutes a safe path. In particular it should accept any "safe" path, even if it would not generate such a path itself.

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
