### PR TITLE
refactor: Group metrics into page and column metrics structs

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -154,6 +154,7 @@ type ColumnCloseResult = (
 );
 
 // Metrics per page
+#[derive(Default)]
 struct PageMetrics {
     num_buffered_values: u32,
     num_buffered_rows: u32,
@@ -749,9 +750,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         // Reset state.
         self.rep_levels_sink.clear();
         self.def_levels_sink.clear();
-        self.page_metrics.num_buffered_values = 0;
-        self.page_metrics.num_buffered_rows = 0;
-        self.page_metrics.num_page_nulls = 0;
+        self.page_metrics = PageMetrics::default();
 
         Ok(())
     }


### PR DESCRIPTION
# Rationale for this change
 
Refactors the metrics fields into sub-structs. Originally this was also supposed to reduce how much generic code were instantiated in `make_typed_statistics` but that method seems to have been removed. So now this is just a refactor.

# What changes are included in this PR?

Moves fields related to page/column metrics into newly added structs for clarity.
