### PR TITLE
refactor: Reduce how much code is instantiated for comparisons

### DIFF
--- a/arrow/src/array/array_primitive.rs
+++ b/arrow/src/array/array_primitive.rs
@@ -134,7 +134,9 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Creates a PrimitiveArray based on a constant value with `count` elements
     pub fn from_value(value: T::Native, count: usize) -> Self {
         // # Safety: iterator (0..count) correctly reports its length
-        let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
+        let val_buf = unsafe {
+            Buffer::from_trusted_len_iter(std::iter::repeat(value).take(count))
+        };
         let data = unsafe {
             ArrayData::new_unchecked(
                 T::DATA_TYPE,

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -2000,16 +2000,16 @@ macro_rules! typed_dict_cmp {
                 cmp_dict::<$KT, Float64Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Utf8, DataType::Utf8) => {
-                cmp_dict_utf8::<$KT, i32, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_utf8::<$KT, i32, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
             }
             (DataType::LargeUtf8, DataType::LargeUtf8) => {
-                cmp_dict_utf8::<$KT, i64, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_utf8::<$KT, i64, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
             }
             (DataType::Binary, DataType::Binary) => {
-               cmp_dict_binary::<$KT, i32, _>($LEFT, $RIGHT, $OP)
+               cmp_dict_binary::<$KT, i32, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
             }
             (DataType::LargeBinary, DataType::LargeBinary) => {
-                cmp_dict_binary::<$KT, i64, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_binary::<$KT, i64, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
             }
             (
                 DataType::Timestamp(TimeUnit::Nanosecond, _),
@@ -2256,7 +2256,14 @@ where
 pub fn eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a == b, |a, b| a == b)
+            #[inline]
+            fn op_eq<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l != r
+            }
+            typed_dict_compares!(left, right, op_eq, op_eq)
         }
         _ => typed_compares!(left, right, |a, b| !(a ^ b), |a, b| a == b),
     }
@@ -2281,7 +2288,14 @@ pub fn eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 pub fn neq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a != b, |a, b| a != b)
+            #[inline]
+            fn op_neq<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l != r
+            }
+            typed_dict_compares!(left, right, op_neq, op_neq)
         }
         _ => typed_compares!(left, right, |a, b| (a ^ b), |a, b| a != b),
     }
@@ -2306,7 +2320,14 @@ pub fn neq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 pub fn lt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a < b, |a, b| a < b)
+            #[inline]
+            fn op_lt<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l < r
+            }
+            typed_dict_compares!(left, right, op_lt, op_lt)
         }
         _ => typed_compares!(left, right, |a, b| ((!a) & b), |a, b| a < b),
     }
@@ -2330,7 +2351,14 @@ pub fn lt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 pub fn lt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a <= b, |a, b| a <= b)
+            #[inline]
+            fn op_le<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l > r
+            }
+            typed_dict_compares!(left, right, op_le, op_le)
         }
         _ => typed_compares!(left, right, |a, b| !(a & (!b)), |a, b| a <= b),
     }
@@ -2354,7 +2382,14 @@ pub fn lt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 pub fn gt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a > b, |a, b| a > b)
+            #[inline]
+            fn op_gt<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l > r
+            }
+            typed_dict_compares!(left, right, op_gt, op_gt)
         }
         _ => typed_compares!(left, right, |a, b| (a & (!b)), |a, b| a > b),
     }
@@ -2377,7 +2412,14 @@ pub fn gt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
 pub fn gt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
     match left.data_type() {
         DataType::Dictionary(_, _) => {
-            typed_dict_compares!(left, right, |a, b| a >= b, |a, b| a >= b)
+            #[inline]
+            fn op_ge<T>(l: T, r: T) -> bool
+            where
+                T: PartialOrd,
+            {
+                l >= r
+            }
+            typed_dict_compares!(left, right, op_ge, op_ge)
         }
         _ => typed_compares!(left, right, |a, b| !((!a) & b), |a, b| a >= b),
     }

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -2248,6 +2248,8 @@ where
     compare_dict_op!(left, right, op, PrimitiveArray<T>)
 }
 
+// Compares two dictionary using bit-equality (helps reduce how much code is instantiated as
+// types with the same underlying native type can share the instantiated code).
 fn cmp_dict_bit_equal<K, T, F>(
     left: &DictionaryArray<K>,
     right: &DictionaryArray<K>,

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -1964,100 +1964,100 @@ macro_rules! typed_compares {
 
 /// Applies $OP to $LEFT and $RIGHT which are two dictionaries which have (the same) key type $KT
 macro_rules! typed_dict_cmp {
-    ($LEFT: expr, $RIGHT: expr, $OP: expr, $OP_BOOL: expr, $KT: tt) => {{
+    ($LEFT: expr, $RIGHT: expr, $OP: expr, $OP_REF: expr, $KT: tt) => {{
         match ($LEFT.value_type(), $RIGHT.value_type()) {
             (DataType::Boolean, DataType::Boolean) => {
-                cmp_dict_bool::<$KT, _>($LEFT, $RIGHT, $OP_BOOL)
+                cmp_dict_bool::<$KT, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Int8, DataType::Int8) => {
-                cmp_dict::<$KT, Int8Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Int8Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Int16, DataType::Int16) => {
-                cmp_dict::<$KT, Int16Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Int16Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Int32, DataType::Int32) => {
-                cmp_dict::<$KT, Int32Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Int32Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Int64, DataType::Int64) => {
-                cmp_dict::<$KT, Int64Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Int64Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::UInt8, DataType::UInt8) => {
-                cmp_dict::<$KT, UInt8Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, UInt8Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::UInt16, DataType::UInt16) => {
-                cmp_dict::<$KT, UInt16Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, UInt16Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::UInt32, DataType::UInt32) => {
-                cmp_dict::<$KT, UInt32Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, UInt32Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::UInt64, DataType::UInt64) => {
-                cmp_dict::<$KT, UInt64Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, UInt64Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Float32, DataType::Float32) => {
-                cmp_dict::<$KT, Float32Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Float32Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Float64, DataType::Float64) => {
-                cmp_dict::<$KT, Float64Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Float64Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Utf8, DataType::Utf8) => {
-                cmp_dict_utf8::<$KT, i32, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
+                cmp_dict_utf8::<$KT, i32, _>($LEFT, $RIGHT, $OP_REF)
             }
             (DataType::LargeUtf8, DataType::LargeUtf8) => {
-                cmp_dict_utf8::<$KT, i64, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
+                cmp_dict_utf8::<$KT, i64, _>($LEFT, $RIGHT, $OP_REF)
             }
             (DataType::Binary, DataType::Binary) => {
-               cmp_dict_binary::<$KT, i32, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
+               cmp_dict_binary::<$KT, i32, _>($LEFT, $RIGHT, $OP_REF)
             }
             (DataType::LargeBinary, DataType::LargeBinary) => {
-                cmp_dict_binary::<$KT, i64, _>($LEFT, $RIGHT, |l, r| $OP(l, r))
+                cmp_dict_binary::<$KT, i64, _>($LEFT, $RIGHT, $OP_REF)
             }
             (
                 DataType::Timestamp(TimeUnit::Nanosecond, _),
                 DataType::Timestamp(TimeUnit::Nanosecond, _),
             ) => {
-                cmp_dict::<$KT, TimestampNanosecondType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, TimestampNanosecondType, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Timestamp(TimeUnit::Microsecond, _),
                 DataType::Timestamp(TimeUnit::Microsecond, _),
             ) => {
-                cmp_dict::<$KT, TimestampMicrosecondType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, TimestampMicrosecondType, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Timestamp(TimeUnit::Millisecond, _),
                 DataType::Timestamp(TimeUnit::Millisecond, _),
             ) => {
-                cmp_dict::<$KT, TimestampMillisecondType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, TimestampMillisecondType, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Timestamp(TimeUnit::Second, _),
                 DataType::Timestamp(TimeUnit::Second, _),
             ) => {
-                cmp_dict::<$KT, TimestampSecondType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, TimestampSecondType, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Date32, DataType::Date32) => {
-                cmp_dict::<$KT, Date32Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Date32Type, _>($LEFT, $RIGHT, $OP)
             }
             (DataType::Date64, DataType::Date64) => {
-                cmp_dict::<$KT, Date64Type, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, Date64Type, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Interval(IntervalUnit::YearMonth),
                 DataType::Interval(IntervalUnit::YearMonth),
             ) => {
-                cmp_dict::<$KT, IntervalYearMonthType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, IntervalYearMonthType, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Interval(IntervalUnit::DayTime),
                 DataType::Interval(IntervalUnit::DayTime),
             ) => {
-                cmp_dict::<$KT, IntervalDayTimeType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, IntervalDayTimeType, _>($LEFT, $RIGHT, $OP)
             }
             (
                 DataType::Interval(IntervalUnit::MonthDayNano),
                 DataType::Interval(IntervalUnit::MonthDayNano),
             ) => {
-                cmp_dict::<$KT, IntervalMonthDayNanoType, _>($LEFT, $RIGHT, $OP)
+                cmp_dict_bit_equal::<$KT, IntervalMonthDayNanoType, _>($LEFT, $RIGHT, $OP)
             }
             (t1, t2) if t1 == t2 => Err(ArrowError::NotYetImplemented(format!(
                 "Comparing dictionary arrays of value type {} is not yet implemented",
@@ -2073,49 +2073,49 @@ macro_rules! typed_dict_cmp {
 
 macro_rules! typed_dict_compares {
    // Applies `LEFT OP RIGHT` when `LEFT` and `RIGHT` both are `DictionaryArray`
-    ($LEFT: expr, $RIGHT: expr, $OP: expr, $OP_BOOL: expr) => {{
+    ($LEFT: expr, $RIGHT: expr, $OP: expr, $OP_REF: expr) => {{
         match ($LEFT.data_type(), $RIGHT.data_type()) {
             (DataType::Dictionary(left_key_type, _), DataType::Dictionary(right_key_type, _))=> {
                 match (left_key_type.as_ref(), right_key_type.as_ref()) {
                     (DataType::Int8, DataType::Int8) => {
                         let left = as_dictionary_array::<Int8Type>($LEFT);
                         let right = as_dictionary_array::<Int8Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, Int8Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, Int8Type)
                     }
                     (DataType::Int16, DataType::Int16) => {
                         let left = as_dictionary_array::<Int16Type>($LEFT);
                         let right = as_dictionary_array::<Int16Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, Int16Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, Int16Type)
                     }
                     (DataType::Int32, DataType::Int32) => {
                         let left = as_dictionary_array::<Int32Type>($LEFT);
                         let right = as_dictionary_array::<Int32Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, Int32Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, Int32Type)
                     }
                     (DataType::Int64, DataType::Int64) => {
                         let left = as_dictionary_array::<Int64Type>($LEFT);
                         let right = as_dictionary_array::<Int64Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, Int64Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, Int64Type)
                     }
                     (DataType::UInt8, DataType::UInt8) => {
                         let left = as_dictionary_array::<UInt8Type>($LEFT);
                         let right = as_dictionary_array::<UInt8Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, UInt8Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, UInt8Type)
                     }
                     (DataType::UInt16, DataType::UInt16) => {
                         let left = as_dictionary_array::<UInt16Type>($LEFT);
                         let right = as_dictionary_array::<UInt16Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, UInt16Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, UInt16Type)
                     }
                     (DataType::UInt32, DataType::UInt32) => {
                         let left = as_dictionary_array::<UInt32Type>($LEFT);
                         let right = as_dictionary_array::<UInt32Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, UInt32Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, UInt32Type)
                     }
                     (DataType::UInt64, DataType::UInt64) => {
                         let left = as_dictionary_array::<UInt64Type>($LEFT);
                         let right = as_dictionary_array::<UInt64Type>($RIGHT);
-                        typed_dict_cmp!(left, right, $OP, $OP_BOOL, UInt64Type)
+                        typed_dict_cmp!(left, right, $OP, $OP_REF, UInt64Type)
                     }
                     (t1, t2) if t1 == t2 => Err(ArrowError::NotYetImplemented(format!(
                         "Comparing dictionary arrays of type {} is not yet implemented",
@@ -2135,9 +2135,60 @@ macro_rules! typed_dict_compares {
     }};
 }
 
+fn comparer<T>(
+    mut op: impl FnMut(T, T) -> bool,
+) -> impl FnMut((Option<T>, Option<T>)) -> Option<bool> {
+    move |(left_value, right_value)| {
+        if let (Some(left), Some(right)) = (left_value, right_value) {
+            Some(op(left, right))
+        } else {
+            None
+        }
+    }
+}
+
 /// Helper function to perform boolean lambda function on values from two dictionary arrays, this
 /// version does not attempt to use SIMD explicitly (though the compiler may auto vectorize)
 macro_rules! compare_dict_op {
+    ($left: expr, $right:expr, $op:expr, $value_ty:ty, $cmp_ty: ty) => {{
+        if $left.len() != $right.len() {
+            return Err(ArrowError::ComputeError(
+                "Cannot perform comparison operation on arrays of different length"
+                    .to_string(),
+            ));
+        }
+
+        // Safety justification: Since the inputs are valid Arrow arrays, all values are
+        // valid indexes into the dictionary (which is verified during construction)
+
+        let left;
+        let left_iter = unsafe {
+            left = $left
+                .values()
+                .as_any()
+                .downcast_ref::<$value_ty>()
+                .unwrap()
+                .as_array_view()
+                .cast::<$cmp_ty>();
+            left.take_iter_unchecked($left.keys_iter())
+        };
+
+        let right;
+        let right_iter = unsafe {
+            right = $right
+                .values()
+                .as_any()
+                .downcast_ref::<$value_ty>()
+                .unwrap()
+                .as_array_view()
+                .cast::<$cmp_ty>();
+            right.take_iter_unchecked($right.keys_iter())
+        };
+
+        let result = left_iter.zip(right_iter).map(comparer($op)).collect();
+
+        Ok(result)
+    }};
     ($left: expr, $right:expr, $op:expr, $value_ty:ty) => {{
         if $left.len() != $right.len() {
             return Err(ArrowError::ComputeError(
@@ -2195,6 +2246,74 @@ where
     F: Fn(T::Native, T::Native) -> bool,
 {
     compare_dict_op!(left, right, op, PrimitiveArray<T>)
+}
+
+fn cmp_dict_bit_equal<K, T, F>(
+    left: &DictionaryArray<K>,
+    right: &DictionaryArray<K>,
+    op: F,
+) -> Result<BooleanArray>
+where
+    K: ArrowNumericType,
+    T: ArrowNumericType,
+    T::Native: CmpRepr,
+    F: Fn(<T::Native as CmpRepr>::Repr, <T::Native as CmpRepr>::Repr) -> bool,
+{
+    compare_dict_op!(
+        left,
+        right,
+        op,
+        PrimitiveArray<T>,
+        <T::Native as CmpRepr>::Repr
+    )
+}
+
+// Trait to help reduce the number of function instantiations by merging types which compare the
+// same (u8/i8 are compared the same way)
+trait CmpRepr: Copy {
+    type Repr: Copy;
+}
+
+impl CmpRepr for u8 {
+    type Repr = u8;
+}
+impl CmpRepr for i8 {
+    type Repr = u8;
+}
+
+impl CmpRepr for u16 {
+    type Repr = u16;
+}
+impl CmpRepr for i16 {
+    type Repr = u16;
+}
+
+impl CmpRepr for u32 {
+    type Repr = u32;
+}
+impl CmpRepr for i32 {
+    type Repr = u32;
+}
+
+impl CmpRepr for u64 {
+    type Repr = u64;
+}
+impl CmpRepr for i64 {
+    type Repr = u64;
+}
+
+impl CmpRepr for u128 {
+    type Repr = u128;
+}
+impl CmpRepr for i128 {
+    type Repr = u128;
+}
+
+impl CmpRepr for f32 {
+    type Repr = f32;
+}
+impl CmpRepr for f64 {
+    type Repr = f64;
 }
 
 /// Perform the given operation on two `DictionaryArray`s which value type is
@@ -2263,7 +2382,7 @@ pub fn eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l != r
             }
-            typed_dict_compares!(left, right, op_eq, op_eq)
+            typed_dict_compares!(left, right, op_eq, <_ as PartialEq>::eq)
         }
         _ => typed_compares!(left, right, |a, b| !(a ^ b), |a, b| a == b),
     }
@@ -2295,7 +2414,7 @@ pub fn neq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l != r
             }
-            typed_dict_compares!(left, right, op_neq, op_neq)
+            typed_dict_compares!(left, right, op_neq, <_ as PartialEq>::ne)
         }
         _ => typed_compares!(left, right, |a, b| (a ^ b), |a, b| a != b),
     }
@@ -2327,7 +2446,7 @@ pub fn lt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l < r
             }
-            typed_dict_compares!(left, right, op_lt, op_lt)
+            typed_dict_compares!(left, right, op_lt, <_ as PartialOrd>::lt)
         }
         _ => typed_compares!(left, right, |a, b| ((!a) & b), |a, b| a < b),
     }
@@ -2358,7 +2477,7 @@ pub fn lt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l > r
             }
-            typed_dict_compares!(left, right, op_le, op_le)
+            typed_dict_compares!(left, right, op_le, <_ as PartialOrd>::le)
         }
         _ => typed_compares!(left, right, |a, b| !(a & (!b)), |a, b| a <= b),
     }
@@ -2389,7 +2508,7 @@ pub fn gt_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l > r
             }
-            typed_dict_compares!(left, right, op_gt, op_gt)
+            typed_dict_compares!(left, right, op_gt, <_ as PartialOrd>::gt)
         }
         _ => typed_compares!(left, right, |a, b| (a & (!b)), |a, b| a > b),
     }
@@ -2419,7 +2538,7 @@ pub fn gt_eq_dyn(left: &dyn Array, right: &dyn Array) -> Result<BooleanArray> {
             {
                 l >= r
             }
-            typed_dict_compares!(left, right, op_ge, op_ge)
+            typed_dict_compares!(left, right, op_ge, <_ as PartialOrd>::ge)
         }
         _ => typed_compares!(left, right, |a, b| !((!a) & b), |a, b| a >= b),
     }


### PR DESCRIPTION
# Rationale for this change

The `arrow` crate generates a lot of code due the the dynamic comparison operators which takes a long time to compile and potentially bloats the final binary. By extracting code from generic functions and otherwise reducing how much code gets instantiated we get a faster and slimmer compilation.

Doesn't really fix https://github.com/apache/arrow-rs/issues/1858 as the amount of code is still huge, but it does still help.

(Output of `cargo llvm-line -p arrow`)

### Before
```
  Lines           Copies        Function name
  -----           ------        -------------
  3923704 (100%)  78533 (100%)  (TOTAL)
   294241 (7.5%)   1163 (1.5%)  <arrow::array::array_boolean::BooleanArray as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
   127937 (3.3%)   2355 (3.0%)  core::option::Option<T>::map
   121895 (3.1%)   1750 (2.2%)  core::iter::traits::iterator::Iterator::fold
   107517 (2.7%)   1908 (2.4%)  core::iter::adapters::map::map_fold::{{closure}}
    93556 (2.4%)   1908 (2.4%)  <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
    92112 (2.3%)    912 (1.2%)  arrow::compute::kernels::comparison::cmp_dict
    85470 (2.2%)   1235 (1.6%)  <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold::enumerate::{{closure}}
    84899 (2.2%)   1163 (1.5%)  <arrow::array::array_boolean::BooleanArray as core::iter::traits::collect::FromIterator<Ptr>>::from_iter::{{closure}}
    78480 (2.0%)    912 (1.2%)  arrow::compute::kernels::comparison::cmp_dict::{{closure}}
    61814 (1.6%)    314 (0.4%)  arrow::buffer::mutable::MutableBuffer::try_from_trusted_len_iter
    61759 (1.6%)    301 (0.4%)  <arrow::array::array_primitive::PrimitiveArray<T> as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
    61748 (1.6%)   1723 (2.2%)  core::iter::traits::iterator::Iterator::for_each
    59900 (1.5%)   1235 (1.6%)  <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold
    57896 (1.5%)     62 (0.1%)  core::slice::sort::partition_in_blocks
    54089 (1.4%)    358 (0.5%)  <core::iter::adapters::zip::Zip<A,B> as core::iter::adapters::zip::ZipImpl<A,B>>::next
    50624 (1.3%)   3198 (4.1%)  core::iter::adapters::map::Map<I,F>::new
    48259 (1.2%)    320 (0.4%)  arrow::buffer::mutable::MutableBuffer::extend_from_iter
    45450 (1.2%)    150 (0.2%)  arrow::compute::kernels::comparison::compare_op
    43368 (1.1%)    312 (0.4%)  <core::iter::adapters::zip::Zip<A,B> as core::iter::adapters::zip::ZipImpl<A,B>>::size_hint
    40331 (1.0%)   1717 (2.2%)  core::iter::traits::iterator::Iterator::for_each::call::{{closure}}
    40109 (1.0%)    145 (0.2%)  arrow::util::trusted_len::trusted_len_unzip
    39509 (1.0%)    312 (0.4%)  <arrow::buffer::immutable::Buffer as core::iter::traits::collect::FromIterator<T>>::from_iter
    36585 (0.9%)   3198 (4.1%)  core::iter::traits::iterator::Iterator::map

```

### After

```
  Lines           Copies        Function name
  -----           ------        -------------
  3348856 (100%)  66644 (100%)  (TOTAL)
   126209 (3.8%)   2323 (3.5%)  core::option::Option<T>::map
   117648 (3.5%)    912 (1.4%)  arrow::compute::kernels::comparison::cmp_dict_bit_equal
    82631 (2.5%)   1174 (1.8%)  core::iter::traits::iterator::Iterator::fold
    76312 (2.3%)    587 (0.9%)  <arrow::array::array_boolean::BooleanArray as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
    76221 (2.3%)   1332 (2.0%)  core::iter::adapters::map::map_fold::{{closure}}
    64660 (1.9%)   1332 (2.0%)  <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
    61814 (1.8%)    314 (0.5%)  arrow::buffer::mutable::MutableBuffer::try_from_trusted_len_iter
    61759 (1.8%)    301 (0.5%)  <arrow::array::array_primitive::PrimitiveArray<T> as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
    57896 (1.7%)     62 (0.1%)  core::slice::sort::partition_in_blocks
    51593 (1.5%)    342 (0.5%)  <core::iter::adapters::zip::Zip<A,B> as core::iter::adapters::zip::ZipImpl<A,B>>::next
    48259 (1.4%)    320 (0.5%)  arrow::buffer::mutable::MutableBuffer::extend_from_iter
    46302 (1.4%)    659 (1.0%)  <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold::enumerate::{{closure}}
    45450 (1.4%)    150 (0.2%)  arrow::compute::kernels::comparison::compare_op
    42851 (1.3%)    587 (0.9%)  <arrow::array::array_boolean::BooleanArray as core::iter::traits::collect::FromIterator<Ptr>>::from_iter::{{closure}}
    41072 (1.2%)   2606 (3.9%)  core::iter::adapters::map::Map<I,F>::new
    41048 (1.2%)    296 (0.4%)  <core::iter::adapters::zip::Zip<A,B> as core::iter::adapters::zip::ZipImpl<A,B>>::size_hint
    41012 (1.2%)   1147 (1.7%)  core::iter::traits::iterator::Iterator::for_each
    40109 (1.2%)    145 (0.2%)  arrow::util::trusted_len::trusted_len_unzip
    39509 (1.2%)    312 (0.5%)  <arrow::buffer::immutable::Buffer as core::iter::traits::collect::FromIterator<T>>::from_iter
    32252 (1.0%)    659 (1.0%)  <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold
    31680 (0.9%)    240 (0.4%)  arrow::compute::kernels::arithmetic::math_op_dict
    30955 (0.9%)   1842 (2.8%)  core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
    30890 (0.9%)    152 (0.2%)  arrow::array::array_primitive::PrimitiveArray<T>::from_trusted_len_iter
    30132 (0.9%)     81 (0.1%)  arrow::compute::kernels::take::take_primitive
    29737 (0.9%)   2606 (3.9%)  core::iter::traits::iterator::Iterator::map
    29531 (0.9%)    241 (0.4%)  <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
    28824 (0.9%)     62 (0.1%)  core::slice::sort::shift_tail

```

# What changes are included in this PR?

Refactorings to reduce how much code is instantiated. The PR is left in draft as some of the changes to compare native types instead of "arrow types" is a bit hacky.