### PR TITLE
Remove get_byte_ranges where bound

### DIFF
--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -108,7 +108,7 @@ use crate::file::FOOTER_SIZE;
 use crate::schema::types::{ColumnDescPtr, SchemaDescPtr, SchemaDescriptor};
 
 /// The asynchronous interface used by [`ParquetRecordBatchStream`] to read parquet files
-pub trait AsyncFileReader {
+pub trait AsyncFileReader: Send {
     /// Retrieve the bytes in `range`
     fn get_bytes(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>>;
 

--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -116,10 +116,7 @@ pub trait AsyncFileReader {
     fn get_byte_ranges(
         &mut self,
         ranges: Vec<Range<usize>>,
-    ) -> BoxFuture<'_, Result<Vec<Bytes>>>
-    where
-        Self: Send,
-    {
+    ) -> BoxFuture<'_, Result<Vec<Bytes>>> {
         async move {
             let mut result = Vec::with_capacity(ranges.len());
 


### PR DESCRIPTION
This makes the trait not object safe - https://github.com/apache/arrow-datafusion/runs/7728204421?check_suite_focus=true

https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint_defs/builtin/static.WHERE_CLAUSES_OBJECT_SAFETY.html

It was added by @thinkharderdev in https://github.com/apache/arrow-rs/pull/2115