### PR TITLE
Fix object_store lint

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -44,7 +44,7 @@ jobs:
           rustup component add clippy
       - name: Run clippy
         run: |
-          cargo clippy -p object_store --all-features
+          cargo clippy -p object_store --all-features -- -D warnings
 
   # test the crate
   linux-test:


### PR DESCRIPTION
https://github.com/apache/arrow-rs/pull/2336 contained failing lints, but CI didn't pick them up because `-- -D warnings` wasn't passed to clippy.