### PR TITLE
feat: add token provider authorization to azure store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ parquet/data.parquet
 # release notes cache
 .githubchangeloggenerator.cache
 .githubchangeloggenerator.cache.log
+justfile
+.prettierignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ parquet/data.parquet
 .githubchangeloggenerator.cache.log
 justfile
 .prettierignore
+.env

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -31,107 +31,46 @@ all-features = true
 [dependencies] # In alphabetical order
 async-trait = "0.1.53"
 # Microsoft Azure Blob storage integration
-azure_core = { version = "0.4", optional = true, default-features = false, features = [
-    "enable_reqwest_rustls",
-] }
-azure_identity = { version = "0.5", optional = true, default-features = false }
-azure_storage = { version = "0.5", optional = true, default-features = false }
-azure_storage_blobs = { version = "0.5", optional = true, default-features = false, features = [
-    "enable_reqwest_rustls",
-] }
+azure_core = { version = "0.4", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
+azure_identity = { version = "0.5", optional = true, default-features = false, features = ["enable_reqwest_rustls"]}
+azure_storage = { version = "0.5", optional = true, default-features = false, features = ["enable_reqwest_rustls"]}
+azure_storage_blobs = { version = "0.5", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # Google Cloud Storage integration
 futures = "0.3"
-serde = { version = "1.0", default-features = false, features = [
-    "derive",
-], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
 quick-xml = { version = "0.23.0", features = ["serialize"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
-ring = { version = "0.16", default-features = false, features = [
-    "std",
-], optional = true }
+ring = { version = "0.16", default-features = false, features = ["std"], optional = true }
 base64 = { version = "0.13", default-features = false, optional = true }
-rand = { version = "0.8", default-features = false, features = [
-    "std",
-    "std_rng",
-], optional = true }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 # for rusoto
 hyper = { version = "0.14", optional = true, default-features = false }
 # for rusoto
-hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = [
-    "webpki-tokio",
-    "http1",
-    "http2",
-    "tls12",
-] }
+hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = ["webpki-tokio", "http1", "http2", "tls12"] }
 itertools = "0.10.1"
 percent-encoding = "2.1"
 # rusoto crates are for Amazon S3 integration
-rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = [
-    "rustls",
-] }
+rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }
-rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = [
-    "rustls",
-] }
-rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = [
-    "rustls",
-] }
+rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
+rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
 snafu = "0.7"
-tokio = { version = "1.18", features = [
-    "sync",
-    "macros",
-    "parking_lot",
-    "rt-multi-thread",
-    "time",
-    "io-util",
-] }
+tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time", "io-util"] }
 tracing = { version = "0.1" }
-reqwest = { version = "0.11", default-features = false, features = [
-    "rustls-tls",
-], optional = true }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"], optional = true }
 parking_lot = { version = "0.12" }
 # Filesystem integration
 url = "2.2"
 walkdir = "2"
 
 [features]
-azure = [
-    "azure_core",
-    "azure_storage_blobs",
-    "azure_storage",
-    "reqwest",
-    "azure_identity",
-]
-azure_test = [
-    "azure",
-    "azure_core/azurite_workaround",
-    "azure_storage/azurite_workaround",
-    "azure_storage_blobs/azurite_workaround",
-]
-gcp = [
-    "serde",
-    "serde_json",
-    "quick-xml",
-    "reqwest",
-    "reqwest/json",
-    "reqwest/stream",
-    "chrono/serde",
-    "rustls-pemfile",
-    "base64",
-    "rand",
-    "ring",
-]
-aws = [
-    "rusoto_core",
-    "rusoto_credential",
-    "rusoto_s3",
-    "rusoto_sts",
-    "hyper",
-    "hyper-rustls",
-]
+azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest", "azure_identity"]
+azure_test = ["azure", "azure_core/azurite_workaround", "azure_storage/azurite_workaround", "azure_storage_blobs/azurite_workaround"]
+gcp = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64", "rand", "ring"]
+aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "hyper", "hyper-rustls"]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -22,11 +22,7 @@ edition = "2021"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 description = "A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files."
-keywords = [
-    "object",
-    "storage",
-    "cloud",
-]
+keywords = ["object", "storage", "cloud"]
 repository = "https://github.com/apache/arrow-rs"
 
 [package.metadata.docs.rs]
@@ -35,45 +31,107 @@ all-features = true
 [dependencies] # In alphabetical order
 async-trait = "0.1.53"
 # Microsoft Azure Blob storage integration
-azure_core = { version = "0.2", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
-azure_storage = { version = "0.2", optional = true, default-features = false, features = ["account"] }
-azure_storage_blobs = { version = "0.2", optional = true, default-features = false, features = ["enable_reqwest_rustls"] }
+azure_core = { version = "0.4", optional = true, default-features = false, features = [
+    "enable_reqwest_rustls",
+] }
+azure_identity = { version = "0.5", optional = true, default-features = false }
+azure_storage = { version = "0.5", optional = true, default-features = false }
+azure_storage_blobs = { version = "0.5", optional = true, default-features = false, features = [
+    "enable_reqwest_rustls",
+] }
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # Google Cloud Storage integration
 futures = "0.3"
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
 quick-xml = { version = "0.23.0", features = ["serialize"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
-ring = { version = "0.16", default-features = false, features = ["std"], optional = true }
+ring = { version = "0.16", default-features = false, features = [
+    "std",
+], optional = true }
 base64 = { version = "0.13", default-features = false, optional = true }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
+rand = { version = "0.8", default-features = false, features = [
+    "std",
+    "std_rng",
+], optional = true }
 # for rusoto
 hyper = { version = "0.14", optional = true, default-features = false }
 # for rusoto
-hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = ["webpki-tokio", "http1", "http2", "tls12"] }
+hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = [
+    "webpki-tokio",
+    "http1",
+    "http2",
+    "tls12",
+] }
 itertools = "0.10.1"
 percent-encoding = "2.1"
 # rusoto crates are for Amazon S3 integration
-rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.48.0", optional = true, default-features = false, features = [
+    "rustls",
+] }
 rusoto_credential = { version = "0.48.0", optional = true, default-features = false }
-rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
-rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = ["rustls"] }
+rusoto_s3 = { version = "0.48.0", optional = true, default-features = false, features = [
+    "rustls",
+] }
+rusoto_sts = { version = "0.48.0", optional = true, default-features = false, features = [
+    "rustls",
+] }
 snafu = "0.7"
-tokio = { version = "1.18", features = ["sync", "macros", "parking_lot", "rt-multi-thread", "time", "io-util"] }
+tokio = { version = "1.18", features = [
+    "sync",
+    "macros",
+    "parking_lot",
+    "rt-multi-thread",
+    "time",
+    "io-util",
+] }
 tracing = { version = "0.1" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"], optional = true }
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+], optional = true }
 parking_lot = { version = "0.12" }
 # Filesystem integration
 url = "2.2"
 walkdir = "2"
 
 [features]
-azure = ["azure_core", "azure_storage_blobs", "azure_storage", "reqwest"]
-azure_test = ["azure", "azure_core/azurite_workaround", "azure_storage/azurite_workaround", "azure_storage_blobs/azurite_workaround"]
-gcp = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "rustls-pemfile", "base64", "rand", "ring"]
-aws = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "hyper", "hyper-rustls"]
+azure = [
+    "azure_core",
+    "azure_storage_blobs",
+    "azure_storage",
+    "reqwest",
+    "azure_identity",
+]
+azure_test = [
+    "azure",
+    "azure_core/azurite_workaround",
+    "azure_storage/azurite_workaround",
+    "azure_storage_blobs/azurite_workaround",
+]
+gcp = [
+    "serde",
+    "serde_json",
+    "quick-xml",
+    "reqwest",
+    "reqwest/json",
+    "reqwest/stream",
+    "chrono/serde",
+    "rustls-pemfile",
+    "base64",
+    "rand",
+    "ring",
+]
+aws = [
+    "rusoto_core",
+    "rusoto_credential",
+    "rusoto_s3",
+    "rusoto_sts",
+    "hyper",
+    "hyper-rustls",
+]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -703,22 +703,18 @@ impl MicrosoftAzureBuilder {
 
             (true, storage_client)
         } else {
-            let client = if bearer_token.is_some() {
-                Ok(StorageClient::new_bearer_token(
-                    &account,
-                    bearer_token.unwrap(),
-                ))
-            } else if access_key.is_some() {
-                Ok(StorageClient::new_access_key(&account, access_key.unwrap()))
-            } else if client_id.is_some()
-                && client_secret.is_some()
-                && tenant_id.is_some()
+            let client = if let Some(bearer_token) = bearer_token {
+                Ok(StorageClient::new_bearer_token(&account, bearer_token))
+            } else if let Some(access_key) = access_key {
+                Ok(StorageClient::new_access_key(&account, access_key))
+            } else if let (Some(client_id), Some(client_secret), Some(tenant_id)) =
+                (tenant_id, client_id, client_secret)
             {
                 let credential = Arc::new(AutoRefreshingTokenCredential::new(Arc::new(
                     ClientSecretCredential::new(
-                        tenant_id.unwrap(),
-                        client_id.unwrap(),
-                        client_secret.unwrap(),
+                        tenant_id,
+                        client_id,
+                        client_secret,
                         TokenCredentialOptions::default(),
                     ),
                 )));

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -634,7 +634,7 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Set a client id used for client secret authorization 
+    /// Set a client id used for client secret authorization
     /// (required - one of access key, bearer token, or client credentials)
     pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
         self.client_id = Some(client_id.into());

--- a/object_store/src/azure.rs
+++ b/object_store/src/azure.rs
@@ -628,7 +628,7 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Set the Azure Access Key (required - one of token_credential ot access key)
+    /// Set the Azure Access Key (required - one of token_credential or access key)
     pub fn with_access_key(mut self, access_key: impl Into<String>) -> Self {
         self.access_key = Some(access_key.into());
         self
@@ -640,7 +640,7 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Set a TokenCredential to be used for authentication (required - one of token_credential ot access key)
+    /// Set a TokenCredential to be used for authentication (required - one of token_credential or access key)
     pub fn with_token_credential(
         mut self,
         token_credential: Arc<dyn TokenCredential>,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2373

cc @tustvold @alamb 

# Rationale for this change
 
Allow a wider range of use by offering more ob the azure native auth methods. While this change might eventually becoem irrelevant, once we move away from SDKs, it is quite helpful in the meantime. 

# What changes are included in this PR?

~~Add an option to provide a `TokenProvider` credential via the `MicrosoftAzureBuilder`.~~
Add an options to provide client credentials via the `MicrosoftAzureBuilder`.

# Are there any user-facing changes?

users now have more authorization options.