### PR TITLE
Minor: Remove dead code in `verify_release_candidate.sh`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -72,24 +72,6 @@ fetch_archive() {
   ${sha512_verify} ${dist_name}.tar.gz.sha512
 }
 
-verify_dir_artifact_signatures() {
-  # verify the signature and the checksums of each artifact
-  find $1 -name '*.asc' | while read sigfile; do
-    artifact=${sigfile/.asc/}
-    gpg --verify $sigfile $artifact || exit 1
-
-    # go into the directory because the checksum files contain only the
-    # basename of the artifact
-    pushd $(dirname $artifact)
-    base_artifact=$(basename $artifact)
-    if [ -f $base_artifact.sha256 ]; then
-      ${sha256_verify} $base_artifact.sha256 || exit 1
-    fi
-    ${sha512_verify} $base_artifact.sha512 || exit 1
-    popd
-  done
-}
-
 setup_tempdir() {
   cleanup() {
     if [ "${TEST_SUCCESS}" = "yes" ]; then


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
While working on #2392  I noticed some unused code in the main `verify_release_candidate.sh` very likely left over form the initial port we did from arrow. Original source https://github.com/apache/arrow/blob/c04f257/dev/release/verify-release-candidate.sh#L150-L170

# What changes are included in this PR?
Remove function that is never called

# Are there any user-facing changes?
No