### PR TITLE
Improve markdown format CI check to show diff

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -52,6 +52,6 @@ jobs:
           node-version: "14"
       - name: Prettier check
         run: |
-          # if you encounter error, try rerun the command below with --write instead of --check
-          # and commit the changes
-          npx prettier@2.3.0 --check {arrow,arrow-flight,dev,integration-testing,parquet}/**/*.md README.md CODE_OF_CONDUCT.md CONTRIBUTING.md
+          # if you encounter error, run the command below and commit the changes
+          npx prettier@2.3.2 --write {arrow,arrow-flight,dev,integration-testing,parquet}/**/*.md README.md CODE_OF_CONDUCT.md CONTRIBUTING.md
+          git diff --exit-code


### PR DESCRIPTION
~Draft until I get an example failure with the updated check~

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/1139

# Rationale for this change

If the CI markdown check fails, users can apply the diffs manually if they don't want to install `npx`

# What changes are included in this PR?
Update arrow check to be the same as datafusion: https://github.com/apache/arrow-datafusion/blob/a8ed874/.github/workflows/dev.yml#L50-L55

1. Use `--write` and `git diff` instead if `--check`
2. Upgrade from `prettier@2.3.2` to `prettier@2.3.2` 

# Example CI failure
Here is an example of what the CI failure looks like with this change: https://github.com/apache/arrow-rs/runs/7769033182?check_suite_focus=true

# Are there any user-facing changes?
No