### PR TITLE
Use correct tags when generating changelogs, fix release tarball typo

### DIFF
--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -48,6 +48,7 @@ docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pw
     --cache-log=.githubchangeloggenerator.cache.log \
     --http-cache \
     --max-issues=300 \
+    --exclude-tags-regex "^object_store_\d+\.\d+\.\d+$" \
     --since-tag ${SINCE_TAG} \
     --future-release ${FUTURE_RELEASE}
 

--- a/object_store/dev/release/README.md
+++ b/object_store/dev/release/README.md
@@ -17,4 +17,4 @@
   under the License.
 -->
 
-See instructons in [`/dev/release/README.md`](../../../dev/release/README.md)
+See instructions in [`/dev/release/README.md`](../../../dev/release/README.md)

--- a/object_store/dev/release/release-tarball.sh
+++ b/object_store/dev/release/release-tarball.sh
@@ -53,7 +53,7 @@ mkdir -p ${tmp_dir}
 echo "Clone dev dist repository"
 svn \
   co \
-  https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-obect-store-rs-${version}-rc${rc} \
+  https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-object-store-rs-${version}-rc${rc} \
   ${tmp_dir}/dev
 
 echo "Clone release dist repository"

--- a/object_store/dev/release/update_change_log.sh
+++ b/object_store/dev/release/update_change_log.sh
@@ -48,6 +48,7 @@ docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pw
     --cache-log=.githubchangeloggenerator.cache.log \
     --http-cache \
     --max-issues=300 \
+    --exclude-tags-regex "^\d+\.\d+\.\d+$" \
     --since-tag ${SINCE_TAG} \
     --future-release ${FUTURE_RELEASE}
 


### PR DESCRIPTION
This prevents the script from generating sections in the object store changelog related to arrow releases, and vice-versa