### PR TITLE
Make the API of `fn Decimal:new` be consistent with `fn Decimal:try_new_bytes` and add length bound for `Decimal::raw_value`

### DIFF
--- a/arrow/src/array/array_decimal.rs
+++ b/arrow/src/array/array_decimal.rs
@@ -123,6 +123,8 @@ impl<const BYTE_WIDTH: usize> BasicDecimalArray<BYTE_WIDTH> {
                 self.raw_value_data_ptr().offset(pos as isize),
                 Self::VALUE_LENGTH as usize,
             )
+            .try_into()
+            .unwrap()
         };
         BasicDecimal::<BYTE_WIDTH>::new(self.precision(), self.scale(), raw_val)
     }

--- a/arrow/src/util/decimal.rs
+++ b/arrow/src/util/decimal.rs
@@ -64,8 +64,7 @@ impl<const BYTE_WIDTH: usize> BasicDecimal<BYTE_WIDTH> {
         Self::MAX_PRECISION_SCALE_CONSTRUCTOR_DEFAULT_TYPE.3;
 
     /// Tries to create a decimal value from precision, scale and bytes.
-    /// If the length of bytes isn't same as the bit width of this decimal,
-    /// returning an error. The bytes should be stored in little-endian order.
+    /// The bytes should be stored in little-endian order.
     ///
     /// Safety:
     /// This method doesn't validate if the decimal value represented by the bytes

--- a/arrow/src/util/decimal.rs
+++ b/arrow/src/util/decimal.rs
@@ -114,17 +114,17 @@ impl<const BYTE_WIDTH: usize> BasicDecimal<BYTE_WIDTH> {
     /// Creates a decimal value from precision, scale, and bytes.
     ///
     /// Safety:
-    /// This method doesn't check if the length of bytes is compatible with this decimal.
+    /// This method doesn't check if the precision and scale are valid.
     /// Use `try_new_from_bytes` for safe constructor.
-    pub fn new(precision: usize, scale: usize, bytes: &[u8]) -> Self {
+    pub fn new(precision: usize, scale: usize, bytes: &[u8; BYTE_WIDTH]) -> Self {
         Self {
             precision,
             scale,
-            value: bytes.try_into().unwrap(),
+            value: *bytes,
         }
     }
     /// Returns the raw bytes of the integer representation of the decimal.
-    pub fn raw_value(&self) -> &[u8] {
+    pub fn raw_value(&self) -> &[u8; BYTE_WIDTH] {
         &self.value
     }
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?
None.

# Rationale for this change
`fn Decimal:new` and `fn Decimal:try_new_bytes` should have same API.

# What changes are included in this PR?
Add length bound for `Decimal:new` and `Decimal::raw_value`.
Update docs

# Are there any user-facing changes?
Yes.
