### PR TITLE
Add comments to changelog generator script

### DIFF
--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -40,6 +40,8 @@ OUTPUT_PATH="${SOURCE_TOP_DIR}/CHANGELOG.md"
 # remove license header so github-changelog-generator has a clean base to append
 sed -i.bak '1,18d' "${OUTPUT_PATH}"
 
+# use exclude-tags-regex to filter out tags used for object_store
+# crates and only only look at tags that DO NOT begin with `object_store_`
 pushd "${SOURCE_TOP_DIR}"
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator \
     --user apache \

--- a/object_store/dev/release/update_change_log.sh
+++ b/object_store/dev/release/update_change_log.sh
@@ -40,6 +40,8 @@ OUTPUT_PATH="${SOURCE_TOP_DIR}/CHANGELOG.md"
 # remove license header so github-changelog-generator has a clean base to append
 sed -i.bak '1,18d' "${OUTPUT_PATH}"
 
+# use exclude-tags-regex to filter out tags used for arrow
+# crates and only look at tags that begin with `object_store_`
 pushd "${SOURCE_TOP_DIR}"
 docker run -it --rm -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator \
     --user apache \


### PR DESCRIPTION
# Which issue does this PR close?

This is a small follow on to https://github.com/apache/arrow-rs/pull/2401 

related to #2261 

# Rationale for this change
 
I will never remember why we added tag filtering to changelog generator without some mental help

# What changes are included in this PR?

Comments in changelog generator script

# Are there any user-facing changes?
No