### PR TITLE
Seal the decimal type.

### DIFF
--- a/arrow/src/util/decimal.rs
+++ b/arrow/src/util/decimal.rs
@@ -26,6 +26,8 @@ use num::bigint::BigInt;
 use num::Signed;
 use std::cmp::{min, Ordering};
 
+/// Indicate which [`BasicDecimal`]s are valid.
+/// Currently we only support [`Decimal128`] and [`Decimal256`].
 pub trait ValidDecimal {
     const MAX_PRECISION: usize;
     const MAX_SCALE: usize;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2440.

# Rationale for this change
The current implementation of `BasicDecimal` cannot restrict the `BYTE_WIDTH` to be 16 or 32, which means that you can create an invalid decimal value like this
```rust
let v = BasicDecimal::<1>::new(1, 1, &[1]);
```

# What changes are included in this PR?
We create a new public trait `ValidDecimal` and implement the trait for `Decimal128` and `Decimal256`. The idea is from https://users.rust-lang.org/t/how-to-seal-the-const-generic/77947/2.
Because of the orphan rule, downstream users cannot implement `ValidDecimal` for other `BasicDecimal` types.

# Are there any user-facing changes?
No breaking.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
