### PR TITLE
Make Parquet reader filter APIs public (#1792)

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -39,16 +39,11 @@ use crate::file::reader::{ChunkReader, FileReader, SerializedFileReader};
 use crate::file::serialized_reader::ReadOptionsBuilder;
 use crate::schema::types::SchemaDescriptor;
 
-#[allow(unused)]
 mod filter;
-#[allow(unused)]
 mod selection;
 
-// TODO: Make these public once stable (#1792)
-#[allow(unused_imports)]
-pub(crate) use filter::{ArrowPredicate, ArrowPredicateFn, RowFilter};
-#[allow(unused_imports)]
-pub(crate) use selection::{RowSelection, RowSelector};
+pub use filter::{ArrowPredicate, ArrowPredicateFn, RowFilter};
+pub use selection::{RowSelection, RowSelector};
 
 /// A generic builder for constructing sync or async arrow parquet readers. This is not intended
 /// to be used directly, instead you should use the specialization for the type of reader
@@ -141,14 +136,16 @@ impl<T> ArrowReaderBuilder<T> {
     }
 
     /// Provide a [`RowSelection] to filter out rows, and avoid fetching their
-    /// data into memory
+    /// data into memory.
     ///
-    /// Row group filtering is applied prior to this, and rows from skipped
+    /// Row group filtering is applied prior to this, and therefore rows from skipped
     /// row groups should not be included in the [`RowSelection`]
     ///
-    /// TODO: Make public once stable (#1792)
-    #[allow(unused)]
-    pub(crate) fn with_row_selection(self, selection: RowSelection) -> Self {
+    /// An example use case of this would be applying a selection determined by
+    /// evaluating predicates against the [`Index`]
+    ///
+    /// [`Index`]: [parquet::file::page_index::index::Index]
+    pub fn with_row_selection(self, selection: RowSelection) -> Self {
         Self {
             selection: Some(selection),
             ..self
@@ -158,10 +155,7 @@ impl<T> ArrowReaderBuilder<T> {
     /// Provide a [`RowFilter`] to skip decoding rows
     ///
     /// Row filters are applied after row group selection and row selection
-    ///
-    /// TODO: Make public once stable (#1792)
-    #[allow(unused)]
-    pub(crate) fn with_row_filter(self, filter: RowFilter) -> Self {
+    pub fn with_row_filter(self, filter: RowFilter) -> Self {
         Self {
             filter: Some(filter),
             ..self

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -135,7 +135,7 @@ impl<T> ArrowReaderBuilder<T> {
         }
     }
 
-    /// Provide a [`RowSelection] to filter out rows, and avoid fetching their
+    /// Provide a [`RowSelection`] to filter out rows, and avoid fetching their
     /// data into memory.
     ///
     /// Row group filtering is applied prior to this, and therefore rows from skipped

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -398,11 +398,11 @@ mod tests {
         let mut rand = thread_rng();
         for _ in 0..100 {
             let a_len = rand.gen_range(10..100);
-            let a_bools: Vec<_> = (0..a_len).map(|x| rand.gen_bool(0.2)).collect();
+            let a_bools: Vec<_> = (0..a_len).map(|_| rand.gen_bool(0.2)).collect();
             let a = RowSelection::from_filters(&[BooleanArray::from(a_bools.clone())]);
 
             let b_len: usize = a_bools.iter().map(|x| *x as usize).sum();
-            let b_bools: Vec<_> = (0..b_len).map(|x| rand.gen_bool(0.8)).collect();
+            let b_bools: Vec<_> = (0..b_len).map(|_| rand.gen_bool(0.8)).collect();
             let b = RowSelection::from_filters(&[BooleanArray::from(b_bools.clone())]);
 
             let mut expected_bools = vec![false; a_len];


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #1792

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There is still more work to be done in this space, but I am confident that this functionality is sufficiently mature that we can expose it and start to get feedback from the wild

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Makes the crate-private row filtering APIs, public

# Are there any user-facing changes?



<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
