### PR TITLE
Remove unnecessary Option from Int96

### DIFF
--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -36,29 +36,27 @@ use crate::util::{
 
 /// Rust representation for logical type INT96, value is backed by an array of `u32`.
 /// The type only takes 12 bytes, without extra padding.
-#[derive(Clone, Debug, PartialOrd, Default)]
+#[derive(Clone, Debug, PartialOrd, Default, PartialEq)]
 pub struct Int96 {
-    value: Option<[u32; 3]>,
+    value: [u32; 3],
 }
 
 impl Int96 {
     /// Creates new INT96 type struct with no data set.
     pub fn new() -> Self {
-        Self { value: None }
+        Self { value: [0; 3] }
     }
 
     /// Returns underlying data as slice of [`u32`].
     #[inline]
     pub fn data(&self) -> &[u32] {
-        self.value
-            .as_ref()
-            .expect("set_data should have been called")
+        &self.value
     }
 
     /// Sets data for this INT96 type.
     #[inline]
     pub fn set_data(&mut self, elem0: u32, elem1: u32, elem2: u32) {
-        self.value = Some([elem0, elem1, elem2]);
+        self.value = [elem0, elem1, elem2];
     }
 
     /// Converts this INT96 into an i64 representing the number of MILLISECONDS since Epoch
@@ -72,16 +70,6 @@ impl Int96 {
         let seconds = (day - JULIAN_DAY_OF_EPOCH) * SECONDS_PER_DAY;
 
         seconds * MILLIS_PER_SECOND + nanoseconds / 1_000_000
-    }
-}
-
-impl PartialEq for Int96 {
-    fn eq(&self, other: &Int96) -> bool {
-        match (&self.value, &other.value) {
-            (Some(v1), Some(v2)) => v1 == v2,
-            (None, None) => true,
-            _ => false,
-        }
     }
 }
 

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -36,7 +36,7 @@ use crate::util::{
 
 /// Rust representation for logical type INT96, value is backed by an array of `u32`.
 /// The type only takes 12 bytes, without extra padding.
-#[derive(Clone, Debug, PartialOrd, Default, PartialEq)]
+#[derive(Clone, Debug, PartialOrd, Default, PartialEq, Eq)]
 pub struct Int96 {
     value: [u32; 3],
 }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -843,7 +843,7 @@ mod tests {
         run_test::<Int96Type>(
             -1,
             &[Int96::from(vec![1, 2, 3]), Int96::from(vec![2, 3, 4])],
-            32,
+            24,
         );
         run_test::<ByteArrayType>(
             -1,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #1661 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I can't see an obvious reason for this Option existing, as nothing seems to be exploiting it. Removing it will allow reading Int96 as a regular "primitive" type 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Theoretically now you can call `Int96::data` before calling `set_data` and it won't panic, not sure this counts...

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
