### PR TITLE
Use OffsetIndex to prune IO with RowSelection

### DIFF
--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1068,6 +1068,7 @@ mod tests {
         integration.head(&path).await.unwrap();
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_list_root() {
         let integration = LocalFileSystem::new();

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1068,7 +1068,6 @@ mod tests {
         integration.head(&path).await.unwrap();
     }
 
-    #[ignore]
     #[tokio::test]
     async fn test_list_root() {
         let integration = LocalFileSystem::new();

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -126,16 +126,14 @@ impl RowSelection {
         let mut ranges = vec![];
         let mut row_offset = 0;
 
-        let mut pages = page_locations.iter().enumerate().peekable();
+        let mut pages = page_locations.iter().peekable();
         let mut selectors = self.selectors.iter().cloned();
         let mut current_selector = selectors.next();
         let mut current_page = pages.next();
 
         let mut current_page_included = false;
 
-        while let Some((selector, (mut page_idx, page))) =
-            current_selector.as_mut().zip(current_page)
-        {
+        while let Some((selector, page)) = current_selector.as_mut().zip(current_page) {
             if !(selector.skip || current_page_included) {
                 let start = page.offset as usize;
                 let end = start + page.compressed_page_size as usize;
@@ -143,7 +141,7 @@ impl RowSelection {
                 current_page_included = true;
             }
 
-            if let Some((_, next_page)) = pages.peek() {
+            if let Some(next_page) = pages.peek() {
                 if row_offset + selector.row_count > next_page.first_row_index as usize {
                     let remaining_in_page =
                         next_page.first_row_index as usize - row_offset;

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -22,7 +22,7 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 
-/// [`RowSelection`] is a collection of [`RowSelect`] used to skip rows when
+/// [`RowSelection`] is a collection of [`RowSelector`] used to skip rows when
 /// scanning a parquet file
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RowSelector {

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -21,8 +21,9 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 
-/// [`RowSelector`] represents a range of rows to scan from a parquet file
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// [`RowSelection`] is a collection of [`RowSelect`] used to skip rows when
+/// scanning a parquet file
+#[derive(Debug, Clone, Copy)]
 pub struct RowSelector {
     /// The number of rows
     pub row_count: usize,
@@ -114,6 +115,10 @@ impl RowSelection {
         }
 
         Self { selectors }
+    }
+
+    pub fn selectors(&self) -> &[RowSelector] {
+        &self.selectors
     }
 
     /// Splits off the first `row_count` from this [`RowSelection`]

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -17,13 +17,14 @@
 
 use arrow::array::{Array, BooleanArray};
 use arrow::compute::SlicesIterator;
+use parquet_format::PageLocation;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 
 /// [`RowSelection`] is a collection of [`RowSelect`] used to skip rows when
 /// scanning a parquet file
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RowSelector {
     /// The number of rows
     pub row_count: usize,
@@ -117,6 +118,108 @@ impl RowSelection {
         Self { selectors }
     }
 
+    /// Given an offset index, return the ranges for data pages selected by `self`
+    pub fn scan_ranges(&self, page_locations: &[PageLocation]) -> Vec<Range<usize>> {
+        let mut ranges = vec![];
+        let mut row_offset = 0;
+
+        let mut pages = page_locations.iter().peekable();
+        let mut selectors = self.selectors.iter().cloned();
+        let mut current_selector = selectors.next();
+        let mut current_page = pages.next();
+
+        let mut current_page_included = false;
+
+        while let Some((selector, page)) = current_selector.as_mut().zip(current_page) {
+            if !selector.skip && !current_page_included {
+                let start = page.offset as usize;
+                let end = start + page.compressed_page_size as usize;
+                ranges.push(start..end);
+                current_page_included = true;
+            }
+
+            if let Some(next_page) = pages.peek() {
+                if row_offset + selector.row_count > next_page.first_row_index as usize {
+                    let remaining_in_page =
+                        next_page.first_row_index as usize - row_offset;
+                    selector.row_count -= remaining_in_page;
+                    row_offset += remaining_in_page;
+                    current_page_included = false;
+                    current_page = pages.next();
+
+                    continue;
+                } else {
+                    if row_offset + selector.row_count
+                        == next_page.first_row_index as usize
+                    {
+                        current_page_included = false;
+                        current_page = pages.next();
+                    }
+                    row_offset += selector.row_count;
+                    current_selector = selectors.next();
+                }
+            } else {
+                break;
+            }
+        }
+
+        ranges
+    }
+
+    /// Given an offset index, return a mask indicating which pages are selected along with their locations by `self`
+    pub fn page_mask(
+        &self,
+        page_locations: &[PageLocation],
+    ) -> (Vec<bool>, Vec<Range<usize>>) {
+        let mut mask = vec![false; page_locations.len()];
+        let mut ranges = vec![];
+        let mut row_offset = 0;
+
+        let mut pages = page_locations.iter().enumerate().peekable();
+        let mut selectors = self.selectors.iter().cloned();
+        let mut current_selector = selectors.next();
+        let mut current_page = pages.next();
+
+        let mut current_page_included = false;
+
+        while let Some((selector, (mut page_idx, page))) =
+            current_selector.as_mut().zip(current_page)
+        {
+            if !selector.skip && !current_page_included {
+                if !mask[page_idx] {
+                    mask[page_idx] = true;
+                    let start = page.offset as usize;
+                    let end = start + page.compressed_page_size as usize;
+                    ranges.push(start..end);
+                }
+            }
+
+            if let Some((_, next_page)) = pages.peek() {
+                if row_offset + selector.row_count > next_page.first_row_index as usize {
+                    let remaining_in_page =
+                        next_page.first_row_index as usize - row_offset;
+                    selector.row_count -= remaining_in_page;
+                    row_offset += remaining_in_page;
+                    current_page = pages.next();
+
+                    continue;
+                } else {
+                    if row_offset + selector.row_count
+                        == next_page.first_row_index as usize
+                    {
+                        current_page = pages.next();
+                    }
+                    row_offset += selector.row_count;
+                    current_selector = selectors.next();
+                }
+            } else {
+                break;
+            }
+        }
+
+        (mask, ranges)
+    }
+
     pub fn selectors(&self) -> &[RowSelector] {
         &self.selectors
     }
@@ -167,7 +270,7 @@ impl RowSelection {
     /// self:     NNNNNNNNNNNNYYYYYYYYYYYYYYYYYYYYYYNNNYYYYY
     /// other:                YYYYYNNNNYYYYYYYYYYYYY   YYNNN
     ///
-    /// returned: NNNNNNNNNNNNYYYYYNNNNYYYYYYYYYYYYYYNNYNNNN
+    /// returned: NNNNNNNNNNNNYYYYYNNNNYYYYYYYYYYYYYNNNYYNNN
     ///
     ///
     pub fn and_then(&self, other: &Self) -> Self {
@@ -427,5 +530,120 @@ mod tests {
 
             assert_eq!(a.and_then(&b), expected);
         }
+    }
+
+    #[test]
+    fn test_scan_ranges() {
+        let selection = RowSelection::from(vec![
+            RowSelector::skip(10),
+            RowSelector::select(3),
+            RowSelector::skip(3),
+            RowSelector::select(4),
+            RowSelector::skip(5),
+            RowSelector::select(5),
+            RowSelector::skip(12),
+            RowSelector::select(12),
+            RowSelector::skip(12),
+        ]);
+
+        let index = vec![
+            PageLocation {
+                offset: 0,
+                compressed_page_size: 10,
+                first_row_index: 0,
+            },
+            PageLocation {
+                offset: 10,
+                compressed_page_size: 10,
+                first_row_index: 10,
+            },
+            PageLocation {
+                offset: 20,
+                compressed_page_size: 10,
+                first_row_index: 20,
+            },
+            PageLocation {
+                offset: 30,
+                compressed_page_size: 10,
+                first_row_index: 30,
+            },
+            PageLocation {
+                offset: 40,
+                compressed_page_size: 10,
+                first_row_index: 40,
+            },
+            PageLocation {
+                offset: 50,
+                compressed_page_size: 10,
+                first_row_index: 50,
+            },
+            PageLocation {
+                offset: 60,
+                compressed_page_size: 10,
+                first_row_index: 60,
+            },
+        ];
+
+        let ranges = selection.scan_ranges(&index);
+
+        assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60]);
+    }
+
+    #[test]
+    fn test_page_mask() {
+        let selection = RowSelection::from(vec![
+            RowSelector::skip(10),
+            RowSelector::select(3),
+            RowSelector::skip(3),
+            RowSelector::select(4),
+            RowSelector::skip(5),
+            RowSelector::select(5),
+            RowSelector::skip(12),
+            RowSelector::select(12),
+            RowSelector::skip(12),
+        ]);
+
+        let index = vec![
+            PageLocation {
+                offset: 0,
+                compressed_page_size: 10,
+                first_row_index: 0,
+            },
+            PageLocation {
+                offset: 10,
+                compressed_page_size: 10,
+                first_row_index: 10,
+            },
+            PageLocation {
+                offset: 20,
+                compressed_page_size: 10,
+                first_row_index: 20,
+            },
+            PageLocation {
+                offset: 30,
+                compressed_page_size: 10,
+                first_row_index: 30,
+            },
+            PageLocation {
+                offset: 40,
+                compressed_page_size: 10,
+                first_row_index: 40,
+            },
+            PageLocation {
+                offset: 50,
+                compressed_page_size: 10,
+                first_row_index: 50,
+            },
+            PageLocation {
+                offset: 60,
+                compressed_page_size: 10,
+                first_row_index: 60,
+            },
+        ];
+
+        let (mask, ranges) = selection.page_mask(&index);
+
+        assert_eq!(mask, vec![false, true, true, false, true, true, false]);
+        assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60]);
     }
 }

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -195,6 +195,7 @@ impl PageWriteSpec {
 }
 
 /// Contains metadata for a page
+#[derive(Clone)]
 pub struct PageMetadata {
     /// The number of rows in this page
     pub num_rows: usize,

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -65,7 +65,7 @@ pub fn read_pages_locations<R: ChunkReader>(
     let (offset, total_length) = get_location_offset_and_total_length(chunks)?;
 
     //read all need data into buffer
-    let mut reader = reader.get_read(offset, reader.len() as usize)?;
+    let mut reader = reader.get_read(offset, total_length)?;
     let mut data = vec![0; total_length];
     reader.read_exact(&mut data)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2426.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

When we have a `RowSelection` and an `OffsetIndex` we can reduce IO by fetching only the pages selected. 

This also builds on #2464 to remove `InMemoryColumnChunk` and unify everything to use `SerializedPageReader` 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

We can represent pre-fetched column chunks as either a "dense" encoding (just `Bytes`) or a "sparse" encoding which contains only the pages relevant to a given `RowSelection`. 

Also remove `InMemoryColumnChunk` to help unify the sync and async parquet paths. 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
