### PR TITLE
Make array_reader and schema modules private

### DIFF
--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -119,7 +119,7 @@
 //!}
 //! ```
 
-experimental!(mod array_reader);
+mod array_reader;
 pub mod arrow_reader;
 pub mod arrow_writer;
 mod buffer;
@@ -128,7 +128,7 @@ mod buffer;
 pub mod async_reader;
 
 mod record_reader;
-experimental!(mod schema);
+mod schema;
 
 #[allow(deprecated)]
 pub use self::arrow_reader::{ArrowReader, ParquetFileArrowReader};


### PR DESCRIPTION
These have been experimental for a whilst as a stepping stone to eventually making them private, let's do that now