### PR TITLE
Derive Copy,Clone for BasicDecimal

### DIFF
--- a/arrow/benches/array_from_vec.rs
+++ b/arrow/benches/array_from_vec.rs
@@ -80,26 +80,18 @@ fn decimal128_array_from_vec(array: &[Option<i128>]) {
     criterion::black_box(
         array
             .iter()
+            .copied()
             .collect::<Decimal128Array>()
             .with_precision_and_scale(34, 2)
             .unwrap(),
     );
 }
 
-fn decimal256_array_from_vec() {
-    // bench decimal256array
-    // create option<into<decimal256>> array
-    let size = 1 << 10;
-    let mut array = vec![];
-    let mut rng = rand::thread_rng();
-    for _ in 0..size {
-        let decimal =
-            Decimal256::from(BigInt::from(rng.gen_range::<i128, _>(0..9999999999999)));
-        array.push(Some(decimal));
-    }
+fn decimal256_array_from_vec(array: &[Option<Decimal256>]) {
     criterion::black_box(
         array
-            .into_iter()
+            .iter()
+            .copied()
             .collect::<Decimal256Array>()
             .with_precision_and_scale(70, 2)
             .unwrap(),
@@ -119,9 +111,20 @@ fn decimal_benchmark(c: &mut Criterion) {
         b.iter(|| decimal128_array_from_vec(array.as_slice()))
     });
 
+    // bench decimal256array
+    // create option<into<decimal256>> array
+    let size = 1 << 10;
+    let mut array = vec![];
+    let mut rng = rand::thread_rng();
+    for _ in 0..size {
+        let decimal =
+            Decimal256::from(BigInt::from(rng.gen_range::<i128, _>(0..9999999999999)));
+        array.push(Some(decimal));
+    }
+
     // bench decimal256 array
     c.bench_function("decimal256_array_from_vec 32768", |b| {
-        b.iter(|| decimal256_array_from_vec)
+        b.iter(|| decimal256_array_from_vec(array.as_slice()))
     });
 }
 

--- a/arrow/src/util/decimal.rs
+++ b/arrow/src/util/decimal.rs
@@ -26,7 +26,7 @@ use num::bigint::BigInt;
 use num::Signed;
 use std::cmp::{min, Ordering};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct BasicDecimal<const BYTE_WIDTH: usize> {
     precision: usize,
     scale: usize,

--- a/arrow/src/util/decimal.rs
+++ b/arrow/src/util/decimal.rs
@@ -247,7 +247,7 @@ impl Decimal256 {
     }
 
     /// Constructs a `BigInt` from this `Decimal256` value.
-    pub(crate) fn to_big_int(&self) -> BigInt {
+    pub(crate) fn to_big_int(self) -> BigInt {
         BigInt::from_signed_bytes_le(&self.value)
     }
 }


### PR DESCRIPTION
Following https://github.com/apache/arrow-rs/pull/2442 changing the DecimalArray from iterator to take Into, the lack of `Copy` or even `Clone` on `BasicDecimal` makes for a very clunky experience.