### PR TITLE
Add API to Retrieve Finished Writer from Parquet Writer

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -223,6 +223,11 @@ impl<W: Write> ArrowWriter<W> {
         Ok(())
     }
 
+    /// Returns the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
+    }
+
     /// Close and finalize the underlying Parquet writer
     pub fn close(mut self) -> Result<parquet_format::FileMetaData> {
         self.flush()?;

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -224,7 +224,8 @@ impl<W: Write> ArrowWriter<W> {
     }
 
     /// Returns the underlying writer.
-    pub fn into_inner(self) -> W {
+    pub fn into_inner(mut self) -> Result<W> {
+        self.flush()?;
         self.writer.into_inner()
     }
 
@@ -649,6 +650,25 @@ mod tests {
         roundtrip(batch, Some(SMALL_SIZE / 2));
     }
 
+    fn get_bytes_after_close(schema: SchemaRef, expected_batch: &RecordBatch) -> Vec<u8> {
+        let mut buffer = vec![];
+
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).unwrap();
+        writer.write(expected_batch).unwrap();
+        writer.close().unwrap();
+
+        buffer
+    }
+
+    fn get_bytes_by_into_inner(
+        schema: SchemaRef,
+        expected_batch: &RecordBatch,
+    ) -> Vec<u8> {
+        let mut writer = ArrowWriter::try_new(Vec::new(), schema, None).unwrap();
+        writer.write(expected_batch).unwrap();
+        writer.into_inner().unwrap()
+    }
+
     #[test]
     fn roundtrip_bytes() {
         // define schema
@@ -665,31 +685,28 @@ mod tests {
         let expected_batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(a), Arc::new(b)]).unwrap();
 
-        let mut buffer = vec![];
+        for buffer in vec![
+            get_bytes_after_close(schema.clone(), &expected_batch),
+            get_bytes_by_into_inner(schema, &expected_batch),
+        ] {
+            let cursor = Bytes::from(buffer);
+            let mut record_batch_reader =
+                ParquetRecordBatchReader::try_new(cursor, 1024).unwrap();
 
-        {
-            let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).unwrap();
-            writer.write(&expected_batch).unwrap();
-            writer.close().unwrap();
-        }
+            let actual_batch = record_batch_reader
+                .next()
+                .expect("No batch found")
+                .expect("Unable to get batch");
 
-        let cursor = Bytes::from(buffer);
-        let mut record_batch_reader =
-            ParquetRecordBatchReader::try_new(cursor, 1024).unwrap();
+            assert_eq!(expected_batch.schema(), actual_batch.schema());
+            assert_eq!(expected_batch.num_columns(), actual_batch.num_columns());
+            assert_eq!(expected_batch.num_rows(), actual_batch.num_rows());
+            for i in 0..expected_batch.num_columns() {
+                let expected_data = expected_batch.column(i).data().clone();
+                let actual_data = actual_batch.column(i).data().clone();
 
-        let actual_batch = record_batch_reader
-            .next()
-            .expect("No batch found")
-            .expect("Unable to get batch");
-
-        assert_eq!(expected_batch.schema(), actual_batch.schema());
-        assert_eq!(expected_batch.num_columns(), actual_batch.num_columns());
-        assert_eq!(expected_batch.num_rows(), actual_batch.num_rows());
-        for i in 0..expected_batch.num_columns() {
-            let expected_data = expected_batch.column(i).data().clone();
-            let actual_data = actual_batch.column(i).data().clone();
-
-            assert_eq!(expected_data, actual_data);
+                assert_eq!(expected_data, actual_data);
+            }
         }
     }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -223,7 +223,7 @@ impl<W: Write> ArrowWriter<W> {
         Ok(())
     }
 
-    /// Returns the underlying writer.
+    /// Flushes any outstanding data and returns the underlying writer.
     pub fn into_inner(mut self) -> Result<W> {
         self.flush()?;
         self.writer.into_inner()

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -313,8 +313,11 @@ impl<W: Write> SerializedFileWriter<W> {
     }
 
     /// Returns the underlying writer.
-    pub fn into_inner(self) -> W {
-        self.buf.into_inner()
+    pub fn into_inner(mut self) -> Result<W> {
+        self.assert_previous_writer_closed()?;
+        let _ = self.write_metadata()?;
+
+        Ok(self.buf.into_inner())
     }
 }
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -312,7 +312,7 @@ impl<W: Write> SerializedFileWriter<W> {
         }
     }
 
-    /// Returns the underlying writer.
+    /// Writes the file footer and returns the underlying writer.
     pub fn into_inner(mut self) -> Result<W> {
         self.assert_previous_writer_closed()?;
         let _ = self.write_metadata()?;

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -60,6 +60,11 @@ impl<W: Write> TrackedWrite<W> {
     pub fn bytes_written(&self) -> usize {
         self.bytes_written
     }
+
+    /// Returns the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
 }
 
 impl<W: Write> Write for TrackedWrite<W> {
@@ -305,6 +310,11 @@ impl<W: Write> SerializedFileWriter<W> {
         } else {
             Ok(())
         }
+    }
+
+    /// Returns the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.buf.into_inner()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2491 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add into_inner in ArrowWriter and its underlying Writer.

# Are there any user-facing changes?

Yes, a new API `into_inner` in ArrowWriter
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
