### PR TITLE
refactoring boolean builder apis

### DIFF
--- a/arrow/benches/builder.rs
+++ b/arrow/benches/builder.rs
@@ -80,7 +80,7 @@ fn bench_bool(c: &mut Criterion) {
     ));
     group.bench_function("bench_bool", |b| {
         b.iter(|| {
-            let mut builder = BooleanBuilder::new(64);
+            let mut builder = BooleanBuilder::with_capacity(64);
             for _ in 0..NUM_BATCHES {
                 builder.append_slice(&data[..]);
             }

--- a/arrow/src/array/array_boolean.rs
+++ b/arrow/src/array/array_boolean.rs
@@ -95,7 +95,7 @@ impl BooleanArray {
 
     // Returns a new boolean array builder
     pub fn builder(capacity: usize) -> BooleanBuilder {
-        BooleanBuilder::new(capacity)
+        BooleanBuilder::with_capacity(capacity)
     }
 
     /// Returns a `Buffer` holding all the values of this array.

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -68,6 +68,7 @@ pub struct BooleanBuilder {
 
 impl BooleanBuilder {
     /// Creates a new boolean builder
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self::with_capacity(1024)
     }

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -39,7 +39,7 @@ use super::NullBufferBuilder;
 /// ```
 ///     use arrow::array::{Array, BooleanArray, BooleanBuilder};
 ///
-///     let mut b = BooleanBuilder::new(4);
+///     let mut b = BooleanBuilder::new();
 ///     b.append_value(true);
 ///     b.append_null();
 ///     b.append_value(false);
@@ -67,8 +67,13 @@ pub struct BooleanBuilder {
 }
 
 impl BooleanBuilder {
-    /// Creates a new primitive array builder
-    pub fn new(capacity: usize) -> Self {
+    /// Creates a new boolean builder
+    pub fn new() -> Self {
+        Self::with_capacity(1024)
+    }
+
+    /// Creates a new boolean builder builder with capacity
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             values_builder: BooleanBufferBuilder::new(capacity),
             null_buffer_builder: NullBufferBuilder::new(capacity),

--- a/arrow/src/array/builder/boolean_builder.rs
+++ b/arrow/src/array/builder/boolean_builder.rs
@@ -73,7 +73,7 @@ impl BooleanBuilder {
         Self::with_capacity(1024)
     }
 
-    /// Creates a new boolean builder builder with capacity
+    /// Creates a new boolean builder with capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             values_builder: BooleanBufferBuilder::new(capacity),

--- a/arrow/src/array/builder/struct_builder.rs
+++ b/arrow/src/array/builder/struct_builder.rs
@@ -96,7 +96,7 @@ impl ArrayBuilder for StructBuilder {
 pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<dyn ArrayBuilder> {
     match datatype {
         DataType::Null => unimplemented!(),
-        DataType::Boolean => Box::new(BooleanBuilder::new(capacity)),
+        DataType::Boolean => Box::new(BooleanBuilder::with_capacity(capacity)),
         DataType::Int8 => Box::new(Int8Builder::new(capacity)),
         DataType::Int16 => Box::new(Int16Builder::new(capacity)),
         DataType::Int32 => Box::new(Int32Builder::new(capacity)),
@@ -321,7 +321,7 @@ mod tests {
     #[test]
     fn test_struct_array_builder_finish() {
         let int_builder = Int32Builder::new(10);
-        let bool_builder = BooleanBuilder::new(10);
+        let bool_builder = BooleanBuilder::new();
 
         let mut fields = Vec::new();
         let mut field_builders = Vec::new();
@@ -426,7 +426,7 @@ mod tests {
     #[should_panic(expected = "StructBuilder and field_builders are of unequal lengths.")]
     fn test_struct_array_builder_unequal_field_builders_lengths() {
         let mut int_builder = Int32Builder::new(10);
-        let mut bool_builder = BooleanBuilder::new(10);
+        let mut bool_builder = BooleanBuilder::new();
 
         int_builder.append_value(1);
         int_builder.append_value(2);

--- a/arrow/src/array/data.rs
+++ b/arrow/src/array/data.rs
@@ -2677,7 +2677,7 @@ mod tests {
             ],
             vec![
                 Box::new(Int32Builder::new(5)),
-                Box::new(BooleanBuilder::new(5)),
+                Box::new(BooleanBuilder::with_capacity(5)),
             ],
         );
 

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -2072,7 +2072,7 @@ fn numeric_to_bool_cast<T>(from: &PrimitiveArray<T>) -> Result<BooleanArray>
 where
     T: ArrowPrimitiveType + ArrowNumericType,
 {
-    let mut b = BooleanBuilder::new(from.len());
+    let mut b = BooleanBuilder::with_capacity(from.len());
 
     for i in 0..from.len() {
         if from.is_null(i) {

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -1039,7 +1039,7 @@ mod tests {
     #[test]
     fn test_filter_string_array_with_negated_boolean_array() {
         let a = StringArray::from(vec!["hello", " ", "world", "!"]);
-        let mut bb = BooleanBuilder::new(2);
+        let mut bb = BooleanBuilder::with_capacity(2);
         bb.append_value(false);
         bb.append_value(true);
         bb.append_value(false);

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1083,7 +1083,7 @@ mod tests {
                 Field::new("b", DataType::Int32, true),
             ],
             vec![
-                Box::new(BooleanBuilder::new(values.len())),
+                Box::new(BooleanBuilder::with_capacity(values.len())),
                 Box::new(Int32Builder::new(values.len())),
             ],
         );

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -950,7 +950,7 @@ impl Decoder {
     }
 
     fn build_boolean_array(&self, rows: &[Value], col_name: &str) -> Result<ArrayRef> {
-        let mut builder = BooleanBuilder::new(rows.len());
+        let mut builder = BooleanBuilder::with_capacity(rows.len());
         for row in rows {
             if let Some(value) = row.get(&col_name) {
                 if let Some(boolean) = value.as_bool() {

--- a/arrow/src/util/integration_util.rs
+++ b/arrow/src/util/integration_util.rs
@@ -284,7 +284,7 @@ pub fn array_from_json(
     match field.data_type() {
         DataType::Null => Ok(Arc::new(NullArray::new(json_col.count))),
         DataType::Boolean => {
-            let mut b = BooleanBuilder::new(json_col.count);
+            let mut b = BooleanBuilder::with_capacity(json_col.count);
             for (is_valid, value) in json_col
                 .validity
                 .as_ref()


### PR DESCRIPTION
# Which issue does this PR close?

Partially implements https://github.com/apache/arrow-rs/issues/2054

# Rationale for this change
 
Refactor apis to make a consistent new and with_capacity functions

# What changes are included in this PR?

Removes capacity from new and added with_capacity function instead.

# Are there any user-facing changes?

Yes
