### PR TITLE
Fix verify_release.sh script to run rustfmt in each crate individually

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -105,7 +105,10 @@ test_source_distribution() {
 
   # raises on any formatting errors
   rustup component add rustfmt --toolchain stable
-  cargo fmt --all -- --check
+  (cd arrow && cargo fmt --check)
+  (cd arrow-flight && cargo fmt --check)
+  (cd parquet && cargo fmt --check)
+  (cd parquet_derive && cargo fmt --check)
 
   # Clone testing repositories if not cloned already
   git clone https://github.com/apache/arrow-testing.git arrow-testing-data


### PR DESCRIPTION
# Which issue does this PR close?

re 

# Rationale for this change
 
https://github.com/apache/arrow-rs/pull/2339 changes the release candidates so there is no workspace (Cargo.toml) any longer and thus `cargo fmt` fails when the `verify_release_candidate.sh` script is run. 

# What changes are included in this PR?
Run rustfmt for each of the crates individually -- as the tests were changed in https://github.com/apache/arrow-rs/pull/2339

# Are there any user-facing changes?
No