### PR TITLE
Avoid large over allocate buffer in sync reader

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -28,7 +28,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use arrow::{array::StructArray, error::ArrowError};
 
 use crate::arrow::array_reader::{
-    build_array_reader, ArrayReader, FileReaderRowGroupCollection,
+    build_array_reader, ArrayReader, FileReaderRowGroupCollection, RowGroupCollection,
 };
 use crate::arrow::schema::parquet_to_arrow_schema;
 use crate::arrow::schema::parquet_to_arrow_schema_by_columns;
@@ -282,6 +282,8 @@ impl ArrowReader for ParquetFileArrowReader {
         let array_reader =
             build_array_reader(Arc::new(self.get_schema()?), mask, &self.file_reader)?;
 
+        // Try to avoid allocate large buffer
+        let batch_size = self.file_reader.num_rows().min(batch_size);
         Ok(ParquetRecordBatchReader::new(
             batch_size,
             array_reader,
@@ -404,6 +406,10 @@ impl<T: ChunkReader + 'static> ArrowReaderBuilder<SyncReader<T>> {
         let mut filter = self.filter;
         let mut selection = self.selection;
 
+        // Try to avoid allocate large buffer
+        let batch_size = self
+            .batch_size
+            .min(self.metadata.file_metadata().num_rows() as usize);
         if let Some(filter) = filter.as_mut() {
             for predicate in filter.predicates.iter_mut() {
                 if !selects_any(selection.as_ref()) {
@@ -415,7 +421,7 @@ impl<T: ChunkReader + 'static> ArrowReaderBuilder<SyncReader<T>> {
                     build_array_reader(Arc::clone(&self.schema), projection, &reader)?;
 
                 selection = Some(evaluate_predicate(
-                    self.batch_size,
+                    batch_size,
                     array_reader,
                     selection,
                     predicate.as_mut(),
@@ -431,7 +437,7 @@ impl<T: ChunkReader + 'static> ArrowReaderBuilder<SyncReader<T>> {
         }
 
         Ok(ParquetRecordBatchReader::new(
-            self.batch_size,
+            batch_size,
             array_reader,
             selection,
         ))
@@ -2151,5 +2157,23 @@ mod tests {
                 .build()
                 .unwrap()
         }
+    }
+
+    #[test]
+    fn test_batch_size_overallocate() {
+        let testdata = arrow::util::test_util::parquet_test_data();
+        // `alltypes_plain.parquet` only have 8 rows
+        let path = format!("{}/alltypes_plain.parquet", testdata);
+        let test_file = File::open(&path).unwrap();
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(test_file).unwrap();
+        let num_rows = builder.metadata.file_metadata().num_rows();
+        let reader = builder
+            .with_batch_size(1024)
+            .with_projection(ProjectionMask::all())
+            .build()
+            .unwrap();
+        assert_ne!(1024, num_rows);
+        assert_eq!(reader.batch_size, num_rows as usize);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2321 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
