### PR TITLE
Improve performance of `%pat%` (>3x speedup)

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -263,8 +263,20 @@ pub fn like_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use ends_with
         let ends_with = &right[1..];
+
         for i in 0..left.len() {
             if left.value(i).ends_with(ends_with) {
+                bit_util::set_bit(bool_slice, i);
+            }
+        }
+    } else if right.starts_with('%')
+        && right.ends_with('%')
+        && !right[1..right.len() - 1].contains(is_like_pattern)
+    {
+        // fast path, can use contains
+        let contains = &right[1..right.len() - 1];
+        for i in 0..left.len() {
+            if left.value(i).contains(contains) {
                 bit_util::set_bit(bool_slice, i);
             }
         }
@@ -382,6 +394,17 @@ pub fn nlike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
         // fast path, can use starts_with
         for i in 0..left.len() {
             result.append(!left.value(i).ends_with(&right[1..]));
+        }
+    } else if right.starts_with('%')
+        && right.ends_with('%')
+        && !right[1..right.len() - 1].contains(is_like_pattern)
+    {
+        // fast path, can use contains
+        let contains = &right[1..right.len() - 1];
+        for i in 0..left.len() {
+            if left.value(i).contains(contains) {
+                result.append(!left.value(i).contains(contains));
+            }
         }
     } else {
         let re_pattern = replace_like_wildcards(right)?;

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -402,9 +402,7 @@ pub fn nlike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
         // fast path, can use contains
         let contains = &right[1..right.len() - 1];
         for i in 0..left.len() {
-            if left.value(i).contains(contains) {
-                result.append(!left.value(i).contains(contains));
-            }
+            result.append(!left.value(i).contains(contains));
         }
     } else {
         let re_pattern = replace_like_wildcards(right)?;


### PR DESCRIPTION
# Which issue does this PR close?
Closes #2519

# Rationale for this change
`LIKE %pat%`  is something that occurs a lot in SQL queries. It's also one of the slower queries in the ClickBench benchmarks. 

Results:
```
like_utf8 scalar contains                        
                        time:   [1.9803 ms 1.9828 ms 1.9853 ms]
                        change: [-71.755% -71.321% -70.997%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

Benchmarking nlike_utf8 scalar contains: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, enable flat sampling, or reduce sample count to 40.
Benchmarking nlike_utf8 scalar contains: Collecting 100 samples in estimated 9.9                                                                                nlike_utf8 scalar contains                        
                        time:   [1.9413 ms 1.9448 ms 1.9488 ms]
                        change: [-71.544% -71.455% -71.344%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
