### PR TITLE
Remove DecimalByteArrayConvert (#2480)

### DIFF
--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -26,7 +26,7 @@ use crate::arrow::array_reader::{
     PrimitiveArrayReader, RowGroupCollection, StructArrayReader,
 };
 use crate::arrow::buffer::converter::{
-    DecimalArrayConverter, DecimalByteArrayConvert, DecimalFixedLengthByteArrayConverter,
+    DecimalArrayConverter, DecimalFixedLengthByteArrayConverter,
     FixedLenBinaryConverter, FixedSizeArrayConverter, Int96ArrayConverter,
     Int96Converter, IntervalDayTimeArrayConverter, IntervalDayTimeConverter,
     IntervalYearMonthArrayConverter, IntervalYearMonthConverter,
@@ -35,7 +35,7 @@ use crate::arrow::schema::{convert_schema, ParquetField, ParquetFieldType};
 use crate::arrow::ProjectionMask;
 use crate::basic::Type as PhysicalType;
 use crate::data_type::{
-    BoolType, ByteArrayType, DoubleType, FixedLenByteArrayType, FloatType, Int32Type,
+    BoolType, DoubleType, FixedLenByteArrayType, FloatType, Int32Type,
     Int64Type, Int96Type,
 };
 use crate::errors::Result;
@@ -216,19 +216,6 @@ fn build_primitive_reader(
         PhysicalType::BYTE_ARRAY => match arrow_type {
             Some(DataType::Dictionary(_, _)) => {
                 make_byte_array_dictionary_reader(page_iterator, column_desc, arrow_type)
-            }
-            Some(DataType::Decimal128(precision, scale)) => {
-                // read decimal data from parquet binary physical type
-                let convert = DecimalByteArrayConvert::new(DecimalArrayConverter::new(
-                    precision as i32,
-                    scale as i32,
-                ));
-                Ok(Box::new(ComplexObjectArrayReader::<
-                    ByteArrayType,
-                    DecimalByteArrayConvert,
-                >::new(
-                    page_iterator, column_desc, convert, arrow_type
-                )?))
             }
             _ => make_byte_array_reader(page_iterator, column_desc, arrow_type),
         },

--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::arrow::array_reader::{read_records, skip_records, ArrayReader};
+use crate::arrow::buffer::bit_util::sign_extend_be;
 use crate::arrow::buffer::offset_buffer::OffsetBuffer;
 use crate::arrow::record_reader::buffer::ScalarValue;
 use crate::arrow::record_reader::GenericRecordReader;
@@ -31,11 +32,12 @@ use crate::encodings::{
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 use crate::util::memory::ByteBufferPtr;
-use arrow::array::{ArrayRef, OffsetSizeTrait};
+use arrow::array::{Array, ArrayRef, BinaryArray, Decimal128Array, OffsetSizeTrait};
 use arrow::buffer::Buffer;
 use arrow::datatypes::DataType as ArrowType;
 use std::any::Any;
 use std::ops::Range;
+use std::sync::Arc;
 
 /// Returns an [`ArrayReader`] that decodes the provided byte array column
 pub fn make_byte_array_reader(
@@ -52,7 +54,7 @@ pub fn make_byte_array_reader(
     };
 
     match data_type {
-        ArrowType::Binary | ArrowType::Utf8 => {
+        ArrowType::Binary | ArrowType::Utf8 | ArrowType::Decimal128(_, _) => {
             let reader = GenericRecordReader::new(column_desc);
             Ok(Box::new(ByteArrayReader::<i32>::new(
                 pages, data_type, reader,
@@ -119,7 +121,22 @@ impl<I: OffsetSizeTrait + ScalarValue> ArrayReader for ByteArrayReader<I> {
         self.rep_levels_buffer = self.record_reader.consume_rep_levels();
         self.record_reader.reset();
 
-        Ok(buffer.into_array(null_buffer, self.data_type.clone()))
+        let array = match self.data_type {
+            ArrowType::Decimal128(p, s) => {
+                let array = buffer.into_array(null_buffer, ArrowType::Binary);
+                let binary = array.as_any().downcast_ref::<BinaryArray>().unwrap();
+                let decimal = binary
+                    .iter()
+                    .map(|opt| Some(i128::from_be_bytes(sign_extend_be(opt?))))
+                    .collect::<Decimal128Array>()
+                    .with_precision_and_scale(p, s)?;
+
+                Arc::new(decimal)
+            }
+            _ => buffer.into_array(null_buffer, self.data_type.clone()),
+        };
+
+        Ok(array)
     }
 
     fn skip_records(&mut self, num_records: usize) -> Result<usize> {

--- a/parquet/src/arrow/buffer/bit_util.rs
+++ b/parquet/src/arrow/buffer/bit_util.rs
@@ -51,6 +51,17 @@ pub fn iter_set_bits_rev(bytes: &[u8]) -> impl Iterator<Item = usize> + '_ {
     })
 }
 
+/// Performs big endian sign extension
+pub fn sign_extend_be<const N: usize>(b: &[u8]) -> [u8; N] {
+    assert!(b.len() <= N, "Array too large, expected less than {}", N);
+    let is_negative = (b[0] & 128u8) == 128u8;
+    let mut result = if is_negative { [255u8; N] } else { [0u8; N] };
+    for (d, s) in result.iter_mut().skip(N - b.len()).zip(b) {
+        *d = *s;
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/parquet/src/arrow/buffer/converter.rs
+++ b/parquet/src/arrow/buffer/converter.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::data_type::{ByteArray, FixedLenByteArray, Int96};
+use crate::data_type::{FixedLenByteArray, Int96};
 use arrow::array::{
     Array, ArrayRef, Decimal128Array, FixedSizeBinaryArray, FixedSizeBinaryBuilder,
     IntervalDayTimeArray, IntervalDayTimeBuilder, IntervalYearMonthArray,
@@ -27,6 +27,9 @@ use crate::errors::Result;
 use std::marker::PhantomData;
 
 use crate::arrow::buffer::bit_util::sign_extend_be;
+#[cfg(test)]
+use crate::data_type::ByteArray;
+
 #[cfg(test)]
 use arrow::array::{StringArray, StringBuilder};
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2480

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This continues the process to move away from ComplexObjectArrayReader, as it slow, doesn't handle nesting correctly, and dates from a time before we had `GenericRecordReader`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Uses the optimized `ByteArrayReader` to read the data, and then reinterprets it as decimal data.

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
