### PR TITLE
Decimal precision scale datatype change

### DIFF
--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -82,7 +82,7 @@ fn build_utf8_date_time_array(size: usize, with_nulls: bool) -> ArrayRef {
     Arc::new(builder.finish())
 }
 
-fn build_decimal128_array(size: usize, precision: usize, scale: usize) -> ArrayRef {
+fn build_decimal128_array(size: usize, precision: u8, scale: u8) -> ArrayRef {
     let mut rng = seedable_rng();
     let mut builder = Decimal128Builder::new(size, precision, scale);
 
@@ -92,7 +92,7 @@ fn build_decimal128_array(size: usize, precision: usize, scale: usize) -> ArrayR
     Arc::new(builder.finish())
 }
 
-fn build_decimal256_array(size: usize, precision: usize, scale: usize) -> ArrayRef {
+fn build_decimal256_array(size: usize, precision: u8, scale: u8) -> ArrayRef {
     let mut rng = seedable_rng();
     let mut builder = Decimal256Builder::new(size, precision, scale);
     let mut bytes = [0; 32];

--- a/arrow/src/array/array_decimal.rs
+++ b/arrow/src/array/array_decimal.rs
@@ -81,29 +81,29 @@ pub type Decimal256Array = DecimalArray<Decimal256Type>;
 pub struct DecimalArray<T: DecimalType> {
     data: ArrayData,
     value_data: RawPtrBox<u8>,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
     _phantom: PhantomData<T>,
 }
 
 impl<T: DecimalType> DecimalArray<T> {
     pub const VALUE_LENGTH: i32 = T::BYTE_LENGTH as i32;
     const DEFAULT_TYPE: DataType = T::DEFAULT_TYPE;
-    pub const MAX_PRECISION: usize = T::MAX_PRECISION;
-    pub const MAX_SCALE: usize = T::MAX_SCALE;
-    const TYPE_CONSTRUCTOR: fn(usize, usize) -> DataType = T::TYPE_CONSTRUCTOR;
+    pub const MAX_PRECISION: u8 = T::MAX_PRECISION;
+    pub const MAX_SCALE: u8 = T::MAX_SCALE;
+    const TYPE_CONSTRUCTOR: fn(u8, u8) -> DataType = T::TYPE_CONSTRUCTOR;
 
     pub fn data(&self) -> &ArrayData {
         &self.data
     }
 
     /// Return the precision (total digits) that can be stored by this array
-    pub fn precision(&self) -> usize {
+    pub fn precision(&self) -> u8 {
         self.precision
     }
 
     /// Return the scale (digits after the decimal) that can be stored by this array
-    pub fn scale(&self) -> usize {
+    pub fn scale(&self) -> u8 {
         self.scale
     }
 
@@ -167,8 +167,8 @@ impl<T: DecimalType> DecimalArray<T> {
     /// range for a decimal
     pub fn from_fixed_size_binary_array(
         v: FixedSizeBinaryArray,
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Self {
         assert!(
             v.value_length() == Self::VALUE_LENGTH,
@@ -194,8 +194,8 @@ impl<T: DecimalType> DecimalArray<T> {
     #[deprecated(note = "please use `from_fixed_size_binary_array` instead")]
     pub fn from_fixed_size_list_array(
         v: FixedSizeListArray,
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Self {
         assert_eq!(
             v.data_ref().child_data().len(),
@@ -261,7 +261,7 @@ impl<T: DecimalType> DecimalArray<T> {
     /// 1. `precision` is larger than [`Self::MAX_PRECISION`]
     /// 2. `scale` is larger than [`Self::MAX_SCALE`];
     /// 3. `scale` is > `precision`
-    pub fn with_precision_and_scale(self, precision: usize, scale: usize) -> Result<Self>
+    pub fn with_precision_and_scale(self, precision: u8, scale: u8) -> Result<Self>
     where
         Self: Sized,
     {
@@ -281,7 +281,7 @@ impl<T: DecimalType> DecimalArray<T> {
     }
 
     // validate that the new precision and scale are valid or not
-    fn validate_precision_scale(&self, precision: usize, scale: usize) -> Result<()> {
+    fn validate_precision_scale(&self, precision: u8, scale: u8) -> Result<()> {
         if precision > Self::MAX_PRECISION {
             return Err(ArrowError::InvalidArgumentError(format!(
                 "precision {} is greater than max {}",
@@ -309,7 +309,7 @@ impl<T: DecimalType> DecimalArray<T> {
     }
 
     // validate all the data in the array are valid within the new precision or not
-    fn validate_data(&self, precision: usize) -> Result<()> {
+    fn validate_data(&self, precision: u8) -> Result<()> {
         // TODO: Move into DecimalType
         match Self::VALUE_LENGTH {
             16 => self
@@ -350,7 +350,7 @@ impl Decimal128Array {
 
     // Validates decimal128 values in this array can be properly interpreted
     // with the specified precision.
-    fn validate_decimal_precision(&self, precision: usize) -> Result<()> {
+    fn validate_decimal_precision(&self, precision: u8) -> Result<()> {
         (0..self.len()).try_for_each(|idx| {
             if self.is_valid(idx) {
                 let decimal = unsafe { self.value_unchecked(idx) };
@@ -365,7 +365,7 @@ impl Decimal128Array {
 impl Decimal256Array {
     // Validates decimal256 values in this array can be properly interpreted
     // with the specified precision.
-    fn validate_decimal_precision(&self, precision: usize) -> Result<()> {
+    fn validate_decimal_precision(&self, precision: u8) -> Result<()> {
         (0..self.len()).try_for_each(|idx| {
             if self.is_valid(idx) {
                 let raw_val = unsafe {

--- a/arrow/src/array/builder/decimal_builder.rs
+++ b/arrow/src/array/builder/decimal_builder.rs
@@ -37,8 +37,8 @@ use crate::util::decimal::Decimal256;
 #[derive(Debug)]
 pub struct Decimal128Builder {
     builder: FixedSizeBinaryBuilder,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
 
     /// Should i128 values be validated for compatibility with scale and precision?
     /// defaults to true
@@ -51,8 +51,8 @@ pub struct Decimal128Builder {
 #[derive(Debug)]
 pub struct Decimal256Builder {
     builder: FixedSizeBinaryBuilder,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
 
     /// Should decimal values be validated for compatibility with scale and precision?
     /// defaults to true
@@ -63,7 +63,7 @@ impl Decimal128Builder {
     const BYTE_LENGTH: i32 = 16;
     /// Creates a new [`Decimal128Builder`], `capacity` is the number of bytes in the values
     /// array
-    pub fn new(capacity: usize, precision: usize, scale: usize) -> Self {
+    pub fn new(capacity: usize, precision: u8, scale: u8) -> Self {
         Self {
             builder: FixedSizeBinaryBuilder::new(capacity, Self::BYTE_LENGTH),
             precision,
@@ -157,7 +157,7 @@ impl Decimal256Builder {
     const BYTE_LENGTH: i32 = 32;
     /// Creates a new [`Decimal256Builder`], `capacity` is the number of bytes in the values
     /// array
-    pub fn new(capacity: usize, precision: usize, scale: usize) -> Self {
+    pub fn new(capacity: usize, precision: u8, scale: u8) -> Self {
         Self {
             builder: FixedSizeBinaryBuilder::new(capacity, Self::BYTE_LENGTH),
             precision,

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -688,8 +688,8 @@ mod tests {
 
     fn create_decimal_array(
         array: Vec<Option<i128>>,
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Decimal128Array {
         array
             .into_iter()

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -301,8 +301,8 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
 fn cast_primitive_to_decimal<T: ArrayAccessor, F>(
     array: T,
     op: F,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
 ) -> Result<Arc<dyn Array>>
 where
     F: Fn(T::Item) -> i128,
@@ -318,8 +318,8 @@ where
 
 fn cast_integer_to_decimal<T: ArrowNumericType>(
     array: &PrimitiveArray<T>,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
 ) -> Result<Arc<dyn Array>>
 where
     <T as ArrowPrimitiveType>::Native: AsPrimitive<i128>,
@@ -333,8 +333,8 @@ where
 
 fn cast_floating_point_to_decimal<T: ArrowNumericType>(
     array: &PrimitiveArray<T>,
-    precision: usize,
-    scale: usize,
+    precision: u8,
+    scale: u8,
 ) -> Result<Arc<dyn Array>>
 where
     <T as ArrowPrimitiveType>::Native: AsPrimitive<f64>,
@@ -1306,9 +1306,9 @@ const fn time_unit_multiple(unit: &TimeUnit) -> i64 {
 /// Cast one type of decimal array to another type of decimal array
 fn cast_decimal_to_decimal<const BYTE_WIDTH1: usize, const BYTE_WIDTH2: usize>(
     array: &ArrayRef,
-    input_scale: &usize,
-    output_precision: &usize,
-    output_scale: &usize,
+    input_scale: &u8,
+    output_precision: &u8,
+    output_scale: &u8,
 ) -> Result<ArrayRef> {
     if input_scale > output_scale {
         // For example, input_scale is 4 and output_scale is 3;
@@ -2592,8 +2592,8 @@ mod tests {
 
     fn create_decimal_array(
         array: Vec<Option<i128>>,
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Result<Decimal128Array> {
         array
             .into_iter()
@@ -2603,8 +2603,8 @@ mod tests {
 
     fn create_decimal256_array(
         array: Vec<Option<BigInt>>,
-        precision: usize,
-        scale: usize,
+        precision: u8,
+        scale: u8,
     ) -> Result<Decimal256Array> {
         array
             .into_iter()

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -987,8 +987,8 @@ mod tests {
         index: &UInt32Array,
         options: Option<TakeOptions>,
         expected_data: Vec<Option<i128>>,
-        precision: &usize,
-        scale: &usize,
+        precision: &u8,
+        scale: &u8,
     ) -> Result<()> {
         let output = data
             .into_iter()
@@ -1105,8 +1105,8 @@ mod tests {
     #[test]
     fn test_take_decimal128_non_null_indices() {
         let index = UInt32Array::from(vec![0, 5, 3, 1, 4, 2]);
-        let precision: usize = 10;
-        let scale: usize = 5;
+        let precision: u8 = 10;
+        let scale: u8 = 5;
         test_take_decimal_arrays(
             vec![None, Some(3), Some(5), Some(2), Some(3), None],
             &index,
@@ -1121,8 +1121,8 @@ mod tests {
     #[test]
     fn test_take_decimal128() {
         let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(2)]);
-        let precision: usize = 10;
-        let scale: usize = 5;
+        let precision: u8 = 10;
+        let scale: u8 = 5;
         test_take_decimal_arrays(
             vec![Some(0), Some(1), Some(2), Some(3), Some(4)],
             &index,

--- a/arrow/src/datatypes/ffi.rs
+++ b/arrow/src/datatypes/ffi.rs
@@ -98,12 +98,12 @@ impl TryFrom<&FFI_ArrowSchema> for DataType {
                     ["d", extra] => {
                         match extra.splitn(3, ',').collect::<Vec<&str>>().as_slice() {
                             [precision, scale] => {
-                                let parsed_precision = precision.parse::<usize>().map_err(|_| {
+                                let parsed_precision = precision.parse::<u8>().map_err(|_| {
                                     ArrowError::CDataInterface(
                                         "The decimal type requires an integer precision".to_string(),
                                     )
                                 })?;
-                                let parsed_scale = scale.parse::<usize>().map_err(|_| {
+                                let parsed_scale = scale.parse::<u8>().map_err(|_| {
                                     ArrowError::CDataInterface(
                                         "The decimal type requires an integer scale".to_string(),
                                     )
@@ -114,12 +114,12 @@ impl TryFrom<&FFI_ArrowSchema> for DataType {
                                 if *bits != "128" {
                                     return Err(ArrowError::CDataInterface("Only 128 bit wide decimal is supported in the Rust implementation".to_string()));
                                 }
-                                let parsed_precision = precision.parse::<usize>().map_err(|_| {
+                                let parsed_precision = precision.parse::<u8>().map_err(|_| {
                                     ArrowError::CDataInterface(
                                         "The decimal type requires an integer precision".to_string(),
                                     )
                                 })?;
-                                let parsed_scale = scale.parse::<usize>().map_err(|_| {
+                                let parsed_scale = scale.parse::<u8>().map_err(|_| {
                                     ArrowError::CDataInterface(
                                         "The decimal type requires an integer scale".to_string(),
                                     )

--- a/arrow/src/datatypes/types.rs
+++ b/arrow/src/datatypes/types.rs
@@ -491,9 +491,9 @@ pub trait DecimalType: 'static + Send + Sync + private::DecimalTypeSealed {
     type Native: NativeDecimalType;
 
     const BYTE_LENGTH: usize;
-    const MAX_PRECISION: usize;
-    const MAX_SCALE: usize;
-    const TYPE_CONSTRUCTOR: fn(usize, usize) -> DataType;
+    const MAX_PRECISION: u8;
+    const MAX_SCALE: u8;
+    const TYPE_CONSTRUCTOR: fn(u8, u8) -> DataType;
     const DEFAULT_TYPE: DataType;
 }
 
@@ -505,9 +505,9 @@ impl DecimalType for Decimal128Type {
     type Native = [u8; 16];
 
     const BYTE_LENGTH: usize = 16;
-    const MAX_PRECISION: usize = DECIMAL128_MAX_PRECISION;
-    const MAX_SCALE: usize = DECIMAL128_MAX_SCALE;
-    const TYPE_CONSTRUCTOR: fn(usize, usize) -> DataType = DataType::Decimal128;
+    const MAX_PRECISION: u8 = DECIMAL128_MAX_PRECISION;
+    const MAX_SCALE: u8 = DECIMAL128_MAX_SCALE;
+    const TYPE_CONSTRUCTOR: fn(u8, u8) -> DataType = DataType::Decimal128;
     const DEFAULT_TYPE: DataType =
         DataType::Decimal128(DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
 }
@@ -520,9 +520,9 @@ impl DecimalType for Decimal256Type {
     type Native = [u8; 32];
 
     const BYTE_LENGTH: usize = 32;
-    const MAX_PRECISION: usize = DECIMAL256_MAX_PRECISION;
-    const MAX_SCALE: usize = DECIMAL256_MAX_SCALE;
-    const TYPE_CONSTRUCTOR: fn(usize, usize) -> DataType = DataType::Decimal256;
+    const MAX_PRECISION: u8 = DECIMAL256_MAX_PRECISION;
+    const MAX_SCALE: u8 = DECIMAL256_MAX_SCALE;
+    const TYPE_CONSTRUCTOR: fn(u8, u8) -> DataType = DataType::Decimal256;
     const DEFAULT_TYPE: DataType =
         DataType::Decimal256(DECIMAL256_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
 }

--- a/arrow/src/ipc/convert.rs
+++ b/arrow/src/ipc/convert.rs
@@ -322,9 +322,15 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
             let fsb = field.type_as_decimal().unwrap();
             let bit_width = fsb.bitWidth();
             if bit_width == 128 {
-                DataType::Decimal128(fsb.precision() as usize, fsb.scale() as usize)
+                DataType::Decimal128(
+                    fsb.precision().try_into().unwrap(),
+                    fsb.scale().try_into().unwrap(),
+                )
             } else if bit_width == 256 {
-                DataType::Decimal256(fsb.precision() as usize, fsb.scale() as usize)
+                DataType::Decimal256(
+                    fsb.precision().try_into().unwrap(),
+                    fsb.scale().try_into().unwrap(),
+                )
             } else {
                 panic!("Unexpected decimal bit width {}", bit_width)
             }

--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -220,8 +220,7 @@ fn build_primitive_reader(
             Some(DataType::Decimal128(precision, scale)) => {
                 // read decimal data from parquet binary physical type
                 let convert = DecimalByteArrayConvert::new(DecimalArrayConverter::new(
-                    precision as i32,
-                    scale as i32,
+                    precision, scale,
                 ));
                 Ok(Box::new(ComplexObjectArrayReader::<
                     ByteArrayType,
@@ -235,7 +234,7 @@ fn build_primitive_reader(
         PhysicalType::FIXED_LEN_BYTE_ARRAY => match field.arrow_type {
             DataType::Decimal128(precision, scale) => {
                 let converter = DecimalFixedLengthByteArrayConverter::new(
-                    DecimalArrayConverter::new(precision as i32, scale as i32),
+                    DecimalArrayConverter::new(precision, scale),
                 );
                 Ok(Box::new(ComplexObjectArrayReader::<
                     FixedLenByteArrayType,

--- a/parquet/src/arrow/buffer/converter.rs
+++ b/parquet/src/arrow/buffer/converter.rs
@@ -68,12 +68,12 @@ impl Converter<Vec<Option<FixedLenByteArray>>, FixedSizeBinaryArray>
 }
 
 pub struct DecimalArrayConverter {
-    precision: i32,
-    scale: i32,
+    precision: u8,
+    scale: u8,
 }
 
 impl DecimalArrayConverter {
-    pub fn new(precision: i32, scale: i32) -> Self {
+    pub fn new(precision: u8, scale: u8) -> Self {
         Self { precision, scale }
     }
 }
@@ -86,7 +86,7 @@ impl Converter<Vec<Option<FixedLenByteArray>>, Decimal128Array>
             .into_iter()
             .map(|array| array.map(|array| from_bytes_to_i128(array.data())))
             .collect::<Decimal128Array>()
-            .with_precision_and_scale(self.precision as usize, self.scale as usize)?;
+            .with_precision_and_scale(self.precision, self.scale)?;
 
         Ok(array)
     }
@@ -98,7 +98,7 @@ impl Converter<Vec<Option<ByteArray>>, Decimal128Array> for DecimalArrayConverte
             .into_iter()
             .map(|array| array.map(|array| from_bytes_to_i128(array.data())))
             .collect::<Decimal128Array>()
-            .with_precision_and_scale(self.precision as usize, self.scale as usize)?;
+            .with_precision_and_scale(self.precision, self.scale)?;
 
         Ok(array)
     }

--- a/parquet/src/arrow/schema.rs
+++ b/parquet/src/arrow/schema.rs
@@ -220,7 +220,7 @@ pub fn parquet_to_arrow_field(parquet_column: &ColumnDescriptor) -> Result<Field
     ))
 }
 
-pub fn decimal_length_from_precision(precision: usize) -> usize {
+pub fn decimal_length_from_precision(precision: u8) -> usize {
     (10.0_f64.powi(precision as i32).log2() / 8.0).ceil() as usize
 }
 

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -235,12 +235,14 @@ fn from_byte_array(info: &BasicTypeInfo, precision: i32, scale: i32) -> Result<D
         (None, ConvertedType::BSON) => Ok(DataType::Binary),
         (None, ConvertedType::ENUM) => Ok(DataType::Binary),
         (None, ConvertedType::UTF8) => Ok(DataType::Utf8),
-        (Some(LogicalType::Decimal { precision, scale }), _) => {
-            Ok(DataType::Decimal128(precision as usize, scale as usize))
-        }
-        (None, ConvertedType::DECIMAL) => {
-            Ok(DataType::Decimal128(precision as usize, scale as usize))
-        }
+        (Some(LogicalType::Decimal { precision, scale }), _) => Ok(DataType::Decimal128(
+            precision.try_into().unwrap(),
+            scale.try_into().unwrap(),
+        )),
+        (None, ConvertedType::DECIMAL) => Ok(DataType::Decimal128(
+            precision.try_into().unwrap(),
+            scale.try_into().unwrap(),
+        )),
         (logical, converted) => Err(arrow_err!(
             "Unable to convert parquet BYTE_ARRAY logical type {:?} or converted type {}",
             logical,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2496.

# Rationale for this change
 
The maximum precision and scale for decimal types is 76, and yet we consume an entire usize to store this information

# What changes are included in this PR?

Changed decimal types precision and scale to u8

# Are there any user-facing changes?

Yes
