### PR TITLE
Build AmazonS3builder from environment variables (#2361)

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -363,7 +363,7 @@ impl AmazonS3Builder {
     ///     .build();
     /// ```
     pub fn from_env() -> Self {
-        let mut builder: AmazonS3Builder = Default::default();
+        let mut builder: Self = Default::default();
 
         if let Ok(access_key_id) = std::env::var("AWS_ACCESS_KEY_ID") {
             builder.access_key_id = Some(access_key_id);

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -616,25 +616,34 @@ mod tests {
 
     #[test]
     fn s3_test_config_from_env() {
-        let aws_access_key_id = "object_store:fake_access_key_id";
-        let aws_secret_access_key = "object_store:fake_secret_key";
-        let aws_default_region = "object_store:fake_default_region";
+        let aws_access_key_id = env::var("AWS_ACCESS_KEY_ID")
+            .unwrap_or("object_store:fake_access_key_id".into());
+        let aws_secret_access_key = env::var("AWS_SECRET_ACCESS_KEY")
+            .unwrap_or("object_store:fake_secret_key".into());
 
-        let aws_endpoint = "object_store:fake_endpoint";
-        let aws_session_token = "object_store:fake_session_token";
+        let aws_default_region = env::var("AWS_DEFAULT_REGION")
+            .unwrap_or("object_store:fake_default_region".into());
+
+        let aws_endpoint =
+            env::var("AWS_ENDPOINT").unwrap_or("object_store:fake_endpoint".into());
+        let aws_session_token = env::var("AWS_SESSION_TOKEN")
+            .unwrap_or("object_store:fake_session_token".into());
 
         // required
-        env::set_var("AWS_ACCESS_KEY_ID", aws_access_key_id);
-        env::set_var("AWS_SECRET_ACCESS_KEY", aws_secret_access_key);
-        env::set_var("AWS_DEFAULT_REGION", aws_default_region);
+        env::set_var("AWS_ACCESS_KEY_ID", &aws_access_key_id);
+        env::set_var("AWS_SECRET_ACCESS_KEY", &aws_secret_access_key);
+        env::set_var("AWS_DEFAULT_REGION", &aws_default_region);
 
         // optional
-        env::set_var("AWS_ENDPOINT", aws_endpoint);
-        env::set_var("AWS_SESSION_TOKEN", aws_session_token);
+        env::set_var("AWS_ENDPOINT", &aws_endpoint);
+        env::set_var("AWS_SESSION_TOKEN", &aws_session_token);
 
         let builder = AmazonS3Builder::from_env();
-        assert_eq!(builder.access_key_id.unwrap(), aws_access_key_id);
-        assert_eq!(builder.secret_access_key.unwrap(), aws_secret_access_key);
+        assert_eq!(builder.access_key_id.unwrap(), aws_access_key_id.as_str());
+        assert_eq!(
+            builder.secret_access_key.unwrap(),
+            aws_secret_access_key.as_str()
+        );
         assert_eq!(builder.region.unwrap(), aws_default_region);
 
         assert_eq!(builder.endpoint.unwrap(), aws_endpoint);

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -357,6 +357,8 @@ impl AmazonS3Builder {
     /// * AWS_SESSION_TOKEN -> token
     /// # Example
     /// ```
+    /// use object_store::aws::AmazonS3Builder;
+    ///
     /// let s3 = AmazonS3Builder::from_env()
     ///     .with_bucket_name("foo")
     ///     .build();

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -348,7 +348,6 @@ impl AmazonS3Builder {
     }
 
     /// Fill the [`AmazonS3Builder`] with regular AWS environment variables
-    /// (read: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
     ///
     /// Variables extracted from environment:
     /// * AWS_ACCESS_KEY_ID -> access_key_id


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2361

# Rationale for this change
 
Building the AmazonS3Builder from environment variable is more convenient than explicitely passing variables to the builder. Thus, introducing the `AmazonS3Builder::from_env()` will help to setup the builder based on regular AWS variables.

* AWS_ACCESS_KEY_ID -> access_key_id
* AWS_SECRET_ACCESS_KEY -> secret_access_key
* AWS_DEFAULT_REGION -> region
* AWS_ENDPOINT -> endpoint
* AWS_SESSION_TOKEN -> token 

I chose to make no specific verifications to leverage only the `.build()` checks.  

# What changes are included in this PR?

Just adding a function to create an AmazonS3Builder from environment variable described above. 

# Are there any user-facing changes?

`AmazonS3Builder::from_env()` is available for commodity use. 
It introduce no breaking changes.