### PR TITLE
MINOR: Fix test_row_type_validation test

### DIFF
--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -2623,7 +2623,7 @@ mod tests {
         let re = builder.build(Cursor::new(json_content));
         assert_eq!(
             re.err().unwrap().to_string(),
-            r#"Json error: Expected JSON record to be an object, found Array([Number(1), String("hello")])"#,
+            r#"Json error: Expected JSON record to be an object, found Array [Number(1), String("hello")]"#,
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Since `serde_json` 1.0.84+, `test_row_type_validation` fails.

```
---- json::reader::tests::test_row_type_validation stdout ----                                                     
thread 'json::reader::tests::test_row_type_validation' panicked at 'assertion failed: `(left == right)`                                                                                                                                
  left: `"Json error: Expected JSON record to be an object, found Array [Number(1), String(\"hello\")]"`,                                                                                                                              
 right: `"Json error: Expected JSON record to be an object, found Array([Number(1), String(\"hello\")])"`', arrow/src/json/reader.rs:2624:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace                                   
```

This is to update the test.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
