### PR TITLE
Fix bug in page skipping

### DIFF
--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -2656,7 +2656,7 @@ mod tests {
         let re = builder.build(Cursor::new(json_content));
         assert_eq!(
             re.err().unwrap().to_string(),
-            r#"Json error: Expected JSON record to be an object, found Array [Number(1), String("hello")]"#,
+            r#"Json error: Expected JSON record to be an object, found Array([Number(1), String("hello")])"#,
         );
     }
 

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -2656,7 +2656,7 @@ mod tests {
         let re = builder.build(Cursor::new(json_content));
         assert_eq!(
             re.err().unwrap().to_string(),
-            r#"Json error: Expected JSON record to be an object, found Array([Number(1), String("hello")])"#,
+            r#"Json error: Expected JSON record to be an object, found Array [Number(1), String("hello")]"#,
         );
     }
 

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -595,5 +595,24 @@ mod tests {
 
         // assert_eq!(mask, vec![false, true, true, false, true, true, true]);
         assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60, 60..70]);
+
+        let selection = RowSelection::from(vec![
+            // Skip first page
+            RowSelector::skip(10),
+            // Multiple selects in same page
+            RowSelector::select(3),
+            RowSelector::skip(3),
+            RowSelector::select(4),
+            // Select to remaining in page and first row of next page
+            RowSelector::skip(5),
+            RowSelector::select(6),
+            // Skip remaining
+            RowSelector::skip(50),
+        ]);
+
+        let ranges = selection.scan_ranges(&index);
+
+        // assert_eq!(mask, vec![false, true, true, false, true, true, true]);
+        assert_eq!(ranges, vec![10..20, 20..30, 30..40]);
     }
 }

--- a/parquet/src/arrow/async_reader.rs
+++ b/parquet/src/arrow/async_reader.rs
@@ -798,6 +798,7 @@ mod tests {
     use arrow::array::{Array, ArrayRef, Int32Array, StringArray};
     use arrow::error::Result as ArrowResult;
     use futures::TryStreamExt;
+    use rand::{thread_rng, Rng};
     use std::sync::Mutex;
 
     struct TestReader {
@@ -934,6 +935,129 @@ mod tests {
             .unwrap();
 
         assert_eq!(async_batches, sync_batches);
+    }
+
+    #[tokio::test]
+    async fn test_async_reader_skip_pages() {
+        let testdata = arrow::util::test_util::parquet_test_data();
+        let path = format!("{}/alltypes_tiny_pages_plain.parquet", testdata);
+        let data = Bytes::from(std::fs::read(path).unwrap());
+
+        let metadata = parse_metadata(&data).unwrap();
+        let metadata = Arc::new(metadata);
+
+        assert_eq!(metadata.num_row_groups(), 1);
+
+        let async_reader = TestReader {
+            data: data.clone(),
+            metadata: metadata.clone(),
+            requests: Default::default(),
+        };
+
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let builder =
+            ParquetRecordBatchStreamBuilder::new_with_options(async_reader, options)
+                .await
+                .unwrap();
+
+        let selection = RowSelection::from(vec![
+            RowSelector::skip(21),   // Skip first page
+            RowSelector::select(21), // Select page to boundary
+            RowSelector::skip(41),   // Skip multiple pages
+            RowSelector::select(41), // Select multiple pages
+            RowSelector::skip(25),   // Skip page across boundary
+            RowSelector::select(25), // Select across page boundary
+            RowSelector::skip(7116), // Skip to final page boundary
+            RowSelector::select(10), // Select final page
+        ]);
+
+        let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![9]);
+
+        let stream = builder
+            .with_projection(mask.clone())
+            .with_row_selection(selection.clone())
+            .build()
+            .expect("building stream");
+
+        let async_batches: Vec<_> = stream.try_collect().await.unwrap();
+
+        let sync_batches = ParquetRecordBatchReaderBuilder::try_new(data)
+            .unwrap()
+            .with_projection(mask)
+            .with_batch_size(1024)
+            .with_row_selection(selection)
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(async_batches, sync_batches);
+    }
+
+    #[tokio::test]
+    async fn test_fuzz_async_reader_selection() {
+        let testdata = arrow::util::test_util::parquet_test_data();
+        let path = format!("{}/alltypes_tiny_pages_plain.parquet", testdata);
+        let data = Bytes::from(std::fs::read(path).unwrap());
+
+        let metadata = parse_metadata(&data).unwrap();
+        let metadata = Arc::new(metadata);
+
+        assert_eq!(metadata.num_row_groups(), 1);
+
+        let mut rand = thread_rng();
+
+        for _ in 0..100 {
+            let mut expected_rows = 0;
+            let mut total_rows = 0;
+            let mut skip = false;
+            let mut selectors = vec![];
+
+            while total_rows < 7300 {
+                let row_count: usize = rand.gen_range(0..100);
+
+                let row_count = row_count.min(7300 - total_rows);
+
+                selectors.push(RowSelector { row_count, skip });
+
+                total_rows += row_count;
+                if !skip {
+                    expected_rows += row_count;
+                }
+
+                skip = !skip;
+            }
+
+            let selection = RowSelection::from(selectors);
+
+            let async_reader = TestReader {
+                data: data.clone(),
+                metadata: metadata.clone(),
+                requests: Default::default(),
+            };
+
+            let options = ArrowReaderOptions::new().with_page_index(true);
+            let builder =
+                ParquetRecordBatchStreamBuilder::new_with_options(async_reader, options)
+                    .await
+                    .unwrap();
+
+            let col_idx: usize = rand.gen_range(0..13);
+            let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![col_idx]);
+
+            let stream = builder
+                .with_projection(mask.clone())
+                .with_row_selection(selection.clone())
+                .build()
+                .expect("building stream");
+
+            let async_batches: Vec<_> = stream.try_collect().await.unwrap();
+
+            let actual_rows: usize =
+                async_batches.into_iter().map(|b| b.num_rows()).sum();
+
+            assert_eq!(actual_rows, expected_rows);
+        }
     }
 
     #[tokio::test]

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -493,6 +493,28 @@ where
         }
     }
 
+    /// Check whether there is more data to read from this column,
+    /// If the current page is fully decoded, this will NOT load the next page
+    /// into the buffer
+    #[inline]
+    pub(crate) fn peek_next(&mut self) -> Result<bool> {
+        if self.num_buffered_values == 0
+            || self.num_buffered_values == self.num_decoded_values
+        {
+            // TODO: should we return false if read_new_page() = true and
+            // num_buffered_values = 0?
+            match self.page_reader.peek_next_page()? {
+                Some(next_page) => Ok(next_page.num_rows != 0),
+                None => Ok(false),
+            }
+        } else {
+            Ok(true)
+        }
+    }
+
+    /// Check whether there is more data to read from this column,
+    /// If the current page is fully decoded, this will load the next page
+    /// (if it exists) into the buffer
     #[inline]
     pub(crate) fn has_next(&mut self) -> Result<bool> {
         if self.num_buffered_values == 0

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -363,7 +363,7 @@ where
     }
 
     /// Read the next page as a dictionary page. If the next page is not a dictionary page,
-    /// this will return an error. 
+    /// this will return an error.
     fn read_dictionary_page(&mut self) -> Result<()> {
         match self.page_reader.get_next_page()? {
             Some(Page::DictionaryPage {

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -306,7 +306,7 @@ where
 
                 // If dictionary, we must read it
                 if metadata.is_dict {
-                    self.read_new_page()?;
+                    self.read_dictionary_page()?;
                     continue;
                 }
 
@@ -360,6 +360,24 @@ where
             remaining -= records_read;
         }
         Ok(num_records - remaining)
+    }
+
+    /// Read the next page as a dictionary page. If the next page is not a dictionary page,
+    /// this will return an error. 
+    fn read_dictionary_page(&mut self) -> Result<()> {
+        match self.page_reader.get_next_page()? {
+            Some(Page::DictionaryPage {
+                buf,
+                num_values,
+                encoding,
+                is_sorted,
+            }) => self
+                .values_decoder
+                .set_dict(buf, num_values, encoding, is_sorted),
+            _ => Err(ParquetError::General(
+                "Invalid page. Expecting dictionary page".to_string(),
+            )),
+        }
     }
 
     /// Reads a new page and set up the decoders for levels, values or dictionary.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2543 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Discovered some small bugs while testing the page pruning logic in `ParquetRecordBatchStream`. We were improperly reading data pages when not necessary in a few cases. When we have only fetched the pages required for a given row selection this causes an error. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

We had a method `GenericColumnReader::has_next` which will check if the current page is fully decoded and then load the next page (if it exists). This method was used in a few places to test whether the column was exhausted. This can cause issues since it will load the next page, which may be skipped according to the current row selection. 

Added a method `GenericColumnReader::has_next` which will test whether the column is exhausted without loading the next page and changed a few places to use that. 

I think a slightly more thorough refactor is not a bad idea since the API is a bit confusing as is, but this should solve the immediate bugs. 

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
