### PR TITLE
Update environment variable name for amazonS3builder in integration (#2550)

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -81,10 +81,10 @@ jobs:
         RUST_BACKTRACE: "1"
         # Run integration tests
         TEST_INTEGRATION: 1
-        AWS_DEFAULT_REGION: "us-east-1"
-        AWS_ACCESS_KEY_ID: test
-        AWS_SECRET_ACCESS_KEY: test
-        AWS_ENDPOINT: http://localstack:4566
+        OBJECT_STORE_AWS_DEFAULT_REGION: "us-east-1"
+        OBJECT_STORE_AWS_ACCESS_KEY_ID: test
+        OBJECT_STORE_AWS_SECRET_ACCESS_KEY: test
+        OBJECT_STORE_AWS_ENDPOINT: http://localstack:4566
         EC2_METADATA_ENDPOINT: http://ec2-metadata:1338
         AZURE_USE_EMULATOR: "1"
         AZURITE_BLOB_STORAGE_URL: "http://azurite:10000"

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -81,10 +81,6 @@ jobs:
         RUST_BACKTRACE: "1"
         # Run integration tests
         TEST_INTEGRATION: 1
-        OBJECT_STORE_AWS_DEFAULT_REGION: "us-east-1"
-        OBJECT_STORE_AWS_ACCESS_KEY_ID: test
-        OBJECT_STORE_AWS_SECRET_ACCESS_KEY: test
-        OBJECT_STORE_AWS_ENDPOINT: http://localstack:4566
         EC2_METADATA_ENDPOINT: http://ec2-metadata:1338
         AZURE_USE_EMULATOR: "1"
         AZURITE_BLOB_STORAGE_URL: "http://azurite:10000"
@@ -101,6 +97,11 @@ jobs:
           echo '{"gcs_base_url": "https://fake-gcs:4443", "disable_oauth": true, "client_email": "", "private_key": ""}' > "$GOOGLE_SERVICE_ACCOUNT"
 
       - name: Setup LocalStack (AWS emulation)
+        env:
+          AWS_DEFAULT_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_ENDPOINT: http://localstack:4566
         run: |
           cd /tmp
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -121,6 +122,11 @@ jobs:
           rustup default stable
 
       - name: Run object_store tests
+        env:
+          OBJECT_STORE_AWS_DEFAULT_REGION: "us-east-1"
+          OBJECT_STORE_AWS_ACCESS_KEY_ID: test
+          OBJECT_STORE_AWS_SECRET_ACCESS_KEY: test
+          OBJECT_STORE_AWS_ENDPOINT: http://localstack:4566
         run: |
           # run tests
           cargo test -p object_store --features=aws,azure,azure_test,gcp

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -547,10 +547,10 @@ mod tests {
             dotenv::dotenv().ok();
 
             let required_vars = [
-                "AWS_DEFAULT_REGION",
+                "OBJECT_STORE_AWS_DEFAULT_REGION",
                 "OBJECT_STORE_BUCKET",
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
+                "OBJECT_STORE_AWS_ACCESS_KEY_ID",
+                "OBJECT_STORE_AWS_SECRET_ACCESS_KEY",
             ];
             let unset_vars: Vec<_> = required_vars
                 .iter()
@@ -582,16 +582,16 @@ mod tests {
             } else {
                 let config = AmazonS3Builder::new()
                     .with_access_key_id(
-                        env::var("AWS_ACCESS_KEY_ID")
-                            .expect("already checked AWS_ACCESS_KEY_ID"),
+                        env::var("OBJECT_STORE_AWS_ACCESS_KEY_ID")
+                            .expect("already checked OBJECT_STORE_AWS_ACCESS_KEY_ID"),
                     )
                     .with_secret_access_key(
-                        env::var("AWS_SECRET_ACCESS_KEY")
-                            .expect("already checked AWS_SECRET_ACCESS_KEY"),
+                        env::var("OBJECT_STORE_AWS_SECRET_ACCESS_KEY")
+                            .expect("already checked OBJECT_STORE_AWS_SECRET_ACCESS_KEY"),
                     )
                     .with_region(
-                        env::var("AWS_DEFAULT_REGION")
-                            .expect("already checked AWS_DEFAULT_REGION"),
+                        env::var("OBJECT_STORE_AWS_DEFAULT_REGION")
+                            .expect("already checked OBJECT_STORE_AWS_DEFAULT_REGION"),
                     )
                     .with_bucket_name(
                         env::var("OBJECT_STORE_BUCKET")
@@ -599,13 +599,16 @@ mod tests {
                     )
                     .with_allow_http(true);
 
-                let config = if let Some(endpoint) = env::var("AWS_ENDPOINT").ok() {
-                    config.with_endpoint(endpoint)
-                } else {
-                    config
-                };
+                let config =
+                    if let Some(endpoint) = env::var("OBJECT_STORE_AWS_ENDPOINT").ok() {
+                        config.with_endpoint(endpoint)
+                    } else {
+                        config
+                    };
 
-                let config = if let Some(token) = env::var("AWS_SESSION_TOKEN").ok() {
+                let config = if let Some(token) =
+                    env::var("OBJECT_STORE_AWS_SESSION_TOKEN").ok()
+                {
                     config.with_token(token)
                 } else {
                     config


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2550 

# Rationale for this change

Update the environment variables names injected in the integration pipeline to test AmazonS3 client. The objective is to avoid conflicts when testing real injection while testing AmazonS3Builder::from_env() function.  

# What changes are included in this PR?

Update the github workflow pipeline + integration tests to leverage new names.

# Are there any user-facing changes?

No