### PR TITLE
Fix panic in `object_store::util::coalesce_ranges`

### DIFF
--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -87,11 +87,17 @@ where
     F: Send + FnMut(std::ops::Range<usize>) -> Fut,
     Fut: std::future::Future<Output = Result<Bytes>> + Send,
 {
+    if ranges.is_empty() {
+        return Ok(vec![]);
+    }
+
     let mut ret = Vec::with_capacity(ranges.len());
     let mut start_idx = 0;
     let mut end_idx = 1;
 
     while start_idx != ranges.len() {
+        let mut range_end = ranges[start_idx].end;
+
         while end_idx != ranges.len()
             && ranges[end_idx]
                 .start
@@ -99,12 +105,14 @@ where
                 .map(|delta| delta <= coalesce)
                 .unwrap_or(false)
         {
+            if ranges[end_idx].end > range_end {
+                range_end = ranges[end_idx].end;
+            }
             end_idx += 1;
         }
 
         let start = ranges[start_idx].start;
-        let end = ranges[end_idx - 1].end;
-        let bytes = fetch(start..end).await?;
+        let bytes = fetch(start..range_end).await?;
         for range in ranges.iter().take(end_idx).skip(start_idx) {
             ret.push(bytes.slice(range.start - start..range.end - start))
         }
@@ -164,5 +172,11 @@ mod tests {
 
         let fetches = do_fetch(vec![0..1, 5..6, 7..9, 2..3, 4..6], 1).await;
         assert_eq!(fetches, vec![0..1, 5..9, 2..6]);
+
+        let fetches = do_fetch(vec![0..1, 5..6, 7..9, 2..3, 4..6], 1).await;
+        assert_eq!(fetches, vec![0..1, 5..9, 2..6]);
+
+        let fetches = do_fetch(vec![0..1, 6..7, 8..9, 10..14, 9..10], 4).await;
+        assert_eq!(fetches, vec![0..1, 6..14]);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Current implementation of `object_store::util::coalesce_ranges` will panic in certain cases where non-adjacent ranges are out of order (see unit test for an example, which panics without the change). 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Track a high-water mark range end when coalescing ranges.  

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
