### PR TITLE
MINOR: Upgrade to pyo3 0.17

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -33,7 +33,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { path = "../arrow", version = "21.0.0", features = ["pyarrow"] }
-pyo3 = { version = "0.16", features = ["extension-module"] }
+pyo3 = { version = "0.17", features = ["extension-module"] }
 
 [package.metadata.maturin]
 requires-dist = ["pyarrow>=1"]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -63,7 +63,7 @@ chrono-tz = { version = "0.6", default-features = false, optional = true }
 flatbuffers = { version = "2.1.2", default-features = false, features = ["thiserror"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 comfy-table = { version = "6.0", optional = true, default-features = false }
-pyo3 = { version = "0.16", default-features = false, optional = true }
+pyo3 = { version = "0.17", default-features = false, optional = true }
 lexical-core = { version = "^0.8", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
 multiversion = { version = "0.6.1", default-features = false }
 bitflags = { version = "1.2.1", default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Rust 1.63.0 add a new lint `borrow_deref_ref` causing Cargo Clippy errors with pymethods that use `&str` as a parameter type. This issue is resolved in pyo3 0.17.

See https://github.com/apache/arrow-datafusion-python/issues/38https://github.com/apache/arrow-datafusion-python/issues/38 for more information about how this is affecting an upstream project (`arrow-datafusion-python`).

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Upgrade crate version.

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
