### PR TITLE
Allow overriding of do_get & export useful macro

### DIFF
--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -69,7 +69,6 @@ pub trait ProstMessageExt: prost::Message + Default {
     fn as_any(&self) -> prost_types::Any;
 }
 
-#[macro_export]
 macro_rules! prost_message_ext {
     ($($name:ty,)*) => {
         $(

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -69,6 +69,7 @@ pub trait ProstMessageExt: prost::Message + Default {
     fn as_any(&self) -> prost_types::Any;
 }
 
+#[macro_export]
 macro_rules! prost_message_ext {
     ($($name:ty,)*) => {
         $(

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -62,7 +62,7 @@ pub trait FlightSqlService:
     }
 
     /// Implementors may override to handle additional calls to do_get()
-    async fn custom_do_get(
+    async fn do_get_fallback(
         &self,
         _request: Request<Ticket>,
         message: prost_types::Any,
@@ -456,7 +456,7 @@ where
             return self.do_get_cross_reference(unpack(msg)?, request).await;
         }
 
-        self.custom_do_get(request, msg).await
+        self.do_get_fallback(request, msg).await
     }
 
     async fn do_put(

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -64,11 +64,12 @@ pub trait FlightSqlService:
     /// Implementors may override to handle additional calls to do_get()
     async fn custom_do_get(
         &self,
-        request: Request<Ticket>,
+        _request: Request<Ticket>,
         message: prost_types::Any,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
         Err(Status::unimplemented(format!(
-            "do_get: The defined request is invalid: {}", message.type_url
+            "do_get: The defined request is invalid: {}",
+            message.type_url
         )))
     }
 
@@ -396,7 +397,8 @@ where
         }
 
         Err(Status::unimplemented(format!(
-            "get_flight_info: The defined request is invalid: {}", message.type_url
+            "get_flight_info: The defined request is invalid: {}",
+            message.type_url
         )))
     }
 
@@ -415,10 +417,9 @@ where
             .map_err(decode_error_to_status)?;
 
         fn unpack<T: ProstMessageExt>(msg: prost_types::Any) -> Result<T, Status> {
-            msg
-                .unpack()
+            msg.unpack()
                 .map_err(arrow_error_to_status)?
-                .ok_or(Status::internal("Expected a command, but found none.".to_string()))
+                .ok_or_else(|| Status::internal("Expected a command, but found none."))
         }
 
         if msg.is::<TicketStatementQuery>() {
@@ -501,7 +502,8 @@ where
         }
 
         Err(Status::invalid_argument(format!(
-            "do_put: The defined request is invalid: {}", message.type_url
+            "do_put: The defined request is invalid: {}",
+            message.type_url
         )))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2581.

# Rationale for this change
 
Described in the issue.

# What changes are included in this PR?

Allowing implementers to override `do_get` and exporting a useful protobuf macro.

# Are there any user-facing changes?

This will empower them to do more, but change no behavior by default.