### PR TITLE
Move JsonSerializable to json module (#2300)

### DIFF
--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -50,6 +50,7 @@ pub type SchemaRef = Arc<Schema>;
 mod tests {
     use super::*;
     use crate::error::Result;
+    use crate::json::JsonSerializable;
     use serde_json::Value::{Bool, Number as VNumber, String as VString};
     use serde_json::{Number, Value};
     use std::{

--- a/arrow/src/datatypes/native.rs
+++ b/arrow/src/datatypes/native.rs
@@ -17,15 +17,9 @@
 
 use super::DataType;
 use half::f16;
-use serde_json::{Number, Value};
 
 mod private {
     pub trait Sealed {}
-}
-
-/// Trait declaring any type that is serializable to JSON. This includes all primitive types (bool, i32, etc.).
-pub trait JsonSerializable: 'static {
-    fn into_json_value(self) -> Option<Value>;
 }
 
 /// Trait expressing a Rust type that has the same in-memory representation
@@ -58,8 +52,8 @@ pub trait ArrowNativeType:
     + PartialOrd
     + std::str::FromStr
     + Default
-    + JsonSerializable
     + private::Sealed
+    + 'static
 {
     /// Convert native type from usize.
     #[inline]
@@ -120,18 +114,6 @@ pub trait ArrowPrimitiveType: 'static {
     }
 }
 
-impl JsonSerializable for bool {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
-impl JsonSerializable for i8 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
 impl private::Sealed for i8 {}
 impl ArrowNativeType for i8 {
     #[inline]
@@ -150,12 +132,6 @@ impl ArrowNativeType for i8 {
     }
 }
 
-impl JsonSerializable for i16 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
 impl private::Sealed for i16 {}
 impl ArrowNativeType for i16 {
     #[inline]
@@ -171,12 +147,6 @@ impl ArrowNativeType for i16 {
     #[inline]
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl JsonSerializable for i32 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
     }
 }
 
@@ -204,12 +174,6 @@ impl ArrowNativeType for i32 {
     }
 }
 
-impl JsonSerializable for i64 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(Value::Number(Number::from(self)))
-    }
-}
-
 impl private::Sealed for i64 {}
 impl ArrowNativeType for i64 {
     #[inline]
@@ -231,16 +195,6 @@ impl ArrowNativeType for i64 {
     #[inline]
     fn from_i64(val: i64) -> Option<Self> {
         Some(val)
-    }
-}
-
-impl JsonSerializable for i128 {
-    fn into_json_value(self) -> Option<Value> {
-        // Serialize as string to avoid issues with arbitrary_precision serde_json feature
-        // - https://github.com/serde-rs/json/issues/559
-        // - https://github.com/serde-rs/json/issues/845
-        // - https://github.com/serde-rs/json/issues/846
-        Some(self.to_string().into())
     }
 }
 
@@ -268,12 +222,6 @@ impl ArrowNativeType for i128 {
     }
 }
 
-impl JsonSerializable for u8 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
 impl private::Sealed for u8 {}
 impl ArrowNativeType for u8 {
     #[inline]
@@ -289,12 +237,6 @@ impl ArrowNativeType for u8 {
     #[inline]
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl JsonSerializable for u16 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
     }
 }
 
@@ -316,12 +258,6 @@ impl ArrowNativeType for u16 {
     }
 }
 
-impl JsonSerializable for u32 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
 impl private::Sealed for u32 {}
 impl ArrowNativeType for u32 {
     #[inline]
@@ -340,12 +276,6 @@ impl ArrowNativeType for u32 {
     }
 }
 
-impl JsonSerializable for u64 {
-    fn into_json_value(self) -> Option<Value> {
-        Some(self.into())
-    }
-}
-
 impl private::Sealed for u64 {}
 impl ArrowNativeType for u64 {
     #[inline]
@@ -361,24 +291,6 @@ impl ArrowNativeType for u64 {
     #[inline]
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl JsonSerializable for f16 {
-    fn into_json_value(self) -> Option<Value> {
-        Number::from_f64(f64::round(f64::from(self) * 1000.0) / 1000.0).map(Value::Number)
-    }
-}
-
-impl JsonSerializable for f32 {
-    fn into_json_value(self) -> Option<Value> {
-        Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0).map(Value::Number)
-    }
-}
-
-impl JsonSerializable for f64 {
-    fn into_json_value(self) -> Option<Value> {
-        Number::from_f64(self).map(Value::Number)
     }
 }
 

--- a/arrow/src/json/mod.rs
+++ b/arrow/src/json/mod.rs
@@ -25,3 +25,58 @@ pub mod writer;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
 pub use self::writer::{ArrayWriter, LineDelimitedWriter, Writer};
+use half::f16;
+use serde_json::{Number, Value};
+
+/// Trait declaring any type that is serializable to JSON. This includes all primitive types (bool, i32, etc.).
+pub trait JsonSerializable: 'static {
+    fn into_json_value(self) -> Option<Value>;
+}
+
+macro_rules! json_serializable {
+    ($t:ty) => {
+        impl JsonSerializable for $t {
+            fn into_json_value(self) -> Option<Value> {
+                Some(self.into())
+            }
+        }
+    };
+}
+
+json_serializable!(bool);
+json_serializable!(u8);
+json_serializable!(u16);
+json_serializable!(u32);
+json_serializable!(u64);
+json_serializable!(i8);
+json_serializable!(i16);
+json_serializable!(i32);
+json_serializable!(i64);
+
+impl JsonSerializable for i128 {
+    fn into_json_value(self) -> Option<Value> {
+        // Serialize as string to avoid issues with arbitrary_precision serde_json feature
+        // - https://github.com/serde-rs/json/issues/559
+        // - https://github.com/serde-rs/json/issues/845
+        // - https://github.com/serde-rs/json/issues/846
+        Some(self.to_string().into())
+    }
+}
+
+impl JsonSerializable for f16 {
+    fn into_json_value(self) -> Option<Value> {
+        Number::from_f64(f64::round(f64::from(self) * 1000.0) / 1000.0).map(Value::Number)
+    }
+}
+
+impl JsonSerializable for f32 {
+    fn into_json_value(self) -> Option<Value> {
+        Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0).map(Value::Number)
+    }
+}
+
+impl JsonSerializable for f64 {
+    fn into_json_value(self) -> Option<Value> {
+        Number::from_f64(self).map(Value::Number)
+    }
+}

--- a/arrow/src/json/writer.rs
+++ b/arrow/src/json/writer.rs
@@ -111,11 +111,14 @@ use serde_json::Value;
 use crate::array::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
+use crate::json::JsonSerializable;
 use crate::record_batch::RecordBatch;
 
-fn primitive_array_to_json<T: ArrowPrimitiveType>(
-    array: &ArrayRef,
-) -> Result<Vec<Value>> {
+fn primitive_array_to_json<T>(array: &ArrayRef) -> Result<Vec<Value>>
+where
+    T: ArrowPrimitiveType,
+    T::Native: JsonSerializable,
+{
     Ok(as_primitive_array::<T>(array)
         .iter()
         .map(|maybe_value| match maybe_value {
@@ -239,12 +242,15 @@ macro_rules! set_temporal_column_by_array_type {
     };
 }
 
-fn set_column_by_primitive_type<T: ArrowPrimitiveType>(
+fn set_column_by_primitive_type<T>(
     rows: &mut [JsonMap<String, Value>],
     row_count: usize,
     array: &ArrayRef,
     col_name: &str,
-) {
+) where
+    T: ArrowPrimitiveType,
+    T::Native: JsonSerializable,
+{
     let primitive_arr = as_primitive_array::<T>(array);
 
     rows.iter_mut()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2300

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Continues the process of decoupling the arrays from the JSON implementation

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Moves JsonSerializable to the json module, and removes from ArrowNativeType

# Are there any user-facing changes?

Yes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
