### PR TITLE
Add `Decimal128` to `DataType::is_numeric` and clean the numeric casting code

### DIFF
--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -172,57 +172,11 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (Date64, Utf8) | (Date64, LargeUtf8) => true,
         (_, Utf8 | LargeUtf8) => from_type.is_numeric() || from_type == &Binary,
 
-        // start numeric casts
+        // numeric casts
         (
-            UInt8,
-            UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
+            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
+            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
         ) => true,
-
-        (
-            UInt16,
-            UInt8 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            UInt32,
-            UInt8 | UInt16 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            UInt64,
-            UInt8 | UInt16 | UInt32 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            Int8,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int16 | Int32 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            Int16,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int32 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            Int32,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int64 | Float32 | Float64,
-        ) => true,
-
-        (
-            Int64,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Float32 | Float64,
-        ) => true,
-
-        (
-            Float32,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float64,
-        ) => true,
-
-        (
-            Float64,
-            UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32,
-        ) => true,
-        // end numeric casts
 
         // temporal casts
         (Int32, Date32 | Date64 | Time32(_)) => true,

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -140,8 +140,8 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (Dictionary(_, value_type), _) => can_cast_types(value_type, to_type),
         (_, Dictionary(_, value_type)) => can_cast_types(from_type, value_type),
 
-        (_, Boolean) => DataType::is_numeric(from_type) || from_type == &Utf8,
-        (Boolean, _) => DataType::is_numeric(to_type) || to_type == &Utf8,
+        (_, Boolean) => from_type.is_numeric() || from_type == &Utf8,
+        (Boolean, _) => to_type.is_numeric() || to_type == &Utf8,
 
         (Utf8, LargeUtf8) => true,
         (LargeUtf8, Utf8) => true,
@@ -155,7 +155,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             | Time64(TimeUnit::Nanosecond)
             | Timestamp(TimeUnit::Nanosecond, None)
         ) => true,
-        (Utf8, _) => DataType::is_numeric(to_type),
+        (Utf8, _) => to_type.is_numeric(),
         (LargeUtf8,
             LargeBinary
             | Date32
@@ -166,11 +166,11 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             | Time64(TimeUnit::Nanosecond)
             | Timestamp(TimeUnit::Nanosecond, None)
         ) => true,
-        (LargeUtf8, _) => DataType::is_numeric(to_type),
+        (LargeUtf8, _) => to_type.is_numeric(),
         (Timestamp(_, _), Utf8) | (Timestamp(_, _), LargeUtf8) => true,
         (Date32, Utf8) | (Date32, LargeUtf8) => true,
         (Date64, Utf8) | (Date64, LargeUtf8) => true,
-        (_, Utf8 | LargeUtf8) => DataType::is_numeric(from_type) || from_type == &Binary,
+        (_, Utf8 | LargeUtf8) => from_type.is_numeric() || from_type == &Binary,
 
         // start numeric casts
         (

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -1391,22 +1391,36 @@ impl DataType {
         }
     }
 
-    /// Returns true if this type is numeric: (UInt*, Int*, or Float*).
-    pub fn is_numeric(t: &DataType) -> bool {
+    /// Returns true if this type is signed numeric: (Int*, Float* or Decimal128).
+    pub fn is_signed_numeric(&self) -> bool {
         use DataType::*;
         matches!(
-            t,
-            UInt8
-                | UInt16
-                | UInt32
-                | UInt64
-                | Int8
+            self,
+            Int8
                 | Int16
                 | Int32
                 | Int64
                 | Float32
                 | Float64
+                | Decimal128(_, _)
         )
+    }
+
+    /// Returns true if this type is unsigned numeric: (UInt*).
+    pub fn is_unsigned_numeric(&self) -> bool {
+        use DataType::*;
+        matches!(
+            self,
+            UInt8
+                | UInt16
+                | UInt32
+                | UInt64
+        )
+    }
+
+    /// Returns true if this type is (signed or unsigned) numeric.
+    pub fn is_numeric(&self) -> bool {
+        self.is_signed_numeric() || self.is_unsigned_numeric()
     }
 
     /// Returns true if this type is temporal: (Date*, Time*, Duration, or Interval).

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -1396,26 +1396,14 @@ impl DataType {
         use DataType::*;
         matches!(
             self,
-            Int8
-                | Int16
-                | Int32
-                | Int64
-                | Float32
-                | Float64
-                | Decimal128(_, _)
+            Int8 | Int16 | Int32 | Int64 | Float32 | Float64 | Decimal128(_, _)
         )
     }
 
     /// Returns true if this type is unsigned numeric: (UInt*).
     pub fn is_unsigned_numeric(&self) -> bool {
         use DataType::*;
-        matches!(
-            self,
-            UInt8
-                | UInt16
-                | UInt32
-                | UInt64
-        )
+        matches!(self, UInt8 | UInt16 | UInt32 | UInt64)
     }
 
     /// Returns true if this type is (signed or unsigned) numeric.

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -1151,7 +1151,7 @@ fn write_array_data(
                 )?;
             }
         }
-    } else if DataType::is_numeric(data_type)
+    } else if data_type.is_numeric()
         || DataType::is_temporal(data_type)
         || matches!(
             array_data.data_type(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2611.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
We try to match the `is_numeric` function in the Datafusion (aka, adding Float16 and Decimal128). However, as `Float16` is not supported by some upstream libraries (such as lexical_core::FromLexical), we can't add it now. (This is not a big deal because Float16 is a minor use case). Decimal128 could be added successfully.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
