### PR TITLE
Help LLVM vectorize comparison kernel ~50-80% faster

### DIFF
--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -373,6 +373,38 @@ impl MutableBuffer {
         assert!(len <= self.capacity());
         self.len = len;
     }
+
+    /// Invokes `f` with values `0..len` collecting the boolean results into a new `MutableBuffer`
+    ///
+    /// This is similar to `from_trusted_len_iter_bool`, however, can be significantly faster
+    /// as it eliminates the conditional `Iterator::next`
+    #[inline]
+    pub(crate) fn collect_bool<F: FnMut(usize) -> bool>(len: usize, mut f: F) -> Self {
+        let mut buffer = Self::new(bit_util::ceil(len, 8));
+
+        let chunks = len / 8;
+        let remainder = len % 8;
+        for chunk in 0..chunks {
+            let mut packed = 0;
+            for bit_idx in 0..8 {
+                let i = bit_idx + chunk * 8;
+                packed |= (f(i) as u8) << bit_idx;
+            }
+
+            unsafe { buffer.push_unchecked(packed) }
+        }
+
+        if remainder != 0 {
+            let mut packed = 0;
+            for bit_idx in 0..remainder {
+                let i = bit_idx + chunks * 8;
+                packed |= (f(i) as u8) << bit_idx;
+            }
+            unsafe { buffer.push_unchecked(packed) }
+        }
+
+        buffer
+    }
 }
 
 /// # Safety
@@ -496,38 +528,9 @@ impl MutableBuffer {
         mut iterator: I,
     ) -> Self {
         let (_, upper) = iterator.size_hint();
-        let upper = upper.expect("from_trusted_len_iter requires an upper limit");
+        let len = upper.expect("from_trusted_len_iter requires an upper limit");
 
-        let mut result = {
-            let byte_capacity: usize = upper.saturating_add(7) / 8;
-            MutableBuffer::new(byte_capacity)
-        };
-
-        'a: loop {
-            let mut byte_accum: u8 = 0;
-            let mut mask: u8 = 1;
-
-            //collect (up to) 8 bits into a byte
-            while mask != 0 {
-                if let Some(value) = iterator.next() {
-                    byte_accum |= match value {
-                        true => mask,
-                        false => 0,
-                    };
-                    mask <<= 1;
-                } else {
-                    if mask != 1 {
-                        // Add last byte
-                        result.push_unchecked(byte_accum);
-                    }
-                    break 'a;
-                }
-            }
-
-            // Soundness: from_trusted_len
-            result.push_unchecked(byte_accum);
-        }
-        result
+        Self::collect_bool(len, |_| iterator.next().unwrap())
     }
 
     /// Creates a [`MutableBuffer`] from an [`Iterator`] with a trusted (upper) length or errors

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -391,6 +391,7 @@ impl MutableBuffer {
                 packed |= (f(i) as u8) << bit_idx;
             }
 
+            // SAFETY: Already allocated sufficient capacity
             unsafe { buffer.push_unchecked(packed) }
         }
 
@@ -400,6 +401,8 @@ impl MutableBuffer {
                 let i = bit_idx + chunks * 8;
                 packed |= (f(i) as u8) << bit_idx;
             }
+
+            // SAFETY: Already allocated sufficient capacity
             unsafe { buffer.push_unchecked(packed) }
         }
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -59,30 +59,9 @@ where
     let null_bit_buffer =
         combine_option_bitmap(&[left.data_ref(), right.data_ref()], left.len())?;
 
-    let mut buffer = MutableBuffer::new((left.len() + 7) / 8);
-
-    let chunks = left.len() / 8;
-    let remainder = left.len() % 8;
-    for chunk in 0..chunks {
-        let mut packed = 0;
-        for bit_idx in 0..8 {
-            let i = bit_idx + chunk * 8;
-            let r = unsafe { op(left.value_unchecked(i), right.value_unchecked(i)) };
-            packed |= (r as u8) << bit_idx;
-        }
-
-        unsafe { buffer.push_unchecked(packed) }
-    }
-
-    if remainder != 0 {
-        let mut packed = 0;
-        for bit_idx in 0..remainder {
-            let i = bit_idx + chunks * 8;
-            let r = unsafe { op(left.value_unchecked(i), right.value_unchecked(i)) };
-            packed |= (r as u8) << bit_idx;
-        }
-        unsafe { buffer.push_unchecked(packed) }
-    }
+    let buffer = MutableBuffer::collect_bool(left.len(), |i| unsafe {
+        op(left.value_unchecked(i), right.value_unchecked(i))
+    });
 
     let data = unsafe {
         ArrayData::new_unchecked(
@@ -109,11 +88,9 @@ where
         .null_buffer()
         .map(|b| b.bit_slice(left.offset(), left.len()));
 
-    // Safety:
-    // `i < $left.len()`
-    let comparison = (0..left.len()).map(|i| unsafe { op(left.value_unchecked(i)) });
-    // same as $left.len()
-    let buffer = unsafe { MutableBuffer::from_trusted_len_iter_bool(comparison) };
+    let buffer = MutableBuffer::collect_bool(left.len(), |i| unsafe {
+        op(left.value_unchecked(i))
+    });
 
     let data = unsafe {
         ArrayData::new_unchecked(

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -60,6 +60,7 @@ where
         combine_option_bitmap(&[left.data_ref(), right.data_ref()], left.len())?;
 
     let buffer = MutableBuffer::collect_bool(left.len(), |i| unsafe {
+        // SAFETY: i in range 0..len
         op(left.value_unchecked(i), right.value_unchecked(i))
     });
 
@@ -89,6 +90,7 @@ where
         .map(|b| b.bit_slice(left.offset(), left.len()));
 
     let buffer = MutableBuffer::collect_bool(left.len(), |i| unsafe {
+        // SAFETY: i in range 0..len
         op(left.value_unchecked(i))
     });
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I was messing around in godbolt and realised these loops were not getting vectorised correctly

**Default flags**

```
eq Float32              time:   [36.531 us 36.547 us 36.566 us]                        
                        change: [-45.190% -45.147% -45.104%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
neq Float32             time:   [36.677 us 36.695 us 36.718 us]                         
                        change: [-48.185% -48.131% -48.071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

```

**Target CPU**

```
eq Float32              time:   [19.023 us 19.040 us 19.060 us]                        
                        change: [-71.418% -71.385% -71.347%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  9 (9.00%) high mild
  7 (7.00%) high severe

neq Float32             time:   [19.172 us 19.184 us 19.197 us]                         
                        change: [-72.938% -72.919% -72.900%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
```

Once this is in, I will give the same treatment to the scalar kernels.

As an added bonus this likely reduces the amount of generated LLVM IR, and so may help very slightly with compile times.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
