### PR TITLE
MutableBuffer::typed_data - shared ref access to the typed slice

### DIFF
--- a/arrow/src/buffer/immutable.rs
+++ b/arrow/src/buffer/immutable.rs
@@ -181,7 +181,7 @@ impl Buffer {
         unsafe { self.data.ptr().as_ptr().add(self.offset) }
     }
 
-    /// View buffer as typed slice.
+    /// View buffer as a slice of a specific type.
     ///
     /// # Panics
     ///

--- a/arrow/src/buffer/mutable.rs
+++ b/arrow/src/buffer/mutable.rs
@@ -288,7 +288,7 @@ impl MutableBuffer {
         Buffer::from_bytes(bytes)
     }
 
-    /// View this buffer as a slice of a specific type.
+    /// View this buffer as a mutable slice of a specific type.
     ///
     /// # Panics
     ///
@@ -300,6 +300,21 @@ impl MutableBuffer {
         // implementation outside this crate, and this method checks alignment
         let (prefix, offsets, suffix) =
             unsafe { self.as_slice_mut().align_to_mut::<T>() };
+        assert!(prefix.is_empty() && suffix.is_empty());
+        offsets
+    }
+
+    /// View buffer as a immutable slice of a specific type.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the underlying buffer is not aligned
+    /// correctly for type `T`.
+    pub fn typed_data<T: ArrowNativeType>(&self) -> &[T] {
+        // SAFETY
+        // ArrowNativeType is trivially transmutable, is sealed to prevent potentially incorrect
+        // implementation outside this crate, and this method checks alignment
+        let (prefix, offsets, suffix) = unsafe { self.as_slice().align_to::<T>() };
         assert!(prefix.is_empty() && suffix.is_empty());
         offsets
     }


### PR DESCRIPTION
# Which issue does this PR close?

Didn't open an issue, let me know if you still need it for the changelog

# Rationale for this change

It's possible to run into ownership difficulties if you want to iterate over a mutable buffers typed data because it only offers a mutable slice which forces exclusive ownership. Provide an immutable slice that can be used as a shared reference.

# What changes are included in this PR?

Simple copy-pasta of `Buffer::typed_data` into `MutableBuffer` and updates to docstrings to match.

# Are there any user-facing changes?

New method in `MutableBuffer`. Not a breaking change.