### PR TITLE
json feature always requires base64 feature

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -74,7 +74,7 @@ arrow = ["dep:arrow", "base64"]
 # Enable CLI tools
 cli = ["json", "base64", "clap", "arrow/csv"]
 # Enable JSON APIs
-json = ["serde_json"]
+json = ["serde_json", "base64"]
 # Enable internal testing APIs
 test_common = ["arrow/test_utils"]
 # Experimental, unstable functionality primarily used for testing


### PR DESCRIPTION
It should fix build failure when only json feature is enabled.

```
% cargo build --no-default-features --features json
error[E0433]: failed to resolve: use of undeclared crate or module `base64`
   --> parquet/src/record/api.rs:691:46
    |
691 |             Field::Bytes(b) => Value::String(base64::encode(b.data())),
    |                                              ^^^^^^ use of undeclared crate or module `base64`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `parquet` due to previous error
```

# Which issue does this PR close?

Closes #2667 .

# Rationale for this change

base64 is required to compile Field::to_json_value() function.
I considered alternative of replacing `#[cfg(any(feature = "json", test)]` with `#[cfg(any(all(feature = "json", feature = "base64"), test)]` , but I noticed that all json features require base64. So I chose to modify parquet/Cargo.toml instead of parquet/src/record/api.rs.

# What changes are included in this PR?

I've added `base64` to `json` feature.

# Are there any user-facing changes?

No.
