### PR TITLE
Faster Null Path Selection in ArrayData Equality

### DIFF
--- a/arrow/src/array/equal/decimal.rs
+++ b/arrow/src/array/equal/decimal.rs
@@ -37,9 +37,9 @@ pub(super) fn decimal_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         equal_len(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/decimal.rs
+++ b/arrow/src/array/equal/decimal.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::datatypes::DataType;
 use crate::util::bit_util::get_bit;
 
@@ -37,10 +37,9 @@ pub(super) fn decimal_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         equal_len(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/dictionary.rs
+++ b/arrow/src/array/equal/dictionary.rs
@@ -34,9 +34,9 @@ pub(super) fn dictionary_equal<T: ArrowNativeType>(
     let lhs_values = &lhs.child_data()[0];
     let rhs_values = &rhs.child_data()[0];
 
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;
             let rhs_pos = rhs_start + i;

--- a/arrow/src/array/equal/dictionary.rs
+++ b/arrow/src/array/equal/dictionary.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::datatypes::ArrowNativeType;
 use crate::util::bit_util::get_bit;
 
@@ -34,10 +34,9 @@ pub(super) fn dictionary_equal<T: ArrowNativeType>(
     let lhs_values = &lhs.child_data()[0];
     let rhs_values = &rhs.child_data()[0];
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;
             let rhs_pos = rhs_start + i;

--- a/arrow/src/array/equal/fixed_binary.rs
+++ b/arrow/src/array/equal/fixed_binary.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::datatypes::DataType;
 use crate::util::bit_util::get_bit;
 
@@ -36,10 +36,9 @@ pub(super) fn fixed_binary_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         equal_len(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/fixed_binary.rs
+++ b/arrow/src/array/equal/fixed_binary.rs
@@ -36,9 +36,9 @@ pub(super) fn fixed_binary_equal(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         equal_len(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/fixed_list.rs
+++ b/arrow/src/array/equal/fixed_list.rs
@@ -36,9 +36,9 @@ pub(super) fn fixed_list_equal(
     let lhs_values = &lhs.child_data()[0];
     let rhs_values = &rhs.child_data()[0];
 
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         equal_range(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/fixed_list.rs
+++ b/arrow/src/array/equal/fixed_list.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::datatypes::DataType;
 use crate::util::bit_util::get_bit;
 
@@ -36,10 +36,9 @@ pub(super) fn fixed_list_equal(
     let lhs_values = &lhs.child_data()[0];
     let rhs_values = &rhs.child_data()[0];
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         equal_range(
             lhs_values,
             rhs_values,

--- a/arrow/src/array/equal/primitive.rs
+++ b/arrow/src/array/equal/primitive.rs
@@ -17,7 +17,7 @@
 
 use std::mem::size_of;
 
-use crate::array::{data::count_nulls, ArrayData};
+use crate::array::{data::contains_nulls, ArrayData};
 use crate::util::bit_util::get_bit;
 
 use super::utils::equal_len;
@@ -33,10 +33,9 @@ pub(super) fn primitive_equal<T>(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * byte_width..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * byte_width..];
 
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         // without nulls, we just need to compare slices
         equal_len(
             lhs_values,

--- a/arrow/src/array/equal/primitive.rs
+++ b/arrow/src/array/equal/primitive.rs
@@ -33,9 +33,9 @@ pub(super) fn primitive_equal<T>(
     let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * byte_width..];
     let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * byte_width..];
 
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         // without nulls, we just need to compare slices
         equal_len(
             lhs_values,

--- a/arrow/src/array/equal/structure.rs
+++ b/arrow/src/array/equal/structure.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{array::data::count_nulls, array::ArrayData, util::bit_util::get_bit};
+use crate::{array::data::contains_nulls, array::ArrayData, util::bit_util::get_bit};
 
 use super::equal_range;
 
@@ -43,11 +43,9 @@ pub(super) fn struct_equal(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    // we have to recalculate null counts from the null buffers
-    let lhs_null_count = count_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-    let rhs_null_count = count_nulls(rhs.null_buffer(), rhs_start + rhs.offset(), len);
+    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
 
-    if lhs_null_count == 0 && rhs_null_count == 0 {
+    if !has_nulls {
         equal_child_values(lhs, rhs, lhs_start, rhs_start, len)
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness

--- a/arrow/src/array/equal/structure.rs
+++ b/arrow/src/array/equal/structure.rs
@@ -43,9 +43,9 @@ pub(super) fn struct_equal(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    let has_nulls = contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len);
-
-    if !has_nulls {
+    // Only checking one null mask here because by the time the control flow reaches
+    // this point, the equality of the two masks would have already been verified.
+    if !contains_nulls(lhs.null_buffer(), lhs_start + lhs.offset(), len) {
         equal_child_values(lhs, rhs, lhs_start, rhs_start, len)
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2188.

# Rationale for this change
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
For the operations that only need to know if there are any nulls to select a more optimized code path, we instead of counting nulls in both `lhs` and `rhs` null masks:
- Replace `count_nulls` with `contains_nulls` to not have to traverse the whole bitmap once a null is found.
- Only check for nulls in `lhs` `ArrayData`'s null mask, as at these points in execution, the null masks have already been compared.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
