### PR TITLE
Deprecate RecordBatch::concat (#2594)

### DIFF
--- a/arrow/src/compute/kernels/concat.rs
+++ b/arrow/src/compute/kernels/concat.rs
@@ -31,8 +31,9 @@
 //! ```
 
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::{DataType, SchemaRef};
 use crate::error::{ArrowError, Result};
+use crate::record_batch::RecordBatch;
 
 fn compute_str_values_length<Offset: OffsetSizeTrait>(arrays: &[&ArrayData]) -> usize {
     arrays
@@ -100,6 +101,35 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef> {
     }
 
     Ok(make_array(mutable.freeze()))
+}
+
+/// Concatenates `batches` together into a single record batch.
+pub fn concat_batches(schema: &SchemaRef, batches: &[RecordBatch]) -> Result<RecordBatch> {
+    if batches.is_empty() {
+        return Ok(RecordBatch::new_empty(schema.clone()));
+    }
+    if let Some((i, _)) = batches
+        .iter()
+        .enumerate()
+        .find(|&(_, batch)| batch.schema() != *schema)
+    {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "batches[{}] schema is different with argument schema.",
+            i
+        )));
+    }
+    let field_num = schema.fields().len();
+    let mut arrays = Vec::with_capacity(field_num);
+    for i in 0..field_num {
+        let array = concat(
+            &batches
+                .iter()
+                .map(|batch| batch.column(i).as_ref())
+                .collect::<Vec<_>>(),
+        )?;
+        arrays.push(array);
+    }
+    RecordBatch::try_new(schema.clone(), arrays)
 }
 
 #[cfg(test)]
@@ -568,5 +598,77 @@ mod tests {
         assert!(!array.data().child_data()[0].ptr_eq(&combined.data().child_data()[0]));
         assert!(!copy.data().child_data()[0].ptr_eq(&combined.data().child_data()[0]));
         assert!(!new.data().child_data()[0].ptr_eq(&combined.data().child_data()[0]));
+    }
+
+    #[test]
+    fn concat_record_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+        ]));
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+            ],
+        )
+            .unwrap();
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![3, 4])),
+                Arc::new(StringArray::from(vec!["c", "d"])),
+            ],
+        )
+            .unwrap();
+        let new_batch = RecordBatch::concat(&schema, &[batch1, batch2]).unwrap();
+        assert_eq!(new_batch.schema().as_ref(), schema.as_ref());
+        assert_eq!(2, new_batch.num_columns());
+        assert_eq!(4, new_batch.num_rows());
+    }
+
+    #[test]
+    fn concat_empty_record_batch() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::concat(&schema, &[]).unwrap();
+        assert_eq!(batch.schema().as_ref(), schema.as_ref());
+        assert_eq!(0, batch.num_rows());
+    }
+
+    #[test]
+    fn concat_record_batches_of_different_schemas() {
+        let schema1 = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+        ]));
+        let schema2 = Arc::new(Schema::new(vec![
+            Field::new("c", DataType::Int32, false),
+            Field::new("d", DataType::Utf8, false),
+        ]));
+        let batch1 = RecordBatch::try_new(
+            schema1.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+            ],
+        )
+            .unwrap();
+        let batch2 = RecordBatch::try_new(
+            schema2,
+            vec![
+                Arc::new(Int32Array::from(vec![3, 4])),
+                Arc::new(StringArray::from(vec!["c", "d"])),
+            ],
+        )
+            .unwrap();
+        let error = RecordBatch::concat(&schema1, &[batch1, batch2]).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Invalid argument error: batches[1] schema is different with argument schema.",
+        );
     }
 }

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -21,7 +21,6 @@
 use std::sync::Arc;
 
 use crate::array::*;
-use crate::compute::kernels::concat::concat;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
@@ -390,32 +389,9 @@ impl RecordBatch {
     }
 
     /// Concatenates `batches` together into a single record batch.
+    #[deprecated(note = "please use arrow::compute::concat_batches")]
     pub fn concat(schema: &SchemaRef, batches: &[Self]) -> Result<Self> {
-        if batches.is_empty() {
-            return Ok(RecordBatch::new_empty(schema.clone()));
-        }
-        if let Some((i, _)) = batches
-            .iter()
-            .enumerate()
-            .find(|&(_, batch)| batch.schema() != *schema)
-        {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "batches[{}] schema is different with argument schema.",
-                i
-            )));
-        }
-        let field_num = schema.fields().len();
-        let mut arrays = Vec::with_capacity(field_num);
-        for i in 0..field_num {
-            let array = concat(
-                &batches
-                    .iter()
-                    .map(|batch| batch.column(i).as_ref())
-                    .collect::<Vec<_>>(),
-            )?;
-            arrays.push(array);
-        }
-        Self::try_new(schema.clone(), arrays)
+        crate::compute::concat_batches(schema, batches)
     }
 }
 
@@ -711,78 +687,6 @@ mod tests {
         );
         assert_eq!(batch.column(0).as_ref(), boolean.as_ref());
         assert_eq!(batch.column(1).as_ref(), int.as_ref());
-    }
-
-    #[test]
-    fn concat_record_batches() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Utf8, false),
-        ]));
-        let batch1 = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["a", "b"])),
-            ],
-        )
-        .unwrap();
-        let batch2 = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![3, 4])),
-                Arc::new(StringArray::from(vec!["c", "d"])),
-            ],
-        )
-        .unwrap();
-        let new_batch = RecordBatch::concat(&schema, &[batch1, batch2]).unwrap();
-        assert_eq!(new_batch.schema().as_ref(), schema.as_ref());
-        assert_eq!(2, new_batch.num_columns());
-        assert_eq!(4, new_batch.num_rows());
-    }
-
-    #[test]
-    fn concat_empty_record_batch() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Utf8, false),
-        ]));
-        let batch = RecordBatch::concat(&schema, &[]).unwrap();
-        assert_eq!(batch.schema().as_ref(), schema.as_ref());
-        assert_eq!(0, batch.num_rows());
-    }
-
-    #[test]
-    fn concat_record_batches_of_different_schemas() {
-        let schema1 = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, false),
-            Field::new("b", DataType::Utf8, false),
-        ]));
-        let schema2 = Arc::new(Schema::new(vec![
-            Field::new("c", DataType::Int32, false),
-            Field::new("d", DataType::Utf8, false),
-        ]));
-        let batch1 = RecordBatch::try_new(
-            schema1.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["a", "b"])),
-            ],
-        )
-        .unwrap();
-        let batch2 = RecordBatch::try_new(
-            schema2,
-            vec![
-                Arc::new(Int32Array::from(vec![3, 4])),
-                Arc::new(StringArray::from(vec!["c", "d"])),
-            ],
-        )
-        .unwrap();
-        let error = RecordBatch::concat(&schema1, &[batch1, batch2]).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "Invalid argument error: batches[1] schema is different with argument schema.",
-        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2594

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In order to split the core data layout structures, such as RecordBatch, away from IO and compute, the two can't depend on each other. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
