### PR TITLE
Simplify DictionaryBuilder constructors (#2684) (#2054)

### DIFF
--- a/arrow/benches/string_dictionary_builder.rs
+++ b/arrow/benches/string_dictionary_builder.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{Int32Builder, StringBuilder, StringDictionaryBuilder};
+use arrow::array::StringDictionaryBuilder;
+use arrow::datatypes::Int32Type;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 
@@ -43,12 +44,11 @@ fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 let strings = build_strings(dict_size, total_size, key_len);
                 b.iter(|| {
-                    let keys = Int32Builder::with_capacity(strings.len());
-                    let values = StringBuilder::with_capacity(
+                    let mut builder = StringDictionaryBuilder::<Int32Type>::with_capacity(
+                        strings.len(),
                         key_len + 1,
                         (key_len + 1) * dict_size,
                     );
-                    let mut builder = StringDictionaryBuilder::new(keys, values);
 
                     for val in &strings {
                         builder.append(val).unwrap();

--- a/arrow/src/array/array_dictionary.rs
+++ b/arrow/src/array/array_dictionary.rs
@@ -22,8 +22,8 @@ use std::iter::IntoIterator;
 use std::{convert::From, iter::FromIterator};
 
 use super::{
-    make_array, Array, ArrayData, ArrayRef, PrimitiveArray, PrimitiveBuilder,
-    StringArray, StringBuilder, StringDictionaryBuilder,
+    make_array, Array, ArrayData, ArrayRef, PrimitiveArray, StringArray,
+    StringDictionaryBuilder,
 };
 use crate::datatypes::{
     ArrowDictionaryKeyType, ArrowNativeType, ArrowPrimitiveType, DataType,
@@ -329,9 +329,7 @@ impl<'a, T: ArrowDictionaryKeyType> FromIterator<Option<&'a str>> for Dictionary
     fn from_iter<I: IntoIterator<Item = Option<&'a str>>>(iter: I) -> Self {
         let it = iter.into_iter();
         let (lower, _) = it.size_hint();
-        let key_builder = PrimitiveBuilder::<T>::with_capacity(lower);
-        let value_builder = StringBuilder::with_capacity(256, 1024);
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::with_capacity(lower, 256, 1024);
         it.for_each(|i| {
             if let Some(i) = i {
                 // Note: impl ... for Result<DictionaryArray<T>> fails with
@@ -367,9 +365,7 @@ impl<'a, T: ArrowDictionaryKeyType> FromIterator<&'a str> for DictionaryArray<T>
     fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
         let it = iter.into_iter();
         let (lower, _) = it.size_hint();
-        let key_builder = PrimitiveBuilder::<T>::with_capacity(lower);
-        let value_builder = StringBuilder::with_capacity(256, 1024);
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::with_capacity(lower, 256, 1024);
         it.for_each(|i| {
             builder
                 .append(i)
@@ -589,9 +585,8 @@ mod tests {
 
     #[test]
     fn test_dictionary_array_fmt_debug() {
-        let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::with_capacity(3, 2);
         builder.append(12345678).unwrap();
         builder.append_null();
         builder.append(22345678).unwrap();
@@ -601,9 +596,8 @@ mod tests {
             format!("{:?}", array)
         );
 
-        let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(20);
-        let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::with_capacity(20, 2);
         for _ in 0..20 {
             builder.append(1).unwrap();
         }

--- a/arrow/src/array/builder/primitive_dictionary_builder.rs
+++ b/arrow/src/array/builder/primitive_dictionary_builder.rs
@@ -108,7 +108,7 @@ where
     K: ArrowPrimitiveType,
     V: ArrowPrimitiveType,
 {
-    /// Creates a new `PrimitiveDictionaryBuilder` from a keys builder and a value builder.
+    /// Creates a new `PrimitiveDictionaryBuilder`.
     pub fn new() -> Self {
         Self {
             keys_builder: PrimitiveBuilder::new(),

--- a/arrow/src/array/builder/primitive_dictionary_builder.rs
+++ b/arrow/src/array/builder/primitive_dictionary_builder.rs
@@ -60,9 +60,7 @@ impl<T: ToByteSlice> Eq for Value<T> {}
 ///    };
 ///  use arrow::datatypes::{UInt8Type, UInt32Type};
 ///
-///  let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(3);
-///  let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(2);
-///  let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+///  let mut builder = PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::new();
 ///  builder.append(12345678).unwrap();
 ///  builder.append_null();
 ///  builder.append(22345678).unwrap();
@@ -95,20 +93,39 @@ where
     map: HashMap<Value<V::Native>, K::Native>,
 }
 
+impl<K, V> Default for PrimitiveDictionaryBuilder<K, V>
+where
+    K: ArrowPrimitiveType,
+    V: ArrowPrimitiveType,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K, V> PrimitiveDictionaryBuilder<K, V>
 where
     K: ArrowPrimitiveType,
     V: ArrowPrimitiveType,
 {
     /// Creates a new `PrimitiveDictionaryBuilder` from a keys builder and a value builder.
-    pub fn new(
-        keys_builder: PrimitiveBuilder<K>,
-        values_builder: PrimitiveBuilder<V>,
-    ) -> Self {
+    pub fn new() -> Self {
         Self {
-            keys_builder,
-            values_builder,
+            keys_builder: PrimitiveBuilder::new(),
+            values_builder: PrimitiveBuilder::new(),
             map: HashMap::new(),
+        }
+    }
+
+    /// Creates a new `PrimitiveDictionaryBuilder` with the provided capacities
+    ///
+    /// `keys_capacity`: the number of keys, i.e. length of array to build
+    /// `values_capacity`: the number of distinct dictionary values, i.e. size of dictionary
+    pub fn with_capacity(keys_capacity: usize, values_capacity: usize) -> Self {
+        Self {
+            keys_builder: PrimitiveBuilder::with_capacity(keys_capacity),
+            values_builder: PrimitiveBuilder::with_capacity(values_capacity),
+            map: HashMap::with_capacity(values_capacity),
         }
     }
 }
@@ -211,9 +228,8 @@ mod tests {
 
     #[test]
     fn test_primitive_dictionary_builder() {
-        let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::with_capacity(3, 2);
         builder.append(12345678).unwrap();
         builder.append_null();
         builder.append(22345678).unwrap();
@@ -239,9 +255,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "DictionaryKeyOverflowError")]
     fn test_primitive_dictionary_overflow() {
-        let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(257);
-        let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(257);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::with_capacity(257, 257);
         // 256 unique keys.
         for i in 0..256 {
             builder.append(i + 1000).unwrap();

--- a/arrow/src/array/builder/string_dictionary_builder.rs
+++ b/arrow/src/array/builder/string_dictionary_builder.rs
@@ -125,7 +125,7 @@ where
         }
     }
 
-    /// Creates a new `StringDictionaryBuilder` from a keys builder and a dictionary
+    /// Creates a new `StringDictionaryBuilder` from a keys capacity and a dictionary
     /// which is initialized with the given values.
     /// The indices of those dictionary values are used as keys.
     ///

--- a/arrow/src/array/equal/mod.rs
+++ b/arrow/src/array/equal/mod.rs
@@ -265,8 +265,8 @@ mod tests {
     use crate::array::{
         array::Array, ArrayData, ArrayDataBuilder, ArrayRef, BooleanArray,
         FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray, Int32Builder,
-        ListBuilder, NullArray, PrimitiveBuilder, StringArray, StringDictionaryBuilder,
-        StructArray, UnionBuilder,
+        ListBuilder, NullArray, StringArray, StringDictionaryBuilder, StructArray,
+        UnionBuilder,
     };
     use crate::array::{GenericStringArray, Int32Array};
     use crate::buffer::Buffer;
@@ -1245,8 +1245,8 @@ mod tests {
 
     fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayData {
         let values = StringArray::from(values.to_vec());
-        let mut builder = StringDictionaryBuilder::new_with_dictionary(
-            PrimitiveBuilder::<Int16Type>::with_capacity(3),
+        let mut builder = StringDictionaryBuilder::<Int16Type>::new_with_dictionary(
+            keys.len(),
             &values,
         )
         .unwrap();

--- a/arrow/src/array/transform/mod.rs
+++ b/arrow/src/array/transform/mod.rs
@@ -675,8 +675,8 @@ mod tests {
         array::{
             Array, ArrayData, ArrayRef, BooleanArray, DictionaryArray,
             FixedSizeBinaryArray, Int16Array, Int16Type, Int32Array, Int64Array,
-            Int64Builder, ListBuilder, MapBuilder, NullArray, PrimitiveBuilder,
-            StringArray, StringDictionaryBuilder, StructArray, UInt8Array,
+            Int64Builder, ListBuilder, MapBuilder, NullArray, StringArray,
+            StringDictionaryBuilder, StructArray, UInt8Array,
         },
         buffer::Buffer,
         datatypes::Field,
@@ -963,8 +963,8 @@ mod tests {
 
     fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayData {
         let values = StringArray::from(values.to_vec());
-        let mut builder = StringDictionaryBuilder::new_with_dictionary(
-            PrimitiveBuilder::<Int16Type>::with_capacity(3),
+        let mut builder = StringDictionaryBuilder::<Int16Type>::new_with_dictionary(
+            keys.len(),
             &values,
         )
         .unwrap();

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -1367,9 +1367,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_add_dyn_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
@@ -1377,9 +1375,7 @@ mod tests {
         builder.append(9).unwrap();
         let a = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
@@ -1408,9 +1404,7 @@ mod tests {
         assert!(c.is_null(3));
         assert_eq!(10, c.value(4));
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append_null();
         builder.append(7).unwrap();
@@ -1451,9 +1445,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_subtract_dyn_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(15).unwrap();
         builder.append(8).unwrap();
         builder.append(7).unwrap();
@@ -1461,9 +1453,7 @@ mod tests {
         builder.append(20).unwrap();
         let a = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
@@ -1492,9 +1482,7 @@ mod tests {
         assert!(c.is_null(3));
         assert_eq!(8, c.value(4));
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append_null();
         builder.append(7).unwrap();
@@ -1535,9 +1523,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_multiply_dyn_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
@@ -1545,9 +1531,7 @@ mod tests {
         builder.append(9).unwrap();
         let a = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();
@@ -1579,9 +1563,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_divide_dyn_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(15).unwrap();
         builder.append(6).unwrap();
         builder.append(1).unwrap();
@@ -1589,9 +1571,7 @@ mod tests {
         builder.append(9).unwrap();
         let a = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append(3).unwrap();
         builder.append(1).unwrap();
@@ -1620,9 +1600,7 @@ mod tests {
         assert!(c.is_null(3));
         assert_eq!(18, c.value(4));
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append_null();
         builder.append(7).unwrap();
@@ -1806,9 +1784,7 @@ mod tests {
         assert!(c.is_null(3));
         assert_eq!(4, c.value(4));
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append_null();
         builder.append(7).unwrap();
@@ -2082,15 +2058,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "DivideByZero")]
     fn test_primitive_array_divide_dyn_by_zero_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(1);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(1);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(1, 1);
         builder.append(15).unwrap();
         let a = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(1);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(1);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(1, 1);
         builder.append(0).unwrap();
         let b = builder.finish();
 

--- a/arrow/src/compute/kernels/arity.rs
+++ b/arrow/src/compute/kernels/arity.rs
@@ -122,9 +122,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::{
-        as_primitive_array, Float64Array, PrimitiveBuilder, PrimitiveDictionaryBuilder,
-    };
+    use crate::array::{as_primitive_array, Float64Array, PrimitiveDictionaryBuilder};
     use crate::datatypes::{Float64Type, Int32Type, Int8Type};
 
     #[test]
@@ -149,9 +147,7 @@ mod tests {
 
     #[test]
     fn test_unary_dict_and_unary_dyn() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(5).unwrap();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
@@ -160,9 +156,7 @@ mod tests {
         builder.append(9).unwrap();
         let dictionary_array = builder.finish();
 
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(6).unwrap();
         builder.append(7).unwrap();
         builder.append(8).unwrap();

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -2563,9 +2563,8 @@ where
         .downcast_ref::<PrimitiveArray<V>>()
         .unwrap();
 
-    let keys_builder = PrimitiveBuilder::<K>::with_capacity(values.len());
-    let values_builder = PrimitiveBuilder::<V>::with_capacity(values.len());
-    let mut b = PrimitiveDictionaryBuilder::new(keys_builder, values_builder);
+    let mut b =
+        PrimitiveDictionaryBuilder::<K, V>::with_capacity(values.len(), values.len());
 
     // copy each element one at a time
     for i in 0..values.len() {
@@ -2589,10 +2588,7 @@ where
 {
     let cast_values = cast_with_options(array, &DataType::Utf8, cast_options)?;
     let values = cast_values.as_any().downcast_ref::<StringArray>().unwrap();
-
-    let keys_builder = PrimitiveBuilder::<K>::with_capacity(values.len());
-    let values_builder = StringBuilder::with_capacity(1024, values.len());
-    let mut b = StringDictionaryBuilder::new(keys_builder, values_builder);
+    let mut b = StringDictionaryBuilder::<K>::with_capacity(values.len(), 1024, 1024);
 
     // copy each element one at a time
     for i in 0..values.len() {
@@ -5001,9 +4997,7 @@ mod tests {
         // FROM a dictionary with of Utf8 values
         use DataType::*;
 
-        let keys_builder = PrimitiveBuilder::<Int8Type>::new();
-        let values_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(keys_builder, values_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("one").unwrap();
         builder.append_null();
         builder.append("three").unwrap();
@@ -5062,9 +5056,7 @@ mod tests {
         // that are out of bounds for a particular other kind of
         // index.
 
-        let keys_builder = PrimitiveBuilder::<Int32Type>::new();
-        let values_builder = PrimitiveBuilder::<Int64Type>::new();
-        let mut builder = PrimitiveDictionaryBuilder::new(keys_builder, values_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int32Type, Int64Type>::new();
 
         // add 200 distinct values (which can be stored by a
         // dictionary indexed by int32, but not a dictionary indexed
@@ -5093,9 +5085,7 @@ mod tests {
         // Same test as test_cast_dict_to_dict_bad_index_value but use
         // string values (and encode the expected behavior here);
 
-        let keys_builder = PrimitiveBuilder::<Int32Type>::new();
-        let values_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(keys_builder, values_builder);
+        let mut builder = StringDictionaryBuilder::<Int32Type>::new();
 
         // add 200 distinct values (which can be stored by a
         // dictionary indexed by int32, but not a dictionary indexed
@@ -5124,9 +5114,7 @@ mod tests {
         // FROM a dictionary with of INT32 values
         use DataType::*;
 
-        let keys_builder = PrimitiveBuilder::<Int8Type>::new();
-        let values_builder = PrimitiveBuilder::<Int32Type>::new();
-        let mut builder = PrimitiveDictionaryBuilder::new(keys_builder, values_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::new();
         builder.append(1).unwrap();
         builder.append_null();
         builder.append(3).unwrap();

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -4884,9 +4884,8 @@ mod tests {
 
     #[test]
     fn test_eq_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(123).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -4928,9 +4927,8 @@ mod tests {
 
     #[test]
     fn test_lt_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(123).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -4971,9 +4969,8 @@ mod tests {
     }
     #[test]
     fn test_lt_eq_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = PrimitiveBuilder::<Int32Type>::new();
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(123).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -5015,9 +5012,8 @@ mod tests {
 
     #[test]
     fn test_gt_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<Int32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(123).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -5059,9 +5055,8 @@ mod tests {
 
     #[test]
     fn test_gt_eq_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = PrimitiveBuilder::<Int32Type>::new();
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(22).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -5103,9 +5098,8 @@ mod tests {
 
     #[test]
     fn test_neq_dyn_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = PrimitiveBuilder::<Int32Type>::new();
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder =
+            PrimitiveDictionaryBuilder::<Int8Type, Int32Type>::with_capacity(3, 2);
         builder.append(22).unwrap();
         builder.append_null();
         builder.append(23).unwrap();
@@ -5247,9 +5241,7 @@ mod tests {
 
     #[test]
     fn test_eq_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();
@@ -5275,9 +5267,7 @@ mod tests {
     }
     #[test]
     fn test_lt_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();
@@ -5304,9 +5294,7 @@ mod tests {
     }
     #[test]
     fn test_lt_eq_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();
@@ -5333,9 +5321,7 @@ mod tests {
     }
     #[test]
     fn test_gt_eq_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();
@@ -5363,9 +5349,7 @@ mod tests {
 
     #[test]
     fn test_gt_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();
@@ -5392,9 +5376,7 @@ mod tests {
     }
     #[test]
     fn test_neq_dyn_utf8_scalar_with_dict() {
-        let key_builder = PrimitiveBuilder::<Int8Type>::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = StringDictionaryBuilder::<Int8Type>::new();
         builder.append("abc").unwrap();
         builder.append_null();
         builder.append("def").unwrap();

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1960,10 +1960,7 @@ mod tests {
 
     #[test]
     fn test_take_dict() {
-        let keys_builder = Int16Builder::new();
-        let values_builder = StringBuilder::new();
-
-        let mut dict_builder = StringDictionaryBuilder::new(keys_builder, values_builder);
+        let mut dict_builder = StringDictionaryBuilder::<Int16Type>::new();
 
         dict_builder.append("foo").unwrap();
         dict_builder.append("bar").unwrap();

--- a/arrow/src/json/reader.rs
+++ b/arrow/src/json/reader.rs
@@ -914,9 +914,7 @@ impl Decoder {
     where
         T: ArrowPrimitiveType + ArrowDictionaryKeyType,
     {
-        let key_builder = PrimitiveBuilder::<T>::with_capacity(row_len);
-        let values_builder = StringBuilder::with_capacity(row_len, row_len * 5);
-        StringDictionaryBuilder::new(key_builder, values_builder)
+        StringDictionaryBuilder::with_capacity(row_len, row_len, row_len * 5)
     }
 
     #[inline(always)]

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -108,10 +108,10 @@ mod tests {
     use crate::{
         array::{
             self, new_null_array, Array, Date32Array, Date64Array,
-            FixedSizeBinaryBuilder, Float16Array, Int32Array, PrimitiveBuilder,
-            StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
-            Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
-            Time64NanosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+            FixedSizeBinaryBuilder, Float16Array, Int32Array, StringArray,
+            StringDictionaryBuilder, StructArray, Time32MillisecondArray,
+            Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+            TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampSecondArray, UnionArray, UnionBuilder,
         },
         buffer::Buffer,
@@ -241,9 +241,7 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
         let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
-        let keys_builder = PrimitiveBuilder::<Int32Type>::with_capacity(10);
-        let values_builder = StringBuilder::new();
-        let mut builder = StringDictionaryBuilder::new(keys_builder, values_builder);
+        let mut builder = StringDictionaryBuilder::<Int32Type>::new();
 
         builder.append("one")?;
         builder.append_null();

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1653,9 +1653,7 @@ mod tests {
         )]));
 
         // create some data
-        let key_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(3);
-        let value_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(2);
-        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        let mut builder = PrimitiveDictionaryBuilder::<UInt8Type, UInt32Type>::new();
         builder.append(12345678).unwrap();
         builder.append_null();
         builder.append(22345678).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2684
Part of #2054

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The previous constructors were confusing, unnecessarily verbose, and allowed creating invalid DictionaryArrays by passing in a non-empty keys builder

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
