### PR TITLE
Add support for empty projection in RecordBatch::project

### DIFF
--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -199,16 +199,6 @@ impl RecordBatch {
 
     /// Projects the schema onto the specified columns
     pub fn project(&self, indices: &[usize]) -> Result<RecordBatch> {
-        if indices.is_empty() {
-            return RecordBatch::try_new_with_options(
-                Arc::new(Schema::empty()),
-                vec![],
-                &RecordBatchOptions {
-                    match_field_names: true,
-                    row_count: Some(self.row_count),
-                },
-            );
-        }
         let projected_schema = self.schema.project(indices)?;
         let batch_fields = indices
             .iter()
@@ -223,7 +213,14 @@ impl RecordBatch {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        RecordBatch::try_new(SchemaRef::new(projected_schema), batch_fields)
+        RecordBatch::try_new_with_options(
+            SchemaRef::new(projected_schema),
+            batch_fields,
+            &RecordBatchOptions {
+                match_field_names: true,
+                row_count: Some(self.row_count),
+            },
+        )
     }
 
     /// Returns the number of columns in the record batch.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2690

# Rationale for this change
Make it easier to deal with zero-column `RecordBatch`es. 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
