### PR TITLE
Trim parquet row selection

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -570,7 +570,7 @@ impl ParquetRecordBatchReader {
             batch_size,
             array_reader,
             schema: Arc::new(schema),
-            selection: selection.map(Into::into),
+            selection: selection.map(|s| s.trim().into()),
         }
     }
 }

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -285,6 +285,14 @@ impl RowSelection {
     pub fn selects_any(&self) -> bool {
         self.selectors.iter().any(|x| !x.skip)
     }
+
+    /// Trims this [`RowSelection`] removing any trailing skips
+    pub(crate) fn trim(mut self) -> Self {
+        while self.selectors.last().map(|x| x.skip).unwrap_or(false) {
+            self.selectors.pop();
+        }
+        self
+    }
 }
 
 impl From<Vec<RowSelector>> for RowSelection {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Skipping over records isn't necessarily free, in particular for variable length types such as strings. There is no point going to this effort if there are no further rows to be read.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Trims trailing skips from a RowSelection prior to the scan

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
