### PR TITLE
Add DataType::is_nested()

### DIFF
--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -1439,6 +1439,20 @@ impl DataType {
         )
     }
 
+    /// Returns true if this type is nested (FixedSizeList, LargeList, Struct, Union, or Map)
+    pub fn is_nested(t: &DataType) -> bool {
+        use DataType::*;
+        matches!(
+            t,
+            List(_)
+                | FixedSizeList(_, _)
+                | LargeList(_)
+                | Struct(_)
+                | Union(_, _, _)
+                | Map(_, _)
+        )
+    }
+
     /// Compares the datatype with another, ignoring nested field names
     /// and metadata.
     pub fn equals_datatype(&self, other: &DataType) -> bool {

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -1439,7 +1439,7 @@ impl DataType {
         )
     }
 
-    /// Returns true if this type is nested (FixedSizeList, LargeList, Struct, Union, or Map)
+    /// Returns true if this type is nested (List, FixedSizeList, LargeList, Struct, Union, or Map)
     pub fn is_nested(t: &DataType) -> bool {
         use DataType::*;
         matches!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2704.

# Rationale for this change
Already described in the issue
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
`is_nested` function is added to `DataType`, that returns `true` if the provided type is nested (`List`, `FixedSizeList`, `LargeList`, `Struct`, `Union` or `Map`)
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
User will be able to use `DataType::is_nested` function

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
