### PR TITLE
Don't Derive Serialize/Deserialize Serde Implementations for Schema Types

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -44,7 +44,6 @@ ahash = { version = "0.8", default-features = false, features = ["compile-time-r
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 indexmap = { version = "1.9", default-features = false, features = ["std"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
@@ -75,7 +74,7 @@ default = ["csv", "ipc", "json"]
 ipc_compression = ["ipc", "zstd", "lz4"]
 csv = ["csv_crate"]
 ipc = ["flatbuffers"]
-json = ["serde", "serde_json"]
+json = ["serde_json"]
 simd = ["packed_simd"]
 prettyprint = ["comfy-table"]
 # The test utils feature enables code used in benchmarks and tests but

--- a/arrow/src/datatypes/datatype.rs
+++ b/arrow/src/datatypes/datatype.rs
@@ -40,7 +40,6 @@ use super::Field;
 /// For more information on these types please see
 /// [the physical memory layout of Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html#physical-memory-layout).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DataType {
     /// Null type
     Null,
@@ -235,7 +234,6 @@ pub enum TimeUnit {
 
 /// YEAR_MONTH, DAY_TIME, MONTH_DAY_NANO interval in SQL style.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IntervalUnit {
     /// Indicates the number of elapsed whole months, stored as 4-byte integers.
     YearMonth,
@@ -254,7 +252,6 @@ pub enum IntervalUnit {
 
 // Sparse or Dense union layouts
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UnionMode {
     Sparse,
     Dense,

--- a/arrow/src/datatypes/field.rs
+++ b/arrow/src/datatypes/field.rs
@@ -27,7 +27,6 @@ use super::DataType;
 /// A [`Schema`](super::Schema) is an ordered collection of
 /// [`Field`] objects.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Field {
     name: String,
     data_type: DataType,
@@ -35,7 +34,6 @@ pub struct Field {
     dict_id: i64,
     dict_is_ordered: bool,
     /// A map of key-value pairs containing additional custom meta data.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     metadata: Option<BTreeMap<String, String>>,
 }
 

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -153,7 +153,7 @@ mod tests {
             ),
         ]);
 
-        let serialized = serde_json::to_string(&person).unwrap();
+        let serialized = person.to_json();
 
         // NOTE that this is testing the default (derived) serialization format, not the
         // JSON format specified in metadata.md
@@ -169,7 +169,7 @@ mod tests {
             serialized
         );
 
-        let deserialized = serde_json::from_str(&serialized).unwrap();
+        let deserialized = DataType::from(&serialized).unwrap();
 
         assert_eq!(person, deserialized);
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #2300 
Part of #2594
Related to #2711

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Serde derive is a non-trivial proc macro dependency, and the nature of the orphan rule forces the Serialize/Deserialize implementations to be defined in the same crate. This in turn forces json to leak into an arrow-schema crate, see #2711.

It turns out we aren't actually using the generated code, although downstreams potentially are.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Removes the serde derives, ensuring we only provide a single way to serialize a schema to JSON, and potentially allowing this to live in a separate arrow-json crate (#2594)

# Are there any user-facing changes?

Yes, theoretically users may have been using these serialize implementations. I'm not sure this duplication was intentional.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
