### PR TITLE
Better construction of RecordBatchOptions

### DIFF
--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -31,7 +31,7 @@ use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef, UnionMode};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
-use crate::record_batch::{RecordBatch, RecordBatchOptionsBuilder, RecordBatchReader};
+use crate::record_batch::{RecordBatch, RecordBatchOptions, RecordBatchReader};
 
 use crate::ipc::compression::CompressionCodec;
 use ipc::CONTINUATION_MARKER;
@@ -578,9 +578,7 @@ pub fn read_record_batch(
     let mut node_index = 0;
     let mut arrays = vec![];
 
-    let options = RecordBatchOptionsBuilder::new()
-        .row_count(batch.length() as usize)
-        .build();
+    let options = RecordBatchOptions::new().with_row_count(Some(batch.length() as usize));
 
     if let Some(projection) = projection {
         // project fields
@@ -1691,10 +1689,9 @@ mod tests {
     #[test]
     fn test_no_columns_batch() {
         let schema = Arc::new(Schema::new(vec![]));
-        let options = RecordBatchOptionsBuilder::new()
-            .match_field_names(true)
-            .row_count(10)
-            .build();
+        let options = RecordBatchOptions::new()
+            .with_match_field_names(true)
+            .with_row_count(Some(10));
         let input_batch =
             RecordBatch::try_new_with_options(schema, vec![], &options).unwrap();
         let output_batch = roundtrip_ipc_stream(&input_batch);

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -31,7 +31,7 @@ use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef, UnionMode};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
-use crate::record_batch::{RecordBatch, RecordBatchOptions, RecordBatchReader};
+use crate::record_batch::{RecordBatch, RecordBatchOptionsBuilder, RecordBatchReader};
 
 use crate::ipc::compression::CompressionCodec;
 use ipc::CONTINUATION_MARKER;
@@ -578,10 +578,9 @@ pub fn read_record_batch(
     let mut node_index = 0;
     let mut arrays = vec![];
 
-    let options = RecordBatchOptions {
-        row_count: Some(batch.length() as usize),
-        ..Default::default()
-    };
+    let options = RecordBatchOptionsBuilder::new()
+        .row_count(batch.length() as usize)
+        .build();
 
     if let Some(projection) = projection {
         // project fields
@@ -1692,10 +1691,10 @@ mod tests {
     #[test]
     fn test_no_columns_batch() {
         let schema = Arc::new(Schema::new(vec![]));
-        let options = RecordBatchOptions {
-            match_field_names: true,
-            row_count: Some(10),
-        };
+        let options = RecordBatchOptionsBuilder::new()
+            .match_field_names(true)
+            .row_count(10)
+            .build();
         let input_batch =
             RecordBatch::try_new_with_options(schema, vec![], &options).unwrap();
         let output_batch = roundtrip_ipc_stream(&input_batch);

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -963,7 +963,7 @@ mod tests {
             .match_field_names(false)
             .row_count(20)
             .build();
-        assert_eq!(options.match_field_names, false);
+        assert!(!options.match_field_names);
         assert_eq!(options.row_count.unwrap(), 20)
     }
 }

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -80,7 +80,7 @@ impl RecordBatch {
     /// # }
     /// ```
     pub fn try_new(schema: SchemaRef, columns: Vec<ArrayRef>) -> Result<Self> {
-        let options = RecordBatchOptionsBuilder::new().build();
+        let options = RecordBatchOptions::new();
         Self::try_new_impl(schema, columns, &options)
     }
 
@@ -412,47 +412,31 @@ pub struct RecordBatchOptions {
     /// Optional row count, useful for specifying a row count for a RecordBatch with no columns
     pub row_count: Option<usize>,
 }
-/// Builder to create new RecordBatchOptions object
-#[derive(Debug)]
-pub struct RecordBatchOptionsBuilder {
-    /// Match field names of structs and lists. If set to `true`, the names must match.
-    match_field_names: bool,
 
-    /// Optional row count, useful for specifying a row count for a RecordBatch with no columns
-    row_count: Option<usize>,
-}
-impl Default for RecordBatchOptionsBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RecordBatchOptionsBuilder {
+impl RecordBatchOptions {
     pub fn new() -> Self {
         Self {
             match_field_names: true,
             row_count: None,
         }
     }
-    pub fn match_field_names(mut self, match_field_names: bool) -> Self {
+    //Sets the row_count of RecordBatchOptions and returns self
+    pub fn with_row_count(mut self, row_count: Option<usize>) -> Self {
+        self.row_count = row_count;
+        self
+    }
+    //Sets the match_field_names of RecordBatchOptions and returns self
+    pub fn with_match_field_names(mut self, match_field_names: bool) -> Self {
         self.match_field_names = match_field_names;
         self
     }
-    pub fn row_count(mut self, row_count: usize) -> Self {
-        self.row_count = Some(row_count);
-        self
-    }
-    pub fn build(self) -> RecordBatchOptions {
-        let Self {
-            match_field_names,
-            row_count,
-        } = self;
-        RecordBatchOptions {
-            match_field_names,
-            row_count,
-        }
+}
+impl Default for RecordBatchOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
+/// Builder to create new RecordBatchOptions object
 impl From<&StructArray> for RecordBatch {
     /// Create a record batch from struct array, where each field of
     /// the `StructArray` becomes a `Field` in the schema.
@@ -932,7 +916,7 @@ mod tests {
             .to_string()
             .contains("must either specify a row count or at least one column"));
 
-        let options = RecordBatchOptionsBuilder::new().row_count(10).build();
+        let options = RecordBatchOptions::new().with_row_count(Some(10));
 
         let ok =
             RecordBatch::try_new_with_options(schema.clone(), vec![], &options).unwrap();
@@ -958,11 +942,10 @@ mod tests {
         assert_eq!("Invalid argument error: Column 'a' is declared as non-nullable but contains null values", format!("{}", maybe_batch.err().unwrap()));
     }
     #[test]
-    fn test_record_batch_options_builder() {
-        let options = RecordBatchOptionsBuilder::new()
-            .match_field_names(false)
-            .row_count(20)
-            .build();
+    fn test_record_batch_options() {
+        let options = RecordBatchOptions::new()
+            .with_match_field_names(false)
+            .with_row_count(Some(20));
         assert!(!options.match_field_names);
         assert_eq!(options.row_count.unwrap(), 20)
     }

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -425,7 +425,7 @@ impl RecordBatchOptions {
         self.row_count = row_count;
         self
     }
-    //Sets the match_field_names of RecordBatchOptions and returns self
+    /// Sets the match_field_names of RecordBatchOptions and returns self
     pub fn with_match_field_names(mut self, match_field_names: bool) -> Self {
         self.match_field_names = match_field_names;
         self

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -436,7 +436,6 @@ impl Default for RecordBatchOptions {
         Self::new()
     }
 }
-/// Builder to create new RecordBatchOptions object
 impl From<&StructArray> for RecordBatch {
     /// Create a record batch from struct array, where each field of
     /// the `StructArray` becomes a `Field` in the schema.

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -421,6 +421,11 @@ pub struct RecordBatchOptionsBuilder {
     /// Optional row count, useful for specifying a row count for a RecordBatch with no columns
     row_count: Option<usize>,
 }
+impl Default for RecordBatchOptionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl RecordBatchOptionsBuilder {
     pub fn new() -> Self {

--- a/arrow/src/record_batch.rs
+++ b/arrow/src/record_batch.rs
@@ -420,7 +420,7 @@ impl RecordBatchOptions {
             row_count: None,
         }
     }
-    //Sets the row_count of RecordBatchOptions and returns self
+    /// Sets the row_count of RecordBatchOptions and returns self
     pub fn with_row_count(mut self, row_count: Option<usize>) -> Self {
         self.row_count = row_count;
         self


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2728 

# What changes are included in this PR?
Removed the current option of initializing using `Default` as the approach will work only within the crate. `Default` does not work outside the crate due to non-exhaustive option.

# Are there any user-facing changes?
Nope.
