### PR TITLE
Partially flatten arrow-buffer

### DIFF
--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -19,6 +19,11 @@
 
 pub mod alloc;
 pub mod buffer;
+pub use buffer::{Buffer, MutableBuffer};
+
 mod bytes;
-pub mod native;
-pub mod util;
+mod native;
+
+pub use native::*;
+mod util;
+pub use util::*;

--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -17,12 +17,11 @@
 
 //! Defines [Bitmap] for tracking validity bitmaps
 
-use crate::buffer::Buffer;
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
 use std::mem;
 
-use arrow_buffer::buffer::{buffer_bin_and, buffer_bin_or};
+use arrow_buffer::buffer::{Buffer, buffer_bin_and, buffer_bin_or};
 use std::ops::{BitAnd, BitOr};
 
 #[derive(Debug, Clone)]

--- a/arrow/src/bitmap.rs
+++ b/arrow/src/bitmap.rs
@@ -21,7 +21,7 @@ use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
 use std::mem;
 
-use arrow_buffer::buffer::{Buffer, buffer_bin_and, buffer_bin_or};
+use arrow_buffer::buffer::{buffer_bin_and, buffer_bin_or, Buffer};
 use std::ops::{BitAnd, BitOr};
 
 #[derive(Debug, Clone)]

--- a/arrow/src/datatypes/native.rs
+++ b/arrow/src/datatypes/native.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::DataType;
-pub use arrow_buffer::native::{ArrowNativeType, ToByteSlice};
+pub use arrow_buffer::{ArrowNativeType, ToByteSlice};
 use half::f16;
 
 /// Trait bridging the dynamic-typed nature of Arrow (via [`DataType`]) with the

--- a/arrow/src/util/mod.rs
+++ b/arrow/src/util/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub use arrow_buffer::util::{bit_chunk_iterator, bit_util};
+pub use arrow_buffer::{bit_chunk_iterator, bit_util};
 
 #[cfg(feature = "test_utils")]
 pub mod bench_util;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Originally proposed by @Jimexist, https://github.com/apache/arrow-rs/pull/2693#discussion_r966743709 I've changed my mind on this :sweat_smile: 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Writing `arrow_buffer::native::ArrowNativeType` or `arrow_buffer::util::bit_util`, etc... seems a little bit redundant.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

It flattens the module schema, but keeping the `alloc` and `buffer` modules to act as containers for their free functions, and to simplify the re-export in `arrow`

# Are there any user-facing changes?

This hasn't yet been released, so no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
