### PR TITLE
Speedup string equal/not equal to empty string, cleanup like/ilike kernels, fix escape bug

### DIFF
--- a/arrow/benches/equal.rs
+++ b/arrow/benches/equal.rs
@@ -20,6 +20,7 @@
 
 #[macro_use]
 extern crate criterion;
+use arrow::compute::eq_utf8_scalar;
 use criterion::Criterion;
 
 extern crate arrow;
@@ -31,6 +32,10 @@ fn bench_equal<A: Array + PartialEq<A>>(arr_a: &A) {
     criterion::black_box(arr_a == arr_a);
 }
 
+fn bench_equal_utf8_scalar(arr_a: &GenericStringArray<i32>, right: &str) {
+    criterion::black_box(eq_utf8_scalar(arr_a, right).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array::<Float32Type>(512, 0.0);
     c.bench_function("equal_512", |b| b.iter(|| bench_equal(&arr_a)));
@@ -40,6 +45,11 @@ fn add_benchmark(c: &mut Criterion) {
 
     let arr_a = create_string_array::<i32>(512, 0.0);
     c.bench_function("equal_string_512", |b| b.iter(|| bench_equal(&arr_a)));
+
+    let arr_a = create_string_array::<i32>(512, 0.0);
+    c.bench_function("equal_string_scalar_empty_512", |b| {
+        b.iter(|| bench_equal_utf8_scalar(&arr_a, ""))
+    });
 
     let arr_a_nulls = create_string_array::<i32>(512, 0.5);
     c.bench_function("equal_string_nulls_512", |b| {

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -4462,6 +4462,15 @@ mod tests {
         vec![true, false]
     );
 
+    test_utf8_scalar!(
+        test_utf8_scalar_like_escape_contains,
+        vec!["ba%", "ba\\x"],
+        "%a\\%",
+        like_utf8_scalar,
+        vec![true, false]
+    );
+
+
     test_utf8!(
         test_utf8_scalar_ilike_regex,
         vec!["%%%"],

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -248,7 +248,7 @@ fn like_scalar_op<'a, F: Fn(bool) -> bool, L: ArrayAccessor<Item = &'a str>>(
         // fast path, can use starts_with
         let starts_with = &right[..right.len() - 1];
 
-        compare_op_scalar(left, |item| item.starts_with(starts_with))
+        compare_op_scalar(left, |item| op(item.starts_with(starts_with)))
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use ends_with
         let ends_with = &right[1..];

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -237,57 +237,30 @@ fn like_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
     left: L,
     right: &str,
 ) -> Result<BooleanArray> {
-    let null_bit_buffer = left.data().null_buffer().cloned();
-    let bytes = bit_util::ceil(left.len(), 8);
-    let mut bool_buf = MutableBuffer::from_len_zeroed(bytes);
-    let bool_slice = bool_buf.as_slice_mut();
-
     if !right.contains(is_like_pattern) {
         // fast path, can use equals
-        for i in 0..left.len() {
-            unsafe {
-                if left.value_unchecked(i) == right {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+        return compare_op_scalar(left, |item| item == right);
     } else if right.ends_with('%')
         && !right.ends_with("\\%")
         && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use starts_with
         let starts_with = &right[..right.len() - 1];
-        for i in 0..left.len() {
-            unsafe {
-                if left.value_unchecked(i).starts_with(starts_with) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+
+        compare_op_scalar(left, |item| item.starts_with(starts_with))
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use ends_with
         let ends_with = &right[1..];
 
-        for i in 0..left.len() {
-            unsafe {
-                if left.value_unchecked(i).ends_with(ends_with) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+        compare_op_scalar(left, |item| item.ends_with(ends_with))
     } else if right.starts_with('%')
         && right.ends_with('%')
+        && !right.ends_with("\\%")
         && !right[1..right.len() - 1].contains(is_like_pattern)
     {
-        // fast path, can use contains
         let contains = &right[1..right.len() - 1];
-        for i in 0..left.len() {
-            unsafe {
-                if left.value_unchecked(i).contains(contains) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+
+        compare_op_scalar(left, |item| item.contains(contains))
     } else {
         let re_pattern = replace_like_wildcards(right)?;
         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
@@ -297,26 +270,8 @@ fn like_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
             ))
         })?;
 
-        for i in 0..left.len() {
-            let haystack = unsafe { left.value_unchecked(i) };
-            if re.is_match(haystack) {
-                bit_util::set_bit(bool_slice, i);
-            }
-        }
-    };
-
-    let data = unsafe {
-        ArrayData::new_unchecked(
-            DataType::Boolean,
-            left.len(),
-            None,
-            null_bit_buffer,
-            0,
-            vec![bool_buf.into()],
-            vec![],
-        )
-    };
-    Ok(BooleanArray::from(data))
+        compare_op_scalar(left, |item| re.is_match(item))
+    }
 }
 
 /// Perform SQL `left LIKE right` operation on [`StringArray`] /
@@ -415,57 +370,30 @@ fn nlike_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
     left: L,
     right: &str,
 ) -> Result<BooleanArray> {
-    let null_bit_buffer = left.data().null_buffer().cloned();
-    let bytes = bit_util::ceil(left.len(), 8);
-    let mut bool_buf = MutableBuffer::from_len_zeroed(bytes);
-    let bool_slice = bool_buf.as_slice_mut();
-
     if !right.contains(is_like_pattern) {
         // fast path, can use equals
-        for i in 0..left.len() {
-            unsafe {
-                if left.value_unchecked(i) != right {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+        compare_op_scalar(left, |item| item == right)
     } else if right.ends_with('%')
         && !right.ends_with("\\%")
         && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use starts_with
         let starts_with = &right[..right.len() - 1];
-        for i in 0..left.len() {
-            unsafe {
-                if !(left.value_unchecked(i).starts_with(starts_with)) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+
+        compare_op_scalar(left, |item| !item.starts_with(starts_with))
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use ends_with
         let ends_with = &right[1..];
 
-        for i in 0..left.len() {
-            unsafe {
-                if !(left.value_unchecked(i).ends_with(ends_with)) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+        compare_op_scalar(left, |item| !item.ends_with(ends_with))
     } else if right.starts_with('%')
         && right.ends_with('%')
+        && !right.ends_with("\\%")
         && !right[1..right.len() - 1].contains(is_like_pattern)
     {
-        // fast path, can use contains
         let contains = &right[1..right.len() - 1];
-        for i in 0..left.len() {
-            unsafe {
-                if !(left.value_unchecked(i).contains(contains)) {
-                    bit_util::set_bit(bool_slice, i);
-                }
-            }
-        }
+
+        compare_op_scalar(left, |item| !item.contains(contains))
     } else {
         let re_pattern = replace_like_wildcards(right)?;
         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
@@ -475,26 +403,8 @@ fn nlike_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
             ))
         })?;
 
-        for i in 0..left.len() {
-            let haystack = unsafe { left.value_unchecked(i) };
-            if !re.is_match(haystack) {
-                bit_util::set_bit(bool_slice, i);
-            }
-        }
-    };
-
-    let data = unsafe {
-        ArrayData::new_unchecked(
-            DataType::Boolean,
-            left.len(),
-            None,
-            null_bit_buffer,
-            0,
-            vec![bool_buf.into()],
-            vec![],
-        )
-    };
-    Ok(BooleanArray::from(data))
+        compare_op_scalar(left, |item| !re.is_match(item))
+    }
 }
 
 /// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
@@ -978,9 +888,9 @@ fn utf8_empty<OffsetSize: OffsetSizeTrait, const EQ: bool>(
         MutableBuffer::from_trusted_len_iter_bool(left.value_offsets().windows(2).map(
             |offset| {
                 if EQ {
-                    offset[1].to_usize().unwrap() - offset[0].to_usize().unwrap() == 0
+                    offset[1].to_usize().unwrap() == offset[0].to_usize().unwrap()
                 } else {
-                    offset[1].to_usize().unwrap() - offset[0].to_usize().unwrap() != 0
+                    offset[1].to_usize().unwrap() > offset[0].to_usize().unwrap()
                 }
             },
         ))
@@ -4364,13 +4274,22 @@ mod tests {
 
     #[test]
     fn test_utf8_eq_scalar_on_slice() {
-        let a = StringArray::from(vec![Some("hi"), None, Some("hello"), Some("world")]);
+        let a = StringArray::from(
+            vec![Some("hi"), None, Some("hello"), Some("world"), Some("")],
+        );
         let a = a.slice(1, 3);
         let a = as_string_array(&a);
         let a_eq = eq_utf8_scalar(a, "hello").unwrap();
         assert_eq!(
             a_eq,
-            BooleanArray::from(vec![None, Some(true), Some(false)])
+            BooleanArray::from(vec![None, Some(true), Some(false), Some(false)])
+        );
+
+        let a_eq2 = eq_utf8_scalar(a, "").unwrap();
+
+        assert_eq!(
+            a_eq2,
+            BooleanArray::from(vec![None, Some(false), Some(false), Some(true)])
         );
     }
 

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -280,7 +280,7 @@ fn like_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
     left: L,
     right: &str,
 ) -> Result<BooleanArray> {
-    like_scalar_op(left, right, |x|x)
+    like_scalar_op(left, right, |x| x)
 }
 
 /// Perform SQL `left LIKE right` operation on [`StringArray`] /
@@ -379,7 +379,7 @@ fn nlike_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
     left: L,
     right: &str,
 ) -> Result<BooleanArray> {
-    like_scalar_op(left, right, |x|!x)
+    like_scalar_op(left, right, |x| !x)
 }
 
 /// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
@@ -4469,7 +4469,6 @@ mod tests {
         like_utf8_scalar,
         vec![true, false]
     );
-
 
     test_utf8!(
         test_utf8_scalar_ilike_regex,

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -4252,7 +4252,7 @@ mod tests {
         let a = StringArray::from(
             vec![Some("hi"), None, Some("hello"), Some("world"), Some("")],
         );
-        let a = a.slice(1, 3);
+        let a = a.slice(1, 4);
         let a = as_string_array(&a);
         let a_eq = eq_utf8_scalar(a, "hello").unwrap();
         assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2574 #2744 #2745


# Rationale for this change
 Fixes a bug, cleans up some code and improves performance for empty string:
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
```
equal_string_scalar_empty_512
                        time:   [802.37 ns 806.33 ns 810.99 ns]
                        change: [-21.974% -20.704% -19.429%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
