### PR TITLE
update new `arrow-buffer` crate to 23.0.0

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "arrow-buffer"
-version = "22.0.0"
+version = "23.0.0"
 description = "Buffer abstractions for Apache Arrow"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -44,7 +44,7 @@ ahash = { version = "0.8", default-features = false, features = ["compile-time-r
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 
 [dependencies]
-arrow-buffer = { path = "../arrow-buffer", version = "22.0.0" }
+arrow-buffer = { path = "../arrow-buffer", version = "23.0.0" }
 
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

re #2594  and #2665 

# Rationale for this change
 
New crate was added but its version was not updated

# What changes are included in this PR?

Update version to 23.0.0 for `arrow-buffer` crate, as was done for other crates in https://github.com/apache/arrow-rs/pull/2734

# Are there any user-facing changes?

No