### PR TITLE
Fix `verify_release_candidate.sh` for new arrow subcrates

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -116,21 +116,16 @@ test_source_distribution() {
   export ARROW_TEST_DATA=$PWD/arrow-testing-data/data
   export PARQUET_TEST_DATA=$PWD/parquet-testing-data/data
 
-  # use local modules because we don't publish modules to crates.io yet
-  sed \
-    -i.bak \
-    -E \
-    -e 's/^arrow = "([^"]*)"/arrow = { version = "\1", path = "..\/arrow" }/g' \
-    -e 's/^parquet = "([^"]*)"/parquet = { version = "\1", path = "..\/parquet" }/g' \
-    */Cargo.toml
-
   (cd arrow && cargo build && cargo test)
   (cd arrow-flight && cargo build && cargo test)
   (cd parquet && cargo build && cargo test)
   (cd parquet_derive && cargo build && cargo test)
 
-  # verify that the crates can be published to crates.io
-  pushd arrow
+  # verify that the leaf crates can be published to crates.io
+  # we can't verify crates that depend on others
+  # (because the others haven't yet been published to crates.io)
+
+  pushd arrow-buffer
     cargo publish --dry-run
   popd
 


### PR DESCRIPTION
# Which issue does this PR close?

Fixes: https://github.com/apache/arrow-rs/issues/2751
re https://github.com/apache/arrow-rs/issues/2665


# Rationale for this change
https://github.com/apache/arrow-rs/pull/2693 added a new `arrow-buffer` crate on which arrow depends which is good 🎉 

⚖️  but it means we can no longer run `cargo publish --dry-run` for `arrow` as it it now depends on an as-yet-unpublushed crate (`arrow-buffer`)


# What changes are included in this PR?

1. change to run `cargo publish --dry-run` for the leaf crate `arrow-buffer` rather than `arrow`
2. Remove unecessary (and ineffective `sed` command)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
