### PR TITLE
Use hashbrown::RawTable API

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -136,6 +136,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "string_dictionary_builder"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "buffer_bit_ops"
 harness = false
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The use of HashMap without a hasher nor keys, is a little perverse. It turns out hashbrown has a RawTable API that we can use directly instead. As an added bonus this provides a very minor performance improvement

```
string_dictionary_builder/(dict_size:20, len:1000, key_len: 5)
                        time:   [18.563 µs 18.605 µs 18.647 µs]
                        change: [-4.5058% -3.6392% -2.7326%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
string_dictionary_builder/(dict_size:100, len:1000, key_len: 5)
                        time:   [21.649 µs 21.693 µs 21.738 µs]
                        change: [-2.2389% -1.8649% -1.5032%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
string_dictionary_builder/(dict_size:100, len:1000, key_len: 10)
                        time:   [21.696 µs 21.715 µs 21.734 µs]
                        change: [-2.0519% -1.8956% -1.6960%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
string_dictionary_builder/(dict_size:100, len:10000, key_len: 10)
                        time:   [176.06 µs 176.14 µs 176.22 µs]
                        change: [-0.9251% -0.6795% -0.4273%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
string_dictionary_builder/(dict_size:100, len:10000, key_len: 100)
                        time:   [463.94 µs 464.12 µs 464.30 µs]
                        change: [-0.1715% -0.0733% +0.0237%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Switches to using hashbrown::RawTable in place of HashMap and the raw entry API

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
