### PR TITLE
MINOR: Fix clippy for rust 1.64.0

### DIFF
--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -178,7 +178,7 @@ pub type UnalignedBitChunkIterator<'a> = std::iter::Chain<
 fn read_u64(input: &[u8]) -> u64 {
     let len = input.len().min(8);
     let mut buf = [0_u8; 8];
-    (&mut buf[..len]).copy_from_slice(input);
+    buf[..len].copy_from_slice(input);
     u64::from_le_bytes(buf)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Fixing a clippy error for rust 1.64.0 in CI:

```
error: this expression borrows a value the compiler would automatically borrow
   --> arrow-buffer/src/util/bit_chunk_iterator.rs:181:5
    |
181 |     (&mut buf[..len]).copy_from_slice(input);
    |     ^^^^^^^^^^^^^^^^^ help: change this to: `buf[..len]`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
