### PR TITLE
MINOR: Fix clippy for rust 1.64.0

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -1392,8 +1392,8 @@ mod tests {
             // verify
             assert_eq!(array, Int32Array::from(vec![2, 4, 6]));
 
-            Box::from_raw(out_array_ptr);
-            Box::from_raw(out_schema_ptr);
+            drop(Box::from_raw(out_array_ptr));
+            drop(Box::from_raw(out_schema_ptr));
         }
         Ok(())
     }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1071,10 +1071,10 @@ fn compare_greater_byte_array_decimals(a: &[u8], b: &[u8]) -> bool {
     if a_length != b_length {
         let not_equal = if a_length > b_length {
             let lead_length = a_length - b_length;
-            (&a[0..lead_length]).iter().any(|&x| x != extension)
+            a[0..lead_length].iter().any(|&x| x != extension)
         } else {
             let lead_length = b_length - a_length;
-            (&b[0..lead_length]).iter().any(|&x| x != extension)
+            b[0..lead_length].iter().any(|&x| x != extension)
         };
 
         if not_equal {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Fixing four clippy errors for rust 1.64.0 in CI:

```
error: unused return value of `std::boxed::Box::<T>::from_raw` that must be used
    --> arrow/src/ffi.rs:1395:13
     |
1395 |             Box::from_raw(out_array_ptr);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D unused-must-use` implied by `-D warnings`
     = note: call `drop(from_raw(ptr))` if you intend to drop the `Box`

error: unused return value of `std::boxed::Box::<T>::from_raw` that must be used
    --> arrow/src/ffi.rs:1396:13
     |
1396 |             Box::from_raw(out_schema_ptr);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: call `drop(from_raw(ptr))` if you intend to drop the `Box`
```

```
error: this expression borrows a value the compiler would automatically borrow
    --> parquet/src/column/writer/mod.rs:1074:13
     |
1074 |             (&a[0..lead_length]).iter().any(|&x| x != extension)
     |             ^^^^^^^^^^^^^^^^^^^^ help: change this to: `a[0..lead_length]`
     |
     = note: `-D clippy::needless-borrow` implied by `-D warnings`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: this expression borrows a value the compiler would automatically borrow
    --> parquet/src/column/writer/mod.rs:1077:13
     |
1077 |             (&b[0..lead_length]).iter().any(|&x| x != extension)
     |             ^^^^^^^^^^^^^^^^^^^^ help: change this to: `b[0..lead_length]`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
