### PR TITLE
Remove ArrowNativeType: FromStr

### DIFF
--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -44,14 +44,7 @@ mod private {
 ///
 /// Due to the above restrictions, this trait is sealed to prevent accidental misuse
 pub trait ArrowNativeType:
-    std::fmt::Debug
-    + Send
-    + Sync
-    + Copy
-    + PartialOrd
-    + Default
-    + private::Sealed
-    + 'static
+    std::fmt::Debug + Send + Sync + Copy + PartialOrd + Default + private::Sealed + 'static
 {
     /// Convert native type from usize.
     #[inline]

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -49,7 +49,6 @@ pub trait ArrowNativeType:
     + Sync
     + Copy
     + PartialOrd
-    + std::str::FromStr
     + Default
     + private::Sealed
     + 'static

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -117,6 +117,7 @@
 //! fn parse_to_primitive<'a, T, I>(iter: I) -> PrimitiveArray<T>
 //! where
 //!     T: ArrowPrimitiveType,
+//!     T::Native: FromStr,
 //!     I: IntoIterator<Item=&'a str>,
 //! {
 //!     PrimitiveArray::from_iter(iter.into_iter().map(|val| T::Native::from_str(val).ok()))

--- a/arrow/src/util/reader_parser.rs
+++ b/arrow/src/util/reader_parser.rs
@@ -21,9 +21,7 @@ use crate::datatypes::*;
 /// Specialized parsing implementations
 /// used by csv and json reader
 pub(crate) trait Parser: ArrowPrimitiveType {
-    fn parse(string: &str) -> Option<Self::Native> {
-        string.parse::<Self::Native>().ok()
-    }
+    fn parse(string: &str) -> Option<Self::Native>;
 
     fn parse_formatted(string: &str, _format: &str) -> Option<Self::Native> {
         Self::parse(string)
@@ -42,21 +40,23 @@ impl Parser for Float64Type {
     }
 }
 
-impl Parser for UInt64Type {}
-
-impl Parser for UInt32Type {}
-
-impl Parser for UInt16Type {}
-
-impl Parser for UInt8Type {}
-
-impl Parser for Int64Type {}
-
-impl Parser for Int32Type {}
-
-impl Parser for Int16Type {}
-
-impl Parser for Int8Type {}
+macro_rules! parser_primitive {
+    ($t:ty) => {
+        impl Parser for $t {
+            fn parse(string: &str) -> Option<Self::Native> {
+                string.parse::<Self::Native>().ok()
+            }
+        }
+    };
+}
+parser_primitive!(UInt64Type);
+parser_primitive!(UInt32Type);
+parser_primitive!(UInt16Type);
+parser_primitive!(UInt8Type);
+parser_primitive!(Int64Type);
+parser_primitive!(Int32Type);
+parser_primitive!(Int16Type);
+parser_primitive!(Int8Type);
 
 impl Parser for TimestampNanosecondType {
     fn parse(string: &str) -> Option<i64> {
@@ -85,13 +85,10 @@ impl Parser for TimestampSecondType {
     }
 }
 
-impl Parser for Time64NanosecondType {}
-
-impl Parser for Time64MicrosecondType {}
-
-impl Parser for Time32MillisecondType {}
-
-impl Parser for Time32SecondType {}
+parser_primitive!(Time64NanosecondType);
+parser_primitive!(Time64MicrosecondType);
+parser_primitive!(Time32MillisecondType);
+parser_primitive!(Time32SecondType);
 
 /// Number of days between 0001-01-01 and 1970-01-01
 const EPOCH_DAYS_FROM_CE: i32 = 719_163;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2637 
Part of #2300 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Builds on the work of https://github.com/apache/arrow-rs/pull/2595 and removes `FromStr` from `ArrowNativeType`. This avoids conflating serialization logic, with the logic for representing data in primitive arrays.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Removes `std::str::FromStr` from `ArrowNativeType`

# Are there any user-facing changes?

Yes, they will need to add an additional trait bound if they are relying on this behaviour

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
