### PR TITLE
Fix min/max computation for sliced arrays (#2779)

### DIFF
--- a/arrow/src/compute/kernels/aggregate.rs
+++ b/arrow/src/compute/kernels/aggregate.rs
@@ -124,12 +124,8 @@ where
             .map(|i| unsafe { array.value_unchecked(i) })
             .reduce(|acc, item| if cmp(&acc, &item) { item } else { acc })
     } else {
-        let null_buffer = array.data_ref().null_buffer();
-        let iter = BitIndexIterator::new(
-            null_buffer.as_deref().unwrap(),
-            array.offset(),
-            array.len(),
-        );
+        let null_buffer = array.data_ref().null_buffer().unwrap();
+        let iter = BitIndexIterator::new(null_buffer, array.offset(), array.len());
         unsafe {
             let idx = iter.reduce(|acc_idx, idx| {
                 let acc = array.value_unchecked(acc_idx);
@@ -678,11 +674,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::types::Float64Type;
     use super::*;
     use crate::array::*;
     use crate::compute::add;
     use crate::datatypes::{Float32Type, Int32Type, Int8Type};
+    use arrow_array::types::Float64Type;
 
     #[test]
     fn test_primitive_array_sum() {
@@ -1130,20 +1126,94 @@ mod tests {
     }
 
     #[test]
-    fn test_min_max_sliced() {
-        let expected_min = Some(4.0);
+    fn test_min_max_sliced_primitive() {
+        let expected = Some(4.0);
         let input: Float64Array = vec![None, Some(4.0)].into_iter().collect();
         let actual = min(&input);
+        assert_eq!(actual, expected);
+        let actual = max(&input);
+        assert_eq!(actual, expected);
 
-        assert_eq!(actual, expected_min);
-
-        let sliced_input: Float64Array = vec![None, None, None, None, None, Some(4.0)].into_iter().collect();
+        let sliced_input: Float64Array = vec![None, None, None, None, None, Some(4.0)]
+            .into_iter()
+            .collect();
         let sliced_input = sliced_input.slice(4, 2);
         let sliced_input = as_primitive_array::<Float64Type>(&sliced_input);
 
         assert_eq!(sliced_input, &input);
 
-        let actual = min(&sliced_input);
-        assert_eq!(actual, expected_min);
+        let actual = min(sliced_input);
+        assert_eq!(actual, expected);
+        let actual = max(sliced_input);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_min_max_sliced_boolean() {
+        let expected = Some(true);
+        let input: BooleanArray = vec![None, Some(true)].into_iter().collect();
+        let actual = min_boolean(&input);
+        assert_eq!(actual, expected);
+        let actual = max_boolean(&input);
+        assert_eq!(actual, expected);
+
+        let sliced_input: BooleanArray = vec![None, None, None, None, None, Some(true)]
+            .into_iter()
+            .collect();
+        let sliced_input = sliced_input.slice(4, 2);
+        let sliced_input = as_boolean_array(&sliced_input);
+
+        assert_eq!(sliced_input, &input);
+
+        let actual = min_boolean(sliced_input);
+        assert_eq!(actual, expected);
+        let actual = max_boolean(sliced_input);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_min_max_sliced_string() {
+        let expected = Some("foo");
+        let input: StringArray = vec![None, Some("foo")].into_iter().collect();
+        let actual = min_string(&input);
+        assert_eq!(actual, expected);
+        let actual = max_string(&input);
+        assert_eq!(actual, expected);
+
+        let sliced_input: StringArray = vec![None, None, None, None, None, Some("foo")]
+            .into_iter()
+            .collect();
+        let sliced_input = sliced_input.slice(4, 2);
+        let sliced_input = as_string_array(&sliced_input);
+
+        assert_eq!(sliced_input, &input);
+
+        let actual = min_string(sliced_input);
+        assert_eq!(actual, expected);
+        let actual = max_string(sliced_input);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_min_max_sliced_binary() {
+        let expected: Option<&[u8]> = Some(&[5]);
+        let input: BinaryArray = vec![None, Some(&[5])].into_iter().collect();
+        let actual = min_binary(&input);
+        assert_eq!(actual, expected);
+        let actual = max_binary(&input);
+        assert_eq!(actual, expected);
+
+        let sliced_input: BinaryArray = vec![None, None, None, None, None, Some(&[5])]
+            .into_iter()
+            .collect();
+        let sliced_input = sliced_input.slice(4, 2);
+        let sliced_input = as_generic_binary_array::<i32>(&sliced_input);
+
+        assert_eq!(sliced_input, &input);
+
+        let actual = min_binary(sliced_input);
+        assert_eq!(actual, expected);
+        let actual = max_binary(sliced_input);
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2779

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The previous logic was incorrect

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

https://github.com/apache/arrow-rs/pull/2675 introduced a bug when computing the min or max for sliced arrays, FYI @viirya 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
