### PR TITLE
Disable test harness for string_dictionary_builder benchmark

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -228,6 +228,10 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "string_dictionary_builder"
+harness = false
+
+[[bench]]
 name = "substring_kernels"
 harness = false
 required-features = ["test_utils"]


### PR DESCRIPTION
This prevents passing arguments like `--save-baseline`