### PR TITLE
Remove some ArrowNativeType from conversions

### DIFF
--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -63,24 +63,6 @@ pub trait ArrowNativeType:
     fn to_isize(&self) -> Option<isize> {
         None
     }
-
-    /// Convert native type from i32.
-    #[inline]
-    fn from_i32(_: i32) -> Option<Self> {
-        None
-    }
-
-    /// Convert native type from i64.
-    #[inline]
-    fn from_i64(_: i64) -> Option<Self> {
-        None
-    }
-
-    /// Convert native type from i128.
-    #[inline]
-    fn from_i128(_: i128) -> Option<Self> {
-        None
-    }
 }
 
 impl private::Sealed for i8 {}
@@ -135,12 +117,6 @@ impl ArrowNativeType for i32 {
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
     }
-
-    /// Convert native type from i32.
-    #[inline]
-    fn from_i32(val: i32) -> Option<Self> {
-        Some(val)
-    }
 }
 
 impl private::Sealed for i64 {}
@@ -159,12 +135,6 @@ impl ArrowNativeType for i64 {
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
     }
-
-    /// Convert native type from i64.
-    #[inline]
-    fn from_i64(val: i64) -> Option<Self> {
-        Some(val)
-    }
 }
 
 impl private::Sealed for i128 {}
@@ -182,12 +152,6 @@ impl ArrowNativeType for i128 {
     #[inline]
     fn to_isize(&self) -> Option<isize> {
         num::ToPrimitive::to_isize(self)
-    }
-
-    /// Convert native type from i128.
-    #[inline]
-    fn from_i128(val: i128) -> Option<Self> {
-        Some(val)
     }
 }
 

--- a/arrow/src/util/reader_parser.rs
+++ b/arrow/src/util/reader_parser.rs
@@ -97,20 +97,20 @@ impl Parser for Date32Type {
     fn parse(string: &str) -> Option<i32> {
         use chrono::Datelike;
         let date = string.parse::<chrono::NaiveDate>().ok()?;
-        Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+        Some(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
     }
 
     fn parse_formatted(string: &str, format: &str) -> Option<i32> {
         use chrono::Datelike;
         let date = chrono::NaiveDate::parse_from_str(string, format).ok()?;
-        Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+        Some(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
     }
 }
 
 impl Parser for Date64Type {
     fn parse(string: &str) -> Option<i64> {
         let date_time = string.parse::<chrono::NaiveDateTime>().ok()?;
-        Self::Native::from_i64(date_time.timestamp_millis())
+        Some(date_time.timestamp_millis())
     }
 
     fn parse_formatted(string: &str, format: &str) -> Option<i64> {
@@ -132,10 +132,10 @@ impl Parser for Date64Type {
         });
         if has_zone {
             let date_time = chrono::DateTime::parse_from_str(string, format).ok()?;
-            Self::Native::from_i64(date_time.timestamp_millis())
+            Some(date_time.timestamp_millis())
         } else {
             let date_time = chrono::NaiveDateTime::parse_from_str(string, format).ok()?;
-            Self::Native::from_i64(date_time.timestamp_millis())
+            Some(date_time.timestamp_millis())
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

These don't seem to serve a purpose, they can't be used in a context where `Self` isn't known statically, as they return `Self`, and only return `Some` when `Self` is the corresponding type. In all cases it can simply be replaced with `Some`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Removes the from conversion functions, these could theoretically be deprecated, but I'm not sure of a use-case that would warrant keeping them around

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
