### PR TITLE
Cleanup ArrowNativeType (#1918)

### DIFF
--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -308,20 +308,13 @@ impl<K: ArrowPrimitiveType> DictionaryArray<K> {
 
     /// Return an iterator over the keys (indexes into the dictionary)
     pub fn keys_iter(&self) -> impl Iterator<Item = Option<usize>> + '_ {
-        self.keys
-            .iter()
-            .map(|key| key.map(|k| k.to_usize().expect("Dictionary index not usize")))
+        self.keys.iter().map(|key| key.map(|k| k.as_usize()))
     }
 
     /// Return the value of `keys` (the dictionary key) at index `i`,
     /// cast to `usize`, `None` if the value at `i` is `NULL`.
     pub fn key(&self, i: usize) -> Option<usize> {
-        self.keys.is_valid(i).then(|| {
-            self.keys
-                .value(i)
-                .to_usize()
-                .expect("Dictionary index not usize")
-        })
+        self.keys.is_valid(i).then(|| self.keys.value(i).as_usize())
     }
 
     /// Downcast this dictionary to a [`TypedDictionaryArray`]
@@ -586,7 +579,7 @@ where
 
     unsafe fn value_unchecked(&self, index: usize) -> Self::Item {
         let val = self.dictionary.keys.value_unchecked(index);
-        let value_idx = val.to_usize().unwrap();
+        let value_idx = val.as_usize();
 
         // As dictionary keys are only verified for non-null indexes
         // we must check the value is within bounds

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -80,18 +80,16 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     /// # Safety
     /// Caller must ensure that the index is within the array bounds
     pub unsafe fn value_unchecked(&self, i: usize) -> ArrayRef {
-        let end = *self.value_offsets().get_unchecked(i + 1);
-        let start = *self.value_offsets().get_unchecked(i);
-        self.values
-            .slice(start.to_usize().unwrap(), (end - start).to_usize().unwrap())
+        let end = self.value_offsets().get_unchecked(i + 1).as_usize();
+        let start = self.value_offsets().get_unchecked(i).as_usize();
+        self.values.slice(start, end - start)
     }
 
     /// Returns ith value of this list array.
     pub fn value(&self, i: usize) -> ArrayRef {
-        let end = self.value_offsets()[i + 1];
-        let start = self.value_offsets()[i];
-        self.values
-            .slice(start.to_usize().unwrap(), (end - start).to_usize().unwrap())
+        let end = self.value_offsets()[i + 1].as_usize();
+        let start = self.value_offsets()[i].as_usize();
+        self.values.slice(start, end - start)
     }
 
     /// Returns the offset values in the offsets buffer

--- a/arrow-array/src/builder/string_dictionary_builder.rs
+++ b/arrow-array/src/builder/string_dictionary_builder.rs
@@ -293,9 +293,9 @@ fn get_bytes<'a, K: ArrowNativeType>(values: &'a StringBuilder, key: &K) -> &'a 
     let offsets = values.offsets_slice();
     let values = values.values_slice();
 
-    let idx = key.to_usize().unwrap();
-    let end_offset = offsets[idx + 1].to_usize().unwrap();
-    let start_offset = offsets[idx].to_usize().unwrap();
+    let idx = key.as_usize();
+    let end_offset = offsets[idx + 1].as_usize();
+    let start_offset = offsets[idx].as_usize();
 
     &values[start_offset..end_offset]
 }

--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -38,7 +38,6 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.0", default-features = false }
 
 [dev-dependencies]

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -46,229 +46,128 @@ mod private {
 pub trait ArrowNativeType:
     std::fmt::Debug + Send + Sync + Copy + PartialOrd + Default + private::Sealed + 'static
 {
-    /// Convert native type from usize.
-    #[inline]
-    fn from_usize(_: usize) -> Option<Self> {
-        None
-    }
+    /// Convert native integer type from usize
+    ///
+    /// Returns `None` if [`Self`] is not an integer or conversion would result
+    /// in truncation/overflow
+    fn from_usize(_: usize) -> Option<Self>;
+
+    /// Convert to usize according to the [`as`] operator
+    ///
+    /// [`as`]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast
+    fn as_usize(self) -> usize;
 
     /// Convert native type to usize.
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        None
-    }
+    ///
+    /// Returns `None` if [`Self`] is not an integer or conversion would result
+    /// in truncation/overflow
+    fn to_usize(self) -> Option<usize>;
 
     /// Convert native type to isize.
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        None
-    }
+    ///
+    /// Returns `None` if [`Self`] is not an integer or conversion would result
+    /// in truncation/overflow
+    fn to_isize(self) -> Option<isize>;
 
     /// Convert native type from i32.
-    #[inline]
+    ///
+    /// Returns `None` if [`Self`] is not `i32`
+    #[deprecated(note = "please use `Option::Some` instead")]
     fn from_i32(_: i32) -> Option<Self> {
         None
     }
 
     /// Convert native type from i64.
-    #[inline]
+    ///
+    /// Returns `None` if [`Self`] is not `i64`
+    #[deprecated(note = "please use `Option::Some` instead")]
     fn from_i64(_: i64) -> Option<Self> {
         None
     }
 
     /// Convert native type from i128.
-    #[inline]
+    ///
+    /// Returns `None` if [`Self`] is not `i128`
+    #[deprecated(note = "please use `Option::Some` instead")]
     fn from_i128(_: i128) -> Option<Self> {
         None
     }
 }
 
-impl private::Sealed for i8 {}
-impl ArrowNativeType for i8 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
+macro_rules! native_integer {
+    ($t: ty $(, $from:ident)*) => {
+        impl private::Sealed for $t {}
+        impl ArrowNativeType for $t {
+            #[inline]
+            fn from_usize(v: usize) -> Option<Self> {
+                v.try_into().ok()
+            }
 
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
+            #[inline]
+            fn to_usize(self) -> Option<usize> {
+                self.try_into().ok()
+            }
 
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
+            #[inline]
+            fn to_isize(self) -> Option<isize> {
+                self.try_into().ok()
+            }
+
+            #[inline]
+            fn as_usize(self) -> usize {
+                self as _
+            }
+
+            $(
+                #[inline]
+                fn $from(v: $t) -> Option<Self> {
+                    Some(v)
+                }
+            )*
+        }
+    };
 }
 
-impl private::Sealed for i16 {}
-impl ArrowNativeType for i16 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
+native_integer!(i8);
+native_integer!(i16);
+native_integer!(i32, from_i32);
+native_integer!(i64, from_i64);
+native_integer!(i128, from_i128);
+native_integer!(u8);
+native_integer!(u16);
+native_integer!(u32);
+native_integer!(u64);
 
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
+macro_rules! native_float {
+    ($t:ty, $s:ident, $as_usize: expr) => {
+        impl private::Sealed for $t {}
+        impl ArrowNativeType for $t {
+            #[inline]
+            fn from_usize(_: usize) -> Option<Self> {
+                None
+            }
 
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
+            #[inline]
+            fn to_usize(self) -> Option<usize> {
+                None
+            }
+
+            #[inline]
+            fn to_isize(self) -> Option<isize> {
+                None
+            }
+
+            #[inline]
+            fn as_usize($s) -> usize {
+                $as_usize
+            }
+        }
+    };
 }
 
-impl private::Sealed for i32 {}
-impl ArrowNativeType for i32 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-
-    /// Convert native type from i32.
-    #[inline]
-    fn from_i32(val: i32) -> Option<Self> {
-        Some(val)
-    }
-}
-
-impl private::Sealed for i64 {}
-impl ArrowNativeType for i64 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-
-    /// Convert native type from i64.
-    #[inline]
-    fn from_i64(val: i64) -> Option<Self> {
-        Some(val)
-    }
-}
-
-impl private::Sealed for i128 {}
-impl ArrowNativeType for i128 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-
-    /// Convert native type from i128.
-    #[inline]
-    fn from_i128(val: i128) -> Option<Self> {
-        Some(val)
-    }
-}
-
-impl private::Sealed for u8 {}
-impl ArrowNativeType for u8 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl private::Sealed for u16 {}
-impl ArrowNativeType for u16 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl private::Sealed for u32 {}
-impl ArrowNativeType for u32 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl private::Sealed for u64 {}
-impl ArrowNativeType for u64 {
-    #[inline]
-    fn from_usize(v: usize) -> Option<Self> {
-        num::FromPrimitive::from_usize(v)
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        num::ToPrimitive::to_usize(self)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        num::ToPrimitive::to_isize(self)
-    }
-}
-
-impl ArrowNativeType for f16 {}
-impl private::Sealed for f16 {}
-impl ArrowNativeType for f32 {}
-impl private::Sealed for f32 {}
-impl ArrowNativeType for f64 {}
-impl private::Sealed for f64 {}
+native_float!(f16, self, self.to_f32() as _);
+native_float!(f32, self, self as _);
+native_float!(f64, self, self as _);
 
 /// Allows conversion from supported Arrow types to a byte slice.
 pub trait ToByteSlice {

--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -17,7 +17,6 @@
 
 //! Utils for working with bits
 
-use num::Integer;
 #[cfg(feature = "simd")]
 use packed_simd::u8x64;
 
@@ -102,7 +101,7 @@ pub unsafe fn unset_bit_raw(data: *mut u8, i: usize) {
 pub fn ceil(value: usize, divisor: usize) -> usize {
     // Rewrite as `value.div_ceil(&divisor)` after
     // https://github.com/rust-lang/rust/issues/88581 is merged.
-    Integer::div_ceil(&value, &divisor)
+    value / divisor + (0 != value % divisor) as usize
 }
 
 /// Performs SIMD bitwise binary operations.

--- a/arrow-data/src/equal/variable_size.rs
+++ b/arrow-data/src/equal/variable_size.rs
@@ -31,8 +31,8 @@ fn offset_value_equal<T: ArrowNativeType + Integer>(
     rhs_pos: usize,
     len: usize,
 ) -> bool {
-    let lhs_start = lhs_offsets[lhs_pos].to_usize().unwrap();
-    let rhs_start = rhs_offsets[rhs_pos].to_usize().unwrap();
+    let lhs_start = lhs_offsets[lhs_pos].as_usize();
+    let rhs_start = rhs_offsets[rhs_pos].as_usize();
     let lhs_len = lhs_offsets[lhs_pos + len] - lhs_offsets[lhs_pos];
     let rhs_len = rhs_offsets[rhs_pos + len] - rhs_offsets[rhs_pos];
 

--- a/arrow-data/src/transform/list.rs
+++ b/arrow-data/src/transform/list.rs
@@ -46,8 +46,8 @@ pub(super) fn build_extend<T: ArrowNativeType + Integer>(array: &ArrayData) -> E
 
                 mutable.child_data[0].extend(
                     index,
-                    offsets[start].to_usize().unwrap(),
-                    offsets[start + len].to_usize().unwrap(),
+                    offsets[start].as_usize(),
+                    offsets[start + len].as_usize(),
                 )
             },
         )
@@ -75,8 +75,8 @@ pub(super) fn build_extend<T: ArrowNativeType + Integer>(array: &ArrayData) -> E
                         // append value
                         child.extend(
                             index,
-                            offsets[i].to_usize().unwrap(),
-                            offsets[i + 1].to_usize().unwrap(),
+                            offsets[i].as_usize(),
+                            offsets[i + 1].as_usize(),
                         );
                     }
                     // append offset

--- a/arrow/src/array/ord.rs
+++ b/arrow/src/array/ord.rs
@@ -97,8 +97,8 @@ where
         PrimitiveArray::from(right.values().data().clone());
 
     Box::new(move |i: usize, j: usize| {
-        let key_left = left_keys.value(i).to_usize().unwrap();
-        let key_right = right_keys.value(j).to_usize().unwrap();
+        let key_left = left_keys.value(i).as_usize();
+        let key_right = right_keys.value(j).as_usize();
         let left = left_values.value(key_left);
         let right = right_values.value(key_right);
         left.cmp(&right)
@@ -118,8 +118,8 @@ where
     let right_values = StringArray::from(right.values().data().clone());
 
     Box::new(move |i: usize, j: usize| {
-        let key_left = left_keys.value(i).to_usize().unwrap();
-        let key_right = right_keys.value(j).to_usize().unwrap();
+        let key_left = left_keys.value(i).as_usize();
+        let key_right = right_keys.value(j).as_usize();
         let left = left_values.value(key_left);
         let right = right_values.value(key_right);
         left.cmp(right)

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -863,9 +863,9 @@ fn utf8_empty<OffsetSize: OffsetSizeTrait, const EQ: bool>(
         MutableBuffer::from_trusted_len_iter_bool(left.value_offsets().windows(2).map(
             |offset| {
                 if EQ {
-                    offset[1].to_usize().unwrap() == offset[0].to_usize().unwrap()
+                    offset[1].as_usize() == offset[0].as_usize()
                 } else {
-                    offset[1].to_usize().unwrap() > offset[0].to_usize().unwrap()
+                    offset[1].as_usize() > offset[0].as_usize()
                 }
             },
         ))
@@ -1793,7 +1793,7 @@ where
         .map(|key| {
             key.map(|key| unsafe {
                 // safety lengths were verified above
-                let key = key.to_usize().expect("Dictionary index not usize");
+                let key = key.as_usize();
                 dict_comparison.value_unchecked(key)
             })
         })

--- a/arrow/src/compute/kernels/concat_elements.rs
+++ b/arrow/src/compute/kernels/concat_elements.rs
@@ -57,20 +57,17 @@ pub fn concat_elements_utf8<Offset: OffsetSizeTrait>(
 
     let mut output_values = BufferBuilder::<u8>::new(
         left_values.len() + right_values.len()
-            - left_offsets[0].to_usize().unwrap()
-            - right_offsets[0].to_usize().unwrap(),
+            - left_offsets[0].as_usize()
+            - right_offsets[0].as_usize(),
     );
 
     let mut output_offsets = BufferBuilder::<Offset>::new(left_offsets.len());
     output_offsets.append(Offset::zero());
     for (left_idx, right_idx) in left_offsets.windows(2).zip(right_offsets.windows(2)) {
+        output_values
+            .append_slice(&left_values[left_idx[0].as_usize()..left_idx[1].as_usize()]);
         output_values.append_slice(
-            &left_values
-                [left_idx[0].to_usize().unwrap()..left_idx[1].to_usize().unwrap()],
-        );
-        output_values.append_slice(
-            &right_values
-                [right_idx[0].to_usize().unwrap()..right_idx[1].to_usize().unwrap()],
+            &right_values[right_idx[0].as_usize()..right_idx[1].as_usize()],
         );
         output_offsets.append(Offset::from_usize(output_values.len()).unwrap());
     }
@@ -137,7 +134,7 @@ pub fn concat_elements_utf8_many<Offset: OffsetSizeTrait>(
         data_values
             .iter()
             .zip(offsets.iter_mut())
-            .map(|(data, offset)| data.len() - offset.peek().unwrap().to_usize().unwrap())
+            .map(|(data, offset)| data.len() - offset.peek().unwrap().as_usize())
             .sum(),
     );
 
@@ -148,8 +145,8 @@ pub fn concat_elements_utf8_many<Offset: OffsetSizeTrait>(
             .iter()
             .zip(offsets.iter_mut())
             .for_each(|(values, offset)| {
-                let index_start = offset.next().unwrap().to_usize().unwrap();
-                let index_end = offset.peek().unwrap().to_usize().unwrap();
+                let index_start = offset.next().unwrap().as_usize();
+                let index_end = offset.peek().unwrap().as_usize();
                 output_values.append_slice(&values[index_start..index_end]);
             });
         output_offsets.append(Offset::from_usize(output_values.len()).unwrap());

--- a/arrow/src/compute/kernels/filter.rs
+++ b/arrow/src/compute/kernels/filter.rs
@@ -568,7 +568,7 @@ where
     /// Returns the byte offset at `idx`
     #[inline]
     fn get_value_offset(&self, idx: usize) -> usize {
-        self.src_offsets[idx].to_usize().expect("illegal offset")
+        self.src_offsets[idx].as_usize()
     }
 
     /// Returns the start and end of the value at index `idx` along with its length

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -565,7 +565,7 @@ where
         .into_iter()
         .map(|index| {
             let key: K::Native = keys.value(index as usize);
-            let value_order = value_indices_map.get(&key.to_usize().unwrap()).unwrap();
+            let value_order = value_indices_map.get(&key.as_usize()).unwrap();
             (index, *value_order)
         })
         .collect::<Vec<(u32, u32)>>();
@@ -690,7 +690,7 @@ fn sort_string_dictionary<T: ArrowDictionaryKeyType>(
         .into_iter()
         .map(|index| {
             let key: T::Native = keys.value(index as usize);
-            let value_order = value_indices_map.get(&key.to_usize().unwrap()).unwrap();
+            let value_order = value_indices_map.get(&key.as_usize()).unwrap();
             (index, *value_order)
         })
         .collect::<Vec<(u32, u32)>>();
@@ -1277,7 +1277,7 @@ mod tests {
             (0..sorted.len())
                 .map(|i| {
                     if sorted.is_valid(i) {
-                        Some(sorted_dict.value(sorted_keys.value(i).to_usize().unwrap()))
+                        Some(sorted_dict.value(sorted_keys.value(i).as_usize()))
                     } else {
                         None
                     }
@@ -1329,7 +1329,7 @@ mod tests {
         let sorted_values: PrimitiveArray<T> = From::<Vec<Option<T::Native>>>::from(
             (0..sorted.len())
                 .map(|i| {
-                    let key = sorted_keys.value(i).to_usize().unwrap();
+                    let key = sorted_keys.value(i).as_usize();
                     if sorted.is_valid(i) && sorted_dict.is_valid(key) {
                         Some(sorted_dict.value(key))
                     } else {

--- a/arrow/src/compute/kernels/substring.rs
+++ b/arrow/src/compute/kernels/substring.rs
@@ -280,14 +280,13 @@ fn binary_substring<OffsetSize: OffsetSizeTrait>(
     });
 
     // concatenate substrings into a buffer
-    let mut new_values =
-        MutableBuffer::new(new_offsets.last().unwrap().to_usize().unwrap());
+    let mut new_values = MutableBuffer::new(new_offsets.last().unwrap().as_usize());
 
     new_starts_ends
         .iter()
         .map(|(start, end)| {
-            let start = start.to_usize().unwrap();
-            let end = end.to_usize().unwrap();
+            let start = start.as_usize();
+            let end = end.as_usize();
             &data[start..end]
         })
         .for_each(|slice| new_values.extend_from_slice(slice));
@@ -375,7 +374,7 @@ fn utf8_substring<OffsetSize: OffsetSizeTrait>(
         // Safety: a StringArray must contain valid UTF8 data
         let data_str = unsafe { std::str::from_utf8_unchecked(data) };
         |offset: OffsetSize| {
-            let offset_usize = offset.to_usize().unwrap();
+            let offset_usize = offset.as_usize();
             if data_str.is_char_boundary(offset_usize) {
                 Ok(offset)
             } else {
@@ -411,14 +410,13 @@ fn utf8_substring<OffsetSize: OffsetSizeTrait>(
     })?;
 
     // concatenate substrings into a buffer
-    let mut new_values =
-        MutableBuffer::new(new_offsets.last().unwrap().to_usize().unwrap());
+    let mut new_values = MutableBuffer::new(new_offsets.last().unwrap().as_usize());
 
     new_starts_ends
         .iter()
         .map(|(start, end)| {
-            let start = start.to_usize().unwrap();
-            let end = end.to_usize().unwrap();
+            let start = start.as_usize();
+            let end = end.as_usize();
             &data[start..end]
         })
         .for_each(|slice| new_values.extend_from_slice(slice));

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -190,7 +190,7 @@ where
                 .iter()
                 .map(|index| {
                     if let Some(index) = index {
-                        struct_.is_valid(ArrowNativeType::to_usize(&index).unwrap())
+                        struct_.is_valid(index.to_usize().unwrap())
                     } else {
                         false
                     }

--- a/arrow/src/util/reader_parser.rs
+++ b/arrow/src/util/reader_parser.rs
@@ -97,20 +97,20 @@ impl Parser for Date32Type {
     fn parse(string: &str) -> Option<i32> {
         use chrono::Datelike;
         let date = string.parse::<chrono::NaiveDate>().ok()?;
-        Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+        Some(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
     }
 
     fn parse_formatted(string: &str, format: &str) -> Option<i32> {
         use chrono::Datelike;
         let date = chrono::NaiveDate::parse_from_str(string, format).ok()?;
-        Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+        Some(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
     }
 }
 
 impl Parser for Date64Type {
     fn parse(string: &str) -> Option<i64> {
         let date_time = string.parse::<chrono::NaiveDateTime>().ok()?;
-        Self::Native::from_i64(date_time.timestamp_millis())
+        Some(date_time.timestamp_millis())
     }
 
     fn parse_formatted(string: &str, format: &str) -> Option<i64> {
@@ -132,10 +132,10 @@ impl Parser for Date64Type {
         });
         if has_zone {
             let date_time = chrono::DateTime::parse_from_str(string, format).ok()?;
-            Self::Native::from_i64(date_time.timestamp_millis())
+            Some(date_time.timestamp_millis())
         } else {
             let date_time = chrono::NaiveDateTime::parse_from_str(string, format).ok()?;
-            Self::Native::from_i64(date_time.timestamp_millis())
+            Some(date_time.timestamp_millis())
         }
     }
 }

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -276,8 +276,8 @@ impl LevelInfoBuilder {
                 // TODO: Faster bitmask iteration (#1757)
                 for (idx, w) in offsets.windows(2).enumerate() {
                     let is_valid = nulls.is_set(idx + null_offset);
-                    let start_idx = w[0].to_usize().unwrap();
-                    let end_idx = w[1].to_usize().unwrap();
+                    let start_idx = w[0].as_usize();
+                    let end_idx = w[1].as_usize();
                     if !is_valid {
                         write_null_slice(child)
                     } else if start_idx == end_idx {
@@ -289,8 +289,8 @@ impl LevelInfoBuilder {
             }
             None => {
                 for w in offsets.windows(2) {
-                    let start_idx = w[0].to_usize().unwrap();
-                    let end_idx = w[1].to_usize().unwrap();
+                    let start_idx = w[0].as_usize();
+                    let end_idx = w[1].as_usize();
                     if start_idx == end_idx {
                         write_empty_slice(child)
                     } else {

--- a/parquet/src/arrow/buffer/offset_buffer.rs
+++ b/parquet/src/arrow/buffer/offset_buffer.rs
@@ -95,15 +95,15 @@ impl<I: OffsetSizeTrait + ScalarValue> OffsetBuffer<I> {
         dict_values: &[u8],
     ) -> Result<()> {
         for key in keys {
-            let index = key.to_usize().unwrap();
+            let index = key.as_usize();
             if index + 1 >= dict_offsets.len() {
                 return Err(general_err!(
                     "dictionary key beyond bounds of dictionary: 0..{}",
                     dict_offsets.len().saturating_sub(1)
                 ));
             }
-            let start_offset = dict_offsets[index].to_usize().unwrap();
-            let end_offset = dict_offsets[index + 1].to_usize().unwrap();
+            let start_offset = dict_offsets[index].as_usize();
+            let end_offset = dict_offsets[index + 1].as_usize();
 
             // Dictionary values are verified when decoding dictionary page
             self.try_push(&dict_values[start_offset..end_offset], false)?;
@@ -167,7 +167,7 @@ impl<I: OffsetSizeTrait + ScalarValue> BufferQueue for OffsetBuffer<I> {
 
         Self {
             offsets: std::mem::replace(&mut self.offsets, new_offsets),
-            values: self.values.take(end_offset.to_usize().unwrap()),
+            values: self.values.take(end_offset.as_usize()),
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1918

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The ArrowNativeType has been a pet peeve of mine for a while, this cleans it up a bit:

* Deprecates some methods that don't seem to serve a purpose
* Remove the use of num as it is unnecessary
* Adds an unchecked conversion to usize

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

`ArrowNativeType::to_usize`  and `ArrowNativeType::to_isize` take values by value, instead of reference

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
