### PR TITLE
Support for overriding instance metadata endpoint

### DIFF
--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -39,8 +39,6 @@ type StdError = Box<dyn std::error::Error + Send + Sync>;
 static EMPTY_SHA256_HASH: &str =
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
-/// Default metadata endpoint
-static METADATA_ENDPOINT: &str = "http://169.254.169.254";
 #[derive(Debug)]
 pub struct AwsCredential {
     pub key_id: String,
@@ -323,6 +321,7 @@ pub struct InstanceCredentialProvider {
     pub client: Client,
     pub retry_config: RetryConfig,
     pub imdsv1_fallback: bool,
+    pub metadata_endpoint: String,
 }
 
 impl InstanceCredentialProvider {
@@ -332,7 +331,7 @@ impl InstanceCredentialProvider {
                 instance_creds(
                     &self.client,
                     &self.retry_config,
-                    METADATA_ENDPOINT,
+                    &self.metadata_endpoint,
                     self.imdsv1_fallback,
                 )
                 .map_err(|source| crate::Error::Generic {

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -39,6 +39,8 @@ type StdError = Box<dyn std::error::Error + Send + Sync>;
 static EMPTY_SHA256_HASH: &str =
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
+/// Default metadata endpoint
+static METADATA_ENDPOINT: &str = "http://169.254.169.254";
 #[derive(Debug)]
 pub struct AwsCredential {
     pub key_id: String,
@@ -327,7 +329,6 @@ impl InstanceCredentialProvider {
     async fn get_credential(&self) -> Result<Arc<AwsCredential>> {
         self.cache
             .get_or_insert_with(|| {
-                const METADATA_ENDPOINT: &str = "http://169.254.169.254";
                 instance_creds(
                     &self.client,
                     &self.retry_config,

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -374,7 +374,7 @@ impl AmazonS3Builder {
     /// * AWS_DEFAULT_REGION -> region
     /// * AWS_ENDPOINT -> endpoint
     /// * AWS_SESSION_TOKEN -> token
-    /// * AWS_CONTAINER_CREDENTIALS_RELATIVE_URI -> metadata_endpoint
+    /// * AWS_CONTAINER_CREDENTIALS_RELATIVE_URI -> <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>
     /// # Example
     /// ```
     /// use object_store::aws::AmazonS3Builder;
@@ -495,8 +495,8 @@ impl AmazonS3Builder {
     /// Set the [instance metadata endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html),
     /// used primarily within AWS EC2.
     ///
-    /// This defaults to the IPv4 endpoint: 169.254.169.254. One can alternatively use the IPv6
-    /// endpoint fd00:ec2::254.
+    /// This defaults to the IPv4 endpoint: http://169.254.169.254. One can alternatively use the IPv6
+    /// endpoint http://fd00:ec2::254.
     pub fn with_metadata_endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.metadata_endpoint = Some(endpoint.into());
         self


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2802.

# Rationale for this change
 
Support getting credentials in AWS ECS.

# What changes are included in this PR?

As suggested, allows user to set instance metadata endpoint. Extract from the documented environment variable.

# Are there any user-facing changes?

Yes, new methods on the AWS builder. I have added docs here and verified the rendered output looks good.