### PR TITLE
Add string_dictionary benches for row format (#2677)

### DIFF
--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -22,7 +22,10 @@ extern crate core;
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Int64Type, UInt64Type};
 use arrow::row::{RowConverter, SortField};
-use arrow::util::bench_util::{create_primitive_array, create_string_array_with_len};
+use arrow::util::bench_util::{
+    create_primitive_array, create_string_array_with_len, create_string_dict_array,
+};
+use arrow_array::types::Int32Type;
 use criterion::{black_box, Criterion};
 use std::sync::Arc;
 
@@ -85,6 +88,46 @@ fn row_bench(c: &mut Criterion) {
         });
     });
 
+    let cols =
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
+
+    c.bench_function("row_batch 4096 string_dictionary(10, 0)", |b| {
+        b.iter(|| {
+            let mut converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]);
+            black_box(converter.convert_columns(&cols))
+        });
+    });
+
+    let cols =
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
+
+    c.bench_function("row_batch 4096 string_dictionary(30, 0)", |b| {
+        b.iter(|| {
+            let mut converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]);
+            black_box(converter.convert_columns(&cols))
+        });
+    });
+
+    let cols =
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
+
+    c.bench_function("row_batch 4096 string_dictionary(100, 0)", |b| {
+        b.iter(|| {
+            let mut converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]);
+            black_box(converter.convert_columns(&cols))
+        });
+    });
+
+    let cols =
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0.5, 100)) as ArrayRef];
+
+    c.bench_function("row_batch 4096 string_dictionary(100, 0.5)", |b| {
+        b.iter(|| {
+            let mut converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]);
+            black_box(converter.convert_columns(&cols))
+        });
+    });
+
     let cols = [
         Arc::new(create_string_array_with_len::<i32>(4096, 0.5, 20)) as ArrayRef,
         Arc::new(create_string_array_with_len::<i32>(4096, 0., 30)) as ArrayRef,
@@ -101,6 +144,30 @@ fn row_bench(c: &mut Criterion) {
 
     c.bench_function(
         "row_batch 4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0)",
+        |b| {
+            b.iter(|| {
+                let mut converter = RowConverter::new(fields.to_vec());
+                black_box(converter.convert_columns(&cols))
+            });
+        },
+    );
+
+    let cols = [
+        Arc::new(create_string_dict_array::<Int32Type>(4096, 0.5, 20)) as ArrayRef,
+        Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 30)) as ArrayRef,
+        Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef,
+        Arc::new(create_primitive_array::<Int64Type>(4096, 0.)) as ArrayRef,
+    ];
+
+    let fields = [
+        SortField::new(DataType::Utf8),
+        SortField::new(DataType::Utf8),
+        SortField::new(DataType::Utf8),
+        SortField::new(DataType::Int64),
+    ];
+
+    c.bench_function(
+        "row_batch 4096 string_dictionary(20, 0.5), string_dictionary(30, 0), string_dictionary(100, 0), i64(0)",
         |b| {
             b.iter(|| {
                 let mut converter = RowConverter::new(fields.to_vec());

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -89,7 +89,7 @@ fn row_bench(c: &mut Criterion) {
     });
 
     let cols =
-        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 10)) as ArrayRef];
 
     c.bench_function("row_batch 4096 string_dictionary(10, 0)", |b| {
         b.iter(|| {
@@ -99,7 +99,7 @@ fn row_bench(c: &mut Criterion) {
     });
 
     let cols =
-        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
+        vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 30)) as ArrayRef];
 
     c.bench_function("row_batch 4096 string_dictionary(30, 0)", |b| {
         b.iter(|| {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2677

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds benchmarks of the dictionary interning logic for the row format

# Are there any user-facing changes?

No, this just adds some more benchmarks

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
