### PR TITLE
Derive ArrowPrimitiveType for Decimal128Type and Decimal256Type (#2637)

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -22,7 +22,7 @@ use crate::temporal_conversions::{as_date, as_datetime, as_duration, as_time};
 use crate::trusted_len::trusted_len_unzip;
 use crate::types::*;
 use crate::{print_long_array, Array, ArrayAccessor};
-use arrow_buffer::{bit_util, ArrowNativeType, Buffer, MutableBuffer};
+use arrow_buffer::{bit_util, i256, ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::bit_iterator::try_for_each_valid_idx;
 use arrow_data::ArrayData;
 use arrow_schema::DataType;
@@ -609,6 +609,8 @@ def_from_for_primitive!(UInt64Type, u64);
 def_from_for_primitive!(Float16Type, f16);
 def_from_for_primitive!(Float32Type, f32);
 def_from_for_primitive!(Float64Type, f64);
+def_from_for_primitive!(Decimal128Type, i128);
+def_from_for_primitive!(Decimal256Type, i256);
 
 impl<T: ArrowPrimitiveType> From<Option<<T as ArrowPrimitiveType>::Native>>
     for NativeAdapter<T>
@@ -733,6 +735,8 @@ def_numeric_from_vec!(UInt32Type);
 def_numeric_from_vec!(UInt64Type);
 def_numeric_from_vec!(Float32Type);
 def_numeric_from_vec!(Float64Type);
+def_numeric_from_vec!(Decimal128Type);
+def_numeric_from_vec!(Decimal256Type);
 
 def_numeric_from_vec!(Date32Type);
 def_numeric_from_vec!(Date64Type);
@@ -1341,5 +1345,43 @@ mod tests {
         let array: Int8Array = [10_i8, 11, 12].into_iter().collect();
 
         array.value(4);
+    }
+
+    #[test]
+    fn test_decimal128() {
+        let values: Vec<_> = vec![0, 1, -1, i128::MIN, i128::MAX];
+        let array: PrimitiveArray<Decimal128Type> =
+            PrimitiveArray::from_iter(values.iter().copied());
+        assert_eq!(array.values(), &values);
+
+        let array: PrimitiveArray<Decimal128Type> =
+            PrimitiveArray::from_iter_values(values.iter().copied());
+        assert_eq!(array.values(), &values);
+
+        let array = PrimitiveArray::<Decimal128Type>::from(values.clone());
+        assert_eq!(array.values(), &values);
+
+        let array = PrimitiveArray::<Decimal128Type>::from(array.data().clone());
+        assert_eq!(array.values(), &values);
+    }
+
+    #[test]
+    fn test_decimal256() {
+        let values: Vec<_> =
+            vec![i256::ZERO, i256::ONE, i256::MINUS_ONE, i256::MIN, i256::MAX];
+
+        let array: PrimitiveArray<Decimal256Type> =
+            PrimitiveArray::from_iter(values.iter().copied());
+        assert_eq!(array.values(), &values);
+
+        let array: PrimitiveArray<Decimal256Type> =
+            PrimitiveArray::from_iter_values(values.iter().copied());
+        assert_eq!(array.values(), &values);
+
+        let array = PrimitiveArray::<Decimal256Type>::from(values.clone());
+        assert_eq!(array.values(), &values);
+
+        let array = PrimitiveArray::<Decimal256Type>::from(array.data().clone());
+        assert_eq!(array.values(), &values);
     }
 }

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -19,6 +19,7 @@
 
 use crate::array::ArrowPrimitiveType;
 use crate::delta::shift_months;
+use arrow_buffer::i256;
 use arrow_data::decimal::{
     DECIMAL128_MAX_PRECISION, DECIMAL128_MAX_SCALE, DECIMAL256_MAX_PRECISION,
     DECIMAL256_MAX_SCALE, DECIMAL_DEFAULT_SCALE,
@@ -515,6 +516,12 @@ impl DecimalType for Decimal128Type {
         DataType::Decimal128(DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
 }
 
+impl ArrowPrimitiveType for Decimal128Type {
+    type Native = i128;
+
+    const DATA_TYPE: DataType = <Self as DecimalType>::DEFAULT_TYPE;
+}
+
 /// The decimal type for a Decimal256Array
 #[derive(Debug)]
 pub struct Decimal256Type {}
@@ -528,6 +535,12 @@ impl DecimalType for Decimal256Type {
     const TYPE_CONSTRUCTOR: fn(u8, u8) -> DataType = DataType::Decimal256;
     const DEFAULT_TYPE: DataType =
         DataType::Decimal256(DECIMAL256_MAX_PRECISION, DECIMAL_DEFAULT_SCALE);
+}
+
+impl ArrowPrimitiveType for Decimal256Type {
+    type Native = i256;
+
+    const DATA_TYPE: DataType = <Self as DecimalType>::DEFAULT_TYPE;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2637

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This allows creating PrimitiveArrays with decimal types, subsequent PRs will flesh out support for this, before switching over the definitions of Decimal128Array and Decimal256Array

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds the ability to declare PrimitiveArray containing decimal data

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
