### PR TITLE
Validate ArrayData type when converting to Array (#2834)

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -290,6 +290,8 @@ impl<OffsetSize: OffsetSizeTrait> From<ArrayData> for GenericBinaryArray<OffsetS
         let values = data.buffers()[1].as_ptr();
         Self {
             data,
+            // SAFETY:
+            // ArrayData must be valid, and validated data type above
             value_offsets: unsafe { RawPtrBox::new(offsets) },
             value_data: unsafe { RawPtrBox::new(values) },
         }
@@ -824,6 +826,13 @@ mod tests {
             .unwrap();
         let binary_array = BinaryArray::from(array_data);
         binary_array.value(4);
+    }
+
+    #[test]
+    #[should_panic(expected = "[Large]BinaryArray expects Datatype::[Large]Binary")]
+    fn test_binary_array_validation() {
+        let array = BinaryArray::from_iter_values(&[&[1, 2]]);
+        let _ = LargeBinaryArray::from(array.into_data());
     }
 
     #[test]

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -202,6 +202,13 @@ impl From<Vec<Option<bool>>> for BooleanArray {
 impl From<ArrayData> for BooleanArray {
     fn from(data: ArrayData) -> Self {
         assert_eq!(
+            data.data_type(),
+            &DataType::Boolean,
+            "BooleanArray expected ArrayData with type {} got {}",
+            DataType::Boolean,
+            data.data_type()
+        );
+        assert_eq!(
             data.buffers().len(),
             1,
             "BooleanArray data should contain a single buffer only (values buffer)"
@@ -209,6 +216,8 @@ impl From<ArrayData> for BooleanArray {
         let ptr = data.buffers()[0].as_ptr();
         Self {
             data,
+            // SAFETY:
+            // ArrayData must be valid, and validated data type above
             raw_values: unsafe { RawPtrBox::new(ptr) },
         }
     }
@@ -413,5 +422,13 @@ mod tests {
                 .build_unchecked()
         };
         drop(BooleanArray::from(data));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "BooleanArray expected ArrayData with type Boolean got Int32"
+    )]
+    fn test_from_array_data_validation() {
+        let _ = BooleanArray::from(ArrayData::new_empty(&DataType::Int32));
     }
 }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1355,7 +1355,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-    expected = "PrimitiveArray expected ArrayData with type Int64 got Int32"
+        expected = "PrimitiveArray expected ArrayData with type Int64 got Int32"
     )]
     fn test_from_array_data_validation() {
         let foo = PrimitiveArray::<Int32Type>::from_iter([1, 2, 3]);

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1244,7 +1244,7 @@ pub fn cast_with_options(
             let array = cast_with_options(array, &Int32, cast_options)?;
             let time_array = as_primitive_array::<Int32Type>(array.as_ref());
             // note: (numeric_cast + SIMD multiply) is faster than (cast & multiply)
-            let c: Int64Array = numeric_cast(&time_array);
+            let c: Int64Array = numeric_cast(time_array);
             let from_size = time_unit_multiple(from_unit);
             let to_size = time_unit_multiple(to_unit);
             // from is only smaller than to if 64milli/64second don't exist
@@ -1291,13 +1291,13 @@ pub fn cast_with_options(
             let divisor = from_size / to_size;
             match to_unit {
                 TimeUnit::Second => {
-                    let values = unary::<_, _, Time32SecondType>(&time_array, |x| {
+                    let values = unary::<_, _, Time32SecondType>(time_array, |x| {
                         (x as i64 / divisor) as i32
                     });
                     Ok(Arc::new(values) as ArrayRef)
                 }
                 TimeUnit::Millisecond => {
-                    let values = unary::<_, _, Time32MillisecondType>(&time_array, |x| {
+                    let values = unary::<_, _, Time32MillisecondType>(time_array, |x| {
                         (x as i64 / divisor) as i32
                     });
                     Ok(Arc::new(values) as ArrayRef)
@@ -1329,9 +1329,9 @@ pub fn cast_with_options(
             // we either divide or multiply, depending on size of each unit
             // units are never the same when the types are the same
             let converted = if from_size >= to_size {
-                divide_scalar(&time_array, from_size / to_size)?
+                divide_scalar(time_array, from_size / to_size)?
             } else {
-                multiply_scalar(&time_array, to_size / from_size)?
+                multiply_scalar(time_array, to_size / from_size)?
             };
             let array_ref = Arc::new(converted) as ArrayRef;
             use TimeUnit::*;

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -1322,7 +1322,7 @@ pub fn cast_with_options(
             let converted = if from_size >= to_size {
                 divide_scalar(time_array, from_size / to_size)?
             } else {
-                multiply_scalar(&time_array, to_size / from_size)?
+                multiply_scalar(time_array, to_size / from_size)?
             };
             Ok(make_timestamp_array(
                 &converted,

--- a/arrow/src/compute/kernels/take.rs
+++ b/arrow/src/compute/kernels/take.rs
@@ -1398,7 +1398,7 @@ mod tests {
     fn test_take_bool_nullable_index() {
         // indices where the masked invalid elements would be out of bounds
         let index_data = ArrayData::try_new(
-            DataType::Int32,
+            DataType::UInt32,
             6,
             Some(Buffer::from_iter(vec![
                 false, true, false, true, false, true,
@@ -1421,7 +1421,7 @@ mod tests {
     fn test_take_bool_nullable_index_nonnull_values() {
         // indices where the masked invalid elements would be out of bounds
         let index_data = ArrayData::try_new(
-            DataType::Int32,
+            DataType::UInt32,
             6,
             Some(Buffer::from_iter(vec![
                 false, true, false, true, false, true,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2834

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Arrays can assume that the provided ArrayData is valid, however, what that means depends on the data type of the ArrayData. We weren't always validating that the ArrayData had the expected data type, which could lead to unsoundness.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
