### PR TITLE
Cleanup cast kernel

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -769,11 +769,16 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
 
     /// Construct a timestamp array with new timezone
     pub fn with_timezone(&self, timezone: String) -> Self {
+        self.with_timezone_opt(Some(timezone))
+    }
+
+    /// Construct a timestamp array with an optional timezone
+    pub fn with_timezone_opt(&self, timezone: Option<String>) -> Self {
         let array_data = unsafe {
             self.data
                 .clone()
                 .into_builder()
-                .data_type(DataType::Timestamp(T::get_time_unit(), Some(timezone)))
+                .data_type(DataType::Timestamp(T::get_time_unit(), timezone))
                 .build_unchecked()
         };
         PrimitiveArray::from(array_data)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The cast kernel predates a lot of the work to introduce safe APIs for interacting with arrays, inspired by the work of arrow2. This updates the cast kernel to make use of these APIs :tada:

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Uses PrimitiveArray::reinterpret_cast added by #2785 to reduce use of unsafe

Cleans up some other callsites

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
