### PR TITLE
parquet: Add `snap` option to README

### DIFF
--- a/parquet/README.md
+++ b/parquet/README.md
@@ -47,6 +47,7 @@ The `parquet` crate provides the following features which may be enabled in your
 - `flate2` (default) - support for parquet using `gzip` compression
 - `lz4` (default) - support for parquet using `lz4` compression
 - `zstd` (default) - support for parquet using `zstd` compression
+- `snap` (default) - support for parquet using `snappy` compression
 - `cli` - parquet [CLI tools](https://github.com/apache/arrow-rs/tree/master/parquet/src/bin)
 - `experimental` - Experimental APIs which may change, even between minor releases
 


### PR DESCRIPTION
# Rationale for this change
 
I tried using parquet with `default-features = false` (and with some options explicitly enabled), but it didn't support snappy compression. Turns out there is an undocumented option for it.

It seems like an omission, but if it's undocumented for a reason, just close this PR.