### PR TITLE
Fix page size on dictionary fallback

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -551,7 +551,10 @@ where
 
     match &mut encoder.dict_encoder {
         Some(dict_encoder) => dict_encoder.encode(values, indices),
-        None => encoder.fallback.encode(values, indices),
+        None => {
+            encoder.num_values += indices.len();
+            encoder.fallback.encode(values, indices)
+        }
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -609,7 +609,6 @@ mod tests {
     use super::*;
 
     use bytes::Bytes;
-    use rand::{thread_rng, Rng};
     use std::fs::File;
     use std::sync::Arc;
 
@@ -1112,16 +1111,13 @@ mod tests {
 
     #[test]
     fn arrow_writer_page_size() {
-        let mut rng = thread_rng();
         let schema =
             Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
 
-        let mut builder = StringBuilder::with_capacity(1_000, 2 * 1_000);
+        let mut builder = StringBuilder::with_capacity(10_000, 2 * 10_000);
 
-        for _ in 0..10_000 {
-            let value = (0..200)
-                .map(|_| rng.gen_range(b'a'..=b'z') as char)
-                .collect::<String>();
+        for i in 0..10_000 {
+            let value = i.to_string().repeat(100);
 
             builder.append_value(value);
         }
@@ -1153,8 +1149,8 @@ mod tests {
 
         assert_eq!(
             offset_index.len(),
-            5,
-            "Expected more than two pages but got {:#?}",
+            8,
+            "Expected 9 pages but got {:#?}",
             offset_index
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2853 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

On fallback `ByteArrayEncoder` wasn't tracking the number of values written so when the dictionary page hits the limit and we fallback, all remaining data was written in a single data page. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make sure `ByteArrayEncoder` tracks the number of encoded values after it falls back to the fallback encoder

# Are there any user-facing changes?

This will change the way data pages are laid out in some cases. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

No
