### PR TITLE
Update test_parse_arg_compression_format_fail

### DIFF
--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -516,7 +516,7 @@ mod tests {
             Ok(_) => panic!("unexpected success"),
             Err(e) => assert_eq!(
                 format!("{}", e),
-                "error: Invalid value \"zip\" for '--parquet-compression <PARQUET_COMPRESSION>': Unknown compression ZIP : possible values UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD \n\nFor more information try --help\n"),
+                "error: Invalid value 'zip' for '--parquet-compression <PARQUET_COMPRESSION>': Unknown compression ZIP : possible values UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD \n\nFor more information try --help\n"),
         }
     }
 


### PR DESCRIPTION
The latest clap changes some quoting of error messages - https://github.com/clap-rs/clap/pull/4381