### PR TITLE
Add downcast_integer and downcast_primitive

### DIFF
--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -32,8 +32,8 @@ macro_rules! repeat_pat {
     }
 }
 
-/// Given one or more expressions evaluating to integer [`DataType`] invokes the provided macro
-/// `m` with the corresponding [`ArrowPrimitiveType`], followed by any additional arguments
+/// Given one or more expressions evaluating to an integer [`DataType`] invokes the provided macro
+/// `m` with the corresponding integer [`ArrowPrimitiveType`], followed by any additional arguments
 ///
 /// ```
 /// # use arrow_array::{downcast_primitive, ArrowPrimitiveType, downcast_integer};

--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -59,6 +59,8 @@ macro_rules! repeat_pat {
 /// assert_eq!(dictionary_key_size(&DataType::Dictionary(Box::new(DataType::Int64), Box::new(DataType::Utf8))), 8);
 /// assert_eq!(dictionary_key_size(&DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8))), 2);
 /// ```
+///
+/// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_integer {
     ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($($p:pat),+ => $fallback:expr $(,)*)*) => {
@@ -116,6 +118,8 @@ macro_rules! downcast_integer {
 /// assert_eq!(primitive_size(&DataType::Int64), 8);
 /// assert_eq!(primitive_size(&DataType::Float16), 2);
 /// ```
+///
+/// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_primitive {
     ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($($p:pat),+ => $fallback:expr $(,)*)*) => {

--- a/arrow/src/row/dictionary.rs
+++ b/arrow/src/row/dictionary.rs
@@ -25,7 +25,7 @@ use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::{ArrowNativeType, MutableBuffer, ToByteSlice};
 use arrow_data::{ArrayData, ArrayDataBuilder};
-use arrow_schema::{ArrowError, DataType, IntervalUnit, TimeUnit};
+use arrow_schema::{ArrowError, DataType};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
@@ -87,6 +87,12 @@ pub fn encode_dictionary<K: ArrowDictionaryKeyType>(
             }
         }
     }
+}
+
+macro_rules! decode_primitive_helper {
+    ($t:ty, $values: ident) => {
+        decode_primitive::<$t>(&$values)
+    };
 }
 
 /// Decodes a string array from `rows` with the provided `options`
@@ -163,65 +169,10 @@ pub unsafe fn decode_dictionary<K: ArrowDictionaryKeyType>(
         null_builder.append(true);
     }
 
-    let child = match &value_type {
+    let child = downcast_primitive! {
+        &value_type => (decode_primitive_helper, values),
         DataType::Null => NullArray::new(values.len()).into_data(),
         DataType::Boolean => decode_bool(&values),
-        DataType::Int8 => decode_primitive::<Int8Type>(&values),
-        DataType::Int16 => decode_primitive::<Int16Type>(&values),
-        DataType::Int32 => decode_primitive::<Int32Type>(&values),
-        DataType::Int64 => decode_primitive::<Int64Type>(&values),
-        DataType::UInt8 => decode_primitive::<UInt8Type>(&values),
-        DataType::UInt16 => decode_primitive::<UInt16Type>(&values),
-        DataType::UInt32 => decode_primitive::<UInt32Type>(&values),
-        DataType::UInt64 => decode_primitive::<UInt64Type>(&values),
-        DataType::Float16 => decode_primitive::<Float16Type>(&values),
-        DataType::Float32 => decode_primitive::<Float32Type>(&values),
-        DataType::Float64 => decode_primitive::<Float64Type>(&values),
-        DataType::Timestamp(TimeUnit::Second, _) => {
-            decode_primitive::<TimestampSecondType>(&values)
-        }
-        DataType::Timestamp(TimeUnit::Millisecond, _) => {
-            decode_primitive::<TimestampMillisecondType>(&values)
-        }
-        DataType::Timestamp(TimeUnit::Microsecond, _) => {
-            decode_primitive::<TimestampMicrosecondType>(&values)
-        }
-        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-            decode_primitive::<TimestampNanosecondType>(&values)
-        }
-        DataType::Date32 => decode_primitive::<Date32Type>(&values),
-        DataType::Date64 => decode_primitive::<Date64Type>(&values),
-        DataType::Time32(t) => match t {
-            TimeUnit::Second => decode_primitive::<Time32SecondType>(&values),
-            TimeUnit::Millisecond => decode_primitive::<Time32MillisecondType>(&values),
-            _ => unreachable!(),
-        },
-        DataType::Time64(t) => match t {
-            TimeUnit::Microsecond => decode_primitive::<Time64MicrosecondType>(&values),
-            TimeUnit::Nanosecond => decode_primitive::<Time64NanosecondType>(&values),
-            _ => unreachable!(),
-        },
-        DataType::Duration(TimeUnit::Second) => {
-            decode_primitive::<DurationSecondType>(&values)
-        }
-        DataType::Duration(TimeUnit::Millisecond) => {
-            decode_primitive::<DurationMillisecondType>(&values)
-        }
-        DataType::Duration(TimeUnit::Microsecond) => {
-            decode_primitive::<DurationMicrosecondType>(&values)
-        }
-        DataType::Duration(TimeUnit::Nanosecond) => {
-            decode_primitive::<DurationNanosecondType>(&values)
-        }
-        DataType::Interval(IntervalUnit::DayTime) => {
-            decode_primitive::<IntervalDayTimeType>(&values)
-        }
-        DataType::Interval(IntervalUnit::MonthDayNano) => {
-            decode_primitive::<IntervalMonthDayNanoType>(&values)
-        }
-        DataType::Interval(IntervalUnit::YearMonth) => {
-            decode_primitive::<IntervalYearMonthType>(&values)
-        }
         DataType::Decimal128(p, s) => {
             decode_decimal::<16, Decimal128Type>(&values, *p, *s)
         }

--- a/arrow/src/row/mod.rs
+++ b/arrow/src/row/mod.rs
@@ -569,6 +569,12 @@ fn encode_column(
     }
 }
 
+macro_rules! decode_primitive_helper {
+    ($t:ty, $rows: ident, $options:ident) => {
+        Arc::new(decode_primitive::<$t>($rows, $options))
+    };
+}
+
 /// Decodes a the provided `field` from `rows`
 ///
 /// # Safety
@@ -580,73 +586,10 @@ unsafe fn decode_column(
     interner: Option<&OrderPreservingInterner>,
 ) -> Result<ArrayRef> {
     let options = field.options;
-    let array: ArrayRef = match &field.data_type {
+    let array: ArrayRef = downcast_primitive! {
+        &field.data_type => (decode_primitive_helper, rows, options),
         DataType::Null => Arc::new(NullArray::new(rows.len())),
         DataType::Boolean => Arc::new(decode_bool(rows, options)),
-        DataType::Int8 => Arc::new(decode_primitive::<Int8Type>(rows, options)),
-        DataType::Int16 => Arc::new(decode_primitive::<Int16Type>(rows, options)),
-        DataType::Int32 => Arc::new(decode_primitive::<Int32Type>(rows, options)),
-        DataType::Int64 => Arc::new(decode_primitive::<Int64Type>(rows, options)),
-        DataType::UInt8 => Arc::new(decode_primitive::<UInt8Type>(rows, options)),
-        DataType::UInt16 => Arc::new(decode_primitive::<UInt16Type>(rows, options)),
-        DataType::UInt32 => Arc::new(decode_primitive::<UInt32Type>(rows, options)),
-        DataType::UInt64 => Arc::new(decode_primitive::<UInt64Type>(rows, options)),
-        DataType::Float16 => Arc::new(decode_primitive::<Float16Type>(rows, options)),
-        DataType::Float32 => Arc::new(decode_primitive::<Float32Type>(rows, options)),
-        DataType::Float64 => Arc::new(decode_primitive::<Float64Type>(rows, options)),
-        DataType::Timestamp(TimeUnit::Second, _) => {
-            Arc::new(decode_primitive::<TimestampSecondType>(rows, options))
-        }
-        DataType::Timestamp(TimeUnit::Millisecond, _) => {
-            Arc::new(decode_primitive::<TimestampMillisecondType>(rows, options))
-        }
-        DataType::Timestamp(TimeUnit::Microsecond, _) => {
-            Arc::new(decode_primitive::<TimestampMicrosecondType>(rows, options))
-        }
-        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-            Arc::new(decode_primitive::<TimestampNanosecondType>(rows, options))
-        }
-        DataType::Date32 => Arc::new(decode_primitive::<Date32Type>(rows, options)),
-        DataType::Date64 => Arc::new(decode_primitive::<Date64Type>(rows, options)),
-        DataType::Time32(t) => match t {
-            TimeUnit::Second => {
-                Arc::new(decode_primitive::<Time32SecondType>(rows, options))
-            }
-            TimeUnit::Millisecond => {
-                Arc::new(decode_primitive::<Time32MillisecondType>(rows, options))
-            }
-            _ => unreachable!(),
-        },
-        DataType::Time64(t) => match t {
-            TimeUnit::Microsecond => {
-                Arc::new(decode_primitive::<Time64MicrosecondType>(rows, options))
-            }
-            TimeUnit::Nanosecond => {
-                Arc::new(decode_primitive::<Time64NanosecondType>(rows, options))
-            }
-            _ => unreachable!(),
-        },
-        DataType::Duration(TimeUnit::Second) => {
-            Arc::new(decode_primitive::<DurationSecondType>(rows, options))
-        }
-        DataType::Duration(TimeUnit::Millisecond) => {
-            Arc::new(decode_primitive::<DurationMillisecondType>(rows, options))
-        }
-        DataType::Duration(TimeUnit::Microsecond) => {
-            Arc::new(decode_primitive::<DurationMicrosecondType>(rows, options))
-        }
-        DataType::Duration(TimeUnit::Nanosecond) => {
-            Arc::new(decode_primitive::<DurationNanosecondType>(rows, options))
-        }
-        DataType::Interval(IntervalUnit::DayTime) => {
-            Arc::new(decode_primitive::<IntervalDayTimeType>(rows, options))
-        }
-        DataType::Interval(IntervalUnit::MonthDayNano) => {
-            Arc::new(decode_primitive::<IntervalMonthDayNanoType>(rows, options))
-        }
-        DataType::Interval(IntervalUnit::YearMonth) => {
-            Arc::new(decode_primitive::<IntervalYearMonthType>(rows, options))
-        }
         DataType::Binary => Arc::new(decode_binary::<i32>(rows, options)),
         DataType::LargeBinary => Arc::new(decode_binary::<i64>(rows, options)),
         DataType::Utf8 => Arc::new(decode_string::<i32>(rows, options)),
@@ -713,13 +656,7 @@ unsafe fn decode_column(
                 )));
             }
         },
-        DataType::FixedSizeBinary(_)
-        | DataType::List(_)
-        | DataType::FixedSizeList(_, _)
-        | DataType::LargeList(_)
-        | DataType::Struct(_)
-        | DataType::Union(_, _, _)
-        | DataType::Map(_, _) => {
+        _ => {
             return Err(ArrowError::NotYetImplemented(format!(
                 "converting {} row is not supported",
                 field.data_type


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds two new macros, downcast_integer and downcast_primitive to provide conversion from DataType to ArrowPrimitiveType. This is useful for situations where there isn't an `Array` that can be fed into `downcast_primitive_array` or similar.

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
