### PR TITLE
Don't validate decimal precision in ArrayData (#2637)

### DIFF
--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -20,12 +20,12 @@ use arrow::array::{
     Int32Array, Int32Builder, Int64Array, StringArray, StructBuilder, UInt64Array,
     UInt8Builder,
 };
+use arrow_array::Decimal128Array;
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_data::ArrayData;
 use arrow_schema::{DataType, Field, UnionMode};
 use std::ptr::NonNull;
 use std::sync::Arc;
-use arrow_array::Decimal128Array;
 
 #[test]
 #[should_panic(
@@ -1058,7 +1058,9 @@ fn test_decimal_full_validation() {
     array_data.validate_full().unwrap();
 
     let array = Decimal128Array::from(array_data);
-    let error = array.validate_decimal_precision(array.precision()).unwrap_err();
+    let error = array
+        .validate_decimal_precision(array.precision())
+        .unwrap_err();
 
     assert_eq!(
         "Invalid argument error: 123456 is too large to store in a Decimal128 of precision 5. Max is 99999",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2637

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

As of #2857 we no longer validate precision, we should not do this as part of full ArrayData validation for consistency

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Disables precision validation as part of ArrayData::validate_values

# Are there any user-facing changes?

Sort of, data that would previously fail to validate may now pass. However, we were so inconsistent about applying validation in the first place #2387 I don't imagine anyone could have relied on this.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
