### PR TITLE
Increase default IPC alignment to 64 (#2883)

### DIFF
--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -46,7 +46,7 @@ use ipc::CONTINUATION_MARKER;
 #[derive(Debug, Clone)]
 pub struct IpcWriteOptions {
     /// Write padding after memory buffers to this multiple of bytes.
-    /// Generally 8 or 64, defaults to 8
+    /// Generally 8 or 64, defaults to 64
     alignment: usize,
     /// The legacy format is for releases before 0.15.0, and uses metadata V4
     write_legacy_ipc_format: bool,
@@ -132,7 +132,7 @@ impl IpcWriteOptions {
 impl Default for IpcWriteOptions {
     fn default() -> Self {
         Self {
-            alignment: 8,
+            alignment: 64,
             write_legacy_ipc_format: false,
             metadata_version: ipc::MetadataVersion::V5,
             batch_compression_type: None,

--- a/arrow/src/ipc/writer.rs
+++ b/arrow/src/ipc/writer.rs
@@ -788,7 +788,8 @@ impl<W: Write> StreamWriter<W> {
     ///
     /// ```
     /// # use arrow::datatypes::Schema;
-    /// # use arrow::ipc::writer::StreamWriter;
+    /// # use arrow::ipc::writer::{StreamWriter, IpcWriteOptions};
+    /// # use arrow::ipc::MetadataVersion;
     /// # use arrow::error::ArrowError;
     /// # fn main() -> Result<(), ArrowError> {
     /// // The result we expect from an empty schema
@@ -807,7 +808,8 @@ impl<W: Write> StreamWriter<W> {
     ///
     /// let schema = Schema::new(vec![]);
     /// let buffer: Vec<u8> = Vec::new();
-    /// let stream_writer = StreamWriter::try_new(buffer, &schema)?;
+    /// let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5)?;
+    /// let stream_writer = StreamWriter::try_new_with_options(buffer, &schema, options)?;
     ///
     /// assert_eq!(stream_writer.into_inner()?, expected);
     /// # Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #2883.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Arm requires 16-byte alignment for i128, to avoid needing to copy we should write files with sufficient padding.

This is also consistent with the recommendations in the [arrow specification](https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding)

>  If possible, we suggest that you prefer using 64-byte alignment and padding.



# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No, the padding in IPC files should be transparent to users

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
