### PR TITLE
Add experimental AWS_PROFILE support (#2178)

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -50,6 +50,8 @@ jobs:
         run: cargo clippy -p object_store -- -D warnings
       - name: Run clippy with aws feature
         run: cargo clippy -p object_store --features aws -- -D warnings
+      - name: Run clippy with aws_profile feature
+        run: cargo clippy -p object_store --features aws_profile -- -D warnings
       - name: Run clippy with gcp feature
         run: cargo clippy -p object_store --features gcp -- -D warnings
       - name: Run clippy with azure feature

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -52,11 +52,18 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 ring = { version = "0.16", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 
+# AWS Profile support
+aws-types = { version = "0.49", optional = true }
+aws-config = { version = "0.49", optional = true }
+
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]
+
+# Experimental support for AWS_PROFILE
+aws_profile = ["aws", "aws-config", "aws-types"]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -198,7 +198,7 @@ pub struct S3Config {
     pub endpoint: String,
     pub bucket: String,
     pub bucket_endpoint: String,
-    pub credentials: CredentialProvider,
+    pub credentials: Box<dyn CredentialProvider>,
     pub retry_config: RetryConfig,
     pub allow_http: bool,
 }

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -514,7 +514,9 @@ async fn web_identity(
 mod profile {
     use super::*;
     use aws_config::profile::ProfileFileCredentialsProvider;
+    use aws_config::provider_config::ProviderConfig;
     use aws_types::credentials::ProvideCredentials;
+    use aws_types::region::Region;
     use std::time::SystemTime;
 
     #[derive(Debug)]
@@ -524,10 +526,13 @@ mod profile {
     }
 
     impl ProfileProvider {
-        pub fn new(name: impl Into<String>) -> Self {
+        pub fn new(name: String, region: String) -> Self {
+            let config = ProviderConfig::default().with_region(Some(Region::new(region)));
+
             Self {
                 cache: Default::default(),
                 credentials: ProfileFileCredentialsProvider::builder()
+                    .configure(&config)
                     .profile_name(name)
                     .build(),
             }

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -22,6 +22,7 @@ use crate::util::hmac_sha256;
 use crate::{Result, RetryConfig};
 use bytes::Buf;
 use chrono::{DateTime, Utc};
+use futures::future::BoxFuture;
 use futures::TryFutureExt;
 use percent_encoding::utf8_percent_encode;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -289,27 +290,20 @@ fn canonicalize_headers(header_map: &HeaderMap) -> (String, String) {
 }
 
 /// Provides credentials for use when signing requests
-#[derive(Debug)]
-pub enum CredentialProvider {
-    Static(StaticCredentialProvider),
-    Instance(InstanceCredentialProvider),
-    WebIdentity(WebIdentityProvider),
-}
-
-impl CredentialProvider {
-    pub async fn get_credential(&self) -> Result<Arc<AwsCredential>> {
-        match self {
-            Self::Static(s) => Ok(Arc::clone(&s.credential)),
-            Self::Instance(c) => c.get_credential().await,
-            Self::WebIdentity(c) => c.get_credential().await,
-        }
-    }
+pub trait CredentialProvider: std::fmt::Debug + Send + Sync {
+    fn get_credential(&self) -> BoxFuture<'_, Result<Arc<AwsCredential>>>;
 }
 
 /// A static set of credentials
 #[derive(Debug)]
 pub struct StaticCredentialProvider {
     pub credential: Arc<AwsCredential>,
+}
+
+impl CredentialProvider for StaticCredentialProvider {
+    fn get_credential(&self) -> BoxFuture<'_, Result<Arc<AwsCredential>>> {
+        Box::pin(futures::future::ready(Ok(Arc::clone(&self.credential))))
+    }
 }
 
 /// Credentials sourced from the instance metadata service
@@ -324,22 +318,20 @@ pub struct InstanceCredentialProvider {
     pub metadata_endpoint: String,
 }
 
-impl InstanceCredentialProvider {
-    async fn get_credential(&self) -> Result<Arc<AwsCredential>> {
-        self.cache
-            .get_or_insert_with(|| {
-                instance_creds(
-                    &self.client,
-                    &self.retry_config,
-                    &self.metadata_endpoint,
-                    self.imdsv1_fallback,
-                )
-                .map_err(|source| crate::Error::Generic {
-                    store: "S3",
-                    source,
-                })
+impl CredentialProvider for InstanceCredentialProvider {
+    fn get_credential(&self) -> BoxFuture<'_, Result<Arc<AwsCredential>>> {
+        Box::pin(self.cache.get_or_insert_with(|| {
+            instance_creds(
+                &self.client,
+                &self.retry_config,
+                &self.metadata_endpoint,
+                self.imdsv1_fallback,
+            )
+            .map_err(|source| crate::Error::Generic {
+                store: "S3",
+                source,
             })
-            .await
+        }))
     }
 }
 
@@ -357,24 +349,22 @@ pub struct WebIdentityProvider {
     pub retry_config: RetryConfig,
 }
 
-impl WebIdentityProvider {
-    async fn get_credential(&self) -> Result<Arc<AwsCredential>> {
-        self.cache
-            .get_or_insert_with(|| {
-                web_identity(
-                    &self.client,
-                    &self.retry_config,
-                    &self.token,
-                    &self.role_arn,
-                    &self.session_name,
-                    &self.endpoint,
-                )
-                .map_err(|source| crate::Error::Generic {
-                    store: "S3",
-                    source,
-                })
+impl CredentialProvider for WebIdentityProvider {
+    fn get_credential(&self) -> BoxFuture<'_, Result<Arc<AwsCredential>>> {
+        Box::pin(self.cache.get_or_insert_with(|| {
+            web_identity(
+                &self.client,
+                &self.retry_config,
+                &self.token,
+                &self.role_arn,
+                &self.session_name,
+                &self.endpoint,
+            )
+            .map_err(|source| crate::Error::Generic {
+                store: "S3",
+                source,
             })
-            .await
+        }))
     }
 }
 
@@ -519,6 +509,69 @@ async fn web_identity(
         expiry: Instant::now() + ttl,
     })
 }
+
+#[cfg(feature = "aws_profile")]
+mod profile {
+    use super::*;
+    use aws_config::profile::ProfileFileCredentialsProvider;
+    use aws_types::credentials::ProvideCredentials;
+    use std::time::SystemTime;
+
+    #[derive(Debug)]
+    pub struct ProfileProvider {
+        cache: TokenCache<Arc<AwsCredential>>,
+        credentials: ProfileFileCredentialsProvider,
+    }
+
+    impl ProfileProvider {
+        pub fn new(name: impl Into<String>) -> Self {
+            Self {
+                cache: Default::default(),
+                credentials: ProfileFileCredentialsProvider::builder()
+                    .profile_name(name)
+                    .build(),
+            }
+        }
+    }
+
+    impl CredentialProvider for ProfileProvider {
+        fn get_credential(&self) -> BoxFuture<'_, Result<Arc<AwsCredential>>> {
+            Box::pin(self.cache.get_or_insert_with(move || async move {
+                let c =
+                    self.credentials
+                        .provide_credentials()
+                        .await
+                        .map_err(|source| crate::Error::Generic {
+                            store: "S3",
+                            source: Box::new(source),
+                        })?;
+
+                let t_now = SystemTime::now();
+                let expiry = match c.expiry().and_then(|e| e.duration_since(t_now).ok()) {
+                    Some(ttl) => Instant::now() + ttl,
+                    None => {
+                        return Err(crate::Error::Generic {
+                            store: "S3",
+                            source: "Invalid expiry".into(),
+                        })
+                    }
+                };
+
+                Ok(TemporaryToken {
+                    token: Arc::new(AwsCredential {
+                        key_id: c.access_key_id().to_string(),
+                        secret_key: c.secret_access_key().to_string(),
+                        token: c.session_token().map(ToString::to_string),
+                    }),
+                    expiry,
+                })
+            }))
+        }
+    }
+}
+
+#[cfg(feature = "aws_profile")]
+pub use profile::ProfileProvider;
 
 #[cfg(test)]
 mod tests {

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -371,14 +371,14 @@ impl AmazonS3Builder {
     /// Fill the [`AmazonS3Builder`] with regular AWS environment variables
     ///
     /// Variables extracted from environment:
-    /// * AWS_ACCESS_KEY_ID -> access_key_id
-    /// * AWS_SECRET_ACCESS_KEY -> secret_access_key
-    /// * AWS_DEFAULT_REGION -> region
-    /// * AWS_ENDPOINT -> endpoint
-    /// * AWS_SESSION_TOKEN -> token
-    /// * AWS_CONTAINER_CREDENTIALS_RELATIVE_URI -> <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>
-    /// * AWS_ALLOW_HTTP -> set to "true" to permit HTTP connections without TLS
-    /// * AWS_PROFILE -> set profile name, requires `aws_profile` feature enabled
+    /// * `AWS_ACCESS_KEY_ID` -> access_key_id
+    /// * `AWS_SECRET_ACCESS_KEY` -> secret_access_key
+    /// * `AWS_DEFAULT_REGION` -> region
+    /// * `AWS_ENDPOINT` -> endpoint
+    /// * `AWS_SESSION_TOKEN` -> token
+    /// * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` -> <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>
+    /// * `AWS_ALLOW_HTTP` -> set to "true" to permit HTTP connections without TLS
+    /// * `AWS_PROFILE` -> set profile name, requires `aws_profile` feature enabled
     /// # Example
     /// ```
     /// use object_store::aws::AmazonS3Builder;
@@ -534,9 +534,18 @@ impl AmazonS3Builder {
         self
     }
 
-    /// Set the AWS profile name
+    /// Set the AWS profile name, see <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html>
     ///
-    /// See <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html>
+    /// This makes use of [aws-config] to provide credentials and therefore requires
+    /// the `aws-profile` feature to be enabled
+    ///
+    /// It is strongly encouraged that users instead make use of a credential manager
+    /// such as [aws-vault] not only to avoid the significant additional dependencies,
+    /// but also to avoid storing credentials in [plain text on disk]
+    ///
+    /// [aws-config]: https://docs.rs/aws-config
+    /// [aws-vault]: https://github.com/99designs/aws-vault
+    /// [plain text on disk]: https://99designs.com.au/blog/engineering/aws-vault/
     #[cfg(feature = "aws_profile")]
     pub fn with_profile(mut self, profile: impl Into<String>) -> Self {
         self.profile = Some(profile.into());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2178

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Support for the more esoteric AWS auth options has been requested in various places, rather than forcing downstreams to workaround this by using an SDK such as aws-sdk-rust, lets just provide an option to use aws-sdk-rust to get credentials from a profile. This lets people explicitly opt-in to the full suite of credential providers, with the accompanying dependency explosion, whilst still using the same code for actual communication with object storage. I still would argue aws-vault is a superior solution for credential management than relying on inconsistent SDK implementations which store credentials in plain text on disk, but we should meet users where they currently are.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds an optional aws_profile feature which uses aws-config to provide the full suite of AWS credential functionality, including SSO, external credential providers, role chaining, etc...

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
