### PR TITLE
Specialize interleave integer

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -177,6 +177,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "interleave_kernels"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "length_kernel"
 harness = false
 

--- a/arrow/benches/interleave_kernels.rs
+++ b/arrow/benches/interleave_kernels.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use std::ops::Range;
+
+use rand::Rng;
+
+extern crate arrow;
+
+use arrow::datatypes::*;
+use arrow::util::test_util::seedable_rng;
+use arrow::{array::*, util::bench_util::*};
+use arrow_select::interleave::interleave;
+
+fn do_bench(
+    c: &mut Criterion,
+    prefix: &str,
+    len: usize,
+    base: &dyn Array,
+    slices: &[Range<usize>],
+) {
+    let mut rng = seedable_rng();
+
+    let arrays: Vec<_> = slices
+        .iter()
+        .map(|r| base.slice(r.start, r.end - r.start))
+        .collect();
+    let values: Vec<_> = arrays.iter().map(|x| x.as_ref()).collect();
+
+    let indices: Vec<_> = (0..len)
+        .map(|_| {
+            let array_idx = rng.gen_range(0..values.len());
+            let value_idx = rng.gen_range(0..values[array_idx].len());
+            (array_idx, value_idx)
+        })
+        .collect();
+
+    c.bench_function(
+        &format!("interleave {} {} {:?}", prefix, len, slices),
+        |b| b.iter(|| criterion::black_box(interleave(&values, &indices).unwrap())),
+    );
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let a = create_primitive_array::<Int32Type>(1024, 0.);
+
+    do_bench(c, "i32(0.0)", 100, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(c, "i32(0.0)", 400, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(c, "i32(0.0)", 1024, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(
+        c,
+        "i32(0.0)",
+        1024,
+        &a,
+        &[0..100, 100..230, 450..1000, 0..1000],
+    );
+
+    let a = create_primitive_array::<Int32Type>(1024, 0.5);
+
+    do_bench(c, "i32(0.5)", 100, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(c, "i32(0.5)", 400, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(c, "i32(0.5)", 1024, &a, &[0..100, 100..230, 450..1000]);
+    do_bench(
+        c,
+        "i32(0.5)",
+        1024,
+        &a,
+        &[0..100, 100..230, 450..1000, 0..1000],
+    );
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2864 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

```
interleave i32(0.0) 100 [0..100, 100..230, 450..1000]
                        time:   [651.12 ns 653.57 ns 656.31 ns]
                        change: [-63.090% -61.957% -60.766%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave i32(0.0) 400 [0..100, 100..230, 450..1000]
                        time:   [1.4171 µs 1.4235 µs 1.4299 µs]
                        change: [-78.002% -77.910% -77.815%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave i32(0.0) 1024 [0..100, 100..230, 450..1000]
                        time:   [3.0353 µs 3.0481 µs 3.0615 µs]
                        change: [-80.172% -80.078% -79.986%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) high mild
  15 (15.00%) high severe

interleave i32(0.0) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [3.0152 µs 3.0182 µs 3.0222 µs]
                        change: [-79.156% -79.115% -79.069%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

interleave i32(0.5) 100 [0..100, 100..230, 450..1000]
                        time:   [1.3152 µs 1.3192 µs 1.3238 µs]
                        change: [-69.214% -69.114% -69.015%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  18 (18.00%) high severe

interleave i32(0.5) 400 [0..100, 100..230, 450..1000]
                        time:   [3.6639 µs 3.6761 µs 3.6898 µs]
                        change: [-76.085% -75.971% -75.851%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave i32(0.5) 1024 [0..100, 100..230, 450..1000]
                        time:   [9.4650 µs 9.4999 µs 9.5384 µs]
                        change: [-76.249% -76.161% -76.071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) high mild
  13 (13.00%) high severe

interleave i32(0.5) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [9.5063 µs 9.5349 µs 9.5671 µs]
                        change: [-76.089% -75.990% -75.895%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  2 (2.00%) high mild
  19 (19.00%) high severe

```


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a specialized implementation for primitives

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
