### PR TITLE
Document crate topology (#2594)

### DIFF
--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! The central type in Apache Arrow are arrays, which are a known-length sequence of values
-//! all having the same type. This module provides concrete implementations of each type, as
+//! all having the same type. This crate provides concrete implementations of each type, as
 //! well as an [`Array`] trait that can be used for type-erasure.
 //!
 //! # Downcasting an Array

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Buffer abstractions for [Apache Arrow](https://docs.rs/arrow)
+//! Array data abstractions for [Apache Arrow](https://docs.rs/arrow)
 
 mod bitmap;
 pub use bitmap::Bitmap;

--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Re-exports APIs from [arrow_array]
+//! Statically typed implementations of Arrow Arrays
+//!
+//! **See [arrow_array] for examples and usage instructions**
 
 #[cfg(feature = "ffi")]
 mod ffi;

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -23,30 +23,34 @@
 //!
 //! # Crate Topology
 //!
-//! The `arrow` project is implemented as multiple sub-crates, which are then re-exported by
-//! this top-level `arrow` crate.
+//! The [`arrow`] project is implemented as multiple sub-crates, which are then re-exported by
+//! this top-level crate.
 //!
-//! Crate authors can choose to depend on this top-level `arrow` crate, or just
+//! Crate authors can choose to depend on this top-level crate, or just
 //! the sub-crates they need.
 //!
 //! The current list of sub-crates is:
 //!
-//! * [`arrow_buffer`] - buffer abstractions for arrow arrays
-//! * [`arrow_schema`] - the logical types for arrow arrays
-//! * [`arrow_data`] - the underlying data of arrow arrays
-//! * [`arrow_array`] - type-safe arrow array abstractions
-//! * [`arrow_select`] - selection kernels for arrow arrays
+//! * [`arrow-array`][arrow_array] - type-safe arrow array abstractions
+//! * [`arrow-buffer`][arrow_buffer] - buffer abstractions for arrow arrays
+//! * [`arrow-data`][arrow_data] - the underlying data of arrow arrays
+//! * [`arrow-schema`][arrow_schema] - the logical types for arrow arrays
+//! * [`arrow-select`][arrow_select] - selection kernels for arrow arrays
 //!
 //! _This list is likely to grow as further functionality is split out from the top-level crate_
 //!
+//! Some functionality is also distributed independently of this crate:
+//!
+//! * [`arrow-flight`] - support for [Arrow Flight RPC]
+//! * [`arrow-integration-test`] - support for [Arrow JSON Test Format]
+//! * [`parquet`](https://docs.rs/parquet/latest/parquet/) - support for [Apache Parquet]
+//!
 //! # Columnar Format
 //!
-//! [`arrow_array`] provides statically typed implementations of all the array types as defined
+//! The [`array`] module provides statically typed implementations of all the array types as defined
 //! by the [Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html)
 //!
-//! These types can be used directly or are re-exported under [`arrow::array`](crate::array).
-//!
-//! For example, an [`Int32Array`](arrow_array::Int32Array) represents a nullable array of [`i32`]
+//! For example, an [`Int32Array`](array::Int32Array) represents a nullable array of `i32`
 //!
 //! ```rust
 //! # use arrow::array::{Array, Int32Array};
@@ -255,12 +259,20 @@
 //! orchestrates the primitives exported by this crate into an embeddable query engine, with
 //! SQL and DataFrame frontends, and heavily influences this crate's roadmap.
 //!
+//! [`arrow`]: https://github.com/apache/arrow-rs
+//! [`array`]: mod@array
 //! [`Array`]: array::Array
 //! [`ArrayRef`]: array::ArrayRef
 //! [`ArrayData`]: array::ArrayData
 //! [`make_array`]: array::make_array
 //! [`Buffer`]: buffer::Buffer
 //! [`RecordBatch`]: record_batch::RecordBatch
+//! [`arrow-flight`]: https://docs.rs/arrow-flight/latest/arrow_flight/
+//! [`arrow-integration-test`]: https://docs.rs/arrow-integration-test/latest/arrow_integration_test/
+//! [`parquet`]: https://docs.rs/parquet/latest/parquet/
+//! [Arrow Flight RPC]: https://arrow.apache.org/docs/format/Flight.html
+//! [Arrow JSON Test Format]: https://github.com/apache/arrow/blob/master/docs/source/format/Integration.rst#json-test-data-format
+//! [Apache Parquet]: https://parquet.apache.org/
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [issue tracker]: https://github.com/apache/arrow-rs/issues
 //!

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -21,12 +21,32 @@
 //! Please see the [arrow crates.io](https://crates.io/crates/arrow)
 //! page for feature flags and tips to improve performance.
 //!
+//! # Crate Topology
+//!
+//! The `arrow` project is implemented as multiple sub-crates, which are then re-exported by
+//! this top-level `arrow` crate.
+//!
+//! Crate authors can choose to depend on this top-level `arrow` crate, or just
+//! the sub-crates they need.
+//!
+//! The current list of sub-crates is:
+//!
+//! * [`arrow_buffer`] - buffer abstractions for arrow arrays
+//! * [`arrow_schema`] - the logical types for arrow arrays
+//! * [`arrow_data`] - the underlying data of arrow arrays
+//! * [`arrow_array`] - type-safe arrow array abstractions
+//! * [`arrow_select`] - selection kernels for arrow arrays
+//!
+//! _This list is likely to grow as further functionality is split out from the top-level crate_
+//!
 //! # Columnar Format
 //!
-//! The [`array`] module provides statically typed implementations of all the array
-//! types as defined by the [Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html).
+//! [`arrow_array`] provides statically typed implementations of all the array types as defined
+//! by the [Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html)
 //!
-//! For example, an [`Int32Array`](array::Int32Array) represents a nullable array of `i32`
+//! These types can be used directly or are re-exported under [`arrow::array`](crate::array).
+//!
+//! For example, an [`Int32Array`](arrow_array::Int32Array) represents a nullable array of [`i32`]
 //!
 //! ```rust
 //! # use arrow::array::{Array, Int32Array};
@@ -77,7 +97,7 @@
 //! assert_eq!(min(&StringArray::from(vec!["b", "a", "c"])), Some("a"));
 //! ```
 //!
-//! For more examples, consult the [`array`] docs.
+//! For more examples, consult the [arrow_array] docs.
 //!
 //! # Type Erasure / Trait Objects
 //!
@@ -235,7 +255,6 @@
 //! orchestrates the primitives exported by this crate into an embeddable query engine, with
 //! SQL and DataFrame frontends, and heavily influences this crate's roadmap.
 //!
-//! [`array`]: mod@array
 //! [`Array`]: array::Array
 //! [`ArrayRef`]: array::ArrayRef
 //! [`ArrayData`]: array::ArrayData


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2594

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I found it non-trivial to find the documentation I wrote for managing arrow arrays, this is because the module docs were moved to the crate docs for arrow_array.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds documentation on the crate topology, and updates links to reference these sub-crates

# Are there any user-facing changes?

No, this just updates docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
