### PR TITLE
Deprecate TimestampArray from_vec and from_opt_vec

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -118,9 +118,9 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// # use arrow_array::TimestampSecondArray;
 /// use chrono::FixedOffset;
 /// // Corresponds to single element array with entry 1970-05-09T14:25:11+0:00
-/// let arr = TimestampSecondArray::from_vec(vec![11111111], None);
+/// let arr = TimestampSecondArray::from(vec![11111111]);
 /// // OR
-/// let arr = TimestampSecondArray::from_opt_vec(vec![Some(11111111)], None);
+/// let arr = TimestampSecondArray::from(vec![Some(11111111)]);
 /// let utc_offset = FixedOffset::east(0);
 ///
 /// assert_eq!(arr.value_as_datetime_with_tz(0, utc_offset).map(|v| v.to_string()).unwrap(), "1970-05-09 14:25:11")
@@ -131,9 +131,9 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// # use arrow_array::TimestampSecondArray;
 /// use chrono::FixedOffset;
 /// // Corresponds to single element array with entry 1969-08-25T09:34:49+0:00
-/// let arr = TimestampSecondArray::from_vec(vec![-11111111], None);
+/// let arr = TimestampSecondArray::from(vec![-11111111]);
 /// // OR
-/// let arr = TimestampSecondArray::from_opt_vec(vec![Some(-11111111)], None);
+/// let arr = TimestampSecondArray::from(vec![Some(-11111111)]);
 /// let utc_offset = FixedOffset::east(0);
 ///
 /// assert_eq!(arr.value_as_datetime_with_tz(0, utc_offset).map(|v| v.to_string()).unwrap(), "1969-08-25 09:34:49")
@@ -144,9 +144,9 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// # use arrow_array::TimestampSecondArray;
 /// use chrono::FixedOffset;
 /// // Corresponds to single element array with entry 1970-05-10T00:25:11+10:00
-/// let arr = TimestampSecondArray::from_vec(vec![11111111], Some("+10:00".to_string()));
+/// let arr = TimestampSecondArray::from(vec![11111111]).with_timezone("+10:00".to_string());
 /// // OR
-/// let arr = TimestampSecondArray::from_opt_vec(vec![Some(11111111)], Some("+10:00".to_string()));
+/// let arr = TimestampSecondArray::from(vec![Some(11111111)]).with_timezone("+10:00".to_string());
 /// let sydney_offset = FixedOffset::east(10 * 60 * 60);
 ///
 /// assert_eq!(arr.value_as_datetime_with_tz(0, sydney_offset).map(|v| v.to_string()).unwrap(), "1970-05-10 00:25:11")
@@ -761,6 +761,7 @@ def_numeric_from_vec!(TimestampNanosecondType);
 
 impl<T: ArrowTimestampType> PrimitiveArray<T> {
     /// Construct a timestamp array from a vec of i64 values and an optional timezone
+    #[deprecated(note = "Use with_timezone_opt instead")]
     pub fn from_vec(data: Vec<i64>, timezone: Option<String>) -> Self
     where
         Self: From<Vec<i64>>,
@@ -769,6 +770,7 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
     }
 
     /// Construct a timestamp array from a vec of `Option<i64>` values and an optional timezone
+    #[deprecated(note = "Use with_timezone_opt instead")]
     pub fn from_opt_vec(data: Vec<Option<i64>>, timezone: Option<String>) -> Self
     where
         Self: From<Vec<Option<i64>>>,
@@ -1150,7 +1152,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_array_from_vec() {
-        let arr = TimestampSecondArray::from_vec(vec![1, -5], None);
+        let arr = TimestampSecondArray::from(vec![1, -5]);
         assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -1158,7 +1160,7 @@ mod tests {
         assert_eq!(-5, arr.value(1));
         assert_eq!(&[1, -5], arr.values());
 
-        let arr = TimestampMillisecondArray::from_vec(vec![1, -5], None);
+        let arr = TimestampMillisecondArray::from(vec![1, -5]);
         assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -1166,7 +1168,7 @@ mod tests {
         assert_eq!(-5, arr.value(1));
         assert_eq!(&[1, -5], arr.values());
 
-        let arr = TimestampMicrosecondArray::from_vec(vec![1, -5], None);
+        let arr = TimestampMicrosecondArray::from(vec![1, -5]);
         assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -1174,7 +1176,7 @@ mod tests {
         assert_eq!(-5, arr.value(1));
         assert_eq!(&[1, -5], arr.values());
 
-        let arr = TimestampNanosecondArray::from_vec(vec![1, -5], None);
+        let arr = TimestampNanosecondArray::from(vec![1, -5]);
         assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -1309,10 +1311,11 @@ mod tests {
     #[test]
     fn test_timestamp_fmt_debug() {
         let arr: PrimitiveArray<TimestampMillisecondType> =
-            TimestampMillisecondArray::from_vec(
-                vec![1546214400000, 1546214400000, -1546214400000],
-                None,
-            );
+            TimestampMillisecondArray::from(vec![
+                1546214400000,
+                1546214400000,
+                -1546214400000,
+            ]);
         assert_eq!(
             "PrimitiveArray<Timestamp(Millisecond, None)>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n  1921-01-02T00:00:00,\n]",
             format!("{:?}", arr)

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -1240,34 +1240,28 @@ mod tests {
             None,
             Some(16584393546415),
         ]);
-        let ts_secs = TimestampSecondArray::from_opt_vec(
-            vec![None, Some(193438817552), None],
+        let ts_secs = TimestampSecondArray::from(vec![None, Some(193438817552), None]);
+        let ts_millis = TimestampMillisecondArray::from(vec![
             None,
-        );
-        let ts_millis = TimestampMillisecondArray::from_opt_vec(
-            vec![None, Some(38606916383008), Some(58113709376587)],
+            Some(38606916383008),
+            Some(58113709376587),
+        ]);
+        let ts_micros = TimestampMicrosecondArray::from(vec![None, None, None]);
+        let ts_nanos =
+            TimestampNanosecondArray::from(vec![None, None, Some(-6473623571954960143)]);
+        let ts_secs_tz = TimestampSecondArray::from(vec![None, Some(193438817552), None])
+            .with_timezone_opt(secs_tz);
+        let ts_millis_tz = TimestampMillisecondArray::from(vec![
             None,
-        );
-        let ts_micros =
-            TimestampMicrosecondArray::from_opt_vec(vec![None, None, None], None);
-        let ts_nanos = TimestampNanosecondArray::from_opt_vec(
-            vec![None, None, Some(-6473623571954960143)],
-            None,
-        );
-        let ts_secs_tz = TimestampSecondArray::from_opt_vec(
-            vec![None, Some(193438817552), None],
-            secs_tz,
-        );
-        let ts_millis_tz = TimestampMillisecondArray::from_opt_vec(
-            vec![None, Some(38606916383008), Some(58113709376587)],
-            millis_tz,
-        );
-        let ts_micros_tz =
-            TimestampMicrosecondArray::from_opt_vec(vec![None, None, None], micros_tz);
-        let ts_nanos_tz = TimestampNanosecondArray::from_opt_vec(
-            vec![None, None, Some(-6473623571954960143)],
-            nanos_tz,
-        );
+            Some(38606916383008),
+            Some(58113709376587),
+        ])
+        .with_timezone_opt(millis_tz);
+        let ts_micros_tz = TimestampMicrosecondArray::from(vec![None, None, None])
+            .with_timezone_opt(micros_tz);
+        let ts_nanos_tz =
+            TimestampNanosecondArray::from(vec![None, None, Some(-6473623571954960143)])
+                .with_timezone_opt(nanos_tz);
         let utf8s = StringArray::from(vec![Some("aa"), None, Some("bbb")]);
 
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -760,22 +760,22 @@ mod tests {
     def_temporal_test!(
         test_filter_timestamp_second,
         TimestampSecondArray,
-        TimestampSecondArray::from_vec(vec![1, 2, 3, 4], None)
+        TimestampSecondArray::from(vec![1, 2, 3, 4])
     );
     def_temporal_test!(
         test_filter_timestamp_millisecond,
         TimestampMillisecondArray,
-        TimestampMillisecondArray::from_vec(vec![1, 2, 3, 4], None)
+        TimestampMillisecondArray::from(vec![1, 2, 3, 4])
     );
     def_temporal_test!(
         test_filter_timestamp_microsecond,
         TimestampMicrosecondArray,
-        TimestampMicrosecondArray::from_vec(vec![1, 2, 3, 4], None)
+        TimestampMicrosecondArray::from(vec![1, 2, 3, 4])
     );
     def_temporal_test!(
         test_filter_timestamp_nanosecond,
         TimestampNanosecondArray,
-        TimestampNanosecondArray::from_vec(vec![1, 2, 3, 4], None)
+        TimestampNanosecondArray::from(vec![1, 2, 3, 4])
     );
 
     #[test]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1348,10 +1348,11 @@ mod tests {
     fn test_take_preserve_timezone() {
         let index = Int64Array::from(vec![Some(0), None]);
 
-        let input = TimestampNanosecondArray::from_vec(
-            vec![1_639_715_368_000_000_000, 1_639_715_368_000_000_000],
-            Some("UTC".to_owned()),
-        );
+        let input = TimestampNanosecondArray::from(vec![
+            1_639_715_368_000_000_000,
+            1_639_715_368_000_000_000,
+        ])
+        .with_timezone("UTC".to_string());
         let result = take_impl(&input, &index, None).unwrap();
         match result.data_type() {
             DataType::Timestamp(TimeUnit::Nanosecond, tz) => {

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -3793,10 +3793,12 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_date32() {
-        let a = TimestampMillisecondArray::from_opt_vec(
-            vec![Some(864000000005), Some(1545696000001), None],
-            Some(String::from("UTC")),
-        );
+        let a = TimestampMillisecondArray::from(vec![
+            Some(864000000005),
+            Some(1545696000001),
+            None,
+        ])
+        .with_timezone("UTC".to_string());
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date32).unwrap();
         let c = b.as_any().downcast_ref::<Date32Array>().unwrap();
@@ -3807,10 +3809,11 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_date64() {
-        let a = TimestampMillisecondArray::from_opt_vec(
-            vec![Some(864000000005), Some(1545696000001), None],
+        let a = TimestampMillisecondArray::from(vec![
+            Some(864000000005),
+            Some(1545696000001),
             None,
-        );
+        ]);
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date64).unwrap();
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
@@ -3821,10 +3824,12 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_i64() {
-        let a = TimestampMillisecondArray::from_opt_vec(
-            vec![Some(864000000005), Some(1545696000001), None],
-            Some("UTC".to_string()),
-        );
+        let a = TimestampMillisecondArray::from(vec![
+            Some(864000000005),
+            Some(1545696000001),
+            None,
+        ])
+        .with_timezone("UTC".to_string());
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Int64).unwrap();
         let c = b.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -3837,10 +3842,12 @@ mod tests {
     #[test]
     #[cfg(feature = "chrono-tz")]
     fn test_cast_timestamp_to_string() {
-        let a = TimestampMillisecondArray::from_opt_vec(
-            vec![Some(864000000005), Some(1545696000001), None],
-            Some("UTC".to_string()),
-        );
+        let a = TimestampMillisecondArray::from(vec![
+            Some(864000000005),
+            Some(1545696000001),
+            None,
+        ])
+        .with_timezone("UTC".to_string());
         let array = Arc::new(a) as ArrayRef;
         dbg!(&array);
         let b = cast(&array, &DataType::Utf8).unwrap();
@@ -3875,10 +3882,11 @@ mod tests {
 
     #[test]
     fn test_cast_between_timestamps() {
-        let a = TimestampMillisecondArray::from_opt_vec(
-            vec![Some(864000003005), Some(1545696002001), None],
+        let a = TimestampMillisecondArray::from(vec![
+            Some(864000003005),
+            Some(1545696002001),
             None,
-        );
+        ]);
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Timestamp(TimeUnit::Second, None)).unwrap();
         let c = b.as_any().downcast_ref::<TimestampSecondArray>().unwrap();
@@ -5474,26 +5482,26 @@ mod tests {
             Arc::new(UInt64Array::from(vec![1, 2])),
             Arc::new(Float32Array::from(vec![1.0, 2.0])),
             Arc::new(Float64Array::from(vec![1.0, 2.0])),
-            Arc::new(TimestampSecondArray::from_vec(vec![1000, 2000], None)),
-            Arc::new(TimestampMillisecondArray::from_vec(vec![1000, 2000], None)),
-            Arc::new(TimestampMicrosecondArray::from_vec(vec![1000, 2000], None)),
-            Arc::new(TimestampNanosecondArray::from_vec(vec![1000, 2000], None)),
-            Arc::new(TimestampSecondArray::from_vec(
-                vec![1000, 2000],
-                Some(tz_name.clone()),
-            )),
-            Arc::new(TimestampMillisecondArray::from_vec(
-                vec![1000, 2000],
-                Some(tz_name.clone()),
-            )),
-            Arc::new(TimestampMicrosecondArray::from_vec(
-                vec![1000, 2000],
-                Some(tz_name.clone()),
-            )),
-            Arc::new(TimestampNanosecondArray::from_vec(
-                vec![1000, 2000],
-                Some(tz_name),
-            )),
+            Arc::new(TimestampSecondArray::from(vec![1000, 2000])),
+            Arc::new(TimestampMillisecondArray::from(vec![1000, 2000])),
+            Arc::new(TimestampMicrosecondArray::from(vec![1000, 2000])),
+            Arc::new(TimestampNanosecondArray::from(vec![1000, 2000])),
+            Arc::new(
+                TimestampSecondArray::from(vec![1000, 2000])
+                    .with_timezone(tz_name.clone()),
+            ),
+            Arc::new(
+                TimestampMillisecondArray::from(vec![1000, 2000])
+                    .with_timezone(tz_name.clone()),
+            ),
+            Arc::new(
+                TimestampMicrosecondArray::from(vec![1000, 2000])
+                    .with_timezone(tz_name.clone()),
+            ),
+            Arc::new(
+                TimestampNanosecondArray::from(vec![1000, 2000])
+                    .with_timezone(tz_name.clone()),
+            ),
             Arc::new(Date32Array::from(vec![1000, 2000])),
             Arc::new(Date64Array::from(vec![1000, 2000])),
             Arc::new(Time32SecondArray::from(vec![1000, 2000])),

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -863,12 +863,12 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_quarter_with_timezone() {
         // 24 * 60 * 60 = 86400
-        let a =
-            TimestampSecondArray::from_vec(vec![86400 * 90], Some("+00:00".to_string()));
+        let a = TimestampSecondArray::from(vec![86400 * 90])
+            .with_timezone("+00:00".to_string());
         let b = quarter(&a).unwrap();
         assert_eq!(2, b.value(0));
-        let a =
-            TimestampSecondArray::from_vec(vec![86400 * 90], Some("-10:00".to_string()));
+        let a = TimestampSecondArray::from(vec![86400 * 90])
+            .with_timezone("-10:00".to_string());
         let b = quarter(&a).unwrap();
         assert_eq!(1, b.value(0));
     }
@@ -899,12 +899,12 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_month_with_timezone() {
         // 24 * 60 * 60 = 86400
-        let a =
-            TimestampSecondArray::from_vec(vec![86400 * 31], Some("+00:00".to_string()));
+        let a = TimestampSecondArray::from(vec![86400 * 31])
+            .with_timezone("+00:00".to_string());
         let b = month(&a).unwrap();
         assert_eq!(2, b.value(0));
-        let a =
-            TimestampSecondArray::from_vec(vec![86400 * 31], Some("-10:00".to_string()));
+        let a = TimestampSecondArray::from(vec![86400 * 31])
+            .with_timezone("-10:00".to_string());
         let b = month(&a).unwrap();
         assert_eq!(1, b.value(0));
     }
@@ -912,10 +912,12 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_day_with_timezone() {
         // 24 * 60 * 60 = 86400
-        let a = TimestampSecondArray::from_vec(vec![86400], Some("+00:00".to_string()));
+        let a =
+            TimestampSecondArray::from(vec![86400]).with_timezone("+00:00".to_string());
         let b = day(&a).unwrap();
         assert_eq!(2, b.value(0));
-        let a = TimestampSecondArray::from_vec(vec![86400], Some("-10:00".to_string()));
+        let a =
+            TimestampSecondArray::from(vec![86400]).with_timezone("-10:00".to_string());
         let b = day(&a).unwrap();
         assert_eq!(1, b.value(0));
     }
@@ -1095,7 +1097,8 @@ mod tests {
 
     #[test]
     fn test_temporal_array_timestamp_second_with_timezone() {
-        let a = TimestampSecondArray::from_vec(vec![10, 20], Some("+00:00".to_string()));
+        let a =
+            TimestampSecondArray::from(vec![10, 20]).with_timezone("+00:00".to_string());
         let b = second(&a).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(20, b.value(1));
@@ -1103,7 +1106,8 @@ mod tests {
 
     #[test]
     fn test_temporal_array_timestamp_minute_with_timezone() {
-        let a = TimestampSecondArray::from_vec(vec![0, 60], Some("+00:50".to_string()));
+        let a =
+            TimestampSecondArray::from(vec![0, 60]).with_timezone("+00:50".to_string());
         let b = minute(&a).unwrap();
         assert_eq!(50, b.value(0));
         assert_eq!(51, b.value(1));
@@ -1111,41 +1115,40 @@ mod tests {
 
     #[test]
     fn test_temporal_array_timestamp_minute_with_negative_timezone() {
-        let a = TimestampSecondArray::from_vec(vec![60 * 55], Some("-00:50".to_string()));
+        let a =
+            TimestampSecondArray::from(vec![60 * 55]).with_timezone("-00:50".to_string());
         let b = minute(&a).unwrap();
         assert_eq!(5, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone() {
-        let a = TimestampSecondArray::from_vec(
-            vec![60 * 60 * 10],
-            Some("+01:00".to_string()),
-        );
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("+01:00".to_string());
         let b = hour(&a).unwrap();
         assert_eq!(11, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_without_colon() {
-        let a =
-            TimestampSecondArray::from_vec(vec![60 * 60 * 10], Some("+0100".to_string()));
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("+0100".to_string());
         let err = hour(&a).unwrap_err().to_string();
         assert!(err.contains("Invalid timezone"), "{}", err);
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_without_initial_sign() {
-        let a =
-            TimestampSecondArray::from_vec(vec![60 * 60 * 10], Some("0100".to_string()));
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("0100".to_string());
         let err = hour(&a).unwrap_err().to_string();
         assert!(err.contains("Invalid timezone"), "{}", err);
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_with_only_colon() {
-        let a =
-            TimestampSecondArray::from_vec(vec![60 * 60 * 10], Some("01:00".to_string()));
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("01:00".to_string());
         let err = hour(&a).unwrap_err().to_string();
         assert!(err.contains("Invalid timezone"), "{}", err);
     }
@@ -1153,10 +1156,8 @@ mod tests {
     #[cfg(feature = "chrono-tz")]
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_using_chrono_tz() {
-        let a = TimestampSecondArray::from_vec(
-            vec![60 * 60 * 10],
-            Some("Asia/Kolkata".to_string()),
-        );
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("Asia/Kolkata".to_string());
         let b = hour(&a).unwrap();
         assert_eq!(15, b.value(0));
     }
@@ -1180,19 +1181,19 @@ mod tests {
     #[cfg(not(feature = "chrono-tz"))]
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_using_chrono_tz() {
-        let a = TimestampSecondArray::from_vec(
-            vec![60 * 60 * 10],
-            Some("Asia/Kolkatta".to_string()),
-        );
+        let a = TimestampSecondArray::from(vec![60 * 60 * 10])
+            .with_timezone("Asia/Kolkatta".to_string());
         assert!(matches!(hour(&a), Err(ArrowError::ParseError(_))))
     }
 
     #[test]
     fn test_hour_minute_second_dictionary_array() {
-        let a = TimestampSecondArray::from_vec(
-            vec![60 * 60 * 10 + 61, 60 * 60 * 20 + 122, 60 * 60 * 30 + 183],
-            Some("+01:00".to_string()),
-        );
+        let a = TimestampSecondArray::from(vec![
+            60 * 60 * 10 + 61,
+            60 * 60 * 20 + 122,
+            60 * 60 * 30 + 183,
+        ])
+        .with_timezone("+01:00".to_string());
 
         let keys = Int8Array::from_iter_values([0_i8, 0, 1, 2, 1]);
         let dict = DictionaryArray::try_new(&keys, &a).unwrap();

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -489,10 +489,11 @@ mod tests {
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
         let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
-        let c5 = TimestampMillisecondArray::from_opt_vec(
-            vec![None, Some(1555584887378), Some(1555555555555)],
+        let c5 = TimestampMillisecondArray::from(vec![
             None,
-        );
+            Some(1555584887378),
+            Some(1555555555555),
+        ]);
         let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
         let c7: DictionaryArray<Int32Type> =
             vec!["cupcakes", "cupcakes", "foo"].into_iter().collect();

--- a/arrow/src/json/writer.rs
+++ b/arrow/src/json/writer.rs
@@ -892,14 +892,10 @@ mod tests {
         let ts_millis = ts_micros / 1000;
         let ts_secs = ts_millis / 1000;
 
-        let arr_nanos =
-            TimestampNanosecondArray::from_opt_vec(vec![Some(ts_nanos), None], None);
-        let arr_micros =
-            TimestampMicrosecondArray::from_opt_vec(vec![Some(ts_micros), None], None);
-        let arr_millis =
-            TimestampMillisecondArray::from_opt_vec(vec![Some(ts_millis), None], None);
-        let arr_secs =
-            TimestampSecondArray::from_opt_vec(vec![Some(ts_secs), None], None);
+        let arr_nanos = TimestampNanosecondArray::from(vec![Some(ts_nanos), None]);
+        let arr_micros = TimestampMicrosecondArray::from(vec![Some(ts_micros), None]);
+        let arr_millis = TimestampMillisecondArray::from(vec![Some(ts_millis), None]);
+        let arr_secs = TimestampSecondArray::from(vec![Some(ts_secs), None]);
         let arr_names = StringArray::from(vec![Some("a"), Some("b")]);
 
         let schema = Schema::new(vec![

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1417,7 +1417,7 @@ mod tests {
     #[test]
     fn timestamp_second_single_column() {
         let raw_values: Vec<_> = (0..SMALL_SIZE as i64).collect();
-        let values = Arc::new(TimestampSecondArray::from_vec(raw_values, None));
+        let values = Arc::new(TimestampSecondArray::from(raw_values));
 
         one_column_roundtrip(values, false);
     }
@@ -1425,7 +1425,7 @@ mod tests {
     #[test]
     fn timestamp_millisecond_single_column() {
         let raw_values: Vec<_> = (0..SMALL_SIZE as i64).collect();
-        let values = Arc::new(TimestampMillisecondArray::from_vec(raw_values, None));
+        let values = Arc::new(TimestampMillisecondArray::from(raw_values));
 
         one_column_roundtrip(values, false);
     }
@@ -1433,7 +1433,7 @@ mod tests {
     #[test]
     fn timestamp_microsecond_single_column() {
         let raw_values: Vec<_> = (0..SMALL_SIZE as i64).collect();
-        let values = Arc::new(TimestampMicrosecondArray::from_vec(raw_values, None));
+        let values = Arc::new(TimestampMicrosecondArray::from(raw_values));
 
         one_column_roundtrip(values, false);
     }
@@ -1441,7 +1441,7 @@ mod tests {
     #[test]
     fn timestamp_nanosecond_single_column() {
         let raw_values: Vec<_> = (0..SMALL_SIZE as i64).collect();
-        let values = Arc::new(TimestampNanosecondArray::from_vec(raw_values, None));
+        let values = Arc::new(TimestampNanosecondArray::from(raw_values));
 
         one_column_roundtrip(values, false);
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

https://github.com/apache/arrow-rs/pull/2906#discussion_r1003664992

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
