### PR TITLE
Use portable simd instead of packed_simd dependency

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -60,7 +60,7 @@ regex = { version = "1.5.6", default-features = false, features = ["std", "unico
 regex-syntax = { version = "0.6.27", default-features = false, features = ["unicode"] }
 lazy_static = { version = "1.4", default-features = false }
 lz4 = { version = "1.23", default-features = false, optional = true }
-packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
+core_simd = { git = "https://github.com/rust-lang/portable-simd", optional = true, branch = "master" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flatbuffers = { version = "22.9.2", default-features = false, features = ["thiserror"], optional = true }
 comfy-table = { version = "6.0", optional = true, default-features = false }
@@ -79,7 +79,13 @@ ipc_compression = ["ipc", "zstd", "lz4"]
 csv = ["csv_crate"]
 ipc = ["flatbuffers"]
 json = ["serde_json"]
-simd = ["packed_simd"]
+# use core_simd for aggregation and some arithmetic kernels
+# requires a nightly build of the rust compiler
+simd = []
+# use core_simd as a crate instead of via std
+# this allows to test some updates before they are included in the standard library
+# this also means the core_simd code gets compiled with the current target features without having to specify `-Zbuild-std`
+external_core_simd = ["core_simd"]
 prettyprint = ["comfy-table"]
 # The test utils feature enables code used in benchmarks and tests but
 # not the core arrow code itself. Be aware that `rand` must be kept as

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -42,23 +42,23 @@ fn bench_min_string(arr_a: &StringArray) {
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    let arr_a = create_primitive_array::<Float32Type>(512, 0.0);
+    let arr_a = create_primitive_array::<Float32Type>(4096, 0.0);
 
-    c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
-    c.bench_function("min 512", |b| b.iter(|| bench_min(&arr_a)));
-    c.bench_function("max 512", |b| b.iter(|| bench_max(&arr_a)));
+    c.bench_function("sum 4096", |b| b.iter(|| bench_sum(&arr_a)));
+    c.bench_function("min 4096", |b| b.iter(|| bench_min(&arr_a)));
+    c.bench_function("max 4096", |b| b.iter(|| bench_max(&arr_a)));
 
-    let arr_a = create_primitive_array::<Float32Type>(512, 0.5);
+    let arr_a = create_primitive_array::<Float32Type>(4096, 0.5);
 
-    c.bench_function("sum nulls 512", |b| b.iter(|| bench_sum(&arr_a)));
-    c.bench_function("min nulls 512", |b| b.iter(|| bench_min(&arr_a)));
-    c.bench_function("max nulls 512", |b| b.iter(|| bench_max(&arr_a)));
+    c.bench_function("sum nulls 4096", |b| b.iter(|| bench_sum(&arr_a)));
+    c.bench_function("min nulls 4096", |b| b.iter(|| bench_min(&arr_a)));
+    c.bench_function("max nulls 4096", |b| b.iter(|| bench_max(&arr_a)));
 
-    let arr_b = create_string_array::<i32>(512, 0.0);
-    c.bench_function("min string 512", |b| b.iter(|| bench_min_string(&arr_b)));
+    let arr_b = create_string_array::<i32>(4096, 0.0);
+    c.bench_function("min string 4096", |b| b.iter(|| bench_min_string(&arr_b)));
 
-    let arr_b = create_string_array::<i32>(512, 0.5);
-    c.bench_function("min nulls string 512", |b| {
+    let arr_b = create_string_array::<i32>(4096, 0.5);
+    c.bench_function("min nulls string 4096", |b| {
         b.iter(|| bench_min_string(&arr_b))
     });
 }

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+#![feature(portable_simd)]
 #[macro_use]
 extern crate criterion;
 use criterion::{Criterion, Throughput};

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -60,11 +60,9 @@ pub fn math_op<LT, RT, F>(
     op: F,
 ) -> Result<PrimitiveArray<LT>>
 where
-    LT: ArrowNumericType,
-    RT: ArrowNumericType,
+    LT: ArrowPrimitiveType,
+    RT: ArrowPrimitiveType,
     F: Fn(LT::Native, RT::Native) -> LT::Native,
-    LT::Native: ArrowNativeTypeOp,
-    RT::Native: ArrowNativeTypeOp,
 {
     binary(left, right, op)
 }
@@ -78,11 +76,9 @@ fn math_checked_op<LT, RT, F>(
     op: F,
 ) -> Result<PrimitiveArray<LT>>
 where
-    LT: ArrowNumericType,
-    RT: ArrowNumericType,
+    LT: ArrowPrimitiveType,
+    RT: ArrowPrimitiveType,
     F: Fn(LT::Native, RT::Native) -> Result<LT::Native>,
-    LT::Native: ArrowNativeTypeOp,
-    RT::Native: ArrowNativeTypeOp,
 {
     try_binary(left, right, op)
 }
@@ -101,8 +97,8 @@ fn math_checked_divide_op<LT, RT, F>(
     op: F,
 ) -> Result<PrimitiveArray<LT>>
 where
-    LT: ArrowNumericType,
-    RT: ArrowNumericType,
+    LT: ArrowPrimitiveType,
+    RT: ArrowPrimitiveType,
     F: Fn(LT::Native, RT::Native) -> Result<LT::Native>,
 {
     try_binary(left, right, op)
@@ -709,8 +705,8 @@ fn math_safe_divide_op<LT, RT, F>(
     op: F,
 ) -> Result<ArrayRef>
 where
-    LT: ArrowNumericType,
-    RT: ArrowNumericType,
+    LT: ArrowPrimitiveType,
+    RT: ArrowPrimitiveType,
     F: Fn(LT::Native, RT::Native) -> Option<LT::Native>,
 {
     let array: PrimitiveArray<LT> = binary_opt::<_, _, _, LT>(left, right, op)?;

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -29,11 +29,10 @@ use crate::compute::util::combine_option_bitmap;
 use crate::datatypes::{
     ArrowNativeType, ArrowNativeTypeOp, ArrowNumericType, DataType, Date32Type,
     Date64Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
-    IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit, IntervalYearMonthType,
-    Time32MillisecondType, Time32SecondType, Time64MicrosecondType, Time64NanosecondType,
-    TimeUnit, TimestampMicrosecondType, TimestampMillisecondType,
-    TimestampNanosecondType, TimestampSecondType, UInt16Type, UInt32Type, UInt64Type,
-    UInt8Type,
+    IntervalDayTimeType, IntervalUnit, IntervalYearMonthType, Time32MillisecondType,
+    Time32SecondType, Time64MicrosecondType, Time64NanosecondType, TimeUnit,
+    TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+    TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
 #[allow(unused_imports)]
 use crate::downcast_dictionary_array;
@@ -2329,10 +2328,10 @@ macro_rules! typed_compares {
                 DataType::Interval(IntervalUnit::DayTime),
                 DataType::Interval(IntervalUnit::DayTime),
             ) => cmp_primitive_array::<IntervalDayTimeType, _>($LEFT, $RIGHT, $OP),
-            (
-                DataType::Interval(IntervalUnit::MonthDayNano),
-                DataType::Interval(IntervalUnit::MonthDayNano),
-            ) => cmp_primitive_array::<IntervalMonthDayNanoType, _>($LEFT, $RIGHT, $OP),
+            // (
+            //     DataType::Interval(IntervalUnit::MonthDayNano),
+            //     DataType::Interval(IntervalUnit::MonthDayNano),
+            // ) => cmp_primitive_array::<IntervalMonthDayNanoType, _>($LEFT, $RIGHT, $OP),
             (t1, t2) if t1 == t2 => Err(ArrowError::NotYetImplemented(format!(
                 "Comparing arrays of type {} is not yet implemented",
                 t1
@@ -4038,6 +4037,8 @@ mod tests {
             )
         );
 
+        // IntervalMonthDayNano is no longer a numeric type and so can't be compared
+        /*
         let a = IntervalMonthDayNanoArray::from(
             vec![Some(0), Some(6), Some(834), None, Some(3), None],
         );
@@ -4053,6 +4054,8 @@ mod tests {
                 vec![Some(true), Some(false), Some(false), None, Some(false), None]
             )
         );
+
+         */
 
         let a = IntervalYearMonthArray::from(
             vec![Some(0), Some(623), Some(834), None, Some(3), None],

--- a/arrow/src/datatypes/native.rs
+++ b/arrow/src/datatypes/native.rs
@@ -98,6 +98,7 @@ macro_rules! native_type_op {
                 })
             }
 
+            #[inline]
             fn add_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
             }
@@ -111,6 +112,7 @@ macro_rules! native_type_op {
                 })
             }
 
+            #[inline]
             fn sub_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_sub(rhs)
             }
@@ -124,6 +126,7 @@ macro_rules! native_type_op {
                 })
             }
 
+            #[inline]
             fn mul_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_mul(rhs)
             }
@@ -141,6 +144,7 @@ macro_rules! native_type_op {
                 }
             }
 
+            #[inline]
             fn div_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_div(rhs)
             }
@@ -158,6 +162,7 @@ macro_rules! native_type_op {
                 }
             }
 
+            #[inline]
             fn mod_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_rem(rhs)
             }
@@ -168,34 +173,42 @@ macro_rules! native_type_op {
                 })
             }
 
+            #[inline]
             fn neg_wrapping(self) -> Self {
                 self.wrapping_neg()
             }
 
+            #[inline]
             fn is_zero(self) -> bool {
                 self == 0
             }
 
+            #[inline]
             fn is_eq(self, rhs: Self) -> bool {
                 self == rhs
             }
 
+            #[inline]
             fn is_ne(self, rhs: Self) -> bool {
                 self != rhs
             }
 
+            #[inline]
             fn is_lt(self, rhs: Self) -> bool {
                 self < rhs
             }
 
+            #[inline]
             fn is_le(self, rhs: Self) -> bool {
                 self <= rhs
             }
 
+            #[inline]
             fn is_gt(self, rhs: Self) -> bool {
                 self > rhs
             }
 
+            #[inline]
             fn is_ge(self, rhs: Self) -> bool {
                 self >= rhs
             }
@@ -219,26 +232,32 @@ macro_rules! native_type_float_op {
             const ZERO: Self = $zero;
             const ONE: Self = $one;
 
+            #[inline]
             fn add_checked(self, rhs: Self) -> Result<Self> {
                 Ok(self + rhs)
             }
 
+            #[inline]
             fn add_wrapping(self, rhs: Self) -> Self {
                 self + rhs
             }
 
+            #[inline]
             fn sub_checked(self, rhs: Self) -> Result<Self> {
                 Ok(self - rhs)
             }
 
+            #[inline]
             fn sub_wrapping(self, rhs: Self) -> Self {
                 self - rhs
             }
 
+            #[inline]
             fn mul_checked(self, rhs: Self) -> Result<Self> {
                 Ok(self * rhs)
             }
 
+            #[inline]
             fn mul_wrapping(self, rhs: Self) -> Self {
                 self * rhs
             }
@@ -251,6 +270,7 @@ macro_rules! native_type_float_op {
                 }
             }
 
+            #[inline]
             fn div_wrapping(self, rhs: Self) -> Self {
                 self / rhs
             }
@@ -263,42 +283,52 @@ macro_rules! native_type_float_op {
                 }
             }
 
+            #[inline]
             fn mod_wrapping(self, rhs: Self) -> Self {
                 self % rhs
             }
 
+            #[inline]
             fn neg_checked(self) -> Result<Self> {
                 Ok(-self)
             }
 
+            #[inline]
             fn neg_wrapping(self) -> Self {
                 -self
             }
 
+            #[inline]
             fn is_zero(self) -> bool {
                 self == $zero
             }
 
+            #[inline]
             fn is_eq(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_eq()
             }
 
+            #[inline]
             fn is_ne(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_ne()
             }
 
+            #[inline]
             fn is_lt(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_lt()
             }
 
+            #[inline]
             fn is_le(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_le()
             }
 
+            #[inline]
             fn is_gt(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_gt()
             }
 
+            #[inline]
             fn is_ge(self, rhs: Self) -> bool {
                 self.total_cmp(&rhs).is_ge()
             }

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -245,7 +245,7 @@
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [issue tracker]: https://github.com/apache/arrow-rs/issues
 //!
-
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 #![allow(rustdoc::invalid_html_tags)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2856.

# Rationale for this change

The `packed_simd` crate is no longer actively maintained and now also causes some issues when run under miri.

Performance numbers are inconclusive. The `sum` aggregation got a bit faster, but `min`/`max` got slower instead.

# What changes are included in this PR?



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

- `IntervalMonthDayNanoType` is no longer a numeric type because of missing support for `i128` lanes in `portable_simd`. The arithmetic kernels on this type should work the same as before since they did not really rely on the numeric type and could instead work with any primitive type. Comparison kernels for this type are no longer implemented though.
- `ArrowFloatNumericType` no longer contains a `pow` method because this is not yet implemented in `portable_simd`. It seems this was only enabled in the simd version of the trait, so it is unlikely there are many users.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

# Aggregation benchmark results

```
$ RUSTFLAGS="-Ctarget-cpu=native -Copt-level=3" perf record cargo +stage1 bench --features simd,test_utils --bench aggregate_kernels -- --baseline base-avx512
Finished bench [optimized] target(s) in 48.15s
     Running benches/aggregate_kernels.rs (/home/jhorstmann/Source/github/apache/arrow-rs/target/release/deps/aggregate_kernels-1fb22fbe1680a1da)
float/sum 4096          time:   [269.73 ns 269.82 ns 269.93 ns]
                        thrpt:  [56.528 GiB/s 56.552 GiB/s 56.571 GiB/s]
                 change:
                        time:   [-5.4739% -5.4122% -5.3486%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6508% +5.7219% +5.7909%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
float/min 4096          time:   [488.84 ns 488.98 ns 489.15 ns]
                        thrpt:  [31.194 GiB/s 31.205 GiB/s 31.214 GiB/s]
                 change:
                        time:   [+1.5681% +1.6031% +1.6388%] (p = 0.00 < 0.05)
                        thrpt:  [-1.6124% -1.5778% -1.5439%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
float/max 4096          time:   [429.91 ns 429.96 ns 430.03 ns]
                        thrpt:  [35.483 GiB/s 35.489 GiB/s 35.493 GiB/s]
                 change:
                        time:   [+1.1078% +1.1743% +1.2240%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2092% -1.1606% -1.0957%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe
float/sum nulls 4096    time:   [350.29 ns 350.31 ns 350.33 ns]
                        thrpt:  [43.556 GiB/s 43.558 GiB/s 43.560 GiB/s]
                 change:
                        time:   [-26.221% -26.194% -26.173%] (p = 0.00 < 0.05)
                        thrpt:  [+35.452% +35.490% +35.540%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
float/min nulls 4096    time:   [1.2936 µs 1.2939 µs 1.2943 µs]
                        thrpt:  [11.789 GiB/s 11.793 GiB/s 11.795 GiB/s]
                 change:
                        time:   [+18.173% +18.230% +18.275%] (p = 0.00 < 0.05)
                        thrpt:  [-15.451% -15.419% -15.378%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
float/max nulls 4096    time:   [1.1110 µs 1.1111 µs 1.1112 µs]
                        thrpt:  [13.732 GiB/s 13.733 GiB/s 13.734 GiB/s]
                 change:
                        time:   [+3.3113% +3.3532% +3.3820%] (p = 0.00 < 0.05)
                        thrpt:  [-3.2714% -3.2444% -3.2052%]
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

double/sum 4096         time:   [568.14 ns 568.17 ns 568.20 ns]
                        thrpt:  [53.709 GiB/s 53.712 GiB/s 53.715 GiB/s]
                 change:
                        time:   [-2.0800% -1.9542% -1.8825%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9186% +1.9931% +2.1241%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
double/min 4096         time:   [948.68 ns 948.72 ns 948.76 ns]
                        thrpt:  [32.166 GiB/s 32.167 GiB/s 32.169 GiB/s]
                 change:
                        time:   [+1.3964% +1.4045% +1.4134%] (p = 0.00 < 0.05)
                        thrpt:  [-1.3937% -1.3850% -1.3772%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
double/max 4096         time:   [832.17 ns 832.27 ns 832.40 ns]
                        thrpt:  [36.662 GiB/s 36.668 GiB/s 36.672 GiB/s]
                 change:
                        time:   [+1.9066% +1.9232% +1.9399%] (p = 0.00 < 0.05)
                        thrpt:  [-1.9029% -1.8869% -1.8709%]
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
double/sum nulls 4096   time:   [654.15 ns 654.19 ns 654.24 ns]
                        thrpt:  [46.646 GiB/s 46.649 GiB/s 46.653 GiB/s]
                 change:
                        time:   [-16.146% -16.137% -16.129%] (p = 0.00 < 0.05)
                        thrpt:  [+19.231% +19.243% +19.255%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
double/min nulls 4096   time:   [2.5084 µs 2.5086 µs 2.5090 µs]
                        thrpt:  [12.163 GiB/s 12.165 GiB/s 12.166 GiB/s]
                 change:
                        time:   [+18.631% +18.650% +18.672%] (p = 0.00 < 0.05)
                        thrpt:  [-15.734% -15.719% -15.705%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
double/max nulls 4096   time:   [2.1508 µs 2.1509 µs 2.1510 µs]
                        thrpt:  [14.188 GiB/s 14.189 GiB/s 14.189 GiB/s]
                 change:
                        time:   [+0.9921% +1.0044% +1.0168%] (p = 0.00 < 0.05)
                        thrpt:  [-1.0065% -0.9945% -0.9824%]
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

string/min string 4096  time:   [11.783 µs 11.786 µs 11.789 µs]
                        thrpt:  [2.5887 GiB/s 2.5894 GiB/s 2.5901 GiB/s]
                 change:
                        time:   [-0.4596% -0.4101% -0.3598%] (p = 0.00 < 0.05)
                        thrpt:  [+0.3611% +0.4118% +0.4617%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
```

The `portable_simd` crate has an internal switch to a bit-based mask representation when the avx512 target feature is enabled. Since target features do not apply to the standard library this can only be used via `Zbuild-std` or by using the crate as a regular dependency. I'm still looking into the performance with that feature activated (see https://github.com/rust-lang/portable-simd/issues/312 and https://github.com/llvm/llvm-project/issues/58546).