### PR TITLE
Update required half from 2.0 --> 2.1

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -51,7 +51,7 @@ arrow-data = { version = "25.0.0", path = "../arrow-data" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.7", optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
-half = { version = "2.0", default-features = false }
+half = { version = "2.1", default-features = false }
 hashbrown = { version = "0.12", default-features = false }
 
 [dev-dependencies]

--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -39,7 +39,7 @@ bench = false
 
 [dependencies]
 num = { version = "0.4", default-features = false, features = ["std"] }
-half = { version = "2.0", default-features = false }
+half = { version = "2.1", default-features = false }
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/arrow-data/Cargo.toml
+++ b/arrow-data/Cargo.toml
@@ -49,7 +49,7 @@ arrow-buffer = { version = "25.0.0", path = "../arrow-buffer" }
 arrow-schema = { version = "25.0.0", path = "../arrow-schema" }
 
 num = { version = "0.4", default-features = false, features = ["std"] }
-half = { version = "2.0", default-features = false }
+half = { version = "2.1", default-features = false }
 
 [dev-dependencies]
 

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 indexmap = { version = "1.9", default-features = false, features = ["std"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
-half = { version = "2.0", default-features = false, features = ["num-traits"] }
+half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.12", default-features = false }
 csv_crate = { version = "1.1", default-features = false, optional = true, package = "csv" }
 regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/2926

# Rationale for this change
 
arrow-rs doesn't compile with half `2.0` -- it needs `2.1`

# What changes are included in this PR?

Update declared dependency

# Are there any user-facing changes?
No