### PR TITLE
Improve panic messages for RowSelection::and_then (#2925)

### DIFF
--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -223,6 +223,11 @@ impl RowSelection {
     /// returned: NNNNNNNNNNNNYYYYYNNNNYYYYYYYYYYYYYNNNYYNNN
     ///
     ///
+    /// # Panics
+    ///
+    /// Panics if `other` does not have a length equal to the number of rows selected
+    /// by this RowSelection
+    ///
     pub fn and_then(&self, other: &Self) -> Self {
         let mut selectors = vec![];
         let mut first = self.selectors.iter().cloned().peekable();
@@ -230,10 +235,14 @@ impl RowSelection {
 
         let mut to_skip = 0;
         while let Some(b) = second.peek_mut() {
-            let a = first.peek_mut().unwrap();
+            let a = first
+                .peek_mut()
+                .expect("selection exceeds the number of selected rows");
 
             if b.row_count == 0 {
-                second.next().unwrap();
+                second
+                    .next()
+                    .expect("selection contains less than the number of selected rows");
                 continue;
             }
 
@@ -269,7 +278,10 @@ impl RowSelection {
 
         for v in first {
             if v.row_count != 0 {
-                assert!(v.skip);
+                assert!(
+                    v.skip,
+                    "selection contains less than the number of selected rows"
+                );
                 to_skip += v.row_count
             }
         }
@@ -458,6 +470,32 @@ mod tests {
                 RowSelector::skip(4)
             ]
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "selection exceeds the number of selected rows")]
+    fn test_and_longer() {
+        let a = RowSelection::from(vec![
+            RowSelector::select(3),
+            RowSelector::skip(33),
+            RowSelector::select(3),
+            RowSelector::skip(33),
+        ]);
+        let b = RowSelection::from(vec![RowSelector::select(36)]);
+        a.and_then(&b);
+    }
+
+    #[test]
+    #[should_panic(expected = "selection contains less than the number of selected rows")]
+    fn test_and_shorter() {
+        let a = RowSelection::from(vec![
+            RowSelector::select(3),
+            RowSelector::skip(33),
+            RowSelector::select(3),
+            RowSelector::skip(33),
+        ]);
+        let b = RowSelection::from(vec![RowSelector::select(3)]);
+        a.and_then(&b);
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -240,9 +240,7 @@ impl RowSelection {
                 .expect("selection exceeds the number of selected rows");
 
             if b.row_count == 0 {
-                second
-                    .next()
-                    .expect("selection contains less than the number of selected rows");
+                second.next().unwrap();
                 continue;
             }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2925

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
