### PR TITLE
Benchmark with prepared row converter

### DIFF
--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -45,6 +45,9 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 
     let mut converter = RowConverter::new(fields);
     let rows = converter.convert_columns(&cols).unwrap();
+    c.bench_function(&format!("convert_columns_prepared {}", name), |b| {
+        b.iter(|| black_box(converter.convert_columns(&cols).unwrap()));
+    });
 
     c.bench_function(&format!("convert_rows {}", name), |b| {
         b.iter(|| black_box(converter.convert_rows(&rows).unwrap()));

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -45,6 +45,7 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 
     let mut converter = RowConverter::new(fields);
     let rows = converter.convert_columns(&cols).unwrap();
+    // using a pre-prepared row converter should be faster than the first time
     c.bench_function(&format!("convert_columns_prepared {}", name), |b| {
         b.iter(|| black_box(converter.convert_columns(&cols).unwrap()));
     });


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There wasn't a benchmark covering the case of seeing a dictionary containing values that have been seen before, this adds that case. It is this case that justifies the hashmap within the Interner, which otherwise is just additional overhead.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Adds additional benchmark coverage.

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
