### PR TITLE
Format Timestamps as RFC3339

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -124,7 +124,7 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// let arr = TimestampSecondArray::from(vec![11111111]);
 /// // OR
 /// let arr = TimestampSecondArray::from(vec![Some(11111111)]);
-/// let utc_tz: Tz = "UTC".parse().unwrap();
+/// let utc_tz: Tz = "+00:00".parse().unwrap();
 ///
 /// assert_eq!(arr.value_as_datetime_with_tz(0, utc_tz).map(|v| v.to_string()).unwrap(), "1970-05-09 14:25:11 +00:00")
 /// ```
@@ -137,7 +137,7 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// let arr = TimestampSecondArray::from(vec![-11111111]);
 /// // OR
 /// let arr = TimestampSecondArray::from(vec![Some(-11111111)]);
-/// let utc_tz: Tz = "UTC".parse().unwrap();
+/// let utc_tz: Tz = "+00:00".parse().unwrap();
 ///
 /// assert_eq!(arr.value_as_datetime_with_tz(0, utc_tz).map(|v| v.to_string()).unwrap(), "1969-08-25 09:34:49 +00:00")
 /// ```

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -18,7 +18,10 @@
 use crate::builder::{BooleanBufferBuilder, BufferBuilder, PrimitiveBuilder};
 use crate::iterator::PrimitiveIter;
 use crate::raw_pointer::RawPtrBox;
-use crate::temporal_conversions::{as_date, as_datetime, as_duration, as_time};
+use crate::temporal_conversions::{
+    as_date, as_datetime, as_datetime_with_timezone, as_duration, as_time,
+};
+use crate::timezone::Tz;
 use crate::trusted_len::trusted_len_unzip;
 use crate::types::*;
 use crate::{print_long_array, Array, ArrayAccessor};
@@ -26,7 +29,7 @@ use arrow_buffer::{i256, ArrowNativeType, Buffer};
 use arrow_data::bit_iterator::try_for_each_valid_idx;
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType};
-use chrono::{Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use half::f16;
 use std::any::Any;
 
@@ -503,12 +506,8 @@ where
     ///
     /// functionally it is same as `value_as_datetime`, however it adds
     /// the passed tz to the to-be-returned NaiveDateTime
-    pub fn value_as_datetime_with_tz(
-        &self,
-        i: usize,
-        tz: FixedOffset,
-    ) -> Option<NaiveDateTime> {
-        as_datetime::<T>(i64::from(self.value(i))).map(|datetime| datetime + tz)
+    pub fn value_as_datetime_with_tz(&self, i: usize, tz: Tz) -> Option<DateTime<Tz>> {
+        as_datetime_with_timezone::<T>(i64::from(self.value(i)), tz)
     }
 
     /// Returns value as a chrono `NaiveDate` by using `Self::datetime()`

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -119,40 +119,40 @@ pub type Float64Array = PrimitiveArray<Float64Type>;
 /// # Example: UTC timestamps post epoch
 /// ```
 /// # use arrow_array::TimestampSecondArray;
-/// use chrono::FixedOffset;
+/// use arrow_array::timezone::Tz;
 /// // Corresponds to single element array with entry 1970-05-09T14:25:11+0:00
 /// let arr = TimestampSecondArray::from(vec![11111111]);
 /// // OR
 /// let arr = TimestampSecondArray::from(vec![Some(11111111)]);
-/// let utc_offset = FixedOffset::east(0);
+/// let utc_tz: Tz = "UTC".parse().unwrap();
 ///
-/// assert_eq!(arr.value_as_datetime_with_tz(0, utc_offset).map(|v| v.to_string()).unwrap(), "1970-05-09 14:25:11")
+/// assert_eq!(arr.value_as_datetime_with_tz(0, utc_tz).map(|v| v.to_string()).unwrap(), "1970-05-09 14:25:11 +00:00")
 /// ```
 ///
 /// # Example: UTC timestamps pre epoch
 /// ```
 /// # use arrow_array::TimestampSecondArray;
-/// use chrono::FixedOffset;
+/// use arrow_array::timezone::Tz;
 /// // Corresponds to single element array with entry 1969-08-25T09:34:49+0:00
 /// let arr = TimestampSecondArray::from(vec![-11111111]);
 /// // OR
 /// let arr = TimestampSecondArray::from(vec![Some(-11111111)]);
-/// let utc_offset = FixedOffset::east(0);
+/// let utc_tz: Tz = "UTC".parse().unwrap();
 ///
-/// assert_eq!(arr.value_as_datetime_with_tz(0, utc_offset).map(|v| v.to_string()).unwrap(), "1969-08-25 09:34:49")
+/// assert_eq!(arr.value_as_datetime_with_tz(0, utc_tz).map(|v| v.to_string()).unwrap(), "1969-08-25 09:34:49 +00:00")
 /// ```
 ///
 /// # Example: With timezone specified
 /// ```
 /// # use arrow_array::TimestampSecondArray;
-/// use chrono::FixedOffset;
+/// use arrow_array::timezone::Tz;
 /// // Corresponds to single element array with entry 1970-05-10T00:25:11+10:00
 /// let arr = TimestampSecondArray::from(vec![11111111]).with_timezone("+10:00".to_string());
 /// // OR
 /// let arr = TimestampSecondArray::from(vec![Some(11111111)]).with_timezone("+10:00".to_string());
-/// let sydney_offset = FixedOffset::east(10 * 60 * 60);
+/// let sydney_tz: Tz = "+10:00".parse().unwrap();
 ///
-/// assert_eq!(arr.value_as_datetime_with_tz(0, sydney_offset).map(|v| v.to_string()).unwrap(), "1970-05-10 00:25:11")
+/// assert_eq!(arr.value_as_datetime_with_tz(0, sydney_tz).map(|v| v.to_string()).unwrap(), "1970-05-10 00:25:11 +10:00")
 /// ```
 ///
 pub type TimestampSecondArray = PrimitiveArray<TimestampSecondType>;

--- a/arrow/src/util/display.rs
+++ b/arrow/src/util/display.rs
@@ -33,6 +33,7 @@ use crate::{array, datatypes::IntervalUnit};
 use array::DictionaryArray;
 
 use crate::error::{ArrowError, Result};
+use arrow_array::timezone::Tz;
 
 macro_rules! make_string {
     ($array_type:ty, $column: ident, $row: ident) => {{
@@ -190,8 +191,31 @@ macro_rules! make_string_datetime {
         } else {
             array
                 .value_as_datetime($row)
-                .map(|d| d.to_string())
+                .map(|d| format!("{:?}", d))
                 .unwrap_or_else(|| "ERROR CONVERTING DATE".to_string())
+        };
+
+        Ok(s)
+    }};
+}
+
+macro_rules! make_string_datetime_with_tz {
+    ($array_type:ty, $tz_string: ident, $column: ident, $row: ident) => {{
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+
+        let s = if array.is_null($row) {
+            "".to_string()
+        } else {
+            match $tz_string.parse::<Tz>() {
+                Ok(tz) => array
+                    .value_as_datetime_with_tz($row, tz)
+                    .map(|d| format!("{}", d.to_rfc3339()))
+                    .unwrap_or_else(|| "ERROR CONVERTING DATE".to_string()),
+                Err(_) => array
+                    .value_as_datetime($row)
+                    .map(|d| format!("{:?} (Unknown Time Zone '{}')", d, $tz_string))
+                    .unwrap_or_else(|| "ERROR CONVERTING DATE".to_string()),
+            }
         };
 
         Ok(s)
@@ -334,17 +358,55 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::Float32 => make_string!(array::Float32Array, column, row),
         DataType::Float64 => make_string!(array::Float64Array, column, row),
         DataType::Decimal128(..) => make_string_from_decimal(column, row),
-        DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
-            make_string_datetime!(array::TimestampSecondArray, column, row)
+        DataType::Timestamp(unit, tz_string_opt) if *unit == TimeUnit::Second => {
+            match tz_string_opt {
+                Some(tz_string) => make_string_datetime_with_tz!(
+                    array::TimestampSecondArray,
+                    tz_string,
+                    column,
+                    row
+                ),
+                None => make_string_datetime!(array::TimestampSecondArray, column, row),
+            }
         }
-        DataType::Timestamp(unit, _) if *unit == TimeUnit::Millisecond => {
-            make_string_datetime!(array::TimestampMillisecondArray, column, row)
+        DataType::Timestamp(unit, tz_string_opt) if *unit == TimeUnit::Millisecond => {
+            match tz_string_opt {
+                Some(tz_string) => make_string_datetime_with_tz!(
+                    array::TimestampMillisecondArray,
+                    tz_string,
+                    column,
+                    row
+                ),
+                None => {
+                    make_string_datetime!(array::TimestampMillisecondArray, column, row)
+                }
+            }
         }
-        DataType::Timestamp(unit, _) if *unit == TimeUnit::Microsecond => {
-            make_string_datetime!(array::TimestampMicrosecondArray, column, row)
+        DataType::Timestamp(unit, tz_string_opt) if *unit == TimeUnit::Microsecond => {
+            match tz_string_opt {
+                Some(tz_string) => make_string_datetime_with_tz!(
+                    array::TimestampMicrosecondArray,
+                    tz_string,
+                    column,
+                    row
+                ),
+                None => {
+                    make_string_datetime!(array::TimestampMicrosecondArray, column, row)
+                }
+            }
         }
-        DataType::Timestamp(unit, _) if *unit == TimeUnit::Nanosecond => {
-            make_string_datetime!(array::TimestampNanosecondArray, column, row)
+        DataType::Timestamp(unit, tz_string_opt) if *unit == TimeUnit::Nanosecond => {
+            match tz_string_opt {
+                Some(tz_string) => make_string_datetime_with_tz!(
+                    array::TimestampNanosecondArray,
+                    tz_string,
+                    column,
+                    row
+                ),
+                None => {
+                    make_string_datetime!(array::TimestampNanosecondArray, column, row)
+                }
+            }
         }
         DataType::Date32 => make_string_date!(array::Date32Array, column, row),
         DataType::Date64 => make_string_date!(array::Date64Array, column, row),

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -400,6 +400,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(features = "chrono-tz")]
     fn test_pretty_format_timestamp_second_with_utc_timezone() {
         let expected = vec![
             "+---------------------------+",
@@ -418,6 +419,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(features = "chrono-tz")]
     fn test_pretty_format_timestamp_second_with_non_utc_timezone() {
         let expected = vec![
             "+---------------------------+",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2934 
Closes #2937 

1. follows rfc3339 to format timestamp as `2000-01-01T00:00:00+08:00` instead of `2000-01-01 00:00:00 +08:00`
2. prettyprint to support timezone

this
```rust

use arrow::array::{
    Array, ArrayData, BooleanArray, Int32Array, Int32Builder, ListArray, PrimitiveArray,
    StringArray, StructArray, TimestampSecondArray,
};
use arrow::datatypes::*;
use arrow::record_batch::RecordBatch;
use std::sync::Arc;

use arrow::util::pretty::{pretty_format_batches, print_batches};

fn main() {
    println!("------------------------------------------------------------------------------------------------------------------");

    let arr =
        TimestampSecondArray::from_vec(vec![0, 1, 2, 3], Some("Asia/Taipei".to_string()));
    let schema = Arc::new(Schema::new(vec![Field::new(
        &arr.data_type().to_string(),
        arr.data_type().clone(),
        true,
    )]));

    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
    print_batches(&[batch]).unwrap();

    println!("------------------------------------------------------------------------------------------------------------------");

    let arr = TimestampSecondArray::from_vec(vec![0], Some("Asia/Taipei2".to_string()));
    let schema = Arc::new(Schema::new(vec![Field::new(
        &arr.data_type().to_string(),
        arr.data_type().clone(),
        true,
    )]));

    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
    print_batches(&[batch]).unwrap();

    println!("------------------------------------------------------------------------------------------------------------------");

    let arr = TimestampSecondArray::from_vec(vec![0], Some("+08:00".to_string()));
    let schema = Arc::new(Schema::new(vec![Field::new(
        &arr.data_type().to_string(),
        arr.data_type().clone(),
        true,
    )]));

    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
    print_batches(&[batch]).unwrap();

    println!("------------------------------------------------------------------------------------------------------------------");

    let arr: PrimitiveArray<TimestampMicrosecondType> =
        vec![Some(37800000000), None, Some(86339000000)].into();
    let schema = Arc::new(Schema::new(vec![Field::new(
        &arr.data_type().to_string(),
        arr.data_type().clone(),
        true,
    )]));

    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
    print_batches(&[batch]).unwrap();

    println!("-----------------------------------------------------------------------------------------------------------------");

    let arr: PrimitiveArray<TimestampMicrosecondType> =
        vec![Some(37800000000), None, Some(86339000000)].into();

    let arr = arr.with_timezone("Australia/Sydney".to_string());

    let schema = Arc::new(Schema::new(vec![Field::new(
        &arr.data_type().to_string(),
        arr.data_type().clone(),
        true,
    )]));

    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
    print_batches(&[batch]).unwrap();
}

```
outputs

```bash
---------------------------------
+----------------------------------------+
| Timestamp(Second, Some("Asia/Taipei")) |
+----------------------------------------+
| 1970-01-01T08:00:00+08:00              |
| 1970-01-01T08:00:01+08:00              |
| 1970-01-01T08:00:02+08:00              |
| 1970-01-01T08:00:03+08:00              |
+----------------------------------------+
------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------+
| Timestamp(Second, Some("Asia/Taipei2"))                |
+--------------------------------------------------------+
| 1970-01-01T00:00:00 (Unknown Time Zone 'Asia/Taipei2') |
+--------------------------------------------------------+
------------------------------------------------------------------------------------------------------------------
+-----------------------------------+
| Timestamp(Second, Some("+08:00")) |
+-----------------------------------+
| 1970-01-01T08:00:00+08:00         |
+-----------------------------------+
------------------------------------------------------------------------------------------------------------------
+------------------------------+
| Timestamp(Microsecond, None) |
+------------------------------+
| 1970-01-01T10:30:00          |
|                              |
| 1970-01-01T23:58:59          |
+------------------------------+
-----------------------------------------------------------------------------------------------------------------
+--------------------------------------------------+
| Timestamp(Microsecond, Some("Australia/Sydney")) |
+--------------------------------------------------+
| 1970-01-01T20:30:00+10:00                        |
|                                                  |
| 1970-01-02T09:58:59+10:00                        |
```

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
yes, timestamp format changed


<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

