### PR TITLE
Added support for LZ4_RAW compression. (#1604)

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -282,6 +282,7 @@ pub enum Encoding {
 
 /// Supported compression algorithms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
 pub enum Compression {
     UNCOMPRESSED,
     SNAPPY,
@@ -290,6 +291,7 @@ pub enum Compression {
     BROTLI,
     LZ4,
     ZSTD,
+    LZ4_RAW,
 }
 
 // ----------------------------------------------------------------------
@@ -826,6 +828,7 @@ impl TryFrom<parquet::CompressionCodec> for Compression {
             parquet::CompressionCodec::BROTLI => Compression::BROTLI,
             parquet::CompressionCodec::LZ4 => Compression::LZ4,
             parquet::CompressionCodec::ZSTD => Compression::ZSTD,
+            parquet::CompressionCodec::LZ4_RAW => Compression::LZ4_RAW,
             _ => {
                 return Err(general_err!(
                     "unexpected parquet compression codec: {}",
@@ -846,6 +849,7 @@ impl From<Compression> for parquet::CompressionCodec {
             Compression::BROTLI => parquet::CompressionCodec::BROTLI,
             Compression::LZ4 => parquet::CompressionCodec::LZ4,
             Compression::ZSTD => parquet::CompressionCodec::ZSTD,
+            Compression::LZ4_RAW => parquet::CompressionCodec::LZ4_RAW,
         }
     }
 }

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -329,8 +329,6 @@ pub use zstd_codec::*;
 
 #[cfg(any(feature = "lz4", test))]
 mod lz4_raw_codec {
-    use std::io::{Read, Write};
-
     use crate::compression::Codec;
     use crate::errors::Result;
 

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -77,6 +77,8 @@ pub fn create_codec(codec: CodecType) -> Result<Option<Box<dyn Codec>>> {
         CodecType::LZ4 => Ok(Some(Box::new(LZ4Codec::new()))),
         #[cfg(any(feature = "zstd", test))]
         CodecType::ZSTD => Ok(Some(Box::new(ZSTDCodec::new()))),
+        #[cfg(any(feature = "lz4", test))]
+        CodecType::LZ4_RAW => Ok(Some(Box::new(LZ4RawCodec::new()))),
         CodecType::UNCOMPRESSED => Ok(None),
         _ => Err(nyi_err!("The codec type {} is not supported yet", codec)),
     }
@@ -325,6 +327,65 @@ mod zstd_codec {
 #[cfg(any(feature = "zstd", test))]
 pub use zstd_codec::*;
 
+#[cfg(any(feature = "lz4", test))]
+mod lz4_raw_codec {
+    use std::io::{Read, Write};
+
+    use crate::compression::Codec;
+    use crate::errors::Result;
+
+    /// Codec for LZ4 Raw compression algorithm.
+    pub struct LZ4RawCodec {}
+
+    impl LZ4RawCodec {
+        /// Creates new LZ4 Raw compression codec.
+        pub(crate) fn new() -> Self {
+            Self {}
+        }
+    }
+
+    // Compute max LZ4 uncompress size.
+    // Check https://stackoverflow.com/questions/25740471/lz4-library-decompressed-data-upper-bound-size-estimation
+    fn max_uncompressed_size(compressed_size: usize) -> usize {
+        (compressed_size << 8) - compressed_size - 2526
+    }
+
+    impl Codec for LZ4RawCodec {
+        fn decompress(
+            &mut self,
+            input_buf: &[u8],
+            output_buf: &mut Vec<u8>,
+        ) -> Result<usize> {
+            let offset = output_buf.len();
+            let required_len = max_uncompressed_size(input_buf.len());
+            output_buf.resize(offset + required_len, 0);
+            let required_len: i32 = required_len.try_into().unwrap();
+            match lz4::block::decompress_to_buffer(input_buf, Some(required_len), &mut output_buf[offset..]) {
+                Ok(n) => {
+                    output_buf.truncate(offset + n);
+                    Ok(n)   
+                },
+                Err(e) => Err(e.into()),
+            }
+        }
+
+        fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
+            let offset = output_buf.len();
+            let required_len = lz4::block::compress_bound(input_buf.len())?;
+            output_buf.resize(offset + required_len, 0);
+            match lz4::block::compress_to_buffer(input_buf, None, false, &mut output_buf[offset..]) {
+                Ok(n) => {
+                    output_buf.truncate(offset + n);
+                    Ok(())
+                },
+                Err(e) => Err(e.into()),
+            }
+        }
+    }
+}
+#[cfg(any(feature = "lz4", test))]
+pub use lz4_raw_codec::*;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -415,5 +476,10 @@ mod tests {
     #[test]
     fn test_codec_zstd() {
         test_codec(CodecType::ZSTD);
+    }
+
+    #[test]
+    fn test_codec_lz4_raw() {
+        test_codec(CodecType::LZ4_RAW);
     }
 }


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1604

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

* This adds the implementation of LZ4_RAW codec by using lz4 block compression algorithm. (#1604)
* This commit uses https://stackoverflow.com/questions/25740471/lz4-library-decompressed-data-upper-bound-size-estimation formula to estime the size of the uncompressed size. As it is said in thread, this algorithm over-estimates the size, but it is probably the best we can get with the current decompress API. As the size of a arrow LZ4_RAW block is not prepended to the block.
* Other option would be to take the C++ approach to bypass the API https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/compression_lz4.cc#L343. This approach consists on relaying on the output_buffer capacity to guess the uncompress_size. This works as `serialized_reader.rs` already knows the uncompressed_size, as it reads it from the page header, and allocates the output_buffer with a capacity equal to the uncompress_size https://github.com/marioloko/arrow-rs/blob/master/parquet/src/file/serialized_reader.rs#L417. I did not follow this approach because:
    1. It is too hacky.
    2. It will limit the use cases of the `decompress` API, as the caller will need to know to allocate the right uncompressed_size.
    3. It is not compatible with the current test logic followed by the other codecs. However, specific tests can be created if needed.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The implementation of an LZ4_RAW codec using LZ4 block algorithm.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No changes in the API, but parquet files compressed using LZ4_RAW will be supported now.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
