### PR TITLE
fix datatype for timestamptz debug fmt

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -535,8 +535,9 @@ where
 
 impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "PrimitiveArray<{:?}>\n[\n", T::DATA_TYPE)?;
-        print_long_array(self, f, |array, index, f| match T::DATA_TYPE {
+        let data_type = self.data_type();
+        write!(f, "PrimitiveArray<{:?}>\n[\n", data_type)?;
+        print_long_array(self, f, |array, index, f| match data_type {
             DataType::Date32 | DataType::Date64 => {
                 let v = self.value(index).to_isize().unwrap() as i64;
                 match as_date::<T>(v) {
@@ -1318,6 +1319,36 @@ mod tests {
             ]);
         assert_eq!(
             "PrimitiveArray<Timestamp(Millisecond, None)>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n  1921-01-02T00:00:00,\n]",
+            format!("{:?}", arr)
+        );
+    }
+
+    #[test]
+    fn test_timestamp_with_tz_fmt_debug() {
+        let arr: PrimitiveArray<TimestampMillisecondType> =
+            TimestampMillisecondArray::from(vec![
+                1546214400000,
+                1546214400000,
+                -1546214400000,
+            ])
+            .with_timezone("Asia/Taipei".to_string());
+        assert_eq!(
+            "PrimitiveArray<Timestamp(Millisecond, Some(\"Asia/Taipei\"))>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n  1921-01-02T00:00:00,\n]",
+            format!("{:?}", arr)
+        );
+    }
+
+    #[test]
+    fn test_timestamp_with_fixed_offset_tz_fmt_debug() {
+        let arr: PrimitiveArray<TimestampMillisecondType> =
+            TimestampMillisecondArray::from(vec![
+                1546214400000,
+                1546214400000,
+                -1546214400000,
+            ])
+            .with_timezone("+08:00".to_string());
+        assert_eq!(
+            "PrimitiveArray<Timestamp(Millisecond, Some(\"+08:00\"))>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n  1921-01-02T00:00:00,\n]",
             format!("{:?}", arr)
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

part of #2917

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

to print the correct data type when timestamp contains timezone

i'd like following

```rust
use arrow::array::{
    TimestampSecondArray,
};

fn main() {
    let a = TimestampSecondArray::from_vec(vec![0], None);
    println!("{:?}", a);

    let a = TimestampSecondArray::from_vec(vec![0], Some("+00:00".to_string()));
    println!("{:?}", a);

    let a = TimestampSecondArray::from_vec(vec![0], Some("UTC".to_string()));
    println!("{:?}", a);
}
```

to output 
```bash
PrimitiveArray<Timestamp(Second, None)>
[
  1970-01-01T00:00:00,
]
PrimitiveArray<Timestamp(Second, Some("+00:00"))>
[
  1970-01-01T00:00:00,
]
PrimitiveArray<Timestamp(Second, Some("UTC"))>
[
  1970-01-01T00:00:00,
]
```

instead of

```bash
PrimitiveArray<Timestamp(Second, None)>
[
  1970-01-01T00:00:00,
]
PrimitiveArray<Timestamp(Second, None)>
[
  1970-01-01T00:00:00,
]
PrimitiveArray<Timestamp(Second, None)>
[
  1970-01-01T00:00:00,
]
```


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

yes, original debug format for timestamptz didn't show timezoe in data type

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
