### PR TITLE
Pass decompressed size to parquet Codec::decompress (#2956)

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -420,7 +420,11 @@ pub(crate) fn decode_page(
             let mut decompressed = Vec::with_capacity(uncompressed_size);
             let compressed = &buffer.as_ref()[offset..];
             decompressed.extend_from_slice(&buffer.as_ref()[..offset]);
-            decompressor.decompress(compressed, &mut decompressed)?;
+            decompressor.decompress(
+                compressed,
+                &mut decompressed,
+                Some(uncompressed_size),
+            )?;
 
             if decompressed.len() != uncompressed_size {
                 return Err(general_err!(

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -423,7 +423,7 @@ pub(crate) fn decode_page(
             decompressor.decompress(
                 compressed,
                 &mut decompressed,
-                Some(uncompressed_size),
+                Some(uncompressed_size - offset),
             )?;
 
             if decompressed.len() != uncompressed_size {


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2956.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added optional argument `uncompressed_size` to `Coded::decompress` to do a better estimation of the required uncompress size.

* snappy: Probably no much improvement as `decompress_len` is already accurate.
* gzip: No improvement. Ignores the size hint.
* brotli: Probably no much improvement. The buffer size will be equal to the uncompressed_size size.
* lz4: No improvement. As the buffer is located at the stack there are no extra allocations. Then, it probably is better to keep it working as it is.
* zstd: No improvement. Ignores the size hint.
* lz4_raw: Improvement. The estimation method over-estimates, so knowin the uncompressed size reduces allocations.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Breaking changes on `Codec` trait. It only affects to users with `experimental` feature enable.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
