### PR TITLE
Move `byte_size` from datafusion::physical_expr

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -379,7 +379,7 @@ impl RecordBatch {
     }
 
     /// Returns the total number of bytes of memory occupied physically by this batch.
-    pub fn byte_size(&self) -> usize {
+    pub fn get_array_memory_size(&self) -> usize {
         self.columns()
             .iter()
             .map(|array| array.get_array_memory_size())
@@ -492,7 +492,7 @@ mod tests {
         let record_batch =
             RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])
                 .unwrap();
-        assert_eq!(record_batch.byte_size(), 592);
+        assert_eq!(record_batch.get_array_memory_size(), 592);
     }
 
     fn check_batch(record_batch: RecordBatch, num_rows: usize) {

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -380,8 +380,7 @@ impl RecordBatch {
 
     /// Returns the total number of bytes of memory occupied physically by this batch.
     pub fn byte_size(&self) -> usize {
-        self
-            .columns()
+        self.columns()
             .iter()
             .map(|array| array.get_array_memory_size())
             .sum()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2964.

# Rationale for this change
 
Explained in the issue.

# What changes are included in this PR?

A `byte_size()` function.

# Are there any user-facing changes?

They can now know the size of their batches.