### PR TITLE
Fix ignored limit on `lexsort_to_indices`

### DIFF
--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -3454,6 +3454,7 @@ mod tests {
         test_lex_sort_arrays(input.clone(), expected.clone(), None);
         test_lex_sort_arrays(input.clone(), slice_arrays(expected, 0, 2), Some(2));
 
+        // Explicitly test a limit on the sort as a demonstration
         let expected = vec![Arc::new(PrimitiveArray::<Int64Type>::from(vec![
             Some(-1),
             Some(0),
@@ -3719,7 +3720,7 @@ mod tests {
             Some(5),
         );
 
-        // Limiting by more rows than present should is ok
+        // Limiting by more rows than present is ok
         test_lex_sort_arrays(input, slice_arrays(expected, 0, 5), Some(10));
     }
 

--- a/arrow/src/compute/kernels/sort.rs
+++ b/arrow/src/compute/kernels/sort.rs
@@ -1422,7 +1422,7 @@ mod tests {
         }
     }
 
-    /// slace all arrays in expected_output to offset/length
+    /// slice all arrays in expected_output to offset/length
     fn slice_arrays(
         expected_output: Vec<ArrayRef>,
         offset: usize,


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/2990


# Rationale for this change
 
Regresssion was introduced in  https://github.com/apache/arrow-rs/pull/2929 by https://github.com/apache/arrow-rs/pull/2929/files#r1005140128  and there was no test coverage 😭 

# What changes are included in this PR?
1. Fix bug
2. Add test coverage

# Are there any user-facing changes?
Not really as we haven't released this code yet


cc @isidentical