### PR TITLE
Add `RowSelection::from_selectors_and_combine` to  merge RowSelectors 

### DIFF
--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -505,7 +505,7 @@ mod tests {
                 RowSelector::select(2),
                 RowSelector::skip(1),
                 RowSelector::select(1),
-                RowSelector::skip(4),
+                RowSelector::skip(4)
             ]
         );
     }

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -145,7 +145,9 @@ impl RowSelection {
         }
         add_selector(selected, sum_rows, &mut combined_result);
 
-        Self::from(combined_result)
+        Self {
+            selectors: combined_result,
+        }
     }
 
     /// Given an offset index, return the offset ranges for all data pages selected by `self`
@@ -338,7 +340,7 @@ impl RowSelection {
 
 impl From<Vec<RowSelector>> for RowSelection {
     fn from(selectors: Vec<RowSelector>) -> Self {
-        Self { selectors }
+        Self::from_selectors_and_combine(selectors.as_slice())
     }
 }
 
@@ -547,6 +549,17 @@ mod tests {
         assert_eq!(RowSelection::from_selectors_and_combine(&a), expected);
         assert_eq!(RowSelection::from_selectors_and_combine(&b), expected);
         assert_eq!(RowSelection::from_selectors_and_combine(&c), expected);
+    }
+
+    #[test]
+    fn test_from_one_and_empty() {
+        let a = vec![RowSelector::select(10)];
+        let selection1 = RowSelection::from(a.clone());
+        assert_eq!(selection1.selectors, a);
+
+        let b = vec![];
+        let selection1 = RowSelection::from(b.clone());
+        assert_eq!(selection1.selectors, b)
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -121,8 +121,7 @@ impl RowSelection {
     /// Like [skip(5),skip(5),read(10)].
     /// After combine will return [skip(10),read(10)]
     /// # Note
-    /// If directly use uncombined `RowSelection` with offset_index in parquet
-    /// will panic.
+    ///  [`RowSelection`] must be combined prior to use within offset_index or else the code will panic.
     fn from_selectors_and_combine(selectors: &[RowSelector]) -> Self {
         if selectors.len() < 2 {
             return Self {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2858 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
