### PR TITLE
`arrow::compute::kernels::temporal` should support nanoseconds 

### DIFF
--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -717,31 +717,46 @@ where
     T: ArrowTemporalType + ArrowNumericType,
     i64: From<T::Native>,
 {
-    second_generic::<T, _>(array)
+    second_fraction_generic::<T, _, _>(array, "second", |t| t.second() as i32)
 }
 
-/// Extracts the seconds of a given temporal array as an array of integers
-pub fn second_generic<T, A: ArrayAccessor<Item = T::Native>>(
+/// Extracts the nanoseconds of a given temporal primitive array as an array of integers
+pub fn nanosecond<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
+where
+    T: ArrowTemporalType + ArrowNumericType,
+    i64: From<T::Native>,
+{
+    second_fraction_generic::<T, _, _>(array, "nanosecond", |t| t.nanosecond() as i32)
+}
+
+/// Extracts the seconds fraction of a given temporal array as an array of integers
+pub fn second_fraction_generic<T, A: ArrayAccessor<Item = T::Native>, F>(
     array: A,
+    name: &str,
+    op: F,
 ) -> Result<Int32Array>
 where
+    F: Fn(NaiveDateTime) -> i32,
     T: ArrowTemporalType + ArrowNumericType,
     i64: From<T::Native>,
 {
     match array.data_type().clone() {
         DataType::Dictionary(_, value_type) => {
-            second_internal::<T, A>(array, value_type.as_ref())
+            second_fraction_internal::<T, A, _>(array, value_type.as_ref(), name, op)
         }
-        dt => second_internal::<T, A>(array, &dt),
+        dt => second_fraction_internal::<T, A, _>(array, &dt, name, op),
     }
 }
 
-/// Extracts the seconds of a given temporal array as an array of integers
-fn second_internal<T, A: ArrayAccessor<Item = T::Native>>(
+/// Extracts the seconds fraction of a given temporal array as an array of integers
+fn second_fraction_internal<T, A: ArrayAccessor<Item = T::Native>, F>(
     array: A,
     dt: &DataType,
+    name: &str,
+    op: F,
 ) -> Result<Int32Array>
 where
+    F: Fn(NaiveDateTime) -> i32,
     T: ArrowTemporalType + ArrowNumericType,
     i64: From<T::Native>,
 {
@@ -749,17 +764,18 @@ where
     match dt {
         DataType::Date64 | DataType::Timestamp(_, None) => {
             let iter = ArrayIter::new(array);
-            Ok(as_datetime_with_op::<A, T, _>(iter, b, |t| {
-                t.second() as i32
-            }))
+            Ok(as_datetime_with_op::<A, T, _>(iter, b, op))
         }
         DataType::Timestamp(_, Some(tz)) => {
             let iter = ArrayIter::new(array);
             extract_component_from_datetime_array::<A, T, _>(iter, b, tz, |t| {
-                t.second() as i32
+                op(t.naive_local())
             })
         }
-        _ => return_compute_error_with!("second does not support", array.data_type()),
+        _ => return_compute_error_with!(
+            format!("{} does not support", name),
+            array.data_type()
+        ),
     }
 }
 
@@ -1220,8 +1236,10 @@ mod tests {
         let expected = Int32Array::from(vec![1, 1, 2, 3, 2]);
         assert_eq!(expected, b);
 
-        let b = second_generic::<TimestampSecondType, _>(
+        let b = second_fraction_generic::<TimestampSecondType, _, _>(
             dict.downcast_dict::<TimestampSecondArray>().unwrap(),
+            "second",
+            |t| t.second() as i32,
         )
         .unwrap();
 
@@ -1312,5 +1330,20 @@ mod tests {
                 .unwrap();
         let expected = Int32Array::from(vec![Some(1), Some(8), Some(8), Some(1), None]);
         assert_eq!(expected, b);
+    }
+
+    #[test]
+    fn test_temporal_array_date64_nanosecond() {
+        // new Date(1667328721453)
+        // Tue Nov 01 2022 11:52:01 GMT-0700 (Pacific Daylight Time)
+        //
+        // new Date(1667328721453).getMilliseconds()
+        // 453
+
+        let a: PrimitiveArray<Date64Type> = vec![None, Some(1667328721453)].into();
+
+        let b = nanosecond(&a).unwrap();
+        assert!(!b.is_valid(0));
+        assert_eq!(453_000_000, b.value(1));
     }
 }

--- a/arrow/src/compute/kernels/temporal.rs
+++ b/arrow/src/compute/kernels/temporal.rs
@@ -1212,7 +1212,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_old = second_generic::<TimestampSecondType, _>(
+        let b_old = minute_generic::<TimestampSecondType, _>(
             dict.downcast_dict::<TimestampSecondArray>().unwrap(),
         )
         .unwrap();
@@ -1228,7 +1228,7 @@ mod tests {
         )
         .unwrap();
 
-        let b_old = minute_generic::<TimestampSecondType, _>(
+        let b_old = second_generic::<TimestampSecondType, _>(
             dict.downcast_dict::<TimestampSecondArray>().unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2995.

# Rationale for this change
`arrow::compute::kernels::temporal` should support nanoseconds to let calculate nanos, millis, micros
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Support nano seconds for temporal
# Are there any user-facing changes?

Added public function `nanosecond`
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
