### PR TITLE
Split out arrow-cast (#2594)

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -28,6 +28,7 @@ on:
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**
+      - arrow-cast/**
       - arrow-data/**
       - arrow-schema/**
       - arrow-select/**
@@ -58,6 +59,8 @@ jobs:
         run: cargo test -p arrow-array --all-features
       - name: Test arrow-select with all features
         run: cargo test -p arrow-select --all-features
+      - name: Test arrow-cast with all features
+        run: cargo test -p arrow-cast --all-features
       - name: Test arrow-integration-test with all features
         run: cargo test -p arrow-integration-test --all-features
       - name: Test arrow with default features
@@ -164,5 +167,7 @@ jobs:
         run: cargo clippy -p arrow-array --all-targets --all-features -- -D warnings
       - name: Clippy arrow-select with all features
         run: cargo clippy -p arrow-select --all-targets --all-features -- -D warnings
+      - name: Clippy arrow-cast with all features
+        run: cargo clippy -p arrow-cast --all-targets --all-features -- -D warnings
       - name: Clippy arrow
         run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,dyn_cmp_dict,dyn_arith_dict,chrono-tz --all-targets -- -D warnings

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -30,6 +30,7 @@ on:
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**
+      - arrow-cast/**
       - arrow-data/**
       - arrow-schema/**
       - arrow-select/**

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -19,6 +19,7 @@ arrow:
   - arrow/**/*
   - arrow-array/**/*
   - arrow-buffer/**/*
+  - arrow-cast/**/*
   - arrow-data/**/*
   - arrow-schema/**/*
   - arrow-select/**/*

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,6 +27,7 @@ on:
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**
+      - arrow-cast/**
       - arrow-data/**
       - arrow-schema/**
       - arrow-select/**

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -27,6 +27,7 @@ on:
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**
+      - arrow-cast/**
       - arrow-data/**
       - arrow-schema/**
       - arrow-select/**

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -30,6 +30,7 @@ on:
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**
+      - arrow-cast/**
       - arrow-data/**
       - arrow-schema/**
       - arrow-select/**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
         "arrow",
         "arrow-array",
         "arrow-buffer",
+        "arrow-cast",
         "arrow-data",
         "arrow-flight",
         "arrow-integration-test",

--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "arrow-cast"
+version = "26.0.0"
+description = "Cast kernel and utilities for Apache Arrow"
+homepage = "https://github.com/apache/arrow-rs"
+repository = "https://github.com/apache/arrow-rs"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+license = "Apache-2.0"
+keywords = ["arrow"]
+include = [
+    "benches/*.rs",
+    "src/**/*.rs",
+    "Cargo.toml",
+]
+edition = "2021"
+rust-version = "1.62"
+
+[lib]
+name = "arrow_cast"
+path = "src/lib.rs"
+bench = false
+
+[dependencies]
+arrow-array = { version = "26.0.0", path = "../arrow-array" }
+arrow-buffer = { version = "26.0.0", path = "../arrow-buffer" }
+arrow-data = { version = "26.0.0", path = "../arrow-data" }
+arrow-schema = { version = "26.0.0", path = "../arrow-schema" }
+arrow-select = { version = "26.0.0", path = "../arrow-select" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+num = { version = "0.4", default-features = false, features = ["std"] }
+lexical-core = { version = "^0.8", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
+
+[dev-dependencies]
+
+[build-dependencies]

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -17,8 +17,7 @@
 
 //! Cast kernel for [Apache Arrow](https://docs.rs/arrow)
 
-
 pub mod cast;
 pub use cast::*;
-pub mod parse;
 pub mod display;
+pub mod parse;

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -15,19 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Converts numeric type to a `String`
-pub fn lexical_to_string<N: lexical_core::ToLexical>(n: N) -> String {
-    let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
-    unsafe {
-        // JUSTIFICATION
-        //  Benefit
-        //      Allows using the faster serializer lexical core and convert to string
-        //  Soundness
-        //      Length of buf is set as written length afterwards. lexical_core
-        //      creates a valid string, so doesn't need to be checked.
-        let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
-        let len = lexical_core::write(n, slice).len();
-        buf.set_len(len);
-        String::from_utf8_unchecked(buf)
-    }
-}
+//! Cast kernel for [Apache Arrow](https://docs.rs/arrow)
+
+
+pub mod cast;
+pub use cast::*;
+pub mod parse;
+pub mod display;

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -45,6 +45,7 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 
 [dependencies]
 arrow-buffer = { version = "26.0.0", path = "../arrow-buffer" }
+arrow-cast = { version = "26.0.0", path = "../arrow-cast" }
 arrow-data = { version = "26.0.0", path = "../arrow-data" }
 arrow-schema = { version = "26.0.0", path = "../arrow-schema" }
 arrow-array = { version = "26.0.0", path = "../arrow-array" }

--- a/arrow/src/compute/kernels/mod.rs
+++ b/arrow/src/compute/kernels/mod.rs
@@ -22,8 +22,6 @@ pub mod arithmetic;
 pub mod arity;
 pub mod bitwise;
 pub mod boolean;
-pub mod cast;
-pub mod cast_utils;
 pub mod comparison;
 pub mod concat_elements;
 pub mod length;
@@ -37,3 +35,5 @@ pub mod window;
 pub mod zip;
 
 pub use arrow_select::{concat, filter, interleave, take};
+pub use arrow_cast::cast;
+pub use arrow_cast::parse as cast_utils;

--- a/arrow/src/compute/kernels/mod.rs
+++ b/arrow/src/compute/kernels/mod.rs
@@ -34,6 +34,6 @@ pub mod temporal;
 pub mod window;
 pub mod zip;
 
-pub use arrow_select::{concat, filter, interleave, take};
 pub use arrow_cast::cast;
 pub use arrow_cast::parse as cast_utils;
+pub use arrow_select::{concat, filter, interleave, take};

--- a/arrow/src/csv/writer.rs
+++ b/arrow/src/csv/writer.rs
@@ -67,12 +67,12 @@ use arrow_array::timezone::Tz;
 use chrono::{DateTime, Utc};
 use std::io::Write;
 
+use crate::array::*;
 use crate::csv::map_csv_error;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
-use crate::util::display::make_string_from_decimal;
-use crate::{array::*, util::serialization::lexical_to_string};
+use crate::util::display::{lexical_to_string, make_string_from_decimal};
 
 const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -33,6 +33,7 @@
 //!
 //! * [`arrow-array`][arrow_array] - type-safe arrow array abstractions
 //! * [`arrow-buffer`][arrow_buffer] - buffer abstractions for arrow arrays
+//! * [`arrow-cast`][arrow_cast] - cast kernels for arrow arrays
 //! * [`arrow-data`][arrow_data] - the underlying data of arrow arrays
 //! * [`arrow-schema`][arrow_schema] - the logical types for arrow arrays
 //! * [`arrow-select`][arrow_select] - selection kernels for arrow arrays

--- a/arrow/src/util/mod.rs
+++ b/arrow/src/util/mod.rs
@@ -24,12 +24,11 @@ pub use arrow_data::bit_mask;
 pub mod bench_util;
 #[cfg(feature = "test_utils")]
 pub mod data_gen;
-pub mod display;
 #[cfg(feature = "prettyprint")]
 pub mod pretty;
-pub(crate) mod serialization;
 pub mod string_writer;
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_util;
 
+pub use arrow_cast::display;
 pub(crate) mod reader_parser;

--- a/arrow/src/util/reader_parser.rs
+++ b/arrow/src/util/reader_parser.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_cast::parse::string_to_timestamp_nanos;
-use arrow_array::*;
 use arrow_array::types::*;
+use arrow_array::*;
+use arrow_cast::parse::string_to_timestamp_nanos;
 
 /// Specialized parsing implementations
 /// used by csv and json reader

--- a/arrow/src/util/reader_parser.rs
+++ b/arrow/src/util/reader_parser.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::compute::kernels::cast_utils::string_to_timestamp_nanos;
-use crate::datatypes::*;
+use arrow_cast::parse::string_to_timestamp_nanos;
+use arrow_array::*;
+use arrow_array::types::*;
 
 /// Specialized parsing implementations
 /// used by csv and json reader


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2594

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The cast kernel is a fairly substantial piece of code, that takes a non-trivial time to compile. 

This is the last remaining kernel that the IO functionality, i.e. IPC, parquet, etc... depend on, and so this is a precursor to splitting them out.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Splits out the casting logic into a separate crate

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
