### PR TITLE
Support Predicate Pushdown for Parquet Lists (#2108)

### DIFF
--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -264,9 +264,13 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     }
 }
 
+const MIN_SKIP_BUFFER_SIZE: usize = 1024;
+
 /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
 pub struct ColumnLevelDecoderImpl {
     decoder: Option<LevelDecoderInner>,
+    /// Temporary buffer populated when skipping values
+    buffer: Vec<i16>,
     bit_width: u8,
 }
 
@@ -275,8 +279,35 @@ impl ColumnLevelDecoderImpl {
         let bit_width = num_required_bits(max_level as u64);
         Self {
             decoder: None,
+            buffer: vec![],
             bit_width,
         }
+    }
+
+    /// Drops the first `len` values from the internal buffer
+    fn split_off_buffer(&mut self, len: usize) {
+        match self.buffer.len() == len {
+            true => self.buffer.clear(),
+            false => {
+                // Move to_read elements to end of slice
+                self.buffer.rotate_left(len);
+                // Truncate buffer
+                self.buffer.truncate(self.buffer.len() - len);
+            }
+        }
+    }
+
+    /// Reads up to `to_read` values to the internal buffer
+    fn read_to_buffer(&mut self, to_read: usize) -> Result<()> {
+        let mut buf = std::mem::take(&mut self.buffer);
+
+        // Repopulate buffer
+        buf.resize(to_read, 0);
+        let actual = self.read(&mut buf, 0..to_read)?;
+        buf.truncate(actual);
+
+        self.buffer = buf;
+        Ok(())
     }
 }
 
@@ -289,6 +320,7 @@ impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
     type Slice = [i16];
 
     fn set_data(&mut self, encoding: Encoding, data: ByteBufferPtr) {
+        self.buffer.clear();
         match encoding {
             Encoding::RLE => {
                 let mut decoder = RleDecoder::new(self.bit_width);
@@ -305,12 +337,25 @@ impl ColumnLevelDecoder for ColumnLevelDecoderImpl {
         }
     }
 
-    fn read(&mut self, out: &mut Self::Slice, range: Range<usize>) -> Result<usize> {
-        match self.decoder.as_mut().unwrap() {
-            LevelDecoderInner::Packed(reader, bit_width) => {
-                Ok(reader.get_batch::<i16>(&mut out[range], *bit_width as usize))
+    fn read(&mut self, out: &mut Self::Slice, mut range: Range<usize>) -> Result<usize> {
+        let read_from_buffer = match self.buffer.is_empty() {
+            true => 0,
+            false => {
+                let read_from_buffer = self.buffer.len().min(range.end - range.start);
+                out[range.start..range.start + read_from_buffer]
+                    .copy_from_slice(&self.buffer[0..read_from_buffer]);
+                self.split_off_buffer(read_from_buffer);
+                read_from_buffer
             }
-            LevelDecoderInner::Rle(reader) => reader.get_batch(&mut out[range]),
+        };
+        range.start += read_from_buffer;
+
+        match self.decoder.as_mut().unwrap() {
+            LevelDecoderInner::Packed(reader, bit_width) => Ok(read_from_buffer
+                + reader.get_batch::<i16>(&mut out[range], *bit_width as usize)),
+            LevelDecoderInner::Rle(reader) => {
+                Ok(read_from_buffer + reader.get_batch(&mut out[range])?)
+            }
         }
     }
 }
@@ -323,35 +368,26 @@ impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
     ) -> Result<(usize, usize)> {
         let mut level_skip = 0;
         let mut value_skip = 0;
-        match self.decoder.as_mut().unwrap() {
-            LevelDecoderInner::Packed(reader, bit_width) => {
-                for _ in 0..num_levels {
-                    // Values are delimited by max_def_level
-                    if max_def_level
-                        == reader
-                            .get_value::<i16>(*bit_width as usize)
-                            .expect("Not enough values in Packed ColumnLevelDecoderImpl.")
-                    {
-                        value_skip += 1;
-                    }
-                    level_skip += 1;
+        while level_skip < num_levels {
+            let remaining_levels = num_levels - level_skip;
+
+            if self.buffer.is_empty() {
+                self.read_to_buffer(remaining_levels.max(MIN_SKIP_BUFFER_SIZE))?;
+                if self.buffer.is_empty() {
+                    break;
                 }
             }
-            LevelDecoderInner::Rle(reader) => {
-                for _ in 0..num_levels {
-                    if let Some(level) = reader
-                        .get::<i16>()
-                        .expect("Not enough values in Rle ColumnLevelDecoderImpl.")
-                    {
-                        // Values are delimited by max_def_level
-                        if level == max_def_level {
-                            value_skip += 1;
-                        }
-                    }
-                    level_skip += 1;
-                }
-            }
+            let to_read = self.buffer.len().min(remaining_levels);
+
+            level_skip += to_read;
+            value_skip += self.buffer[..to_read]
+                .iter()
+                .filter(|x| **x == max_def_level)
+                .count();
+
+            self.split_off_buffer(to_read)
         }
+
         Ok((value_skip, level_skip))
     }
 }
@@ -359,5 +395,67 @@ impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
 impl RepetitionLevelDecoder for ColumnLevelDecoderImpl {
     fn skip_rep_levels(&mut self, _num_records: usize) -> Result<(usize, usize)> {
         Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encodings::rle::RleEncoder;
+    use rand::prelude::*;
+
+    #[test]
+    fn test_skip() {
+        let mut rng = thread_rng();
+        let total_len = 10000;
+        let encoded: Vec<i16> = (0..total_len).map(|_| rng.gen_range(0..5)).collect();
+        let mut encoder = RleEncoder::new(3, 1024);
+        for v in &encoded {
+            encoder.put(*v as _)
+        }
+        let buf = ByteBufferPtr::new(encoder.consume());
+
+        let mut encoder = ColumnLevelDecoderImpl::new(5);
+        encoder.set_data(Encoding::RLE, buf.clone());
+
+        let mut values = vec![0; total_len];
+        let read = encoder.read(&mut values, 0..total_len).unwrap();
+        assert_eq!(read, total_len);
+        assert_eq!(values, encoded);
+
+        for _ in 0..10 {
+            let mut encoder = ColumnLevelDecoderImpl::new(5);
+            encoder.set_data(Encoding::RLE, buf.clone());
+
+            let mut read = 0;
+            let mut decoded = vec![];
+            let mut expected = vec![];
+            while read < total_len {
+                let to_read = rng.gen_range(0..(total_len - read).min(100)) + 1;
+
+                let skip = rng.gen_bool(0.5);
+                if skip {
+                    let (values_skipped, levels_skipped) =
+                        encoder.skip_def_levels(to_read, 5).unwrap();
+                    assert_eq!(levels_skipped, to_read);
+                    let expected_values = encoded[read..read + to_read]
+                        .iter()
+                        .filter(|x| **x == 5)
+                        .count();
+
+                    assert_eq!(values_skipped, expected_values);
+                } else {
+                    let start = decoded.len();
+                    let end = decoded.len() + to_read;
+                    decoded.resize(end, 0);
+                    let actual_read = encoder.read(&mut decoded, start..end).unwrap();
+                    assert_eq!(actual_read, to_read);
+                    expected.extend_from_slice(&encoded[read..read + to_read]);
+                }
+
+                read += to_read;
+            }
+            assert_eq!(decoded, expected);
+        }
     }
 }

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -449,7 +449,7 @@ mod tests {
     {
         let mut rng = thread_rng();
         let mut decoder = ColumnLevelDecoderImpl::new(5);
-        decoder.set_data(Encoding::RLE, data.clone());
+        decoder.set_data(Encoding::RLE, data);
 
         let mut read = 0;
         let mut decoded = vec![];

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -264,7 +264,7 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     }
 }
 
-const MIN_SKIP_BUFFER_SIZE: usize = 1024;
+const SKIP_BUFFER_SIZE: usize = 1024;
 
 /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
 pub struct ColumnLevelDecoderImpl {
@@ -372,8 +372,10 @@ impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
             let remaining_levels = num_levels - level_skip;
 
             if self.buffer.is_empty() {
-                self.read_to_buffer(remaining_levels.max(MIN_SKIP_BUFFER_SIZE))?;
+                // Only read number of needed values
+                self.read_to_buffer(remaining_levels.min(SKIP_BUFFER_SIZE))?;
                 if self.buffer.is_empty() {
+                    // Reached end of page
                     break;
                 }
             }
@@ -393,8 +395,45 @@ impl DefinitionLevelDecoder for ColumnLevelDecoderImpl {
 }
 
 impl RepetitionLevelDecoder for ColumnLevelDecoderImpl {
-    fn skip_rep_levels(&mut self, _num_records: usize) -> Result<(usize, usize)> {
-        Err(nyi_err!("https://github.com/apache/arrow-rs/issues/1792"))
+    fn skip_rep_levels(&mut self, num_records: usize) -> Result<(usize, usize)> {
+        let mut level_skip = 0;
+        let mut record_skip = 0;
+
+        loop {
+            if self.buffer.is_empty() {
+                // Read SKIP_BUFFER_SIZE as we don't know how many to read
+                self.read_to_buffer(SKIP_BUFFER_SIZE)?;
+                if self.buffer.is_empty() {
+                    // Reached end of page
+                    break;
+                }
+            }
+
+            let mut to_skip = 0;
+            while to_skip < self.buffer.len() && record_skip != num_records {
+                if self.buffer[to_skip] == 0 {
+                    record_skip += 1;
+                }
+                to_skip += 1;
+            }
+
+            // Find end of record
+            while to_skip < self.buffer.len() && self.buffer[to_skip] != 0 {
+                to_skip += 1;
+            }
+
+            level_skip += to_skip;
+            if to_skip >= self.buffer.len() {
+                // Need to to read more values
+                self.buffer.clear();
+                continue;
+            }
+
+            self.split_off_buffer(to_skip);
+            break;
+        }
+
+        Ok((record_skip, level_skip))
     }
 }
 
@@ -403,6 +442,35 @@ mod tests {
     use super::*;
     use crate::encodings::rle::RleEncoder;
     use rand::prelude::*;
+
+    fn test_skip_levels<F>(encoded: &[i16], data: ByteBufferPtr, skip: F)
+    where
+        F: Fn(&mut ColumnLevelDecoderImpl, &mut usize, usize),
+    {
+        let mut rng = thread_rng();
+        let mut decoder = ColumnLevelDecoderImpl::new(5);
+        decoder.set_data(Encoding::RLE, data.clone());
+
+        let mut read = 0;
+        let mut decoded = vec![];
+        let mut expected = vec![];
+        while read < encoded.len() {
+            let to_read = rng.gen_range(0..(encoded.len() - read).min(100)) + 1;
+
+            if rng.gen_bool(0.5) {
+                skip(&mut decoder, &mut read, to_read)
+            } else {
+                let start = decoded.len();
+                let end = decoded.len() + to_read;
+                decoded.resize(end, 0);
+                let actual_read = decoder.read(&mut decoded, start..end).unwrap();
+                assert_eq!(actual_read, to_read);
+                expected.extend_from_slice(&encoded[read..read + to_read]);
+                read += to_read;
+            }
+        }
+        assert_eq!(decoded, expected);
+    }
 
     #[test]
     fn test_skip() {
@@ -413,49 +481,40 @@ mod tests {
         for v in &encoded {
             encoder.put(*v as _)
         }
-        let buf = ByteBufferPtr::new(encoder.consume());
-
-        let mut encoder = ColumnLevelDecoderImpl::new(5);
-        encoder.set_data(Encoding::RLE, buf.clone());
-
-        let mut values = vec![0; total_len];
-        let read = encoder.read(&mut values, 0..total_len).unwrap();
-        assert_eq!(read, total_len);
-        assert_eq!(values, encoded);
+        let data = ByteBufferPtr::new(encoder.consume());
 
         for _ in 0..10 {
-            let mut encoder = ColumnLevelDecoderImpl::new(5);
-            encoder.set_data(Encoding::RLE, buf.clone());
+            test_skip_levels(&encoded, data.clone(), |decoder, read, to_read| {
+                let (values_skipped, levels_skipped) =
+                    decoder.skip_def_levels(to_read, 5).unwrap();
+                assert_eq!(levels_skipped, to_read);
 
-            let mut read = 0;
-            let mut decoded = vec![];
-            let mut expected = vec![];
-            while read < total_len {
-                let to_read = rng.gen_range(0..(total_len - read).min(100)) + 1;
+                let expected = &encoded[*read..*read + to_read];
+                let expected_values_skipped =
+                    expected.iter().filter(|x| **x == 5).count();
+                assert_eq!(values_skipped, expected_values_skipped);
+                *read += to_read;
+            });
 
-                let skip = rng.gen_bool(0.5);
-                if skip {
-                    let (values_skipped, levels_skipped) =
-                        encoder.skip_def_levels(to_read, 5).unwrap();
-                    assert_eq!(levels_skipped, to_read);
-                    let expected_values = encoded[read..read + to_read]
-                        .iter()
-                        .filter(|x| **x == 5)
-                        .count();
+            test_skip_levels(&encoded, data.clone(), |decoder, read, to_read| {
+                let (records_skipped, levels_skipped) =
+                    decoder.skip_rep_levels(to_read).unwrap();
 
-                    assert_eq!(values_skipped, expected_values);
-                } else {
-                    let start = decoded.len();
-                    let end = decoded.len() + to_read;
-                    decoded.resize(end, 0);
-                    let actual_read = encoder.read(&mut decoded, start..end).unwrap();
-                    assert_eq!(actual_read, to_read);
-                    expected.extend_from_slice(&encoded[read..read + to_read]);
+                // If not run out of values
+                if levels_skipped + *read != encoded.len() {
+                    // Should have read correct number of records
+                    assert_eq!(records_skipped, to_read);
+                    // Next value should be start of record
+                    assert_eq!(encoded[levels_skipped + *read], 0);
                 }
 
-                read += to_read;
-            }
-            assert_eq!(decoded, expected);
+                let expected = &encoded[*read..*read + levels_skipped];
+                let expected_records_skipped =
+                    expected.iter().filter(|x| **x == 0).count();
+                assert_eq!(records_skipped, expected_records_skipped);
+
+                *read += levels_skipped;
+            });
         }
     }
 }

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -338,6 +338,7 @@ impl RleDecoder {
     // These functions inline badly, they tend to inline and then create very large loop unrolls
     // that damage L1d-cache occupancy. This results in a ~18% performance drop
     #[inline(never)]
+    #[allow(unused)]
     pub fn get<T: FromBytes>(&mut self) -> Result<Option<T>> {
         assert!(size_of::<T>() <= 8);
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2108

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This PR adds support for skipping repetition levels by adding a buffer to ColumnLevelDecoderImpl. This buffer is also used to speed up skipping definition levels, as it allows for vectorised decoding.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
