### PR TITLE
Round instead of Truncate while casting float to decimal

### DIFF
--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -297,8 +297,8 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
 /// * Time32 and Time64: precision lost when going to higher interval
 /// * Timestamp and Date{32|64}: precision lost when going to higher interval
 /// * Temporal to/from backing primitive: zero-copy with data type change
-/// * Casting from `float32/float64` to `Decimal(precision, scale)` rounds to the `scale` decimals 
-///   (i.e. casting 6.4999 to Decimal(10, 1) becomes 6.5). This is the breaking change from `26.0.0`. 
+/// * Casting from `float32/float64` to `Decimal(precision, scale)` rounds to the `scale` decimals
+///   (i.e. casting 6.4999 to Decimal(10, 1) becomes 6.5). This is the breaking change from `26.0.0`.
 ///   It used to truncate it instead of round (i.e. outputs 6.4 instead)
 ///
 /// Unsupported Casts

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -6007,13 +6007,39 @@ mod tests {
         // to reproduce https://github.com/apache/arrow-rs/issues/2997
 
         let decimal_type = DataType::Decimal128(18, 2);
-        let array = Float64Array::from(vec![Some(0.0699999999)]);
+        let array = Float64Array::from(vec![
+            Some(0.0699999999),
+            Some(0.0659999999),
+            Some(0.0649999999),
+        ]);
         let array = Arc::new(array) as ArrayRef;
         generate_cast_test_case!(
             &array,
             Decimal128Array,
             &decimal_type,
-            vec![Some(7_i128),]
+            vec![
+                Some(7_i128), // round up
+                Some(7_i128), // round up
+                Some(6_i128), // round down
+            ]
+        );
+
+        let decimal_type = DataType::Decimal128(18, 3);
+        let array = Float64Array::from(vec![
+            Some(0.0699999999),
+            Some(0.0659999999),
+            Some(0.0649999999),
+        ]);
+        let array = Arc::new(array) as ArrayRef;
+        generate_cast_test_case!(
+            &array,
+            Decimal128Array,
+            &decimal_type,
+            vec![
+                Some(70_i128), // round up
+                Some(66_i128), // round up
+                Some(65_i128), // round up
+            ]
         );
     }
 }

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -6010,6 +6010,7 @@ mod tests {
         let array = Float64Array::from(vec![
             Some(0.0699999999),
             Some(0.0659999999),
+            Some(0.0650000000),
             Some(0.0649999999),
         ]);
         let array = Arc::new(array) as ArrayRef;
@@ -6018,6 +6019,7 @@ mod tests {
             Decimal128Array,
             &decimal_type,
             vec![
+                Some(7_i128), // round up
                 Some(7_i128), // round up
                 Some(7_i128), // round up
                 Some(6_i128), // round down
@@ -6028,6 +6030,7 @@ mod tests {
         let array = Float64Array::from(vec![
             Some(0.0699999999),
             Some(0.0659999999),
+            Some(0.0650000000),
             Some(0.0649999999),
         ]);
         let array = Arc::new(array) as ArrayRef;
@@ -6038,6 +6041,7 @@ mod tests {
             vec![
                 Some(70_i128), // round up
                 Some(66_i128), // round up
+                Some(65_i128), // round down
                 Some(65_i128), // round up
             ]
         );

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -297,6 +297,9 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
 /// * Time32 and Time64: precision lost when going to higher interval
 /// * Timestamp and Date{32|64}: precision lost when going to higher interval
 /// * Temporal to/from backing primitive: zero-copy with data type change
+/// * Casting from `float32/float64` to `Decimal(precision, scale)` rounds to the `scale` decimals 
+///   (i.e. casting 6.4999 to Decimal(10, 1) becomes 6.5). This is the breaking change from `26.0.0`. 
+///   It used to truncate it instead of round (i.e. outputs 6.4 instead)
 ///
 /// Unsupported Casts
 /// * To or from `StructArray`


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2997

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

casting 0.06999999 to `Decimal(18, 2)` should be  0.07 instead of 0.06

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

add `.round()` before casting to int

# Are there any user-facing changes?

yes, we round the floating number instead of truncating it

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
