### PR TITLE
Parquet Writer: Make column descriptor public on the writer

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -427,6 +427,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         self.column_metrics.total_rows_written
     }
 
+    /// Returns a reference to a [`ColumnDescPtr`]
+    pub fn get_descriptor(&self) -> &ColumnDescPtr {
+        &self.descr
+    }
+
     /// Finalises writes and closes the column writer.
     /// Returns total bytes written, total rows written and column chunk metadata.
     pub fn close(mut self) -> Result<ColumnCloseResult> {


### PR DESCRIPTION
# Which issue does this PR close?
There's no issue currently, because I just had this issue this morning and decided to make a PR for it. I can open up an issue if it helps.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

This is so that it's possible to gather information from the column we're about to write to. That information was already present in the column but buried inside the internal of the GenericColumnWriter.

The getter returns a reference of `ColumnDescPtr`.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The PR is missing tests, I wasn't sure if the test would add any value/safety. I'm more than happy to provide some tests if you think it's important.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
None, I believe.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
