### PR TITLE
do not read 1-past-size

### DIFF
--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -476,7 +476,7 @@ impl RleDecoder {
                 let mut num_values =
                     cmp::min(max_values - values_read, self.bit_packed_left as usize);
 
-                num_values = cmp::min(num_values, index_buf.len());
+                num_values = cmp::min(num_values, index_buf.len() - 1);
                 loop {
                     num_values = bit_reader.get_batch::<i32>(
                         &mut index_buf[..num_values],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3029.

# Rationale for this change
 
Fixes a bug where parquet attempts to read past the buffer.