### PR TITLE
Enable casting from Date64 to Timestamp

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -244,7 +244,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (Timestamp(_, _), Int64) => true,
         (Int64, Timestamp(_, _)) => true,
         (Timestamp(_, _), Timestamp(_, _) | Date32 | Date64) => true,
-        // date64 to timestamp might not make sense,
+        (Date64, Timestamp(_, None)) => true,
         (Int64, Duration(_)) => true,
         (Duration(_), Int64) => true,
         (Interval(from_type), Int64) => {
@@ -1484,7 +1484,24 @@ pub fn cast_with_options(
                 .unary::<_, Date64Type>(|x| x / (NANOSECONDS / MILLISECONDS)),
         )),
 
-        // date64 to timestamp might not make sense,
+        (Date64, Timestamp(TimeUnit::Second, None)) => Ok(Arc::new(
+            as_primitive_array::<Date64Type>(array)
+                .unary::<_, TimestampSecondType>(|x| x / MILLISECONDS),
+        )),
+        (Date64, Timestamp(TimeUnit::Millisecond, None)) => {
+            cast_reinterpret_arrays::<Date64Type, TimestampMillisecondType>(array)
+        }
+        (Date64, Timestamp(TimeUnit::Microsecond, None)) => Ok(Arc::new(
+            as_primitive_array::<Date64Type>(array).unary::<_, TimestampMicrosecondType>(
+                |x| x * (MICROSECONDS / MILLISECONDS),
+            ),
+        )),
+        (Date64, Timestamp(TimeUnit::Nanosecond, None)) => Ok(Arc::new(
+            as_primitive_array::<Date64Type>(array).unary::<_, TimestampNanosecondType>(
+                |x| x * (NANOSECONDS / MILLISECONDS),
+            ),
+        )),
+
         (Int64, Duration(TimeUnit::Second)) => {
             cast_reinterpret_arrays::<Int64Type, DurationSecondType>(array)
         }
@@ -4070,6 +4087,59 @@ mod tests {
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(864000000005, c.value(0));
         assert_eq!(1545696000001, c.value(1));
+        assert!(c.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_date64_to_timestamp() {
+        let a = Date64Array::from(vec![Some(864000000005), Some(1545696000001), None]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Timestamp(TimeUnit::Second, None)).unwrap();
+        let c = b.as_any().downcast_ref::<TimestampSecondArray>().unwrap();
+        assert_eq!(864000000, c.value(0));
+        assert_eq!(1545696000, c.value(1));
+        assert!(c.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_date64_to_timestamp_ms() {
+        let a = Date64Array::from(vec![Some(864000000005), Some(1545696000001), None]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Timestamp(TimeUnit::Millisecond, None)).unwrap();
+        let c = b
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap();
+        assert_eq!(864000000005, c.value(0));
+        assert_eq!(1545696000001, c.value(1));
+        assert!(c.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_date64_to_timestamp_us() {
+        let a = Date64Array::from(vec![Some(864000000005), Some(1545696000001), None]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Timestamp(TimeUnit::Microsecond, None)).unwrap();
+        let c = b
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(864000000005000, c.value(0));
+        assert_eq!(1545696000001000, c.value(1));
+        assert!(c.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_date64_to_timestamp_ns() {
+        let a = Date64Array::from(vec![Some(864000000005), Some(1545696000001), None]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Timestamp(TimeUnit::Nanosecond, None)).unwrap();
+        let c = b
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .unwrap();
+        assert_eq!(864000000005000000, c.value(0));
+        assert_eq!(1545696000001000000, c.value(1));
         assert!(c.is_null(2));
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3037 

# Rationale for this change
 
I'm working on adding support for [remote tables](https://github.com/splitgraph/seafowl/pull/190) in Seafowl (in analogy with PG FDWs) using the connector-x crate. An issue that comes up is the fact that connector-x uses arrow's Date64 as the target type for coercion of various datetime/timestamp types from other DBs.

More specifically, Postgres TIMESTAMP [is converted into](https://github.com/sfu-db/connector-x/blob/9bc2bf455fd0a9ad3e8ff7834694fb317b497f4a/connectorx/src/transports/postgres_arrow.rs#L53) Date64. On the other hand, Datafusion [interprets](https://arrow.apache.org/datafusion/user-guide/sql/data_types.html#date-time-types) TIMESTAMP type as arrow's Timestamp(TimeUnit::Nanosecond, None). Consequently, I end up needing to cast from Date64 (as returned by connector-x) into Timestamp (as expected by Datafusion), but such cast is not supported at the moment.

# What changes are included in this PR?

I expanded the cast kernel to facilitate the Date64 -> Timestamp cast, as well as the `can_cast_types` function to reflect this.

# Are there any user-facing changes?

Trying to cast from Date64 to Timestamp will not error out after this; not sure whether this warrants a doc change somewhere.
