### PR TITLE
fix: pin ahash to 0.8.0

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -38,10 +38,10 @@ path = "src/lib.rs"
 bench = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
+ahash = { version = "0.8.0", default-features = false, features = ["compile-time-rng"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
+ahash = { version = "0.8.0", default-features = false, features = ["runtime-rng"] }
 
 [dependencies]
 arrow-buffer = { version = "26.0.0", path = "../arrow-buffer" }


### PR DESCRIPTION
0.8.1 has a bug https://github.com/tkaitchuck/aHash/issues/143