### PR TITLE
Minor: Remove cloning ArrayData in with_precision_and_scale

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -832,7 +832,7 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
     /// 2. `scale` is larger than `T::MAX_SCALE`
     /// 3. `scale` is > `precision`
     pub fn with_precision_and_scale(
-        self,
+        &self,
         precision: u8,
         scale: u8,
     ) -> Result<Self, ArrowError>

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -832,7 +832,7 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
     /// 2. `scale` is larger than `T::MAX_SCALE`
     /// 3. `scale` is > `precision`
     pub fn with_precision_and_scale(
-        &self,
+        self,
         precision: u8,
         scale: u8,
     ) -> Result<Self, ArrowError>
@@ -844,7 +844,7 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
 
         // safety: self.data is valid DataType::Decimal as checked above
         let new_data_type = T::TYPE_CONSTRUCTOR(precision, scale);
-        let data = self.data().clone().into_builder().data_type(new_data_type);
+        let data = self.data.into_builder().data_type(new_data_type);
 
         // SAFETY
         // Validated data above


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`with_precision_and_scale` doesn't need `self` actually but only a reference.

And more, usually we get a reference of decimal array with APIs like `as_primitive_array`. Currently it makes harder to call `with_precision_and_scale` with that.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
