### PR TITLE
Fix null_count computation in binary

### DIFF
--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -3044,4 +3044,61 @@ mod tests {
         let c = add(&a, &b).unwrap();
         assert_eq!(c, expected);
     }
+
+    #[test]
+    fn test_resize_builder() {
+        let mut null_buffer_builder = BooleanBufferBuilder::new(16);
+        null_buffer_builder.append_slice(&[
+            false, false, false, false, false, false, false, false, false, false, false,
+            false, false, true, true, true,
+        ]);
+        // `resize` resizes the buffer length to the ceil of byte numbers.
+        // So the underlying buffer is not changed.
+        null_buffer_builder.resize(13);
+        assert_eq!(null_buffer_builder.len(), 13);
+
+        let null_buffer = null_buffer_builder.finish();
+
+        // `count_set_bits` counts 1-bits in entire buffer. Because above `resize` doesn't
+        // actually truncate the buffer, `count_set_bits` still return 3.
+        assert_eq!(null_buffer.count_set_bits(), 3);
+        // `count_set_bits_offset` takes len in bits as parameter.
+        assert_eq!(null_buffer.count_set_bits_offset(0, 13), 0);
+
+        let mut data_buffer_builder = BufferBuilder::<i32>::new(13);
+        data_buffer_builder.append_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        let data_buffer = data_buffer_builder.finish();
+
+        let arg1: Int32Array = ArrayDataBuilder::new(DataType::Int32)
+            .len(13)
+            .null_count(13)
+            .buffers(vec![data_buffer])
+            .null_bit_buffer(Some(null_buffer))
+            .build()
+            .unwrap()
+            .into();
+
+        assert_eq!(arg1.null_count(), 13);
+
+        let mut data_buffer_builder = BufferBuilder::<i32>::new(13);
+        data_buffer_builder.append_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        let data_buffer = data_buffer_builder.finish();
+
+        let arg2: Int32Array = ArrayDataBuilder::new(DataType::Int32)
+            .len(13)
+            .null_count(0)
+            .buffers(vec![data_buffer])
+            .null_bit_buffer(None)
+            .build()
+            .unwrap()
+            .into();
+
+        assert_eq!(arg2.null_count(), 0);
+
+        let result_dyn = add_dyn(&arg1, &arg2).unwrap();
+        let result = result_dyn.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        assert_eq!(result.len(), 13);
+        assert_eq!(result.null_count(), 13);
+    }
 }

--- a/arrow/src/compute/kernels/arity.rs
+++ b/arrow/src/compute/kernels/arity.rs
@@ -191,7 +191,7 @@ where
     let null_buffer = combine_option_bitmap(&[a.data(), b.data()], len).unwrap();
     let null_count = null_buffer
         .as_ref()
-        .map(|x| len - x.count_set_bits())
+        .map(|x| len - x.count_set_bits_offset(0, len))
         .unwrap_or_default();
 
     let values = a.values().iter().zip(b.values()).map(|(l, r)| op(*l, *r));
@@ -241,7 +241,7 @@ where
 
         let null_count = null_buffer
             .as_ref()
-            .map(|x| len - x.count_set_bits())
+            .map(|x| len - x.count_set_bits_offset(0, len))
             .unwrap_or_default();
 
         let mut buffer = BufferBuilder::<O::Native>::new(len);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3061.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
