### PR TITLE
Minor: Improve docstrings on WriterPropertiesBuilder

### DIFF
--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -306,38 +306,46 @@ impl WriterPropertiesBuilder {
         self
     }
 
-    /// Sets best effort maximum size of a data page in bytes
+    /// Sets best effort maximum size of a data page in bytes.
     ///
-    /// Note: this is a best effort limit based on the write batch size
+    /// Note: this is a best effort limit based on value of
+    /// [`set_write_batch_size`](Self::set_write_batch_size).
     pub fn set_data_pagesize_limit(mut self, value: usize) -> Self {
         self.data_pagesize_limit = value;
         self
     }
 
-    /// Sets best effort maximum number of rows in a data page
+    /// Sets best effort maximum number of rows in a data page.
     ///
     ///
     /// This can be used to limit the number of rows within a page to
-    /// yield better page pruning
+    /// yield better page pruning.
     ///
-    /// Note: this is a best effort limit based on the write batch size
+    /// Note: this is a best effort limit based on value of
+    /// [`set_write_batch_size`](Self::set_write_batch_size).
     pub fn set_data_page_row_count_limit(mut self, value: usize) -> Self {
         self.data_page_row_count_limit = value;
         self
     }
 
-    /// Sets best effort maximum dictionary page size, in bytes
+    /// Sets best effort maximum dictionary page size, in bytes.
     ///
-    /// Note: this is a best effort limit based on the write batch size
+    /// Note: this is a best effort limit based on value of
+    /// [`set_write_batch_size`](Self::set_write_batch_size).
     pub fn set_dictionary_pagesize_limit(mut self, value: usize) -> Self {
         self.dictionary_pagesize_limit = value;
         self
     }
 
-    /// Sets write batch size
+    /// Sets write batch size.
     ///
-    /// Data is written in batches of this size, acting as an upper-bound on
-    /// the enforcement granularity of page limits
+    /// For performance reasons, data for each column is written in
+    /// batches of this size.
+    ///
+    /// Additional limits such as such as
+    /// [`set_data_page_row_count_limit`](Self::set_data_page_row_count_limit)
+    /// are checked between batches, and thus the write batch size value acts as an
+    /// upper-bound on the enforcement granularity of other limits.
     pub fn set_write_batch_size(mut self, value: usize) -> Self {
         self.write_batch_size = value;
         self


### PR DESCRIPTION
# Which issue does this PR close?

N/A
# Rationale for this change

Even though the docs did mention the fact that the limits were a function of the write batch size, I think both @Ted-Jiang and I missed the subtlety initially. See conversation on  https://github.com/apache/arrow-datafusion/pull/4131#discussion_r1016554574


# What changes are included in this PR?
Add some additional commentary on write batch size docs as well as backlinks from other limits

# Are there any user-facing changes?
Only docstrings