### PR TITLE
Deprecate Buffer::count_set_bits (#3067)

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -215,6 +215,7 @@ impl Buffer {
     }
 
     /// Returns the number of 1-bits in this buffer.
+    #[deprecated(note = "use count_set_bits_offset instead")]
     pub fn count_set_bits(&self) -> usize {
         let len_in_bits = self.len() * 8;
         // self.offset is already taken into consideration by the bit_chunks implementation
@@ -466,11 +467,11 @@ mod tests {
 
     #[test]
     fn test_count_bits() {
-        assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits());
-        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits());
-        assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits());
-        assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits());
-        assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits());
+        assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits_offset(0, 8));
+        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 8));
+        assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits_offset(0, 8));
+        assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits_offset(0, 16));
+        assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 16));
     }
 
     #[test]
@@ -479,31 +480,31 @@ mod tests {
             0,
             Buffer::from(&[0b11111111, 0b00000000])
                 .slice(1)
-                .count_set_bits()
+                .count_set_bits_offset(0, 8)
         );
         assert_eq!(
             8,
             Buffer::from(&[0b11111111, 0b11111111])
                 .slice_with_length(1, 1)
-                .count_set_bits()
+                .count_set_bits_offset(0, 8)
         );
         assert_eq!(
             3,
             Buffer::from(&[0b11111111, 0b11111111, 0b00001101])
                 .slice(2)
-                .count_set_bits()
+                .count_set_bits_offset(0, 8)
         );
         assert_eq!(
             6,
             Buffer::from(&[0b11111111, 0b01001001, 0b01010010])
                 .slice_with_length(1, 2)
-                .count_set_bits()
+                .count_set_bits_offset(0, 16)
         );
         assert_eq!(
             16,
             Buffer::from(&[0b11111111, 0b11111111, 0b11111111, 0b11111111])
                 .slice(2)
-                .count_set_bits()
+                .count_set_bits_offset(0, 16)
         );
     }
 

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -470,8 +470,14 @@ mod tests {
         assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits_offset(0, 8));
         assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 8));
         assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits_offset(0, 8));
-        assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits_offset(0, 16));
-        assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 16));
+        assert_eq!(
+            6,
+            Buffer::from(&[0b01001001, 0b01010010]).count_set_bits_offset(0, 16)
+        );
+        assert_eq!(
+            16,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 16)
+        );
     }
 
     #[test]

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -413,7 +413,7 @@ fn filter_null_mask(
     let nulls = filter_bits(data.null_buffer()?, data.offset(), predicate);
     // The filtered `nulls` has a length of `predicate.count` bits and
     // therefore the null count is this minus the number of valid bits
-    let null_count = predicate.count - nulls.count_set_bits();
+    let null_count = predicate.count - nulls.count_set_bits_offset(0, predicate.count);
 
     if null_count == 0 {
         return None;

--- a/arrow/src/compute/kernels/arithmetic.rs
+++ b/arrow/src/compute/kernels/arithmetic.rs
@@ -3059,9 +3059,6 @@ mod tests {
 
         let null_buffer = null_buffer_builder.finish();
 
-        // `count_set_bits` counts 1-bits in entire buffer. Because above `resize` doesn't
-        // actually truncate the buffer, `count_set_bits` still return 3.
-        assert_eq!(null_buffer.count_set_bits(), 3);
         // `count_set_bits_offset` takes len in bits as parameter.
         assert_eq!(null_buffer.count_set_bits_offset(0, 13), 0);
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3067

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
