### PR TITLE
early type checks in `RowConverter`

### DIFF
--- a/arrow/benches/lexsort.rs
+++ b/arrow/benches/lexsort.rs
@@ -105,7 +105,7 @@ fn do_bench(c: &mut Criterion, columns: &[Column], len: usize) {
                     .iter()
                     .map(|a| SortField::new(a.data_type().clone()))
                     .collect();
-                let mut converter = RowConverter::new(fields);
+                let mut converter = RowConverter::new(fields).unwrap();
                 let rows = converter.convert_columns(&arrays).unwrap();
                 let mut sort: Vec<_> = rows.iter().enumerate().collect();
                 sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -38,12 +38,12 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 
     c.bench_function(&format!("convert_columns {}", name), |b| {
         b.iter(|| {
-            let mut converter = RowConverter::new(fields.clone());
+            let mut converter = RowConverter::new(fields.clone()).unwrap();
             black_box(converter.convert_columns(&cols).unwrap())
         });
     });
 
-    let mut converter = RowConverter::new(fields);
+    let mut converter = RowConverter::new(fields).unwrap();
     let rows = converter.convert_columns(&cols).unwrap();
     // using a pre-prepared row converter should be faster than the first time
     c.bench_function(&format!("convert_columns_prepared {}", name), |b| {

--- a/arrow/src/row/dictionary.rs
+++ b/arrow/src/row/dictionary.rs
@@ -33,8 +33,8 @@ use std::collections::HashMap;
 pub fn compute_dictionary_mapping(
     interner: &mut OrderPreservingInterner,
     values: &ArrayRef,
-) -> Result<Vec<Option<Interned>>, ArrowError> {
-    Ok(downcast_primitive_array! {
+) -> Vec<Option<Interned>> {
+    downcast_primitive_array! {
         values => interner
             .intern(values.iter().map(|x| x.map(|x| x.encode()))),
         DataType::Binary => {
@@ -53,8 +53,8 @@ pub fn compute_dictionary_mapping(
             let iter = as_largestring_array(values).iter().map(|x| x.map(|x| x.as_bytes()));
             interner.intern(iter)
         }
-        t => return Err(ArrowError::NotYetImplemented(format!("dictionary value {} is not supported", t))),
-    })
+        _ => unreachable!(),
+    }
 }
 
 /// Dictionary types are encoded as
@@ -177,12 +177,7 @@ pub unsafe fn decode_dictionary<K: ArrowDictionaryKeyType>(
         DataType::LargeUtf8 => decode_string::<i64>(&values),
         DataType::Binary => decode_binary::<i32>(&values),
         DataType::LargeBinary => decode_binary::<i64>(&values),
-        _ => {
-            return Err(ArrowError::NotYetImplemented(format!(
-                "decoding dictionary values of {}",
-                value_type
-            )))
-        }
+        _ => unreachable!(),
     };
 
     let data_type =

--- a/arrow/src/row/dictionary.rs
+++ b/arrow/src/row/dictionary.rs
@@ -173,8 +173,6 @@ pub unsafe fn decode_dictionary<K: ArrowDictionaryKeyType>(
         value_type => (decode_primitive_helper, values, value_type),
         DataType::Null => NullArray::new(values.len()).into_data(),
         DataType::Boolean => decode_bool(&values),
-        DataType::Decimal128(_, _) => decode_primitive_helper!(Decimal128Type, values, value_type),
-        DataType::Decimal256(_, _) => decode_primitive_helper!(Decimal256Type, values, value_type),
         DataType::Utf8 => decode_string::<i32>(&values),
         DataType::LargeUtf8 => decode_string::<i64>(&values),
         DataType::Binary => decode_binary::<i32>(&values),


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3077.

# Rationale for this change
1. There should be an easy way to check if a row format supports a certain type before conversion. This can be useful for DataFusion, where certain decisions are made during planning time.
2. Improve `RowConverter` API by implementing "if you can create it, you can also feed data into it (modulo overflows)".

# What changes are included in this PR?
- `RowConverter::supports_fields` to check if fields are supported by row format
- `RowConverter::new` can now fail
- Small clean (remove unnecessary match arm) 

# Are there any user-facing changes?

**BREAKING CHANGE:** `RowConverter::new` can now fail