### PR TITLE
Parse Time32/Time64 from formatted string

### DIFF
--- a/arrow-csv/src/reader.rs
+++ b/arrow-csv/src/reader.rs
@@ -584,6 +584,24 @@ fn parse(
                     i,
                     datetime_format,
                 ),
+                DataType::Time32(TimeUnit::Second) => {
+                    build_primitive_array::<Time32SecondType>(line_number, rows, i, None)
+                }
+                DataType::Time32(TimeUnit::Millisecond) => build_primitive_array::<
+                    Time32MillisecondType,
+                >(
+                    line_number, rows, i, None
+                ),
+                DataType::Time64(TimeUnit::Microsecond) => build_primitive_array::<
+                    Time64MicrosecondType,
+                >(
+                    line_number, rows, i, None
+                ),
+                DataType::Time64(TimeUnit::Nanosecond) => build_primitive_array::<
+                    Time64NanosecondType,
+                >(
+                    line_number, rows, i, None
+                ),
                 DataType::Timestamp(TimeUnit::Microsecond, _) => {
                     build_primitive_array::<TimestampMicrosecondType>(
                         line_number,
@@ -1591,6 +1609,23 @@ mod tests {
         assert_eq!(parse_item::<Date32Type>("1970-01-01").unwrap(), 0);
         assert_eq!(parse_item::<Date32Type>("2020-03-15").unwrap(), 18336);
         assert_eq!(parse_item::<Date32Type>("1945-05-08").unwrap(), -9004);
+    }
+
+    #[test]
+    fn parse_time() {
+        assert_eq!(
+            parse_item::<Time64NanosecondType>("12:10:01.123456789 AM"),
+            Some(601_123_456_789)
+        );
+        assert_eq!(
+            parse_item::<Time64MicrosecondType>("12:10:01.123456 am"),
+            Some(601_123_456)
+        );
+        assert_eq!(
+            parse_item::<Time32MillisecondType>("2:10:01.12 PM"),
+            Some(51_001_120)
+        );
+        assert_eq!(parse_item::<Time32SecondType>("2:10:01 pm"), Some(51_001));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3100.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Enable parsing `Time32`/`Time64` from formatted string.

Enable reading `Time32`/`Time64` from CSV files.

# Are there any user-facing changes?

Able to parse `Time32`/`Time64` types from formatted string, and from CSV.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
