### PR TITLE
parquet bloom filter part II: read sbbf bitset from row group reader, update API, and add cli demo

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -39,7 +39,6 @@ on:
       - .github/**
 
 jobs:
-
   # test the crate
   linux-test:
     name: Test
@@ -133,7 +132,6 @@ jobs:
         run: cargo check -p arrow --features simd
       - name: Check compilation --features simd --all-targets
         run: cargo check -p arrow --features simd --all-targets
-
 
   # test the arrow crate builds against wasm32 in nightly rust
   wasm32-build:

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -39,6 +39,7 @@ on:
       - .github/**
 
 jobs:
+
   # test the crate
   linux-test:
     name: Test
@@ -132,6 +133,7 @@ jobs:
         run: cargo check -p arrow --features simd
       - name: Check compilation --features simd --all-targets
         run: cargo check -p arrow --features simd --all-targets
+
 
   # test the arrow crate builds against wasm32 in nightly rust
   wasm32-build:

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -113,6 +113,10 @@ required-features = ["cli"]
 name = "parquet-fromcsv"
 required-features = ["arrow", "cli"]
 
+[[bin]]
+name = "parquet-show-bloom-filter"
+required-features = ["cli"]
+
 [[bench]]
 name = "arrow_writer"
 required-features = ["arrow"]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -115,7 +115,7 @@ required-features = ["arrow", "cli"]
 
 [[bin]]
 name = "parquet-show-bloom-filter"
-required-features = ["cli"]
+required-features = ["cli", "bloom"]
 
 [[bench]]
 name = "arrow_writer"

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -41,6 +41,7 @@ However, for historical reasons, this crate uses versions with major numbers gre
 The `parquet` crate provides the following features which may be enabled in your `Cargo.toml`:
 
 - `arrow` (default) - support for reading / writing [`arrow`](https://crates.io/crates/arrow) arrays to / from parquet
+- `bloom` (default) - support for [split block bloom filter](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) for reading from / writing to parquet
 - `async` - support `async` APIs for reading parquet
 - `json` - support for reading / writing `json` data to / from parquet
 - `brotli` (default) - support for parquet using `brotli` compression

--- a/parquet/src/bin/parquet-read.rs
+++ b/parquet/src/bin/parquet-read.rs
@@ -36,8 +36,6 @@
 //! Note that `parquet-read` reads full file schema, no projection or filtering is
 //! applied.
 
-extern crate parquet;
-
 use clap::Parser;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::record::Row;

--- a/parquet/src/bin/parquet-rowcount.rs
+++ b/parquet/src/bin/parquet-rowcount.rs
@@ -36,7 +36,6 @@
 //! Note that `parquet-rowcount` reads full file schema, no projection or filtering is
 //! applied.
 
-extern crate parquet;
 use clap::Parser;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::{fs::File, path::Path};

--- a/parquet/src/bin/parquet-schema.rs
+++ b/parquet/src/bin/parquet-schema.rs
@@ -36,7 +36,6 @@
 //! Note that `verbose` is an optional boolean flag that allows to print schema only,
 //! when not provided or print full file metadata when provided.
 
-extern crate parquet;
 use clap::Parser;
 use parquet::{
     file::reader::{FileReader, SerializedFileReader},

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Binary file to read bloom filter data from a Parquet file.
+//!
+//! # Install
+//!
+//! `parquet-show-bloom-filter` can be installed using `cargo`:
+//! ```
+//! cargo install parquet --features=cli
+//! ```
+//! After this `parquet-show-bloom-filter` should be available:
+//! ```
+//! parquet-show-bloom-filter --file-name XYZ.parquet --column id --values a
+//! ```
+//!
+//! The binary can also be built from the source code and run as follows:
+//! ```
+//! cargo run --features=cli --bin parquet-show-bloom-filter -- --file-name XYZ.parquet --column id --values a
+//! ```
+
+extern crate parquet;
+use clap::Parser;
+use parquet::bloom_filter::hash_bytes;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use std::iter;
+use std::{fs::File, path::Path};
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Binary file to read bloom filter data from a Parquet file"), long_about = None)]
+struct Args {
+    #[clap(short, long, help("Path to a parquet file, or - for stdin"))]
+    file_name: String,
+    #[clap(
+        short,
+        long,
+        help("Check the bloom filter indexes for the given column")
+    )]
+    column: String,
+    #[clap(
+        short,
+        long,
+        help("Check if the given values match bloom filter"),
+        required = true
+    )]
+    values: Vec<String>,
+}
+
+fn main() {
+    let args = Args::parse();
+    let file_name = args.file_name;
+    let path = Path::new(&file_name);
+    let file = File::open(path).expect("Unable to open file");
+
+    let file_reader =
+        SerializedFileReader::new(file).expect("Unable to open file as Parquet");
+    let metadata = file_reader.metadata();
+    for (ri, row_group) in metadata.row_groups().iter().enumerate() {
+        println!("Row group #{}", ri);
+        println!("{}", iter::repeat("=").take(80).collect::<String>());
+        if let Some((column_index, _)) = row_group
+            .columns()
+            .iter()
+            .enumerate()
+            .find(|(_, column)| column.column_path().string() == args.column)
+        {
+            let row_group_reader = file_reader
+                .get_row_group(ri)
+                .expect("Unable to read row group");
+            if let Some(sbbf) = row_group_reader
+                .get_column_bloom_filter(column_index)
+                .expect("Failed to parse bloom filter")
+            {
+                args.values.iter().for_each(|value| {
+                    println!(
+                        "Value {} is {} in bloom filter",
+                        value,
+                        if sbbf.check(hash_bytes(value)) {
+                            "present"
+                        } else {
+                            "absent"
+                        }
+                    )
+                });
+            }
+        } else {
+            println!(
+                "No column named {} found, candidate columns are: {}",
+                args.column,
+                row_group
+                    .columns()
+                    .iter()
+                    .map(|c| c.column_path().string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+}

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -34,7 +34,7 @@
 //! ```
 
 use clap::Parser;
-use parquet::bloom_filter::hash_bytes;
+use parquet::data_type::AsBytes;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::{fs::File, path::Path};
 
@@ -87,7 +87,7 @@ fn main() {
                     println!(
                         "Value {} is {} in bloom filter",
                         value,
-                        if sbbf.check(hash_bytes(value)) {
+                        if sbbf.check(value.as_str()) {
                             "present"
                         } else {
                             "absent"

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -37,7 +37,6 @@ extern crate parquet;
 use clap::Parser;
 use parquet::bloom_filter::hash_bytes;
 use parquet::file::reader::{FileReader, SerializedFileReader};
-use std::iter;
 use std::{fs::File, path::Path};
 
 #[derive(Debug, Parser)]
@@ -71,7 +70,7 @@ fn main() {
     let metadata = file_reader.metadata();
     for (ri, row_group) in metadata.row_groups().iter().enumerate() {
         println!("Row group #{}", ri);
-        println!("{}", iter::repeat("=").take(80).collect::<String>());
+        println!("=".repeat(80));
         if let Some((column_index, _)) = row_group
             .columns()
             .iter()

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -34,7 +34,6 @@
 //! ```
 
 use clap::Parser;
-use parquet::data_type::AsBytes;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::{fs::File, path::Path};
 

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -70,7 +70,7 @@ fn main() {
     let metadata = file_reader.metadata();
     for (ri, row_group) in metadata.row_groups().iter().enumerate() {
         println!("Row group #{}", ri);
-        println!("=".repeat(80));
+        println!("{}", "=".repeat(80));
         if let Some((column_index, _)) = row_group
             .columns()
             .iter()

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -40,7 +40,7 @@ use std::{fs::File, path::Path};
 #[derive(Debug, Parser)]
 #[clap(author, version, about("Binary file to read bloom filter data from a Parquet file"), long_about = None)]
 struct Args {
-    #[clap(short, long, help("Path to a parquet file, or - for stdin"))]
+    #[clap(short, long, help("Path to the parquet file"))]
     file_name: String,
     #[clap(
         short,
@@ -51,7 +51,7 @@ struct Args {
     #[clap(
         short,
         long,
-        help("Check if the given values match bloom filter"),
+        help("Check if the given values match bloom filter, the values will be evaluated as strings"),
         required = true
     )]
     values: Vec<String>,

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -33,7 +33,6 @@
 //! cargo run --features=cli --bin parquet-show-bloom-filter -- --file-name XYZ.parquet --column id --values a
 //! ```
 
-extern crate parquet;
 use clap::Parser;
 use parquet::bloom_filter::hash_bytes;
 use parquet::file::reader::{FileReader, SerializedFileReader};

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -26,7 +26,6 @@ use crate::format::{
 };
 use bytes::{Buf, BufMut, BytesMut};
 use std::hash::Hasher;
-use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 use thrift::protocol::{TCompactInputProtocol, TSerializable};
 use twox_hash::XxHash64;

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -83,8 +83,8 @@ pub struct Sbbf(Vec<Block>);
 
 // this size should not be too large to not to hit short read too early (although unlikely)
 // but also not to small to ensure cache efficiency, this is essential a "guess" of the header
-// size
-const STEP_SIZE: usize = 32;
+// size. In the demo test the size is 15 bytes.
+const STEP_SIZE: usize = 16;
 
 /// given an initial offset, and a chunk reader, try to read out a bloom filter header by trying
 /// one or more iterations, returns both the header and the offset after it (for bitset).
@@ -107,6 +107,12 @@ fn chunk_read_bloom_filter_header_and_offset<R: ChunkReader>(
         if let Ok(h) = BloomFilterHeader::read_from_in_protocol(&mut prot) {
             let buffer = buf_reader.into_inner();
             let bitset_offset = start + STEP_SIZE - buffer.remaining();
+            println!(
+                "offset: {}, bitset_offset: {}, size: {}",
+                offset,
+                bitset_offset,
+                bitset_offset - offset
+            );
             return Ok((h, bitset_offset));
         } else {
             // continue to try by reading another batch

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -21,6 +21,8 @@
 use bytes::Bytes;
 use std::{boxed::Box, io::Read, sync::Arc};
 
+#[cfg(feature = "bloom")]
+use crate::bloom_filter::Sbbf;
 use crate::column::page::PageIterator;
 use crate::column::{page::PageReader, reader::ColumnReader};
 use crate::errors::{ParquetError, Result};
@@ -142,6 +144,10 @@ pub trait RowGroupReader: Send + Sync {
         };
         Ok(col_reader)
     }
+
+    #[cfg(feature = "bloom")]
+    /// Get bloom filter for the `i`th column chunk, if present.
+    fn get_column_bloom_filter(&self, i: usize) -> Result<Option<Sbbf>>;
 
     /// Get iterator of `Row`s from this row group.
     ///

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -389,9 +389,10 @@ impl<'a, R: 'static + ChunkReader> RowGroupReader for SerializedRowGroupReader<'
     }
 
     #[cfg(feature = "bloom")]
-    /// get bloom filter for the ith column
+    /// get bloom filter for the `i`th column
     fn get_column_bloom_filter(&self, i: usize) -> Result<Option<Sbbf>> {
-        todo!()
+        let col = self.metadata.column(i);
+        Sbbf::read_from_column_chunk(col, self.chunk_reader.clone())
     }
 
     fn get_row_iter(&self, projection: Option<SchemaType>) -> Result<RowIter> {

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -22,11 +22,9 @@ use std::collections::VecDeque;
 use std::io::Cursor;
 use std::{convert::TryFrom, fs::File, io::Read, path::Path, sync::Arc};
 
-use crate::format::{PageHeader, PageLocation, PageType};
-use bytes::{Buf, Bytes};
-use thrift::protocol::{TCompactInputProtocol, TSerializable};
-
 use crate::basic::{Encoding, Type};
+#[cfg(feature = "bloom")]
+use crate::bloom_filter::Sbbf;
 use crate::column::page::{Page, PageMetadata, PageReader};
 use crate::compression::{create_codec, Codec};
 use crate::errors::{ParquetError, Result};
@@ -38,11 +36,14 @@ use crate::file::{
     reader::*,
     statistics,
 };
+use crate::format::{PageHeader, PageLocation, PageType};
 use crate::record::reader::RowIter;
 use crate::record::Row;
 use crate::schema::types::Type as SchemaType;
 use crate::util::{io::TryClone, memory::ByteBufferPtr};
-// export `SliceableCursor` and `FileSource` publically so clients can
+use bytes::{Buf, Bytes};
+use thrift::protocol::{TCompactInputProtocol, TSerializable};
+// export `SliceableCursor` and `FileSource` publicly so clients can
 // re-use the logic in their own ParquetFileWriter wrappers
 pub use crate::util::io::FileSource;
 
@@ -385,6 +386,12 @@ impl<'a, R: 'static + ChunkReader> RowGroupReader for SerializedRowGroupReader<'
             page_locations,
             props,
         )?))
+    }
+
+    #[cfg(feature = "bloom")]
+    /// get bloom filter for the ith column
+    fn get_column_bloom_filter(&self, i: usize) -> Result<Option<Sbbf>> {
+        todo!()
     }
 
     fn get_row_iter(&self, projection: Option<SchemaType>) -> Result<RowIter> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- related #3057
- part II of #3023

# Rationale for this change
 
parquet bloom filter part II: 
- read sbbf bitset from row group reader 
- update API
- add cli demo
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

data generation:

```
In [1]: import pyspark.sql

In [2]: spark = pyspark.sql.SparkSession.builder.getOrCreate()

In [4]: spark.conf.set("parquet.bloom.filter.max.bytes", 32)

In [5]: spark.conf.set("parquet.bloom.filter.expected.ndv", 10)

In [6]: spark.conf.set("parquet.bloom.filter.enabled", True)

In [8]: data=[('a'+str(i%10),) for i in range(100)]

In [9]: df = spark.createDataFrame(data, ["id"]).repartition(1)

In [10]: df.write.parquet("bla.parquet", mode = "overwrite")
```

```
❯ cargo run --features=cli --bin parquet-show-bloom-filter -- --file-name bla.parquet/part-00000-3da010f4-d863-497e-a525-3519b58d00ae-c000.snappy.parquet --column id -v a0 -v a1 -v aa
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/parquet-show-bloom-filter --file-name bla.parquet/part-00000-3da010f4-d863-497e-a525-3519b58d00ae-c000.snappy.parquet --column id -v a0 -v a1 -v aa`
Row group #0
================================================================================
Value a0 is present in bloom filter
Value a1 is present in bloom filter
Value aa is absent in bloom filter
```

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
