### PR TITLE
Remove dangling `csv` and `ipc` tests in `arrow/Cargo.toml`

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -260,11 +260,3 @@ required-features = ["test_utils"]
 name = "lexsort"
 harness = false
 required-features = ["test_utils"]
-
-[[test]]
-name = "ipc"
-required-features = ["test_utils", "ipc"]
-
-[[test]]
-name = "csv"
-required-features = ["csv", "chrono-tz"]


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/3045

# Rationale for this change
 
When trying to release arrow 27.0.0 using `(cd arrow && cargo release)` I got the following errors until I removed these entries:

```
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Downloads/apache-arrow-rs-27.0.0/arrow/target/package/arrow-27.0.0/Cargo.toml`

Caused by:
can't find `ipc` test at `tests/ipc.rs` or `tests/ipc/main.rs`. Please specify test.path if you want to use a non-default path.



error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Downloads/apache-arrow-rs-27.0.0/arrow/target/package/arrow-27.0.0/Cargo.toml`

Caused by:
can't find `csv` test at `tests/csv.rs` or `tests/csv/main.rs`. Please specify test.path if you want to use a non-default path.
```


# What changes are included in this PR?
Delete offending entries in `Cargo.toml`

I am not at all sure deleting them is correct but it is what I needed to do to get the package released on crates.io

# Are there any user-facing changes?

