### PR TITLE
Add COW conversion for Buffer and PrimitiveArray and unary_mut

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -372,6 +372,28 @@ impl<'a, T: Array> Array for &'a T {
     }
 }
 
+/// A kind of `Array` which can be downcasted by `downcast_array`.
+pub(crate) trait SizedArray: AsDynAny + Array {}
+
+/// A trait used to help conversion from `Arc<Self>` to `Arc<Any>`.
+pub(crate) trait AsDynAny: Any {
+    fn as_dyn_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static>;
+}
+
+impl<T: Sized + Send + Sync + 'static> AsDynAny for T {
+    fn as_dyn_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+}
+
+/// Downcasts an Arc-ed sized `Array` to Arc-ed underlying arrow type.
+#[allow(dead_code)]
+pub(crate) fn downcast_array<T: Send + Sync + 'static>(
+    array: Arc<dyn SizedArray>,
+) -> Option<Arc<T>> {
+    AsDynAny::as_dyn_any(array).downcast().ok()
+}
+
 /// A generic trait for accessing the values of an [`Array`]
 ///
 /// # Validity
@@ -1112,5 +1134,16 @@ mod tests {
         let arr: ArrayRef = Arc::new(arr);
         assert!(compute_my_thing(&arr));
         assert!(compute_my_thing(arr.as_ref()));
+    }
+
+    #[test]
+    fn test_downcast_array() {
+        let array: Int32Array = vec![1, 2, 3].into_iter().map(Some).collect();
+
+        let boxed: Arc<dyn SizedArray> = Arc::new(array);
+        let array: Arc<Int32Array> = downcast_array(boxed).unwrap();
+
+        let expected: Int32Array = vec![1, 2, 3].into_iter().map(Some).collect();
+        assert_eq!(&array, &Arc::new(expected));
     }
 }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -2069,6 +2069,18 @@ mod tests {
     }
 
     #[test]
+    fn test_into_builder_on_sliced_array() {
+        let array: Int32Array = vec![1, 2, 3].into_iter().map(Some).collect();
+        let slice = array.slice(1, 2);
+        let col: Int32Array = downcast_array(&slice);
+
+        drop(slice);
+
+        col.into_builder()
+            .expect_err("Should not build builder from sliced array");
+    }
+
+    #[test]
     fn test_unary_mut() {
         let array: Int32Array = vec![1, 2, 3].into_iter().map(Some).collect();
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -532,7 +532,8 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let len = self.len();
         let null_bit_buffer = self.data.null_buffer().cloned();
 
-        let buffer = self.data.buffers()[0].clone();
+        let buffer = self.data.buffers()[0]
+            .slice_with_length(0, len * std::mem::size_of::<T::Native>());
 
         drop(self.data);
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -526,8 +526,9 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let len = self.len();
         let null_bit_buffer = self.data.null_buffer().cloned();
 
+        let element_len = std::mem::size_of::<T::Native>();
         let buffer = self.data.buffers()[0]
-            .slice_with_length(0, len * std::mem::size_of::<T::Native>());
+            .slice_with_length(self.data.offset() * element_len, len * element_len);
 
         drop(self.data);
 

--- a/arrow-array/src/builder/boolean_buffer_builder.rs
+++ b/arrow-array/src/builder/boolean_buffer_builder.rs
@@ -34,6 +34,7 @@ impl BooleanBufferBuilder {
     }
 
     pub fn new_from_buffer(buffer: MutableBuffer, len: usize) -> Self {
+        assert!(len <= buffer.len() * 8);
         Self { buffer, len }
     }
 

--- a/arrow-array/src/builder/boolean_buffer_builder.rs
+++ b/arrow-array/src/builder/boolean_buffer_builder.rs
@@ -33,8 +33,8 @@ impl BooleanBufferBuilder {
         Self { buffer, len: 0 }
     }
 
-    pub fn new_from_buffer(buffer: MutableBuffer) -> Self {
-        Self { buffer, len: 0 }
+    pub fn new_from_buffer(buffer: MutableBuffer, len: usize) -> Self {
+        Self { buffer, len }
     }
 
     #[inline]

--- a/arrow-array/src/builder/boolean_buffer_builder.rs
+++ b/arrow-array/src/builder/boolean_buffer_builder.rs
@@ -33,6 +33,10 @@ impl BooleanBufferBuilder {
         Self { buffer, len: 0 }
     }
 
+    pub fn new_from_buffer(buffer: MutableBuffer) -> Self {
+        Self { buffer, len: 0 }
+    }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.len

--- a/arrow-array/src/builder/buffer_builder.rs
+++ b/arrow-array/src/builder/buffer_builder.rs
@@ -124,6 +124,14 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
         }
     }
 
+    pub fn new_from_buffer(buffer: MutableBuffer) -> Self {
+        Self {
+            buffer,
+            len: 0,
+            _marker: PhantomData,
+        }
+    }
+
     /// Returns the current number of array elements in the internal buffer.
     ///
     /// # Example:

--- a/arrow-array/src/builder/buffer_builder.rs
+++ b/arrow-array/src/builder/buffer_builder.rs
@@ -125,9 +125,10 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     }
 
     pub fn new_from_buffer(buffer: MutableBuffer) -> Self {
+        let buffer_len = buffer.len();
         Self {
             buffer,
-            len: 0,
+            len: buffer_len / std::mem::size_of::<T>(),
             _marker: PhantomData,
         }
     }

--- a/arrow-array/src/builder/null_buffer_builder.rs
+++ b/arrow-array/src/builder/null_buffer_builder.rs
@@ -42,9 +42,22 @@ impl NullBufferBuilder {
         }
     }
 
+    /// Creates a new builder with given length.
+    pub fn new_with_len(len: usize) -> Self {
+        Self {
+            bitmap_builder: None,
+            len,
+            capacity: len,
+        }
+    }
+
     /// Creates a new builder from a `MutableBuffer`.
-    pub fn new_from_buffer(buffer: MutableBuffer, len: usize, capacity: usize) -> Self {
-        let bitmap_builder = Some(BooleanBufferBuilder::new_from_buffer(buffer));
+    pub fn new_from_buffer(buffer: MutableBuffer, len: usize) -> Self {
+        let capacity = buffer.len() * 8;
+
+        assert!(len < capacity);
+
+        let bitmap_builder = Some(BooleanBufferBuilder::new_from_buffer(buffer, len));
         Self {
             bitmap_builder,
             len,

--- a/arrow-array/src/builder/null_buffer_builder.rs
+++ b/arrow-array/src/builder/null_buffer_builder.rs
@@ -42,8 +42,9 @@ impl NullBufferBuilder {
         }
     }
 
-    pub fn new_from_buffer(buffer: Option<MutableBuffer>, capacity: usize) -> Self {
-        let bitmap_builder = buffer.map(BooleanBufferBuilder::new_from_buffer);
+    /// Creates a new builder from a `MutableBuffer`.
+    pub fn new_from_buffer(buffer: MutableBuffer, capacity: usize) -> Self {
+        let bitmap_builder = Some(BooleanBufferBuilder::new_from_buffer(buffer));
         Self {
             bitmap_builder,
             len: 0,

--- a/arrow-array/src/builder/null_buffer_builder.rs
+++ b/arrow-array/src/builder/null_buffer_builder.rs
@@ -43,11 +43,11 @@ impl NullBufferBuilder {
     }
 
     /// Creates a new builder from a `MutableBuffer`.
-    pub fn new_from_buffer(buffer: MutableBuffer, capacity: usize) -> Self {
+    pub fn new_from_buffer(buffer: MutableBuffer, len: usize, capacity: usize) -> Self {
         let bitmap_builder = Some(BooleanBufferBuilder::new_from_buffer(buffer));
         Self {
             bitmap_builder,
-            len: 0,
+            len,
             capacity,
         }
     }

--- a/arrow-array/src/builder/null_buffer_builder.rs
+++ b/arrow-array/src/builder/null_buffer_builder.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::builder::BooleanBufferBuilder;
-use arrow_buffer::Buffer;
+use arrow_buffer::{Buffer, MutableBuffer};
 
 /// Builder for creating the null bit buffer.
 /// This builder only materializes the buffer when we append `false`.
@@ -37,6 +37,15 @@ impl NullBufferBuilder {
     pub fn new(capacity: usize) -> Self {
         Self {
             bitmap_builder: None,
+            len: 0,
+            capacity,
+        }
+    }
+
+    pub fn new_from_buffer(buffer: Option<MutableBuffer>, capacity: usize) -> Self {
+        let bitmap_builder = buffer.map(BooleanBufferBuilder::new_from_buffer);
+        Self {
+            bitmap_builder,
             len: 0,
             capacity,
         }

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -119,15 +119,13 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         values_buffer: MutableBuffer,
         null_buffer: Option<MutableBuffer>,
     ) -> Self {
-        let capacity = values_buffer.capacity();
-
         let values_builder = BufferBuilder::<T::Native>::new_from_buffer(values_buffer);
 
         let null_buffer_builder = null_buffer
             .map(|buffer| {
-                NullBufferBuilder::new_from_buffer(buffer, values_builder.len(), capacity)
+                NullBufferBuilder::new_from_buffer(buffer, values_builder.len())
             })
-            .unwrap_or_else(|| NullBufferBuilder::new(capacity));
+            .unwrap_or_else(|| NullBufferBuilder::new_with_len(values_builder.len()));
 
         Self {
             values_builder,

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -121,12 +121,13 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     ) -> Self {
         let capacity = values_buffer.capacity();
 
+        let null_buffer_builder = null_buffer
+            .map(|buffer| NullBufferBuilder::new_from_buffer(buffer, capacity))
+            .unwrap_or_else(|| NullBufferBuilder::new(capacity));
+
         Self {
             values_builder: BufferBuilder::<T::Native>::new_from_buffer(values_buffer),
-            null_buffer_builder: NullBufferBuilder::new_from_buffer(
-                null_buffer,
-                capacity,
-            ),
+            null_buffer_builder,
         }
     }
 

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -19,6 +19,7 @@ use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::{ArrayBuilder, BufferBuilder};
 use crate::types::*;
 use crate::{ArrayRef, ArrowPrimitiveType, PrimitiveArray};
+use arrow_buffer::MutableBuffer;
 use arrow_data::ArrayData;
 use std::any::Any;
 use std::sync::Arc;
@@ -111,6 +112,21 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         Self {
             values_builder: BufferBuilder::<T::Native>::new(capacity),
             null_buffer_builder: NullBufferBuilder::new(capacity),
+        }
+    }
+
+    pub fn new_from_buffer(
+        values_buffer: MutableBuffer,
+        null_buffer: Option<MutableBuffer>,
+    ) -> Self {
+        let capacity = values_buffer.capacity();
+
+        Self {
+            values_builder: BufferBuilder::<T::Native>::new_from_buffer(values_buffer),
+            null_buffer_builder: NullBufferBuilder::new_from_buffer(
+                null_buffer,
+                capacity,
+            ),
         }
     }
 

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -121,12 +121,16 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     ) -> Self {
         let capacity = values_buffer.capacity();
 
+        let values_builder = BufferBuilder::<T::Native>::new_from_buffer(values_buffer);
+
         let null_buffer_builder = null_buffer
-            .map(|buffer| NullBufferBuilder::new_from_buffer(buffer, capacity))
+            .map(|buffer| {
+                NullBufferBuilder::new_from_buffer(buffer, values_builder.len(), capacity)
+            })
             .unwrap_or_else(|| NullBufferBuilder::new(capacity));
 
         Self {
-            values_builder: BufferBuilder::<T::Native>::new_from_buffer(values_buffer),
+            values_builder,
             null_buffer_builder,
         }
     }
@@ -220,6 +224,11 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     /// Returns the current values buffer as a slice
     pub fn values_slice(&self) -> &[T::Native] {
         self.values_builder.as_slice()
+    }
+
+    /// Returns the current values buffer as a mutable slice
+    pub fn values_slice_mut(&mut self) -> &mut [T::Native] {
+        self.values_builder.as_slice_mut()
     }
 }
 

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -230,7 +230,7 @@ impl Buffer {
 
     /// Returns `MutableBuffer` for mutating the buffer if this buffer is not shared.
     /// Returns `Err` if this is shared or its allocation is from an external source.
-    pub fn into_mutable(self, len: usize) -> Result<MutableBuffer, Self> {
+    pub fn into_mutable(self) -> Result<MutableBuffer, Self> {
         let offset_ptr = self.as_ptr();
         let offset = self.offset;
         let length = self.length;
@@ -238,7 +238,7 @@ impl Buffer {
             .and_then(|bytes| {
                 // The pointer of underlying buffer should not be offset.
                 assert_eq!(offset_ptr, bytes.ptr().as_ptr());
-                MutableBuffer::from_bytes(bytes, len).map_err(Arc::new)
+                MutableBuffer::from_bytes(bytes).map_err(Arc::new)
             })
             .map_err(|bytes| Buffer {
                 data: bytes,

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -229,7 +229,7 @@ impl Buffer {
     }
 
     /// Returns `MutableBuffer` for mutating the buffer if this buffer is not shared.
-    pub fn into_mutable(self) -> Result<MutableBuffer, Self> {
+    pub fn into_mutable(self, len: usize) -> Result<MutableBuffer, Self> {
         let offset_ptr = self.as_ptr();
         let offset = self.offset;
         let length = self.length;
@@ -239,7 +239,7 @@ impl Buffer {
                 assert_eq!(offset_ptr, bytes.ptr().as_ptr());
 
                 let mutable_buffer =
-                    MutableBuffer::from_ptr(bytes.ptr(), bytes.capacity());
+                    MutableBuffer::from_ptr(bytes.ptr(), len, bytes.capacity());
                 mem::forget(bytes);
                 mutable_buffer
             })

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -93,10 +93,10 @@ impl MutableBuffer {
     }
 
     /// Allocates a new [MutableBuffer] from given pointer `ptr`, `capacity`.
-    pub(crate) fn from_ptr(ptr: NonNull<u8>, capacity: usize) -> Self {
+    pub(crate) fn from_ptr(ptr: NonNull<u8>, len: usize, capacity: usize) -> Self {
         Self {
             data: ptr,
-            len: 0,
+            len,
             capacity,
         }
     }

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -92,6 +92,15 @@ impl MutableBuffer {
         }
     }
 
+    /// Allocates a new [MutableBuffer] from given pointer `ptr`, `capacity`.
+    pub(crate) fn from_ptr(ptr: NonNull<u8>, capacity: usize) -> Self {
+        Self {
+            data: ptr,
+            len: 0,
+            capacity,
+        }
+    }
+
     /// creates a new [MutableBuffer] with capacity and length capable of holding `len` bits.
     /// This is useful to create a buffer for packed bitmaps.
     pub fn new_null(len: usize) -> Self {

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -23,6 +23,7 @@ use crate::{
     native::{ArrowNativeType, ToByteSlice},
     util::bit_util,
 };
+use std::mem;
 use std::ptr::NonNull;
 
 /// A [`MutableBuffer`] is Arrow's interface to build a [`Buffer`] out of items or slices of items.
@@ -92,13 +93,21 @@ impl MutableBuffer {
         }
     }
 
-    /// Allocates a new [MutableBuffer] from given pointer `ptr`, `capacity`.
-    pub(crate) fn from_ptr(ptr: NonNull<u8>, len: usize, capacity: usize) -> Self {
-        Self {
+    /// Allocates a new [MutableBuffer] from given `Bytes`.
+    pub(crate) fn from_bytes(bytes: Bytes, len: usize) -> Result<Self, Bytes> {
+        if !matches!(bytes.deallocation(), Deallocation::Arrow(_)) {
+            return Err(bytes);
+        }
+
+        let capacity = bytes.capacity();
+        let ptr = bytes.ptr();
+        mem::forget(bytes);
+
+        Ok(Self {
             data: ptr,
             len,
             capacity,
-        }
+        })
     }
 
     /// creates a new [MutableBuffer] with capacity and length capable of holding `len` bits.

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -94,11 +94,12 @@ impl MutableBuffer {
     }
 
     /// Allocates a new [MutableBuffer] from given `Bytes`.
-    pub(crate) fn from_bytes(bytes: Bytes, len: usize) -> Result<Self, Bytes> {
+    pub(crate) fn from_bytes(bytes: Bytes) -> Result<Self, Bytes> {
         if !matches!(bytes.deallocation(), Deallocation::Arrow(_)) {
             return Err(bytes);
         }
 
+        let len = bytes.len();
         let capacity = bytes.capacity();
         let ptr = bytes.ptr();
         mem::forget(bytes);

--- a/arrow-buffer/src/bytes.rs
+++ b/arrow-buffer/src/bytes.rs
@@ -99,6 +99,11 @@ impl Bytes {
             Deallocation::Custom(_) => 0,
         }
     }
+
+    #[inline]
+    pub(crate) fn deallocation(&self) -> &Deallocation {
+        &self.deallocation
+    }
 }
 
 // Deallocation is Send + Sync, repeating the bound here makes that refactoring safe

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -387,6 +387,10 @@ impl ArrayData {
         &self.buffers[..]
     }
 
+    pub fn get_buffers(self) -> Vec<Buffer> {
+        self.buffers
+    }
+
     /// Returns a slice of children data arrays
     pub fn child_data(&self) -> &[ArrayData] {
         &self.child_data[..]

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -387,10 +387,6 @@ impl ArrayData {
         &self.buffers[..]
     }
 
-    pub fn get_buffers(self) -> Vec<Buffer> {
-        self.buffers
-    }
-
     /// Returns a slice of children data arrays
     pub fn child_data(&self) -> &[ArrayData] {
         &self.child_data[..]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #1981.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I've played around with the code to add some initial APIs for copy-on-write support. The COW support can benefit for our use cases to reduce memory allocation cost. I'd like to add some initial support to move it forward.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This change is not fully COW support but adds some initial APIs for that.

* Add COW conversion from `Buffer` to `MutableBuffer`
* Add COW conversion from `PrimitiveArray` to corresponding builder
* Add `unary_mut` to `PrimitiveArray` for mutating its content

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
