### PR TITLE
parquet bloom filter part III: add sbbf writer, remove `bloom` default feature, add reader properties

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -57,7 +57,8 @@ seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.13", default-features = false }
-twox-hash = { version = "1.6", optional = true }
+twox-hash = { version = "1.6" }
+paste = { version = "1.0" }
 
 [dev-dependencies]
 base64 = { version = "0.13", default-features = false, features = ["std"] }
@@ -77,7 +78,7 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 all-features = true
 
 [features]
-default = ["arrow", "bloom", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
+default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 # Enable arrow reader/writer APIs
 arrow = ["base64", "arrow-array", "arrow-buffer", "arrow-cast", "arrow-data", "arrow-schema", "arrow-select", "arrow-ipc"]
 # Enable CLI tools
@@ -90,8 +91,6 @@ test_common = ["arrow/test_utils"]
 experimental = []
 # Enable async APIs
 async = ["futures", "tokio"]
-# Bloomfilter
-bloom = ["twox-hash"]
 
 [[test]]
 name = "arrow_writer_layout"
@@ -115,7 +114,7 @@ required-features = ["arrow", "cli"]
 
 [[bin]]
 name = "parquet-show-bloom-filter"
-required-features = ["cli", "bloom"]
+required-features = ["cli"]
 
 [[bench]]
 name = "arrow_writer"

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -57,7 +57,7 @@ seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.13", default-features = false }
-twox-hash = { version = "1.6" }
+twox-hash = { version = "1.6", default-features = false }
 paste = { version = "1.0" }
 
 [dev-dependencies]

--- a/parquet/src/bin/parquet-show-bloom-filter.rs
+++ b/parquet/src/bin/parquet-show-bloom-filter.rs
@@ -78,10 +78,7 @@ fn main() {
             let row_group_reader = file_reader
                 .get_row_group(ri)
                 .expect("Unable to read row group");
-            if let Some(sbbf) = row_group_reader
-                .get_column_bloom_filter(column_index)
-                .expect("Failed to parse bloom filter")
-            {
+            if let Some(sbbf) = row_group_reader.get_column_bloom_filter(column_index) {
                 args.values.iter().for_each(|value| {
                     println!(
                         "Value {} is {} in bloom filter",

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -127,10 +127,14 @@ fn optimal_num_of_bytes(num_bytes: usize) -> usize {
 }
 
 impl Sbbf {
-    /// Create a new Sbbf with given number of distinct values and false positive probability.
+    /// Create a new [Sbbf] with given number of distinct values and false positive probability.
     /// Will panic if `fpp` is greater than 1.0 or less than 0.0.
     pub fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Self {
         assert!(0.0 <= fpp && fpp <= 1.0, "invalid fpp: {}", fpp);
+        // see http://algo2.iti.kit.edu/documents/cacheefficientbloomfilters-jea.pdf
+        // given fpp = (1 - e^(-k * n / m)) ^ k
+        // we have m = - k * n / ln(1 - fpp ^ (1 / k))
+        // where k = number of hash functions, m = number of bits, n = number of distinct values
         let num_bits: f64 = -8.0 * ndv as f64 / (1.0 - fpp.powf(1.0 / 8.0)).ln();
         let num_bits = if num_bits < 0.0 {
             // overflow here
@@ -141,8 +145,8 @@ impl Sbbf {
         Self::new_with_num_of_bytes(num_bits / 8)
     }
 
-    /// Create a new Sbbf with given number of bytes, the exact number of bytes will be adjusted
-    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
+    /// to the next power of two bounded by `BITSET_MIN_LENGTH` and `BITSET_MAX_LENGTH`.
     pub fn new_with_num_of_bytes(num_bytes: usize) -> Self {
         let num_bytes = optimal_num_of_bytes(num_bytes);
         let bitset = vec![0_u8; num_bytes];

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -139,7 +139,7 @@ impl Sbbf {
     /// Create a new [Sbbf] with given number of distinct values and false positive probability.
     /// Will panic if `fpp` is greater than 1.0 or less than 0.0.
     pub fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Self {
-        assert!(0.0 <= fpp && fpp <= 1.0, "invalid fpp: {}", fpp);
+        assert!((0.0..-1.0).contains(&fpp), "invalid fpp: {}", fpp);
         let num_bits = num_of_bits_from_ndv_fpp(ndv, fpp);
         let num_bits = if num_bits < 0.0 {
             // overflow here

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -236,7 +236,7 @@ pub struct RowGroupMetaData {
 }
 
 impl RowGroupMetaData {
-    /// Returns builer for row group metadata.
+    /// Returns builder for row group metadata.
     pub fn builder(schema_descr: SchemaDescPtr) -> RowGroupMetaDataBuilder {
         RowGroupMetaDataBuilder::new(schema_descr)
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -64,6 +64,7 @@
 //!     .build();
 //! ```
 
+use paste::paste;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::basic::{Compression, Encoding};
@@ -82,6 +83,9 @@ const DEFAULT_STATISTICS_ENABLED: EnabledStatistics = EnabledStatistics::Page;
 const DEFAULT_MAX_STATISTICS_SIZE: usize = 4096;
 const DEFAULT_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
 const DEFAULT_CREATED_BY: &str = env!("PARQUET_CREATED_BY");
+const DEFAULT_BLOOM_FILTER_ENABLED: bool = false;
+const DEFAULT_BLOOM_FILTER_MAX_BYTES: u32 = 1024 * 1024;
+const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
 
 /// Parquet writer version.
 ///
@@ -123,6 +127,26 @@ pub struct WriterProperties {
     default_column_properties: ColumnProperties,
     column_properties: HashMap<ColumnPath, ColumnProperties>,
     sorting_columns: Option<Vec<SortingColumn>>,
+}
+
+macro_rules! def_col_property_getter {
+    ($field:ident, $field_type:ty) => {
+        pub fn $field(&self, col: &ColumnPath) -> Option<$field_type> {
+            self.column_properties
+                .get(col)
+                .and_then(|c| c.$field())
+                .or_else(|| self.default_column_properties.$field())
+        }
+    };
+    ($field:ident, $field_type:ty, $default_val:expr) => {
+        pub fn $field(&self, col: &ColumnPath) -> $field_type {
+            self.column_properties
+                .get(col)
+                .and_then(|c| c.$field())
+                .or_else(|| self.default_column_properties.$field())
+                .unwrap_or($default_val)
+        }
+    };
 }
 
 impl WriterProperties {
@@ -255,6 +279,11 @@ impl WriterProperties {
             .or_else(|| self.default_column_properties.max_statistics_size())
             .unwrap_or(DEFAULT_MAX_STATISTICS_SIZE)
     }
+
+    def_col_property_getter!(bloom_filter_enabled, bool, DEFAULT_BLOOM_FILTER_ENABLED);
+    def_col_property_getter!(bloom_filter_fpp, f64, DEFAULT_BLOOM_FILTER_FPP);
+    def_col_property_getter!(bloom_filter_ndv, u64);
+    def_col_property_getter!(bloom_filter_max_bytes, u32, DEFAULT_BLOOM_FILTER_MAX_BYTES);
 }
 
 /// Writer properties builder.
@@ -272,6 +301,40 @@ pub struct WriterPropertiesBuilder {
     sorting_columns: Option<Vec<SortingColumn>>,
 }
 
+macro_rules! def_opt_field_setter {
+    ($field: ident, $type: ty) => {
+        paste! {
+            pub fn [<set_ $field>](&mut self, value: $type) -> &mut Self {
+                self.$field = Some(value);
+                self
+            }
+        }
+    };
+}
+
+macro_rules! def_opt_field_getter {
+    ($field: ident, $type: ty) => {
+        paste! {
+            #[doc = "Returns " $field " if set."]
+            pub fn $field(&self) -> Option<$type> {
+                self.$field
+            }
+        }
+    };
+}
+
+macro_rules! def_per_col_setter {
+    ($field:ident, $field_type:ty) => {
+        paste! {
+            #[doc = "Sets " $field " for a column. Takes precedence over globally defined settings."]
+            pub fn [<set_column_ $field>](mut self, col: ColumnPath, value: $field_type) -> Self {
+                self.get_mut_props(col).[<set_ $field>](value);
+                self
+            }
+        }
+    }
+}
+
 impl WriterPropertiesBuilder {
     /// Returns default state of the builder.
     fn with_defaults() -> Self {
@@ -284,7 +347,7 @@ impl WriterPropertiesBuilder {
             writer_version: DEFAULT_WRITER_VERSION,
             created_by: DEFAULT_CREATED_BY.to_string(),
             key_value_metadata: None,
-            default_column_properties: ColumnProperties::new(),
+            default_column_properties: Default::default(),
             column_properties: HashMap::new(),
             sorting_columns: None,
         }
@@ -439,7 +502,7 @@ impl WriterPropertiesBuilder {
     fn get_mut_props(&mut self, col: ColumnPath) -> &mut ColumnProperties {
         self.column_properties
             .entry(col)
-            .or_insert_with(ColumnProperties::new)
+            .or_insert_with(Default::default)
     }
 
     /// Sets encoding for a column.
@@ -492,6 +555,11 @@ impl WriterPropertiesBuilder {
         self.get_mut_props(col).set_max_statistics_size(value);
         self
     }
+
+    def_per_col_setter!(bloom_filter_enabled, bool);
+    def_per_col_setter!(bloom_filter_fpp, f64);
+    def_per_col_setter!(bloom_filter_max_bytes, u32);
+    def_per_col_setter!(bloom_filter_ndv, u64);
 }
 
 /// Controls the level of statistics to be computed by the writer
@@ -515,27 +583,24 @@ impl Default for EnabledStatistics {
 ///
 /// If a field is `None`, it means that no specific value has been set for this column,
 /// so some subsequent or default value must be used.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 struct ColumnProperties {
     encoding: Option<Encoding>,
     codec: Option<Compression>,
     dictionary_enabled: Option<bool>,
     statistics_enabled: Option<EnabledStatistics>,
     max_statistics_size: Option<usize>,
+    /// bloom filter enabled
+    bloom_filter_enabled: Option<bool>,
+    /// bloom filter expected number of distinct values
+    bloom_filter_ndv: Option<u64>,
+    /// bloom filter false positive probability
+    bloom_filter_fpp: Option<f64>,
+    /// bloom filter max number of bytes
+    bloom_filter_max_bytes: Option<u32>,
 }
 
 impl ColumnProperties {
-    /// Initialise column properties with default values.
-    fn new() -> Self {
-        Self {
-            encoding: None,
-            codec: None,
-            dictionary_enabled: None,
-            statistics_enabled: None,
-            max_statistics_size: None,
-        }
-    }
-
     /// Sets encoding for this column.
     ///
     /// If dictionary is not enabled, this is treated as a primary encoding for a column.
@@ -572,6 +637,11 @@ impl ColumnProperties {
         self.max_statistics_size = Some(value);
     }
 
+    def_opt_field_setter!(bloom_filter_enabled, bool);
+    def_opt_field_setter!(bloom_filter_fpp, f64);
+    def_opt_field_setter!(bloom_filter_max_bytes, u32);
+    def_opt_field_setter!(bloom_filter_ndv, u64);
+
     /// Returns optional encoding for this column.
     fn encoding(&self) -> Option<Encoding> {
         self.encoding
@@ -599,10 +669,17 @@ impl ColumnProperties {
     fn max_statistics_size(&self) -> Option<usize> {
         self.max_statistics_size
     }
+
+    def_opt_field_getter!(bloom_filter_enabled, bool);
+    def_opt_field_getter!(bloom_filter_fpp, f64);
+    def_opt_field_getter!(bloom_filter_max_bytes, u32);
+    def_opt_field_getter!(bloom_filter_ndv, u64);
 }
 
 /// Reference counted reader properties.
 pub type ReaderPropertiesPtr = Arc<ReaderProperties>;
+
+const DEFAULT_READ_BLOOM_FILTER: bool = true;
 
 /// Reader properties.
 ///
@@ -610,6 +687,7 @@ pub type ReaderPropertiesPtr = Arc<ReaderProperties>;
 /// Use [`ReaderPropertiesBuilder`] to assemble these properties.
 pub struct ReaderProperties {
     codec_options: CodecOptions,
+    read_bloom_filter: bool,
 }
 
 impl ReaderProperties {
@@ -622,11 +700,17 @@ impl ReaderProperties {
     pub(crate) fn codec_options(&self) -> &CodecOptions {
         &self.codec_options
     }
+
+    /// Returns whether to read bloom filter
+    pub(crate) fn read_bloom_filter(&self) -> bool {
+        self.read_bloom_filter
+    }
 }
 
 /// Reader properties builder.
 pub struct ReaderPropertiesBuilder {
     codec_options_builder: CodecOptionsBuilder,
+    read_bloom_filter: Option<bool>,
 }
 
 /// Reader properties builder.
@@ -635,6 +719,7 @@ impl ReaderPropertiesBuilder {
     fn with_defaults() -> Self {
         Self {
             codec_options_builder: CodecOptionsBuilder::default(),
+            read_bloom_filter: None,
         }
     }
 
@@ -642,6 +727,9 @@ impl ReaderPropertiesBuilder {
     pub fn build(self) -> ReaderProperties {
         ReaderProperties {
             codec_options: self.codec_options_builder.build(),
+            read_bloom_filter: self
+                .read_bloom_filter
+                .unwrap_or(DEFAULT_READ_BLOOM_FILTER),
         }
     }
 
@@ -657,6 +745,17 @@ impl ReaderPropertiesBuilder {
         self.codec_options_builder = self
             .codec_options_builder
             .set_backward_compatible_lz4(value);
+        self
+    }
+
+    /// Enable/disable reading bloom filter
+    ///
+    /// If reading bloom filter is enabled, bloom filter will be read from the file.
+    /// If reading bloom filter is disabled, bloom filter will not be read from the file.
+    ///
+    /// By default bloom filter is set to be read.
+    pub fn set_read_bloom_filter(mut self, value: bool) -> Self {
+        self.read_bloom_filter = Some(value);
         self
     }
 }
@@ -700,6 +799,13 @@ mod tests {
         assert_eq!(
             props.max_statistics_size(&ColumnPath::from("col")),
             DEFAULT_MAX_STATISTICS_SIZE
+        );
+        assert_eq!(props.bloom_filter_enabled(&ColumnPath::from("col")), false);
+        assert_eq!(props.bloom_filter_fpp(&ColumnPath::from("col")), 0.01);
+        assert_eq!(props.bloom_filter_ndv(&ColumnPath::from("col")), None);
+        assert_eq!(
+            props.bloom_filter_max_bytes(&ColumnPath::from("col")),
+            1024 * 1024
         );
     }
 
@@ -784,6 +890,10 @@ mod tests {
                 EnabledStatistics::Chunk,
             )
             .set_column_max_statistics_size(ColumnPath::from("col"), 123)
+            .set_column_bloom_filter_enabled(ColumnPath::from("col"), true)
+            .set_column_bloom_filter_ndv(ColumnPath::from("col"), 100)
+            .set_column_bloom_filter_fpp(ColumnPath::from("col"), 0.1)
+            .set_column_bloom_filter_max_bytes(ColumnPath::from("col"), 1000)
             .build();
 
         assert_eq!(props.writer_version(), WriterVersion::PARQUET_2_0);
@@ -858,6 +968,7 @@ mod tests {
             .build();
 
         assert_eq!(props.codec_options(), &codec_options);
+        assert_eq!(props.read_bloom_filter(), true);
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -313,7 +313,7 @@ macro_rules! def_opt_field_setter {
     ($field: ident, $type: ty, $min_value:expr, $max_value:expr) => {
         paste! {
             pub fn [<set_ $field>](&mut self, value: $type) -> &mut Self {
-                if value >= $min_value && value <= $max_value {
+                if ($min_value..=$max_value).contains(&value) {
                     self.$field = Some(value);
                 } else {
                     self.$field = None

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -310,6 +310,18 @@ macro_rules! def_opt_field_setter {
             }
         }
     };
+    ($field: ident, $type: ty, $min_value:expr, $max_value:expr) => {
+        paste! {
+            pub fn [<set_ $field>](&mut self, value: $type) -> &mut Self {
+                if value >= $min_value && value <= $max_value {
+                    self.$field = Some(value);
+                } else {
+                    self.$field = None
+                }
+                self
+            }
+        }
+    };
 }
 
 macro_rules! def_opt_field_getter {
@@ -638,7 +650,7 @@ impl ColumnProperties {
     }
 
     def_opt_field_setter!(bloom_filter_enabled, bool);
-    def_opt_field_setter!(bloom_filter_fpp, f64);
+    def_opt_field_setter!(bloom_filter_fpp, f64, 0.0, 1.0);
     def_opt_field_setter!(bloom_filter_max_bytes, u32);
     def_opt_field_setter!(bloom_filter_ndv, u64);
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -800,7 +800,7 @@ mod tests {
             props.max_statistics_size(&ColumnPath::from("col")),
             DEFAULT_MAX_STATISTICS_SIZE
         );
-        assert_eq!(props.bloom_filter_enabled(&ColumnPath::from("col")), false);
+        assert!(!props.bloom_filter_enabled(&ColumnPath::from("col")));
         assert_eq!(props.bloom_filter_fpp(&ColumnPath::from("col")), 0.01);
         assert_eq!(props.bloom_filter_ndv(&ColumnPath::from("col")), None);
         assert_eq!(
@@ -968,7 +968,7 @@ mod tests {
             .build();
 
         assert_eq!(props.codec_options(), &codec_options);
-        assert_eq!(props.read_bloom_filter(), true);
+        assert!(props.read_bloom_filter());
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -980,7 +980,7 @@ mod tests {
             .build();
 
         assert_eq!(props.codec_options(), &codec_options);
-        assert!(props.read_bloom_filter());
+        assert!(!props.read_bloom_filter());
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -691,7 +691,7 @@ impl ColumnProperties {
 /// Reference counted reader properties.
 pub type ReaderPropertiesPtr = Arc<ReaderProperties>;
 
-const DEFAULT_READ_BLOOM_FILTER: bool = true;
+const DEFAULT_READ_BLOOM_FILTER: bool = false;
 
 /// Reader properties.
 ///

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -21,7 +21,6 @@
 use bytes::Bytes;
 use std::{boxed::Box, io::Read, sync::Arc};
 
-#[cfg(feature = "bloom")]
 use crate::bloom_filter::Sbbf;
 use crate::column::page::PageIterator;
 use crate::column::{page::PageReader, reader::ColumnReader};
@@ -145,9 +144,8 @@ pub trait RowGroupReader: Send + Sync {
         Ok(col_reader)
     }
 
-    #[cfg(feature = "bloom")]
     /// Get bloom filter for the `i`th column chunk, if present.
-    fn get_column_bloom_filter(&self, i: usize) -> Result<Option<Sbbf>>;
+    fn get_column_bloom_filter(&self, i: usize) -> Option<&Sbbf>;
 
     /// Get iterator of `Row`s from this row group.
     ///

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -144,7 +144,8 @@ pub trait RowGroupReader: Send + Sync {
         Ok(col_reader)
     }
 
-    /// Get bloom filter for the `i`th column chunk, if present.
+    /// Get bloom filter for the `i`th column chunk, if present and the reader was configured
+    /// to read bloom filters.
     fn get_column_bloom_filter(&self, i: usize) -> Option<&Sbbf>;
 
     /// Get iterator of `Row`s from this row group.

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -230,11 +230,7 @@ impl<W: Write> SerializedFileWriter<W> {
                 match &self.bloom_filters[row_group_idx][column_idx] {
                     Some(bloom_filter) => {
                         let start_offset = self.buf.bytes_written();
-                        let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
-                        let header = bloom_filter.header();
-                        header.write_to_out_protocol(&mut protocol)?;
-                        protocol.flush()?;
-                        bloom_filter.write_bitset(&mut self.buf)?;
+                        bloom_filter.write(&mut self.buf)?;
                         // set offset and index for bloom filter
                         column_chunk
                             .meta_data

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -84,7 +84,6 @@ pub mod arrow;
 pub mod column;
 experimental!(mod compression);
 experimental!(mod encodings);
-#[cfg(feature = "bloom")]
 pub mod bloom_filter;
 pub mod file;
 pub mod record;


### PR DESCRIPTION
# Which issue does this PR close?

- previous PR: #3102
- related issue: #3023 

# Rationale for this change
 
- add sbbf filter during metadata writing phase
- add reading support for bloom filter in reader properties
- create bloom filter per column chunk per row group as per writer properties
- remove `bloom` feature

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

now the API is considered _complete_, the next step is to have an end to end test or cross test with actual parquet file generation.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
