### PR TITLE
feat: `{Field,DataType}::size`

### DIFF
--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -459,6 +459,21 @@ impl Field {
             }
         }
     }
+
+    /// Return size of this instance in bytes.
+    ///
+    /// Includes the size of `Self`.
+    pub fn size(&self) -> usize {
+        std::mem::size_of_val(self) - std::mem::size_of_val(&self.data_type)
+            + self.data_type.size()
+            + self.name.capacity()
+            + (std::mem::size_of::<(String, String)>() * self.metadata.capacity())
+            + self
+                .metadata
+                .iter()
+                .map(|(k, v)| k.capacity() + v.capacity())
+                .sum::<usize>()
+    }
 }
 
 // TODO: improve display with crate https://crates.io/crates/derive_more ?


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3147.

# Rationale for this change
In DataFusion, it would be nice to know how much data is allocated so we can bail out early instead of OOMing (a slight over-allocation is OK, so this can be measured after the fact). For that purpose, it would be nice to know how much memory a specific instance of `Field`/`DataType` requires.

# What changes are included in this PR?
`DataType::size` and `Schema::size`.

# Are there any user-facing changes?
New methods, not breaking.