### PR TITLE
Remove unnecessary Buffer::from_slice_ref reference

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -296,8 +296,8 @@ mod tests {
         // Array data: ["hello", "", "parquet"]
         let array_data = ArrayData::builder(DataType::Binary)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array = BinaryArray::from(array_data);
@@ -335,8 +335,8 @@ mod tests {
         let array_data = ArrayData::builder(DataType::Binary)
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array = BinaryArray::from(array_data);
@@ -360,8 +360,8 @@ mod tests {
         // Array data: ["hello", "", "parquet"]
         let array_data = ArrayData::builder(DataType::LargeBinary)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array = LargeBinaryArray::from(array_data);
@@ -399,8 +399,8 @@ mod tests {
         let array_data = ArrayData::builder(DataType::LargeBinary)
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array = LargeBinaryArray::from(array_data);
@@ -429,8 +429,8 @@ mod tests {
         // Array data: ["hello", "", "parquet"]
         let array_data1 = ArrayData::builder(GenericBinaryArray::<O>::DATA_TYPE)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array1 = GenericBinaryArray::<O>::from(array_data1);
@@ -441,7 +441,7 @@ mod tests {
 
         let array_data2 = ArrayData::builder(data_type)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .add_child_data(child_data)
             .build()
             .unwrap();
@@ -484,7 +484,7 @@ mod tests {
             .unwrap();
 
         let offsets = [0, 5, 8, 15].map(|n| O::from_usize(n).unwrap());
-        let null_buffer = Buffer::from_slice_ref(&[0b101]);
+        let null_buffer = Buffer::from_slice_ref([0b101]);
         let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
             Field::new("item", DataType::UInt8, false),
         ));
@@ -493,7 +493,7 @@ mod tests {
         let array_data = ArrayData::builder(data_type)
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .null_bit_buffer(Some(null_buffer))
             .add_child_data(child_data)
             .build()
@@ -525,7 +525,7 @@ mod tests {
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(10)
             .add_buffer(Buffer::from(&values[..]))
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[0b1010101010])))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([0b1010101010])))
             .build()
             .unwrap();
 
@@ -537,7 +537,7 @@ mod tests {
         // [None, Some(b"Parquet")]
         let array_data = ArrayData::builder(data_type)
             .len(2)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .add_child_data(child_data)
             .build()
             .unwrap();
@@ -617,7 +617,7 @@ mod tests {
         let values: [u32; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         let values_data = ArrayData::builder(DataType::UInt32)
             .len(12)
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let offsets: [i32; 4] = [0, 5, 5, 12];
@@ -626,7 +626,7 @@ mod tests {
             DataType::List(Box::new(Field::new("item", DataType::UInt32, false)));
         let array_data = ArrayData::builder(data_type)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .add_child_data(values_data)
             .build()
             .unwrap();
@@ -644,8 +644,8 @@ mod tests {
         let offsets: [i32; 4] = [0, 5, 5, 12];
         let array_data = ArrayData::builder(DataType::Binary)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let binary_array = BinaryArray::from(array_data);

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -539,7 +539,7 @@ mod tests {
         let values_data = ArrayData::builder(DataType::UInt8)
             .len(12)
             .offset(2)
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         // [null, [10, 11, 12, 13]]
@@ -551,7 +551,7 @@ mod tests {
             .len(2)
             .offset(1)
             .add_child_data(values_data)
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[0b101])))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([0b101])))
             .build_unchecked()
         };
         let list_array = FixedSizeListArray::from(array_data);
@@ -575,7 +575,7 @@ mod tests {
         let values: [u32; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         let values_data = ArrayData::builder(DataType::UInt32)
             .len(12)
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
 
@@ -598,8 +598,8 @@ mod tests {
         let values = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         let values_data = ArrayData::builder(DataType::UInt8)
             .len(12)
-            .add_buffer(Buffer::from_slice_ref(&values))
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[0b101010101010])))
+            .add_buffer(Buffer::from_slice_ref(values))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([0b101010101010])))
             .build()
             .unwrap();
 

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -245,7 +245,7 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(9)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8]))
             .build()
             .unwrap();
 
@@ -320,7 +320,7 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
@@ -343,7 +343,7 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 
@@ -405,7 +405,7 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -416,13 +416,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
 
         // Construct a list array from the above two
         let list_data_type =
@@ -506,13 +506,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 3, 6, 8]);
 
         // Construct a list array from the above two
         let list_data_type =
@@ -596,13 +596,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1], null, null, [2, 3], [4, 5], null, [6, 7, 8], null, [9]]
-        let value_offsets = Buffer::from_slice_ref(&[0, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
+        let value_offsets = Buffer::from_slice_ref([0, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
         // 01011001 00000001
         let mut null_bits: [u8; 2] = [0; 2];
         bit_util::set_bit(&mut null_bits, 0);
@@ -660,13 +660,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1], null, null, [2, 3], [4, 5], null, [6, 7, 8], null, [9]]
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
         // 01011001 00000001
         let mut null_bits: [u8; 2] = [0; 2];
         bit_util::set_bit(&mut null_bits, 0);
@@ -727,13 +727,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1], null, null, [2, 3], [4, 5], null, [6, 7, 8], null, [9]]
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 2, 2, 2, 4, 6, 6, 9, 9, 10]);
         // 01011001 00000001
         let mut null_bits: [u8; 2] = [0; 2];
         bit_util::set_bit(&mut null_bits, 0);
@@ -768,7 +768,7 @@ mod tests {
         let value_data = unsafe {
             ArrayData::builder(DataType::Int32)
                 .len(8)
-                .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+                .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
                 .build_unchecked()
         };
         let list_data_type =
@@ -790,7 +790,7 @@ mod tests {
     // https://github.com/apache/arrow-rs/issues/1545
     #[cfg(not(feature = "force_validate"))]
     fn test_list_array_invalid_child_array_len() {
-        let value_offsets = Buffer::from_slice_ref(&[0, 2, 5, 7]);
+        let value_offsets = Buffer::from_slice_ref([0, 2, 5, 7]);
         let list_data_type =
             DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = unsafe {
@@ -818,11 +818,11 @@ mod tests {
     fn test_list_array_offsets_need_not_start_at_zero() {
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
-        let value_offsets = Buffer::from_slice_ref(&[2, 2, 5, 7]);
+        let value_offsets = Buffer::from_slice_ref([2, 2, 5, 7]);
 
         let list_data_type =
             DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
@@ -865,7 +865,7 @@ mod tests {
         let values: [i32; 8] = [0; 8];
         let value_data = unsafe {
             ArrayData::builder(DataType::Int32)
-                .add_buffer(Buffer::from_slice_ref(&values))
+                .add_buffer(Buffer::from_slice_ref(values))
                 .build_unchecked()
         };
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1132,7 +1132,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_from_vec() {
-        let buf = Buffer::from_slice_ref(&[0, 1, 2, 3, 4]);
+        let buf = Buffer::from_slice_ref([0, 1, 2, 3, 4]);
         let arr = Int32Array::from(vec![0, 1, 2, 3, 4]);
         assert_eq!(buf, arr.data.buffers()[0]);
         assert_eq!(5, arr.len());
@@ -1631,7 +1631,7 @@ mod tests {
     #[test]
     fn test_primitive_array_builder() {
         // Test building a primitive array with ArrayData builder and offset
-        let buf = Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4, 5, 6]);
+        let buf = Buffer::from_slice_ref([0i32, 1, 2, 3, 4, 5, 6]);
         let buf2 = buf.clone();
         let data = ArrayData::builder(DataType::Int32)
             .len(5)
@@ -1700,7 +1700,7 @@ mod tests {
     // https://github.com/apache/arrow-rs/issues/1545
     #[cfg(not(feature = "force_validate"))]
     fn test_primitive_array_invalid_buffer_len() {
-        let buffer = Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4]);
+        let buffer = Buffer::from_slice_ref([0i32, 1, 2, 3, 4]);
         let data = unsafe {
             ArrayData::builder(DataType::Int32)
                 .add_buffer(buffer.clone())

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -371,8 +371,8 @@ mod tests {
         let offsets: [i32; 4] = [0, 5, 5, 12];
         let array_data = ArrayData::builder(DataType::Utf8)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_buffer(Buffer::from_slice_ref(&values))
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_buffer(Buffer::from_slice_ref(values))
             .build()
             .unwrap();
         let string_array = StringArray::from(array_data);
@@ -548,7 +548,7 @@ mod tests {
             .unwrap();
 
         let offsets = [0, 5, 8, 15].map(|n| O::from_usize(n).unwrap());
-        let null_buffer = Buffer::from_slice_ref(&[0b101]);
+        let null_buffer = Buffer::from_slice_ref([0b101]);
         let data_type = GenericListArray::<O>::DATA_TYPE_CONSTRUCTOR(Box::new(
             Field::new("item", DataType::UInt8, false),
         ));
@@ -557,7 +557,7 @@ mod tests {
         let array_data = ArrayData::builder(data_type)
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .null_bit_buffer(Some(null_buffer))
             .add_child_data(child_data)
             .build()
@@ -589,7 +589,7 @@ mod tests {
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(10)
             .add_buffer(Buffer::from(&values[..]))
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[0b1010101010])))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([0b1010101010])))
             .build()
             .unwrap();
 
@@ -601,7 +601,7 @@ mod tests {
         // [None, Some(b"Parquet")]
         let array_data = ArrayData::builder(data_type)
             .len(2)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .add_child_data(child_data)
             .build()
             .unwrap();
@@ -636,7 +636,7 @@ mod tests {
 
         let array_data = ArrayData::builder(data_type)
             .len(2)
-            .add_buffer(Buffer::from_slice_ref(&offsets))
+            .add_buffer(Buffer::from_slice_ref(offsets))
             .add_child_data(child_data)
             .build()
             .unwrap();

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -418,15 +418,15 @@ mod tests {
         // Check data
         assert_eq!(
             union.data().child_data()[0].buffers()[0],
-            Buffer::from_slice_ref(&[1_i32, 4, 6])
+            Buffer::from_slice_ref([1_i32, 4, 6])
         );
         assert_eq!(
             union.data().child_data()[1].buffers()[0],
-            Buffer::from_slice_ref(&[2_i32, 7])
+            Buffer::from_slice_ref([2_i32, 7])
         );
         assert_eq!(
             union.data().child_data()[2].buffers()[0],
-            Buffer::from_slice_ref(&[3_i32, 5]),
+            Buffer::from_slice_ref([3_i32, 5]),
         );
 
         assert_eq!(expected_array_values.len(), union.len());
@@ -627,8 +627,8 @@ mod tests {
         let type_ids = [1_i8, 0, 0, 2, 0, 1];
         let value_offsets = [0_i32, 0, 1, 0, 2, 1];
 
-        let type_id_buffer = Buffer::from_slice_ref(&type_ids);
-        let value_offsets_buffer = Buffer::from_slice_ref(&value_offsets);
+        let type_id_buffer = Buffer::from_slice_ref(type_ids);
+        let value_offsets_buffer = Buffer::from_slice_ref(value_offsets);
 
         let children: Vec<(Field, Arc<dyn Array>)> = vec![
             (
@@ -650,14 +650,14 @@ mod tests {
         .unwrap();
 
         // Check type ids
-        assert_eq!(Buffer::from_slice_ref(&type_ids), array.data().buffers()[0]);
+        assert_eq!(Buffer::from_slice_ref(type_ids), array.data().buffers()[0]);
         for (i, id) in type_ids.iter().enumerate() {
             assert_eq!(id, &array.type_id(i));
         }
 
         // Check offsets
         assert_eq!(
-            Buffer::from_slice_ref(&value_offsets),
+            Buffer::from_slice_ref(value_offsets),
             array.data().buffers()[1]
         );
         for (i, id) in value_offsets.iter().enumerate() {
@@ -738,14 +738,14 @@ mod tests {
         // Check data
         assert_eq!(
             union.data().child_data()[0].buffers()[0],
-            Buffer::from_slice_ref(&[1_i32, 0, 0, 4, 0, 6, 0]),
+            Buffer::from_slice_ref([1_i32, 0, 0, 4, 0, 6, 0]),
         );
         assert_eq!(
-            Buffer::from_slice_ref(&[0_i32, 2_i32, 0, 0, 0, 0, 7]),
+            Buffer::from_slice_ref([0_i32, 2_i32, 0, 0, 0, 0, 7]),
             union.data().child_data()[1].buffers()[0]
         );
         assert_eq!(
-            Buffer::from_slice_ref(&[0_i32, 0, 3_i32, 0, 5, 0, 0]),
+            Buffer::from_slice_ref([0_i32, 0, 3_i32, 0, 5, 0, 0]),
             union.data().child_data()[2].buffers()[0]
         );
 

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -176,9 +176,9 @@ mod tests {
         let list_array = builder.finish();
 
         let values = list_array.values().data().buffers()[0].clone();
-        assert_eq!(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]), values);
+        assert_eq!(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]), values);
         assert_eq!(
-            Buffer::from_slice_ref(&[0, 3, 6, 8].map(|n| O::from_usize(n).unwrap())),
+            Buffer::from_slice_ref([0, 3, 6, 8].map(|n| O::from_usize(n).unwrap())),
             list_array.data().buffers()[0].clone()
         );
         assert_eq!(DataType::Int32, list_array.value_type());
@@ -296,21 +296,21 @@ mod tests {
         assert_eq!(4, list_array.len());
         assert_eq!(1, list_array.null_count());
         assert_eq!(
-            Buffer::from_slice_ref(&[0, 2, 5, 5, 6]),
+            Buffer::from_slice_ref([0, 2, 5, 5, 6]),
             list_array.data().buffers()[0].clone()
         );
 
         assert_eq!(6, list_array.values().data().len());
         assert_eq!(1, list_array.values().data().null_count());
         assert_eq!(
-            Buffer::from_slice_ref(&[0, 2, 4, 7, 7, 8, 10]),
+            Buffer::from_slice_ref([0, 2, 4, 7, 7, 8, 10]),
             list_array.values().data().buffers()[0].clone()
         );
 
         assert_eq!(10, list_array.values().data().child_data()[0].len());
         assert_eq!(0, list_array.values().data().child_data()[0].null_count());
         assert_eq!(
-            Buffer::from_slice_ref(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+            Buffer::from_slice_ref([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
             list_array.values().data().child_data()[0].buffers()[0].clone()
         );
     }

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -228,15 +228,15 @@ mod tests {
         let expected_string_data = ArrayData::builder(DataType::Utf8)
             .len(4)
             .null_bit_buffer(Some(Buffer::from(&[9_u8])))
-            .add_buffer(Buffer::from_slice_ref(&[0, 3, 3, 3, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 3, 3, 3, 7]))
             .add_buffer(Buffer::from_slice_ref(b"joemark"))
             .build()
             .unwrap();
 
         let expected_int_data = ArrayData::builder(DataType::Int32)
             .len(4)
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[11_u8])))
-            .add_buffer(Buffer::from_slice_ref(&[1, 2, 0, 4]))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([11_u8])))
+            .add_buffer(Buffer::from_slice_ref([1, 2, 0, 4]))
             .build()
             .unwrap();
 

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -300,15 +300,15 @@ mod tests {
         let expected_string_data = ArrayData::builder(DataType::Utf8)
             .len(4)
             .null_bit_buffer(Some(Buffer::from(&[9_u8])))
-            .add_buffer(Buffer::from_slice_ref(&[0, 3, 3, 3, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 3, 3, 3, 7]))
             .add_buffer(Buffer::from_slice_ref(b"joemark"))
             .build()
             .unwrap();
 
         let expected_int_data = ArrayData::builder(DataType::Int32)
             .len(4)
-            .null_bit_buffer(Some(Buffer::from_slice_ref(&[11_u8])))
-            .add_buffer(Buffer::from_slice_ref(&[1, 2, 0, 4]))
+            .null_bit_buffer(Some(Buffer::from_slice_ref([11_u8])))
+            .add_buffer(Buffer::from_slice_ref([1, 2, 0, 4]))
             .build()
             .unwrap();
 

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -55,7 +55,7 @@ impl Buffer {
     }
 
     /// Initializes a [Buffer] from a slice of items.
-    pub fn from_slice_ref<U: ArrowNativeType, T: AsRef<[U]>>(items: &T) -> Self {
+    pub fn from_slice_ref<U: ArrowNativeType, T: AsRef<[U]>>(items: T) -> Self {
         let slice = items.as_ref();
         let capacity = slice.len() * std::mem::size_of::<U>();
         let mut buffer = MutableBuffer::with_capacity(capacity);

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -4460,7 +4460,7 @@ mod tests {
             .data()
             .clone();
 
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
 
         // Construct a list array from the above two
         // [[0,0,0], [-1, -2, -1], [2, 100000000]]
@@ -4525,7 +4525,7 @@ mod tests {
             .data()
             .clone();
 
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 9]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 9]);
 
         // Construct a list array from the above two
         let list_data_type =
@@ -6765,13 +6765,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
 
         // Construct a list array from the above two
         let list_data_type =
@@ -6789,13 +6789,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 3, 6, 8]);
 
         // Construct a list array from the above two
         let list_data_type =
@@ -7007,7 +7007,7 @@ mod tests {
     #[test]
     fn test_list_to_string() {
         let str_array = StringArray::from(vec!["a", "b", "c", "d", "e", "f", "g", "h"]);
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
         let value_data = ArrayData::builder(DataType::Utf8)
             .len(str_array.len())
             .buffers(str_array.data().buffers().to_vec())

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1575,7 +1575,7 @@ mod tests {
             5,
             None,
             0,
-            vec![Buffer::from_slice_ref(&[1i32, 2, 3, 4, 5])],
+            vec![Buffer::from_slice_ref([1i32, 2, 3, 4, 5])],
             vec![],
         )
         .unwrap();
@@ -1690,8 +1690,8 @@ mod tests {
         assert!(!int_data.ptr_eq(&int_data_slice));
         assert!(!int_data_slice.ptr_eq(&int_data));
 
-        let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-        let offsets_buffer = Buffer::from_slice_ref(&[0_i32, 2_i32, 2_i32, 5_i32]);
+        let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+        let offsets_buffer = Buffer::from_slice_ref([0_i32, 2_i32, 2_i32, 5_i32]);
         let string_data = ArrayData::try_new(
             DataType::Utf8,
             3,

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -1262,7 +1262,7 @@ mod tests {
         let utf8s = StringArray::from(vec![Some("aa"), None, Some("bbb")]);
 
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 4, 4]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 4, 4]);
         let list_data_type =
             DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -525,7 +525,7 @@ fn get_aligned_buffer<T>(buffer: &Buffer, length: usize) -> Buffer {
     if align_offset != 0 {
         let len_in_bytes = (length * std::mem::size_of::<T>()).min(buffer.len());
         let slice = &buffer.as_slice()[0..len_in_bytes];
-        Buffer::from_slice_ref(&slice)
+        Buffer::from_slice_ref(slice)
     } else {
         buffer.clone()
     }
@@ -1282,9 +1282,7 @@ mod tests {
 
         let array8_values = ArrayData::builder(DataType::Int32)
             .len(9)
-            .add_buffer(Buffer::from_slice_ref(&[
-                40, 41, 42, 43, 44, 45, 46, 47, 48,
-            ]))
+            .add_buffer(Buffer::from_slice_ref([40, 41, 42, 43, 44, 45, 46, 47, 48]))
             .build()
             .unwrap();
         let array8_data = ArrayData::builder(schema.field(8).data_type().clone())
@@ -1593,7 +1591,7 @@ mod tests {
             false,
         );
 
-        let entry_offsets = Buffer::from_slice_ref(&[0, 2, 4, 6]);
+        let entry_offsets = Buffer::from_slice_ref([0, 2, 4, 6]);
         let map_data = ArrayData::builder(map_data_type)
             .len(3)
             .add_buffer(entry_offsets)

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1557,8 +1557,8 @@ mod tests {
         let dctfield =
             Field::new_dict("dict", array.data_type().clone(), false, 2, false);
 
-        let types = Buffer::from_slice_ref(&[0_i8, 0, 0]);
-        let offsets = Buffer::from_slice_ref(&[0_i32, 1, 2]);
+        let types = Buffer::from_slice_ref([0_i8, 0, 0]);
+        let offsets = Buffer::from_slice_ref([0_i32, 1, 2]);
 
         let union =
             UnionArray::try_new(&[0], types, Some(offsets), vec![(dctfield, array)])

--- a/arrow-json/src/reader.rs
+++ b/arrow-json/src/reader.rs
@@ -2194,7 +2194,7 @@ mod tests {
             // test that the list offsets are correct
             assert_eq!(
                 cc.data().buffers()[0],
-                Buffer::from_slice_ref(&[0i32, 2, 2, 4, 5])
+                Buffer::from_slice_ref([0i32, 2, 2, 4, 5])
             );
             let cc = cc.values();
             let cc = cc.as_any().downcast_ref::<BooleanArray>().unwrap();
@@ -2215,7 +2215,7 @@ mod tests {
             // test that the list offsets are correct
             assert_eq!(
                 dd.data().buffers()[0],
-                Buffer::from_slice_ref(&[0i32, 1, 1, 2, 6])
+                Buffer::from_slice_ref([0i32, 1, 1, 2, 6])
             );
             let dd = dd.values();
             let dd = dd.as_any().downcast_ref::<StringArray>().unwrap();
@@ -2343,7 +2343,7 @@ mod tests {
             .unwrap();
         let a_list = ArrayDataBuilder::new(a_field.data_type().clone())
             .len(6)
-            .add_buffer(Buffer::from_slice_ref(&[0i32, 2, 3, 6, 6, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0i32, 2, 3, 6, 6, 6, 7]))
             .add_child_data(a)
             .null_bit_buffer(Some(Buffer::from(vec![0b00110111])))
             .build()
@@ -2359,7 +2359,7 @@ mod tests {
         let expected = expected.as_any().downcast_ref::<ListArray>().unwrap();
         assert_eq!(
             read.data().buffers()[0],
-            Buffer::from_slice_ref(&[0i32, 2, 3, 6, 6, 6, 7])
+            Buffer::from_slice_ref([0i32, 2, 3, 6, 6, 6, 7])
         );
         // compare list null buffers
         assert_eq!(read.data().null_buffer(), expected.data().null_buffer());

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -924,11 +924,11 @@ mod tests {
     fn test_filter_list_array() {
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 8, 8]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 3, 6, 8, 8]);
 
         let list_data_type =
             DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
@@ -948,11 +948,11 @@ mod tests {
         // expected: [[3, 4, 5], null]
         let value_data = ArrayData::builder(DataType::Int32)
             .len(3)
-            .add_buffer(Buffer::from_slice_ref(&[3, 4, 5]))
+            .add_buffer(Buffer::from_slice_ref([3, 4, 5]))
             .build()
             .unwrap();
 
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 3]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 3, 3]);
 
         let list_data_type =
             DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
@@ -1305,7 +1305,7 @@ mod tests {
     fn test_filter_fixed_size_list_arrays() {
         let value_data = ArrayData::builder(DataType::Int32)
             .len(9)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8]))
             .build()
             .unwrap();
         let list_data_type = DataType::FixedSizeList(
@@ -1355,7 +1355,7 @@ mod tests {
     fn test_filter_fixed_size_list_arrays_with_null() {
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1846,7 +1846,7 @@ mod tests {
             .data()
             .clone();
         // Construct offsets
-        let value_offsets = Buffer::from_slice_ref(&[0, 3, 6, 8]);
+        let value_offsets = Buffer::from_slice_ref([0, 3, 6, 8]);
         // Construct a list array from the above two
         let list_data_type =
             DataType::List(Box::new(Field::new("item", DataType::Int32, false)));

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -4026,7 +4026,7 @@ mod tests {
         ])
         .data()
         .clone();
-        let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 6, 9]);
+        let value_offsets = Buffer::from_slice_ref([0i64, 3, 6, 6, 9]);
         let list_data_type =
             DataType::LargeList(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)

--- a/arrow/src/compute/kernels/limit.rs
+++ b/arrow/src/compute/kernels/limit.rs
@@ -91,13 +91,13 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
             .build()
             .unwrap();
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1], null, [2, 3], null, [4, 5], null, [6, 7, 8], null, [9]]
-        let value_offsets = Buffer::from_slice_ref(&[0, 2, 2, 4, 4, 6, 6, 9, 9, 10]);
+        let value_offsets = Buffer::from_slice_ref([0, 2, 2, 4, 4, 6, 6, 9, 9, 10]);
         // 01010101 00000001
         let mut null_bits: [u8; 2] = [0; 2];
         bit_util::set_bit(&mut null_bits, 0);
@@ -150,7 +150,7 @@ mod tests {
             .unwrap();
         let int_data = ArrayData::builder(DataType::Int32)
             .len(5)
-            .add_buffer(Buffer::from_slice_ref(&[0, 28, 42, 0, 0]))
+            .add_buffer(Buffer::from_slice_ref([0, 28, 42, 0, 0]))
             .null_bit_buffer(Some(Buffer::from([0b00000110])))
             .build()
             .unwrap();

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -1017,7 +1017,7 @@ mod tests {
         // Construct a value array
         let value_data = ArrayData::builder(DataType::Int32)
             .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
+            .add_buffer(Buffer::from_slice_ref([0, 1, 2, 3, 4, 5, 6, 7]))
             .build()
             .unwrap();
 

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -874,7 +874,7 @@ mod tests {
 
         // Can't use UnionBuilder with non-primitive types, so manually build outer UnionArray
         let a_array = Int32Array::from(vec![None, None, None, Some(1234), Some(23)]);
-        let type_ids = Buffer::from_slice_ref(&[1_i8, 1, 0, 0, 1]);
+        let type_ids = Buffer::from_slice_ref([1_i8, 1, 0, 0, 1]);
 
         let children: Vec<(Field, Arc<dyn Array>)> = vec![
             (Field::new("a", DataType::Int32, true), Arc::new(a_array)),

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -557,8 +557,7 @@ fn test_list_append() {
         Some(14),
         Some(15),
     ]);
-    let list_value_offsets =
-        Buffer::from_slice_ref(&[0i32, 3, 5, 11, 13, 13, 15, 15, 17]);
+    let list_value_offsets = Buffer::from_slice_ref([0i32, 3, 5, 11, 13, 13, 15, 15, 17]);
     let expected_list_data = ArrayData::try_new(
         DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
         8,
@@ -637,7 +636,7 @@ fn test_list_nulls_append() {
         Some(15),
     ]);
     let list_value_offsets =
-        Buffer::from_slice_ref(&[0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23]);
+        Buffer::from_slice_ref([0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23]);
     let expected_list_data = ArrayData::try_new(
         DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
         12,
@@ -772,7 +771,7 @@ fn test_map_nulls_append() {
     ]);
 
     let map_offsets =
-        Buffer::from_slice_ref(&[0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23]);
+        Buffer::from_slice_ref([0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23]);
 
     let expected_list_data = ArrayData::try_new(
         DataType::Map(
@@ -852,7 +851,7 @@ fn test_list_of_strings_append() {
         None,
         // extend b[0..0]
     ]);
-    let list_value_offsets = Buffer::from_slice_ref(&[0, 3, 5, 6, 9, 10, 13]);
+    let list_value_offsets = Buffer::from_slice_ref([0, 3, 5, 6, 9, 10, 13]);
     let expected_list_data = ArrayData::try_new(
         DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
         6,

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
     expected = "Need at least 80 bytes in buffers[0] in array of type Int64, but got 8"
 )]
 fn test_buffer_too_small() {
-    let buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     // should fail as the declared size (10*8 = 80) is larger than the underlying bfufer (8)
     ArrayData::try_new(DataType::Int64, 10, None, 0, vec![buffer], vec![]).unwrap();
 }
@@ -42,7 +42,7 @@ fn test_buffer_too_small() {
     expected = "Need at least 16 bytes in buffers[0] in array of type Int64, but got 8"
 )]
 fn test_buffer_too_small_offset() {
-    let buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     // should fail -- size is ok, but also has offset
     ArrayData::try_new(DataType::Int64, 1, None, 1, vec![buffer], vec![]).unwrap();
 }
@@ -50,8 +50,8 @@ fn test_buffer_too_small_offset() {
 #[test]
 #[should_panic(expected = "Expected 1 buffers in array of type Int64, got 2")]
 fn test_bad_number_of_buffers() {
-    let buffer1 = Buffer::from_slice_ref(&[0i32, 2i32]);
-    let buffer2 = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let buffer1 = Buffer::from_slice_ref([0i32, 2i32]);
+    let buffer2 = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(DataType::Int64, 1, None, 0, vec![buffer1, buffer2], vec![])
         .unwrap();
 }
@@ -59,7 +59,7 @@ fn test_bad_number_of_buffers() {
 #[test]
 #[should_panic(expected = "integer overflow computing min buffer size")]
 fn test_fixed_width_overflow() {
-    let buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(DataType::Int64, usize::MAX, None, 0, vec![buffer], vec![])
         .unwrap();
 }
@@ -85,7 +85,7 @@ fn test_bitmap_too_small() {
 #[test]
 #[should_panic(expected = "Dictionary key type must be integer, but was Utf8")]
 fn test_non_int_dictionary() {
-    let i32_buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let i32_buffer = Buffer::from_slice_ref([0i32, 2i32]);
     let data_type =
         DataType::Dictionary(Box::new(DataType::Utf8), Box::new(DataType::Int32));
     let child_data = ArrayData::try_new(
@@ -113,7 +113,7 @@ fn test_non_int_dictionary() {
 fn test_mismatched_dictionary_types() {
     // test w/ dictionary created with a child array data that has type different than declared
     let string_array: StringArray = vec![Some("foo"), Some("bar")].into_iter().collect();
-    let i32_buffer = Buffer::from_slice_ref(&[0i32, 1i32]);
+    let i32_buffer = Buffer::from_slice_ref([0i32, 1i32]);
     // Dict says LargeUtf8 but array is Utf8
     let data_type =
         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::LargeUtf8));
@@ -140,7 +140,7 @@ fn test_empty_utf8_array_with_empty_offsets_buffer() {
 #[test]
 fn test_empty_utf8_array_with_single_zero_offset() {
     let data_buffer = Buffer::from(&[]);
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32]);
+    let offsets_buffer = Buffer::from_slice_ref([0i32]);
     ArrayData::try_new(
         DataType::Utf8,
         0,
@@ -156,7 +156,7 @@ fn test_empty_utf8_array_with_single_zero_offset() {
 #[should_panic(expected = "First offset 1 of Utf8 is larger than values length 0")]
 fn test_empty_utf8_array_with_invalid_offset() {
     let data_buffer = Buffer::from(&[]);
-    let offsets_buffer = Buffer::from_slice_ref(&[1i32]);
+    let offsets_buffer = Buffer::from_slice_ref([1i32]);
     ArrayData::try_new(
         DataType::Utf8,
         0,
@@ -170,8 +170,8 @@ fn test_empty_utf8_array_with_invalid_offset() {
 
 #[test]
 fn test_empty_utf8_array_with_non_zero_offset() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32, 2, 6, 0]);
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+    let offsets_buffer = Buffer::from_slice_ref([0i32, 2, 6, 0]);
     ArrayData::try_new(
         DataType::Utf8,
         0,
@@ -189,7 +189,7 @@ fn test_empty_utf8_array_with_non_zero_offset() {
 )]
 fn test_empty_large_utf8_array_with_wrong_type_offsets() {
     let data_buffer = Buffer::from(&[]);
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32]);
+    let offsets_buffer = Buffer::from_slice_ref([0i32]);
     ArrayData::try_new(
         DataType::LargeUtf8,
         0,
@@ -204,8 +204,8 @@ fn test_empty_large_utf8_array_with_wrong_type_offsets() {
 #[test]
 #[should_panic(expected = "Buffer 0 of Utf8 isn't large enough. Expected 12 bytes got 8")]
 fn test_validate_offsets_i32() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32, 2i32]);
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+    let offsets_buffer = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -222,8 +222,8 @@ fn test_validate_offsets_i32() {
     expected = "Buffer 0 of LargeUtf8 isn't large enough. Expected 24 bytes got 16"
 )]
 fn test_validate_offsets_i64() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-    let offsets_buffer = Buffer::from_slice_ref(&[0i64, 2i64]);
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+    let offsets_buffer = Buffer::from_slice_ref([0i64, 2i64]);
     ArrayData::try_new(
         DataType::LargeUtf8,
         2,
@@ -238,8 +238,8 @@ fn test_validate_offsets_i64() {
 #[test]
 #[should_panic(expected = "Error converting offset[0] (-2) to usize for Utf8")]
 fn test_validate_offsets_negative_first_i32() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-    let offsets_buffer = Buffer::from_slice_ref(&[-2i32, 1i32, 3i32]);
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+    let offsets_buffer = Buffer::from_slice_ref([-2i32, 1i32, 3i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -254,8 +254,8 @@ fn test_validate_offsets_negative_first_i32() {
 #[test]
 #[should_panic(expected = "Error converting offset[2] (-3) to usize for Utf8")]
 fn test_validate_offsets_negative_last_i32() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32, 2i32, -3i32]);
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
+    let offsets_buffer = Buffer::from_slice_ref([0i32, 2i32, -3i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -270,9 +270,9 @@ fn test_validate_offsets_negative_last_i32() {
 #[test]
 #[should_panic(expected = "First offset 4 in Utf8 is smaller than last offset 3")]
 fn test_validate_offsets_range_too_small() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
     // start offset is larger than end
-    let offsets_buffer = Buffer::from_slice_ref(&[4i32, 2i32, 3i32]);
+    let offsets_buffer = Buffer::from_slice_ref([4i32, 2i32, 3i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -287,9 +287,9 @@ fn test_validate_offsets_range_too_small() {
 #[test]
 #[should_panic(expected = "Last offset 10 of Utf8 is larger than values length 6")]
 fn test_validate_offsets_range_too_large() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
     // 10 is off the end of the buffer
-    let offsets_buffer = Buffer::from_slice_ref(&[0i32, 2i32, 10i32]);
+    let offsets_buffer = Buffer::from_slice_ref([0i32, 2i32, 10i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -304,9 +304,9 @@ fn test_validate_offsets_range_too_large() {
 #[test]
 #[should_panic(expected = "First offset 10 of Utf8 is larger than values length 6")]
 fn test_validate_offsets_first_too_large() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
     // 10 is off the end of the buffer
-    let offsets_buffer = Buffer::from_slice_ref(&[10i32, 2i32, 10i32]);
+    let offsets_buffer = Buffer::from_slice_ref([10i32, 2i32, 10i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -320,9 +320,9 @@ fn test_validate_offsets_first_too_large() {
 
 #[test]
 fn test_validate_offsets_first_too_large_skipped() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
     // 10 is off the end of the buffer, but offset starts at 1 so it is skipped
-    let offsets_buffer = Buffer::from_slice_ref(&[10i32, 2i32, 3i32, 4i32]);
+    let offsets_buffer = Buffer::from_slice_ref([10i32, 2i32, 3i32, 4i32]);
     let data = ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -340,9 +340,9 @@ fn test_validate_offsets_first_too_large_skipped() {
 #[test]
 #[should_panic(expected = "Last offset 8 of Utf8 is larger than values length 6")]
 fn test_validate_offsets_last_too_large() {
-    let data_buffer = Buffer::from_slice_ref(&"abcdef".as_bytes());
+    let data_buffer = Buffer::from_slice_ref("abcdef".as_bytes());
     // 10 is off the end of the buffer
-    let offsets_buffer = Buffer::from_slice_ref(&[5i32, 7i32, 8i32]);
+    let offsets_buffer = Buffer::from_slice_ref([5i32, 7i32, 8i32]);
     ArrayData::try_new(
         DataType::Utf8,
         2,
@@ -421,7 +421,7 @@ fn test_validate_struct_child_length() {
 /// Test that the array of type `data_type` that has invalid utf8 data errors
 fn check_utf8_validation<T: ArrowNativeType>(data_type: DataType) {
     // 0x80 is a utf8 continuation sequence and is not a valid utf8 sequence itself
-    let data_buffer = Buffer::from_slice_ref(&[b'a', b'a', 0x80, 0x00]);
+    let data_buffer = Buffer::from_slice_ref([b'a', b'a', 0x80, 0x00]);
     let offsets: Vec<T> = [0, 2, 3]
         .iter()
         .map(|&v| T::from_usize(v).unwrap())
@@ -485,7 +485,7 @@ fn test_validate_large_utf8_char_boundary() {
 
 /// Test that the array of type `data_type` that has invalid indexes (out of bounds)
 fn check_index_out_of_bounds_validation<T: ArrowNativeType>(data_type: DataType) {
-    let data_buffer = Buffer::from_slice_ref(&[b'a', b'b', b'c', b'd']);
+    let data_buffer = Buffer::from_slice_ref([b'a', b'b', b'c', b'd']);
     // First two offsets are fine, then 5 is out of bounds
     let offsets: Vec<T> = [0, 1, 2, 5, 2]
         .iter()
@@ -538,7 +538,7 @@ fn test_validate_large_binary_out_of_bounds() {
 
 // validate that indexes don't go bacwards check indexes that go backwards
 fn check_index_backwards_validation<T: ArrowNativeType>(data_type: DataType) {
-    let data_buffer = Buffer::from_slice_ref(&[b'a', b'b', b'c', b'd']);
+    let data_buffer = Buffer::from_slice_ref([b'a', b'b', b'c', b'd']);
     // First three offsets are fine, then 1 goes backwards
     let offsets: Vec<T> = [0, 1, 2, 2, 1]
         .iter()
@@ -799,7 +799,7 @@ fn test_validate_union_different_types() {
 
     let field2 = vec![Some(1), Some(2)].into_iter().collect::<Int32Array>();
 
-    let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+    let type_ids = Buffer::from_slice_ref([0i8, 1i8]);
 
     ArrayData::try_new(
         DataType::Union(
@@ -830,7 +830,7 @@ fn test_validate_union_sparse_different_child_len() {
     // field 2 only has 1 item but array should have 2
     let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
 
-    let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+    let type_ids = Buffer::from_slice_ref([0i8, 1i8]);
 
     ArrayData::try_new(
         DataType::Union(
@@ -857,7 +857,7 @@ fn test_validate_union_dense_without_offsets() {
 
     let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
 
-    let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
+    let type_ids = Buffer::from_slice_ref([0i8, 1i8]);
 
     ArrayData::try_new(
         DataType::Union(
@@ -884,8 +884,8 @@ fn test_validate_union_dense_with_bad_len() {
 
     let field2 = vec![Some(1)].into_iter().collect::<Int64Array>();
 
-    let type_ids = Buffer::from_slice_ref(&[0i8, 1i8]);
-    let offsets = Buffer::from_slice_ref(&[0i32]); // should have 2 offsets, but only have 1
+    let type_ids = Buffer::from_slice_ref([0i8, 1i8]);
+    let offsets = Buffer::from_slice_ref([0i32]); // should have 2 offsets, but only have 1
 
     ArrayData::try_new(
         DataType::Union(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The current interface can result in rather unhelpful errors - https://github.com/apache/arrow-rs/pull/3158#issuecomment-1323850323 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Technically no, all previous uses will continue to work. However, clippy will complain about unnecessary borrows.

I ran the following to generate https://github.com/apache/arrow-rs/commit/c05ab2d1e04e2d0166aac4f432469247db80cbd6
```
cargo clippy --workspace --fix --all-targets
cargo fmt --all
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
