### PR TITLE
Prevent precision=0 for decimal type

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -993,12 +993,13 @@ impl<T: ArrowPrimitiveType> From<ArrayData> for PrimitiveArray<T> {
 
 impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
     /// Returns a Decimal array with the same data as self, with the
-    /// specified precision.
+    /// specified precision and scale.
     ///
     /// Returns an Error if:
-    /// 1. `precision` is larger than `T:MAX_PRECISION`
-    /// 2. `scale` is larger than `T::MAX_SCALE`
-    /// 3. `scale` is > `precision`
+    /// - `precision` is zero
+    /// - `precision` is larger than `T:MAX_PRECISION`
+    /// - `scale` is larger than `T::MAX_SCALE`
+    /// - `scale` is > `precision`
     pub fn with_precision_and_scale(
         self,
         precision: u8,


### PR DESCRIPTION
# Which issue does this PR close?

observed as part of #2852 .

# Rationale for this change
Precision should not be zero for decimal type

# What changes are included in this PR?
Added validation for decimal type

# Are there any user-facing changes?
No
