### PR TITLE
Add sleep to object_store CI

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Configure Fake GCS Server (GCP emulation)
         run: |
           docker run -d -p 4443:4443 fsouza/fake-gcs-server -scheme http
+          # Give the container a moment to start up prior to configuring it
           sleep 1
           curl -v -X POST --data-binary '{"name":"test-bucket"}' -H "Content-Type: application/json" "http://localhost:4443/storage/v1/b"
           echo '{"gcs_base_url": "http://localhost:4443", "disable_oauth": true, "client_email": "", "private_key": ""}' > "$GOOGLE_SERVICE_ACCOUNT"

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Configure Fake GCS Server (GCP emulation)
         run: |
           docker run -d -p 4443:4443 fsouza/fake-gcs-server -scheme http
+          sleep 1
           curl -v -X POST --data-binary '{"name":"test-bucket"}' -H "Content-Type: application/json" "http://localhost:4443/storage/v1/b"
           echo '{"gcs_base_url": "http://localhost:4443", "disable_oauth": true, "client_email": "", "private_key": ""}' > "$GOOGLE_SERVICE_ACCOUNT"
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Frequently this job fails with 

```
* TCP_NODELAY set
* Connected to localhost (::1) port 4443 (#0)
> POST /storage/v1/b HTTP/1.1
> Host: localhost:4443
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 22
> 
} [22 bytes data]
* upload completely sent off: 22 out of 22 bytes
* Empty reply from server

100    22    0     0  100    22      0  22000 --:--:-- --:--:-- --:--:-- 22000
```

https://github.com/apache/arrow-rs/actions/runs/3546438851/jobs/5955482110

Where success looks like

```
* TCP_NODELAY set
* Connected to localhost (::1) port 4443 (#0)
> POST /storage/v1/b HTTP/1.1
> Host: localhost:4443
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 22
> 
} [22 bytes data]
* upload completely sent off: 22 out of 22 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 25 Nov 2022 07:06:50 GMT
< Content-Length: 151
< 
{ [151 bytes data]
```

It is possible this is some sort of startup race, so lets add a sleep and see if it helps

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
