### PR TITLE
Improve regex related kernels by upto 85%

### DIFF
--- a/arrow-csv/Cargo.toml
+++ b/arrow-csv/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 csv = { version = "1.1", default-features = false }
 lazy_static = { version = "1.4", default-features = false }
 lexical-core = { version = "^0.8", default-features = false }
-regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -57,7 +57,7 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.13", default-features = false }
-regex = { version = "1.5.6", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 regex-syntax = { version = "0.6.27", default-features = false, features = ["unicode"] }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }


### PR DESCRIPTION
# Which issue does this PR close?

NA

# Rationale for this change
 
Improves regex related kernels by a lot.

# What changes are included in this PR?
The regex crate was complied with perf flag. Due to this we were missing a lot of performance. It seems to be an unintended side effect of https://github.com/apache/arrow-rs/issues/1876  .

# Are there any user-facing changes?
No
