### PR TITLE
Include integration tests in arrow crate

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -27,6 +27,7 @@ keywords = ["arrow"]
 include = [
     "benches/*.rs",
     "src/**/*.rs",
+    "tests/*.rs",
     "Cargo.toml",
 ]
 edition = "2021"


### PR DESCRIPTION
# Which issue does this PR close?

re #3118 

# Rationale for this change
 
When I published version 27, I got

```
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Downloads/apache-arrow-rs-27.0.0/arrow/target/package/arrow-27.0.0/Cargo.toml`

Caused by:
can't find `ipc` test at `tests/ipc.rs` or `tests/ipc/main.rs`. Please specify test.path if you want to use a non-default path.



error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Downloads/apache-arrow-rs-27.0.0/arrow/target/package/arrow-27.0.0/Cargo.toml`

Caused by:
can't find `csv` test at `tests/csv.rs` or `tests/csv/main.rs`. Please specify test.path if you want to use a non-default path.
```

I had to delete some entries in the Cargo.toml fil. 

# What changes are included in this PR?

Include tests directory in the list of files to publish as suggested by @tustvold at https://github.com/apache/arrow-rs/pull/3112#issuecomment-1314608674

# Testing

You can see the failure by  checking out `27.0.0` and running `cargo publish --dry-run`:

```shell
(arrow_dev) alamb@MacBook-Pro-8:~/Software/arrow-rs/arrow$ cargo publish --dry-run
    Updating crates.io index
   Packaging arrow v27.0.0 (/Users/alamb/Software/arrow-rs/arrow)
   Verifying arrow v27.0.0 (/Users/alamb/Software/arrow-rs/arrow)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/Users/alamb/Software/arrow-rs/target/package/arrow-27.0.0/Cargo.toml`

Caused by:
  can't find `ipc` test at `tests/ipc.rs` or `tests/ipc/main.rs`. Please specify test.path if you want to use a non-default path.
```

With this patch:

```
(arrow_dev) alamb@MacBook-Pro-8:~/Software/arrow-rs/arrow$ git cherry-pick  a082f96
Auto-merging arrow/Cargo.toml
[detached HEAD 94083a282] Include integration tests in arrow crate
 Date: Fri Nov 25 14:29:08 2022 -0500
 1 file changed, 1 insertion(+)
(arrow_dev) alamb@MacBook-Pro-8:~/Software/arrow-rs/arrow$ cargo publish --dry-run
    Updating crates.io index
....
ow-27.0.0)
    Finished dev [unoptimized + debuginfo] target(s) in 17.93s
   Uploading arrow v27.0.0 (/Users/alamb/Software/arrow-rs/arrow)
warning: aborting upload due to dry run
```

# Are there any user-facing changes?
No

