### PR TITLE
Ensure StructArrays check nullability of fields

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -916,7 +916,7 @@ mod tests {
     #[test]
     fn test_null_struct() {
         let struct_type =
-            DataType::Struct(vec![Field::new("data", DataType::Int64, false)]);
+            DataType::Struct(vec![Field::new("data", DataType::Int64, true)]);
         let array = new_null_array(&struct_type, 9);
 
         let a = array.as_any().downcast_ref::<StructArray>().unwrap();

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -37,8 +37,8 @@ use std::sync::Arc;
 ///
 /// let string_builder = builder.keys();
 /// string_builder.append_value("joe");
-/// string_builder.append_null();
-/// string_builder.append_null();
+/// string_builder.append_value("n1");
+/// string_builder.append_value("n2");
 /// string_builder.append_value("mark");
 ///
 /// let int_builder = builder.values();
@@ -58,7 +58,7 @@ use std::sync::Arc;
 /// );
 /// assert_eq!(
 ///     *arr.keys(),
-///     StringArray::from(vec![Some("joe"), None, None, Some("mark")])
+///     StringArray::from(vec![Some("joe"), Some("n1"), Some("n2"), Some("mark")])
 /// );
 /// ```
 #[derive(Debug)]
@@ -286,8 +286,8 @@ mod tests {
 
         let string_builder = builder.keys();
         string_builder.append_value("joe");
-        string_builder.append_null();
-        string_builder.append_null();
+        string_builder.append_value("n1");
+        string_builder.append_value("n2");
         string_builder.append_value("mark");
 
         let int_builder = builder.values();
@@ -312,9 +312,8 @@ mod tests {
 
         let expected_string_data = ArrayData::builder(DataType::Utf8)
             .len(4)
-            .null_bit_buffer(Some(Buffer::from(&[9_u8])))
-            .add_buffer(Buffer::from_slice_ref([0, 3, 3, 3, 7]))
-            .add_buffer(Buffer::from_slice_ref(b"joemark"))
+            .add_buffer(Buffer::from_slice_ref([0, 3, 5, 7, 11]))
+            .add_buffer(Buffer::from_slice_ref(b"joen1n2mark"))
             .build()
             .unwrap();
 

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -6686,8 +6686,7 @@ mod tests {
         cast_from_null_to_other(&data_type);
 
         // Cast null from and to struct
-        let data_type =
-            DataType::Struct(vec![Field::new("data", DataType::Int64, false)]);
+        let data_type = DataType::Struct(vec![Field::new("data", DataType::Int64, true)]);
         cast_from_null_to_other(&data_type);
     }
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1799,7 +1799,7 @@ mod tests {
                     Arc::new(strings) as ArrayRef,
                 ),
                 (
-                    Field::new("c", DataType::Int32, false),
+                    Field::new("c", DataType::Int32, true),
                     Arc::new(ints) as ArrayRef,
                 ),
             ]);

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1069,7 +1069,7 @@ mod tests {
             Field::new(
                 "c1",
                 DataType::Struct(vec![
-                    Field::new("c11", DataType::Int32, false),
+                    Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
                         DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
@@ -1083,7 +1083,7 @@ mod tests {
 
         let c1 = StructArray::from(vec![
             (
-                Field::new("c11", DataType::Int32, false),
+                Field::new("c11", DataType::Int32, true),
                 Arc::new(Int32Array::from(vec![Some(1), None, Some(5)])) as ArrayRef,
             ),
             (
@@ -1230,7 +1230,7 @@ mod tests {
             DataType::List(Box::new(Field::new(
                 "s",
                 DataType::Struct(vec![
-                    Field::new("c11", DataType::Int32, false),
+                    Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
                         DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
@@ -1246,7 +1246,7 @@ mod tests {
 
         let struct_values = StructArray::from(vec![
             (
-                Field::new("c11", DataType::Int32, false),
+                Field::new("c11", DataType::Int32, true),
                 Arc::new(Int32Array::from(vec![Some(1), None, Some(5)])) as ArrayRef,
             ),
             (

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -713,7 +713,7 @@ mod tests {
             Field::new(
                 "c1",
                 DataType::Struct(vec![
-                    Field::new("c11", DataType::Int32, false),
+                    Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
                         DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
@@ -727,7 +727,7 @@ mod tests {
 
         let c1 = StructArray::from(vec![
             (
-                Field::new("c11", DataType::Int32, false),
+                Field::new("c11", DataType::Int32, true),
                 Arc::new(Int32Array::from(vec![Some(1), None, Some(5)])) as ArrayRef,
             ),
             (


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1167

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Main fix: when building using `StructArray::from`, check that if child fields are set as non-nullable, then their values respect this; if they don't then will panic

Other fixes to `StructArray::from`:

- Fix issue  where if pass empty vector then it panics (since used to index `[0]` to get length to compare)
- Fix issue where not checking datatype of field against values if vector is of size 1

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
