### PR TITLE
Fix CI build by upgrading tonic-build to 0.8.4

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -51,7 +51,7 @@ flight-sql-experimental = ["prost-types"]
 # (and checked in) arrow.flight.protocol.rs from changing
 proc-macro2 = { version = "=1.0.47", default-features = false }
 prost-build = { version = "=0.11.3", default-features = false }
-tonic-build = { version = "=0.8.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "=0.8.4", default-features = false, features = ["transport", "prost"] }
 
 [[example]]
 name = "flight_sql_server"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

CI now failed by

```
error: failed to select a version for the requirement `tonic-build = "=0.8.3"`
candidate versions found which didn't match: 0.8.4, 0.8.2, 0.8.0, ...
location searched: crates.io index
required by package `arrow-flight v28.0.0 (/__w/arrow-rs/arrow-rs/arrow-flight)`
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
