### PR TITLE
fix(object_store,aws,gcp): multipart upload enforce size limit of 5 MiB not 5MB

### DIFF
--- a/object_store/CONTRIBUTING.md
+++ b/object_store/CONTRIBUTING.md
@@ -46,9 +46,9 @@ Setup environment
 
 ```
 export TEST_INTEGRATION=1
-export AWS_DEFAULT_REGION=us-east-1
-export AWS_ACCESS_KEY_ID=test
-export AWS_SECRET_ACCESS_KEY=test
+export OBJECT_STORE_AWS_DEFAULT_REGION=us-east-1
+export OBJECT_STORE_AWS_ACCESS_KEY_ID=test
+export OBJECT_STORE_AWS_SECRET_ACCESS_KEY=test
 export AWS_ENDPOINT=http://128.0.0.1:4566
 export OBJECT_STORE_BUCKET=test-bucket
 ```

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(bytes_expected, bytes_written);
 
         // Can overwrite some storage
-        let data = get_vec_of_bytes(5_123_000, 5);
+        let data = get_vec_of_bytes(1_123_000, 5);
         let bytes_expected = data.concat();
         let (_, mut writer) = storage.put_multipart(&location).await.unwrap();
         for chunk in &data {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -769,7 +769,8 @@ mod tests {
         assert_eq!(bytes_expected, bytes_written);
 
         // Can overwrite some storage
-        let data = get_vec_of_bytes(1_123_000, 5);
+        // Sizes carefully chosen to exactly hit min limit of 5 MiB
+        let data = get_vec_of_bytes(242_880, 22);
         let bytes_expected = data.concat();
         let (_, mut writer) = storage.put_multipart(&location).await.unwrap();
         for chunk in &data {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(bytes_expected, bytes_written);
 
         // Can overwrite some storage
-        let data = get_vec_of_bytes(5_000, 5);
+        let data = get_vec_of_bytes(5_123_000, 5);
         let bytes_expected = data.concat();
         let (_, mut writer) = storage.put_multipart(&location).await.unwrap();
         for chunk in &data {

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -123,7 +123,8 @@ where
 
         // If adding buf to pending buffer would trigger send, check
         // whether we have capacity for another task.
-        let enough_to_send = (buf.len() + self.current_buffer.len()) >= self.min_part_size;
+        let enough_to_send =
+            (buf.len() + self.current_buffer.len()) >= self.min_part_size;
         if enough_to_send && self.tasks.len() < self.max_concurrency {
             // If we do, copy into the buffer and submit the task, and return ready.
             self.current_buffer.extend_from_slice(buf);

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -81,7 +81,7 @@ where
             current_buffer: Vec::new(),
             // TODO: Should self vary by provider?
             // TODO: Should we automatically increase then when part index gets large?
-            min_part_size: 5_000_000,
+            min_part_size: 6_000_000,
             current_part_idx: 0,
             completion_task: None,
         }

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -81,7 +81,11 @@ where
             current_buffer: Vec::new(),
             // TODO: Should self vary by provider?
             // TODO: Should we automatically increase then when part index gets large?
-            min_part_size: 6_000_000,
+
+            // Minimum size of 5 MiB
+            // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+            // https://cloud.google.com/storage/quotas#requests
+            min_part_size: 5_242_880,
             current_part_idx: 0,
             completion_task: None,
         }
@@ -113,13 +117,13 @@ where
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<Result<usize, io::Error>> {
+    ) -> Poll<Result<usize, io::Error>> {
         // Poll current tasks
         self.as_mut().poll_tasks(cx)?;
 
         // If adding buf to pending buffer would trigger send, check
         // whether we have capacity for another task.
-        let enough_to_send = (buf.len() + self.current_buffer.len()) > self.min_part_size;
+        let enough_to_send = (buf.len() + self.current_buffer.len()) >= self.min_part_size;
         if enough_to_send && self.tasks.len() < self.max_concurrency {
             // If we do, copy into the buffer and submit the task, and return ready.
             self.current_buffer.extend_from_slice(buf);
@@ -149,7 +153,7 @@ where
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
+    ) -> Poll<Result<(), io::Error>> {
         // Poll current tasks
         self.as_mut().poll_tasks(cx)?;
 
@@ -177,7 +181,7 @@ where
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
+    ) -> Poll<Result<(), io::Error>> {
         // First, poll flush
         match self.as_mut().poll_flush(cx) {
             Poll::Pending => return Poll::Pending,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3233.

# Rationale for this change
 
Bumping up the size of the test data as well, so it's easier to catch this. However, I think the localstack emulator might not enforce this limit, which is why we didn't catch this earlier.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
