### PR TITLE
Add ObjectStore ClientConfig

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -89,9 +89,6 @@ pub(crate) enum Error {
 
     #[snafu(display("Got invalid multipart response: {}", source))]
     InvalidMultipartResponse { source: quick_xml::de::DeError },
-
-    #[snafu(display("Unable to use proxy url: {}", source))]
-    ProxyUrl { source: reqwest::Error },
 }
 
 impl From<Error> for crate::Error {

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -23,7 +23,8 @@ use crate::multipart::UploadPart;
 use crate::path::DELIMITER;
 use crate::util::{format_http_range, format_prefix};
 use crate::{
-    BoxStream, ListResult, MultipartId, ObjectMeta, Path, Result, RetryConfig, StreamExt,
+    BoxStream, ClientOptions, ListResult, MultipartId, ObjectMeta, Path, Result,
+    RetryConfig, StreamExt,
 };
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, Utc};
@@ -203,8 +204,7 @@ pub struct S3Config {
     pub bucket_endpoint: String,
     pub credentials: Box<dyn CredentialProvider>,
     pub retry_config: RetryConfig,
-    pub allow_http: bool,
-    pub proxy_url: Option<String>,
+    pub client_options: ClientOptions,
 }
 
 impl S3Config {
@@ -221,18 +221,7 @@ pub(crate) struct S3Client {
 
 impl S3Client {
     pub fn new(config: S3Config) -> Result<Self> {
-        let builder = reqwest::ClientBuilder::new().https_only(!config.allow_http);
-        let client = match &config.proxy_url {
-            Some(ref url) => {
-                let pr = reqwest::Proxy::all(url)
-                    .map_err(|source| Error::ProxyUrl { source })?;
-                builder.proxy(pr)
-            }
-            _ => builder,
-        }
-        .build()
-        .unwrap();
-
+        let client = config.client_options.client()?;
         Ok(Self { config, client })
     }
 

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -941,7 +941,7 @@ mod tests {
             .to_string();
 
         assert_eq!(
-            "Generic client error: builder error: unknown proxy scheme",
+            "Generic HTTP client error: builder error: unknown proxy scheme",
             err
         );
     }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -36,7 +36,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::stream::BoxStream;
 use futures::TryStreamExt;
-use reqwest::{Client, Proxy};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::collections::BTreeSet;
 use std::ops::Range;
@@ -51,8 +50,8 @@ use crate::aws::credential::{
 };
 use crate::multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart};
 use crate::{
-    GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Path, Result,
-    RetryConfig, StreamExt,
+    ClientOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Path,
+    Result, RetryConfig, StreamExt,
 };
 
 mod client;
@@ -361,12 +360,11 @@ pub struct AmazonS3Builder {
     endpoint: Option<String>,
     token: Option<String>,
     retry_config: RetryConfig,
-    allow_http: bool,
     imdsv1_fallback: bool,
     virtual_hosted_style_request: bool,
     metadata_endpoint: Option<String>,
     profile: Option<String>,
-    proxy_url: Option<String>,
+    client_options: ClientOptions,
 }
 
 impl AmazonS3Builder {
@@ -431,7 +429,8 @@ impl AmazonS3Builder {
         }
 
         if let Ok(text) = std::env::var("AWS_ALLOW_HTTP") {
-            builder.allow_http = text == "true";
+            builder.client_options =
+                builder.client_options.with_allow_http(text == "true");
         }
 
         builder
@@ -487,7 +486,7 @@ impl AmazonS3Builder {
     /// * false (default):  Only HTTPS are allowed
     /// * true:  HTTP and HTTPS are allowed
     pub fn with_allow_http(mut self, allow_http: bool) -> Self {
-        self.allow_http = allow_http;
+        self.client_options = self.client_options.with_allow_http(allow_http);
         self
     }
 
@@ -543,7 +542,13 @@ impl AmazonS3Builder {
 
     /// Set the proxy_url to be used by the underlying client
     pub fn with_proxy_url(mut self, proxy_url: impl Into<String>) -> Self {
-        self.proxy_url = Some(proxy_url.into());
+        self.client_options = self.client_options.with_proxy_url(proxy_url);
+        self
+    }
+
+    /// Sets the client options, overriding any already set
+    pub fn with_client_options(mut self, options: ClientOptions) -> Self {
+        self.client_options = options;
         self
     }
 
@@ -571,14 +576,6 @@ impl AmazonS3Builder {
         let bucket = self.bucket_name.context(MissingBucketNameSnafu)?;
         let region = self.region.context(MissingRegionSnafu)?;
 
-        let clientbuilder = match self.proxy_url {
-            Some(ref url) => {
-                let pr: Proxy =
-                    Proxy::all(url).map_err(|source| Error::ProxyUrl { source })?;
-                Client::builder().proxy(pr)
-            }
-            None => Client::builder(),
-        };
         let credentials = match (self.access_key_id, self.secret_access_key, self.token) {
             (Some(key_id), Some(secret_key), token) => {
                 info!("Using Static credential provider");
@@ -608,7 +605,11 @@ impl AmazonS3Builder {
                     let endpoint = format!("https://sts.{}.amazonaws.com", region);
 
                     // Disallow non-HTTPs requests
-                    let client = clientbuilder.https_only(true).build().unwrap();
+                    let client = self
+                        .client_options
+                        .clone()
+                        .with_allow_http(false)
+                        .client()?;
 
                     Box::new(WebIdentityProvider {
                         cache: Default::default(),
@@ -629,11 +630,12 @@ impl AmazonS3Builder {
                         info!("Using Instance credential provider");
 
                         // The instance metadata endpoint is access over HTTP
-                        let client = clientbuilder.https_only(false).build().unwrap();
+                        let client_options =
+                            self.client_options.clone().with_allow_http(true);
 
                         Box::new(InstanceCredentialProvider {
                             cache: Default::default(),
-                            client,
+                            client: client_options.client()?,
                             retry_config: self.retry_config.clone(),
                             imdsv1_fallback: self.imdsv1_fallback,
                             metadata_endpoint: self
@@ -670,11 +672,10 @@ impl AmazonS3Builder {
             bucket_endpoint,
             credentials,
             retry_config: self.retry_config,
-            allow_http: self.allow_http,
-            proxy_url: self.proxy_url,
+            client_options: self.client_options,
         };
 
-        let client = Arc::new(S3Client::new(config).unwrap());
+        let client = Arc::new(S3Client::new(config)?);
 
         Ok(AmazonS3 { client })
     }

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -85,9 +85,6 @@ pub(crate) enum Error {
     Authorization {
         source: crate::azure::credential::Error,
     },
-
-    #[snafu(display("Unable to use proxy url: {}", source))]
-    ProxyUrl { source: reqwest::Error },
 }
 
 impl From<Error> for crate::Error {

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -21,13 +21,16 @@ use crate::client::pagination::stream_paginated;
 use crate::client::retry::RetryExt;
 use crate::path::DELIMITER;
 use crate::util::{format_http_range, format_prefix};
-use crate::{BoxStream, ListResult, ObjectMeta, Path, Result, RetryConfig, StreamExt};
+use crate::{
+    BoxStream, ClientOptions, ListResult, ObjectMeta, Path, Result, RetryConfig,
+    StreamExt,
+};
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, TimeZone, Utc};
 use itertools::Itertools;
 use reqwest::{
     header::{HeaderValue, CONTENT_LENGTH, IF_NONE_MATCH, RANGE},
-    Client as ReqwestClient, Method, Proxy, Response, StatusCode,
+    Client as ReqwestClient, Method, Response, StatusCode,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -124,10 +127,9 @@ pub struct AzureConfig {
     pub container: String,
     pub credentials: CredentialProvider,
     pub retry_config: RetryConfig,
-    pub allow_http: bool,
     pub service: Url,
     pub is_emulator: bool,
-    pub proxy_url: Option<String>,
+    pub client_options: ClientOptions,
 }
 
 impl AzureConfig {
@@ -153,18 +155,7 @@ pub(crate) struct AzureClient {
 impl AzureClient {
     /// create a new instance of [AzureClient]
     pub fn new(config: AzureConfig) -> Result<Self> {
-        let builder = ReqwestClient::builder();
-
-        let client = if let Some(url) = config.proxy_url.as_ref() {
-            let pr = Proxy::all(url).map_err(|source| Error::ProxyUrl { source });
-            builder.proxy(pr.unwrap())
-        } else {
-            builder
-        }
-        .https_only(!config.allow_http)
-        .build()
-        .unwrap();
-
+        let client = config.client_options.client()?;
         Ok(Self { config, client })
     }
 

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -28,7 +28,7 @@ use reqwest::{Client, ClientBuilder, Proxy};
 
 fn map_client_error(e: reqwest::Error) -> super::Error {
     super::Error::Generic {
-        store: "client",
+        store: "HTTP client",
         source: Box::new(e),
     }
 }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -41,7 +41,6 @@ use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::RANGE;
-use reqwest::Proxy;
 use reqwest::{header, Client, Method, Response, StatusCode};
 use snafu::{ResultExt, Snafu};
 use tokio::io::AsyncWrite;
@@ -53,7 +52,8 @@ use crate::{
     multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart},
     path::{Path, DELIMITER},
     util::{format_http_range, format_prefix},
-    GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result, RetryConfig,
+    ClientOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result,
+    RetryConfig,
 };
 
 use credential::OAuthProvider;
@@ -743,9 +743,8 @@ fn reader_credentials_file(
 pub struct GoogleCloudStorageBuilder {
     bucket_name: Option<String>,
     service_account_path: Option<String>,
-    client: Option<Client>,
     retry_config: RetryConfig,
-    proxy_url: Option<String>,
+    client_options: ClientOptions,
 }
 
 impl GoogleCloudStorageBuilder {
@@ -787,9 +786,15 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
-    /// Set proxy url used for connection
+    /// Set the proxy_url to be used by the underlying client
     pub fn with_proxy_url(mut self, proxy_url: impl Into<String>) -> Self {
-        self.proxy_url = Some(proxy_url.into());
+        self.client_options = self.client_options.with_proxy_url(proxy_url);
+        self
+    }
+
+    /// Sets the client options, overriding any already set
+    pub fn with_client_options(mut self, options: ClientOptions) -> Self {
+        self.client_options = options;
         self
     }
 
@@ -799,27 +804,15 @@ impl GoogleCloudStorageBuilder {
         let Self {
             bucket_name,
             service_account_path,
-            client,
             retry_config,
-            proxy_url,
+            client_options,
         } = self;
 
         let bucket_name = bucket_name.ok_or(Error::MissingBucketName {})?;
         let service_account_path =
             service_account_path.ok_or(Error::MissingServiceAccountPath)?;
 
-        let client = match (proxy_url, client) {
-            (_, Some(client)) => client,
-            (Some(url), None) => {
-                let pr = Proxy::all(&url).map_err(|source| Error::ProxyUrl { source })?;
-                Client::builder()
-                    .proxy(pr)
-                    .build()
-                    .map_err(|source| Error::ProxyUrl { source })?
-            }
-            (None, None) => Client::new(),
-        };
-
+        let client = client_options.client()?;
         let credentials = reader_credentials_file(service_account_path)?;
 
         // TODO: https://cloud.google.com/storage/docs/authentication#oauth-scopes

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -1064,7 +1064,7 @@ mod test {
             .to_string();
 
         assert_eq!(
-            "Generic client error: builder error: unknown proxy scheme",
+            "Generic HTTP client error: builder error: unknown proxy scheme",
             err
         );
     }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -739,12 +739,23 @@ fn reader_credentials_file(
 ///  .with_bucket_name(BUCKET_NAME)
 ///  .build();
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct GoogleCloudStorageBuilder {
     bucket_name: Option<String>,
     service_account_path: Option<String>,
     retry_config: RetryConfig,
     client_options: ClientOptions,
+}
+
+impl Default for GoogleCloudStorageBuilder {
+    fn default() -> Self {
+        Self {
+            bucket_name: None,
+            service_account_path: None,
+            retry_config: Default::default(),
+            client_options: ClientOptions::new().with_allow_http(true),
+        }
+    }
 }
 
 impl GoogleCloudStorageBuilder {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -197,6 +197,9 @@ use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
 use tokio::io::AsyncWrite;
 
+#[cfg(any(feature = "azure", feature = "aws", feature = "gcp"))]
+pub use client::ClientOptions;
+
 /// An alias for a dynamically dispatched object store implementation.
 pub type DynObjectStore = dyn ObjectStore;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #2989 #3127

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This should make it easier to introduce customisations for the reqwest client, without having to modify every object store implementation.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Extracts a common `ClientOptions` that can be used to control the configuration of the generated `reqwest::Client`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
