### PR TITLE
Minor: skip aws integration test if TEST_INTEGRATION is not set

### DIFF
--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -664,6 +664,7 @@ mod tests {
     async fn test_instance_metadata() {
         if env::var("TEST_INTEGRATION").is_err() {
             eprintln!("skipping AWS integration test");
+            return;
         }
 
         // For example https://github.com/aws/amazon-ec2-metadata-mock


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Found the following while testing Apache Arrow Rust Object Store 0.5.2 RC1:
```
---- aws::credential::tests::test_instance_metadata stdout ----
skipping AWS integration test
thread 'aws::credential::tests::test_instance_metadata' panicked at 'called `Result::unwrap()` on an `Err` value: NotPresent', src/aws/credential.rs:670:58
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I think the purpose of the `env` check is to skip the test, but it just prints out the message without skipping the test.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
