### PR TITLE
Add parquet-layout binary

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -52,6 +52,7 @@ num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 base64 = { version = "0.13", default-features = false, features = ["std"], optional = true }
 clap = { version = "4", default-features = false, features = ["std", "derive", "env", "help", "error-context", "usage"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
@@ -82,7 +83,7 @@ default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 # Enable arrow reader/writer APIs
 arrow = ["base64", "arrow-array", "arrow-buffer", "arrow-cast", "arrow-data", "arrow-schema", "arrow-select", "arrow-ipc"]
 # Enable CLI tools
-cli = ["json", "base64", "clap", "arrow-csv"]
+cli = ["json", "base64", "clap", "arrow-csv", "serde"]
 # Enable JSON APIs
 json = ["serde_json", "base64"]
 # Enable internal testing APIs
@@ -124,6 +125,10 @@ required-features = ["arrow", "cli"]
 
 [[bin]]
 name = "parquet-show-bloom-filter"
+required-features = ["cli"]
+
+[[bin]]
+name = "parquet-layout"
 required-features = ["cli"]
 
 [[bench]]

--- a/parquet/src/bin/parquet-layout.rs
+++ b/parquet/src/bin/parquet-layout.rs
@@ -201,7 +201,7 @@ fn encoding(encoding: parquet::format::Encoding) -> &'static str {
         Ok(Encoding::DELTA_BYTE_ARRAY) => "delta_byte_array",
         Ok(Encoding::RLE_DICTIONARY) => "rle_dictionary",
         Ok(Encoding::BYTE_STREAM_SPLIT) => "byte_stream_split",
-        Err(_) => return "unknown",
+        Err(_) => "unknown",
     }
 }
 

--- a/parquet/src/bin/parquet-layout.rs
+++ b/parquet/src/bin/parquet-layout.rs
@@ -53,6 +53,7 @@ struct ParquetFile {
 #[derive(Serialize, Debug)]
 struct RowGroup {
     columns: Vec<ColumnChunk>,
+    row_count: i64,
 }
 
 #[derive(Serialize, Debug)]
@@ -144,7 +145,10 @@ fn do_layout<C: ChunkReader>(reader: &C) -> Result<ParquetFile> {
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            Ok(RowGroup { columns })
+            Ok(RowGroup {
+                columns,
+                row_count: row_group.num_rows(),
+            })
         })
         .collect::<Result<Vec<_>>>()?;
 

--- a/parquet/src/bin/parquet-layout.rs
+++ b/parquet/src/bin/parquet-layout.rs
@@ -1,0 +1,195 @@
+use std::fs::File;
+use std::io::Read;
+
+use clap::Parser;
+use serde::Serialize;
+use thrift::protocol::{TCompactInputProtocol, TSerializable};
+
+use parquet::basic::{Compression, Encoding};
+use parquet::errors::Result;
+use parquet::file::reader::ChunkReader;
+use parquet::format::PageHeader;
+
+#[derive(Serialize, Debug)]
+struct ParquetFile {
+    row_groups: Vec<RowGroup>,
+}
+
+#[derive(Serialize, Debug)]
+struct RowGroup {
+    columns: Vec<ColumnChunk>,
+}
+
+#[derive(Serialize, Debug)]
+struct ColumnChunk {
+    path: String,
+    has_offset_index: bool,
+    has_column_index: bool,
+    has_bloom_filter: bool,
+    pages: Vec<Page>,
+}
+
+#[derive(Serialize, Debug)]
+struct Page {
+    compression: Option<&'static str>,
+    encoding: &'static str,
+    page_type: &'static str,
+    compressed_bytes: i32,
+    uncompressed_bytes: i32,
+    header_bytes: i32,
+    num_values: i32,
+}
+
+fn do_layout<C: ChunkReader>(reader: &C) -> Result<ParquetFile> {
+    let metadata = parquet::file::footer::parse_metadata(reader)?;
+    let schema = metadata.file_metadata().schema_descr();
+
+    let row_groups = (0..metadata.num_row_groups())
+        .map(|row_group_idx| {
+            let row_group = metadata.row_group(row_group_idx);
+            let columns = row_group
+                .columns()
+                .iter()
+                .zip(schema.columns())
+                .map(|(column, column_schema)| {
+                    let compression = compression(column.compression());
+                    let mut pages = vec![];
+
+                    let mut start = column
+                        .dictionary_page_offset()
+                        .unwrap_or_else(|| column.data_page_offset())
+                        as u64;
+
+                    let end = start + column.compressed_size() as u64;
+                    while start != end {
+                        let (header_len, header) = read_page_header(reader, start)?;
+                        if let Some(dictionary) = header.dictionary_page_header {
+                            pages.push(Page {
+                                compression,
+                                encoding: encoding(dictionary.encoding),
+                                page_type: "dictionary",
+                                compressed_bytes: header.compressed_page_size,
+                                uncompressed_bytes: header.uncompressed_page_size,
+                                header_bytes: header_len as _,
+                                num_values: dictionary.num_values,
+                            })
+                        } else if let Some(data_page) = header.data_page_header {
+                            pages.push(Page {
+                                compression,
+                                encoding: encoding(data_page.encoding),
+                                page_type: "data_page_v1",
+                                compressed_bytes: header.compressed_page_size,
+                                uncompressed_bytes: header.uncompressed_page_size,
+                                header_bytes: header_len as _,
+                                num_values: data_page.num_values,
+                            })
+                        } else if let Some(data_page) = header.data_page_header_v2 {
+                            let is_compressed = data_page.is_compressed.unwrap_or(true);
+
+                            pages.push(Page {
+                                compression: compression.filter(|_| is_compressed),
+                                encoding: encoding(data_page.encoding),
+                                page_type: "data_page_v2",
+                                compressed_bytes: header.compressed_page_size,
+                                uncompressed_bytes: header.uncompressed_page_size,
+                                header_bytes: header_len as _,
+                                num_values: data_page.num_values,
+                            })
+                        }
+                        start += header.compressed_page_size as u64 + header_len as u64;
+                    }
+
+                    Ok(ColumnChunk {
+                        path: column_schema.path().parts().join("."),
+                        has_offset_index: column.offset_index_offset().is_some(),
+                        has_column_index: column.column_index_offset().is_some(),
+                        has_bloom_filter: column.bloom_filter_offset().is_some(),
+                        pages,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            Ok(RowGroup { columns })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(ParquetFile { row_groups })
+}
+
+/// Reads the page header at `offset` from `reader`, returning
+/// both the `PageHeader` and its length in bytes
+fn read_page_header<C: ChunkReader>(
+    reader: &C,
+    offset: u64,
+) -> Result<(usize, PageHeader)> {
+    struct TrackedRead<R>(R, usize);
+
+    impl<R: Read> Read for TrackedRead<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let v = self.0.read(buf)?;
+            self.1 += v;
+            Ok(v)
+        }
+    }
+
+    let len = reader.len().checked_sub(offset).unwrap() as usize;
+    let input = reader.get_read(offset, len)?;
+    let mut tracked = TrackedRead(input, 0);
+    let mut prot = TCompactInputProtocol::new(&mut tracked);
+    let header = PageHeader::read_from_in_protocol(&mut prot)?;
+    Ok((tracked.1, header))
+}
+
+/// Returns a string representation for a given compression
+fn compression(compression: Compression) -> Option<&'static str> {
+    match compression {
+        Compression::UNCOMPRESSED => None,
+        Compression::SNAPPY => Some("snappy"),
+        Compression::GZIP => Some("gzip"),
+        Compression::LZO => Some("lzo"),
+        Compression::BROTLI => Some("brotli"),
+        Compression::LZ4 => Some("lz4"),
+        Compression::ZSTD => Some("zstd"),
+        Compression::LZ4_RAW => Some("lz4_raw"),
+    }
+}
+
+/// Returns a string representation for a given encoding
+fn encoding(encoding: parquet::format::Encoding) -> &'static str {
+    match Encoding::try_from(encoding) {
+        Ok(Encoding::PLAIN) => "plain",
+        Ok(Encoding::PLAIN_DICTIONARY) => "plain_dictionary",
+        Ok(Encoding::RLE) => "rle",
+        Ok(Encoding::BIT_PACKED) => "bit_packed",
+        Ok(Encoding::DELTA_BINARY_PACKED) => "delta_binary_packed",
+        Ok(Encoding::DELTA_LENGTH_BYTE_ARRAY) => "delta_length_byte_array",
+        Ok(Encoding::DELTA_BYTE_ARRAY) => "delta_byte_array",
+        Ok(Encoding::RLE_DICTIONARY) => "rle_dictionary",
+        Ok(Encoding::BYTE_STREAM_SPLIT) => "byte_stream_split",
+        Err(_) => return "unknown",
+    }
+}
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Prints the layout of a parquet file"), long_about = None)]
+struct Args {
+    #[clap(help("Path to a parquet file"))]
+    file: String,
+}
+
+impl Args {
+    fn run(&self) -> Result<()> {
+        let file = File::open(&self.file)?;
+        let layout = do_layout(&file)?;
+
+        let out = std::io::stdout();
+        let writer = out.lock();
+
+        serde_json::to_writer_pretty(writer, &layout).unwrap();
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    Args::parse().run()
+}

--- a/parquet/src/bin/parquet-layout.rs
+++ b/parquet/src/bin/parquet-layout.rs
@@ -1,3 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Binary that prints the physical layout of a parquet file
+//!
+//! # Install
+//!
+//! `parquet-layout` can be installed using `cargo`:
+//! ```
+//! cargo install parquet --features=cli
+//! ```
+//! After this `parquet-layout` should be available:
+//! ```
+//! parquet-layout XYZ.parquet
+//! ```
+//!
+//! The binary can also be built from the source code and run as follows:
+//! ```
+//! cargo run --features=cli --bin parquet-layout XYZ.parquet
+//! ```
+
 use std::fs::File;
 use std::io::Read;
 
@@ -171,7 +206,7 @@ fn encoding(encoding: parquet::format::Encoding) -> &'static str {
 }
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about("Prints the layout of a parquet file"), long_about = None)]
+#[clap(author, version, about("Prints the physical layout of a parquet file"), long_about = None)]
 struct Args {
     #[clap(help("Path to a parquet file"))]
     file: String,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Frequently when debugging an issue the first port of call is working out the physical layout of the data in the parquet file, what indexes are present, what encodings are being used, how large the pages are, etc...

I have been unable to find such a tool, so I quickly wrote one up to replace the ad-hoc code I keep having to write :sweat_smile: 

<details>
<summary>parquet-testing/data/nested_lists.snappy.parquet</summary>
<pre><code>{
  "row_groups": [
    {
      "columns": [
        {
          "path": "a.list.element.list.element.list.element",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": "snappy",
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 30,
              "uncompressed_bytes": 30,
              "header_bytes": 13,
              "num_values": 6
            },
            {
              "compression": "snappy",
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 34,
              "uncompressed_bytes": 33,
              "header_bytes": 27,
              "num_values": 18
            }
          ]
        },
        {
          "path": "b",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": "snappy",
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 6,
              "uncompressed_bytes": 4,
              "header_bytes": 13,
              "num_values": 1
            },
            {
              "compression": "snappy",
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 4,
              "uncompressed_bytes": 2,
              "header_bytes": 33,
              "num_values": 3
            }
          ]
        }
      ]
    }
  ]
}
</code></pre>
</details>

<details>
<summary>parquet-testing/data/data_index_bloom_encoding_stats.parquet</summary>
<pre><code>{
  "row_groups": [
    {
      "columns": [
        {
          "path": "String",
          "has_offset_index": true,
          "has_column_index": true,
          "has_bloom_filter": true,
          "pages": [
            {
              "compression": "gzip",
              "encoding": "plain",
              "page_type": "data_page_v1",
              "compressed_bytes": 127,
              "uncompressed_bytes": 138,
              "header_bytes": 25,
              "num_values": 14
            }
          ]
        }
      ]
    }
  ]
}
</code></pre>
</details>

<details>
<summary>parquet-testing/data/alltypes_dictionary.parquet</summary>
<pre><code>{
  "row_groups": [
    {
      "columns": [
        {
          "path": "id",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 8,
              "uncompressed_bytes": 8,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "bool_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain",
              "page_type": "data_page_v1",
              "compressed_bytes": 7,
              "uncompressed_bytes": 7,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "tinyint_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 8,
              "uncompressed_bytes": 8,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "smallint_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 8,
              "uncompressed_bytes": 8,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "int_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 8,
              "uncompressed_bytes": 8,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "bigint_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 16,
              "uncompressed_bytes": 16,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "float_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 8,
              "uncompressed_bytes": 8,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "double_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 16,
              "uncompressed_bytes": 16,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "date_string_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 12,
              "uncompressed_bytes": 12,
              "header_bytes": 13,
              "num_values": 1
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "string_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 10,
              "uncompressed_bytes": 10,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        },
        {
          "path": "timestamp_col",
          "has_offset_index": false,
          "has_column_index": false,
          "has_bloom_filter": false,
          "pages": [
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "dictionary",
              "compressed_bytes": 24,
              "uncompressed_bytes": 24,
              "header_bytes": 13,
              "num_values": 2
            },
            {
              "compression": null,
              "encoding": "plain_dictionary",
              "page_type": "data_page_v1",
              "compressed_bytes": 9,
              "uncompressed_bytes": 9,
              "header_bytes": 17,
              "num_values": 2
            }
          ]
        }
      ]
    }
  ]
}
</code></pre>
</details>

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
