### PR TITLE
fix(ffi): handle null data buffers from empty arrays

### DIFF
--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -20,6 +20,7 @@
 
 use std::sync::Arc;
 
+use arrow::array::Int32Array;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
@@ -68,6 +69,13 @@ fn double_py(lambda: &PyAny, py: Python) -> PyResult<bool> {
     let array = make_array(ArrayData::from_pyarrow(pyarray)?);
 
     Ok(array == expected)
+}
+
+#[pyfunction]
+fn create_int32_array(data: Vec<Option<i32>>, py: Python) -> PyResult<PyObject> {
+    let array = Int32Array::from_iter(data.iter());
+
+    array.data().to_pyarrow(py)
 }
 
 /// Returns the substring
@@ -134,6 +142,7 @@ fn round_trip_record_batch_reader(
 fn arrow_pyarrow_integration_testing(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(double))?;
     m.add_wrapped(wrap_pyfunction!(double_py))?;
+    m.add_wrapped(wrap_pyfunction!(create_int32_array))?;
     m.add_wrapped(wrap_pyfunction!(substring))?;
     m.add_wrapped(wrap_pyfunction!(concatenate))?;
     m.add_wrapped(wrap_pyfunction!(round_trip_type))?;

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::Int32Array;
+use arrow::array::new_empty_array;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
@@ -72,8 +72,8 @@ fn double_py(lambda: &PyAny, py: Python) -> PyResult<bool> {
 }
 
 #[pyfunction]
-fn create_int32_array(data: Vec<Option<i32>>, py: Python) -> PyResult<PyObject> {
-    let array = Int32Array::from_iter(data.iter());
+fn make_empty_array(datatype: PyArrowType<DataType>, py: Python) -> PyResult<PyObject> {
+    let array = new_empty_array(&datatype.0);
 
     array.data().to_pyarrow(py)
 }
@@ -142,7 +142,7 @@ fn round_trip_record_batch_reader(
 fn arrow_pyarrow_integration_testing(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(double))?;
     m.add_wrapped(wrap_pyfunction!(double_py))?;
-    m.add_wrapped(wrap_pyfunction!(create_int32_array))?;
+    m.add_wrapped(wrap_pyfunction!(make_empty_array))?;
     m.add_wrapped(wrap_pyfunction!(substring))?;
     m.add_wrapped(wrap_pyfunction!(concatenate))?;
     m.add_wrapped(wrap_pyfunction!(round_trip_type))?;

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -161,13 +161,6 @@ def test_primitive_rust():
     """
     Rust -> Python -> Rust
     """
-    a = rust.create_int32_array([1, 2, 3])
-    a.validate(full=True)
-    assert a == pa.array([1, 2, 3], type=pa.int32())
-
-    a = rust.create_int32_array([None, None])
-    a.validate(full=True)
-    assert a == pa.array([None, None], type=pa.int32())
 
     def double(array):
         array = array.to_pylist()
@@ -218,13 +211,13 @@ def test_empty_array_python(datatype):
     del b
 
 
-def test_empty_array_rust():
+@pytest.mark.parametrize("datatype", _supported_pyarrow_types, ids=str)
+def test_empty_array_rust(datatype):
     """
-    Python -> Rust -> Python
+    Rust -> Python
     """
-    data = []
-    a = pa.array(data, type=pa.int32())
-    b = rust.create_int32_array(data)
+    a = pa.array([], type=datatype)
+    b = rust.make_empty_array(datatype)
     b.validate(full=True)
     assert a.to_pylist() == b.to_pylist()
     assert a.type == b.type

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -201,11 +201,15 @@ def test_time32_python():
     del expected
 
 
-def test_empty_array_python():
+@pytest.mark.parametrize("datatype", _supported_pyarrow_types, ids=str)
+def test_empty_array_python(datatype):
     """
     Python -> Rust -> Python
     """
-    a = pa.array([], pa.int32())
+    if datatype == pa.float16():
+        pytest.skip("Float 16 is not implemented in Rust")
+
+    a = pa.array([], datatype)
     b = rust.round_trip_array(a)
     b.validate(full=True)
     assert a.to_pylist() == b.to_pylist()

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -161,6 +161,13 @@ def test_primitive_rust():
     """
     Rust -> Python -> Rust
     """
+    a = rust.create_int32_array([1, 2, 3])
+    a.validate(full=True)
+    assert a == pa.array([1, 2, 3], type=pa.int32())
+
+    a = rust.create_int32_array([None, None])
+    a.validate(full=True)
+    assert a == pa.array([None, None], type=pa.int32())
 
     def double(array):
         array = array.to_pylist()
@@ -192,6 +199,34 @@ def test_time32_python():
     del a
     del b
     del expected
+
+
+def test_empty_array_python():
+    """
+    Python -> Rust -> Python
+    """
+    a = pa.array([], pa.int32())
+    b = rust.round_trip_array(a)
+    b.validate(full=True)
+    assert a.to_pylist() == b.to_pylist()
+    assert a.type == b.type
+    del a
+    del b
+
+
+def test_empty_array_rust():
+    """
+    Python -> Rust -> Python
+    """
+    data = []
+    a = pa.array(data, type=pa.int32())
+    b = rust.create_int32_array(data)
+    b.validate(full=True)
+    assert a.to_pylist() == b.to_pylist()
+    assert a.type == b.type
+    del a
+    del b
+
 
 def test_binary_array():
     """

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -578,7 +578,7 @@ unsafe fn create_buffer(
     index: usize,
     len: usize,
 ) -> Option<Buffer> {
-    if array.buffers.is_null() {
+    if array.buffers.is_null() || array.n_buffers == 0 {
         return None;
     }
     let buffers = array.buffers as *mut *const u8;


### PR DESCRIPTION
# Which issue does this PR close?

This is a followup to discussion here: https://github.com/apache/arrow-nanoarrow/issues/76

# Rationale for this change
 
While testing PyArrow integration, found that PyArrow can create empty null and dictionary arrays that arrow-rs cannot import. The empty null array had an empty `buffers` array instead of a nullptr. And the empty dictionary array had a nullptr for the indices data buffer.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
