### PR TITLE
Disable const-random ahash feature on non-WASM (#3271)

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -28,6 +28,12 @@ readme = "README.md"
 edition = "2021"
 rust-version = "1.62"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
+
 [dependencies]
 arrow-array = { version = "28.0.0", path = "../arrow-array", default-features = false, optional = true }
 arrow-buffer = { version = "28.0.0", path = "../arrow-buffer", default-features = false, optional = true }
@@ -38,7 +44,6 @@ arrow-schema = { version = "28.0.0", path = "../arrow-schema", default-features 
 arrow-select = { version = "28.0.0", path = "../arrow-select", default-features = false, optional = true }
 arrow-ipc = { version = "28.0.0", path = "../arrow-ipc", default-features = false, optional = true }
 
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3271

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Copy configuration from arrow crate to only enable compile-time-rng where necessary.

Added in https://github.com/apache/arrow-rs/pull/2896

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
