### PR TITLE
Fix ipc schema custom_metadata serialization

### DIFF
--- a/arrow-ipc/src/convert.rs
+++ b/arrow-ipc/src/convert.rs
@@ -63,7 +63,9 @@ pub fn schema_to_fb_offset<'a>(
 
     let mut builder = crate::SchemaBuilder::new(fbb);
     builder.add_fields(fb_field_list);
-    builder.add_custom_metadata(fb_metadata_list);
+    if !custom_metadata.is_empty() {
+        builder.add_custom_metadata(fb_metadata_list);
+    }
     builder.finish()
 }
 
@@ -1031,32 +1033,45 @@ mod tests {
 
     #[test]
     fn schema_from_bytes() {
-        // bytes of a schema generated from python (0.14.0), saved as an `crate::Message`.
-        // the schema is: Field("field1", DataType::UInt32, false)
+        // Bytes of a schema generated via following python code, using pyarrow 10.0.1:
+        //
+        // import pyarrow as pa
+        // schema = pa.schema([pa.field('field1', pa.uint32(), nullable=False)])
+        // sink = pa.BufferOutputStream()
+        // with pa.ipc.new_stream(sink, schema) as writer:
+        //     pass
+        // # stripping continuation & length prefix & suffix bytes to get only schema bytes
+        // [x for x in sink.getvalue().to_pybytes()][8:-8]
         let bytes: Vec<u8> = vec![
-            16, 0, 0, 0, 0, 0, 10, 0, 12, 0, 6, 0, 5, 0, 8, 0, 10, 0, 0, 0, 0, 1, 3, 0,
+            16, 0, 0, 0, 0, 0, 10, 0, 12, 0, 6, 0, 5, 0, 8, 0, 10, 0, 0, 0, 0, 1, 4, 0,
             12, 0, 0, 0, 8, 0, 8, 0, 0, 0, 4, 0, 8, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 20,
             0, 0, 0, 16, 0, 20, 0, 8, 0, 0, 0, 7, 0, 12, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0,
-            0, 0, 2, 32, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 8, 0,
-            4, 0, 6, 0, 0, 0, 32, 0, 0, 0, 6, 0, 0, 0, 102, 105, 101, 108, 100, 49, 0, 0,
-            0, 0, 0, 0,
+            0, 0, 2, 16, 0, 0, 0, 32, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 102,
+            105, 101, 108, 100, 49, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 32, 0, 0,
+            0,
         ];
-        let ipc = crate::root_as_message(&bytes[..]).unwrap();
+        let ipc = crate::root_as_message(&bytes).unwrap();
         let schema = ipc.header_as_schema().unwrap();
 
-        // a message generated from Rust, same as the Python one
-        let bytes: Vec<u8> = vec![
-            16, 0, 0, 0, 0, 0, 10, 0, 14, 0, 12, 0, 11, 0, 4, 0, 10, 0, 0, 0, 20, 0, 0,
-            0, 0, 0, 0, 1, 3, 0, 10, 0, 12, 0, 0, 0, 8, 0, 4, 0, 10, 0, 0, 0, 8, 0, 0, 0,
-            8, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 16, 0, 0, 0, 12, 0, 18, 0, 12, 0, 0, 0,
-            11, 0, 4, 0, 12, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 2, 20, 0, 0, 0, 0, 0, 6, 0,
-            8, 0, 4, 0, 6, 0, 0, 0, 32, 0, 0, 0, 6, 0, 0, 0, 102, 105, 101, 108, 100, 49,
-            0, 0,
-        ];
-        let ipc2 = crate::root_as_message(&bytes[..]).unwrap();
-        let schema2 = ipc.header_as_schema().unwrap();
+        // generate same message with Rust
+        let data_gen = crate::writer::IpcDataGenerator::default();
+        let arrow_schema =
+            Schema::new(vec![Field::new("field1", DataType::UInt32, false)]);
+        let bytes = data_gen
+            .schema_to_bytes(&arrow_schema, &crate::writer::IpcWriteOptions::default())
+            .ipc_message;
 
-        assert_eq!(schema, schema2);
+        let ipc2 = crate::root_as_message(&bytes).unwrap();
+        let schema2 = ipc2.header_as_schema().unwrap();
+
+        // can't compare schema directly as though is same message, the underlying bytes seem to differ
+        assert!(schema.custom_metadata().is_none());
+        assert!(schema2.custom_metadata().is_none());
+        assert_eq!(schema.endianness(), schema2.endianness());
+        assert!(schema.features().is_none());
+        assert!(schema2.features().is_none());
+        assert_eq!(fb_to_schema(schema), fb_to_schema(schema2));
+
         assert_eq!(ipc.version(), ipc2.version());
         assert_eq!(ipc.header_type(), ipc2.header_type());
         assert_eq!(ipc.bodyLength(), ipc2.bodyLength());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #250.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Thought meant to address #250, it is outdated in that the error doesn't seem to be due to empty children array anymore, but persists with empty custom_metadata (at schema level, not field level).

Have updated the bytes generated from pyarrow as those were from a very old version, and also made adjustments to how bytes are generated from Rust too, to make it more dynamic.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix test

Fix ipc serialization of schema to fb for empty custom_metadata field to ensure it serializes as a None/null instead of an empty array (since pyarrow appears to do the same)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
