### PR TITLE
Don't use dangling NonNull as sentinel

### DIFF
--- a/arrow-buffer/src/alloc/mod.rs
+++ b/arrow-buffer/src/alloc/mod.rs
@@ -35,7 +35,7 @@ pub use alignment::ALIGNMENT;
 ///
 /// Types that lazily allocate must track initialization by some other means.
 #[inline]
-fn dangling() -> NonNull<u8> {
+fn dangling_ptr() -> NonNull<u8> {
     // SAFETY: ALIGNMENT is a non-zero usize which is then casted
     // to a *mut T. Therefore, `ptr` is not null and the conditions for
     // calling new_unchecked() are respected.
@@ -48,7 +48,7 @@ fn dangling() -> NonNull<u8> {
 pub fn allocate_aligned(size: usize) -> NonNull<u8> {
     unsafe {
         if size == 0 {
-            dangling()
+            dangling_ptr()
         } else {
             let layout = Layout::from_size_align_unchecked(size, ALIGNMENT);
             let raw_ptr = std::alloc::alloc(layout);
@@ -63,7 +63,7 @@ pub fn allocate_aligned(size: usize) -> NonNull<u8> {
 pub fn allocate_aligned_zeroed(size: usize) -> NonNull<u8> {
     unsafe {
         if size == 0 {
-            dangling()
+            dangling_ptr()
         } else {
             let layout = Layout::from_size_align_unchecked(size, ALIGNMENT);
             let raw_ptr = std::alloc::alloc_zeroed(layout);
@@ -111,7 +111,7 @@ pub unsafe fn reallocate(
 
     if new_size == 0 {
         free_aligned(ptr, old_size);
-        return dangling();
+        return dangling_ptr();
     }
 
     let raw_ptr = std::alloc::realloc(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Aside from a method called `null_pointer` returning a `NonNull` being slightly oxymoronic, using the returned value as a sentinel could in extremely unlikely situations lead to a false positive. This would only ever result in leaking memory, but we might as well clean it up.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
