### PR TITLE
csv: Support Binary-typed columns in the CSV writer

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -158,6 +158,10 @@ impl<W: Write> Writer<W> {
                     let c = col.as_any().downcast_ref::<BooleanArray>().unwrap();
                     c.value(row_index).to_string()
                 }
+                DataType::Binary => {
+                    let c = col.as_any().downcast_ref::<BinaryArray>().unwrap();
+                    c.value(row_index).escape_ascii().to_string()
+                }
                 DataType::Utf8 => {
                     let c = col.as_any().downcast_ref::<StringArray>().unwrap();
                     c.value(row_index).to_owned()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3291.

# Are there any user-facing changes?

The API is not changed.

The docs currently say:

> The writer does not support writing ListArray and StructArray.

So no documentation changes are required - this MR actually brings the code more in line with the existing docs.