### PR TITLE
Split out arrow-ord (#2594)

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -25,18 +25,20 @@ on:
       - master
   pull_request:
     paths:
-      - arrow/**
+      - .github/**
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**
+      - arrow-csv/**
       - arrow-data/**
-      - arrow-schema/**
-      - arrow-select/**
       - arrow-integration-test/**
       - arrow-ipc/**
-      - arrow-csv/**
       - arrow-json/**
-      - .github/**
+      - arrow-ord/**
+      - arrow-schema/**
+      - arrow-select/**
+      - arrow-string/**
+      - arrow/**
 
 jobs:
 
@@ -58,8 +60,8 @@ jobs:
         run: cargo test -p arrow-data --all-features
       - name: Test arrow-schema with all features
         run: cargo test -p arrow-schema --all-features
-      - name: Test arrow-array with all features
-        run: cargo test -p arrow-array --all-features
+      - name: Test arrow-array with all features except SIMD
+        run: cargo test -p arrow-array
       - name: Test arrow-select with all features
         run: cargo test -p arrow-select --all-features
       - name: Test arrow-cast with all features
@@ -72,6 +74,8 @@ jobs:
         run: cargo test -p arrow-json --all-features
       - name: Test arrow-string with all features
         run: cargo test -p arrow-string --all-features
+      - name: Test arrow-ord with all features except SIMD
+        run: cargo test -p arrow-ord --features dyn_cmp_dict
       - name: Test arrow-integration-test with all features
         run: cargo test -p arrow-integration-test --all-features
       - name: Test arrow with default features
@@ -129,10 +133,12 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: nightly
-      - name: Run tests --features "simd"
-        run: cargo test -p arrow --features "simd"
-      - name: Check compilation --features "simd"
-        run: cargo check -p arrow --features simd
+      - name: Test arrow-array with SIMD
+        run: cargo test -p arrow-array --features simd
+      - name: Test arrow-ord with SIMD
+        run: cargo test -p arrow-ord --features simd
+      - name: Test arrow with SIMD
+        run: cargo test -p arrow --features simd
       - name: Check compilation --features simd --all-targets
         run: cargo check -p arrow --features simd --all-targets
 
@@ -174,8 +180,8 @@ jobs:
         run: cargo clippy -p arrow-data --all-targets --all-features -- -D warnings
       - name: Clippy arrow-schema with all features
         run: cargo clippy -p arrow-schema --all-targets --all-features -- -D warnings
-      - name: Clippy arrow-array with all features
-        run: cargo clippy -p arrow-array --all-targets --all-features -- -D warnings
+      - name: Clippy arrow-array without SIMD
+        run: cargo clippy -p arrow-array --all-targets -- -D warnings
       - name: Clippy arrow-select with all features
         run: cargo clippy -p arrow-select --all-targets --all-features -- -D warnings
       - name: Clippy arrow-cast with all features
@@ -188,5 +194,7 @@ jobs:
         run: cargo clippy -p arrow-json --all-targets --all-features -- -D warnings
       - name: Clippy arrow-string with all features
         run: cargo clippy -p arrow-string --all-targets --all-features -- -D warnings
+      - name: Clippy arrow-ord without SIMD
+        run: cargo clippy -p arrow-ord --all-targets -- -D warnings
       - name: Clippy arrow
         run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,dyn_cmp_dict,dyn_arith_dict,chrono-tz --all-targets -- -D warnings

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -180,7 +180,7 @@ jobs:
         run: cargo clippy -p arrow-data --all-targets --all-features -- -D warnings
       - name: Clippy arrow-schema with all features
         run: cargo clippy -p arrow-schema --all-targets --all-features -- -D warnings
-      - name: Clippy arrow-array without SIMD
+      - name: Clippy arrow-array with all features except SIMD
         run: cargo clippy -p arrow-array --all-targets -- -D warnings
       - name: Clippy arrow-select with all features
         run: cargo clippy -p arrow-select --all-targets --all-features -- -D warnings
@@ -194,7 +194,7 @@ jobs:
         run: cargo clippy -p arrow-json --all-targets --all-features -- -D warnings
       - name: Clippy arrow-string with all features
         run: cargo clippy -p arrow-string --all-targets --all-features -- -D warnings
-      - name: Clippy arrow-ord without SIMD
-        run: cargo clippy -p arrow-ord --all-targets -- -D warnings
+      - name: Clippy arrow-ord with all features except SIMD
+        run: cargo clippy -p arrow-ord --all-targets --features dyn_cmp_dict -- -D warnings
       - name: Clippy arrow
         run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,dyn_cmp_dict,dyn_arith_dict,chrono-tz --all-targets -- -D warnings

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -33,6 +33,7 @@ on:
       - arrow-data/**
       - arrow-flight/**
       - arrow-ipc/**
+      - arrow-ord/**
       - arrow-schema/**
       - arrow-select/**
       - arrow-string/**

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -33,10 +33,8 @@ on:
       - arrow-data/**
       - arrow-flight/**
       - arrow-ipc/**
-      - arrow-ord/**
       - arrow-schema/**
       - arrow-select/**
-      - arrow-string/**
       - .github/**
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,7 @@ on:
       - arrow-integration-test/**
       - arrow-integration-testing/**
       - arrow-ipc/**
+      - arrow-ord/**
       - arrow-json/**
       - arrow-pyarrow-integration-testing/**
       - arrow-schema/**

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -36,7 +36,6 @@ on:
       - arrow-ipc/**
       - arrow-csv/**
       - arrow-json/**
-      - arrow-string/**
       - parquet/**
       - .github/**
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "arrow-integration-testing",
     "arrow-ipc",
     "arrow-json",
+    "arrow-ord",
     "arrow-schema",
     "arrow-select",
     "arrow-string",

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -170,6 +170,9 @@ pub use record_batch::{RecordBatch, RecordBatchOptions, RecordBatchReader};
 mod arithmetic;
 pub use arithmetic::ArrowNativeTypeOp;
 
+mod numeric;
+pub use numeric::*;
+
 pub mod builder;
 pub mod cast;
 mod delta;

--- a/arrow-array/src/numeric.rs
+++ b/arrow-array/src/numeric.rs
@@ -589,11 +589,7 @@ make_float_numeric_type!(Float64Type, f64x8);
 
 #[cfg(all(test, feature = "simd"))]
 mod tests {
-    use crate::datatypes::{
-        ArrowNumericType, Float32Type, Float64Type, Int32Type, Int64Type, Int8Type,
-        IntervalMonthDayNanoType, UInt16Type,
-    };
-    use packed_simd::*;
+    use super::*;
     use FromCast;
 
     /// calculate the expected mask by iterating over all bits

--- a/arrow-array/src/numeric.rs
+++ b/arrow-array/src/numeric.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::*;
+use crate::types::*;
+use crate::ArrowPrimitiveType;
 #[cfg(feature = "simd")]
 use packed_simd::*;
 #[cfg(feature = "simd")]
@@ -106,9 +107,11 @@ where
     /// Writes a SIMD result back to a slice
     fn write(simd_result: Self::Simd, slice: &mut [Self::Native]);
 
+    /// Performs a SIMD unary operation
     fn unary_op<F: Fn(Self::Simd) -> Self::Simd>(a: Self::Simd, op: F) -> Self::Simd;
 }
 
+/// A subtype of primitive type that represents numeric values.
 #[cfg(not(feature = "simd"))]
 pub trait ArrowNumericType: ArrowPrimitiveType {}
 
@@ -468,7 +471,7 @@ impl ArrowNumericType for Decimal256Type {}
 
 #[cfg(feature = "simd")]
 impl ArrowNumericType for Decimal256Type {
-    type Simd = i256;
+    type Simd = arrow_buffer::i256;
     type SimdMask = bool;
 
     fn lanes() -> usize {
@@ -555,11 +558,14 @@ impl ArrowNumericType for Decimal256Type {
     }
 }
 
+/// A subtype of primitive type that represents numeric float values
 #[cfg(feature = "simd")]
 pub trait ArrowFloatNumericType: ArrowNumericType {
+    /// SIMD version of pow
     fn pow(base: Self::Simd, raise: Self::Simd) -> Self::Simd;
 }
 
+/// A subtype of primitive type that represents numeric float values
 #[cfg(not(feature = "simd"))]
 pub trait ArrowFloatNumericType: ArrowNumericType {}
 

--- a/arrow-ord/Cargo.toml
+++ b/arrow-ord/Cargo.toml
@@ -16,9 +16,9 @@
 # under the License.
 
 [package]
-name = "arrow-array"
+name = "arrow-ord"
 version = "28.0.0"
-description = "Array abstractions for Apache Arrow"
+description = "Ordering kernels for arrow arrays"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -33,32 +33,21 @@ edition = "2021"
 rust-version = "1.62"
 
 [lib]
-name = "arrow_array"
+name = "arrow_ord"
 path = "src/lib.rs"
 bench = false
 
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-
 [dependencies]
+arrow-array = { version = "28.0.0", path = "../arrow-array" }
 arrow-buffer = { version = "28.0.0", path = "../arrow-buffer" }
-arrow-schema = { version = "28.0.0", path = "../arrow-schema" }
 arrow-data = { version = "28.0.0", path = "../arrow-data" }
-chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
-chrono-tz = { version = "0.8", optional = true }
+arrow-schema = { version = "28.0.0", path = "../arrow-schema" }
+arrow-select = { version = "28.0.0", path = "../arrow-select" }
 num = { version = "0.4", default-features = false, features = ["std"] }
-half = { version = "2.1", default-features = false, features = ["num-traits"] }
-hashbrown = { version = "0.13", default-features = false }
-packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
-
-[features]
-simd = ["packed_simd"]
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 
-[build-dependencies]
+[features]
+dyn_cmp_dict = []
+simd = ["arrow-array/simd"]

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -15,27 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Statically typed implementations of Arrow Arrays
-//!
-//! **See [arrow_array] for examples and usage instructions**
+//! Arrow ordering kernels
 
-#[cfg(feature = "ffi")]
-mod ffi;
-
-// --------------------- Array & ArrayData ---------------------
-pub use arrow_array::array::*;
-pub use arrow_array::builder::*;
-pub use arrow_array::cast::*;
-pub use arrow_array::iterator::*;
-pub use arrow_data::{
-    layout, ArrayData, ArrayDataBuilder, ArrayDataRef, BufferSpec, DataTypeLayout,
-};
-
-pub use arrow_data::transform::{Capacities, MutableArrayData};
-
-#[cfg(feature = "ffi")]
-pub use self::ffi::{export_array_into_raw, make_array_from_raw};
-
-// --------------------- Array's values comparison ---------------------
-
-pub use arrow_ord::ord::{build_compare, DynComparator};
+pub mod comparison;
+pub mod ord;
+pub mod partition;
+pub mod sort;

--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -90,7 +90,7 @@ fn exponential_search_next_partition_point(
     let target = start;
     let mut bound = 1;
     while bound + start < end
-        && comparator.compare(&(bound + start), &target) != Ordering::Greater
+        && comparator.compare(bound + start, target) != Ordering::Greater
     {
         bound *= 2;
     }
@@ -101,7 +101,7 @@ fn exponential_search_next_partition_point(
     // note here we have right = min(end, start + bound + 1) because (start + bound) might
     // actually be considered and must be included.
     partition_point(start + bound / 2, end.min(start + bound + 1), |idx| {
-        comparator.compare(&idx, &target) != Ordering::Greater
+        comparator.compare(idx, target) != Ordering::Greater
     })
 }
 

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -52,10 +52,10 @@ arrow-csv = { version = "28.0.0", path = "../arrow-csv", optional = true }
 arrow-data = { version = "28.0.0", path = "../arrow-data" }
 arrow-ipc = { version = "28.0.0", path = "../arrow-ipc", optional = true }
 arrow-json = { version = "28.0.0", path = "../arrow-json", optional = true }
+arrow-ord = { version = "28.0.0", path = "../arrow-ord" }
 arrow-schema = { version = "28.0.0", path = "../arrow-schema" }
 arrow-select = { version = "28.0.0", path = "../arrow-select" }
 arrow-string = { version = "28.0.0", path = "../arrow-string" }
-arrow-ord = { version = "28.0.0", path = "../arrow-ord" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -55,12 +55,12 @@ arrow-json = { version = "28.0.0", path = "../arrow-json", optional = true }
 arrow-schema = { version = "28.0.0", path = "../arrow-schema" }
 arrow-select = { version = "28.0.0", path = "../arrow-select" }
 arrow-string = { version = "28.0.0", path = "../arrow-string" }
+arrow-ord = { version = "28.0.0", path = "../arrow-ord" }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.13", default-features = false }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
-packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 comfy-table = { version = "6.0", optional = true, default-features = false }
 pyo3 = { version = "0.17", default-features = false, optional = true }
@@ -76,7 +76,7 @@ ipc_compression = ["ipc", "arrow-ipc/lz4", "arrow-ipc/zstd"]
 csv = ["arrow-csv"]
 ipc = ["arrow-ipc"]
 json = ["arrow-json"]
-simd = ["packed_simd"]
+simd = ["arrow-array/simd", "arrow-ord/simd"]
 prettyprint = ["comfy-table"]
 # The test utils feature enables code used in benchmarks and tests but
 # not the core arrow code itself. Be aware that `rand` must be kept as
@@ -92,7 +92,7 @@ force_validate = ["arrow-data/force_validate"]
 ffi = ["bitflags"]
 # Enable dyn-comparison of dictionary arrays with other arrays
 # Note: this does not impact comparison against scalars
-dyn_cmp_dict = ["arrow-string/dyn_cmp_dict"]
+dyn_cmp_dict = ["arrow-string/dyn_cmp_dict", "arrow-ord/dyn_cmp_dict"]
 # Enable dyn-arithmetic kernels for dictionary arrays
 # Note: this does not impact arithmetic with scalars
 dyn_arith_dict = []

--- a/arrow/src/compute/kernels/mod.rs
+++ b/arrow/src/compute/kernels/mod.rs
@@ -22,13 +22,18 @@ pub mod arithmetic;
 pub mod arity;
 pub mod bitwise;
 pub mod boolean;
-pub mod comparison;
 pub mod limit;
-pub mod partition;
-pub mod sort;
 pub mod temporal;
 
 pub use arrow_cast::cast;
 pub use arrow_cast::parse as cast_utils;
+pub use arrow_ord::{partition, sort};
 pub use arrow_select::{concat, filter, interleave, take, window, zip};
 pub use arrow_string::{concat_elements, length, regexp, substring};
+
+/// Comparison kernels for `Array`s.
+pub mod comparison {
+    pub use arrow_ord::comparison::*;
+    pub use arrow_string::like::*;
+    pub use arrow_string::regexp::{regexp_is_match_utf8, regexp_is_match_utf8_scalar};
+}

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -22,11 +22,10 @@
 //!  * [`Field`](crate::datatypes::Field) to describe one field within a schema.
 //!  * [`DataType`](crate::datatypes::DataType) to describe the type of a field.
 
-mod numeric;
-pub use numeric::*;
-
 pub use arrow_array::types::*;
-pub use arrow_array::{ArrowNativeTypeOp, ArrowPrimitiveType};
+pub use arrow_array::{
+    ArrowFloatNumericType, ArrowNativeTypeOp, ArrowNumericType, ArrowPrimitiveType,
+};
 pub use arrow_buffer::{i256, ArrowNativeType, ToByteSlice};
 pub use arrow_data::decimal::*;
 pub use arrow_schema::{

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -36,7 +36,9 @@
 //! * [`arrow-cast`][arrow_cast] - cast kernels for arrow arrays
 //! * [`arrow-csv`][arrow_csv] - read/write CSV to arrow format
 //! * [`arrow-data`][arrow_data] - the underlying data of arrow arrays
+//! * [`arrow-ipc`][arrow_ipc] - read/write IPC to arrow format
 //! * [`arrow-json`][arrow_json] - read/write JSON to arrow format
+//! * [`arrow-ord`][arrow_ord] - ordering kernels for arrow arrays
 //! * [`arrow-schema`][arrow_schema] - the logical types for arrow arrays
 //! * [`arrow-select`][arrow_select] - selection kernels for arrow arrays
 //! * [`arrow-string`][arrow_string] - string kernels for arrow arrays

--- a/arrow/src/row/mod.rs
+++ b/arrow/src/row/mod.rs
@@ -1264,13 +1264,13 @@ mod tests {
 
     use arrow_array::NullArray;
     use arrow_buffer::Buffer;
+    use arrow_ord::sort::{LexicographicalComparator, SortColumn, SortOptions};
 
     use crate::array::{
         BinaryArray, BooleanArray, DictionaryArray, Float32Array, GenericStringArray,
         Int16Array, Int32Array, OffsetSizeTrait, PrimitiveArray,
         PrimitiveDictionaryBuilder, StringArray,
     };
-    use crate::compute::{LexicographicalComparator, SortColumn};
     use crate::util::display::array_value_to_string;
 
     use super::*;
@@ -2154,7 +2154,7 @@ mod tests {
                     let row_i = rows.row(i);
                     let row_j = rows.row(j);
                     let row_cmp = row_i.cmp(&row_j);
-                    let lex_cmp = comparator.compare(&i, &j);
+                    let lex_cmp = comparator.compare(i, j);
                     assert_eq!(
                         row_cmp,
                         lex_cmp,

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -259,6 +259,7 @@ Rust Arrow Crates:
 (cd arrow-select && cargo publish)
 (cd arrow-cast && cargo publish)
 (cd arrow-string && cargo publish)
+(cd arrow-ord && cargo publish)
 (cd arrow-ipc && cargo publish)
 (cd arrow-csv && cargo publish)
 (cd arrow-json && cargo publish)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #2594

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Makes LexicographicalComparator public and tweaks its interface slightly
* Moves ArrowNumericType to arrow-array
* Moves ordering kernels to arrow-ord
* Moves some tests left over from #3295 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
