### PR TITLE
Add ASCII fast path for ILIKE scalar (90% faster)

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -70,6 +70,14 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         self.data.buffers()[1].as_slice()
     }
 
+    /// Returns true if all data within this array is ASCII
+    pub fn is_ascii(&self) -> bool {
+        let offsets = self.value_offsets();
+        let start = offsets.first().unwrap();
+        let end = offsets.last().unwrap();
+        self.value_data()[start.as_usize()..end.as_usize()].is_ascii()
+    }
+
     /// Returns the offset values in the offsets buffer
     #[inline]
     pub fn value_offsets(&self) -> &[T::Offset] {

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -1361,69 +1361,74 @@ mod tests {
     test_utf8_scalar!(
         test_utf8_array_ilike_unicode,
         test_utf8_array_ilike_unicode_dyn,
-        vec!["FFooß", "FFooSS", "FFooss", "FFooS", "FFoos", "ﬀooSS", "ﬀooß"],
-        "FFooSS",
+        vec![
+            "FFkoß", "FFkoSS", "FFkoss", "FFkoS", "FFkos", "ﬀkoSS", "ﬀkoß", "FFKoSS"
+        ],
+        "FFkoSS",
         ilike_utf8_scalar,
         ilike_utf8_scalar_dyn,
-        vec![false, true, true, false, false, false, false]
+        vec![false, true, true, false, false, false, false, true]
     );
 
     test_utf8_scalar!(
         test_utf8_array_ilike_unicode_starts,
         test_utf8_array_ilike_unicode_start_dyn,
         vec![
-            "FFooßsdlkdf",
-            "FFooSSsdlkdf",
-            "FFoosssdlkdf",
-            "FFooS",
-            "FFoos",
-            "ﬀooSS",
-            "ﬀooß",
-            "FfoosSsdfd",
+            "FFkoßsdlkdf",
+            "FFkoSSsdlkdf",
+            "FFkosssdlkdf",
+            "FFkoS",
+            "FFkos",
+            "ﬀkoSS",
+            "ﬀkoß",
+            "FfkosSsdfd",
+            "FFKoSS",
         ],
-        "FFooSS%",
+        "FFkoSS%",
         ilike_utf8_scalar,
         ilike_utf8_scalar_dyn,
-        vec![false, true, true, false, false, false, false, true]
+        vec![false, true, true, false, false, false, false, true, true]
     );
 
     test_utf8_scalar!(
         test_utf8_array_ilike_unicode_ends,
         test_utf8_array_ilike_unicode_ends_dyn,
         vec![
-            "sdlkdfFFooß",
-            "sdlkdfFFooSS",
-            "sdlkdfFFooss",
-            "FFooS",
-            "FFoos",
-            "ﬀooSS",
-            "ﬀooß",
-            "h😃klFfoosS",
+            "sdlkdfFFkoß",
+            "sdlkdfFFkoSS",
+            "sdlkdfFFkoss",
+            "FFkoS",
+            "FFkos",
+            "ﬀkoSS",
+            "ﬀkoß",
+            "h😃klFfkosS",
+            "FFKoSS",
         ],
-        "%FFooSS",
+        "%FFkoSS",
         ilike_utf8_scalar,
         ilike_utf8_scalar_dyn,
-        vec![false, true, true, false, false, false, false, true]
+        vec![false, true, true, false, false, false, false, true, true]
     );
 
     test_utf8_scalar!(
         test_utf8_array_ilike_unicode_contains,
         test_utf8_array_ilike_unicode_contains_dyn,
         vec![
-            "sdlkdfFooßsdfs",
-            "sdlkdfFooSSdggs",
-            "sdlkdfFoosssdsd",
-            "FooS",
-            "Foos",
-            "ﬀooSS",
-            "ﬀooß",
-            "😃sadlksffoosSsh😃klF",
-            "😱slgffoosSsh😃klF",
+            "sdlkdfFkoßsdfs",
+            "sdlkdfFkoSSdggs",
+            "sdlkdfFkosssdsd",
+            "FkoS",
+            "Fkos",
+            "ﬀkoSS",
+            "ﬀkoß",
+            "😃sadlksffkosSsh😃klF",
+            "😱slgffkosSsh😃klF",
+            "FFKoSS",
         ],
-        "%FFooSS%",
+        "%FFkoSS%",
         ilike_utf8_scalar,
         ilike_utf8_scalar_dyn,
-        vec![false, true, true, false, false, false, false, true, true]
+        vec![false, true, true, false, false, false, false, true, true, true]
     );
 
     test_utf8_scalar!(
@@ -1439,11 +1444,12 @@ mod tests {
             "ﬀooß",
             "😃sadlksffofsSsh😃klF",
             "😱slgffoesSsh😃klF",
+            "FFKoSS",
         ],
         "%FF__SS%",
         ilike_utf8_scalar,
         ilike_utf8_scalar_dyn,
-        vec![false, true, true, false, false, false, false, true, true]
+        vec![false, true, true, false, false, false, false, true, true, true]
     );
 
     test_utf8_scalar!(

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -543,13 +543,13 @@ fn ilike_dict<K: ArrowPrimitiveType>(
 }
 
 #[inline]
-fn ilike_scalar_op<'a, F: Fn(bool) -> bool, L: ArrayAccessor<Item = &'a str>>(
-    left: L,
+fn ilike_scalar_op<O: OffsetSizeTrait, F: Fn(bool) -> bool>(
+    left: &GenericStringArray<O>,
     right: &str,
     op: F,
 ) -> Result<BooleanArray, ArrowError> {
-    // If not ASCII faster to use case insensitive regex than allocating using to_uppercase
-    if right.is_ascii() {
+    // If not ASCII faster to use case insensitive regex than using to_uppercase
+    if right.is_ascii() && left.is_ascii() {
         if !right.contains(is_like_pattern) {
             return Ok(BooleanArray::from_unary(left, |item| {
                 op(item.eq_ignore_ascii_case(right))
@@ -590,8 +590,8 @@ fn ilike_scalar_op<'a, F: Fn(bool) -> bool, L: ArrayAccessor<Item = &'a str>>(
 }
 
 #[inline]
-fn ilike_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
-    left: L,
+fn ilike_scalar<O: OffsetSizeTrait>(
+    left: &GenericStringArray<O>,
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     ilike_scalar_op(left, right, |x| x)
@@ -748,8 +748,8 @@ fn nilike_dict<K: ArrowPrimitiveType>(
 }
 
 #[inline]
-fn nilike_scalar<'a, L: ArrayAccessor<Item = &'a str>>(
-    left: L,
+fn nilike_scalar<O: OffsetSizeTrait>(
+    left: &GenericStringArray<O>,
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     ilike_scalar_op(left, right, |x| !x)

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -614,7 +614,7 @@ fn ilike_scalar_op<'a, F: Fn(bool) -> bool, L: ArrayAccessor<Item = &'a str>>(
                 let result = item.is_char_boundary(start)
                     && ends_str.eq_ignore_ascii_case(&item[start..]);
                 op(result)
-            }))
+            }));
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3311 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

```
ilike_utf8 scalar equals
                        time:   [218.99 µs 219.05 µs 219.10 µs]
                        change: [-90.262% -90.257% -90.253%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking ilike_utf8 scalar contains: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 50.
ilike_utf8 scalar contains
                        time:   [1.8097 ms 1.8104 ms 1.8111 ms]
                        change: [-56.369% -56.326% -56.264%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

ilike_utf8 scalar ends with
                        time:   [261.52 µs 261.58 µs 261.65 µs]
                        change: [-88.863% -88.850% -88.831%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

ilike_utf8 scalar starts with
                        time:   [265.40 µs 265.45 µs 265.50 µs]
                        change: [-88.692% -88.679% -88.656%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking ilike_utf8 scalar complex: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.2s, enable flat sampling, or reduce sample count to 50.
ilike_utf8 scalar complex
                        time:   [1.8319 ms 1.8327 ms 1.8334 ms]
                        change: [-4.2733% -4.1030% -3.9344%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

nilike_utf8 scalar equals
                        time:   [232.53 µs 232.59 µs 232.65 µs]
                        change: [-90.314% -90.298% -90.265%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking nilike_utf8 scalar contains: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 50.
nilike_utf8 scalar contains
                        time:   [1.7942 ms 1.7962 ms 1.7993 ms]
                        change: [-57.816% -57.765% -57.701%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

nilike_utf8 scalar ends with
                        time:   [243.52 µs 243.58 µs 243.66 µs]
                        change: [-89.761% -89.758% -89.754%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe

nilike_utf8 scalar starts with
                        time:   [253.10 µs 253.18 µs 253.28 µs]
                        change: [-89.367% -89.347% -89.313%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

Benchmarking nilike_utf8 scalar complex: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.2s, enable flat sampling, or reduce sample count to 50.
nilike_utf8 scalar complex
                        time:   [1.8143 ms 1.8152 ms 1.8162 ms]
                        change: [-5.6406% -5.5148% -5.3303%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
