### PR TITLE
Use take for dictionary like comparisons

### DIFF
--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -42,6 +42,7 @@ arrow-buffer = { version = "28.0.0", path = "../arrow-buffer" }
 arrow-data = { version = "28.0.0", path = "../arrow-data" }
 arrow-schema = { version = "28.0.0", path = "../arrow-schema" }
 arrow-array = { version = "28.0.0", path = "../arrow-array" }
+arrow-select = { version = "28.0.0", path = "../arrow-select" }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 regex-syntax = { version = "0.6.27", default-features = false, features = ["unicode"] }
 

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -21,6 +21,7 @@ use arrow_array::*;
 use arrow_data::bit_mask::combine_option_bitmap;
 use arrow_data::ArrayData;
 use arrow_schema::*;
+use arrow_select::take::take;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -214,7 +215,10 @@ pub fn like_utf8_scalar_dyn(
         DataType::Dictionary(_, _) => {
             downcast_dictionary_array!(
                 left => {
-                    like_dict_scalar(left, right)
+                    let dict_comparison = like_utf8_scalar_dyn(left.values().as_ref(), right)?;
+                    // TODO: Use take_boolean (#2967)
+                    let array = take(&dict_comparison, left.keys(), None)?;
+                    Ok(BooleanArray::from(array.data().clone()))
                 }
                 t => Err(ArrowError::ComputeError(format!(
                     "Should be DictionaryArray but got: {}", t
@@ -238,31 +242,6 @@ pub fn like_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     like_scalar(left, right)
-}
-
-/// Perform SQL `left LIKE right` operation on [`DictionaryArray`] with values
-/// [`StringArray`]/[`LargeStringArray`] and a scalar.
-///
-/// See the documentation on [`like_utf8`] for more details.
-fn like_dict_scalar<K: ArrowPrimitiveType>(
-    left: &DictionaryArray<K>,
-    right: &str,
-) -> Result<BooleanArray, ArrowError> {
-    match left.value_type() {
-        DataType::Utf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i32>>().unwrap();
-            like_scalar(left, right)
-        }
-        DataType::LargeUtf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i64>>().unwrap();
-            like_scalar(left, right)
-        }
-        _ => {
-            Err(ArrowError::ComputeError(
-                "like_dict_scalar only supports DictionaryArray with Utf8 or LargeUtf8 values".to_string(),
-            ))
-        }
-    }
 }
 
 /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
@@ -431,7 +410,10 @@ pub fn nlike_utf8_scalar_dyn(
         DataType::Dictionary(_, _) => {
             downcast_dictionary_array!(
                 left => {
-                    nlike_dict_scalar(left, right)
+                    let dict_comparison = nlike_utf8_scalar_dyn(left.values().as_ref(), right)?;
+                    // TODO: Use take_boolean (#2967)
+                    let array = take(&dict_comparison, left.keys(), None)?;
+                    Ok(BooleanArray::from(array.data().clone()))
                 }
                 t => Err(ArrowError::ComputeError(format!(
                     "Should be DictionaryArray but got: {}", t
@@ -455,31 +437,6 @@ pub fn nlike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     nlike_scalar(left, right)
-}
-
-/// Perform SQL `left NOT LIKE right` operation on [`DictionaryArray`] with values
-/// [`StringArray`]/[`LargeStringArray`] and a scalar.
-///
-/// See the documentation on [`like_utf8`] for more details.
-fn nlike_dict_scalar<K: ArrowPrimitiveType>(
-    left: &DictionaryArray<K>,
-    right: &str,
-) -> Result<BooleanArray, ArrowError> {
-    match left.value_type() {
-        DataType::Utf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i32>>().unwrap();
-            nlike_scalar(left, right)
-        }
-        DataType::LargeUtf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i64>>().unwrap();
-            nlike_scalar(left, right)
-        }
-        _ => {
-            Err(ArrowError::ComputeError(
-                "nlike_dict_scalar only supports DictionaryArray with Utf8 or LargeUtf8 values".to_string(),
-            ))
-        }
-    }
 }
 
 /// Perform SQL `left ILIKE right` operation on [`StringArray`] /
@@ -663,7 +620,10 @@ pub fn ilike_utf8_scalar_dyn(
         DataType::Dictionary(_, _) => {
             downcast_dictionary_array!(
                 left => {
-                    ilike_dict_scalar(left, right)
+                    let dict_comparison = ilike_utf8_scalar_dyn(left.values().as_ref(), right)?;
+                    // TODO: Use take_boolean (#2967)
+                    let array = take(&dict_comparison, left.keys(), None)?;
+                    Ok(BooleanArray::from(array.data().clone()))
                 }
                 t => Err(ArrowError::ComputeError(format!(
                     "Should be DictionaryArray but got: {}", t
@@ -687,31 +647,6 @@ pub fn ilike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     ilike_scalar(left, right)
-}
-
-/// Perform SQL `left ILIKE right` operation on [`DictionaryArray`] with values
-/// [`StringArray`]/[`LargeStringArray`] and a scalar.
-///
-/// See the documentation on [`like_utf8`] for more details.
-fn ilike_dict_scalar<K: ArrowPrimitiveType>(
-    left: &DictionaryArray<K>,
-    right: &str,
-) -> Result<BooleanArray, ArrowError> {
-    match left.value_type() {
-        DataType::Utf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i32>>().unwrap();
-            ilike_scalar(left, right)
-        }
-        DataType::LargeUtf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i64>>().unwrap();
-            ilike_scalar(left, right)
-        }
-        _ => {
-            Err(ArrowError::ComputeError(
-                "ilike_dict_scalar only supports DictionaryArray with Utf8 or LargeUtf8 values".to_string(),
-            ))
-        }
-    }
 }
 
 /// Perform SQL `left NOT ILIKE right` operation on [`StringArray`] /
@@ -843,7 +778,10 @@ pub fn nilike_utf8_scalar_dyn(
         DataType::Dictionary(_, _) => {
             downcast_dictionary_array!(
                 left => {
-                    nilike_dict_scalar(left, right)
+                    let dict_comparison = nilike_utf8_scalar_dyn(left.values().as_ref(), right)?;
+                    // TODO: Use take_boolean (#2967)
+                    let array = take(&dict_comparison, left.keys(), None)?;
+                    Ok(BooleanArray::from(array.data().clone()))
                 }
                 t => Err(ArrowError::ComputeError(format!(
                     "Should be DictionaryArray but got: {}", t
@@ -867,31 +805,6 @@ pub fn nilike_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     right: &str,
 ) -> Result<BooleanArray, ArrowError> {
     nilike_scalar(left, right)
-}
-
-/// Perform SQL `left NOT ILIKE right` operation on [`DictionaryArray`] with values
-/// [`StringArray`]/[`LargeStringArray`] and a scalar.
-///
-/// See the documentation on [`like_utf8`] for more details.
-fn nilike_dict_scalar<K: ArrowPrimitiveType>(
-    left: &DictionaryArray<K>,
-    right: &str,
-) -> Result<BooleanArray, ArrowError> {
-    match left.value_type() {
-        DataType::Utf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i32>>().unwrap();
-            nilike_scalar(left, right)
-        }
-        DataType::LargeUtf8 => {
-            let left = left.downcast_dict::<GenericStringArray<i64>>().unwrap();
-            nilike_scalar(left, right)
-        }
-        _ => {
-            Err(ArrowError::ComputeError(
-                "nilike_dict_scalar only supports DictionaryArray with Utf8 or LargeUtf8 values".to_string(),
-            ))
-        }
-    }
 }
 
 fn is_like_pattern(c: char) -> bool {

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -326,9 +326,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| eq_dyn_utf8_scalar(&dict_arr_a, "test"))
     });
 
-    c.bench_function("gt_eq_dyn_utf8_scalar scalar dictionary[10] string[4])", |b| {
-        b.iter(|| gt_eq_dyn_utf8_scalar(&dict_arr_a, "test"))
-    });
+    c.bench_function(
+        "gt_eq_dyn_utf8_scalar scalar dictionary[10] string[4])",
+        |b| b.iter(|| gt_eq_dyn_utf8_scalar(&dict_arr_a, "test")),
+    );
 
     c.bench_function("like_utf8_scalar_dyn dictionary[10] string[4])", |b| {
         b.iter(|| like_utf8_scalar_dyn(&dict_arr_a, "test"))

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -314,11 +314,28 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_regexp_is_match_utf8_scalar(&arr_string, "xx$"))
     });
 
-    let dict_arr_a = create_string_dict_array::<Int32Type>(size, 0.0, 4);
-    let dict_arr_b = create_string_dict_array::<Int32Type>(size, 0.0, 4);
+    let strings = create_string_array::<i32>(20, 0.);
+    let dict_arr_a = create_dict_from_values::<Int32Type>(size, 0., &strings);
+    let dict_arr_b = create_dict_from_values::<Int32Type>(size, 0., &strings);
 
-    c.bench_function("dict eq string", |b| {
+    c.bench_function("eq dictionary[10] string[4])", |b| {
         b.iter(|| bench_dict_eq(&dict_arr_a, &dict_arr_b))
+    });
+
+    c.bench_function("eq_dyn_utf8_scalar dictionary[10] string[4])", |b| {
+        b.iter(|| eq_dyn_utf8_scalar(&dict_arr_a, "test"))
+    });
+
+    c.bench_function("eq_dyn_utf8_scalar scalar dictionary[10] string[4])", |b| {
+        b.iter(|| gt_eq_dyn_utf8_scalar(&dict_arr_a, "test"))
+    });
+
+    c.bench_function("like_utf8_scalar_dyn dictionary[10] string[4])", |b| {
+        b.iter(|| like_utf8_scalar_dyn(&dict_arr_a, "test"))
+    });
+
+    c.bench_function("ilike_utf8_scalar_dyn dictionary[10] string[4])", |b| {
+        b.iter(|| ilike_utf8_scalar_dyn(&dict_arr_a, "test"))
     });
 }
 

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -326,7 +326,7 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| eq_dyn_utf8_scalar(&dict_arr_a, "test"))
     });
 
-    c.bench_function("eq_dyn_utf8_scalar scalar dictionary[10] string[4])", |b| {
+    c.bench_function("gt_eq_dyn_utf8_scalar scalar dictionary[10] string[4])", |b| {
         b.iter(|| gt_eq_dyn_utf8_scalar(&dict_arr_a, "test"))
     });
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Other comparison kernels perform an operation on the underlying child array, before taking the result based on the dictionary indexes. Especially for more expensive operations like those involving strings, this can yield significant returns. As an added bonus it results in less codegen

```
eq dictionary[10] string[4])
                        time:   [358.35 µs 358.43 µs 358.53 µs]
                        change: [-0.9058% -0.7716% -0.5611%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

eq_dyn_utf8_scalar dictionary[10] string[4])
                        time:   [53.265 µs 53.284 µs 53.306 µs]
                        change: [-12.029% -11.781% -11.537%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

gt_eq_dyn_utf8_scalar scalar dictionary[10] string[4])
                        time:   [113.34 µs 113.36 µs 113.39 µs]
                        change: [-5.2402% -4.9959% -4.7432%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe

like_utf8_scalar_dyn dictionary[10] string[4])
                        time:   [53.307 µs 53.326 µs 53.347 µs]
                        change: [-80.849% -80.811% -80.757%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

ilike_utf8_scalar_dyn dictionary[10] string[4])
                        time:   [53.972 µs 53.990 µs 54.013 µs]
                        change: [-97.799% -97.796% -97.790%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
