### PR TITLE
Use BufWriter when writing bloom filters and limit tests (#3318)

### DIFF
--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -630,7 +630,7 @@ struct ColumnProperties {
     statistics_enabled: Option<EnabledStatistics>,
     max_statistics_size: Option<usize>,
     /// bloom filter related properties
-    bloom_filter_properies: Option<BloomFilterProperties>,
+    bloom_filter_properties: Option<BloomFilterProperties>,
 }
 
 impl ColumnProperties {
@@ -674,10 +674,10 @@ impl ColumnProperties {
     /// otherwise it is a no-op.
     /// If `value` is `false`, resets bloom filter properties to `None`.
     fn set_bloom_filter_enabled(&mut self, value: bool) {
-        if value && self.bloom_filter_properies.is_none() {
-            self.bloom_filter_properies = Some(Default::default())
+        if value && self.bloom_filter_properties.is_none() {
+            self.bloom_filter_properties = Some(Default::default())
         } else if !value {
-            self.bloom_filter_properies = None
+            self.bloom_filter_properties = None
         }
     }
 
@@ -694,7 +694,7 @@ impl ColumnProperties {
             value
         );
 
-        self.bloom_filter_properies
+        self.bloom_filter_properties
             .get_or_insert_with(Default::default)
             .fpp = value;
     }
@@ -702,7 +702,7 @@ impl ColumnProperties {
     /// Sets the number of distinct (unique) values for bloom filter for this column, and implicitly
     /// enables bloom filter if not previously enabled.
     fn set_bloom_filter_ndv(&mut self, value: u64) {
-        self.bloom_filter_properies
+        self.bloom_filter_properties
             .get_or_insert_with(Default::default)
             .ndv = value;
     }
@@ -737,7 +737,7 @@ impl ColumnProperties {
 
     /// Returns the bloom filter properties, or `None` if not enabled
     fn bloom_filter_properties(&self) -> Option<&BloomFilterProperties> {
-        self.bloom_filter_properies.as_ref()
+        self.bloom_filter_properties.as_ref()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3318

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The tests were taking an exceedingly long time to run, this disables them except for a few select tests that explicitly test the bloom filter.

This also adds a BufWriter when writing bloom filters, it is almost certain that this can be optimised further, but this was a quick win that took `i32_column_bloom_filter` from taking 17 seconds to 2. This is still terrible, but not catastrophic :sweat_smile: 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
