### PR TITLE
feat(object_store): parse well-known storage urls

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -439,7 +439,7 @@ impl AmazonS3Builder {
     /// - s3a://<bucket>/<path>
     /// - https://s3.<bucket>.amazonaws.com
     ///
-    /// Please not that this is a best effort implementation, and will not fail for malformed URLs,
+    /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the
     /// storage is accessed - e.g. which driver or protocol is used for reading from the location.
     ///

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -485,6 +485,7 @@ impl AmazonS3Builder {
                         {
                             self.bucket_name = Some(parts[0].to_string());
                             self.region = Some(parts[2].to_string());
+                            self.virtual_hosted_style_request = true;
                         }
                     }
                 }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -435,9 +435,9 @@ impl AmazonS3Builder {
     ///
     /// The supported url schemes are:
     ///
-    /// - s3://<bucket>/<path>
-    /// - s3a://<bucket>/<path>
-    /// - https://s3.<bucket>.amazonaws.com
+    /// - `s3://<bucket>/<path>`
+    /// - `s3a://<bucket>/<path>`
+    /// - `https://s3.<bucket>.amazonaws.com`
     ///
     /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -41,7 +41,7 @@ use std::collections::BTreeSet;
 use std::ops::Range;
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 use crate::aws::client::{S3Client, S3Config};
@@ -440,12 +440,12 @@ impl AmazonS3Builder {
     /// - https://s3.<bucket>.amazonaws.com
     ///
     /// Please not that this is a best effort implementation, and will not fail for malformed URLs,
-    /// but rather silently ignore the passed url. The url also has no effect on how the
+    /// but rather warn and ignore the passed url. The url also has no effect on how the
     /// storage is accessed - e.g. which driver or protocol is used for reading from the location.
     ///
     /// # Example
     /// ```
-    /// use object_store::azure::MicrosoftAzureBuilder;
+    /// use object_store::aws::AmazonS3Builder;
     ///
     /// let s3 = AmazonS3Builder::from_env()
     ///     .with_url("s3://bucket/path")
@@ -468,8 +468,14 @@ impl AmazonS3Builder {
                         }
                     }
                 }
-                _ => (),
+                other => {
+                    warn!(
+                        "Ignoring passed S3 url due to unrecognized url scheme: {other}"
+                    );
+                }
             }
+        } else {
+            warn!("Ignoring passed S3 url due to parsing error.");
         };
         self
     }

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -380,7 +380,7 @@ impl MicrosoftAzureBuilder {
         Default::default()
     }
 
-    /// Create an instance of [MicrosoftAzureBuilder] with values pre-populated from environment variables.
+    /// Create an instance of [`MicrosoftAzureBuilder`] with values pre-populated from environment variables.
     ///
     /// Variables extracted from environment:
     /// * AZURE_STORAGE_ACCOUNT_NAME: storage account name

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -437,7 +437,7 @@ impl MicrosoftAzureBuilder {
     /// - https://account.dfs.core.windows.net
     /// - https://account.blob.core.windows.net
     ///
-    /// Please not that this is a best effort implementation, and will not fail for malformed URLs,
+    /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the
     /// storage is accessed - e.g. which driver or protocol is used for reading from the location.
     ///

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -429,13 +429,13 @@ impl MicrosoftAzureBuilder {
     ///
     /// The supported url schemes are:
     ///
-    /// - abfs[s]://<container>/<path> (according to [fsspec](https://github.com/fsspec/adlfs))
-    /// - abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>
-    /// - az://<container>/<path> (according to [fsspec](https://github.com/fsspec/adlfs))
-    /// - adl://<container>/<path> (according to [fsspec](https://github.com/fsspec/adlfs))
-    /// - azure://<container>/<path> (custom)
-    /// - https://account.dfs.core.windows.net
-    /// - https://account.blob.core.windows.net
+    /// - `abfs[s]://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+    /// - `abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>`
+    /// - `az://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+    /// - `adl://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+    /// - `azure://<container>/<path>` (custom)
+    /// - `https://<account>.dfs.core.windows.net`
+    /// - `https://<account>.blob.core.windows.net`
     ///
     /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -821,7 +821,7 @@ impl GoogleCloudStorageBuilder {
     ///
     /// - gs://<bucket>/<path>
     ///
-    /// Please not that this is a best effort implementation, and will not fail for malformed URLs,
+    /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the
     /// storage is accessed - e.g. which driver or protocol is used for reading from the location.
     ///

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -787,6 +787,34 @@ impl GoogleCloudStorageBuilder {
         Default::default()
     }
 
+    /// Create an instance of [`GoogleCloudStorageBuilder`] with values pre-populated from environment variables.
+    ///
+    /// Variables extracted from environment:
+    /// * GOOGLE_SERVICE_ACCOUNT: location of service account file
+    /// * SERVICE_ACCOUNT: (alias) location of service account file
+    ///
+    /// # Example
+    /// ```
+    /// use object_store::gcp::GoogleCloudStorageBuilder;
+    ///
+    /// let azure = GoogleCloudStorageBuilder::from_env()
+    ///     .with_bucket_name("foo")
+    ///     .build();
+    /// ```
+    pub fn from_env() -> Self {
+        let mut builder = Self::default();
+
+        if let Ok(service_account_path) = std::env::var("SERVICE_ACCOUNT") {
+            builder.service_account_path = Some(service_account_path);
+        }
+
+        if let Ok(service_account_path) = std::env::var("GOOGLE_SERVICE_ACCOUNT") {
+            builder.service_account_path = Some(service_account_path);
+        }
+
+        builder
+    }
+
     /// Parse available connection info form a well-known storage URL.
     ///
     /// The supported url schemes are:

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -819,7 +819,7 @@ impl GoogleCloudStorageBuilder {
     ///
     /// The supported url schemes are:
     ///
-    /// - gs://<bucket>/<path>
+    /// - `gs://<bucket>/<path>`
     ///
     /// Please note that this is a best effort implementation, and will not fail for malformed URLs,
     /// but rather warn and ignore the passed url. The url also has no effect on how the


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2304

cc @tustvold 

# Rationale for this change
 
See discussion in #2304 - in a nutshell, accessible storage locations can be described by various url formats (especially for azure storage) and we aim to provide url parsing centrally since it is a very common task to perform in consuming applications.

# What changes are included in this PR?

Added new `with_url` memebrs to aws, gcp, and azure builders to be used via:

```rust
AmazonS3Builder::from_env().with_url("s3://foo/").build().unwrap();
```

# Are there any user-facing changes?

yes.