### PR TITLE
Use ArrayData::ptr_eq in DictionaryTracker

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -537,7 +537,7 @@ impl DictionaryTracker {
 
         // If a dictionary with this id was already emitted, check if it was the same.
         if let Some(last) = self.written.get(&dict_id) {
-            if last.data().child_data()[0] == *dict_values {
+            if ArrayData::ptr_eq(&last.data().child_data()[0], dict_values) {
                 // Same dictionary values => no need to emit it again
                 return Ok(false);
             } else if self.error_on_replacement {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -540,7 +540,13 @@ impl DictionaryTracker {
             if ArrayData::ptr_eq(&last.data().child_data()[0], dict_values) {
                 // Same dictionary values => no need to emit it again
                 return Ok(false);
-            } else if self.error_on_replacement {
+            }
+            if self.error_on_replacement {
+                // If error on replacement perform a logical comparison
+                if last.data().child_data()[0] == *dict_values {
+                    // Same dictionary values => no need to emit it again
+                    return Ok(false);
+                }
                 return Err(ArrowError::InvalidArgumentError(
                     "Dictionary replacement detected when writing IPC file format. \
                      Arrow IPC files only support a single dictionary for a given field \


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Performing a logical comparison of array data is very expensive, we can do a cheaper pointer comparison if we don't care about potential false positives

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
