### PR TITLE
Use bytes in arrow-flight

### DIFF
--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Setup Clippy
         run: rustup component add clippy
       - name: Run clippy
-        run: cargo clippy -p arrow-flight --all-features -- -D warnings
+        run: cargo clippy -p arrow-flight --all-targets --all-features -- -D warnings

--- a/arrow-flight/build.rs
+++ b/arrow-flight/build.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // protoc in unbuntu builder needs this option
             .protoc_arg("--experimental_allow_proto3_optional")
             .out_dir("src")
-            .compile(&[proto_path], &[proto_dir])?;
+            .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
         // read file contents to string
         let mut file = OpenOptions::new()
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // protoc in ubuntu builder needs this option
             .protoc_arg("--experimental_allow_proto3_optional")
             .out_dir("src/sql")
-            .compile(&[proto_path], &[proto_dir])?;
+            .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
         // read file contents to string
         let mut file = OpenOptions::new()
@@ -93,4 +93,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // As the proto file is checked in, the build should not fail if the file is not found
     Ok(())
+}
+
+fn prost_config() -> prost_build::Config {
+    let mut config = prost_build::Config::new();
+    config.bytes([".arrow"]);
+    config
 }

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -23,18 +23,14 @@ use arrow_flight::{
     Location, SchemaAsIpc, Ticket,
 };
 use futures::{stream, Stream};
+use prost::Message;
 use prost_types::Any;
-use std::fs;
 use std::pin::Pin;
 use std::sync::Arc;
-use tempfile::NamedTempFile;
-use tokio::net::{UnixListener, UnixStream};
-use tokio_stream::wrappers::UnixListenerStream;
-use tonic::transport::{Endpoint, Server};
+use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 
 use arrow_flight::flight_descriptor::DescriptorType;
-use arrow_flight::sql::client::FlightSqlServiceClient;
 use arrow_flight::utils::batches_to_flight_data;
 use arrow_flight::{
     flight_service_server::FlightService,
@@ -87,7 +83,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let authorization = request
             .metadata()
             .get("authorization")
-            .ok_or(Status::invalid_argument("authorization field not present"))?
+            .ok_or_else(|| Status::invalid_argument("authorization field not present"))?
             .to_str()
             .map_err(|e| status!("authorization not parsable", e))?;
         if !authorization.starts_with(basic) {
@@ -101,7 +97,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
             .map_err(|e| status!("authorization not decodable", e))?;
         let str = String::from_utf8(bytes)
             .map_err(|e| status!("authorization not parsable", e))?;
-        let parts: Vec<_> = str.split(":").collect();
+        let parts: Vec<_> = str.split(':').collect();
         let (user, pass) = match parts.as_slice() {
             [user, pass] => (user, pass),
             _ => Err(Status::invalid_argument(
@@ -114,7 +110,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
 
         let result = HandshakeResponse {
             protocol_version: 0,
-            payload: "random_uuid_token".as_bytes().to_vec(),
+            payload: "random_uuid_token".into(),
         };
         let result = Ok(result);
         let output = futures::stream::iter(vec![result]);
@@ -156,7 +152,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         cmd: CommandPreparedStatementQuery,
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        let handle = String::from_utf8(cmd.prepared_statement_handle)
+        let handle = std::str::from_utf8(&cmd.prepared_statement_handle)
             .map_err(|e| status!("Unable to parse handle", e))?;
         let batch =
             Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
@@ -169,7 +165,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let fetch = FetchResults {
             handle: handle.to_string(),
         };
-        let buf = ::prost::Message::encode_to_vec(&fetch.as_any());
+        let buf = fetch.as_any().encode_to_vec().into();
         let ticket = Ticket { ticket: buf };
         let endpoint = FlightEndpoint {
             ticket: Some(ticket),
@@ -184,7 +180,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
 
         let flight_desc = FlightDescriptor {
             r#type: DescriptorType::Cmd.into(),
-            cmd: vec![],
+            cmd: Default::default(),
             path: vec![],
         };
         let info = FlightInfo {
@@ -430,9 +426,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
             .map_err(|e| status!("Unable to serialize schema", e))?;
         let IpcMessage(schema_bytes) = message;
         let res = ActionCreatePreparedStatementResult {
-            prepared_statement_handle: handle.as_bytes().to_vec(),
+            prepared_statement_handle: handle.into(),
             dataset_schema: schema_bytes,
-            parameter_schema: vec![], // TODO: parameters
+            parameter_schema: Default::default(), // TODO: parameters
         };
         Ok(res)
     }

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -11,8 +11,8 @@ pub struct HandshakeRequest {
     pub protocol_version: u64,
     ///
     /// Arbitrary auth/handshake info.
-    #[prost(bytes = "vec", tag = "2")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub payload: ::prost::bytes::Bytes,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -23,8 +23,8 @@ pub struct HandshakeResponse {
     pub protocol_version: u64,
     ///
     /// Arbitrary auth/handshake info.
-    #[prost(bytes = "vec", tag = "2")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub payload: ::prost::bytes::Bytes,
 }
 ///
 /// A message for doing simple auth.
@@ -56,8 +56,8 @@ pub struct ActionType {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Criteria {
-    #[prost(bytes = "vec", tag = "1")]
-    pub expression: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub expression: ::prost::bytes::Bytes,
 }
 ///
 /// An opaque action specific for the service.
@@ -66,16 +66,16 @@ pub struct Criteria {
 pub struct Action {
     #[prost(string, tag = "1")]
     pub r#type: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
-    pub body: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub body: ::prost::bytes::Bytes,
 }
 ///
 /// An opaque result returned after executing an action.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes = "vec", tag = "1")]
-    pub body: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub body: ::prost::bytes::Bytes,
 }
 ///
 /// Wrap the result of a getSchema call
@@ -86,8 +86,8 @@ pub struct SchemaResult {
     ///    4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
     ///    4 bytes - the byte length of the payload
     ///    a flatbuffer Message whose header is the Schema
-    #[prost(bytes = "vec", tag = "1")]
-    pub schema: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub schema: ::prost::bytes::Bytes,
 }
 ///
 /// The name or tag for a Flight. May be used as a way to retrieve or generate
@@ -100,8 +100,8 @@ pub struct FlightDescriptor {
     ///
     /// Opaque value used to express a command. Should only be defined when
     /// type = CMD.
-    #[prost(bytes = "vec", tag = "2")]
-    pub cmd: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub cmd: ::prost::bytes::Bytes,
     ///
     /// List of strings identifying a particular dataset. Should only be defined
     /// when type = PATH.
@@ -160,8 +160,8 @@ pub struct FlightInfo {
     ///    4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
     ///    4 bytes - the byte length of the payload
     ///    a flatbuffer Message whose header is the Schema
-    #[prost(bytes = "vec", tag = "1")]
-    pub schema: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub schema: ::prost::bytes::Bytes,
     ///
     /// The descriptor associated with this info.
     #[prost(message, optional, tag = "2")]
@@ -229,8 +229,8 @@ pub struct Location {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ticket {
-    #[prost(bytes = "vec", tag = "1")]
-    pub ticket: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub ticket: ::prost::bytes::Bytes,
 }
 ///
 /// A batch of Arrow data as part of a stream of batches.
@@ -244,27 +244,27 @@ pub struct FlightData {
     pub flight_descriptor: ::core::option::Option<FlightDescriptor>,
     ///
     /// Header for message data as described in Message.fbs::Message.
-    #[prost(bytes = "vec", tag = "2")]
-    pub data_header: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub data_header: ::prost::bytes::Bytes,
     ///
     /// Application-defined metadata.
-    #[prost(bytes = "vec", tag = "3")]
-    pub app_metadata: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub app_metadata: ::prost::bytes::Bytes,
     ///
     /// The actual batch of Arrow data. Preferably handled with minimal-copies
     /// coming last in the definition to help with sidecar patterns (it is
     /// expected that some implementations will fetch this field off the wire
     /// with specialized code to avoid extra memory copies).
-    #[prost(bytes = "vec", tag = "1000")]
-    pub data_body: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1000")]
+    pub data_body: ::prost::bytes::Bytes,
 }
 /// *
 /// The response message associated with the submission of a DoPut.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PutResult {
-    #[prost(bytes = "vec", tag = "1")]
-    pub app_metadata: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub app_metadata: ::prost::bytes::Bytes,
 }
 /// Generated client implementations.
 pub mod flight_service_client {

--- a/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
+++ b/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
@@ -446,16 +446,16 @@ pub struct ActionCreatePreparedStatementRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionCreatePreparedStatementResult {
     /// Opaque handle for the prepared statement on the server.
-    #[prost(bytes = "vec", tag = "1")]
-    pub prepared_statement_handle: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub prepared_statement_handle: ::prost::bytes::Bytes,
     /// If a result set generating query was provided, dataset_schema contains the
     /// schema of the dataset as described in Schema.fbs::Schema, it is serialized as an IPC message.
-    #[prost(bytes = "vec", tag = "2")]
-    pub dataset_schema: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub dataset_schema: ::prost::bytes::Bytes,
     /// If the query provided contained parameters, parameter_schema contains the
     /// schema of the expected parameters as described in Schema.fbs::Schema, it is serialized as an IPC message.
-    #[prost(bytes = "vec", tag = "3")]
-    pub parameter_schema: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "3")]
+    pub parameter_schema: ::prost::bytes::Bytes,
 }
 ///
 /// Request message for the "ClosePreparedStatement" action on a Flight SQL enabled backend.
@@ -464,8 +464,8 @@ pub struct ActionCreatePreparedStatementResult {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionClosePreparedStatementRequest {
     /// Opaque handle for the prepared statement on the server.
-    #[prost(bytes = "vec", tag = "1")]
-    pub prepared_statement_handle: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub prepared_statement_handle: ::prost::bytes::Bytes,
 }
 ///
 /// Represents a SQL query. Used in the command member of FlightDescriptor
@@ -497,8 +497,8 @@ pub struct CommandStatementQuery {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TicketStatementQuery {
     /// Unique identifier for the instance of the statement to execute.
-    #[prost(bytes = "vec", tag = "1")]
-    pub statement_handle: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub statement_handle: ::prost::bytes::Bytes,
 }
 ///
 /// Represents an instance of executing a prepared statement. Used in the command member of FlightDescriptor for
@@ -521,8 +521,8 @@ pub struct TicketStatementQuery {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandPreparedStatementQuery {
     /// Opaque handle for the prepared statement on the server.
-    #[prost(bytes = "vec", tag = "1")]
-    pub prepared_statement_handle: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub prepared_statement_handle: ::prost::bytes::Bytes,
 }
 ///
 /// Represents a SQL update query. Used in the command member of FlightDescriptor
@@ -542,8 +542,8 @@ pub struct CommandStatementUpdate {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandPreparedStatementUpdate {
     /// Opaque handle for the prepared statement on the server.
-    #[prost(bytes = "vec", tag = "1")]
-    pub prepared_statement_handle: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub prepared_statement_handle: ::prost::bytes::Bytes,
 }
 ///
 /// Returned from the RPC call DoPut when a CommandStatementUpdate

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -118,10 +119,10 @@ impl FlightSqlServiceClient {
         &mut self,
         username: &str,
         password: &str,
-    ) -> Result<Vec<u8>, ArrowError> {
+    ) -> Result<Bytes, ArrowError> {
         let cmd = HandshakeRequest {
             protocol_version: 0,
-            payload: vec![],
+            payload: Default::default(),
         };
         let mut req = tonic::Request::new(stream::iter(vec![cmd]));
         let val = base64::encode(format!("{}:{}", username, password));
@@ -278,7 +279,7 @@ impl FlightSqlServiceClient {
         let cmd = ActionCreatePreparedStatementRequest { query };
         let action = Action {
             r#type: CREATE_PREPARED_STATEMENT.to_string(),
-            body: cmd.as_any().encode_to_vec(),
+            body: cmd.as_any().encode_to_vec().into(),
         };
         let mut req = tonic::Request::new(action);
         if let Some(token) = &self.token {
@@ -328,7 +329,7 @@ impl FlightSqlServiceClient {
 pub struct PreparedStatement<T> {
     flight_client: Arc<Mutex<FlightServiceClient<T>>>,
     parameter_binding: Option<RecordBatch>,
-    handle: Vec<u8>,
+    handle: Bytes,
     dataset_schema: Schema,
     parameter_schema: Schema,
 }
@@ -336,14 +337,14 @@ pub struct PreparedStatement<T> {
 impl PreparedStatement<Channel> {
     pub(crate) fn new(
         client: Arc<Mutex<FlightServiceClient<Channel>>>,
-        handle: Vec<u8>,
+        handle: impl Into<Bytes>,
         dataset_schema: Schema,
         parameter_schema: Schema,
     ) -> Self {
         PreparedStatement {
             flight_client: client,
             parameter_binding: None,
-            handle,
+            handle: handle.into(),
             dataset_schema,
             parameter_schema,
         }
@@ -417,7 +418,7 @@ impl PreparedStatement<Channel> {
         };
         let action = Action {
             r#type: CLOSE_PREPARED_STATEMENT.to_string(),
-            body: cmd.as_any().encode_to_vec(),
+            body: cmd.as_any().encode_to_vec().into(),
         };
         let _ = self
             .mut_client()?

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -473,7 +473,7 @@ where
             let record_count = self.do_put_statement_update(token, request).await?;
             let result = DoPutUpdateResult { record_count };
             let output = futures::stream::iter(vec![Ok(PutResult {
-                app_metadata: result.encode_to_vec(),
+                app_metadata: result.encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
         }
@@ -494,7 +494,7 @@ where
                 .await?;
             let result = DoPutUpdateResult { record_count };
             let output = futures::stream::iter(vec![Ok(PutResult {
-                app_metadata: result.encode_to_vec(),
+                app_metadata: result.encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
         }
@@ -551,7 +551,7 @@ where
                 .do_action_create_prepared_statement(cmd, request)
                 .await?;
             let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
-                body: stmt.as_any().encode_to_vec(),
+                body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
         }

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -18,9 +18,9 @@
 //! Utilities to assist with reading and writing Arrow data as Flight messages
 
 use crate::{FlightData, IpcMessage, SchemaAsIpc, SchemaResult};
+use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::Arc;
-use bytes::Bytes;
 
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_buffer::Buffer;

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -20,6 +20,7 @@
 use crate::{FlightData, IpcMessage, SchemaAsIpc, SchemaResult};
 use std::collections::HashMap;
 use std::sync::Arc;
+use bytes::Bytes;
 
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_buffer::Buffer;
@@ -138,7 +139,7 @@ pub fn flight_data_from_arrow_schema(
 pub fn ipc_message_from_arrow_schema(
     schema: &Schema,
     options: &IpcWriteOptions,
-) -> Result<Vec<u8>, ArrowError> {
+) -> Result<Bytes, ArrowError> {
     let message = SchemaAsIpc::new(schema, options).try_into()?;
     let IpcMessage(vals) = message;
     Ok(vals)

--- a/arrow-integration-testing/src/flight_client_scenarios/auth_basic_proto.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/auth_basic_proto.rs
@@ -74,7 +74,7 @@ pub async fn run_scenario(host: &str, port: u16) -> Result {
         .expect("No response received")
         .expect("Invalid response received");
 
-    let body = String::from_utf8(r.body).unwrap();
+    let body = std::str::from_utf8(&r.body).unwrap();
     assert_eq!(body, AUTH_USERNAME);
 
     Ok(())
@@ -94,7 +94,7 @@ async fn authenticate(
 
     let req = stream::once(async {
         HandshakeRequest {
-            payload,
+            payload: payload.into(),
             ..HandshakeRequest::default()
         }
     });
@@ -105,5 +105,5 @@ async fn authenticate(
     let r = rx.next().await.expect("must respond from handshake")?;
     assert!(rx.next().await.is_none(), "must not respond a second time");
 
-    Ok(String::from_utf8(r.payload).unwrap())
+    Ok(std::str::from_utf8(&r.payload).unwrap().into())
 }

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -138,7 +138,7 @@ async fn send_batch(
         .await?;
 
     // Only the record batch's FlightData gets app_metadata
-    batch_flight_data.app_metadata = metadata.to_vec();
+    batch_flight_data.app_metadata = metadata.to_vec().into();
     upload_tx.send(batch_flight_data).await?;
     Ok(())
 }

--- a/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
@@ -19,6 +19,7 @@ use arrow_flight::{
     flight_descriptor::DescriptorType, flight_service_client::FlightServiceClient,
     FlightDescriptor,
 };
+use prost::bytes::Bytes;
 use tonic::{Request, Status};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -31,7 +32,7 @@ pub async fn run_scenario(host: &str, port: u16) -> Result {
 
     let mut descriptor = FlightDescriptor::default();
     descriptor.set_type(DescriptorType::Cmd);
-    descriptor.cmd = b"".to_vec();
+    descriptor.cmd = Bytes::from_static(b"");
 
     // This call is expected to fail.
     match client
@@ -56,7 +57,7 @@ pub async fn run_scenario(host: &str, port: u16) -> Result {
     }
 
     // This call should succeed
-    descriptor.cmd = b"success".to_vec();
+    descriptor.cmd = Bytes::from_static(b"success");
     let resp = client.get_flight_info(Request::new(descriptor)).await?;
 
     let headers = resp.metadata();

--- a/arrow-integration-testing/src/flight_server_scenarios.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios.rs
@@ -39,7 +39,7 @@ pub async fn listen_on(port: u16) -> Result<SocketAddr> {
 pub fn endpoint(ticket: &str, location_uri: impl Into<String>) -> FlightEndpoint {
     FlightEndpoint {
         ticket: Some(Ticket {
-            ticket: ticket.as_bytes().to_vec(),
+            ticket: ticket.as_bytes().to_vec().into(),
         }),
         location: vec![Location {
             uri: location_uri.into(),

--- a/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -149,7 +149,7 @@ impl FlightService for AuthBasicProtoScenarioImpl {
                             && *auth.password == *password
                         {
                             Ok(HandshakeResponse {
-                                payload: username.as_bytes().to_vec(),
+                                payload: username.as_bytes().to_vec().into(),
                                 ..HandshakeResponse::default()
                             })
                         } else {
@@ -203,7 +203,7 @@ impl FlightService for AuthBasicProtoScenarioImpl {
     ) -> Result<Response<Self::DoActionStream>, Status> {
         let flight_context = self.check_auth(request.metadata()).await?;
         // Respond with the authenticated username.
-        let buf = flight_context.peer_identity().as_bytes().to_vec();
+        let buf = flight_context.peer_identity().as_bytes().to_vec().into();
         let result = arrow_flight::Result { body: buf };
         let output = futures::stream::once(async { Ok(result) });
         Ok(Response::new(Box::pin(output) as Self::DoActionStream))

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -125,7 +125,7 @@ impl FlightService for FlightServiceImpl {
                     arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
 
                 // Only the record batch's FlightData gets app_metadata
-                let metadata = counter.to_string().into_bytes();
+                let metadata = counter.to_string().into();
                 batch_flight_data.app_metadata = metadata;
 
                 dictionary_flight_data
@@ -275,7 +275,7 @@ async fn send_app_metadata(
     app_metadata: &[u8],
 ) -> Result<(), Status> {
     tx.send(Ok(PutResult {
-        app_metadata: app_metadata.to_vec(),
+        app_metadata: app_metadata.to_vec().into(),
     }))
     .await
     .map_err(|e| Status::internal(format!("Could not send PutResult: {:?}", e)))

--- a/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
@@ -93,7 +93,8 @@ impl FlightService for MiddlewareScenarioImpl {
 
         let descriptor = request.into_inner();
 
-        if descriptor.r#type == DescriptorType::Cmd as i32 && descriptor.cmd == b"success"
+        if descriptor.r#type == DescriptorType::Cmd as i32
+            && descriptor.cmd.as_ref() == b"success"
         {
             // Return a fake location - the test doesn't read it
             let endpoint = super::endpoint("foo", "grpc+tcp://localhost:10010");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Prost supports zero-copy reading of binary payloads, internally slicing the original `Bytes` comprising the HTTP frame read by hyper. This PR tweaks prost-build to generate structs with `Bytes` instead of `Vec<u8>` which should cut down on the amount of data copying during decode.

TBC there will still be copies resulting from:

* `prost_types::Any` uses `Vec` not `Bytes` (we could work around this in a subsequent PR)
* Conversion to `Buffer` involves a memcpy

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
