### PR TITLE
Add csv-core based reader (#3338)

### DIFF
--- a/arrow-csv/Cargo.toml
+++ b/arrow-csv/Cargo.toml
@@ -45,6 +45,7 @@ arrow-data = { version = "29.0.0", path = "../arrow-data" }
 arrow-schema = { version = "29.0.0", path = "../arrow-schema" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 csv = { version = "1.1", default-features = false }
+csv-core = { version = "0.1"}
 lazy_static = { version = "1.4", default-features = false }
 lexical-core = { version = "^0.8", default-features = false }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -40,13 +40,14 @@
 //! let batch = csv.next().unwrap().unwrap();
 //! ```
 
-use core::cmp::min;
+mod records;
+
 use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 use std::collections::HashSet;
 use std::fmt;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use arrow_array::builder::Decimal128Builder;
@@ -56,8 +57,9 @@ use arrow_cast::parse::Parser;
 use arrow_schema::*;
 
 use crate::map_csv_error;
+use crate::reader::records::{RecordReader, StringRecords};
 use arrow_data::decimal::validate_decimal_precision;
-use csv::{ByteRecord, StringRecord};
+use csv::StringRecord;
 use std::ops::Neg;
 
 lazy_static! {
@@ -107,7 +109,7 @@ fn infer_field_schema(string: &str, datetime_re: Option<Regex>) -> DataType {
 /// This is a collection of options for csv reader when the builder pattern cannot be used
 /// and the parameters need to be passed around
 #[derive(Debug, Default, Clone)]
-pub struct ReaderOptions {
+struct ReaderOptions {
     has_header: bool,
     delimiter: Option<u8>,
     escape: Option<u8>,
@@ -177,11 +179,36 @@ pub fn infer_reader_schema<R: Read>(
     infer_reader_schema_with_csv_options(reader, roptions)
 }
 
+/// Creates a `csv::Reader`
+fn build_csv_reader<R: Read>(
+    reader: R,
+    has_header: bool,
+    delimiter: Option<u8>,
+    escape: Option<u8>,
+    quote: Option<u8>,
+    terminator: Option<u8>,
+) -> csv::Reader<R> {
+    let mut reader_builder = csv::ReaderBuilder::new();
+    reader_builder.has_headers(has_header);
+
+    if let Some(c) = delimiter {
+        reader_builder.delimiter(c);
+    }
+    reader_builder.escape(escape);
+    if let Some(c) = quote {
+        reader_builder.quote(c);
+    }
+    if let Some(t) = terminator {
+        reader_builder.terminator(csv::Terminator::Any(t));
+    }
+    reader_builder.from_reader(reader)
+}
+
 fn infer_reader_schema_with_csv_options<R: Read>(
     reader: R,
     roptions: ReaderOptions,
 ) -> Result<(Schema, usize), ArrowError> {
-    let mut csv_reader = Reader::build_csv_reader(
+    let mut csv_reader = build_csv_reader(
         reader,
         roptions.has_header,
         roptions.delimiter,
@@ -305,15 +332,15 @@ pub struct Reader<R: Read> {
     /// Optional projection for which columns to load (zero-based column indices)
     projection: Option<Vec<usize>>,
     /// File reader
-    reader: csv::Reader<R>,
+    reader: RecordReader<BufReader<R>>,
+    /// Rows to skip
+    to_skip: usize,
     /// Current line number
     line_number: usize,
-    /// Maximum number of rows to read
+    /// End line number
     end: usize,
     /// Number of records per batch
     batch_size: usize,
-    /// Vector that can hold the `StringRecord`s of the batches
-    batch_records: Vec<StringRecord>,
     /// datetime format used to parse datetime values, (format understood by chrono)
     ///
     /// For format refer to [chrono docs](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html)
@@ -351,16 +378,23 @@ impl<R: Read> Reader<R> {
         projection: Option<Vec<usize>>,
         datetime_format: Option<String>,
     ) -> Self {
-        Self::from_reader(
-            reader,
-            schema,
-            has_header,
-            delimiter,
-            batch_size,
-            bounds,
-            projection,
-            datetime_format,
-        )
+        let mut builder = ReaderBuilder::new()
+            .has_header(has_header)
+            .with_batch_size(batch_size);
+
+        if let Some(delimiter) = delimiter {
+            builder = builder.with_delimiter(delimiter);
+        }
+        if let Some((start, end)) = bounds {
+            builder = builder.with_bounds(start, end);
+        }
+        if let Some(projection) = projection {
+            builder = builder.with_projection(projection)
+        }
+        if let Some(format) = datetime_format {
+            builder = builder.with_datetime_format(format)
+        }
+        builder.build_with_schema(reader, schema)
     }
 
     /// Returns the schema of the reader, useful for getting the schema without reading
@@ -383,6 +417,7 @@ impl<R: Read> Reader<R> {
     /// This constructor allows you more flexibility in what records are processed by the
     /// csv reader.
     #[allow(clippy::too_many_arguments)]
+    #[deprecated(note = "Use Reader::new or ReaderBuilder")]
     pub fn from_reader(
         reader: R,
         schema: SchemaRef,
@@ -393,86 +428,16 @@ impl<R: Read> Reader<R> {
         projection: Option<Vec<usize>>,
         datetime_format: Option<String>,
     ) -> Self {
-        let csv_reader =
-            Self::build_csv_reader(reader, has_header, delimiter, None, None, None);
-        Self::from_csv_reader(
-            csv_reader,
+        Self::new(
+            reader,
             schema,
             has_header,
+            delimiter,
             batch_size,
             bounds,
             projection,
             datetime_format,
         )
-    }
-
-    fn build_csv_reader(
-        reader: R,
-        has_header: bool,
-        delimiter: Option<u8>,
-        escape: Option<u8>,
-        quote: Option<u8>,
-        terminator: Option<u8>,
-    ) -> csv::Reader<R> {
-        let mut reader_builder = csv::ReaderBuilder::new();
-        reader_builder.has_headers(has_header);
-
-        if let Some(c) = delimiter {
-            reader_builder.delimiter(c);
-        }
-        reader_builder.escape(escape);
-        if let Some(c) = quote {
-            reader_builder.quote(c);
-        }
-        if let Some(t) = terminator {
-            reader_builder.terminator(csv::Terminator::Any(t));
-        }
-        reader_builder.from_reader(reader)
-    }
-
-    fn from_csv_reader(
-        mut csv_reader: csv::Reader<R>,
-        schema: SchemaRef,
-        has_header: bool,
-        batch_size: usize,
-        bounds: Bounds,
-        projection: Option<Vec<usize>>,
-        datetime_format: Option<String>,
-    ) -> Self {
-        let (start, end) = match bounds {
-            None => (0, usize::MAX),
-            Some((start, end)) => (start, end),
-        };
-
-        // First we will skip `start` rows
-        // note that this skips by iteration. This is because in general it is not possible
-        // to seek in CSV. However, skipping still saves the burden of creating arrow arrays,
-        // which is a slow operation that scales with the number of columns
-
-        let mut record = ByteRecord::new();
-        // Skip first start items
-        for _ in 0..start {
-            let res = csv_reader.read_byte_record(&mut record);
-            if !res.unwrap_or(false) {
-                break;
-            }
-        }
-
-        // Initialize batch_records with StringRecords so they
-        // can be reused across batches
-        let mut batch_records = Vec::with_capacity(batch_size);
-        batch_records.resize_with(batch_size, Default::default);
-
-        Self {
-            schema,
-            projection,
-            reader: csv_reader,
-            line_number: if has_header { start + 1 } else { start },
-            batch_size,
-            end,
-            batch_records,
-            datetime_format,
-        }
     }
 }
 
@@ -480,55 +445,40 @@ impl<R: Read> Iterator for Reader<R> {
     type Item = Result<RecordBatch, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let remaining = self.end - self.line_number;
-
-        let mut read_records = 0;
-        for i in 0..min(self.batch_size, remaining) {
-            match self.reader.read_record(&mut self.batch_records[i]) {
-                Ok(true) => {
-                    read_records += 1;
-                }
-                Ok(false) => break,
-                Err(e) => {
-                    return Some(Err(ArrowError::ParseError(format!(
-                        "Error parsing line {}: {:?}",
-                        self.line_number + i,
-                        e
-                    ))));
-                }
+        if self.to_skip != 0 {
+            if let Err(e) = self.reader.skip(std::mem::take(&mut self.to_skip)) {
+                return Some(Err(e));
             }
         }
 
-        // return early if no data was loaded
-        if read_records == 0 {
-            return None;
-        }
+        let remaining = self.end - self.line_number;
+        let to_read = self.batch_size.min(remaining);
 
-        let format: Option<&str> = match self.datetime_format {
-            Some(ref format) => Some(format.as_ref()),
-            _ => None,
+        let batch = match self.reader.read(to_read) {
+            Ok(b) if b.is_empty() => return None,
+            Ok(b) => b,
+            Err(e) => return Some(Err(e)),
         };
 
         // parse the batches into a RecordBatch
         let result = parse(
-            &self.batch_records[..read_records],
+            &batch,
             self.schema.fields(),
             Some(self.schema.metadata.clone()),
             self.projection.as_ref(),
             self.line_number,
-            format,
+            self.datetime_format.as_deref(),
         );
 
-        self.line_number += read_records;
+        self.line_number += batch.len();
 
         Some(result)
     }
 }
 
-/// parses a slice of [csv::StringRecord] into a
-/// [RecordBatch]
+/// Parses a slice of [`StringRecords`] into a [RecordBatch]
 fn parse(
-    rows: &[StringRecord],
+    rows: &StringRecords<'_>,
     fields: &[Field],
     metadata: Option<std::collections::HashMap<String, String>>,
     projection: Option<&Vec<usize>>,
@@ -624,7 +574,9 @@ fn parse(
                     )
                 }
                 DataType::Utf8 => Ok(Arc::new(
-                    rows.iter().map(|row| row.get(i)).collect::<StringArray>(),
+                    rows.iter()
+                        .map(|row| Some(row.get(i)))
+                        .collect::<StringArray>(),
                 ) as ArrayRef),
                 DataType::Dictionary(key_type, value_type)
                     if value_type.as_ref() == &DataType::Utf8 =>
@@ -723,34 +675,26 @@ fn parse_bool(string: &str) -> Option<bool> {
 // parse the column string to an Arrow Array
 fn build_decimal_array(
     _line_number: usize,
-    rows: &[StringRecord],
+    rows: &StringRecords<'_>,
     col_idx: usize,
     precision: u8,
     scale: i8,
 ) -> Result<ArrayRef, ArrowError> {
     let mut decimal_builder = Decimal128Builder::with_capacity(rows.len());
-    for row in rows {
-        let col_s = row.get(col_idx);
-        match col_s {
-            None => {
-                // No data for this row
-                decimal_builder.append_null();
-            }
-            Some(s) => {
-                if s.is_empty() {
-                    // append null
-                    decimal_builder.append_null();
-                } else {
-                    let decimal_value: Result<i128, _> =
-                        parse_decimal_with_parameter(s, precision, scale);
-                    match decimal_value {
-                        Ok(v) => {
-                            decimal_builder.append_value(v);
-                        }
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    }
+    for row in rows.iter() {
+        let s = row.get(col_idx);
+        if s.is_empty() {
+            // append null
+            decimal_builder.append_null();
+        } else {
+            let decimal_value: Result<i128, _> =
+                parse_decimal_with_parameter(s, precision, scale);
+            match decimal_value {
+                Ok(v) => {
+                    decimal_builder.append_value(v);
+                }
+                Err(e) => {
+                    return Err(e);
                 }
             }
         }
@@ -878,35 +822,31 @@ fn parse_decimal(s: &str) -> Result<i128, ArrowError> {
 // parses a specific column (col_idx) into an Arrow Array.
 fn build_primitive_array<T: ArrowPrimitiveType + Parser>(
     line_number: usize,
-    rows: &[StringRecord],
+    rows: &StringRecords<'_>,
     col_idx: usize,
     format: Option<&str>,
 ) -> Result<ArrayRef, ArrowError> {
     rows.iter()
         .enumerate()
         .map(|(row_index, row)| {
-            match row.get(col_idx) {
-                Some(s) => {
-                    if s.is_empty() {
-                        return Ok(None);
-                    }
+            let s = row.get(col_idx);
+            if s.is_empty() {
+                return Ok(None);
+            }
 
-                    let parsed = match format {
-                        Some(format) => parse_formatted::<T>(s, format),
-                        _ => parse_item::<T>(s),
-                    };
-                    match parsed {
-                        Some(e) => Ok(Some(e)),
-                        None => Err(ArrowError::ParseError(format!(
-                            // TODO: we should surface the underlying error here.
-                            "Error while parsing value {} for column {} at line {}",
-                            s,
-                            col_idx,
-                            line_number + row_index
-                        ))),
-                    }
-                }
-                None => Ok(None),
+            let parsed = match format {
+                Some(format) => parse_formatted::<T>(s, format),
+                _ => parse_item::<T>(s),
+            };
+            match parsed {
+                Some(e) => Ok(Some(e)),
+                None => Err(ArrowError::ParseError(format!(
+                    // TODO: we should surface the underlying error here.
+                    "Error while parsing value {} for column {} at line {}",
+                    s,
+                    col_idx,
+                    line_number + row_index
+                ))),
             }
         })
         .collect::<Result<PrimitiveArray<T>, ArrowError>>()
@@ -916,31 +856,23 @@ fn build_primitive_array<T: ArrowPrimitiveType + Parser>(
 // parses a specific column (col_idx) into an Arrow Array.
 fn build_boolean_array(
     line_number: usize,
-    rows: &[StringRecord],
+    rows: &StringRecords<'_>,
     col_idx: usize,
 ) -> Result<ArrayRef, ArrowError> {
     rows.iter()
         .enumerate()
         .map(|(row_index, row)| {
-            match row.get(col_idx) {
-                Some(s) => {
-                    if s.is_empty() {
-                        return Ok(None);
-                    }
-
-                    let parsed = parse_bool(s);
-                    match parsed {
-                        Some(e) => Ok(Some(e)),
-                        None => Err(ArrowError::ParseError(format!(
-                            // TODO: we should surface the underlying error here.
-                            "Error while parsing value {} for column {} at line {}",
-                            s,
-                            col_idx,
-                            line_number + row_index
-                        ))),
-                    }
-                }
-                None => Ok(None),
+            let s = row.get(col_idx);
+            let parsed = parse_bool(s);
+            match parsed {
+                Some(e) => Ok(Some(e)),
+                None => Err(ArrowError::ParseError(format!(
+                    // TODO: we should surface the underlying error here.
+                    "Error while parsing value {} for column {} at line {}",
+                    s,
+                    col_idx,
+                    line_number + row_index
+                ))),
             }
         })
         .collect::<Result<BooleanArray, _>>()
@@ -1109,10 +1041,13 @@ impl ReaderBuilder {
     }
 
     /// Create a new `Reader` from the `ReaderBuilder`
-    pub fn build<R: Read + Seek>(self, mut reader: R) -> Result<Reader<R>, ArrowError> {
+    pub fn build<R: Read + Seek>(
+        mut self,
+        mut reader: R,
+    ) -> Result<Reader<R>, ArrowError> {
         // check if schema should be inferred
         let delimiter = self.delimiter.unwrap_or(b',');
-        let schema = match self.schema {
+        let schema = match self.schema.take() {
             Some(schema) => schema,
             None => {
                 let roptions = ReaderOptions {
@@ -1122,7 +1057,7 @@ impl ReaderBuilder {
                     escape: self.escape,
                     quote: self.quote,
                     terminator: self.terminator,
-                    datetime_re: self.datetime_re,
+                    datetime_re: self.datetime_re.take(),
                 };
                 let (inferred_schema, _) =
                     infer_file_schema_with_csv_options(&mut reader, roptions)?;
@@ -1130,23 +1065,45 @@ impl ReaderBuilder {
                 Arc::new(inferred_schema)
             }
         };
-        let csv_reader = Reader::build_csv_reader(
-            reader,
-            self.has_header,
-            self.delimiter,
-            self.escape,
-            self.quote,
-            self.terminator,
+        Ok(self.build_with_schema(reader, schema))
+    }
+
+    fn build_with_schema<R: Read>(self, reader: R, schema: SchemaRef) -> Reader<R> {
+        let mut reader_builder = csv_core::ReaderBuilder::new();
+        reader_builder.escape(self.escape);
+
+        if let Some(c) = self.delimiter {
+            reader_builder.delimiter(c);
+        }
+        if let Some(c) = self.quote {
+            reader_builder.quote(c);
+        }
+        if let Some(t) = self.terminator {
+            reader_builder.terminator(csv_core::Terminator::Any(t));
+        }
+        let reader = RecordReader::new(
+            BufReader::new(reader),
+            reader_builder.build(),
+            schema.fields().len(),
         );
-        Ok(Reader::from_csv_reader(
-            csv_reader,
+
+        let header = self.has_header as usize;
+
+        let (start, end) = match self.bounds {
+            Some((start, end)) => (start + header, end + header),
+            None => (header, usize::MAX),
+        };
+
+        Reader {
             schema,
-            self.has_header,
-            self.batch_size,
-            self.bounds,
-            self.projection.clone(),
-            self.datetime_format,
-        ))
+            projection: self.projection,
+            reader,
+            to_skip: start,
+            line_number: start,
+            end,
+            batch_size: self.batch_size,
+            datetime_format: self.datetime_format,
+        }
     }
 }
 
@@ -1285,7 +1242,7 @@ mod tests {
         let both_files = file_with_headers
             .chain(Cursor::new("\n".to_string()))
             .chain(file_without_headers);
-        let mut csv = Reader::from_reader(
+        let mut csv = Reader::new(
             both_files,
             Arc::new(schema),
             true,
@@ -1480,6 +1437,7 @@ mod tests {
             Field::new("c_int", DataType::UInt64, false),
             Field::new("c_float", DataType::Float32, true),
             Field::new("c_string", DataType::Utf8, false),
+            Field::new("c_bool", DataType::Boolean, false),
         ]);
 
         let file = File::open("test/data/null_test.csv").unwrap();
@@ -2073,5 +2031,32 @@ mod tests {
         assert_eq!(col1.len(), 10);
         let col1_arr = col1.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(col1_arr.value(5), "value5");
+    }
+
+    #[test]
+    fn test_header_bounds() {
+        let csv = "a,b\na,b\na,b\na,b\na,b\n";
+        let tests = [
+            (None, false, 5),
+            (None, true, 4),
+            (Some((0, 4)), false, 4),
+            (Some((1, 4)), false, 3),
+            (Some((0, 4)), true, 4),
+            (Some((1, 4)), true, 3),
+        ];
+
+        for (idx, (bounds, has_header, expected)) in tests.into_iter().enumerate() {
+            let mut reader = ReaderBuilder::new().has_header(has_header);
+            if let Some((start, end)) = bounds {
+                reader = reader.with_bounds(start, end);
+            }
+            let b = reader
+                .build(Cursor::new(csv.as_bytes()))
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap();
+            assert_eq!(b.num_rows(), expected, "{}", idx);
+        }
     }
 }

--- a/arrow-csv/src/reader/records.rs
+++ b/arrow-csv/src/reader/records.rs
@@ -1,0 +1,254 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_schema::ArrowError;
+use csv_core::{ReadRecordResult, Reader};
+use std::io::BufRead;
+
+/// The estimated length of a field in bytes
+const AVERAGE_FIELD_SIZE: usize = 8;
+
+/// The minimum amount of data in a single read
+const MIN_CAPACITY: usize = 1024;
+
+pub struct RecordReader<R> {
+    reader: R,
+    delimiter: Reader,
+
+    num_columns: usize,
+
+    num_rows: usize,
+    offsets: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl<R: BufRead> RecordReader<R> {
+    pub fn new(reader: R, delimiter: Reader, num_columns: usize) -> Self {
+        Self {
+            reader,
+            delimiter,
+            num_columns,
+            num_rows: 0,
+            offsets: vec![],
+            data: vec![],
+        }
+    }
+
+    fn fill_buf(&mut self, to_read: usize) -> Result<(), ArrowError> {
+        // Reserve sufficient capacity in field_ends
+        self.offsets.resize(to_read * self.num_columns + 1, 0);
+        self.num_rows = 0;
+
+        if to_read == 0 {
+            return Ok(());
+        }
+
+        let mut output_offset = 0;
+        let mut input_offset = 0;
+        let mut field_offset = 1;
+        let mut field_count = 0;
+
+        'outer: loop {
+            let input = self.reader.fill_buf()?;
+
+            'input: loop {
+                // Reserve necessary space in output data based on best estimate
+                let remaining_rows = to_read - self.num_rows;
+                let capacity = remaining_rows * self.num_columns * AVERAGE_FIELD_SIZE;
+                let estimated_data = capacity.max(MIN_CAPACITY);
+                self.data.resize(output_offset + estimated_data, 0);
+
+                loop {
+                    let (result, bytes_read, bytes_written, end_positions) =
+                        self.delimiter.read_record(
+                            &input[input_offset..],
+                            &mut self.data[output_offset..],
+                            &mut self.offsets[field_offset..],
+                        );
+
+                    field_count += end_positions;
+                    field_offset += end_positions;
+                    input_offset += bytes_read;
+                    output_offset += bytes_written;
+
+                    match result {
+                        ReadRecordResult::End => break 'outer,
+                        ReadRecordResult::InputEmpty => break 'input,
+                        ReadRecordResult::OutputFull => break, // Need to allocate more capacity
+                        ReadRecordResult::OutputEndsFull => {
+                            return Err(ArrowError::CsvError(format!("incorrect number of fields, expected {} got more than {}", self.num_columns, field_count)))
+                        }
+                        ReadRecordResult::Record => {
+                            if field_count != self.num_columns {
+                                return Err(ArrowError::CsvError(format!("incorrect number of fields, expected {} got {}", self.num_columns, field_count)))
+                            }
+                            self.num_rows += 1;
+                            field_count = 0;
+
+                            if self.num_rows == to_read {
+                                break 'outer
+                            }
+
+                            if input.len() == input_offset {
+                                break 'input
+                            }
+                        }
+                    }
+                }
+            }
+            self.reader.consume(input_offset);
+            input_offset = 0;
+        }
+        self.reader.consume(input_offset);
+
+        let mut row_offset = 0;
+        self.offsets[1..]
+            .chunks_mut(self.num_columns)
+            .for_each(|row| {
+                let offset = row_offset;
+                row.iter_mut().for_each(|x| {
+                    *x += offset;
+                    row_offset = *x;
+                });
+            });
+
+        Ok(())
+    }
+
+    /// Skips forward `to_skip` rows
+    pub fn skip(&mut self, mut to_skip: usize) -> Result<(), ArrowError> {
+        // TODO: This could be done by scanning for unquoted newline delimiters
+        while to_skip != 0 {
+            self.fill_buf(to_skip.min(1024))?;
+            to_skip -= self.num_rows;
+        }
+        Ok(())
+    }
+
+    /// Reads up to `to_read` rows from the reader
+    pub fn read(&mut self, to_read: usize) -> Result<StringRecords<'_>, ArrowError> {
+        self.fill_buf(to_read)?;
+
+        // Need to truncate fields to the actual number of rows read
+        let num_fields = self.num_rows * self.num_columns;
+        let last_offset = self.offsets[num_fields];
+
+        // Need to truncate data to the actual amount of data read
+        let data = std::str::from_utf8(&self.data[..last_offset]).map_err(|e| {
+            ArrowError::CsvError(format!("Encountered invalid UTF-8 data: {}", e))
+        })?;
+
+        Ok(StringRecords {
+            num_columns: self.num_columns,
+            num_rows: self.num_rows,
+            offsets: &self.offsets[..num_fields + 1],
+            data,
+        })
+    }
+}
+
+/// A collection of parsed, UTF-8 CSV records
+#[derive(Debug)]
+pub struct StringRecords<'a> {
+    num_columns: usize,
+    num_rows: usize,
+    offsets: &'a [usize],
+    data: &'a str,
+}
+
+impl<'a> StringRecords<'a> {
+    fn get(&self, index: usize) -> StringRecord<'a> {
+        let field_idx = index * self.num_columns;
+        StringRecord {
+            data: self.data,
+            offsets: &self.offsets[field_idx..field_idx + self.num_columns + 1],
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.num_rows
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_rows == 0
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = StringRecord<'a>> + '_ {
+        (0..self.num_rows).map(|x| self.get(x))
+    }
+}
+
+/// A single parsed, UTF-8 CSV record
+#[derive(Debug, Clone, Copy)]
+pub struct StringRecord<'a> {
+    data: &'a str,
+    offsets: &'a [usize],
+}
+
+impl<'a> StringRecord<'a> {
+    pub fn get(&self, index: usize) -> &'a str {
+        let end = self.offsets[index + 1];
+        let start = self.offsets[index];
+
+        // SAFETY:
+        // Parsing produces offsets at valid byte boundaries
+        unsafe { self.data.get_unchecked(start..end) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reader::records::RecordReader;
+    use csv_core::Reader;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_basic() {
+        let csv = [
+            "foo,bar,baz",
+            "a,b,c",
+            "12,3,5",
+            "\"asda\"\"asas\",\"sdffsnsd\", as",
+        ]
+        .join("\n");
+
+        let mut expected = vec![
+            vec!["foo", "bar", "baz"],
+            vec!["a", "b", "c"],
+            vec!["12", "3", "5"],
+            vec!["asda\"asas", "sdffsnsd", " as"],
+        ]
+        .into_iter();
+
+        let cursor = Cursor::new(csv.as_bytes());
+        let mut reader = RecordReader::new(cursor, Reader::new(), 3);
+
+        loop {
+            let b = reader.read(3).unwrap();
+            if b.is_empty() {
+                break;
+            }
+
+            b.iter().zip(&mut expected).for_each(|(record, expected)| {
+                let actual = (0..3)
+                    .map(|field_idx| record.get(field_idx))
+                    .collect::<Vec<_>>();
+                assert_eq!(actual, expected)
+            })
+        }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3338
Closes #3364 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Yields anything from 25% to 75% faster, with larger improvements with larger batch sizes.

```
4096 u64(0) - 128       time:   [360.72 µs 360.87 µs 361.05 µs]
                        change: [-23.673% -23.491% -23.370%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

4096 u64(0) - 1024      time:   [331.16 µs 331.27 µs 331.38 µs]
                        change: [-48.717% -48.649% -48.543%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

4096 u64(0) - 4096      time:   [330.40 µs 330.53 µs 330.71 µs]
                        change: [-75.546% -75.482% -75.444%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

4096 i64(0) - 128       time:   [356.13 µs 356.22 µs 356.32 µs]
                        change: [-25.166% -25.142% -25.120%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

4096 i64(0) - 1024      time:   [328.21 µs 328.32 µs 328.43 µs]
                        change: [-48.985% -48.896% -48.843%] (p = 0.00 < 0.05)
                        Performance has improved.

4096 i64(0) - 4096      time:   [327.60 µs 327.77 µs 327.94 µs]
                        change: [-75.634% -75.622% -75.610%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

4096 f32(0) - 128       time:   [293.13 µs 293.22 µs 293.31 µs]
                        change: [-26.308% -26.126% -25.945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

4096 f32(0) - 1024      time:   [265.46 µs 265.52 µs 265.59 µs]
                        change: [-50.188% -50.037% -49.897%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

4096 f32(0) - 4096      time:   [266.15 µs 266.23 µs 266.32 µs]
                        change: [-75.647% -75.632% -75.618%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

4096 f64(0) - 128       time:   [316.88 µs 316.95 µs 317.03 µs]
                        change: [-25.096% -24.949% -24.860%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

4096 f64(0) - 1024      time:   [285.10 µs 285.16 µs 285.23 µs]
                        change: [-51.985% -51.965% -51.946%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

4096 f64(0) - 4096      time:   [285.62 µs 285.72 µs 285.84 µs]
                        change: [-77.933% -77.901% -77.848%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

4096 string(10, 0) - 128
                        time:   [163.92 µs 163.96 µs 164.00 µs]
                        change: [-37.060% -37.015% -36.956%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

4096 string(10, 0) - 1024
                        time:   [127.45 µs 127.49 µs 127.54 µs]
                        change: [-67.408% -67.348% -67.247%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

4096 string(10, 0) - 4096
                        time:   [125.65 µs 125.71 µs 125.77 µs]
                        change: [-86.901% -86.880% -86.842%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

4096 string(30, 0) - 128
                        time:   [225.21 µs 225.25 µs 225.30 µs]
                        change: [-31.578% -31.423% -31.306%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

4096 string(30, 0) - 1024
                        time:   [182.79 µs 182.88 µs 182.98 µs]
                        change: [-64.628% -64.497% -64.342%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

4096 string(30, 0) - 4096
                        time:   [183.36 µs 183.43 µs 183.52 µs]
                        change: [-84.714% -84.702% -84.691%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

4096 string(100, 0) - 128
                        time:   [490.86 µs 491.27 µs 491.70 µs]
                        change: [-19.107% -18.963% -18.816%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

4096 string(100, 0) - 1024
                        time:   [445.64 µs 445.85 µs 446.07 µs]
                        change: [-49.217% -49.155% -49.065%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

4096 string(100, 0) - 4096
                        time:   [490.16 µs 490.55 µs 490.89 µs]
                        change: [-75.088% -75.052% -75.012%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 26 outliers among 100 measurements (26.00%)
  15 (15.00%) low severe
  3 (3.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

4096 string(100, 0.5) - 128
                        time:   [357.47 µs 357.56 µs 357.66 µs]
                        change: [-27.187% -27.017% -26.761%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

4096 string(100, 0.5) - 1024
                        time:   [316.25 µs 316.36 µs 316.49 µs]
                        change: [-58.868% -58.846% -58.827%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

4096 string(100, 0.5) - 4096
                        time:   [325.66 µs 325.82 µs 326.00 µs]
                        change: [-77.121% -77.107% -77.094%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking 4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 128: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 128
                        time:   [1.1570 ms 1.1576 ms 1.1583 ms]
                        change: [-18.339% -18.157% -17.945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  3 (3.00%) high mild
  16 (16.00%) high severe

Benchmarking 4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 1024: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, enable flat sampling, or reduce sample count to 60.
4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 1024
                        time:   [1.0139 ms 1.0146 ms 1.0154 ms]
                        change: [-35.902% -35.849% -35.794%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  7 (7.00%) low severe
  7 (7.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe

Benchmarking 4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, enable flat sampling, or reduce sample count to 60.
4096 string(20, 0.5), string(30, 0), string(100, 0), i64(0) - 4096
                        time:   [1.0514 ms 1.0524 ms 1.0535 ms]
                        change: [-63.795% -63.754% -63.713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

4096 string(20, 0.5), string(30, 0), f64(0), i64(0) - 128
                        time:   [941.30 µs 941.55 µs 941.85 µs]
                        change: [-21.932% -21.887% -21.842%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

4096 string(20, 0.5), string(30, 0), f64(0), i64(0) - 1024
                        time:   [802.95 µs 803.27 µs 803.65 µs]
                        change: [-40.134% -40.095% -40.059%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

4096 string(20, 0.5), string(30, 0), f64(0), i64(0) - 4096
                        time:   [813.42 µs 813.84 µs 814.26 µs]
                        change: [-66.732% -66.690% -66.632%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a custom record reader based on csv-core, that significantly reduces allocations whilst parsing arrow data. 

# Are there any user-facing changes?

Previously if provided with a schema that was a valid prefix of the columns, it wouldn't complain. It now will. This behaviour was undocumented, and I think an accident, but is technically a user-facing change

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
