### PR TITLE
minor: Improve arrow-flight docs

### DIFF
--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -32,4 +32,13 @@ arrow-flight = "29.0.0"
 
 Apache Arrow Flight is a gRPC based protocol for exchanging Arrow data between processes. See the blog post [Introducing Apache Arrow Flight: A Framework for Fast Data Transport](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/) for more information.
 
-This crate provides a Rust implementation of the [Flight.proto](../../format/Flight.proto) gRPC protocol and provides an example that demonstrates how to build a Flight server implemented with Tonic.
+This crate provides a Rust implementation of the
+[Flight.proto](../../format/Flight.proto) gRPC protocol and
+[examples](https://github.com/apache/arrow-rs/tree/master/arrow-flight/examples)
+that demonstrate how to build a Flight server implemented with [tonic](https://docs.rs/crate/tonic/latest).
+
+## Feature Flags
+
+* `flight-sql-experimental`: Enables experimental support for
+   [Apache Arrow FlightSQL](https://arrow.apache.org/docs/format/FlightSql.html),
+   a protocol for interacting with SQL databases.

--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -39,6 +39,6 @@ that demonstrate how to build a Flight server implemented with [tonic](https://d
 
 ## Feature Flags
 
-* `flight-sql-experimental`: Enables experimental support for
-   [Apache Arrow FlightSQL](https://arrow.apache.org/docs/format/FlightSql.html),
-   a protocol for interacting with SQL databases.
+- `flight-sql-experimental`: Enables experimental support for
+  [Apache Arrow FlightSQL](https://arrow.apache.org/docs/format/FlightSql.html),
+  a protocol for interacting with SQL databases.

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -15,6 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! A native Rust implementaiton of [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html)
+//! for exchanging [Arrow](https://arrow.apache.org) data between processes.
+//!
+//! Please see the [arrow-flight crates.io](https://crates.io/crates/arrow-flight)
+//! page for feature flags and more information.
+//!
+//! # Overview
+//!
+//! This crate contains:
+//!
+//! 1. Low level [prost] generated structs
+//!  for Flight gRPC protobuf messages, such as [`FlightData`].
+//!
+//! 2. Low level [tonic] generated [`flight_service_client`] and
+//! [`flight_service_server`].
 #![allow(rustdoc::invalid_html_tags)]
 
 use arrow_ipc::{convert, writer, writer::EncodedData, writer::IpcWriteOptions};
@@ -35,16 +50,20 @@ mod gen {
     include!("arrow.flight.protocol.rs");
 }
 
+/// Defines a `Flight` for generation or retrieval.
 pub mod flight_descriptor {
     use super::gen;
     pub use gen::flight_descriptor::DescriptorType;
 }
 
+/// Low Level [tonic] [`FlightServiceClient`](gen::flight_service_client::FlightServiceClient).
 pub mod flight_service_client {
     use super::gen;
     pub use gen::flight_service_client::FlightServiceClient;
 }
 
+/// Low Level [tonic] [`FlightServiceServer`](gen::flight_service_server::FlightServiceServer)
+/// and [`FlightService`](gen::flight_service_server::FlightService).
 pub mod flight_service_server {
     use super::gen;
     pub use gen::flight_service_server::FlightService;

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! A native Rust implementaiton of [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html)
+//! A native Rust implementation of [Apache Arrow Flight](https://arrow.apache.org/docs/format/Flight.html)
 //! for exchanging [Arrow](https://arrow.apache.org) data between processes.
 //!
 //! Please see the [arrow-flight crates.io](https://crates.io/crates/arrow-flight)

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -44,7 +44,7 @@ The `arrow` crate provides the following features which may be enabled in your `
 - `csv` (default) - support for reading and writing Arrow arrays to/from csv files
 - `json` (default) - support for reading and writing Arrow array to/from json files
 - `ipc` (default) - support for reading [Arrow IPC Format](https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc), also used as the wire protocol in [arrow-flight](https://crates.io/crates/arrow-flight)
-- `ipc_compression`  - Enables reading and writing compressed IPC streams (also enables `ipc`)
+- `ipc_compression` - Enables reading and writing compressed IPC streams (also enables `ipc`)
 - `prettyprint` - support for formatting record batches as textual columns
 - `js` - support for building arrow for WebAssembly / JavaScript
 - `simd` - (_Requires Nightly Rust_) Use alternate hand optimized


### PR DESCRIPTION
# Which issue does this PR close?


Related to flightsql: https://github.com/apache/arrow-rs/issues/3301

# Rationale for this change
 

I want to make this crate easier to understand and navigate, especially as we add features like FlightSQL

# What changes are included in this PR?

Improve some docstrings and the readme 

# Are there any user-facing changes?
Docs