### PR TITLE
Remove unnecessary flush calls on TrackedWrite

### DIFF
--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -23,7 +23,7 @@ use crate::format as parquet;
 use crate::format::{ColumnIndex, OffsetIndex, RowGroup};
 use std::io::{BufWriter, IoSlice};
 use std::{io::Write, sync::Arc};
-use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol, TSerializable};
+use thrift::protocol::{TCompactOutputProtocol, TSerializable};
 
 use crate::basic::PageType;
 use crate::column::writer::{
@@ -227,7 +227,6 @@ impl<W: Write> SerializedFileWriter<W> {
                         let start_offset = self.buf.bytes_written();
                         let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
                         offset_index.write_to_out_protocol(&mut protocol)?;
-                        protocol.flush()?;
                         let end_offset = self.buf.bytes_written();
                         // set offset and index for offset index
                         column_metadata.offset_index_offset = Some(start_offset as i64);
@@ -279,7 +278,6 @@ impl<W: Write> SerializedFileWriter<W> {
                         let start_offset = self.buf.bytes_written();
                         let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
                         column_index.write_to_out_protocol(&mut protocol)?;
-                        protocol.flush()?;
                         let end_offset = self.buf.bytes_written();
                         // set offset and index for offset index
                         column_metadata.column_index_offset = Some(start_offset as i64);
@@ -326,7 +324,6 @@ impl<W: Write> SerializedFileWriter<W> {
         {
             let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
             file_metadata.write_to_out_protocol(&mut protocol)?;
-            protocol.flush()?;
         }
         let end_pos = self.buf.bytes_written();
 
@@ -592,7 +589,6 @@ impl<'a, W: Write> SerializedPageWriter<'a, W> {
         {
             let mut protocol = TCompactOutputProtocol::new(&mut self.sink);
             header.write_to_out_protocol(&mut protocol)?;
-            protocol.flush()?;
         }
         Ok(self.sink.bytes_written() - start_pos)
     }
@@ -689,7 +685,6 @@ impl<'a, W: Write> PageWriter for SerializedPageWriter<'a, W> {
         metadata
             .to_column_metadata_thrift()
             .write_to_out_protocol(&mut protocol)?;
-        protocol.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We have `BufWriter` inside `TrackedWrite` which buffers output and flushes if necessary. We don't need to call flush in the middle before closing the writer.

It seems to be a simple win without regression.

```
write_batch primitive/4096 values primitive non-null
                        time:   [639.52 µs 642.46 µs 646.64 µs]
                        thrpt:  [267.70 MiB/s 269.44 MiB/s 270.68 MiB/s]
                 change:
                        time:   [-7.1374% -6.3056% -5.1252%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4021% +6.7299% +7.6860%]
                        Performance has improved.
write_batch primitive/4096 values bool non-null
                        time:   [81.192 µs 83.273 µs 86.123 µs]
                        thrpt:  [7.7071 MiB/s 7.9708 MiB/s 8.1752 MiB/s]
                 change:
                        time:   [-6.9304% -4.3398% -1.8032%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8363% +4.5367% +7.4465%]
                        Performance has improved.
write_batch primitive/4096 values string non-null
                        time:   [447.68 µs 448.90 µs 450.81 µs]
                        thrpt:  [174.48 MiB/s 175.23 MiB/s 175.71 MiB/s]
                 change:
                        time:   [-9.6784% -9.1649% -8.6186%] (p = 0.00 < 0.05)
                        thrpt:  [+9.4314% +10.090% +10.715%]
                        Performance has improved.
write_batch nested/4096 values primitive list non-null
                        time:   [1.2610 ms 1.2647 ms 1.2708 ms]
                        thrpt:  [149.95 MiB/s 150.67 MiB/s 151.12 MiB/s]
                 change:
                        time:   [-4.5901% -3.9472% -3.2749%] (p = 0.00 < 0.05)
                        thrpt:  [+3.3858% +4.1094% +4.8109%]
                        Performance has improved.
```



# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
