### PR TITLE
Add derive for Clone and Debug for `ParquetObjectReader`

### DIFF
--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -29,6 +29,7 @@ use crate::errors::{ParquetError, Result};
 use crate::file::metadata::ParquetMetaData;
 
 /// Implements [`AsyncFileReader`] for a parquet file in object storage
+#[derive(Clone, Debug)]
 pub struct ParquetObjectReader {
     store: Arc<dyn ObjectStore>,
     meta: ObjectMeta,


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3381 

# Rationale for this change
 Seems like it'd be useful to have these traits implemented and there aren't really any costs to this change.

# What changes are included in this PR?
Added derived implementation of Clone and Debug to `ParquetObjectReader`

# Are there any user-facing changes?
Additional trait implementations of Clone and Debug