### PR TITLE
object_store: update localstack instructions

### DIFF
--- a/object_store/CONTRIBUTING.md
+++ b/object_store/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To test the S3 integration against [localstack](https://localstack.cloud/)
 First start up a container running localstack
 
 ```
-$ podman run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack
+$ podman run --rm -it -e PROVIDER_OVERRIDE_S3=asf -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack 
 ```
 
 Setup environment
@@ -49,7 +49,9 @@ export TEST_INTEGRATION=1
 export OBJECT_STORE_AWS_DEFAULT_REGION=us-east-1
 export OBJECT_STORE_AWS_ACCESS_KEY_ID=test
 export OBJECT_STORE_AWS_SECRET_ACCESS_KEY=test
-export AWS_ENDPOINT=http://128.0.0.1:4566
+export OBJECT_STORE_AWS_ENDPOINT=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
 export OBJECT_STORE_BUCKET=test-bucket
 ```
 
@@ -57,6 +59,12 @@ Create a bucket using the AWS CLI
 
 ```
 podman run --net=host --env-host amazon/aws-cli --endpoint-url=http://localhost:4566 s3 mb s3://test-bucket
+```
+
+Or directly with:
+
+```
+aws s3 mb s3://test-bucket --endpoint-url=http://localhost:4566
 ```
 
 Run tests


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3379.

# Rationale for this change
 
In the newer version of localstack, we need to change the provider to make sure our tests pass. The new provider is more aligned with the true behavior of S3 than the current default in 1.x of localstack. (See upstream issue).

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
