### PR TITLE
Add parquet-index binary

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -138,6 +138,10 @@ required-features = ["cli"]
 name = "parquet-layout"
 required-features = ["cli"]
 
+[[bin]]
+name = "parquet-index"
+required-features = ["cli"]
+
 [[bench]]
 name = "arrow_writer"
 required-features = ["arrow"]

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Binary that prints the [page index] of a parquet file
+//!
+//! # Install
+//!
+//! `parquet-layout` can be installed using `cargo`:
+//! ```
+//! cargo install parquet --features=cli
+//! ```
+//! After this `parquet-index` should be available:
+//! ```
+//! parquet-index XYZ.parquet COLUMN_NAME
+//! ```
+//!
+//! The binary can also be built from the source code and run as follows:
+//! ```
+//! cargo run --features=cli --bin parquet-index XYZ.parquet COLUMN_NAME
+//!
+//! [page index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+
+use clap::Parser;
+use parquet::errors::{ParquetError, Result};
+use parquet::file::page_index::index::{Index, PageIndex};
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::file::serialized_reader::ReadOptionsBuilder;
+use parquet::format::PageLocation;
+use std::fs::File;
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about("Prints the page index of a parquet file"), long_about = None)]
+struct Args {
+    #[clap(help("Path to a parquet file"))]
+    file: String,
+
+    #[clap(help("Column name to print"))]
+    column: String,
+}
+
+impl Args {
+    fn run(&self) -> Result<()> {
+        let file = File::open(&self.file)?;
+        let options = ReadOptionsBuilder::new().with_page_index().build();
+        let reader = SerializedFileReader::new_with_options(file, options)?;
+
+        let schema = reader.metadata().file_metadata().schema_descr();
+        let column_idx = schema
+            .columns()
+            .iter()
+            .position(|x| x.name() == self.column.as_str())
+            .ok_or_else(|| {
+                ParquetError::General(format!("Failed to find column {}", self.column))
+            })?;
+
+        // Column index data for all row groups and columns
+        let column_index = reader
+            .metadata()
+            .page_indexes()
+            .ok_or_else(|| ParquetError::General("Column index not found".to_string()))?;
+
+        // Offset index data for all row groups and columns
+        let offset_index = reader
+            .metadata()
+            .offset_indexes()
+            .ok_or_else(|| ParquetError::General("Offset index not found".to_string()))?;
+
+        // Iterate through each row group
+        for (row_group_idx, ((column_indices, offset_indices), row_group)) in column_index
+            .iter()
+            .zip(offset_index)
+            .zip(reader.metadata().row_groups())
+            .enumerate()
+        {
+            println!("Row Group: {}", row_group_idx);
+            let offset_index = &offset_indices[column_idx];
+
+            let row_counts = compute_row_counts(offset_index, row_group.num_rows());
+            match &column_indices[column_idx] {
+                Index::NONE => println!("NO INDEX"),
+                Index::BOOLEAN(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::INT32(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::INT64(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::INT96(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::FLOAT(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::DOUBLE(v) => print_index(&v.indexes, offset_index, &row_counts)?,
+                Index::BYTE_ARRAY(_) => println!("BYTE_ARRAY not supported"),
+                Index::FIXED_LEN_BYTE_ARRAY(_) => {
+                    println!("FIXED_LEN_BYTE_ARRAY not supported")
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Computes the number of rows in each page within a column chunk
+fn compute_row_counts(offset_index: &[PageLocation], rows: i64) -> Vec<i64> {
+    if offset_index.is_empty() {
+        return vec![];
+    }
+
+    let mut last = offset_index[0].first_row_index;
+    let mut out = Vec::with_capacity(offset_index.len());
+    for o in offset_index.iter().skip(1) {
+        out.push(o.first_row_index - last);
+        last = o.first_row_index;
+    }
+    out.push(rows);
+    out
+}
+
+/// Prints index information for a single column chunk
+fn print_index<T: std::fmt::Display>(
+    column_index: &[PageIndex<T>],
+    offset_index: &[PageLocation],
+    row_counts: &[i64],
+) -> Result<()> {
+    if column_index.len() != offset_index.len() {
+        return Err(ParquetError::General(format!(
+            "Index length mismatch, got {} and {}",
+            column_index.len(),
+            offset_index.len()
+        )));
+    }
+
+    for (idx, ((c, o), row_count)) in column_index
+        .iter()
+        .zip(offset_index)
+        .zip(row_counts)
+        .enumerate()
+    {
+        print!(
+            "Page {:>5} at offset {:#010x} with length {:>10} and row count {:>10}",
+            idx, o.offset, o.compressed_page_size, row_count
+        );
+        match &c.min {
+            Some(m) => print!(", min {:>10}", m),
+            None => print!(", min {:>10}", "NONE"),
+        }
+
+        match &c.max {
+            Some(m) => print!(", max {:>10}", m),
+            None => print!(", max {:>10}", "NONE"),
+        }
+        println!()
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    Args::parse().run()
+}

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -87,7 +87,12 @@ impl Args {
             .enumerate()
         {
             println!("Row Group: {}", row_group_idx);
-            let offset_index = &offset_indices[column_idx];
+            let offset_index = offset_indices.get(column_idx).ok_or_else(|| {
+                ParquetError::General(format!(
+                    "No offset index for row group {} column chunk {}",
+                    row_group_idx, column_idx
+                ))
+            })?;
 
             let row_counts = compute_row_counts(offset_index, row_group.num_rows());
             match &column_indices[column_idx] {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I recently found myself wanting to debug filter pushdown for a specific parquet file, this file had a page index but did not store statistics inline within the pages (as is perfectly valid). Unfortunately this meant that parquet-tools dump fails to print the statistics, which made debugging this issue complicated.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a parquet-index binary which can be used to dump the page index for a given column of a given file. Longer-term I wonder if we should merge some of these tools together into a single binary, I may write up a ticket.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
