### PR TITLE
Update verify_release.sh to work with 30.0.0 via workaround

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -118,6 +118,11 @@ test_source_distribution() {
 
   (cd arrow && cargo build && cargo test)
   (cd arrow-flight && cargo build && cargo test)
+  # To avoid https://github.com/apache/arrow-rs/issues/3410,
+  # remove path reference from parquet:
+  # object_store = { version = "0.5", path = "../object_store", default-features = false, optional = true }
+  # object_store = { version = "0.5", default-features = false, optional = true }
+  sed -i -e 's/\(^object_store.*\)\(path = ".*", \)/\1/g' parquet/Cargo.toml
   (cd parquet && cargo build && cargo test)
   (cd parquet_derive && cargo build && cargo test)
 


### PR DESCRIPTION
# Which issue does this PR close?
closes https://github.com/apache/arrow-rs/issues/3410

# Rationale for this change
 parquet now has an optional dependence on `object_store` but object_store is not part of the tarball and thus the verify script fails

# What changes are included in this PR?

A hack to the `verify_release` script to fix the verification and remove the `path` marker in the object store dependency declaration

@tustvold  has noted that rather than changing the verify script the actual tarball should probably be fixed (aka so that it does not have references to `path`. I will write up a follow on ticket for this issue

# Are there any user-facing changes?

No