### PR TITLE
Minor: Improve docs for arrow-ipc, remove clippy ignore

### DIFF
--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Support for the Arrow IPC format
-
-// TODO: (vcq): Protobuf codegen is not generating Debug impls.
-#![allow(missing_debug_implementations)]
+//! Support for the [Arrow IPC Format](https://arrow.apache.org/docs/format/IPC.html)
 
 pub mod convert;
 pub mod reader;

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Support for the [Arrow IPC Format](https://arrow.apache.org/docs/format/IPC.html)
+//! Support for the [Arrow IPC Format]
+//!
+//! [Arrow IPC Format]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
 
 pub mod convert;
 pub mod reader;

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -138,7 +138,7 @@ impl Default for IpcWriteOptions {
 
 #[derive(Debug, Default)]
 /// Handles low level details of encoding [`Array`] and [`Schema`] into the
-/// [Arrow IPC Format](https://arrow.apache.org/docs/format/IPC.html)
+/// [Arrow IPC Format].
 ///
 /// # Example:
 /// ```
@@ -165,6 +165,10 @@ impl Default for IpcWriteOptions {
 ///   .encoded_batch(&batch, &mut dictionary_tracker, &options)
 ///   .unwrap();
 /// # }
+/// ```
+///
+/// [Arrow IPC Format]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
+
 pub struct IpcDataGenerator {}
 
 impl IpcDataGenerator {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -137,8 +137,8 @@ impl Default for IpcWriteOptions {
 }
 
 #[derive(Debug, Default)]
-/// Handles low level details of encoding [`Array`] and [`Schema`] into the Arrow IPC
-/// format. [TODO get doc link for IPC Format]
+/// Handles low level details of encoding [`Array`] and [`Schema`] into the
+/// [Arrow IPC Format](https://arrow.apache.org/docs/format/IPC.html)
 ///
 /// # Example:
 /// ```

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -137,6 +137,34 @@ impl Default for IpcWriteOptions {
 }
 
 #[derive(Debug, Default)]
+/// Handles low level details of encoding [`Array`] and [`Schema`] into the Arrow IPC
+/// format. [TODO get doc link for IPC Format]
+///
+/// # Example:
+/// ```
+/// # fn run() {
+/// # use std::sync::Arc;
+/// # use arrow_array::UInt64Array;
+/// # use arrow_array::RecordBatch;
+/// # use arrow_ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
+///
+/// // Create a record batch
+/// let batch = RecordBatch::try_from_iter(vec![
+///  ("col2", Arc::new(UInt64Array::from_iter([10, 23, 33])) as _)
+/// ]).unwrap();
+///
+/// // Error of dictionary ids are replaced.
+/// let error_on_replacement = true;
+/// let options = IpcWriteOptions::default();
+/// let mut dictionary_tracker = DictionaryTracker::new(error_on_replacement);
+///
+/// // encode the batch into zero or more encoded dictionaries
+/// // and the data for the actual array.
+/// let data_gen = IpcDataGenerator {};
+/// let (encoded_dictionaries, encoded_message) = data_gen
+///   .encoded_batch(&batch, &mut dictionary_tracker, &options)
+///   .unwrap();
+/// # }
 pub struct IpcDataGenerator {}
 
 impl IpcDataGenerator {


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
A deprecation warning says to use `IpcDataGenerator` but then there are no docstrings for that generator

# What changes are included in this PR?

1. Add a doc example for `IpcDataGenerator` 
2. Update the module docs with a link
3. Remove an uneeded clippy lint

# Are there any user-facing changes?

Better docs