### PR TITLE
Derive Clone for the object-store builders

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -358,7 +358,7 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
 ///  .with_secret_access_key(SECRET_KEY)
 ///  .build();
 /// ```
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AmazonS3Builder {
     access_key_id: Option<String>,
     secret_access_key: Option<String>,

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -354,7 +354,7 @@ impl CloudMultiPartUploadImpl for AzureMultiPartUpload {
 ///  .with_container_name(BUCKET_NAME)
 ///  .build();
 /// ```
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MicrosoftAzureBuilder {
     account_name: Option<String>,
     access_key: Option<String>,

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -246,7 +246,7 @@ impl std::fmt::Display for GoogleCloudStorage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct GoogleCloudStorageClient {
     client: Client,
     base_url: String,

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -210,7 +210,7 @@ impl ObjectStore for HttpStore {
 }
 
 /// Configure a connection to a generic HTTP server
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct HttpBuilder {
     url: Option<Result<Url>>,
     client_options: ClientOptions,


### PR DESCRIPTION
Add Clone to the existing derive list for the Builder structs in
object-store. This allows them to be defined once by the user and
passed to various parts of the code as-needed.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3419.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No user-facing changes.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
