### PR TITLE
Minor: run clippy on `arrow-integration-testing`

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -208,5 +208,9 @@ jobs:
         run: cargo clippy -p arrow-arith --all-targets --features dyn_arith_dict -- -D warnings
       - name: Clippy arrow-row with all features
         run: cargo clippy -p arrow-row --all-targets --all-features -- -D warnings
+      - name: Clippy arrow-integration-test with all features
+        run: cargo clippy -p arrow-integration-test --all-targets --all-features -- -D warnings
+      - name: Clippy arrow-integration-testing with all features
+        run: cargo clippy -p arrow-integration-testing --all-targets --all-features -- -D warnings
       - name: Clippy arrow with all features except SIMD
         run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,dyn_cmp_dict,dyn_arith_dict,chrono-tz --all-targets -- -D warnings


### PR DESCRIPTION
# Which issue does this PR close?

N/a

# Rationale for this change
I see this warning a bunch locally:

```
error: use of deprecated function `arrow_flight::utils::flight_data_from_arrow_batch`: Use IpcDataGenerator directly with DictionaryTracker to avoid re-sending dictionaries
   --> arrow-integration-testing/src/flight_client_scenarios/integration_test.rs:134:30
    |
134 |         arrow_flight::utils::flight_data_from_arrow_batch(batch, options);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

error: use of deprecated function `arrow_flight::utils::flight_data_from_arrow_batch`: Use IpcDataGenerator directly with DictionaryTracker to avoid re-sending dictionaries
   --> arrow-integration-testing/src/flight_server_scenarios/integration_test.rs:125:42
    |
125 |                     arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

# What changes are included in this PR?
1. Run clippy on integration testing crates
2. Fix clippy errors found by 1.

# Are there any user-facing changes?
No