### PR TITLE
Implement serde serializers and deserializers for the builders

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -362,7 +362,7 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
 ///  .with_secret_access_key(SECRET_KEY)
 ///  .build();
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AmazonS3Builder {
     access_key_id: Option<String>,
     secret_access_key: Option<String>,

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -357,7 +357,7 @@ impl CloudMultiPartUploadImpl for AzureMultiPartUpload {
 ///  .with_container_name(BUCKET_NAME)
 ///  .build();
 /// ```
-#[derive(Default, Clone)]
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MicrosoftAzureBuilder {
     account_name: Option<String>,
     access_key: Option<String>,

--- a/object_store/src/client/backoff.rs
+++ b/object_store/src/client/backoff.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 ///
 /// See <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
 #[allow(missing_copy_implementations)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct BackoffConfig {
     /// The initial backoff duration
     pub init_backoff: Duration,

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -273,7 +273,6 @@ impl ClientOptions {
 mod tests {
     use super::*;
     use hyper::header::InvalidHeaderValue;
-    use serde_json;
 
     /// Errors that can show up during testing.
     #[derive(Debug)]
@@ -284,13 +283,13 @@ mod tests {
 
     impl From<serde_json::Error> for TestError {
         fn from(value: serde_json::Error) -> Self {
-            TestError::Json(value)
+            Self::Json(value)
         }
     }
 
     impl From<InvalidHeaderValue> for TestError {
         fn from(_value: InvalidHeaderValue) -> Self {
-            TestError::Message("invalid header value".into())
+            Self::Message("invalid header value".into())
         }
     }
 

--- a/object_store/src/client/reqwest_serde.rs
+++ b/object_store/src/client/reqwest_serde.rs
@@ -17,7 +17,7 @@
 
 /// Implement serialization for the structs re-exported from the http crate: HeaderValue and HeaderMap.
 /// Some of the code here is copied from the crate http_serde, depending on that crate creates a sync between the two serde versions.
-/// https://gitlab.com/kornelski/http-serde/-/blob/master/src/lib.rs
+/// <https://gitlab.com/kornelski/http-serde/-/blob/master/src/lib.rs>
 
 pub mod header_value {
     use reqwest::header::HeaderValue;

--- a/object_store/src/client/reqwest_serde.rs
+++ b/object_store/src/client/reqwest_serde.rs
@@ -1,0 +1,321 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Implement serialization for the structs re-exported from the http crate: HeaderValue and HeaderMap.
+/// Some of the code here is copied from the crate http_serde, depending on that crate creates a sync between the two serde versions.
+/// https://gitlab.com/kornelski/http-serde/-/blob/master/src/lib.rs
+
+pub mod header_value {
+    use reqwest::header::HeaderValue;
+    use serde::de;
+    use serde::{de::Visitor, Deserializer, Serialize, Serializer};
+    use std::fmt;
+
+    struct SHeaderValue<'a>(&'a HeaderValue);
+
+    impl<'a> Serialize for SHeaderValue<'a> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer
+                .serialize_newtype_struct("SHeaderValue in serializer", self.0.as_bytes())
+        }
+    }
+
+    pub fn serialize<S: Serializer>(
+        value: &HeaderValue,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        SHeaderValue(value).serialize(ser)
+    }
+
+    struct HeaderValueVisitor;
+
+    impl<'de> Visitor<'de> for HeaderValueVisitor {
+        type Value = HeaderValue;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("SHeaderValue in deserializer")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut buffer = Vec::with_capacity(seq.size_hint().unwrap_or(100));
+            loop {
+                let b: Option<u8> = seq.next_element()?;
+                match b {
+                    Some(b) => buffer.push(b),
+                    None => break,
+                }
+            }
+            HeaderValue::from_bytes(&buffer[..]).map_err(de::Error::custom)
+        }
+
+        fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_bytes(self)
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<HeaderValue, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_newtype_struct("SHeaderValue", HeaderValueVisitor)
+    }
+}
+
+pub mod option_header_value {
+    use super::header_value;
+    use reqwest::header::HeaderValue;
+    use serde::{de::Visitor, Deserializer, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<HeaderValue>,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(inner) => super::header_value::serialize(inner, ser),
+            None => ser.serialize_none(),
+        }
+    }
+
+    struct HeaderValueVisitor;
+
+    impl<'de> Visitor<'de> for HeaderValueVisitor {
+        type Value = Option<HeaderValue>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Option HeaderValue")
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Ok(Some(header_value::deserialize(deserializer)?))
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Option<HeaderValue>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_option(HeaderValueVisitor)
+    }
+}
+
+/// For `http::HeaderMap`, this is adapted from the http_serde crate.
+///
+/// `#[serde(with = "http_serde::header_map")]`
+pub mod header_map {
+    use reqwest::header::{GetAll, HeaderName};
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use serde::de;
+    use serde::de::{Deserializer, MapAccess, Unexpected, Visitor};
+    use serde::ser::SerializeSeq;
+    use serde::{Serialize, Serializer};
+    use std::borrow::Cow;
+    use std::fmt;
+
+    struct ToSeq<'a>(GetAll<'a, HeaderValue>);
+
+    impl<'a> Serialize for ToSeq<'a> {
+        fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            let count = self.0.iter().count();
+            if ser.is_human_readable() {
+                if count == 1 {
+                    if let Some(v) = self.0.iter().next() {
+                        if let Ok(s) = v.to_str() {
+                            return ser.serialize_str(s);
+                        }
+                    }
+                }
+                ser.collect_seq(self.0.iter().filter_map(|v| v.to_str().ok()))
+            } else {
+                let mut seq = ser.serialize_seq(Some(count))?;
+                for v in self.0.iter() {
+                    seq.serialize_element(v.as_bytes())?;
+                }
+                seq.end()
+            }
+        }
+    }
+
+    /// Implementation detail. Use derive annotations instead.
+    pub fn serialize<S: Serializer>(
+        headers: &HeaderMap,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        ser.collect_map(
+            headers
+                .keys()
+                .map(|k| (k.as_str(), ToSeq(headers.get_all(k)))),
+        )
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMore<'a> {
+        One(Cow<'a, str>),
+        Strings(Vec<Cow<'a, str>>),
+        Bytes(Vec<Cow<'a, [u8]>>),
+    }
+
+    struct HeaderMapVisitor {
+        is_human_readable: bool,
+    }
+
+    impl<'de> Visitor<'de> for HeaderMapVisitor {
+        type Value = HeaderMap;
+
+        // Format a message stating what data this Visitor expects to receive.
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("lots of things can go wrong with HeaderMap")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = HeaderMap::with_capacity(access.size_hint().unwrap_or(0));
+
+            if !self.is_human_readable {
+                while let Some((key, arr)) =
+                    access.next_entry::<Cow<'_, str>, Vec<Cow<'_, [u8]>>>()?
+                {
+                    let key = HeaderName::from_bytes(key.as_bytes()).map_err(|_| {
+                        de::Error::invalid_value(Unexpected::Str(&key), &self)
+                    })?;
+                    for val in arr {
+                        let val = HeaderValue::from_bytes(&val).map_err(|_| {
+                            de::Error::invalid_value(Unexpected::Bytes(&val), &self)
+                        })?;
+                        map.append(&key, val);
+                    }
+                }
+            } else {
+                while let Some((key, val)) =
+                    access.next_entry::<Cow<'_, str>, OneOrMore<'_>>()?
+                {
+                    let key = HeaderName::from_bytes(key.as_bytes()).map_err(|_| {
+                        de::Error::invalid_value(Unexpected::Str(&key), &self)
+                    })?;
+                    match val {
+                        OneOrMore::One(val) => {
+                            let val = val.parse().map_err(|_| {
+                                de::Error::invalid_value(Unexpected::Str(&val), &self)
+                            })?;
+                            map.insert(key, val);
+                        }
+                        OneOrMore::Strings(arr) => {
+                            for val in arr {
+                                let val = val.parse().map_err(|_| {
+                                    de::Error::invalid_value(Unexpected::Str(&val), &self)
+                                })?;
+                                map.append(&key, val);
+                            }
+                        }
+                        OneOrMore::Bytes(arr) => {
+                            for val in arr {
+                                let val =
+                                    HeaderValue::from_bytes(&val).map_err(|_| {
+                                        de::Error::invalid_value(
+                                            Unexpected::Bytes(&val),
+                                            &self,
+                                        )
+                                    })?;
+                                map.append(&key, val);
+                            }
+                        }
+                    };
+                }
+            }
+            Ok(map)
+        }
+    }
+
+    /// Implementation detail.
+    pub fn deserialize<'de, D>(de: D) -> Result<HeaderMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let is_human_readable = de.is_human_readable();
+        de.deserialize_map(HeaderMapVisitor { is_human_readable })
+    }
+}
+
+pub mod option_header_map {
+    use super::header_map;
+    use reqwest::header::HeaderMap;
+    use serde::{de::Visitor, Deserializer, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<HeaderMap>,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(inner) => header_map::serialize(inner, ser),
+            None => ser.serialize_none(),
+        }
+    }
+
+    struct HeaderMapVisitor;
+
+    impl<'de> Visitor<'de> for HeaderMapVisitor {
+        type Value = Option<HeaderMap>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("Option HeaderMap")
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Ok(Some(header_map::deserialize(deserializer)?))
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
+    }
+
+    pub fn deserialize<'de, D>(de: D) -> Result<Option<HeaderMap>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        de.deserialize_option(HeaderMapVisitor)
+    }
+}

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -87,7 +87,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// By default they will be retried up to some limit, using exponential
 /// backoff with jitter. See [`BackoffConfig`] for more information
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RetryConfig {
     /// The backoff configuration
     pub backoff: BackoffConfig,

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -787,7 +787,7 @@ fn reader_credentials_file(
 ///  .with_bucket_name(BUCKET_NAME)
 ///  .build();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GoogleCloudStorageBuilder {
     bucket_name: Option<String>,
     url: Option<String>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3419 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

When integrating the `object-store` crate in other libraries it is desirable to propagate configuration settings from the top level to different layers/threads in the app. At least `polars` relies on serde in some use cases.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Derive serde Serializers and Deserializers when appropriate. Manually implement them for types re-exported from the `http` crate.

# Are there any user-facing changes?

No API changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
