### PR TITLE
object_store: builder configuration api

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -44,7 +44,6 @@ walkdir = "2"
 
 # Cloud storage support
 base64 = { version = "0.20", default-features = false, features = ["std"], optional = true }
-once_cell = { version = "1.12.0", optional = true }
 quick-xml = { version = "0.27.0", features = ["serialize"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
@@ -58,7 +57,7 @@ aws-types = { version = "0.52", optional = true }
 aws-config = { version = "0.52", optional = true }
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "once_cell"]
+cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -44,6 +44,7 @@ walkdir = "2"
 
 # Cloud storage support
 base64 = { version = "0.20", default-features = false, features = ["std"], optional = true }
+once_cell = { version = "1.12.0", optional = true }
 quick-xml = { version = "0.27.0", features = ["serialize"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
@@ -57,7 +58,7 @@ aws-types = { version = "0.52", optional = true }
 aws-config = { version = "0.52", optional = true }
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
+cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "once_cell"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -521,19 +521,6 @@ pub enum AmazonS3ConfigKey {
     Profile,
 }
 
-impl AmazonS3ConfigKey {
-    /// Helper function to filter an iterator to only contain valid configuration keys.
-    pub fn filter_options<
-        I: IntoIterator<Item = (impl AsRef<str>, impl Into<String>)>,
-    >(
-        options: I,
-    ) -> impl IntoIterator<Item = (impl AsRef<str>, impl Into<String>)> {
-        options
-            .into_iter()
-            .filter_map(|(key, value)| Some((Self::from_str(key.as_ref()).ok()?, value)))
-    }
-}
-
 impl AsRef<str> for AmazonS3ConfigKey {
     fn as_ref(&self) -> &str {
         match self {
@@ -1220,9 +1207,6 @@ mod tests {
 
         let builder = AmazonS3Builder::new().try_with_options(&options);
         assert!(builder.is_err());
-        let builder = AmazonS3Builder::new()
-            .try_with_options(AmazonS3ConfigKey::filter_options(&options));
-        assert!(builder.is_ok());
     }
 
     #[tokio::test]

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -1109,10 +1109,7 @@ mod tests {
         let aws_session_token = "object_store:fake_session_token".to_string();
         let options = HashMap::from([
             ("aws_access_key_id".to_string(), aws_access_key_id.clone()),
-            (
-                "aws_secret_access_key".to_string(),
-                aws_secret_access_key.clone(),
-            ),
+            ("aws_secret_access_key".to_string(), aws_secret_access_key),
             ("aws_default_region".to_string(), aws_default_region.clone()),
             ("aws_endpoint".to_string(), aws_endpoint.clone()),
             ("aws_session_token".to_string(), aws_session_token.clone()),

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -392,8 +392,8 @@ pub struct AmazonS3Builder {
 
 /// Configuration keys for [`AmazonS3Builder`]
 ///
-/// Configuration via keys can be dome via the [`with_option`](AmazonS3Builder::with_option)
-/// or [`with_options`](AmazonS3Builder::with_options) methods on the builder.
+/// Configuration via keys can be dome via the [`try_with_option`](AmazonS3Builder::try_with_option)
+/// or [`with_options`](AmazonS3Builder::try_with_options) methods on the builder.
 ///
 /// # Example
 /// ```
@@ -408,9 +408,12 @@ pub struct AmazonS3Builder {
 ///     (AmazonS3ConfigKey::DefaultRegion, "my-default-region"),
 /// ];
 /// let azure = AmazonS3Builder::new()
-///     .with_options(options)
-///     .with_options(typed_options)
-///     .with_option(AmazonS3ConfigKey::Region, "my-region");
+///     .try_with_options(options)
+///     .unwrap()
+///     .try_with_options(typed_options)
+///     .unwrap()
+///     .try_with_option(AmazonS3ConfigKey::Region, "my-region")
+///     .unwrap();
 /// ```
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Copy, Serialize, Deserialize)]
 pub enum AmazonS3ConfigKey {

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -394,8 +394,8 @@ pub struct MicrosoftAzureBuilder {
 
 /// Configuration keys for [`MicrosoftAzureBuilder`]
 ///
-/// Configuration via keys can be dome via the [`with_option`](MicrosoftAzureBuilder::with_option)
-/// or [`with_options`](MicrosoftAzureBuilder::with_options) methods on the builder.
+/// Configuration via keys can be dome via the [`try_with_option`](MicrosoftAzureBuilder::try_with_option)
+/// or [`with_options`](MicrosoftAzureBuilder::try_with_options) methods on the builder.
 ///
 /// # Example
 /// ```
@@ -410,9 +410,12 @@ pub struct MicrosoftAzureBuilder {
 ///     (AzureConfigKey::AccountName, "my-account-name"),
 /// ];
 /// let azure = MicrosoftAzureBuilder::new()
-///     .with_options(options)
-///     .with_options(typed_options)
-///     .with_option(AzureConfigKey::AuthorityId, "my-tenant-id");
+///     .try_with_options(options)
+///     .unwrap()
+///     .try_with_options(typed_options)
+///     .unwrap()
+///     .try_with_option(AzureConfigKey::AuthorityId, "my-tenant-id")
+///     .unwrap();
 /// ```
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Copy, Deserialize, Serialize)]
 pub enum AzureConfigKey {

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -1054,20 +1054,17 @@ mod tests {
 
     #[test]
     fn azure_test_config_from_map() {
-        let azure_client_id = "object_store:fake_access_key_id".to_string();
-        let azure_storage_account_name = "object_store:fake_secret_key".to_string();
-        let azure_storage_token = "object_store:fake_default_region".to_string();
+        let azure_client_id = "object_store:fake_access_key_id";
+        let azure_storage_account_name = "object_store:fake_secret_key";
+        let azure_storage_token = "object_store:fake_default_region";
         let options = HashMap::from([
-            ("azure_client_id", azure_client_id.clone()),
-            (
-                "azure_storage_account_name",
-                azure_storage_account_name.clone(),
-            ),
-            ("azure_storage_token", azure_storage_token.clone()),
+            ("azure_client_id", azure_client_id),
+            ("azure_storage_account_name", azure_storage_account_name),
+            ("azure_storage_token", azure_storage_token),
         ]);
 
         let builder = MicrosoftAzureBuilder::new()
-            .try_with_options(&options)
+            .try_with_options(options)
             .unwrap();
         assert_eq!(builder.client_id.unwrap(), azure_client_id);
         assert_eq!(builder.account_name.unwrap(), azure_storage_account_name);
@@ -1107,5 +1104,23 @@ mod tests {
 
         let builder = MicrosoftAzureBuilder::new().try_with_options(&options);
         assert!(builder.is_err());
+    }
+
+    #[test]
+    fn azure_test_split_sas() {
+        let raw_sas = "?sv=2021-10-04&st=2023-01-04T17%3A48%3A57Z&se=2023-01-04T18%3A15%3A00Z&sr=c&sp=rcwl&sig=C7%2BZeEOWbrxPA3R0Cw%2Fw1EZz0%2B4KBvQexeKZKe%2BB6h0%3D";
+        let expected = vec![
+            ("sv".to_string(), "2021-10-04".to_string()),
+            ("st".to_string(), "2023-01-04T17:48:57Z".to_string()),
+            ("se".to_string(), "2023-01-04T18:15:00Z".to_string()),
+            ("sr".to_string(), "c".to_string()),
+            ("sp".to_string(), "rcwl".to_string()),
+            (
+                "sig".to_string(),
+                "C7+ZeEOWbrxPA3R0Cw/w1EZz0+4KBvQexeKZKe+B6h0=".to_string(),
+            ),
+        ];
+        let pairs = split_sas(raw_sas).unwrap();
+        assert_eq!(expected, pairs);
     }
 }

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -493,19 +493,6 @@ pub enum AzureConfigKey {
     UseEmulator,
 }
 
-impl AzureConfigKey {
-    /// Helper function to filter an iterator to only contain valid configuration keys.
-    pub fn filter_options<
-        I: IntoIterator<Item = (impl AsRef<str>, impl Into<String>)>,
-    >(
-        options: I,
-    ) -> impl IntoIterator<Item = (impl AsRef<str>, impl Into<String>)> {
-        options
-            .into_iter()
-            .filter_map(|(key, value)| Some((Self::from_str(key.as_ref()).ok()?, value)))
-    }
-}
-
 impl AsRef<str> for AzureConfigKey {
     fn as_ref(&self) -> &str {
         match self {
@@ -1120,8 +1107,5 @@ mod tests {
 
         let builder = MicrosoftAzureBuilder::new().try_with_options(&options);
         assert!(builder.is_err());
-        let builder = MicrosoftAzureBuilder::new()
-            .try_with_options(AzureConfigKey::filter_options(&options));
-        assert!(builder.is_ok());
     }
 }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -808,7 +808,7 @@ enum GoogleConfigKey {
 
     /// Bucket name
     ///
-    /// See [`AmazonS3Builder::with_bucket_name`] for details.
+    /// See [`GoogleCloudStorageBuilder::with_bucket_name`] for details.
     ///
     /// Supported keys:
     /// - `google_bucket`

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -806,8 +806,8 @@ pub struct GoogleCloudStorageBuilder {
 
 /// Configuration keys for [`GoogleCloudStorageBuilder`]
 ///
-/// Configuration via keys can be dome via the [`with_option`](GoogleCloudStorageBuilder::with_option)
-/// or [`with_options`](GoogleCloudStorageBuilder::with_options) methods on the builder.
+/// Configuration via keys can be dome via the [`try_with_option`](GoogleCloudStorageBuilder::try_with_option)
+/// or [`with_options`](GoogleCloudStorageBuilder::try_with_options) methods on the builder.
 ///
 /// # Example
 /// ```
@@ -821,9 +821,12 @@ pub struct GoogleCloudStorageBuilder {
 ///     (GoogleConfigKey::Bucket, "my-bucket"),
 /// ];
 /// let azure = GoogleCloudStorageBuilder::new()
-///     .with_options(options)
-///     .with_options(typed_options)
-///     .with_option(GoogleConfigKey::Bucket, "my-new-bucket");
+///     .try_with_options(options)
+///     .unwrap()
+///     .try_with_options(typed_options)
+///     .unwrap()
+///     .try_with_option(GoogleConfigKey::Bucket, "my-new-bucket")
+///     .unwrap();
 /// ```
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Copy, Serialize, Deserialize)]
 pub enum GoogleConfigKey {

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -849,19 +849,6 @@ pub enum GoogleConfigKey {
     Bucket,
 }
 
-impl GoogleConfigKey {
-    /// Helper function to filter an iterator to only contain valid configuration keys.
-    pub fn filter_options<
-        I: IntoIterator<Item = (impl AsRef<str>, impl Into<String>)>,
-    >(
-        options: I,
-    ) -> impl IntoIterator<Item = (impl AsRef<str>, impl Into<String>)> {
-        options
-            .into_iter()
-            .filter_map(|(key, value)| Some((Self::from_str(key.as_ref()).ok()?, value)))
-    }
-}
-
 impl AsRef<str> for GoogleConfigKey {
     fn as_ref(&self) -> &str {
         match self {
@@ -1383,8 +1370,5 @@ mod test {
 
         let builder = GoogleCloudStorageBuilder::new().try_with_options(&options);
         assert!(builder.is_err());
-        let builder = GoogleCloudStorageBuilder::new()
-            .try_with_options(GoogleConfigKey::filter_options(&options));
-        assert!(builder.is_ok());
     }
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -555,6 +555,13 @@ pub enum Error {
 
     #[snafu(display("Operation not yet implemented."))]
     NotImplemented,
+
+    #[snafu(display(
+        "Configuration key: '{}' is not valid for store '{}'.",
+        key,
+        store
+    ))]
+    UnknownConfigurationKey { store: &'static str, key: String },
 }
 
 impl From<Error> for std::io::Error {

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -185,6 +185,15 @@ fn merge_ranges(
     ret
 }
 
+#[allow(dead_code)]
+pub(crate) fn str_is_truthy(val: &str) -> bool {
+    val == "1"
+        || val.to_lowercase() == "true"
+        || val.to_lowercase() == "on"
+        || val.to_lowercase() == "yes"
+        || val.to_lowercase() == "y"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -187,11 +187,11 @@ fn merge_ranges(
 
 #[allow(dead_code)]
 pub(crate) fn str_is_truthy(val: &str) -> bool {
-    val == "1"
-        || val.to_lowercase() == "true"
-        || val.to_lowercase() == "on"
-        || val.to_lowercase() == "yes"
-        || val.to_lowercase() == "y"
+    val.eq_ignore_ascii_case("1")
+        | val.eq_ignore_ascii_case("true")
+        | val.eq_ignore_ascii_case("on")
+        | val.eq_ignore_ascii_case("yes")
+        | val.eq_ignore_ascii_case("y")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/3419.

# Rationale for this change
 
See discussion in  #3429

# What changes are included in this PR?

This is just a quick draft based on some previous work in other crates, to get some feedback on the API. As an example I implemented a proposal for the azure builder, since one issue is most prominent with azure. Specifically, for azure there are many different commonly used keys vor configuration options and environment variables. Thus the implementation includes some handling for aliases. While I do see the need for this to be handled, I am unsure if this shuld be the responsibility of this crate.

Any feedback is great appreciated - @tustvold @crepererum @winding-lines 

# Are there any user-facing changes?

yes, a new way to provide configuration to object sore builders.
