### PR TITLE
Improve arrow flight batch splitting and naming

### DIFF
--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -131,7 +131,7 @@ async fn test_max_message_size() {
     let input_batch_stream = futures::stream::iter(vec![Ok(make_primative_batch(5))]);
 
     // 5 input rows, with a very small limit should result in 5 batch messages
-    let encoder = FlightDataEncoderBuilder::default().with_max_message_size(1);
+    let encoder = FlightDataEncoderBuilder::default().with_max_message_size_bytes(1);
 
     let encode_stream = encoder.build(input_batch_stream);
 
@@ -164,9 +164,9 @@ async fn test_max_message_size_fuzz() {
         make_primative_batch(127),
     ];
 
-    for max_message_size in [10, 1024, 2048, 6400, 3211212] {
-        let encoder =
-            FlightDataEncoderBuilder::default().with_max_message_size(max_message_size);
+    for max_message_size_bytes in [10, 1024, 2048, 6400, 3211212] {
+        let encoder = FlightDataEncoderBuilder::default()
+            .with_max_message_size_bytes(max_message_size_bytes);
 
         let input_batch_stream = futures::stream::iter(input.clone()).map(Ok);
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -131,7 +131,7 @@ async fn test_max_message_size() {
     let input_batch_stream = futures::stream::iter(vec![Ok(make_primative_batch(5))]);
 
     // 5 input rows, with a very small limit should result in 5 batch messages
-    let encoder = FlightDataEncoderBuilder::default().with_max_message_size_bytes(1);
+    let encoder = FlightDataEncoderBuilder::default().with_max_flight_data_size(1);
 
     let encode_stream = encoder.build(input_batch_stream);
 
@@ -166,7 +166,7 @@ async fn test_max_message_size_fuzz() {
 
     for max_message_size_bytes in [10, 1024, 2048, 6400, 3211212] {
         let encoder = FlightDataEncoderBuilder::default()
-            .with_max_message_size_bytes(max_message_size_bytes);
+            .with_max_flight_data_size(max_message_size_bytes);
 
         let input_batch_stream = futures::stream::iter(input.clone()).map(Ok);
 


### PR DESCRIPTION
# Which issue does this PR close?

re #3371 

# Rationale for this change
 
I wrote some tests for this code in  https://github.com/influxdata/influxdb_iox/pull/6484 (actually covers a bug I fixed when upstreaming to arrow-rs)

Also, it would be nice to clarify that the units are in bytes and not some other unit (like rows, for example) as suggested by @carols10cents on https://github.com/influxdata/influxdb_iox/pull/6460

# What changes are included in this PR?

1. Add more tests for record batch splitting
2. Change name of parameter from `max_message_size` to `max_message_size_bytes`

# Are there any user-facing changes?

No : Note that this code has not been released yet, so there are no external API changes.

