### PR TITLE
feat: `column_name` based index access for `RecordBatch` and `StructArray`

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -291,11 +291,9 @@ impl RecordBatch {
 
     /// Get a reference to a column's array by name.
     pub fn column_by_name(&self, name: &str) -> Option<&ArrayRef> {
-        if let Some((index, _)) = self.schema().column_with_name(name) {
-            Some(&self.columns[index])
-        } else {
-            None
-        }
+        self.schema()
+            .column_with_name(name)
+            .map(|(index, _)| &self.columns[index])
     }
 
     /// Get a reference to all columns in the record batch.


### PR DESCRIPTION
# Which issue does this PR close?

Part of #3448 

# What changes are included in this PR?
The `column_name` based access is added for `RecordBatch` and `StructArray`

# Are there any user-facing changes?
Yes, users will get new ways to access columns in `RecordBatch` and `StructArray`.


