### PR TITLE
Add tests for `FlightClient::{list_flights, list_actions, do_action, get_schema}`

### DIFF
--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -454,6 +454,13 @@ impl Action {
     }
 }
 
+impl Result {
+    /// Create a new Result with the specified body
+    pub fn new(body: impl Into<Bytes>) -> Self {
+        Self { body: body.into() }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION


# Which issue does this PR close?

re https://github.com/apache/arrow-rs/issues/3371

# Rationale for this change

Somehow these tests were not included in https://github.com/apache/arrow-rs/pull/3402 when I was in rebase fun land.

# What changes are included in this PR?
Add tests for `FlightClient::{list_flights, list_actions, do_action, get_schema}`

# Are there any user-facing changes?
Add a constructor to `arrow_flight::Result`