### PR TITLE
Preserve empty list array elements in take kernel

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1680,7 +1680,7 @@ mod tests {
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
-                .null_bit_buffer(Some(Buffer::from([0b01111101])))
+                .null_bit_buffer(Some(Buffer::from([0b11111011])))
                 .add_child_data(value_data)
                 .build()
                 .unwrap();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -691,26 +691,10 @@ where
 {
     // TODO: Some optimizations can be done here such as if it is
     // taking the whole list or a contiguous sublist
-    let (list_indices, offsets) =
+    let (list_indices, offsets, null_buf) =
         take_value_indices_from_list::<IndexType, OffsetType>(values, indices)?;
 
     let taken = take_impl::<OffsetType>(values.values().as_ref(), &list_indices, None)?;
-    // determine null count and null buffer, which are a function of `values` and `indices`
-    let mut null_count = 0;
-    let num_bytes = bit_util::ceil(indices.len(), 8);
-    let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-    {
-        let null_slice = null_buf.as_slice_mut();
-        offsets[..].windows(2).enumerate().for_each(
-            |(i, window): (usize, &[OffsetType::Native])| {
-                if window[0] == window[1] {
-                    // offsets are equal, slot is null
-                    bit_util::unset_bit(null_slice, i);
-                    null_count += 1;
-                }
-            },
-        );
-    }
     let value_offsets = Buffer::from_slice_ref(&offsets);
     // create a new list with taken data and computed null information
     let list_data = ArrayDataBuilder::new(values.data_type().clone())
@@ -834,7 +818,14 @@ where
 fn take_value_indices_from_list<IndexType, OffsetType>(
     list: &GenericListArray<OffsetType::Native>,
     indices: &PrimitiveArray<IndexType>,
-) -> Result<(PrimitiveArray<OffsetType>, Vec<OffsetType::Native>), ArrowError>
+) -> Result<
+    (
+        PrimitiveArray<OffsetType>,
+        Vec<OffsetType::Native>,
+        MutableBuffer,
+    ),
+    ArrowError,
+>
 where
     IndexType: ArrowPrimitiveType,
     IndexType::Native: ToPrimitive,
@@ -850,6 +841,12 @@ where
     let mut current_offset = OffsetType::Native::zero();
     // add first offset
     new_offsets.push(OffsetType::Native::zero());
+
+    // Initialize null buffer
+    let num_bytes = bit_util::ceil(indices.len(), 8);
+    let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
+    let null_slice = null_buf.as_slice_mut();
+
     // compute the value indices, and set offsets accordingly
     for i in 0..indices.len() {
         if indices.is_valid(i) {
@@ -868,12 +865,20 @@ where
                 values.push(Some(curr));
                 curr += num::One::one();
             }
+            if !list.is_valid(ix) {
+                bit_util::unset_bit(null_slice, i);
+            }
         } else {
+            bit_util::unset_bit(null_slice, i);
             new_offsets.push(current_offset);
         }
     }
 
-    Ok((PrimitiveArray::<OffsetType>::from(values), new_offsets))
+    Ok((
+        PrimitiveArray::<OffsetType>::from(values),
+        new_offsets,
+        null_buf,
+    ))
 }
 
 /// Takes/filters a fixed size list array's inner data using the offsets of the list array.
@@ -2055,10 +2060,12 @@ mod tests {
         ]);
         let indices = UInt32Array::from(vec![2, 0]);
 
-        let (indexed, offsets) = take_value_indices_from_list(&list, &indices).unwrap();
+        let (indexed, offsets, null_buf) =
+            take_value_indices_from_list(&list, &indices).unwrap();
 
         assert_eq!(indexed, Int32Array::from(vec![5, 6, 7, 8, 9, 0, 1]));
         assert_eq!(offsets, vec![0, 5, 7]);
+        assert_eq!(null_buf.as_slice(), &[0b11111111]);
     }
 
     #[test]
@@ -2070,11 +2077,12 @@ mod tests {
         ]);
         let indices = UInt32Array::from(vec![2, 0]);
 
-        let (indexed, offsets) =
+        let (indexed, offsets, null_buf) =
             take_value_indices_from_list::<_, Int64Type>(&list, &indices).unwrap();
 
         assert_eq!(indexed, Int64Array::from(vec![5, 6, 7, 8, 9, 0, 1]));
         assert_eq!(offsets, vec![0, 5, 7]);
+        assert_eq!(null_buf.as_slice(), &[0b11111111]);
     }
 
     #[test]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1607,7 +1607,7 @@ mod tests {
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
-                .null_bit_buffer(Some(Buffer::from([0b10111101, 0b00000000])))
+                .null_bit_buffer(Some(Buffer::from([0b11111111])))
                 .add_child_data(value_data)
                 .build()
                 .unwrap();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -695,7 +695,7 @@ where
         take_value_indices_from_list::<IndexType, OffsetType>(values, indices)?;
 
     let taken = take_impl::<OffsetType>(values.values().as_ref(), &list_indices, None)?;
-    let value_offsets = Buffer::from_slice_ref(&offsets);
+    let value_offsets = Buffer::from_slice_ref(offsets);
     // create a new list with taken data and computed null information
     let list_data = ArrayDataBuilder::new(values.data_type().clone())
         .len(indices.len())
@@ -815,6 +815,7 @@ where
 /// Where a list array has indices `[0,2,5,10]`, taking indices of `[2,0]` returns
 /// an array of the indices `[5..10, 0..2]` and offsets `[0,5,7]` (5 elements and 2
 /// elements)
+#[allow(clippy::type_complexity)]
 fn take_value_indices_from_list<IndexType, OffsetType>(
     list: &GenericListArray<OffsetType::Native>,
     indices: &PrimitiveArray<IndexType>,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3471.

# What changes are included in this PR?

74bad75429f52cda53f66a2b4a794ec6d56ef5ff update the `test_take_slice_string` test to include an extra empty list element. This fails on its own as the empty list is converted to a `null` in `take`

290d6cca64c89b415abe52c279ec903f888c9568 and b01f9e59d1c15fcc757adf4569a936594a7b449b fix the null buffer for the input data in `test_take_list_with_nulls` and `test_take_list_with_value_nulls` respectively.  The previous implementation of `take` for lists actually ignores the null mask of the input list array, so my guess is that it why it wasn't noticed that these masks don't match the intended arrays expressed in the surrounding comments. Without these fixes the change below causes these tests to fail, but I think that's expected given the null masks that were previously provided.

2ff14fa4cda8e77fd4c23b2f9951f437225b74d5 moves the calculation of the null buffer into `take_value_indices_from_list` where we have access to the null info of both the indices and list array.

# Are there any user-facing changes?
This is a bug fix, but could be considered breaking as it's been around for a while and downstream code has likely adapted to the behavior.
