### PR TITLE
change `concat_batches` parameter to non owned reference

### DIFF
--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -616,6 +616,10 @@ mod tests {
         assert_eq!(new_batch.schema().as_ref(), schema.as_ref());
         assert_eq!(2, new_batch.num_columns());
         assert_eq!(4, new_batch.num_rows());
+        let new_batch_owned = concat_batches(&schema, &[batch1, batch2]).unwrap();
+        assert_eq!(new_batch_owned.schema().as_ref(), schema.as_ref());
+        assert_eq!(2, new_batch_owned.num_columns());
+        assert_eq!(4, new_batch_owned.num_rows());
     }
 
     #[test]

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -104,10 +104,11 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef, ArrowError> {
 }
 
 /// Concatenates `batches` together into a single record batch.
-pub fn concat_batches(
+pub fn concat_batches<'a>(
     schema: &SchemaRef,
-    batches: &[RecordBatch],
+    input_batches: impl IntoIterator<Item = &'a RecordBatch>,
 ) -> Result<RecordBatch, ArrowError> {
+    let batches: Vec<&RecordBatch> = input_batches.into_iter().collect();
     if batches.is_empty() {
         return Ok(RecordBatch::new_empty(schema.clone()));
     }
@@ -611,7 +612,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let new_batch = concat_batches(&schema, &[batch1, batch2]).unwrap();
+        let new_batch = concat_batches(&schema, [&batch1, &batch2]).unwrap();
         assert_eq!(new_batch.schema().as_ref(), schema.as_ref());
         assert_eq!(2, new_batch.num_columns());
         assert_eq!(4, new_batch.num_rows());
@@ -623,7 +624,7 @@ mod tests {
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Utf8, false),
         ]));
-        let batch = concat_batches(&schema, &[]).unwrap();
+        let batch = concat_batches(&schema, []).unwrap();
         assert_eq!(batch.schema().as_ref(), schema.as_ref());
         assert_eq!(0, batch.num_rows());
     }
@@ -654,7 +655,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let error = concat_batches(&schema1, &[batch1, batch2]).unwrap_err();
+        let error = concat_batches(&schema1, [&batch1, &batch2]).unwrap_err();
         assert_eq!(
             error.to_string(),
             "Invalid argument error: batches[1] schema is different with argument schema.",


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3456 

# Are there any user-facing changes?
The users will be able to call `concat_batches` function by passing non owned references to `RecordBatch`
No breaking changes. Rust magically converts `&[T]` to `impl IntoIterator <Item=&RecordBatch>` while calling `concat_batches` function. So existing code calling `concat_batches` need no change.
