### PR TITLE
[doc] Fix broken URLs

### DIFF
--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -39,9 +39,9 @@ use crate::array::{
 /// there are more efficient ways to iterate over just the non-null indices, this functionality
 /// is provided by [`compute::try_unary`]
 ///
-/// [`PrimitiveArray`]: [crate::PrimitiveArray]
-/// [`compute::unary`]: [arrow::compute::unary]
-/// [`compute::try_unary`]: [arrow::compute::try_unary]
+/// [`PrimitiveArray`]: crate::PrimitiveArray
+/// [`compute::unary`]: arrow::compute::unary
+/// [`compute::try_unary`]: arrow::compute::try_unary
 #[derive(Debug)]
 pub struct ArrayIter<T: ArrayAccessor> {
     array: T,

--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -40,8 +40,8 @@ use crate::array::{
 /// is provided by [`compute::try_unary`]
 ///
 /// [`PrimitiveArray`]: crate::PrimitiveArray
-/// [`compute::unary`]: arrow::compute::unary
-/// [`compute::try_unary`]: arrow::compute::try_unary
+/// [`compute::unary`]: https://docs.rs/arrow/latest/arrow/compute/fn.unary.html
+/// [`compute::try_unary`]: https://docs.rs/arrow/latest/arrow/compute/fn.try_unary.html
 #[derive(Debug)]
 pub struct ArrayIter<T: ArrayAccessor> {
     array: T,

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -565,9 +565,9 @@ mod decimal {
 /// Implemented by [`Decimal128Type`] and [`Decimal256Type`] for [`Decimal128Array`]
 /// and [`Decimal256Array`] respectively
 ///
-/// [`DecimalArray`]: [crate::array::DecimalArray]
-/// [`Decimal128Array`]: [crate::array::Decimal128Array]
-/// [`Decimal256Array`]: [crate::array::Decimal256Array]
+/// [`DecimalArray`]: crate::array::DecimalArray
+/// [`Decimal128Array`]: crate::array::Decimal128Array
+/// [`Decimal256Array`]: crate::array::Decimal256Array
 pub trait DecimalType:
     'static + Send + Sync + ArrowPrimitiveType + decimal::DecimalTypeSealed
 {

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -559,13 +559,13 @@ mod decimal {
     impl DecimalTypeSealed for Decimal256Type {}
 }
 
-/// A trait over the decimal types, used by [`DecimalArray`] to provide a generic
+/// A trait over the decimal types, used by [`PrimitiveArray`] to provide a generic
 /// implementation across the various decimal types
 ///
 /// Implemented by [`Decimal128Type`] and [`Decimal256Type`] for [`Decimal128Array`]
 /// and [`Decimal256Array`] respectively
 ///
-/// [`DecimalArray`]: crate::array::DecimalArray
+/// [`PrimitiveArray`]: crate::array::PrimitiveArray
 /// [`Decimal128Array`]: crate::array::Decimal128Array
 /// [`Decimal256Array`]: crate::array::Decimal256Array
 pub trait DecimalType:

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -814,8 +814,8 @@ impl AmazonS3Builder {
     ///
     /// This option has no effect if not using instance credentials
     ///
-    /// [IMDSv2]: [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html]
-    /// [SSRF attack]: [https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/]
+    /// [IMDSv2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+    /// [SSRF attack]: https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
     ///
     pub fn with_imdsv1_fallback(mut self) -> Self {
         self.imdsv1_fallback = true;

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -94,7 +94,7 @@ where
 /// leaves 99% of the rows, it may be better to not filter the data from parquet and
 /// apply the filter after the RecordBatch has been fully decoded.
 ///
-/// [`RowSelection`]: [super::selection::RowSelection]
+/// [`RowSelection`]: crate::arrow::arrow_reader::RowSelection
 pub struct RowFilter {
     /// A list of [`ArrowPredicate`]
     pub(crate) predicates: Vec<Box<dyn ArrowPredicate>>,

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -50,7 +50,7 @@ pub use selection::{RowSelection, RowSelector};
 /// * For a synchronous API - [`ParquetRecordBatchReaderBuilder`]
 /// * For an asynchronous API - [`ParquetRecordBatchStreamBuilder`]
 ///
-/// [`ParquetRecordBatchStreamBuilder`]: [crate::arrow::async_reader::ParquetRecordBatchStreamBuilder]
+/// [`ParquetRecordBatchStreamBuilder`]: crate::arrow::async_reader::ParquetRecordBatchStreamBuilder
 pub struct ArrowReaderBuilder<T> {
     pub(crate) input: T,
 
@@ -150,7 +150,7 @@ impl<T> ArrowReaderBuilder<T> {
     /// An example use case of this would be applying a selection determined by
     /// evaluating predicates against the [`Index`]
     ///
-    /// [`Index`]: [parquet::file::page_index::index::Index]
+    /// [`Index`]: crate::file::page_index::index::Index
     pub fn with_row_selection(self, selection: RowSelection) -> Self {
         Self {
             selection: Some(selection),
@@ -238,7 +238,7 @@ impl ArrowReaderOptions {
     /// Set this true to enable decoding of the [PageIndex] if present. This can be used
     /// to push down predicates to the parquet scan, potentially eliminating unnecessary IO
     ///
-    /// [PageIndex]: [https://github.com/apache/parquet-format/blob/master/PageIndex.md]
+    /// [PageIndex]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
     pub fn with_page_index(self, page_index: bool) -> Self {
         Self { page_index, ..self }
     }

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -83,7 +83,7 @@ impl RowSelector {
 /// assert_eq!(actual, expected);
 /// ```
 ///
-/// [`PageIndex`]: [crate::file::page_index::index::PageIndex]
+/// [`PageIndex`]: crate::file::page_index::index::PageIndex
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct RowSelection {
     selectors: Vec<RowSelector>,


### PR DESCRIPTION
Use proper syntax when [linking to items by name].

Before:
https://docs.rs/arrow-array/latest/arrow_array/iterator/%5Bcrate::PrimitiveArray%5D

After:
https://docs.rs/arrow-array/latest/arrow_array/array/struct.PrimitiveArray.html

[linking to items by name]: https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html
