### PR TITLE
feat: Allow providing a service account key directly for GCS

### DIFF
--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -841,6 +841,8 @@ pub enum GoogleConfigKey {
     /// Supported keys:
     /// - `google_service_account`
     /// - `service_account`
+    /// - `google_service_account_path`
+    /// - `service_account_path`
     ServiceAccount,
 
     /// The serialized service account key.
@@ -877,7 +879,10 @@ impl FromStr for GoogleConfigKey {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "google_service_account" | "service_account" => Ok(Self::ServiceAccount),
+            "google_service_account"
+            | "service_account"
+            | "google_service_account_path"
+            | "service_account_path" => Ok(Self::ServiceAccount),
             "google_service_account_key" | "service_account_key" => {
                 Ok(Self::ServiceAccountKey)
             }
@@ -912,13 +917,17 @@ impl GoogleCloudStorageBuilder {
     ///
     /// Variables extracted from environment:
     /// * GOOGLE_SERVICE_ACCOUNT: location of service account file
+    /// * GOOGLE_SERVICE_ACCOUNT_PATH: (alias) location of service account file
     /// * SERVICE_ACCOUNT: (alias) location of service account file
+    /// * GOOGLE_SERVICE_ACCOUNT_KEY: JSON serialized service account key
+    /// * GOOGLE_BUCKET: bucket name
+    /// * GOOGLE_BUCKET_NAME: (alias) bucket name
     ///
     /// # Example
     /// ```
     /// use object_store::gcp::GoogleCloudStorageBuilder;
     ///
-    /// let azure = GoogleCloudStorageBuilder::from_env()
+    /// let gcs = GoogleCloudStorageBuilder::from_env()
     ///     .with_bucket_name("foo")
     ///     .build();
     /// ```

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -1446,4 +1446,41 @@ mod test {
         let builder = GoogleCloudStorageBuilder::new().try_with_options(&options);
         assert!(builder.is_err());
     }
+
+    #[test]
+    fn gcs_test_config_aliases() {
+        // Service account path
+        for alias in [
+            "google_service_account",
+            "service_account",
+            "google_service_account_path",
+            "service_account_path",
+        ] {
+            let builder = GoogleCloudStorageBuilder::new()
+                .try_with_options([(alias, "/fake/path.json")])
+                .unwrap();
+            assert_eq!("/fake/path.json", builder.service_account_path.unwrap());
+        }
+
+        // Service account key
+        for alias in ["google_service_account_key", "service_account_key"] {
+            let builder = GoogleCloudStorageBuilder::new()
+                .try_with_options([(alias, FAKE_KEY)])
+                .unwrap();
+            assert_eq!(FAKE_KEY, builder.service_account_key.unwrap());
+        }
+
+        // Bucket name
+        for alias in [
+            "google_bucket",
+            "google_bucket_name",
+            "bucket",
+            "bucket_name",
+        ] {
+            let builder = GoogleCloudStorageBuilder::new()
+                .try_with_options([(alias, "fake_bucket")])
+                .unwrap();
+            assert_eq!("fake_bucket", builder.bucket_name.unwrap());
+        }
+    }
 }


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/3488

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Use case:

We're storing service accounts keys external to where the object store client is
being created. We do not want to have to write the key to a file before creating
the object store client. This change allows for providing the key directly.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds an appropriate method to the GCS object store builder for supplying the service account key directly. Only one of service account path or service account key may be provided, otherwise `build` will return an appropriate error.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

An additional method on GCS object store builder.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

There are currently no breaking changes, however I believe the `ServiceAccount` variant for the `GoogleConfigKey` should be renamed to `ServiceAccountPath` to better represent what that option is for. I held off on making that change because I saw that the changelog was already generated for 0.5.3 which includes the new `GoogleConfigKey` stuff, making that a breaking change. If that's an acceptable breaking change, I'm down to go ahead and do that in this PR as well.
