### PR TITLE
Fix negative interval prettyprint

### DIFF
--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -67,14 +67,20 @@ macro_rules! make_string_interval_day_time {
         let days_parts: i32 = ((value & 0xFFFFFFFF00000000) >> 32) as i32;
         let milliseconds_part: i32 = (value & 0xFFFFFFFF) as i32;
 
-        let secs = milliseconds_part / 1000;
+        let secs = milliseconds_part / 1_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let secs_sign = if milliseconds_part < 0 { "-" } else { "" };
+        let milliseconds = milliseconds_part % 1_000;
+
+        let secs_sign = if secs < 0 || milliseconds < 0 {
+            "-"
+        } else {
+            ""
+        };
 
         Ok(format!(
             "0 years 0 mons {} days {} hours {} mins {}{}.{:03} secs",
@@ -83,7 +89,7 @@ macro_rules! make_string_interval_day_time {
             mins,
             secs_sign,
             secs.abs(),
-            (milliseconds_part % 1000).abs(),
+            milliseconds.abs(),
         ))
     }};
 }
@@ -102,14 +108,16 @@ macro_rules! make_string_interval_month_day_nano {
         let days_part: i32 = ((value & 0xFFFFFFFF0000000000000000) >> 64) as i32;
         let nanoseconds_part: i64 = (value & 0xFFFFFFFFFFFFFFFF) as i64;
 
-        let secs = nanoseconds_part / 1000000000;
+        let secs = nanoseconds_part / 1_000_000_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let secs_sign = if nanoseconds_part < 0 { "-" } else { "" };
+        let nanoseconds = nanoseconds_part % 1_000_000_000;
+
+        let secs_sign = if secs < 0 || nanoseconds < 0 { "-" } else { "" };
 
         Ok(format!(
             "0 years {} mons {} days {} hours {} mins {}{}.{:09} secs",
@@ -119,7 +127,7 @@ macro_rules! make_string_interval_month_day_nano {
             mins,
             secs_sign,
             secs.abs(),
-            (nanoseconds_part % 1000000000).abs(),
+            nanoseconds.abs(),
         ))
     }};
 }

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -74,13 +74,20 @@ macro_rules! make_string_interval_day_time {
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
+        let secs_sign = if secs < 0 || secs == 0 && milliseconds_part < 0 {
+            "-"
+        } else {
+            ""
+        };
+
         Ok(format!(
-            "0 years 0 mons {} days {} hours {} mins {}.{:03} secs",
+            "0 years 0 mons {} days {} hours {} mins {}{}.{:03} secs",
             days_parts,
             hours,
             mins,
-            secs,
-            (milliseconds_part % 1000),
+            secs_sign,
+            secs.abs(),
+            (milliseconds_part % 1000).abs(),
         ))
     }};
 }
@@ -106,14 +113,21 @@ macro_rules! make_string_interval_month_day_nano {
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
+        let secs_sign = if secs < 0 || secs == 0 && nanoseconds_part < 0 {
+            "-"
+        } else {
+            ""
+        };
+
         Ok(format!(
-            "0 years {} mons {} days {} hours {} mins {}.{:09} secs",
+            "0 years {} mons {} days {} hours {} mins {}{}.{:09} secs",
             months_part,
             days_part,
             hours,
             mins,
-            secs,
-            (nanoseconds_part % 1000000000),
+            secs_sign,
+            secs.abs(),
+            (nanoseconds_part % 1000000000).abs(),
         ))
     }};
 }

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -74,11 +74,7 @@ macro_rules! make_string_interval_day_time {
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let secs_sign = if secs < 0 || secs == 0 && milliseconds_part < 0 {
-            "-"
-        } else {
-            ""
-        };
+        let secs_sign = if milliseconds_part < 0 { "-" } else { "" };
 
         Ok(format!(
             "0 years 0 mons {} days {} hours {} mins {}{}.{:03} secs",
@@ -113,11 +109,7 @@ macro_rules! make_string_interval_month_day_nano {
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let secs_sign = if secs < 0 || secs == 0 && nanoseconds_part < 0 {
-            "-"
-        } else {
-            ""
-        };
+        let secs_sign = if nanoseconds_part < 0 { "-" } else { "" };
 
         Ok(format!(
             "0 years {} mons {} days {} hours {} mins {}{}.{:09} secs",

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -991,6 +991,8 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_day_time() -> Result<()> {
         let arr = Arc::new(arrow_array::IntervalDayTimeArray::from(vec![
+            Some(4294966295),
+            Some(4294967295),
             Some(1),
             Some(10),
             Some(100),
@@ -1007,13 +1009,15 @@ mod tests {
         let table = pretty_format_batches(&[batch])?.to_string();
 
         let expected = vec![
-            "+-------------------------------------------------+",
-            "| IntervalDayTime                                 |",
-            "+-------------------------------------------------+",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100 secs |",
-            "+-------------------------------------------------+",
+            "+--------------------------------------------------+",
+            "| IntervalDayTime                                  |",
+            "+--------------------------------------------------+",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -1.001 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -0.001 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100 secs  |",
+            "+--------------------------------------------------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -1026,6 +1030,8 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_month_day_nano_array() -> Result<()> {
         let arr = Arc::new(arrow_array::IntervalMonthDayNanoArray::from(vec![
+            Some(18446744072709551615),
+            Some(18446744073709551615),
             Some(1),
             Some(10),
             Some(100),
@@ -1049,20 +1055,22 @@ mod tests {
         let table = pretty_format_batches(&[batch])?.to_string();
 
         let expected = vec![
-            "+-------------------------------------------------------+",
-            "| IntervalMonthDayNano                                  |",
-            "+-------------------------------------------------------+",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000010 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000100 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000001000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000010000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000100000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001000000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010000000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100000000 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 1.000000000 secs |",
-            "+-------------------------------------------------------+",
+            "+--------------------------------------------------------+",
+            "| IntervalMonthDayNano                                   |",
+            "+--------------------------------------------------------+",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -1.000000001 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -0.000000001 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000001 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000010 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000100 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000001000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000010000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000100000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001000000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010000000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100000000 secs  |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 1.000000000 secs  |",
+            "+--------------------------------------------------------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();

--- a/arrow/src/util/pretty.rs
+++ b/arrow/src/util/pretty.rs
@@ -991,6 +991,7 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_day_time() -> Result<()> {
         let arr = Arc::new(arrow_array::IntervalDayTimeArray::from(vec![
+            Some(-600000),
             Some(4294966295),
             Some(4294967295),
             Some(1),
@@ -1009,15 +1010,16 @@ mod tests {
         let table = pretty_format_batches(&[batch])?.to_string();
 
         let expected = vec![
-            "+--------------------------------------------------+",
-            "| IntervalDayTime                                  |",
-            "+--------------------------------------------------+",
-            "| 0 years 0 mons 0 days 0 hours 0 mins -1.001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins -0.001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100 secs  |",
-            "+--------------------------------------------------+",
+            "+----------------------------------------------------+",
+            "| IntervalDayTime                                    |",
+            "+----------------------------------------------------+",
+            "| 0 years 0 mons -1 days 0 hours -10 mins 0.000 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -1.001 secs   |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -0.001 secs   |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001 secs    |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010 secs    |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100 secs    |",
+            "+----------------------------------------------------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();
@@ -1030,6 +1032,7 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_month_day_nano_array() -> Result<()> {
         let arr = Arc::new(arrow_array::IntervalMonthDayNanoArray::from(vec![
+            Some(-600000000000),
             Some(18446744072709551615),
             Some(18446744073709551615),
             Some(1),
@@ -1055,22 +1058,23 @@ mod tests {
         let table = pretty_format_batches(&[batch])?.to_string();
 
         let expected = vec![
-            "+--------------------------------------------------------+",
-            "| IntervalMonthDayNano                                   |",
-            "+--------------------------------------------------------+",
-            "| 0 years 0 mons 0 days 0 hours 0 mins -1.000000001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins -0.000000001 secs |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000001 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000010 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000100 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000001000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000010000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000100000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001000000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010000000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100000000 secs  |",
-            "| 0 years 0 mons 0 days 0 hours 0 mins 1.000000000 secs  |",
-            "+--------------------------------------------------------+",
+            "+-----------------------------------------------------------+",
+            "| IntervalMonthDayNano                                      |",
+            "+-----------------------------------------------------------+",
+            "| 0 years -1 mons -1 days 0 hours -10 mins 0.000000000 secs |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -1.000000001 secs    |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins -0.000000001 secs    |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000001 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000010 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000000100 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000001000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000010000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.000100000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.001000000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.010000000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 0.100000000 secs     |",
+            "| 0 years 0 mons 0 days 0 hours 0 mins 1.000000000 secs     |",
+            "+-----------------------------------------------------------+",
         ];
 
         let actual: Vec<&str> = table.lines().collect();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-datafusion/issues/4220

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Current issue where nanoseconds/milliseconds part can print the minus sign if negative, which can double up with the seconds, not to mention is incorrectly placed (after the decimal). This fixes it to only have a single sign before the seconds, if negative

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
