### PR TITLE
Fix IPCWriter for Sliced BooleanArray

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1202,7 +1202,7 @@ fn write_array_data(
         )
     {
         // Truncate values
-        assert!(array_data.buffers().len() == 1);
+        assert_eq!(array_data.buffers().len(), 1);
 
         let buffer = &array_data.buffers()[0];
         let layout = layout(data_type);
@@ -1234,7 +1234,7 @@ fn write_array_data(
     } else if matches!(data_type, DataType::Boolean) {
         // Bools are special because the payload (= 1 bit) is smaller than the physical container elements (= bytes).
         // The array data may not start at the physical boundary of the underlying buffer, so we need to shift bits around.
-        assert!(array_data.buffers().len() == 1);
+        assert_eq!(array_data.buffers().len(), 1);
 
         let buffer = &array_data.buffers()[0];
         let buffer = buffer.bit_slice(array_data.offset(), array_data.len());


### PR DESCRIPTION
# Which issue does this PR close?
Closes #3496.

# Rationale for this change
It seems that the IPC writer doesn't correctly account for sliced boolean columns. See #3496.

# What changes are included in this PR?
New IPC writer routine for bools that shifts data correctly + tests.

# Are there any user-facing changes?
IPC for bools no longer broken.