### PR TITLE
Enable cast Date32 to Timestamp

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -255,6 +255,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (Timestamp(_, _), Int64) => true,
         (Int64, Timestamp(_, _)) => true,
         (Date64, Timestamp(_, None)) => true,
+        (Date32, Timestamp(_, None)) => true,
         (Timestamp(_, _),
             Timestamp(_, _)
             | Date32


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3504 .

# Rationale for this change
In Datafusion project we cannot run queries compating dates and timestamps, however its possible in postgres
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Enable cast Date32 to Timestamp
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
