### PR TITLE
Add Global deallocation variant (#3516)

### DIFF
--- a/arrow-buffer/src/alloc/mod.rs
+++ b/arrow-buffer/src/alloc/mod.rs
@@ -135,8 +135,10 @@ pub(crate) enum Deallocation {
     /// An allocation of the given capacity that needs to be deallocated using arrows's cache aligned allocator.
     /// See [allocate_aligned] and [free_aligned].
     Arrow(usize),
-    /// An allocation from an external source like the FFI interface or a Rust Vec.
-    /// Deallocation will happen
+    /// An allocation using the system's default global allocator and the provided layout
+    Global(Layout),
+    /// An allocation from an external source like the FFI interface
+    /// Deallocation should happen when `Allocation` is dropped
     Custom(Arc<dyn Allocation>),
 }
 
@@ -144,10 +146,13 @@ impl Debug for Deallocation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Deallocation::Arrow(capacity) => {
-                write!(f, "Deallocation::Arrow {{ capacity: {} }}", capacity)
+                write!(f, "Deallocation::Arrow {{ capacity: {capacity} }}")
             }
             Deallocation::Custom(_) => {
                 write!(f, "Deallocation::Custom {{ capacity: unknown }}")
+            }
+            Deallocation::Global(layout) => {
+                write!(f, "Deallocation::Global {{ alignment: {layout:?} }}")
             }
         }
     }

--- a/arrow-buffer/src/alloc/mod.rs
+++ b/arrow-buffer/src/alloc/mod.rs
@@ -136,6 +136,7 @@ pub(crate) enum Deallocation {
     /// See [allocate_aligned] and [free_aligned].
     Arrow(usize),
     /// An allocation using the system's default global allocator and the provided layout
+    #[allow(unused)]
     Global(Layout),
     /// An allocation from an external source like the FFI interface
     /// Deallocation should happen when `Allocation` is dropped

--- a/arrow-buffer/src/bytes.rs
+++ b/arrow-buffer/src/bytes.rs
@@ -94,6 +94,7 @@ impl Bytes {
     pub fn capacity(&self) -> usize {
         match self.deallocation {
             Deallocation::Arrow(capacity) => capacity,
+            Deallocation::Global(l) => l.size(),
             // we cannot determine this in general,
             // and thus we state that this is externally-owned memory
             Deallocation::Custom(_) => 0,
@@ -117,6 +118,9 @@ impl Drop for Bytes {
         match &self.deallocation {
             Deallocation::Arrow(capacity) => {
                 unsafe { alloc::free_aligned(self.ptr, *capacity) };
+            }
+            Deallocation::Global(layout) => {
+                unsafe { std::alloc::dealloc(self.ptr.as_ptr(), *layout) };
             }
             // The automatic drop implementation will free the memory once the reference count reaches zero
             Deallocation::Custom(_allocation) => (),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3516

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This is the first part of supporting zero-copy conversion between `Vec` and `MutableBuffer`. Crucially we need to carry along the `Layout` as it is UB to call realloc or dealloc with a different layout from the one provided to the initial call to `alloc`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
