### PR TITLE
Write backwards compatible row group statistics (#3526)

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -330,6 +330,13 @@ pub enum SortOrder {
     UNDEFINED,
 }
 
+impl SortOrder {
+    /// Returns true if this is [`Self::SIGNED`]
+    pub fn is_signed(&self) -> bool {
+        matches!(self, Self::SIGNED)
+    }
+}
+
 /// Column order that specifies what method was used to aggregate min/max values for
 /// statistics.
 ///

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -331,8 +331,16 @@ impl Statistics {
         statistics_enum_func![self, is_min_max_deprecated]
     }
 
-    /// Returns `true` if the statistics are backwards compatible with the
-    /// deprecated `min` and `max` fields
+    /// Old versions of parquet stored statistics in `min` and `max` fields, ordered
+    /// using signed comparison. This resulted in an undefined ordering for unsigned
+    /// quantities, such as booleans and unsigned integers.
+    ///
+    /// These fields were therefore deprecated in favour of `min_value` and `max_value`,
+    /// which have a type-defined sort order.
+    ///
+    /// However, not all readers have been updated. For backwards compatibility, this method
+    /// returns `true` if the statistics within this have a signed sort order, that is
+    /// compatible with being stored in the deprecated `min` and `max` fields
     pub fn is_min_max_backwards_compatible(&self) -> bool {
         statistics_enum_func![self, is_min_max_backwards_compatible]
     }
@@ -418,7 +426,9 @@ pub struct ValueStatistics<T> {
     /// `min_value` and `max_value`
     is_min_max_deprecated: bool,
 
-    /// If `true` should always write deprecated `min` and `max` fields
+    /// If `true` should always write deprecated `min` and `max` fields,
+    /// potentially in addition to `min_value` and `max_value` if not
+    /// `is_min_max_deprecated`
     is_min_max_backwards_compatible: bool,
 }
 
@@ -442,6 +452,10 @@ impl<T: ParquetValueType> ValueStatistics<T> {
     }
 
     /// Set whether to write the deprecated `min` and `max` fields
+    /// for compatibility with older parquet writers
+    ///
+    /// This should only be enabled if the field is signed,
+    /// see [`Self::is_min_max_backwards_compatible`]
     pub fn with_backwards_compatible_min_max(self, backwards_compatible: bool) -> Self {
         Self {
             is_min_max_backwards_compatible: backwards_compatible,
@@ -502,8 +516,16 @@ impl<T: ParquetValueType> ValueStatistics<T> {
         self.is_min_max_deprecated
     }
 
-    /// Returns `true` if the statistics are backwards compatible
-    /// with the deprecated `min` and `max` fields
+    /// Old versions of parquet stored statistics in `min` and `max` fields, ordered
+    /// using signed comparison. This resulted in an undefined ordering for unsigned
+    /// quantities, such as booleans and unsigned integers.
+    ///
+    /// These fields were therefore deprecated in favour of `min_value` and `max_value`,
+    /// which have a type-defined sort order.
+    ///
+    /// However, not all readers have been updated. For backwards compatibility, this method
+    /// returns `true` if the statistics within this have a signed sort order, that is
+    /// compatible with being stored in the deprecated `min` and `max` fields
     pub fn is_min_max_backwards_compatible(&self) -> bool {
         self.is_min_max_backwards_compatible
     }

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -253,6 +253,7 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
     };
 
     if stats.is_min_max_backwards_compatible() {
+        // Copy to deprecated min, max values for compatibility with older readers
         thrift_stats.min = min.clone();
         thrift_stats.max = max.clone();
     }
@@ -426,9 +427,8 @@ pub struct ValueStatistics<T> {
     /// `min_value` and `max_value`
     is_min_max_deprecated: bool,
 
-    /// If `true` should always write deprecated `min` and `max` fields,
-    /// potentially in addition to `min_value` and `max_value` if not
-    /// `is_min_max_deprecated`
+    /// If `true` the statistics are compatible with the deprecated `min` and
+    /// `max` fields. See [`ValueStatistics::is_min_max_backwards_compatible`]
     is_min_max_backwards_compatible: bool,
 }
 

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -22,7 +22,8 @@ use std::{collections::HashMap, convert::From, fmt, sync::Arc};
 use crate::format::SchemaElement;
 
 use crate::basic::{
-    ConvertedType, LogicalType, Repetition, TimeUnit, Type as PhysicalType,
+    ColumnOrder, ConvertedType, LogicalType, Repetition, SortOrder, TimeUnit,
+    Type as PhysicalType,
 };
 use crate::errors::{ParquetError, Result};
 
@@ -845,6 +846,15 @@ impl ColumnDescriptor {
             Type::PrimitiveType { scale, .. } => *scale,
             _ => panic!("Expected primitive type!"),
         }
+    }
+
+    /// Returns the sort order for this column
+    pub fn sort_order(&self) -> SortOrder {
+        ColumnOrder::get_sort_order(
+            self.logical_type(),
+            self.converted_type(),
+            self.physical_type(),
+        )
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3526
Closes #799

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This helps with compatibility with pyarrow, which doesn't understand min_value yet https://github.com/apache/arrow/issues/13976

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
