### PR TITLE
Update aws-config and aws-types requirements from 0.52 to 0.53

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -53,8 +53,9 @@ ring = { version = "0.16", default-features = false, features = ["std"], optiona
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 
 # AWS Profile support
-aws-types = { version = "0.52", optional = true }
-aws-config = { version = "0.52", optional = true }
+aws-types = { version = "0.53", optional = true }
+aws-credential-types = { version = "0.53", optional = true }
+aws-config = { version = "0.53", optional = true }
 
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
@@ -64,7 +65,7 @@ aws = ["cloud"]
 http = ["cloud"]
 
 # Experimental support for AWS_PROFILE
-aws_profile = ["aws", "aws-config", "aws-types"]
+aws_profile = ["aws", "aws-config", "aws-types", "aws-credential-types"]
 
 [dev-dependencies] # In alphabetical order
 dotenv = "0.15.0"

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -518,7 +518,7 @@ mod profile {
     use super::*;
     use aws_config::profile::ProfileFileCredentialsProvider;
     use aws_config::provider_config::ProviderConfig;
-    use aws_types::credentials::ProvideCredentials;
+    use aws_credential_types::provider::ProvideCredentials;
     use aws_types::region::Region;
     use std::time::SystemTime;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Update `aws-config` and `aws-types` requirements from 0.52 to 0.53. Also adds `aws-credential-types`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
