### PR TITLE
Additional GCP authentication

### DIFF
--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -328,7 +328,6 @@ fn b64_encode_obj<T: serde::Serialize>(obj: &T) -> Result<String> {
     Ok(BASE64_URL_SAFE_NO_PAD.encode(string))
 }
 
-
 /// A provider that uses the Google Cloud Platform metadata server to fetch a token.
 #[derive(Debug, Default)]
 pub struct InstanceCredentialProvider {

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -1130,14 +1130,15 @@ impl GoogleCloudStorageBuilder {
                     application_default_credentials
                         .map(|a| Box::new(a) as Box<dyn TokenProvider>)
                 })
-                .or_else(|| Some(Box::new(InstanceCredentialProvider::new(audience))));
+                .or_else(|| {
+                    Some(Box::new(InstanceCredentialProvider::new(
+                        audience,
+                        self.client_options.clone(),
+                    )))
+                });
 
             // A provider is required at this point, bail out if we don't have one.
-            if best_provider.is_some() {
-                best_provider
-            } else {
-                return Err(Error::MissingCredentials.into());
-            }
+            Some(best_provider.ok_or(Error::MissingCredentials)?)
         };
 
         let encoded_bucket_name =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3533.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This is WIP. I may be missing something, however workload identity federation is big. https://google.aip.dev/auth/4117. Definitely more than one of my weekends :) Is this what you had in mind @tustvold ?

I am happy to keep on pushing on this but I am wondering if we could maybe land the Application Default Credentials in the mean time because that would unblock some end-user scenarios.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
