### PR TITLE
Update pyarrow method call to avoid warning

### DIFF
--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -196,7 +196,8 @@ impl PyArrowConvert for RecordBatch {
 
         let module = py.import("pyarrow")?;
         let class = module.getattr("RecordBatch")?;
-        let record = class.call_method1("from_arrays", (py_arrays, None, py_schema))?;
+        let record = class
+            .call_method1("from_arrays", (py_arrays, None::<PyObject>, py_schema))?;
 
         Ok(PyObject::from(record))
     }

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -196,7 +196,7 @@ impl PyArrowConvert for RecordBatch {
 
         let module = py.import("pyarrow")?;
         let class = module.getattr("RecordBatch")?;
-        let record = class.call_method1("from_arrays", (py_arrays, py_schema))?;
+        let record = class.call_method1("from_arrays", (py_arrays, None, py_schema))?;
 
         Ok(PyObject::from(record))
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3543 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Pyarrow has changed its function signature and warns if the function is called in old way. https://github.com/apache/arrow/blob/85b167c05c2f93a95b23e8ac4fd4da576ea5b899/python/pyarrow/table.pxi#L2496-L2502
I update the function call of `from_arrays` in  RecordBatch's `to_pyarrow` to fix it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change the arguments of pyarrow function call

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->