### PR TITLE
[python] Remove FutureWarning

### DIFF
--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::import_exception;
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PyTuple};
+use pyo3::types::{PyDict, PyList, PyTuple};
 
 use crate::array::{make_array, Array, ArrayData};
 use crate::datatypes::{DataType, Field, Schema};
@@ -196,9 +196,10 @@ impl PyArrowConvert for RecordBatch {
 
         let module = py.import("pyarrow")?;
         let class = module.getattr("RecordBatch")?;
-        let record = class
-            .call_method1("from_arrays", (py_arrays, None::<PyObject>, py_schema))?;
 
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("schema", py_schema)?;
+        let record = class.call_method("from_arrays", (py_arrays,), Some(kwargs))?;
         Ok(PyObject::from(record))
     }
 }


### PR DESCRIPTION
Currently RecordBatch::to_pyarrow passes the Schema in the second arg position which causes a FutureWarning. Instead we change it to use the `schema` kwarg.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
