### PR TITLE
Implement `std::error::Error::source` for `ArrowError` and `FlightError`

### DIFF
--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -129,15 +129,10 @@ mod test {
         let e3 = FlightError::ExternalError(Box::new(e2));
 
         // ensure we can find the lowest level error by following source()
-
         let mut root_error: &dyn Error = &e3;
-        loop {
-            match root_error.source() {
-                // walk the next level
-                Some(source) => root_error = source,
-                // at root (as much as we know)
-                None => break,
-            }
+        while let Some(source) = root_error.source() {
+            // walk the next level
+            root_error = source;
         }
 
         let source = root_error.downcast_ref::<FlightError>().unwrap();

--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -32,7 +32,7 @@ pub enum FlightError {
     ProtocolError(String),
     /// An error occured during decoding
     DecodeError(String),
-    /// Some other (opaque) error
+    /// External error that can provide source of error by calling `Error::source`.
     ExternalError(Box<dyn Error + Send + Sync>),
 }
 

--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::error::Error;
+
 use arrow_schema::ArrowError;
 
 /// Errors for the Apache Arrow Flight crate
@@ -31,7 +33,7 @@ pub enum FlightError {
     /// An error occured during decoding
     DecodeError(String),
     /// Some other (opaque) error
-    ExternalError(Box<dyn std::error::Error + Send + Sync>),
+    ExternalError(Box<dyn Error + Send + Sync>),
 }
 
 impl FlightError {
@@ -40,7 +42,7 @@ impl FlightError {
     }
 
     /// Wraps an external error in an `ArrowError`.
-    pub fn from_external_error(error: Box<dyn std::error::Error + Send + Sync>) -> Self {
+    pub fn from_external_error(error: Box<dyn Error + Send + Sync>) -> Self {
         Self::ExternalError(error)
     }
 }
@@ -52,7 +54,15 @@ impl std::fmt::Display for FlightError {
     }
 }
 
-impl std::error::Error for FlightError {}
+impl Error for FlightError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Self::ExternalError(e) = self {
+            Some(e.as_ref())
+        } else {
+            None
+        }
+    }
+}
 
 impl From<tonic::Status> for FlightError {
     fn from(status: tonic::Status) -> Self {
@@ -82,3 +92,55 @@ impl From<FlightError> for tonic::Status {
 }
 
 pub type Result<T> = std::result::Result<T, FlightError>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn error_source() {
+        let e1 = FlightError::DecodeError("foo".into());
+        assert!(e1.source().is_none());
+
+        // one level of wrapping
+        let e2 = FlightError::ExternalError(Box::new(e1));
+        let source = e2.source().unwrap().downcast_ref::<FlightError>().unwrap();
+        assert!(matches!(source, FlightError::DecodeError(_)));
+
+        let e3 = FlightError::ExternalError(Box::new(e2));
+        let source = e3
+            .source()
+            .unwrap()
+            .downcast_ref::<FlightError>()
+            .unwrap()
+            .source()
+            .unwrap()
+            .downcast_ref::<FlightError>()
+            .unwrap();
+
+        assert!(matches!(source, FlightError::DecodeError(_)));
+    }
+
+    #[test]
+    fn error_through_arrow() {
+        // flight error that wraps an arrow error that wraps a flight error
+        let e1 = FlightError::DecodeError("foo".into());
+        let e2 = ArrowError::ExternalError(Box::new(e1));
+        let e3 = FlightError::ExternalError(Box::new(e2));
+
+        // ensure we can find the lowest level error by following source()
+
+        let mut root_error: &dyn Error = &e3;
+        loop {
+            match root_error.source() {
+                // walk the next level
+                Some(source) => root_error = source,
+                // at root (as much as we know)
+                None => break,
+            }
+        }
+
+        let source = root_error.downcast_ref::<FlightError>().unwrap();
+        assert!(matches!(source, FlightError::DecodeError(_)));
+    }
+}

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -100,4 +100,42 @@ impl Display for ArrowError {
     }
 }
 
-impl Error for ArrowError {}
+impl Error for ArrowError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let ArrowError::ExternalError(e) = self {
+            Some(e.as_ref())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn error_source() {
+        let e1 = ArrowError::DivideByZero;
+        assert!(e1.source().is_none());
+
+        // one level of wrapping
+        let e2 = ArrowError::ExternalError(Box::new(e1));
+        let source = e2.source().unwrap().downcast_ref::<ArrowError>().unwrap();
+        assert!(matches!(source, ArrowError::DivideByZero));
+
+        // two levels of wrapping
+        let e3 = ArrowError::ExternalError(Box::new(e2));
+        let source = e3
+            .source()
+            .unwrap()
+            .downcast_ref::<ArrowError>()
+            .unwrap()
+            .source()
+            .unwrap()
+            .downcast_ref::<ArrowError>()
+            .unwrap();
+
+        assert!(matches!(source, ArrowError::DivideByZero));
+    }
+}

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -102,7 +102,7 @@ impl Display for ArrowError {
 
 impl Error for ArrowError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        if let ArrowError::ExternalError(e) = self {
+        if let Self::ExternalError(e) = self {
             Some(e.as_ref())
         } else {
             None


### PR DESCRIPTION
# Which issue does this PR close?

Close https://github.com/apache/arrow-rs/issues/3566

# Rationale for this change
 
In IOx (and in DataFusion) we often want to know what the root cause of an error is (e.g was it a bug or was it a resources exhausted). ArrowError can wrap other errors with `Arrow::External` (and DataFusion has something similar) but there is no easy way to get at the source of the error to walk the chain without knowing all the possible types that may be present

I believe this is what https://doc.rust-lang.org/std/error/trait.Error.html#method.source is for

I would like to be able to write something like this to walk the chain
```rust

        let mut root_error: &dyn Error = &e3;
        loop {
            match root_error.source() {
                // walk the next level
                Some(source) => root_error = source,
                // at root (as much as we know)
                None => break,
            }
        }

```
However, ArrowError does not implement `source` yet

Of course, all the errors in the chain need to implement this

# What changes are included in this PR?
1. Implement `std::error::Error::source` for `ArrowError` and `FlightError`
2. tests for same

# Are there any user-facing changes?

source() sometimes now returns something useful
