### PR TITLE
[object_store] support azure managed and workload identities

### DIFF
--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -169,9 +169,11 @@ impl AzureClient {
             CredentialProvider::AccessKey(key) => {
                 Ok(AzureCredential::AccessKey(key.to_owned()))
             }
-            CredentialProvider::TokenCredential(cred) => {
-                let token = cred
-                    .fetch_token(&self.client, &self.config.retry_config)
+            CredentialProvider::TokenCredential(cache, cred) => {
+                let token = cache
+                    .get_or_insert_with(|| {
+                        cred.fetch_token(&self.client, &self.config.retry_config)
+                    })
                     .await
                     .context(AuthorizationSnafu)?;
                 Ok(AzureCredential::AuthorizationToken(

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -169,7 +169,7 @@ impl AzureClient {
             CredentialProvider::AccessKey(key) => {
                 Ok(AzureCredential::AccessKey(key.to_owned()))
             }
-            CredentialProvider::ClientSecret(cred) => {
+            CredentialProvider::TokenCredential(cred) => {
                 let token = cred
                     .fetch_token(&self.client, &self.config.retry_config)
                     .await

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -425,17 +425,18 @@ impl TokenCredential for ImdsManagedIdentityOAuthProvider {
             ("resource", AZURE_STORAGE_SCOPE),
         ];
 
-        match (
-            self.object_id.as_ref(),
-            self.client_id.as_ref(),
-            self.msi_res_id.as_ref(),
-        ) {
-            (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
-            (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
-            (None, None, Some(msi_res_id)) => {
-                query_items.push(("msi_res_id", msi_res_id))
-            }
-            _ => (),
+        let mut identity = None;
+        if let Some(client_id) = &self.client_id {
+            identity = Some(("client_id", client_id));
+        }
+        if let Some(object_id) = &self.object_id {
+            identity = Some(("object_id", object_id));
+        }
+        if let Some(msi_res_id) = &self.msi_res_id {
+            identity = Some(("msi_res_id", msi_res_id));
+        }
+        if let Some((key, value)) = identity {
+            query_items.push((key, value));
         }
 
         let mut builder = self

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -898,7 +898,7 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Sets the enddpoint for acquiring managed identity token
+    /// Sets the endpoint for acquiring managed identity token
     pub fn with_msi_endpoint(mut self, msi_endpoint: impl Into<String>) -> Self {
         self.msi_endpoint = Some(msi_endpoint.into());
         self.use_managed_identity = true;

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -785,7 +785,7 @@ fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<By
     Ok(buf.into())
 }
 
-pub(crate) fn open_file(path: &PathBuf) -> Result<File> {
+fn open_file(path: &PathBuf) -> Result<File> {
     let file = File::open(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             Error::NotFound {

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -785,7 +785,7 @@ fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<By
     Ok(buf.into())
 }
 
-fn open_file(path: &PathBuf) -> Result<File> {
+pub(crate) fn open_file(path: &PathBuf) -> Result<File> {
     let file = File::open(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             Error::NotFound {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3580

# Rationale for this change
 
see linked issue

# What changes are included in this PR?

added implementations for a managed identity and federated workload credential for azure along with corresponding configuration on the azure builder.

# Are there any user-facing changes?

users can now use managed identities and workload credentials to authenticate object store requests. 

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
