### PR TITLE
Iterate all dictionary key types in cast test

### DIFF
--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -351,7 +351,7 @@ fn get_all_types() -> Vec<DataType> {
     use DataType::*;
     let tz_name = String::from("America/New_York");
 
-    vec![
+    let mut types = vec![
         Null,
         Boolean,
         Int8,
@@ -409,19 +409,28 @@ fn get_all_types() -> Vec<DataType> {
             vec![0, 1],
             UnionMode::Dense,
         ),
-        Dictionary(Box::new(DataType::Int8), Box::new(DataType::Int32)),
-        Dictionary(Box::new(DataType::Int16), Box::new(DataType::Utf8)),
-        Dictionary(Box::new(DataType::Int16), Box::new(DataType::Binary)),
-        Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
-        Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Binary)),
         Decimal128(38, 0),
-        Dictionary(Box::new(DataType::Int8), Box::new(Decimal128(38, 0))),
-        Dictionary(Box::new(DataType::Int16), Box::new(Decimal128(38, 0))),
-        Dictionary(Box::new(DataType::UInt32), Box::new(Decimal128(38, 0))),
-        Dictionary(Box::new(DataType::Int8), Box::new(Decimal256(76, 0))),
-        Dictionary(Box::new(DataType::Int16), Box::new(Decimal256(76, 0))),
-        Dictionary(Box::new(DataType::UInt32), Box::new(Decimal256(76, 0))),
-    ]
+    ];
+
+    let dictionary_key_types =
+        vec![Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64];
+
+    let mut dictionary_types = dictionary_key_types
+        .into_iter()
+        .flat_map(|key_type| {
+            vec![
+                Dictionary(Box::new(key_type.clone()), Box::new(Int32)),
+                Dictionary(Box::new(key_type.clone()), Box::new(Utf8)),
+                Dictionary(Box::new(key_type.clone()), Box::new(Binary)),
+                Dictionary(Box::new(key_type.clone()), Box::new(Decimal128(38, 0))),
+                Dictionary(Box::new(key_type), Box::new(Decimal256(76, 0))),
+            ]
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    types.append(&mut dictionary_types);
+    types
 }
 
 #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Increasing test coverage. Per the comment https://github.com/apache/arrow-rs/pull/3482#discussion_r1065506680, the dictionary key types are chose arbitrarily and we can improve it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
