### PR TITLE
Support sending schemas for empty streams

### DIFF
--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -101,7 +101,7 @@ impl FlightRecordBatchStream {
     }
 
     /// Has a message defining the schema been received yet?
-    #[deprecated = "use metadata() instead"]
+    #[deprecated = "use schema().is_some() instead"]
     pub fn got_schema(&self) -> bool {
         self.schema().is_some()
     }

--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -100,8 +100,14 @@ impl FlightRecordBatchStream {
         }
     }
 
+    /// Has a message defining the schema been received yet?
+    #[deprecated = "use metadata() instead"]
+    pub fn got_schema(&self) -> bool {
+        self.schema().is_some()
+    }
+
     /// Return schema for the stream, if it has been received
-    pub fn schema(&self) -> Option<SchemaRef> {
+    pub fn schema(&self) -> Option<&SchemaRef> {
         self.inner.schema()
     }
 
@@ -215,8 +221,8 @@ impl FlightDataDecoder {
     }
 
     /// Returns the current schema for this stream
-    pub fn schema(&self) -> Option<SchemaRef> {
-        self.state.as_ref().map(|state| state.schema.clone())
+    pub fn schema(&self) -> Option<&SchemaRef> {
+        self.state.as_ref().map(|state| &state.schema)
     }
 
     /// Extracts flight data from the next message, updating decoding

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -198,7 +198,7 @@ impl FlightDataEncoder {
 
         // If schema is known up front, enqueue it immediately
         if let Some(schema) = schema {
-            encoder.encode_schema(schema);
+            encoder.encode_schema(&schema);
         }
         encoder
     }
@@ -217,10 +217,10 @@ impl FlightDataEncoder {
 
     /// Encodes schema as a [`FlightData`] in self.queue.
     /// Updates `self.schema` and returns the new schema
-    fn encode_schema(&mut self, schema: SchemaRef) -> SchemaRef {
+    fn encode_schema(&mut self, schema: &SchemaRef) -> SchemaRef {
         // The first message is the schema message, and all
         // batches have the same schema
-        let schema = Arc::new(prepare_schema_for_flight(&schema));
+        let schema = Arc::new(prepare_schema_for_flight(schema));
         let mut schema_flight_data = self.encoder.encode_schema(&schema);
 
         // attach any metadata requested
@@ -238,7 +238,7 @@ impl FlightDataEncoder {
         let schema = match &self.schema {
             Some(schema) => schema.clone(),
             // encode the schema if this is the first time we have seen it
-            None => self.encode_schema(batch.schema()),
+            None => self.encode_schema(&batch.schema()),
         };
 
         // encode the batch

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -280,8 +280,9 @@ impl Stream for FlightDataEncoder {
                 None => {
                     // inner is done
                     self.done = true;
-                    // queue might still have a message (if the stream
-                    // was empty but schema was specified), so loop again
+                    // queue must also be empty so we are done
+                    assert!(self.queue.is_empty());
+                    return Poll::Ready(None);
                 }
                 Some(Err(e)) => {
                     // error from inner

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -127,7 +127,7 @@ impl FlightDataEncoderBuilder {
 
     /// Specify a schema for the RecordBatches being sent. If a schema
     /// is not specified, an encoded Schema message will be sent when
-    /// the first [`RecordBatch`], if any, encoded. Some clients
+    /// the first [`RecordBatch`], if any, is encoded. Some clients
     /// expect a Schema message even if there is no data sent.
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema = Some(schema);
@@ -163,7 +163,6 @@ impl FlightDataEncoderBuilder {
 pub struct FlightDataEncoder {
     /// Input stream
     inner: BoxStream<'static, Result<RecordBatch>>,
-
     /// schema, set after the first batch
     schema: Option<SchemaRef>,
     /// Target maximum size of flight data
@@ -197,6 +196,7 @@ impl FlightDataEncoder {
             done: false,
         };
 
+        // If schema is known up front, enqueue it immediately
         if let Some(schema) = schema {
             encoder.encode_schema(schema);
         }

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -101,11 +101,11 @@ async fn test_zero_batches_no_schema() {
     let stream = FlightDataEncoderBuilder::default().build(futures::stream::iter(vec![]));
 
     let mut decoder = FlightRecordBatchStream::new_from_flight_data(stream);
-    assert!(!decoder.schema().is_some());
+    assert!(decoder.schema().is_none());
     // No batches come out
     assert!(decoder.next().await.is_none());
     // schema has not been received
-    assert!(!decoder.schema().is_some());
+    assert!(decoder.schema().is_none());
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn test_zero_batches_schema_specified() {
         .build(futures::stream::iter(vec![]));
 
     let mut decoder = FlightRecordBatchStream::new_from_flight_data(stream);
-    assert!(!decoder.schema().is_some());
+    assert!(decoder.schema().is_none());
     // No batches come out
     assert!(decoder.next().await.is_none());
     // But schema has been received correctly

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -120,7 +120,7 @@ async fn test_zero_batches_schema_specified() {
     // No batches come out
     assert!(decoder.next().await.is_none());
     // But schema has been received correctly
-    assert_eq!(decoder.schema(), Some(schema));
+    assert_eq!(decoder.schema(), Some(&schema));
 }
 
 #[tokio::test]

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -97,6 +97,33 @@ async fn test_dictionary_many() {
 }
 
 #[tokio::test]
+async fn test_zero_batches_no_schema() {
+    let stream = FlightDataEncoderBuilder::default().build(futures::stream::iter(vec![]));
+
+    let mut decoder = FlightRecordBatchStream::new_from_flight_data(stream);
+    assert!(!decoder.schema().is_some());
+    // No batches come out
+    assert!(decoder.next().await.is_none());
+    // schema has not been received
+    assert!(!decoder.schema().is_some());
+}
+
+#[tokio::test]
+async fn test_zero_batches_schema_specified() {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+    let stream = FlightDataEncoderBuilder::default()
+        .with_schema(schema.clone())
+        .build(futures::stream::iter(vec![]));
+
+    let mut decoder = FlightRecordBatchStream::new_from_flight_data(stream);
+    assert!(!decoder.schema().is_some());
+    // No batches come out
+    assert!(decoder.next().await.is_none());
+    // But schema has been received correctly
+    assert_eq!(decoder.schema(), Some(schema));
+}
+
+#[tokio::test]
 async fn test_app_metadata() {
     let input_batch_stream = futures::stream::iter(vec![Ok(make_primative_batch(78))]);
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/3591

# Rationale for this change
 
Some Flight clients expect to see Schema messages even if there is no data (e.g. an empty result set)

# What changes are included in this PR?
1. Add `with_schema` to `FlightDataEncoderBuilder` to specify schema when creating streams
2. Allow users to retrieve the decoded schema in the `FlightDataDecoder`
3. Tests

# Are there any user-facing changes?
1. `FlightDataDecoder` now has `schema()` that returns the actual schema rather than `got_schema()` which returns a boolean

2. `FlightDataEncoderBuilder::with_schema`