### PR TITLE
Allow `StringArray` construction with `Vec<Option<String>>`

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1072,7 +1072,8 @@ mod tests {
 
     #[test]
     fn test_string_min_max_all_nulls() {
-        let a = StringArray::from(vec![None, None]);
+        let v: Vec<Option<&str>> = vec![None, None];
+        let a = StringArray::from(v);
         assert_eq!(None, min_string(&a));
         assert_eq!(None, max_string(&a));
     }

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -249,6 +249,14 @@ impl<OffsetSize: OffsetSizeTrait> From<Vec<&str>> for GenericStringArray<OffsetS
     }
 }
 
+impl<OffsetSize: OffsetSizeTrait> From<Vec<Option<String>>>
+    for GenericStringArray<OffsetSize>
+{
+    fn from(v: Vec<Option<String>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
 impl<OffsetSize: OffsetSizeTrait> From<Vec<String>> for GenericStringArray<OffsetSize> {
     fn from(v: Vec<String>) -> Self {
         Self::from_iter_values(v)
@@ -439,6 +447,13 @@ mod tests {
 
         assert_eq!(array1.value(0), "hello");
         assert_eq!(array1.value(1), "hello2");
+
+        // Also works with String types.
+        let data2: Vec<String> = vec!["goodbye".into(), "goodbye2".into()];
+        let array2 = StringArray::from_iter_values(data2.iter());
+
+        assert_eq!(array2.value(0), "goodbye");
+        assert_eq!(array2.value(1), "goodbye2");
     }
 
     #[test]
@@ -467,7 +482,7 @@ mod tests {
 
     #[test]
     fn test_string_array_all_null() {
-        let data = vec![None];
+        let data: Vec<Option<&str>> = vec![None];
         let array = StringArray::from(data);
         array
             .data()
@@ -477,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_large_string_array_all_null() {
-        let data = vec![None];
+        let data: Vec<Option<&str>> = vec![None];
         let array = LargeStringArray::from(data);
         array
             .data()

--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -641,8 +641,9 @@ mod tests {
 
     #[test]
     fn test_string_dictionary_builder_with_reserved_null_value() {
+        let v: Vec<Option<&str>> = vec![None];
         test_bytes_dictionary_builder_with_reserved_null_value::<GenericStringType<i32>>(
-            StringArray::from(vec![None]),
+            StringArray::from(v),
             vec!["abc", "def"],
         );
     }

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -3712,7 +3712,8 @@ mod tests {
         // value_offsets = [0, 3, 6, 6]
         let list_array = builder.finish();
 
-        let nulls = StringArray::from(vec![None, None, None, None]);
+        let v: Vec<Option<&str>> = vec![None, None, None, None];
+        let nulls = StringArray::from(v);
         let nulls_result = contains_utf8(&nulls, &list_array).unwrap();
         assert_eq!(
             nulls_result

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -433,7 +433,8 @@ fn test_struct_nulls() {
     let data = mutable.freeze();
     let array = StructArray::from(data);
 
-    let expected_string = Arc::new(StringArray::from(vec![None, None])) as ArrayRef;
+    let v: Vec<Option<&str>> = vec![None, None];
+    let expected_string = Arc::new(StringArray::from(v)) as ArrayRef;
     let expected_int = Arc::new(Int32Array::from(vec![Some(2), None])) as ArrayRef;
 
     let expected =


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3599

# Rationale for this change

This is an ergonomic addition, allows StringArrays to be constructed from more types (specifically Vec<Option<String>> here.

# What changes are included in this PR?

Added the impl, and fixed the tests that were ambiguous.

# Are there any user-facing changes?

If a user tries to make a StringArray completely out of None values, before they could rely on it being inferred to a `Vec<Option<&str>>` impl. Now they must specify that (as shown in the test fixes).

This is possibly considered a ***breaking change***.

Thanks!!