### PR TITLE
Add ArrayAccessor, Iterator, Extend and benchmarks for RunArray

### DIFF
--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -707,15 +707,15 @@ mod tests {
             .downcast_ref::<PrimitiveArray<Int32Type>>()
             .unwrap();
 
-        let len = input_array.len();
-        for i in 0..len {
-            let actual = typed.value(i);
-            match input_array[i] {
-                Some(val) => assert_eq!(val, actual),
-                None => {
-                    // TODO: should `array.is_null` be overwritten to return nullability
-                    // of logical array index?
-                }
+        for (i, inp_val) in input_array.iter().enumerate() {
+            if let Some(val) = inp_val {
+                let actual = typed.value(i);
+                assert_eq!(*val, actual)
+            } else {
+                // TODO: Check if the value in logical index is null.
+                // It seems, currently, there is no way to check nullability of logical index.
+                // Should `array.is_null` be overwritten to return nullability
+                // of logical index?
             };
         }
     }

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -360,9 +360,18 @@ impl<'a, R: RunEndIndexType, V> TypedRunArray<'a, R, V> {
         let mut en: usize = self.run_ends().len();
         while st + 1 < en {
             let mid: usize = (st + en) / 2;
-            // The check `st + 1 < en` ensures `mid` can never be zero and hence
-            // there is no need to check for underflow for `mid - 1`
-            if logical_index < self.run_ends().value(mid - 1).as_usize() {
+            if logical_index
+                < unsafe {
+                    // Safety:
+                    // The value of mid will always be between 1 and len - 1,
+                    // where len is length of run ends array.
+                    // This is based on the fact that `st` starts with 0 and
+                    // `en` starts with len. The condition `st + 1 < en` ensures
+                    // `st` and `en` differs atleast by two. So the value of `mid`
+                    // will never be either `st` or `en`
+                    self.run_ends().value_unchecked(mid - 1).as_usize()
+                }
+            {
                 en = mid
             } else {
                 st = mid

--- a/arrow-array/src/builder/primitive_run_builder.rs
+++ b/arrow-array/src/builder/primitive_run_builder.rs
@@ -253,6 +253,18 @@ where
     }
 }
 
+impl<R, V> Extend<Option<V::Native>> for PrimitiveRunBuilder<R, V>
+where
+    R: RunEndIndexType,
+    V: ArrowPrimitiveType,
+{
+    fn extend<T: IntoIterator<Item = Option<V::Native>>>(&mut self, iter: T) {
+        for elem in iter {
+            self.append_option(elem);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::builder::PrimitiveRunBuilder;
@@ -290,5 +302,24 @@ mod tests {
         let ava: &UInt32Array = as_primitive_array::<UInt32Type>(av.as_ref());
 
         assert_eq!(ava, &UInt32Array::from(vec![Some(1234), None, Some(5678)]));
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut builder = PrimitiveRunBuilder::<Int16Type, Int16Type>::new();
+        builder.extend([1, 2, 2, 5, 5, 4, 4].into_iter().map(Some));
+        builder.extend([4, 4, 6, 2].into_iter().map(Some));
+        let array = builder.finish();
+
+        assert_eq!(array.len(), 11);
+        assert_eq!(array.null_count(), 0);
+        assert_eq!(
+            as_primitive_array::<Int16Type>(array.run_ends()).values(),
+            &[1, 3, 5, 9, 10, 11]
+        );
+        assert_eq!(
+            as_primitive_array::<Int16Type>(array.values().as_ref()).values(),
+            &[1, 2, 5, 4, 6, 2]
+        );
     }
 }

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -178,6 +178,7 @@ pub mod cast;
 mod delta;
 pub mod iterator;
 mod raw_pointer;
+pub mod run_iterator;
 pub mod temporal_conversions;
 pub mod timezone;
 mod trusted_len;

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -149,7 +149,7 @@ where
             // reason the next value can be accessed by decrementing physical index once.
             self.current_end_physical -= 1;
         }
-        
+
         Some(if self.array.values().is_null(self.current_end_physical) {
             None
         } else {

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -1,0 +1,271 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Idiomatic iterator for [`RunArray`](crate::Array)
+
+use arrow_buffer::ArrowNativeType;
+
+use crate::{array::ArrayAccessor, types::RunEndIndexType, Array, TypedRunArray};
+
+/// The [`RunArrayIter`] provides an idiomatic way to iterate over the run array.
+/// It returns Some(T) if there is a value or None if the value is null.
+///
+/// The iterator comes with a cost as it has to iterate over three arrays to determine
+/// the value to be returned. The run_ends array is used to determine the index of the value.
+/// The nulls array is used to determine if the value is null and the values array is used to
+/// get the value.
+///
+/// Unlike other iterators in this crate, [`RunArrayIter`] does not use [`ArrayAccessor`]
+/// because the run array accessor does binary search to access each value which is too slow.
+/// The run array iterator can determine the next value in constant time.
+///
+#[derive(Debug)]
+pub struct RunArrayIter<'a, R, V>
+where
+    R: RunEndIndexType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Default,
+{
+    array: TypedRunArray<'a, R, V>,
+    current_logical: usize,
+    current_physical: usize,
+    current_end_logical: usize,
+    current_end_physical: usize,
+}
+
+impl<'a, R, V> RunArrayIter<'a, R, V>
+where
+    R: RunEndIndexType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Default,
+{
+    /// create a new iterator
+    pub fn new(array: TypedRunArray<'a, R, V>) -> Self {
+        let logical_len = array.len();
+        let physical_len: usize = array.values().len();
+        RunArrayIter {
+            array,
+            current_logical: 0,
+            current_physical: 0,
+            current_end_logical: logical_len,
+            current_end_physical: physical_len,
+        }
+    }
+}
+
+impl<'a, R, V> Iterator for RunArrayIter<'a, R, V>
+where
+    R: RunEndIndexType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Default,
+{
+    type Item = Option<<&'a V as ArrayAccessor>::Item>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_logical == self.current_end_logical {
+            return None;
+        }
+        // If current logical index is greater than current run end index then increment
+        // the physical index.
+        if self.current_logical
+            >= self
+                .array
+                .run_ends()
+                .value(self.current_physical)
+                .as_usize()
+        {
+            // As the run_ends is expected to be strictly increasing, there
+            // should be at least one logical entry in one physical entry. Because of this
+            // reason the next value can be accessed by incrementing physical index once.
+            self.current_physical += 1;
+        }
+        if self.array.values().is_null(self.current_physical) {
+            self.current_logical += 1;
+            Some(None)
+        } else {
+            self.current_logical += 1;
+            // Safety:
+            // The self.current_physical is kept within bounds of self.current_logical.
+            // The self.current_logical will not go out of bounds because of the check
+            // `self.current_logical = self.current_end_logical` above.
+            unsafe {
+                Some(Some(
+                    self.array.values().value_unchecked(self.current_physical),
+                ))
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.current_end_logical - self.current_logical,
+            Some(self.current_end_logical - self.current_logical),
+        )
+    }
+}
+
+impl<'a, R, V> DoubleEndedIterator for RunArrayIter<'a, R, V>
+where
+    R: RunEndIndexType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Default,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.current_end_logical == self.current_logical {
+            None
+        } else {
+            self.current_end_logical -= 1;
+            if self.current_end_physical > 0
+                && self.current_end_logical
+                    < self
+                        .array
+                        .run_ends()
+                        .value(self.current_end_physical - 1)
+                        .as_usize()
+            {
+                // As the run_ends is expected to be strictly increasing, there
+                // should be at least one logical entry in one physical entry. Because of this
+                // reason the next value can be accessed by decrementing physical index once.
+                self.current_end_physical -= 1;
+            }
+            Some(if self.array.values().is_null(self.current_end_physical) {
+                None
+            } else {
+                // Safety:
+                // The check `self.current_end_physical > 0` ensures the value will not underflow.
+                // Also self.current_end_physical starts with array.len() and
+                // decrements based on the bounds of self.current_end_logical.
+                unsafe {
+                    Some(
+                        self.array
+                            .values()
+                            .value_unchecked(self.current_end_physical),
+                    )
+                }
+            })
+        }
+    }
+}
+
+/// all arrays have known size.
+impl<'a, R, V> ExactSizeIterator for RunArrayIter<'a, R, V>
+where
+    R: RunEndIndexType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Default,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        array::{Int32Array, StringArray},
+        builder::PrimitiveRunBuilder,
+        types::Int32Type,
+        Int64RunArray,
+    };
+
+    #[test]
+    fn test_primitive_array_iter_round_trip() {
+        let mut input_vec = vec![
+            Some(32),
+            Some(32),
+            None,
+            Some(64),
+            Some(64),
+            Some(64),
+            Some(72),
+        ];
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
+        builder.extend(input_vec.clone().into_iter());
+        let ree_array = builder.finish();
+        let ree_array = ree_array.downcast_ref::<Int32Array>().unwrap();
+
+        let output_vec: Vec<Option<i32>> = ree_array.into_iter().collect();
+        assert_eq!(input_vec, output_vec);
+
+        let rev_output_vec: Vec<Option<i32>> = ree_array.into_iter().rev().collect();
+        input_vec.reverse();
+        assert_eq!(input_vec, rev_output_vec);
+    }
+
+    #[test]
+    fn test_double_ended() {
+        let input_vec = vec![
+            Some(32),
+            Some(32),
+            None,
+            Some(64),
+            Some(64),
+            Some(64),
+            Some(72),
+        ];
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
+        builder.extend(input_vec.into_iter());
+        let ree_array = builder.finish();
+        let ree_array = ree_array.downcast_ref::<Int32Array>().unwrap();
+
+        let mut iter = ree_array.into_iter();
+        assert_eq!(Some(Some(32)), iter.next());
+        assert_eq!(Some(Some(72)), iter.next_back());
+        assert_eq!(Some(Some(32)), iter.next());
+        assert_eq!(Some(Some(64)), iter.next_back());
+        assert_eq!(Some(None), iter.next());
+        assert_eq!(Some(Some(64)), iter.next_back());
+        assert_eq!(Some(Some(64)), iter.next());
+        assert_eq!(None, iter.next_back());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn test_string_array_iter_round_trip() {
+        let input_vec = vec!["ab", "ab", "ba", "cc", "cc"];
+        let input_ree_array: Int64RunArray = input_vec.into_iter().collect();
+        let string_ree_array = input_ree_array.downcast_ref::<StringArray>().unwrap();
+
+        // to and from iter, with a +1
+        let result: Vec<Option<String>> = string_ree_array
+            .into_iter()
+            .map(|e| {
+                e.map(|e| {
+                    let mut a = e.to_string();
+                    a.push('b');
+                    a
+                })
+            })
+            .collect();
+
+        let result_asref: Vec<Option<&str>> =
+            result.iter().map(|f| f.as_deref()).collect();
+
+        let expected_vec = vec![
+            Some("abb"),
+            Some("abb"),
+            Some("bab"),
+            Some("ccb"),
+            Some("ccb"),
+        ];
+
+        assert_eq!(expected_vec, result_asref);
+    }
+}

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -238,6 +238,10 @@ name = "string_dictionary_builder"
 harness = false
 
 [[bench]]
+name = "string_run_builder"
+harness = false
+
+[[bench]]
 name = "substring_kernels"
 harness = false
 required-features = ["test_utils"]

--- a/arrow/benches/string_run_builder.rs
+++ b/arrow/benches/string_run_builder.rs
@@ -41,12 +41,12 @@ fn build_strings(
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("string_run_builder");
 
-    let mut do_bench =
-        |physical_array_len: usize, logical_array_len: usize, string_len: usize| {
-            group.bench_function(
+    let mut do_bench = |physical_array_len: usize,
+                        logical_array_len: usize,
+                        string_len: usize| {
+        group.bench_function(
                 format!(
-                    "(run_array_len:{}, physical_array_len:{}, string_len: {})",
-                    logical_array_len, physical_array_len, string_len
+                    "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len}, string_len: {string_len})",
                 ),
                 |b| {
                     let strings =
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     })
                 },
             );
-        };
+    };
 
     do_bench(20, 1000, 5);
     do_bench(100, 1000, 5);

--- a/arrow/benches/string_run_builder.rs
+++ b/arrow/benches/string_run_builder.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::StringRunBuilder;
+use arrow::datatypes::Int32Type;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{thread_rng, Rng};
+
+fn build_strings(
+    physical_array_len: usize,
+    logical_array_len: usize,
+    string_len: usize,
+) -> Vec<String> {
+    let mut rng = thread_rng();
+    let run_len = logical_array_len / physical_array_len;
+    let mut values: Vec<String> = (0..physical_array_len)
+        .map(|_| (0..string_len).map(|_| rng.gen::<char>()).collect())
+        .flat_map(|s| std::iter::repeat(s).take(run_len))
+        .collect();
+    while values.len() < logical_array_len {
+        let last_val = values[values.len() - 1].clone();
+        values.push(last_val);
+    }
+    values
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_run_builder");
+
+    let mut do_bench =
+        |physical_array_len: usize, logical_array_len: usize, string_len: usize| {
+            group.bench_function(
+                format!(
+                    "(run_array_len:{}, physical_array_len:{}, string_len: {})",
+                    logical_array_len, physical_array_len, string_len
+                ),
+                |b| {
+                    let strings =
+                        build_strings(physical_array_len, logical_array_len, string_len);
+                    b.iter(|| {
+                        let mut builder = StringRunBuilder::<Int32Type>::with_capacity(
+                            physical_array_len,
+                            (string_len + 1) * physical_array_len,
+                        );
+
+                        for val in &strings {
+                            builder.append_value(val);
+                        }
+
+                        builder.finish();
+                    })
+                },
+            );
+        };
+
+    do_bench(20, 1000, 5);
+    do_bench(100, 1000, 5);
+    do_bench(100, 1000, 10);
+    do_bench(100, 10000, 10);
+    do_bench(100, 10000, 100);
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?
Part of #3520 

# Rationale for this change
See issue description. 

# What changes are included in this PR?

- Implement `Extend` for the `PrimitiveRunBuilder` and `GenericByteRunBuilder`
- Add `TypedRunArray` 
- Add `RunArrayIter` and `ArrayAccessor` for `TypedRunArray`
- Add benchmarks for `StringRunBuilder`

# Are there any user-facing changes?

Users will get new features for RunArray.

No breaking changes.