### PR TITLE
Minor: Add test for dictionary encoding of batches

### DIFF
--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -124,6 +124,33 @@ async fn test_zero_batches_schema_specified() {
 }
 
 #[tokio::test]
+async fn test_zero_batches_dictonary_schema_specified() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, false),
+        Field::new(
+            "b",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            false,
+        ),
+    ]));
+
+    let expected_schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, false),
+        Field::new("b", DataType::Utf8, false),
+    ]));
+    let stream = FlightDataEncoderBuilder::default()
+        .with_schema(schema.clone())
+        .build(futures::stream::iter(vec![]));
+
+    let mut decoder = FlightRecordBatchStream::new_from_flight_data(stream);
+    assert!(decoder.schema().is_none());
+    // No batches come out
+    assert!(decoder.next().await.is_none());
+    // But schema has been received correctly
+    assert_eq!(decoder.schema(), Some(&expected_schema));
+}
+
+#[tokio::test]
 async fn test_app_metadata() {
     let input_batch_stream = futures::stream::iter(vec![Ok(make_primative_batch(78))]);
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -134,6 +134,7 @@ async fn test_zero_batches_dictonary_schema_specified() {
         ),
     ]));
 
+    // Expect dictionary to be hydrated in output (#3389)
     let expected_schema = Arc::new(Schema::new(vec![
         Field::new("a", DataType::Int64, false),
         Field::new("b", DataType::Utf8, false),


### PR DESCRIPTION
# Which issue does this PR close?
re https://github.com/apache/arrow-rs/issues/3591
Adds another test for code added in  https://github.com/apache/arrow-rs/pull/3594

# Rationale for this change
We hit a bug (see https://github.com/influxdata/influxdb_iox/pull/6711) downstream in IOx due to the schema for empty stream being different than the schema for non empty stream --  I wanted to make sure this case was covered in arrow-rs

# What changes are included in this PR?

Add a new test
# Are there any user-facing changes?

no

