### PR TITLE
RFC: Require schema when creating FlightDataEncoderStream

### DIFF
--- a/arrow-flight/tests/client.rs
+++ b/arrow-flight/tests/client.rs
@@ -754,7 +754,7 @@ async fn test_flight_data() -> Vec<FlightData> {
     .unwrap();
 
     // encode the batch as a stream of FlightData
-    FlightDataEncoderBuilder::new()
+    FlightDataEncoderBuilder::new(batch.schema())
         .build(futures::stream::iter(vec![Ok(batch)]))
         .try_collect()
         .await
@@ -769,7 +769,7 @@ async fn test_flight_data2() -> Vec<FlightData> {
     .unwrap();
 
     // encode the batch as a stream of FlightData
-    FlightDataEncoderBuilder::new()
+    FlightDataEncoderBuilder::new(batch.schema())
         .build(futures::stream::iter(vec![Ok(batch)]))
         .try_collect()
         .await

--- a/arrow-flight/tests/common/server.rs
+++ b/arrow-flight/tests/common/server.rs
@@ -353,9 +353,15 @@ impl FlightService for TestFlightServer {
             .take()
             .ok_or_else(|| Status::internal("No do_get response configured"))?;
 
+        let schema = if let Some(Ok(batch)) = batches.get(0) {
+            batch.schema()
+        } else {
+            Arc::new(Schema::new(vec![]))
+        };
+
         let batch_stream = futures::stream::iter(batches).map_err(Into::into);
 
-        let stream = FlightDataEncoderBuilder::new()
+        let stream = FlightDataEncoderBuilder::new(schema)
             .build(batch_stream)
             .map_err(Into::into);
 


### PR DESCRIPTION
# Which issue does this PR close?

re #3594 

# Rationale for this change
 
As suggested by @viirya https://github.com/apache/arrow-rs/pull/3594#discussion_r1087732786

This is an API change. I am not sure if it is better / worse so I figured I would put up the changes and we could have a look at them. It certainly makes using `FlightDataEncoderBuilder` harder

# What changes are included in this PR?

Require a schema to encode a flight data stream FlightDataEncoder 

# Are there any user-facing changes?

Yes