### PR TITLE
Reduce Dictionary Builder Codegen

### DIFF
--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -240,11 +240,9 @@ where
                 let idx = storage.len();
                 storage.append_value(value);
 
-                entry
-                    .insert_with_hasher(hash, idx, (), |idx| {
-                        state.hash_one(get_bytes(storage, *idx))
-                    })
-                    .0;
+                entry.insert_with_hasher(hash, idx, (), |idx| {
+                    state.hash_one(get_bytes(storage, *idx))
+                });
 
                 K::Native::from_usize(idx)
                     .ok_or(ArrowError::DictionaryKeyOverflowError)?

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -194,7 +194,6 @@ impl ArrowNativeType for i256 {
 
     fn as_usize(self) -> usize {
         self.to_parts().0 as usize
-
     }
 
     fn usize_as(i: usize) -> Self {

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -58,6 +58,11 @@ pub trait ArrowNativeType:
     /// [`as`]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast
     fn as_usize(self) -> usize;
 
+    /// Convert from usize according to the [`as`] operator
+    ///
+    /// [`as`]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast
+    fn usize_as(i: usize) -> Self;
+
     /// Convert native type to usize.
     ///
     /// Returns `None` if [`Self`] is not an integer or conversion would result
@@ -119,6 +124,12 @@ macro_rules! native_integer {
                 self as _
             }
 
+            #[inline]
+            fn usize_as(i: usize) -> Self {
+                i as _
+            }
+
+
             $(
                 #[inline]
                 fn $from(v: $t) -> Option<Self> {
@@ -140,7 +151,7 @@ native_integer!(u32);
 native_integer!(u64);
 
 macro_rules! native_float {
-    ($t:ty, $s:ident, $as_usize: expr) => {
+    ($t:ty, $s:ident, $as_usize: expr, $i:ident, $usize_as: expr) => {
         impl private::Sealed for $t {}
         impl ArrowNativeType for $t {
             #[inline]
@@ -162,13 +173,18 @@ macro_rules! native_float {
             fn as_usize($s) -> usize {
                 $as_usize
             }
+
+            #[inline]
+            fn usize_as($i: usize) -> Self {
+                $usize_as
+            }
         }
     };
 }
 
-native_float!(f16, self, self.to_f32() as _);
-native_float!(f32, self, self as _);
-native_float!(f64, self, self as _);
+native_float!(f16, self, self.to_f32() as _, i, f16::from_f32(i as _));
+native_float!(f32, self, self as _, i, i as _);
+native_float!(f64, self, self as _, i, i as _);
 
 impl private::Sealed for i256 {}
 impl ArrowNativeType for i256 {
@@ -178,6 +194,11 @@ impl ArrowNativeType for i256 {
 
     fn as_usize(self) -> usize {
         self.to_parts().0 as usize
+
+    }
+
+    fn usize_as(i: usize) -> Self {
+        Self::from_parts(i as u128, 0)
     }
 
     fn to_usize(self) -> Option<usize> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This reduces the amount of generated LLVM code for arrow-cast by 10% according to `llvm-lines`.

```
  Lines           Copies        Function name
  -----           ------        -------------
  1149994 (100%)  26363 (100%)  (TOTAL)
```

Down to

```
  Lines           Copies        Function name
  -----           ------        -------------
  1004711 (100%)  22241 (100%)  (TOTAL)
```

Build times go from

```
________________________________________________________
Executed in   15.47 secs    fish           external
   usr time   97.61 secs  446.00 micros   97.61 secs
   sys time    4.21 secs  102.00 micros    4.21 secs
```

To

```
________________________________________________________
Executed in   15.28 secs    fish           external
   usr time   94.61 secs  627.00 micros   94.61 secs
   sys time    4.17 secs    0.00 micros    4.17 secs
```

So not hugely noticeable, but every little helps :sweat_smile: 

It also makes the code faster, likely by reducing branching

```
string_dictionary_builder/(dict_size:20, len:1000, key_len: 5)
                        time:   [15.543 µs 15.580 µs 15.625 µs]
                        change: [-11.050% -10.027% -8.8655%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) low mild
  14 (14.00%) high severe
string_dictionary_builder/(dict_size:100, len:1000, key_len: 5)
                        time:   [18.659 µs 18.700 µs 18.740 µs]
                        change: [-1.8355% -1.6221% -1.3921%] (p = 0.00 < 0.05)
                        Performance has improved.
string_dictionary_builder/(dict_size:100, len:1000, key_len: 10)
                        time:   [19.782 µs 19.804 µs 19.825 µs]
                        change: [-1.0721% -0.8720% -0.6280%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
string_dictionary_builder/(dict_size:100, len:10000, key_len: 10)
                        time:   [156.43 µs 156.50 µs 156.58 µs]
                        change: [-0.8631% -0.7213% -0.5152%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
string_dictionary_builder/(dict_size:100, len:10000, key_len: 100)
                        time:   [455.15 µs 455.39 µs 455.62 µs]
                        change: [-0.0976% -0.0156% +0.0749%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
