### PR TITLE
Remove BitSliceIterator specialization from try_for_each_valid_idx

### DIFF
--- a/arrow-data/src/bit_iterator.rs
+++ b/arrow-data/src/bit_iterator.rs
@@ -186,14 +186,7 @@ pub fn try_for_each_valid_idx<E, F: FnMut(usize) -> Result<(), E>>(
     if valid_count == len {
         (0..len).try_for_each(f)
     } else if null_count != len {
-        let selectivity = valid_count as f64 / len as f64;
-        if selectivity > 0.8 {
-            BitSliceIterator::new(nulls.unwrap(), offset, len)
-                .flat_map(|(start, end)| start..end)
-                .try_for_each(f)
-        } else {
-            BitIndexIterator::new(nulls.unwrap(), offset, len).try_for_each(f)
-        }
+        BitIndexIterator::new(nulls.unwrap(), offset, len).try_for_each(f)
     } else {
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In theory the idea of using the slices iterator is that LLVM is able to vectorise the inner iteration. This was copied across from the filter kernels where this made a non-trivial difference. However, in practice because the operation is fallible, unlike the filter kernels, it fails to do so. As a result this special case is just resulting in additional codegen and actually ends up marginally slower.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
