### PR TITLE
feat: take kernel for RunArray

### DIFF
--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -206,15 +206,10 @@ impl<R: RunEndIndexType> RunArray<R> {
 
         let mut physical_indices = vec![0; indices_len];
 
-        let mut physical_index = 0_usize;
         let mut ordered_index = 0_usize;
-        while physical_index < self.run_ends.len() && ordered_index < indices_len {
+        for (physical_index, run_end) in self.run_ends.values().iter().enumerate() {
             // Get the run end index of current physical index
-            let run_end_value =
-                // Safety:
-                //  The check `run_ends_index < self.run_ends.len()` ensures the index
-                //  is in bounds and can be accessed without validation.
-                unsafe { self.run_ends.value_unchecked(physical_index).as_usize() };
+            let run_end_value = run_end.as_usize();
 
             // All the `logical_indices` that are less than current run end index
             // belongs to current physical index.
@@ -225,7 +220,6 @@ impl<R: RunEndIndexType> RunArray<R> {
                 physical_indices[ordered_indices[ordered_index]] = physical_index;
                 ordered_index += 1;
             }
-            physical_index += 1;
         }
 
         // If there are input values >= run_ends.last_value then we'll not be able to convert

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -779,7 +779,7 @@ mod tests {
                 let actual = typed.value(i);
                 assert_eq!(*val, actual)
             } else {
-                let physical_ix = typed.get_physical_index(i).unwrap();
+                let physical_ix = run_array.get_physical_index(i).unwrap();
                 assert!(typed.values().is_null(physical_ix));
             };
         }
@@ -796,7 +796,7 @@ mod tests {
 
             let run_array = builder.finish();
             let physical_values_array =
-                run_array.downcast_ref::<Int32Array>().unwrap().values();
+                run_array.downcast::<Int32Array>().unwrap().values();
 
             let mut indices: Vec<u32> = (0_u32..(logical_len as u32)).collect();
             let mut rng = thread_rng();

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -181,7 +181,7 @@ impl<R: RunEndIndexType> RunArray<R> {
     /// finding physical index for each logical index using binary search using the function
     /// `get_physical_index`. Running benchmarks on both approaches showed that the approach used here
     /// scaled well for larger inputs.
-    /// See https://github.com/apache/arrow-rs/pull/3622#issuecomment-1407753727 for more details.
+    /// See <https://github.com/apache/arrow-rs/pull/3622#issuecomment-1407753727> for more details.
     #[inline]
     pub fn get_physical_indices<I>(
         &self,

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -522,15 +522,16 @@ mod tests {
         let mut result: Vec<Option<i32>> = Vec::with_capacity(size);
         let mut ix = 0;
         let mut rng = thread_rng();
-        // Cap run length for smaller arrays
-        let max_run_length = (size + 2) / 2;
+        // run length can go up to 8. Cap the max run length for smaller arrays to size / 2.
+        let max_run_length = 8_usize.min(1_usize.max(size / 2));
         while result.len() < size {
             // shuffle the seed array if all the values are iterated.
             if ix == 0 {
                 seed.shuffle(&mut rng);
             }
             // repeat the items between 1 and 8 times. Cap the length for smaller sized arrays
-            let num = max_run_length.min(rand::thread_rng().gen_range(1..9));
+            let num =
+                max_run_length.min(rand::thread_rng().gen_range(1..=max_run_length));
             for _ in 0..num {
                 result.push(seed[ix]);
             }

--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -539,7 +539,7 @@ macro_rules! downcast_run_array_helper {
 ///     downcast_run_array!(
 ///         array => match array.values().data_type() {
 ///             DataType::Utf8 => {
-///                 for v in array.downcast_ref::<StringArray>().unwrap() {
+///                 for v in array.downcast::<StringArray>().unwrap() {
 ///                     println!("{:?}", v);
 ///                 }
 ///             }

--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -95,6 +95,53 @@ macro_rules! downcast_integer {
     };
 }
 
+/// Given one or more expressions evaluating to an integer [`DataType`] invokes the provided macro
+/// `m` with the corresponding integer [`RunEndIndexType`], followed by any additional arguments
+///
+/// ```
+/// # use arrow_array::{downcast_primitive, ArrowPrimitiveType, downcast_run_end_index};
+/// # use arrow_schema::{DataType, Field};
+///
+/// macro_rules! run_end_size_helper {
+///   ($t:ty, $o:ty) => {
+///       std::mem::size_of::<<$t as ArrowPrimitiveType>::Native>() as $o
+///   };
+/// }
+///
+/// fn run_end_index_size(t: &DataType) -> u8 {
+///     match t {
+///         DataType::RunEndEncoded(k, _) => downcast_run_end_index! {
+///             k.data_type() => (run_end_size_helper, u8),
+///             _ => unreachable!(),
+///         },
+///         _ => u8::MAX,
+///     }
+/// }
+///
+/// assert_eq!(run_end_index_size(&DataType::RunEndEncoded(Box::new(Field::new("a", DataType::Int32, false)), Box::new(Field::new("b", DataType::Utf8, true)))), 4);
+/// assert_eq!(run_end_index_size(&DataType::RunEndEncoded(Box::new(Field::new("a", DataType::Int64, false)), Box::new(Field::new("b", DataType::Utf8, true)))), 8);
+/// assert_eq!(run_end_index_size(&DataType::RunEndEncoded(Box::new(Field::new("a", DataType::Int16, false)), Box::new(Field::new("b", DataType::Utf8, true)))), 2);
+/// ```
+///
+/// [`DataType`]: arrow_schema::DataType
+#[macro_export]
+macro_rules! downcast_run_end_index {
+    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($($p:pat),+ => $fallback:expr $(,)*)*) => {
+        match ($($data_type),+) {
+            $crate::repeat_pat!(arrow_schema::DataType::Int16, $($data_type),+) => {
+                $m!($crate::types::Int16Type $(, $args)*)
+            }
+            $crate::repeat_pat!(arrow_schema::DataType::Int32, $($data_type),+) => {
+                $m!($crate::types::Int32Type $(, $args)*)
+            }
+            $crate::repeat_pat!(arrow_schema::DataType::Int64, $($data_type),+) => {
+                $m!($crate::types::Int64Type $(, $args)*)
+            }
+            $(($($p),+) => $fallback,)*
+        }
+    };
+}
+
 /// Given one or more expressions evaluating to primitive [`DataType`] invokes the provided macro
 /// `m` with the corresponding [`ArrowPrimitiveType`], followed by any additional arguments
 ///
@@ -447,6 +494,85 @@ where
     arr.as_any()
         .downcast_ref::<DictionaryArray<T>>()
         .expect("Unable to downcast to dictionary array")
+}
+
+/// Force downcast of an [`Array`], such as an [`ArrayRef`] to
+/// [`RunArray<T>`], panic'ing on failure.
+///
+/// # Example
+///
+/// ```
+/// # use arrow_array::{ArrayRef, RunArray};
+/// # use arrow_array::cast::as_run_array;
+/// # use arrow_array::types::Int32Type;
+///
+/// let arr: RunArray<Int32Type> = vec![Some("foo")].into_iter().collect();
+/// let arr: ArrayRef = std::sync::Arc::new(arr);
+/// let run_array: &RunArray<Int32Type> = as_run_array::<Int32Type>(&arr);
+/// ```
+pub fn as_run_array<T>(arr: &dyn Array) -> &RunArray<T>
+where
+    T: RunEndIndexType,
+{
+    arr.as_any()
+        .downcast_ref::<RunArray<T>>()
+        .expect("Unable to downcast to run array")
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! downcast_run_array_helper {
+    ($t:ty, $($values:ident),+, $e:block) => {{
+        $(let $values = $crate::cast::as_run_array::<$t>($values);)+
+        $e
+    }};
+}
+
+/// Downcast an [`Array`] to a [`RunArray`] based on its [`DataType`], accepts
+/// a number of subsequent patterns to match the data type
+///
+/// ```
+/// # use arrow_array::{Array, StringArray, downcast_run_array, cast::as_string_array};
+/// # use arrow_schema::DataType;
+///
+/// fn print_strings(array: &dyn Array) {
+///     downcast_run_array!(
+///         array => match array.values().data_type() {
+///             DataType::Utf8 => {
+///                 for v in array.downcast_ref::<StringArray>().unwrap() {
+///                     println!("{:?}", v);
+///                 }
+///             }
+///             t => println!("Unsupported run array value type {}", t),
+///         },
+///         DataType::Utf8 => {
+///             for v in as_string_array(array) {
+///                 println!("{:?}", v);
+///             }
+///         }
+///         t => println!("Unsupported datatype {}", t)
+///     )
+/// }
+/// ```
+///
+/// [`DataType`]: arrow_schema::DataType
+#[macro_export]
+macro_rules! downcast_run_array {
+    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
+        downcast_run_array!($values => {$e} $($p => $fallback)*)
+    };
+
+    ($values:ident => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+        match $values.data_type() {
+            arrow_schema::DataType::RunEndEncoded(k, _) => {
+                $crate::downcast_run_end_index! {
+                    k.data_type() => ($crate::downcast_run_array_helper, $values, $e),
+                    k => unreachable!("unsupported run end index type: {}", k)
+                }
+            }
+            $($p => $fallback,)*
+        }
+    }
 }
 
 /// Force downcast of an [`Array`], such as an [`ArrayRef`] to

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -149,7 +149,6 @@ where
             // reason the next value can be accessed by decrementing physical index once.
             self.current_end_physical -= 1;
         }
-
         Some(if self.array.values().is_null(self.current_end_physical) {
             None
         } else {

--- a/arrow-select/Cargo.toml
+++ b/arrow-select/Cargo.toml
@@ -46,6 +46,7 @@ num = { version = "0.4", default-features = false, features = ["std"] }
 
 [features]
 default = []
+take_run_loop = []
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/arrow-select/Cargo.toml
+++ b/arrow-select/Cargo.toml
@@ -46,7 +46,6 @@ num = { version = "0.4", default-features = false, features = ["std"] }
 
 [features]
 default = []
-take_run_loop = []
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -860,7 +860,6 @@ where
 }
 
 // Builds a `RunArray` by taking values from given array for the given indices.
-#[cfg(not(feature = "take_run_value_take"))]
 fn take_primitive_run_values<R, V>(
     physical_indices: Vec<usize>,
     values: &PrimitiveArray<V>,

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -19,13 +19,15 @@
 
 use std::sync::Arc;
 
-use arrow_array::types::*;
 use arrow_array::*;
+use arrow_array::{builder::PrimitiveRunBuilder, types::*};
 use arrow_buffer::{bit_util, ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, Field};
 
-use arrow_array::cast::{as_generic_binary_array, as_largestring_array, as_string_array};
+use arrow_array::cast::{
+    as_generic_binary_array, as_largestring_array, as_primitive_array, as_string_array,
+};
 use num::{ToPrimitive, Zero};
 
 /// Take elements by index from [Array], creating a new [Array] from those indexes.
@@ -200,6 +202,10 @@ where
         DataType::Dictionary(_, _) => downcast_dictionary_array! {
             values => Ok(Arc::new(take_dict(values, indices)?)),
             t => unimplemented!("Take not supported for dictionary type {:?}", t)
+        }
+        DataType::RunEndEncoded(_, _) => downcast_run_array! {
+            values => Ok(Arc::new(take_run(values, indices)?)),
+            t => unimplemented!("Take not supported for run type {:?}", t)
         }
         DataType::Binary => {
             Ok(Arc::new(take_bytes(as_generic_binary_array::<i32>(values), indices)?))
@@ -808,6 +814,70 @@ where
     };
 
     Ok(DictionaryArray::<T>::from(data))
+}
+
+macro_rules! primitive_run_take {
+    ($t:ty, $o:ty, $indices:ident, $value:ident) => {
+        take_primitive_run_values::<$o, $t>(
+            $indices,
+            as_primitive_array::<$t>($value.values()),
+        )
+    };
+}
+
+/// `take` implementation for run arrays
+///
+/// performs binary search on `run_ends` to get physical indices for the given logical indices.
+/// builds output run array by taking values in the input run array at the physical indices.
+/// for e.g. an input `RunArray{ run_ends = [2,4,6,8], values=[1,2,1,2] }` and `indices=[2,7]`
+/// would be converted to `physical_indices=[1,3]` which will be used to build
+/// output `RunArray{ run_ends=[2], values=[2] }`
+
+pub fn take_run<T, I>(
+    run_array: &RunArray<T>,
+    logical_indices: &PrimitiveArray<I>,
+) -> Result<RunArray<T>, ArrowError>
+where
+    T: RunEndIndexType,
+    T::Native: num::Num,
+    I: ArrowPrimitiveType,
+    I::Native: ToPrimitive,
+{
+    match run_array.data_type() {
+        DataType::RunEndEncoded(_, fl) => {
+            let physical_indices =
+                run_array.get_physical_indices(logical_indices.values())?;
+            downcast_primitive! {
+                fl.data_type() => (primitive_run_take, T, physical_indices, run_array),
+                dt => Err(ArrowError::NotYetImplemented(format!("take_run is not implemented for {dt:?}")))
+            }
+        }
+        dt => Err(ArrowError::InvalidArgumentError(format!(
+            "Expected DataType::RunEndEncoded found {dt:?}"
+        ))),
+    }
+}
+// Builds a `RunArray` by taking values from given array for the given indices.
+fn take_primitive_run_values<R, V>(
+    physical_indices: Vec<usize>,
+    values: &PrimitiveArray<V>,
+) -> Result<RunArray<R>, ArrowError>
+where
+    R: RunEndIndexType,
+    V: ArrowPrimitiveType,
+{
+    let mut builder = PrimitiveRunBuilder::<R, V>::new();
+    let values_len = values.len();
+    for ix in physical_indices {
+        if ix >= values_len {
+            return Err(ArrowError::InvalidArgumentError("The requested index {ix} is out of bounds for values array with length {values_len}".to_string()));
+        } else if values.is_null(ix) {
+            builder.append_null()
+        } else {
+            builder.append_value(values.value(ix))
+        }
+    }
+    Ok(builder.finish())
 }
 
 /// Takes/filters a list array's inner data using the offsets of the list array.
@@ -2084,6 +2154,28 @@ mod tests {
         assert_eq!(indexed, Int64Array::from(vec![5, 6, 7, 8, 9, 0, 1]));
         assert_eq!(offsets, vec![0, 5, 7]);
         assert_eq!(null_buf.as_slice(), &[0b11111111]);
+    }
+
+    #[test]
+    fn test_take_runs() {
+        let logical_array: Vec<i32> = vec![1_i32, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2];
+
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
+        builder.extend(logical_array.into_iter().map(Some));
+        let run_array = builder.finish();
+
+        let take_indices: PrimitiveArray<Int32Type> =
+            vec![2, 7, 10].into_iter().collect();
+
+        let take_out = take_run(&run_array, &take_indices).unwrap();
+
+        assert_eq!(take_out.len(), 3);
+
+        assert_eq!(take_out.run_ends().len(), 1);
+        assert_eq!(take_out.run_ends().value(0), 3);
+
+        let take_out_values = as_primitive_array::<Int32Type>(take_out.values());
+        assert_eq!(take_out_values.value(0), 2);
     }
 
     #[test]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -242,6 +242,7 @@ harness = false
 [[bench]]
 name = "string_run_builder"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "string_run_iterator"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -102,6 +102,8 @@ half = { version = "2.1", default-features = false, features = ["num-traits"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 tempfile = { version = "3", default-features = false }
 
+
+
 [build-dependencies]
 
 [[example]]
@@ -239,6 +241,14 @@ harness = false
 
 [[bench]]
 name = "string_run_builder"
+harness = false
+
+[[bench]]
+name = "string_run_iterator"
+harness = false
+
+[[bench]]
+name = "primitive_run_accessor"
 harness = false
 
 [[bench]]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -250,6 +250,7 @@ harness = false
 [[bench]]
 name = "primitive_run_accessor"
 harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "substring_kernels"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -253,6 +253,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "primitive_run_take"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "substring_kernels"
 harness = false
 required-features = ["test_utils"]

--- a/arrow/benches/primitive_run_accessor.rs
+++ b/arrow/benches/primitive_run_accessor.rs
@@ -44,11 +44,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
     };
 
-    do_bench(20, 1000);
-    do_bench(100, 1000);
-    do_bench(500, 5000);
-    do_bench(1000, 10000);
-    do_bench(5000, 50000);
+    do_bench(128, 512);
+    do_bench(256, 1024);
+    do_bench(512, 2048);
+    do_bench(1024, 4096);
+    do_bench(2048, 8192);
 
     group.finish();
 }

--- a/arrow/benches/primitive_run_accessor.rs
+++ b/arrow/benches/primitive_run_accessor.rs
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     physical_array_len,
                 );
                 let typed = run_array
-                    .downcast_ref::<PrimitiveArray<Int32Type>>()
+                    .downcast::<PrimitiveArray<Int32Type>>()
                     .unwrap();
                 b.iter(|| {
                     for i in 0..logical_array_len {

--- a/arrow/benches/primitive_run_accessor.rs
+++ b/arrow/benches/primitive_run_accessor.rs
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{ArrayAccessor, PrimitiveArray};
 use arrow::datatypes::Int32Type;
-use arrow::util::bench_util::create_primitive_run_array;
+use arrow::{array::PrimitiveArray, util::bench_util::create_primitive_run_array};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -26,10 +25,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut do_bench = |physical_array_len: usize, logical_array_len: usize| {
         group.bench_function(
             format!(
-                "(run_array_len:{}, physical_array_len:{})",
-                logical_array_len, physical_array_len
-            ),
+                "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len})"),
             |b| {
+                use arrow_array::ArrayAccessor;
                 let run_array = create_primitive_run_array::<Int32Type, Int32Type>(
                     logical_array_len,
                     physical_array_len,

--- a/arrow/benches/primitive_run_accessor.rs
+++ b/arrow/benches/primitive_run_accessor.rs
@@ -17,6 +17,7 @@
 
 use arrow::datatypes::Int32Type;
 use arrow::{array::PrimitiveArray, util::bench_util::create_primitive_run_array};
+use arrow_array::ArrayAccessor;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -27,7 +28,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             format!(
                 "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len})"),
             |b| {
-                use arrow_array::ArrayAccessor;
                 let run_array = create_primitive_run_array::<Int32Type, Int32Type>(
                     logical_array_len,
                     physical_array_len,

--- a/arrow/benches/primitive_run_accessor.rs
+++ b/arrow/benches/primitive_run_accessor.rs
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{ArrayAccessor, PrimitiveArray};
+use arrow::datatypes::Int32Type;
+use arrow::util::bench_util::create_primitive_run_array;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("primitive_run_accessor");
+
+    let mut do_bench = |physical_array_len: usize, logical_array_len: usize| {
+        group.bench_function(
+            format!(
+                "(run_array_len:{}, physical_array_len:{})",
+                logical_array_len, physical_array_len
+            ),
+            |b| {
+                let run_array = create_primitive_run_array::<Int32Type, Int32Type>(
+                    logical_array_len,
+                    physical_array_len,
+                );
+                let typed = run_array
+                    .downcast_ref::<PrimitiveArray<Int32Type>>()
+                    .unwrap();
+                b.iter(|| {
+                    for i in 0..logical_array_len {
+                        let _ = unsafe { typed.value_unchecked(i) };
+                    }
+                })
+            },
+        );
+    };
+
+    do_bench(20, 1000);
+    do_bench(100, 1000);
+    do_bench(500, 5000);
+    do_bench(1000, 10000);
+    do_bench(5000, 50000);
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow/benches/primitive_run_take.rs
+++ b/arrow/benches/primitive_run_take.rs
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::UInt32Builder;
+use arrow::compute::take;
+use arrow::datatypes::{Int32Type, Int64Type};
+use arrow::util::bench_util::*;
+use arrow::util::test_util::seedable_rng;
+use arrow_array::UInt32Array;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
+
+fn create_random_index(size: usize, null_density: f32) -> UInt32Array {
+    let mut rng = seedable_rng();
+    let mut builder = UInt32Builder::with_capacity(size);
+    for _ in 0..size {
+        if rng.gen::<f32>() < null_density {
+            builder.append_null();
+        } else {
+            let value = rng.gen_range::<u32, _>(0u32..size as u32);
+            builder.append_value(value);
+        }
+    }
+    builder.finish()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("primitive_run_take");
+
+    let mut do_bench = |physical_array_len: usize,
+                        logical_array_len: usize,
+                        take_len: usize| {
+        let run_array = create_primitive_run_array::<Int32Type, Int64Type>(
+            logical_array_len,
+            physical_array_len,
+        );
+        let indices = create_random_index(take_len, 0.0);
+        group.bench_function(
+            format!(
+                "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len}, take_len:{take_len})"),
+            |b| {
+                b.iter(|| {
+                    criterion::black_box(take(&run_array, &indices, None).unwrap());
+                })
+            },
+        );
+    };
+
+    do_bench(512, 1024, 4);
+    do_bench(512, 1024, 16);
+    do_bench(512, 1024, 64);
+
+    do_bench(64, 512, 256);
+    do_bench(128, 512, 512);
+    do_bench(256, 1024, 128);
+    do_bench(512, 1024, 1024);
+    do_bench(1024, 2048, 1024);
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow/benches/primitive_run_take.rs
+++ b/arrow/benches/primitive_run_take.rs
@@ -60,15 +60,17 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
     };
 
-    do_bench(512, 1024, 4);
-    do_bench(512, 1024, 16);
-    do_bench(512, 1024, 64);
-
-    do_bench(64, 512, 256);
+    do_bench(64, 512, 512);
     do_bench(128, 512, 512);
-    do_bench(256, 1024, 128);
-    do_bench(512, 1024, 1024);
-    do_bench(1024, 2048, 1024);
+
+    do_bench(256, 1024, 512);
+    do_bench(256, 1024, 1024);
+
+    do_bench(512, 2048, 512);
+    do_bench(512, 2048, 1024);
+
+    do_bench(1024, 4096, 512);
+    do_bench(1024, 4096, 1024);
 
     group.finish();
 }

--- a/arrow/benches/string_run_builder.rs
+++ b/arrow/benches/string_run_builder.rs
@@ -17,26 +17,8 @@
 
 use arrow::array::StringRunBuilder;
 use arrow::datatypes::Int32Type;
+use arrow::util::bench_util::create_string_array_for_runs;
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::{thread_rng, Rng};
-
-fn build_strings(
-    physical_array_len: usize,
-    logical_array_len: usize,
-    string_len: usize,
-) -> Vec<String> {
-    let mut rng = thread_rng();
-    let run_len = logical_array_len / physical_array_len;
-    let mut values: Vec<String> = (0..physical_array_len)
-        .map(|_| (0..string_len).map(|_| rng.gen::<char>()).collect())
-        .flat_map(|s| std::iter::repeat(s).take(run_len))
-        .collect();
-    while values.len() < logical_array_len {
-        let last_val = values[values.len() - 1].clone();
-        values.push(last_val);
-    }
-    values
-}
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("string_run_builder");
@@ -50,7 +32,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 ),
                 |b| {
                     let strings =
-                        build_strings(physical_array_len, logical_array_len, string_len);
+                    create_string_array_for_runs(physical_array_len, logical_array_len, string_len);
                     b.iter(|| {
                         let mut builder = StringRunBuilder::<Int32Type>::with_capacity(
                             physical_array_len,

--- a/arrow/benches/string_run_iterator.rs
+++ b/arrow/benches/string_run_iterator.rs
@@ -56,7 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 let run_array =
                     build_strings_runs(physical_array_len, logical_array_len, string_len);
-                let typed = run_array.downcast_ref::<StringArray>().unwrap();
+                let typed = run_array.downcast::<StringArray>().unwrap();
                 b.iter(|| {
                     let iter = typed.into_iter();
                     for _ in iter {}

--- a/arrow/benches/string_run_iterator.rs
+++ b/arrow/benches/string_run_iterator.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{Int32RunArray, StringArray, StringRunBuilder};
+use arrow::datatypes::Int32Type;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{thread_rng, Rng};
+
+fn build_strings_runs(
+    physical_array_len: usize,
+    logical_array_len: usize,
+    string_len: usize,
+) -> Int32RunArray {
+    let mut rng = thread_rng();
+    let run_len = logical_array_len / physical_array_len;
+    let mut values: Vec<String> = (0..physical_array_len)
+        .map(|_| (0..string_len).map(|_| rng.gen::<char>()).collect())
+        .flat_map(|s| std::iter::repeat(s).take(run_len))
+        .collect();
+    while values.len() < logical_array_len {
+        let last_val = values[values.len() - 1].clone();
+        values.push(last_val);
+    }
+    let mut builder = StringRunBuilder::<Int32Type>::with_capacity(
+        physical_array_len,
+        (string_len + 1) * physical_array_len,
+    );
+    builder.extend(values.into_iter().map(Some));
+
+    builder.finish()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_run_iterator");
+
+    let mut do_bench = |physical_array_len: usize,
+                        logical_array_len: usize,
+                        string_len: usize| {
+        group.bench_function(
+            format!(
+                "(run_array_len:{}, physical_array_len:{}, string_len: {})",
+                logical_array_len, physical_array_len, string_len
+            ),
+            |b| {
+                let run_array =
+                    build_strings_runs(physical_array_len, logical_array_len, string_len);
+                let typed = run_array.downcast_ref::<StringArray>().unwrap();
+                b.iter(|| {
+                    let mut iter = typed.clone().into_iter();
+                    while let Some(_) = iter.next() {}
+                })
+            },
+        );
+    };
+
+    do_bench(20, 1000, 5);
+    do_bench(100, 1000, 5);
+    do_bench(100, 1000, 10);
+    do_bench(1000, 10000, 10);
+    do_bench(1000, 10000, 100);
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow/benches/string_run_iterator.rs
+++ b/arrow/benches/string_run_iterator.rs
@@ -58,7 +58,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     build_strings_runs(physical_array_len, logical_array_len, string_len);
                 let typed = run_array.downcast_ref::<StringArray>().unwrap();
                 b.iter(|| {
-                    let mut iter = typed.into_iter();
+                    let iter = typed.into_iter();
                     for _ in iter {}
                 })
             },

--- a/arrow/benches/string_run_iterator.rs
+++ b/arrow/benches/string_run_iterator.rs
@@ -65,11 +65,17 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
     };
 
-    do_bench(20, 1000, 5);
-    do_bench(100, 1000, 5);
-    do_bench(100, 1000, 10);
-    do_bench(1000, 10000, 10);
-    do_bench(1000, 10000, 100);
+    do_bench(256, 1024, 5);
+    do_bench(256, 1024, 25);
+    do_bench(256, 1024, 100);
+
+    do_bench(512, 2048, 5);
+    do_bench(512, 2048, 25);
+    do_bench(512, 2048, 100);
+
+    do_bench(1024, 4096, 5);
+    do_bench(1024, 4096, 25);
+    do_bench(1024, 4096, 100);
 
     group.finish();
 }

--- a/arrow/benches/string_run_iterator.rs
+++ b/arrow/benches/string_run_iterator.rs
@@ -52,16 +52,14 @@ fn criterion_benchmark(c: &mut Criterion) {
                         string_len: usize| {
         group.bench_function(
             format!(
-                "(run_array_len:{}, physical_array_len:{}, string_len: {})",
-                logical_array_len, physical_array_len, string_len
-            ),
+                "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len}, string_len: {string_len})"),
             |b| {
                 let run_array =
                     build_strings_runs(physical_array_len, logical_array_len, string_len);
                 let typed = run_array.downcast_ref::<StringArray>().unwrap();
                 b.iter(|| {
-                    let mut iter = typed.clone().into_iter();
-                    while let Some(_) = iter.next() {}
+                    let mut iter = typed.into_iter();
+                    for _ in iter {}
                 })
             },
         );

--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -139,6 +139,13 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("take str null values null indices 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
+
+    let values = create_primitive_run_array::<Int32Type, Int32Type>(1024, 512);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function(
+        "take primitive run logical len: 1024, physical len: 512, indices: 1024",
+        |b| b.iter(|| bench_take(&values, &indices)),
+    );
 }
 
 criterion_group!(benches, add_benchmark);

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -151,6 +151,7 @@ pub fn create_primitive_run_array<R: RunEndIndexType, V: ArrowPrimitiveType>(
     logical_array_len: usize,
     physical_array_len: usize,
 ) -> RunArray<R> {
+    assert!(logical_array_len >= physical_array_len);
     // typical length of each run
     let run_len = logical_array_len / physical_array_len;
 
@@ -185,6 +186,7 @@ pub fn create_string_array_for_runs(
     logical_array_len: usize,
     string_len: usize,
 ) -> Vec<String> {
+    assert!(logical_array_len >= physical_array_len);
     let mut rng = thread_rng();
 
     // typical length of each run

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -150,8 +150,16 @@ pub fn create_primitive_run_array<R: RunEndIndexType, V: ArrowPrimitiveType>(
     physical_array_len: usize,
 ) -> RunArray<R> {
     let run_len = logical_array_len / physical_array_len;
+    let mut run_len_extra = logical_array_len % physical_array_len;
     let mut values: Vec<V::Native> = (0..physical_array_len)
-        .flat_map(|s| std::iter::repeat(V::Native::from_usize(s).unwrap()).take(run_len))
+        .flat_map(|s| {
+            let mut take_len = run_len;
+            if run_len_extra > 0 {
+                take_len += 1;
+                run_len_extra -= 1;
+            }
+            std::iter::repeat(V::Native::from_usize(s).unwrap()).take(take_len)
+        })
         .collect();
     while values.len() < logical_array_len {
         let last_val = values[values.len() - 1];


### PR DESCRIPTION
# Which issue does this PR close?

Part of #3520 

# Rationale for this change
 
See issue description.

# What changes are included in this PR?

- Take kernel support for primitive run array
- Benchmark for take kernel for primitive run array
- Benchmark for primitive run array accessor.
- Additional test for `RunArrayIter`.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
