### PR TITLE
Minor: Update doc strings about Page Index / Column Index

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -252,7 +252,7 @@ pub struct RowGroupMetaData {
     sorting_columns: Option<Vec<SortingColumn>>,
     total_byte_size: i64,
     schema_descr: SchemaDescPtr,
-    /// `page_offset_index[column_number][row_number]`
+    /// `page_offset_index[column_number][row_group_number]`
     page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
@@ -299,7 +299,7 @@ impl RowGroupMetaData {
 
     /// Returns reference of page offset index of all column in this row group.
     ///
-    /// The returned vector contains `page_offset[column_number][row_number]`
+    /// The returned vector contains `page_offset[column_number][row_group_number]`
     pub fn page_offset_index(&self) -> Option<&Vec<Vec<PageLocation>>> {
         self.page_offset_index.as_ref()
     }
@@ -316,7 +316,7 @@ impl RowGroupMetaData {
 
     /// Sets page offset index for this row group.
     ///
-    /// The vector represents `page_offset[column_number][row_number]`
+    /// The vector represents `page_offset[column_number][row_group_number]`
     pub fn set_page_offset(&mut self, page_offset: Vec<Vec<PageLocation>>) {
         self.page_offset_index = Some(page_offset);
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -299,7 +299,7 @@ impl RowGroupMetaData {
 
     /// Returns reference of page offset index of all column in this row group.
     ///
-    /// The returned vector contains `page_offset[column_number][row_group_number]`
+    /// The returned vector contains `page_offset[column_number][page_number]`
     pub fn page_offset_index(&self) -> Option<&Vec<Vec<PageLocation>>> {
         self.page_offset_index.as_ref()
     }
@@ -316,7 +316,7 @@ impl RowGroupMetaData {
 
     /// Sets page offset index for this row group.
     ///
-    /// The vector represents `page_offset[column_number][row_group_number]`
+    /// The vector represents `page_offset[column_number][page_number]`
     pub fn set_page_offset(&mut self, page_offset: Vec<Vec<PageLocation>>) {
         self.page_offset_index = Some(page_offset);
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -50,7 +50,25 @@ use crate::schema::types::{
     Type as SchemaType,
 };
 
+/// [`Index`] page level for each row group of each column.
+///
+/// `column_index[row_group_number][column_number]` holds the
+/// [`Index`] corresponding to column `column_number` of row group
+/// `row_group_number`.
+///
+/// For example `column_index[2][3]` holds the [`Index`] for the forth
+/// column in the third row group of the parquet file.
 pub type ParquetColumnIndex = Vec<Vec<Index>>;
+
+/// [`PageLocation`] page level for each row group of each column.
+///
+/// `offset_index[row_group_number][column_number][page_number]` holds
+/// the [`PageLocation`] corresponding to page `page_number` of column
+/// `column_number`of row group `row_group_number`.
+///
+/// For example `offset_index[2][3][4]` holds the [`PageLocation`] for
+/// the fifth page of the forth column in the third row group of the
+/// parquet file.
 pub type ParquetOffsetIndex = Vec<Vec<Vec<PageLocation>>>;
 
 /// Global Parquet metadata.
@@ -65,8 +83,8 @@ pub struct ParquetMetaData {
 }
 
 impl ParquetMetaData {
-    /// Creates Parquet metadata from file metadata and a list of row group metadata `Arc`s
-    /// for each available row group.
+    /// Creates Parquet metadata from file metadata and a list of row
+    /// group metadata
     pub fn new(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>) -> Self {
         ParquetMetaData {
             file_metadata,
@@ -76,6 +94,8 @@ impl ParquetMetaData {
         }
     }
 
+    /// Creates Parquet metadata from file metadata, a list of row
+    /// group metadata, and the column index structures.
     pub fn new_with_page_index(
         file_metadata: FileMetaData,
         row_groups: Vec<RowGroupMetaData>,
@@ -232,6 +252,7 @@ pub struct RowGroupMetaData {
     sorting_columns: Option<Vec<SortingColumn>>,
     total_byte_size: i64,
     schema_descr: SchemaDescPtr,
+    /// `page_offset_index[column_number][row_number]`
     page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 
@@ -277,6 +298,8 @@ impl RowGroupMetaData {
     }
 
     /// Returns reference of page offset index of all column in this row group.
+    ///
+    /// The returned vector contains `page_offset[column_number][row_number]`
     pub fn page_offset_index(&self) -> Option<&Vec<Vec<PageLocation>>> {
         self.page_offset_index.as_ref()
     }
@@ -292,6 +315,8 @@ impl RowGroupMetaData {
     }
 
     /// Sets page offset index for this row group.
+    ///
+    /// The vector represents `page_offset[column_number][row_number]`
     pub fn set_page_offset(&mut self, page_offset: Vec<Vec<PageLocation>>) {
         self.page_offset_index = Some(page_offset);
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -50,7 +50,7 @@ use crate::schema::types::{
     Type as SchemaType,
 };
 
-/// [`Index`] page level for each row group of each column.
+/// [`Index`] for each row group of each column.
 ///
 /// `column_index[row_group_number][column_number]` holds the
 /// [`Index`] corresponding to column `column_number` of row group
@@ -60,7 +60,7 @@ use crate::schema::types::{
 /// column in the third row group of the parquet file.
 pub type ParquetColumnIndex = Vec<Vec<Index>>;
 
-/// [`PageLocation`] page level for each row group of each column.
+/// [`PageLocation`] for each datapage of each row group of each column.
 ///
 /// `offset_index[row_group_number][column_number][page_number]` holds
 /// the [`PageLocation`] corresponding to page `page_number` of column

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -252,7 +252,7 @@ pub struct RowGroupMetaData {
     sorting_columns: Option<Vec<SortingColumn>>,
     total_byte_size: i64,
     schema_descr: SchemaDescPtr,
-    /// `page_offset_index[column_number][row_group_number]`
+    /// `page_offset_index[column_number][page_number]`
     page_offset_index: Option<Vec<Vec<PageLocation>>>,
 }
 

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Per-page encoding information.
+
 use crate::basic::{Encoding, PageType};
 use crate::errors::Result;
 use crate::format::{

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -30,7 +30,7 @@ use thrift::protocol::{TCompactInputProtocol, TSerializable};
 /// Reads per-column [`Index`] for all columns of a row group by
 /// decoding [`ColumnIndex`] .
 ///
-/// Returns a vecotr of `index[column_number]`.
+/// Returns a vector of `index[column_number]`.
 ///
 /// Returns an empty vector if this row group does not contain a
 /// [`ColumnIndex`].

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Support for reading [`Index`] and [`PageLocation`] from parquet metadata.
+
 use crate::basic::Type;
 use crate::data_type::Int96;
 use crate::errors::ParquetError;
@@ -25,8 +27,17 @@ use crate::format::{ColumnIndex, OffsetIndex, PageLocation};
 use std::io::{Cursor, Read};
 use thrift::protocol::{TCompactInputProtocol, TSerializable};
 
-/// Read on row group's all columns indexes and change into  [`Index`]
-/// If not the format not available return an empty vector.
+/// Reads per-column [`Index`] for all columns of a row group by
+/// decoding [`ColumnIndex`] .
+///
+/// Returns a vecotr of `index[column_number]`.
+///
+/// Returns an empty vector if this row group does not contain a
+/// [`ColumnIndex`].
+///
+/// See [Column Index Documentation] for more details.
+///
+/// [Column Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 pub fn read_columns_indexes<R: ChunkReader>(
     reader: &R,
     chunks: &[ColumnChunkMetaData],
@@ -60,8 +71,17 @@ pub fn read_columns_indexes<R: ChunkReader>(
         .collect()
 }
 
-/// Read on row group's all indexes and change into  [`Index`]
-/// If not the format not available return an empty vector.
+/// Reads per-page [`PageLocation`] for all columns of a row group by
+/// decoding the [`OffsetIndex`].
+///
+/// Returns a vector of `location[column_number][page_number]`
+///
+/// Return an empty vector if this row group does not contain an
+/// [`OffsetIndex]`.
+///
+/// See [Column Index Documentation] for more details.
+///
+/// [Column Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 pub fn read_pages_locations<R: ChunkReader>(
     reader: &R,
     chunks: &[ColumnChunkMetaData],

--- a/parquet/src/file/page_index/mod.rs
+++ b/parquet/src/file/page_index/mod.rs
@@ -15,5 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Page Index of "[Column Index] Layout to Support Page Skipping"
+//!
+//! [Column Index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+
 pub mod index;
 pub mod index_reader;

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Writer properties.
+//! [`WriterProperties`]
 //!
 //! # Usage
 //!

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Contains file reader API and provides methods to access file metadata, row group
-//! readers to read individual column chunks, or access record iterator.
+//! File reader API and methods to access file metadata, row group
+//! readers to read individual column chunks, or access record
+//! iterator.
 
 use bytes::Bytes;
 use std::{boxed::Box, io::Read, sync::Arc};

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -189,13 +189,16 @@ impl ReadOptionsBuilder {
         self
     }
 
-    /// Enable page index in the reading option,
+    /// Enable reading the page index structures described in
+    /// "[Column Index] Layout to Support Page Skipping"
+    ///
+    /// [Column Index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
     pub fn with_page_index(mut self) -> Self {
         self.enable_page_index = true;
         self
     }
 
-    /// Set the `ReaderProperties` configuration.
+    /// Set the [`ReaderProperties`] configuration.
     pub fn with_reader_properties(mut self, properties: ReaderProperties) -> Self {
         self.props = Some(properties);
         self


### PR DESCRIPTION
# Which issue does this PR close?

N/A
# Rationale for this change
 
While working on a bug downstream in DataFusion https://github.com/apache/arrow-datafusion/issues/5104 I found myself often confused about what the `Vec<Vec<Vec<..>>>` and other various structured represented in parquet.

I spent a while reading the code so I figured I would encode this learning into some more documentation to help my future sef and hopefully other readers

# What changes are included in this PR?

Doc comments about various ColumnIndex / Page Index structures.


# Are there any user-facing changes?

docstrings