### PR TITLE
object_store: add Path::from_url_path

### DIFF
--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -166,7 +166,7 @@ impl Path {
     /// Convert a filesystem path to a [`Path`] relative to the filesystem root
     ///
     /// This will return an error if the path contains illegal character sequences
-    /// as defined by [`Path::parse`] or does not exist
+    /// as defined on the docstring for [`Path`] or does not exist
     ///
     /// Note: this will canonicalize the provided path, resolving any symlinks
     pub fn from_filesystem_path(
@@ -182,8 +182,8 @@ impl Path {
     #[cfg(not(target_arch = "wasm32"))]
     /// Convert an absolute filesystem path to a [`Path`] relative to the filesystem root
     ///
-    /// This will return an error if the path contains illegal character sequences
-    /// as defined by [`Path::parse`], or `base` is not an absolute path
+    /// This will return an error if the path contains illegal character sequences,
+    /// as defined on the docstring for [`Path`], or `base` is not an absolute path
     pub fn from_absolute_path(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
         Self::from_absolute_path_with_base(path, None)
     }
@@ -191,9 +191,9 @@ impl Path {
     #[cfg(not(target_arch = "wasm32"))]
     /// Convert a filesystem path to a [`Path`] relative to the provided base
     ///
-    /// This will return an error if the path contains illegal character sequences
-    /// as defined by [`Path::parse`], or `base` does not refer to a parent path of `path`,
-    /// or `base` is not an absolute path
+    /// This will return an error if the path contains illegal character sequences,
+    /// as defined on the docstring for [`Path`], or `base` does not refer to a parent
+    /// path of `path`, or `base` is not an absolute path
     pub(crate) fn from_absolute_path_with_base(
         path: impl AsRef<std::path::Path>,
         base: Option<&Url>,
@@ -213,9 +213,12 @@ impl Path {
         Self::from_url_path(path)
     }
 
-    /// Parse a url encoded string as a [`Path`], returning a [`Error`] if invalid,
+    /// Parse a url encoded string as a [`Path`], returning a [`Error`] if invalid
+    ///
+    /// This will return an error if the path contains illegal character sequences
     /// as defined on the docstring for [`Path`]
-    pub fn from_url_path(path: &str) -> Result<Self, Error> {
+    pub fn from_url_path(path: impl AsRef<str>) -> Result<Self, Error> {
+        let path = path.as_ref();
         let decoded = percent_decode(path.as_bytes())
             .decode_utf8()
             .context(NonUnicodeSnafu { path })?;

--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -162,6 +162,13 @@ impl Path {
         })
     }
 
+    /// Parse a url encoded string as a [`Path`], returning a [`Error`] if invalid,
+    /// as defined on the docstring for [`Path`]
+    pub fn from_url_path(path: impl AsRef<str>) -> Result<Self, Error> {
+        let decoded_path = percent_encoding::percent_decode_str(path.as_ref()).decode_utf8_lossy();
+        Self::parse(decoded_path.as_ref())
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     /// Convert a filesystem path to a [`Path`] relative to the filesystem root
     ///
@@ -549,6 +556,15 @@ mod tests {
         assert_eq!(a.raw, "foo bar/baz");
         assert_eq!(a.raw, b.raw);
         assert_eq!(b.raw, c.raw);
+    }
+
+    #[test]
+    fn from_url_path() {
+        let a = Path::from_url_path("foo%20bar/baz").unwrap();
+        assert_eq!(a.raw, "foo bar/baz");
+
+        let b = Path::from_url_path("bar/baz").unwrap();
+        assert_eq!(b.raw, "bar/baz");
     }
 
     #[test]

--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -18,7 +18,6 @@
 //! Path abstraction for Object Storage
 
 use itertools::Itertools;
-#[cfg(not(target_arch = "wasm32"))]
 use percent_encoding::percent_decode;
 use snafu::{ensure, ResultExt, Snafu};
 use std::fmt::Formatter;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/3651

# Rationale for this change
 
https://github.com/apache/arrow-rs/issues/3651#issuecomment-1414512964

This would simplify user usage of Path, e.g.
- arrow datafusion ([code](https://github.com/apache/arrow-datafusion/blob/3133526c1f697de43173f6a10c111588307835da/datafusion/core/src/datasource/listing/url.rs#L116-L118))
- roapi ([code](https://github.com/roapi/roapi/blob/f9b17888cbb5119f8168c729eac1cc5958c78889/columnq/src/io/object_store.rs#L63-L64))

# What changes are included in this PR?

Implement new method `from_url_path`

# Are there any user-facing changes?


New method is provided, no impact to existing methods