### PR TITLE
Add timezone accessor for Timestamp*Array

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1019,6 +1019,14 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
         Self::from(data).with_timezone_opt(timezone)
     }
 
+    /// Returns the timezone of this array if any
+    pub fn timezone(&self) -> Option<&str> {
+        match self.data_type() {
+            DataType::Timestamp(_, tz) => tz.as_deref(),
+            _ => unreachable!(),
+        }
+    }
+
     /// Construct a timestamp array with new timezone
     pub fn with_timezone(&self, timezone: impl Into<String>) -> Self {
         self.with_timezone_opt(Some(timezone.into()))
@@ -2213,5 +2221,14 @@ mod tests {
     fn test_invalid_interval_type() {
         let array = IntervalDayTimeArray::from(vec![1, 2, 3]);
         let _ = IntervalMonthDayNanoArray::from(array.into_data());
+    }
+
+    #[test]
+    fn test_timezone() {
+        let array = TimestampNanosecondArray::from_iter_values([1, 2]);
+        assert_eq!(array.timezone(), None);
+
+        let array = array.with_timezone("+02:00");
+        assert_eq!(array.timezone(), Some("+02:00"));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We provide `precision` and `scale` for decimal arrays, we should do something similar for timestamp arrays.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
