### PR TITLE
Use ArrayFormatter in Cast Kernel

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -154,13 +154,12 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (_, Boolean) => DataType::is_numeric(from_type) || from_type == &Utf8 || from_type == &LargeUtf8,
         (Boolean, _) => DataType::is_numeric(to_type) || to_type == &Utf8 || to_type == &LargeUtf8,
 
-        (Utf8, LargeUtf8) => true,
-        (LargeUtf8, Utf8) => true,
         (Binary, LargeBinary | Utf8 | LargeUtf8) => true,
         (LargeBinary, Binary | Utf8 | LargeUtf8) => true,
         (Utf8,
             Binary
             | LargeBinary
+            | LargeUtf8
             | Date32
             | Date64
             | Time32(TimeUnit::Second)
@@ -169,10 +168,11 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             | Time64(TimeUnit::Nanosecond)
             | Timestamp(TimeUnit::Nanosecond, None)
         ) => true,
-        (Utf8, _) => DataType::is_numeric(to_type) && to_type != &Float16,
+        (Utf8, _) => to_type.is_numeric() && to_type != &Float16,
         (LargeUtf8,
             Binary
             | LargeBinary
+            | Utf8
             | Date32
             | Date64
             | Time32(TimeUnit::Second)
@@ -181,11 +181,8 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             | Time64(TimeUnit::Nanosecond)
             | Timestamp(TimeUnit::Nanosecond, None)
         ) => true,
-        (LargeUtf8, _) => DataType::is_numeric(to_type) && to_type != &Float16,
-        (Timestamp(_, _), Utf8) | (Timestamp(_, _), LargeUtf8) => true,
-        (Date32, Utf8) | (Date32, LargeUtf8) => true,
-        (Date64, Utf8) | (Date64, LargeUtf8) => true,
-        (_, Utf8 | LargeUtf8) => DataType::is_numeric(from_type) && from_type != &Float16,
+        (LargeUtf8, _) => to_type.is_numeric() && to_type != &Float16,
+        (_, Utf8 | LargeUtf8) => from_type.is_primitive(),
 
         // start numeric casts
         (
@@ -1114,7 +1111,6 @@ pub fn cast_with_options(
             ))),
         },
         (Utf8, _) => match to_type {
-            LargeUtf8 => cast_byte_container::<Utf8Type, LargeUtf8Type, str>(array),
             UInt8 => cast_string_to_numeric::<UInt8Type, i32>(array, cast_options),
             UInt16 => cast_string_to_numeric::<UInt16Type, i32>(array, cast_options),
             UInt32 => cast_string_to_numeric::<UInt32Type, i32>(array, cast_options),
@@ -1130,8 +1126,9 @@ pub fn cast_with_options(
             Binary => Ok(Arc::new(BinaryArray::from(as_string_array(array).clone()))),
             LargeBinary => {
                 let binary = BinaryArray::from(as_string_array(array).clone());
-                cast_byte_container::<BinaryType, LargeBinaryType, [u8]>(&binary)
+                cast_byte_container::<BinaryType, LargeBinaryType>(&binary)
             }
+            LargeUtf8 => cast_byte_container::<Utf8Type, LargeUtf8Type>(array),
             Time32(TimeUnit::Second) => {
                 cast_string_to_time32second::<i32>(array, cast_options)
             }
@@ -1151,12 +1148,6 @@ pub fn cast_with_options(
                 "Casting from {from_type:?} to {to_type:?} not supported",
             ))),
         },
-        (Binary, Utf8) => cast_binary_to_string::<i32>(array, cast_options),
-        (LargeBinary, LargeUtf8) => cast_binary_to_string::<i64>(array, cast_options),
-        (LargeBinary, Utf8) => cast_binary_to_generic_string::<i64, i32>(array, cast_options),
-        (Binary, LargeUtf8) => cast_binary_to_generic_string::<i32, i64>(array, cast_options),
-        (_, LargeUtf8) => value_to_string::<i64>(array),
-        (_, Utf8) => value_to_string::<i32>(array),
         (LargeUtf8, _) => match to_type {
             UInt8 => cast_string_to_numeric::<UInt8Type, i64>(array, cast_options),
             UInt16 => cast_string_to_numeric::<UInt16Type, i64>(array, cast_options),
@@ -1170,10 +1161,11 @@ pub fn cast_with_options(
             Float64 => cast_string_to_numeric::<Float64Type, i64>(array, cast_options),
             Date32 => cast_string_to_date32::<i64>(array, cast_options),
             Date64 => cast_string_to_date64::<i64>(array, cast_options),
+            Utf8 => cast_byte_container::<LargeUtf8Type, Utf8Type>(array),
             Binary => {
                 let large_binary =
                     LargeBinaryArray::from(as_largestring_array(array).clone());
-                cast_byte_container::<LargeBinaryType, BinaryType, [u8]>(&large_binary)
+                cast_byte_container::<LargeBinaryType, BinaryType>(&large_binary)
             }
             LargeBinary => Ok(Arc::new(LargeBinaryArray::from(
                 as_largestring_array(array).clone(),
@@ -1198,19 +1190,31 @@ pub fn cast_with_options(
             ))),
         },
         (Binary, _) => match to_type {
+            Utf8 => cast_binary_to_string::<i32>(array, cast_options),
+            LargeUtf8 => {
+                let array = cast_binary_to_string::<i32>(array, cast_options)?;
+                cast_byte_container::<Utf8Type, LargeUtf8Type>(array.as_ref())
+            }
             LargeBinary => {
-                cast_byte_container::<BinaryType, LargeBinaryType, [u8]>(array)
+                cast_byte_container::<BinaryType, LargeBinaryType>(array)
             }
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
             ))),
         },
         (LargeBinary, _) => match to_type {
-            Binary => cast_byte_container::<LargeBinaryType, BinaryType, [u8]>(array),
+            Utf8 => {
+                let array = cast_binary_to_string::<i64>(array, cast_options)?;
+                cast_byte_container::<LargeUtf8Type, Utf8Type>(array.as_ref())
+            }
+            LargeUtf8 => cast_binary_to_string::<i64>(array, cast_options),
+            Binary => cast_byte_container::<LargeBinaryType, BinaryType>(array),
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
             ))),
         },
+        (from_type, LargeUtf8) if from_type.is_primitive() => value_to_string::<i64>(array),
+        (from_type, Utf8) if from_type.is_primitive() => value_to_string::<i32>(array),
         // start numeric casts
         (UInt8, UInt16) => {
             cast_numeric_arrays::<UInt8Type, UInt16Type>(array, cast_options)
@@ -3188,13 +3192,10 @@ fn cast_list_inner<OffsetSize: OffsetSizeTrait>(
 
 /// A specified helper to cast from `GenericBinaryArray` to `GenericStringArray` when they have same
 /// offset size so re-encoding offset is unnecessary.
-fn cast_binary_to_string<O>(
+fn cast_binary_to_string<O: OffsetSizeTrait>(
     array: &dyn Array,
     cast_options: &CastOptions,
-) -> Result<ArrayRef, ArrowError>
-where
-    O: OffsetSizeTrait + ToPrimitive,
-{
+) -> Result<ArrayRef, ArrowError> {
     let array = array
         .as_any()
         .downcast_ref::<GenericByteArray<GenericBinaryType<O>>>()
@@ -3246,86 +3247,12 @@ where
     }
 }
 
-/// Helper function to cast from `GenericBinaryArray` to `GenericStringArray`. This function performs
-/// UTF8 validation during casting. For invalid UTF8 value, it could be Null or returning `Err` depending
-/// `CastOptions`.
-fn cast_binary_to_generic_string<I, O>(
-    array: &dyn Array,
-    cast_options: &CastOptions,
-) -> Result<ArrayRef, ArrowError>
-where
-    I: OffsetSizeTrait + ToPrimitive,
-    O: OffsetSizeTrait + NumCast,
-{
-    let array = array
-        .as_any()
-        .downcast_ref::<GenericByteArray<GenericBinaryType<I>>>()
-        .unwrap();
-
-    if !cast_options.safe {
-        let offsets = array.value_offsets();
-        let values = array.value_data();
-
-        // We only need to validate that all values are valid UTF-8
-        let validated = std::str::from_utf8(values)
-            .map_err(|_| ArrowError::CastError("Invalid UTF-8 sequence".to_string()))?;
-
-        let mut offset_builder = BufferBuilder::<O>::new(offsets.len());
-        // Checks if the offset is a valid char boundary and re-encode the offset
-        offsets
-            .iter()
-            .try_for_each::<_, Result<_, ArrowError>>(|offset| {
-                if !validated.is_char_boundary(offset.as_usize()) {
-                    return Err(ArrowError::CastError(
-                        "Invalid UTF-8 sequence".to_string(),
-                    ));
-                }
-
-                let offset = <O as NumCast>::from(*offset).ok_or_else(|| {
-                    ArrowError::ComputeError(format!(
-                        "{}Binary array too large to cast to {}String array",
-                        I::PREFIX,
-                        O::PREFIX
-                    ))
-                })?;
-                offset_builder.append(offset);
-                Ok(())
-            })?;
-
-        let offset_buffer = offset_builder.finish();
-
-        let builder = ArrayData::builder(GenericStringArray::<O>::DATA_TYPE)
-            .len(array.len())
-            .add_buffer(offset_buffer)
-            .add_buffer(array.data().buffers()[1].clone())
-            .null_count(array.null_count())
-            .null_bit_buffer(array.data().null_buffer().cloned());
-
-        // SAFETY:
-        // Validated UTF-8 above
-        Ok(Arc::new(GenericStringArray::<O>::from(unsafe {
-            builder.build_unchecked()
-        })))
-    } else {
-        Ok(Arc::new(
-            array
-                .iter()
-                .map(|maybe_value| {
-                    maybe_value.and_then(|value| std::str::from_utf8(value).ok())
-                })
-                .collect::<GenericByteArray<GenericStringType<O>>>(),
-        ))
-    }
-}
-
 /// Helper function to cast from one `ByteArrayType` to another and vice versa.
 /// If the target one (e.g., `LargeUtf8`) is too large for the source array it will return an Error.
-fn cast_byte_container<FROM, TO, N: ?Sized>(
-    array: &dyn Array,
-) -> Result<ArrayRef, ArrowError>
+fn cast_byte_container<FROM, TO>(array: &dyn Array) -> Result<ArrayRef, ArrowError>
 where
-    FROM: ByteArrayType<Native = N>,
-    TO: ByteArrayType<Native = N>,
+    FROM: ByteArrayType,
+    TO: ByteArrayType<Native = FROM::Native>,
     FROM::Offset: OffsetSizeTrait + ToPrimitive,
     TO::Offset: OffsetSizeTrait + NumCast,
 {

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -2123,6 +2123,7 @@ fn value_to_string<O: OffsetSizeTrait>(
             true => builder.append_null(),
             false => {
                 formatter.value(i).write(&mut builder)?;
+                // tell the builder the row is finished
                 builder.append_value("");
             }
         }

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -56,8 +56,8 @@ fn test_cast_timestamp_to_string() {
     let b = cast(&array, &DataType::Utf8).unwrap();
     let c = b.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(&DataType::Utf8, c.data_type());
-    assert_eq!("1997-05-19 00:00:00.005 +00:00", c.value(0));
-    assert_eq!("2018-12-25 00:00:00.001 +00:00", c.value(1));
+    assert_eq!("1997-05-19T00:00:00.005Z", c.value(0));
+    assert_eq!("2018-12-25T00:00:00.001Z", c.value(1));
     assert!(c.is_null(2));
 }
 
@@ -442,9 +442,9 @@ fn test_timestamp_cast_utf8() {
     let out = cast(&(Arc::new(array) as ArrayRef), &DataType::Utf8).unwrap();
 
     let expected = StringArray::from(vec![
-        Some("1970-01-01 10:30:00"),
+        Some("1970-01-01T10:30:00"),
         None,
-        Some("1970-01-01 23:58:59"),
+        Some("1970-01-01T23:58:59"),
     ]);
 
     assert_eq!(
@@ -458,9 +458,9 @@ fn test_timestamp_cast_utf8() {
     let out = cast(&(Arc::new(array) as ArrayRef), &DataType::Utf8).unwrap();
 
     let expected = StringArray::from(vec![
-        Some("1970-01-01 20:30:00 +10:00"),
+        Some("1970-01-01T20:30:00+10:00"),
         None,
-        Some("1970-01-02 09:58:59 +10:00"),
+        Some("1970-01-02T09:58:59+10:00"),
     ]);
 
     assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Using the ArrayFormatter is less code, more consistent, and is ~10% faster as it avoids intermediate string allocations

```
cast i64 to string 512  time:   [10.723 µs 10.728 µs 10.733 µs]
                        change: [-11.208% -11.131% -11.052%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

cast f32 to string 512  time:   [16.210 µs 16.222 µs 16.233 µs]
                        change: [-7.7917% -7.6542% -7.5083%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

This changes the formatting of Date64 from `1997-05-19 00:00:00` to `1997-05-19T00:00:00`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
