### PR TITLE
Add ArrayData::new_null and DataType::primitive_width

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -857,12 +857,29 @@ mod tests {
                     assert_eq!(array.null_count(), 0);
                     assert_eq!(array.values().len(), 1);
                     assert_eq!(array.values().null_count(), 1);
+                    assert_eq!(array.run_ends().values(), &[4]);
 
                     let idx = array.get_physical_indices(&[0, 1, 2, 3]).unwrap();
                     assert_eq!(idx, &[0,0,0,0]);
                 }
                 d => unreachable!("{d}")
             }
+        }
+    }
+
+    #[test]
+    fn test_null_fixed_size_binary() {
+        for size in [1, 2, 7] {
+            let array = new_null_array(&DataType::FixedSizeBinary(size), 6);
+            let array = array
+                .as_ref()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
+
+            assert_eq!(array.len(), 6);
+            assert_eq!(array.null_count(), 6);
+            array.iter().for_each(|x| assert!(x.is_none()));
         }
     }
 

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -667,7 +667,7 @@ impl ArrayData {
                             let i = i64::from_usize(len).expect("run overflow");
                             Buffer::from_slice_ref([i])
                         }
-                        _ => unreachable!(),
+                        dt => unreachable!("Invalid run ends data type {dt}"),
                     };
 
                     let builder = ArrayData::builder(r.data_type().clone())

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -671,7 +671,7 @@ impl ArrayData {
                     };
 
                     let builder = ArrayData::builder(r.data_type().clone())
-                        .len(2)
+                        .len(1)
                         .buffers(vec![runs]);
 
                     // SAFETY:

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -648,7 +648,11 @@ impl ArrayData {
 
                     let children = f
                         .iter()
-                        .map(|f| Self::new_null(f.data_type(), len))
+                        .enumerate()
+                        .map(|(idx, f)| match idx {
+                            0 => Self::new_null(f.data_type(), len),
+                            _ => Self::new_empty(f.data_type()),
+                        })
                         .collect();
 
                     (buffers, children, false)

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -21,8 +21,7 @@
 use crate::{bit_iterator::BitSliceIterator, bitmap::Bitmap};
 use arrow_buffer::bit_chunk_iterator::BitChunks;
 use arrow_buffer::{bit_util, ArrowNativeType, Buffer, MutableBuffer};
-use arrow_schema::{ArrowError, DataType, IntervalUnit, UnionMode};
-use half::f16;
+use arrow_schema::{ArrowError, DataType, UnionMode};
 use std::convert::TryInto;
 use std::mem;
 use std::ops::Range;
@@ -69,71 +68,25 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
             let buffer = MutableBuffer::new(bytes);
             [buffer, empty_buffer]
         }
-        DataType::UInt8 => [
-            MutableBuffer::new(capacity * mem::size_of::<u8>()),
-            empty_buffer,
-        ],
-        DataType::UInt16 => [
-            MutableBuffer::new(capacity * mem::size_of::<u16>()),
-            empty_buffer,
-        ],
-        DataType::UInt32 => [
-            MutableBuffer::new(capacity * mem::size_of::<u32>()),
-            empty_buffer,
-        ],
-        DataType::UInt64 => [
-            MutableBuffer::new(capacity * mem::size_of::<u64>()),
-            empty_buffer,
-        ],
-        DataType::Int8 => [
-            MutableBuffer::new(capacity * mem::size_of::<i8>()),
-            empty_buffer,
-        ],
-        DataType::Int16 => [
-            MutableBuffer::new(capacity * mem::size_of::<i16>()),
-            empty_buffer,
-        ],
-        DataType::Int32 => [
-            MutableBuffer::new(capacity * mem::size_of::<i32>()),
-            empty_buffer,
-        ],
-        DataType::Int64 => [
-            MutableBuffer::new(capacity * mem::size_of::<i64>()),
-            empty_buffer,
-        ],
-        DataType::Float16 => [
-            MutableBuffer::new(capacity * mem::size_of::<f16>()),
-            empty_buffer,
-        ],
-        DataType::Float32 => [
-            MutableBuffer::new(capacity * mem::size_of::<f32>()),
-            empty_buffer,
-        ],
-        DataType::Float64 => [
-            MutableBuffer::new(capacity * mem::size_of::<f64>()),
-            empty_buffer,
-        ],
-        DataType::Date32 | DataType::Time32(_) => [
-            MutableBuffer::new(capacity * mem::size_of::<i32>()),
-            empty_buffer,
-        ],
-        DataType::Date64
+        DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Date64
         | DataType::Time64(_)
         | DataType::Duration(_)
-        | DataType::Timestamp(_, _) => [
-            MutableBuffer::new(capacity * mem::size_of::<i64>()),
-            empty_buffer,
-        ],
-        DataType::Interval(IntervalUnit::YearMonth) => [
-            MutableBuffer::new(capacity * mem::size_of::<i32>()),
-            empty_buffer,
-        ],
-        DataType::Interval(IntervalUnit::DayTime) => [
-            MutableBuffer::new(capacity * mem::size_of::<i64>()),
-            empty_buffer,
-        ],
-        DataType::Interval(IntervalUnit::MonthDayNano) => [
-            MutableBuffer::new(capacity * mem::size_of::<i128>()),
+        | DataType::Timestamp(_, _)
+        | DataType::Interval(_) => [
+            MutableBuffer::new(capacity * data_type.primitive_width().unwrap()),
             empty_buffer,
         ],
         DataType::Utf8 | DataType::Binary => {
@@ -163,41 +116,10 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
         DataType::FixedSizeBinary(size) => {
             [MutableBuffer::new(capacity * *size as usize), empty_buffer]
         }
-        DataType::Dictionary(child_data_type, _) => match child_data_type.as_ref() {
-            DataType::UInt8 => [
-                MutableBuffer::new(capacity * mem::size_of::<u8>()),
-                empty_buffer,
-            ],
-            DataType::UInt16 => [
-                MutableBuffer::new(capacity * mem::size_of::<u16>()),
-                empty_buffer,
-            ],
-            DataType::UInt32 => [
-                MutableBuffer::new(capacity * mem::size_of::<u32>()),
-                empty_buffer,
-            ],
-            DataType::UInt64 => [
-                MutableBuffer::new(capacity * mem::size_of::<u64>()),
-                empty_buffer,
-            ],
-            DataType::Int8 => [
-                MutableBuffer::new(capacity * mem::size_of::<i8>()),
-                empty_buffer,
-            ],
-            DataType::Int16 => [
-                MutableBuffer::new(capacity * mem::size_of::<i16>()),
-                empty_buffer,
-            ],
-            DataType::Int32 => [
-                MutableBuffer::new(capacity * mem::size_of::<i32>()),
-                empty_buffer,
-            ],
-            DataType::Int64 => [
-                MutableBuffer::new(capacity * mem::size_of::<i64>()),
-                empty_buffer,
-            ],
-            _ => unreachable!(),
-        },
+        DataType::Dictionary(k, _) => [
+            MutableBuffer::new(capacity * k.primitive_width().unwrap()),
+            empty_buffer,
+        ],
         DataType::FixedSizeList(_, _)
         | DataType::Struct(_)
         | DataType::RunEndEncoded(_, _) => [empty_buffer, MutableBuffer::new(0)],
@@ -667,83 +589,121 @@ impl ArrayData {
         &values.1[self.offset..]
     }
 
-    /// Returns a new empty [ArrayData] valid for `data_type`.
-    pub fn new_empty(data_type: &DataType) -> Self {
-        let buffers = new_buffers(data_type, 0);
-        let [buffer1, buffer2] = buffers;
-        let buffers = into_buffers(data_type, buffer1, buffer2);
+    /// Returns a new [`ArrayData`] valid for `data_type` containing `len` null values
+    pub fn new_null(data_type: &DataType, len: usize) -> Self {
+        let bit_len = bit_util::ceil(len, 8);
+        let zeroed = |len: usize| Buffer::from(MutableBuffer::from_len_zeroed(len));
 
-        let child_data = match data_type {
-            DataType::Null
-            | DataType::Boolean
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Duration(_)
-            | DataType::Timestamp(_, _)
-            | DataType::Utf8
-            | DataType::Binary
-            | DataType::LargeUtf8
-            | DataType::LargeBinary
-            | DataType::Interval(_)
-            | DataType::FixedSizeBinary(_)
-            | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _) => vec![],
-            DataType::List(field) => {
-                vec![Self::new_empty(field.data_type())]
-            }
-            DataType::FixedSizeList(field, _) => {
-                vec![Self::new_empty(field.data_type())]
-            }
-            DataType::LargeList(field) => {
-                vec![Self::new_empty(field.data_type())]
-            }
-            DataType::Struct(fields) => fields
-                .iter()
-                .map(|field| Self::new_empty(field.data_type()))
-                .collect(),
-            DataType::Map(field, _) => {
-                vec![Self::new_empty(field.data_type())]
-            }
-            DataType::Union(fields, _, _) => fields
-                .iter()
-                .map(|field| Self::new_empty(field.data_type()))
-                .collect(),
-            DataType::Dictionary(_, data_type) => {
-                vec![Self::new_empty(data_type)]
-            }
-            DataType::RunEndEncoded(run_ends, values) => {
-                vec![
-                    Self::new_empty(run_ends.data_type()),
-                    Self::new_empty(values.data_type()),
-                ]
-            }
+        let (buffers, child_data, has_nulls) = match data_type.primitive_width() {
+            Some(width) => (vec![zeroed(width * len)], vec![], true),
+            None => match data_type {
+                DataType::Null => (vec![], vec![], false),
+                DataType::Boolean => (vec![zeroed(bit_len)], vec![], true),
+                DataType::Binary | DataType::Utf8 => {
+                    (vec![zeroed((len + 1) * 4), zeroed(0)], vec![], true)
+                }
+                DataType::LargeBinary | DataType::LargeUtf8 => {
+                    (vec![zeroed((len + 1) * 8), zeroed(0)], vec![], true)
+                }
+                DataType::FixedSizeBinary(i) => {
+                    (vec![zeroed(*i as usize * len)], vec![], true)
+                }
+                DataType::List(f) | DataType::Map(f, _) => (
+                    vec![zeroed((len + 1) * 4)],
+                    vec![ArrayData::new_empty(f.data_type())],
+                    true,
+                ),
+                DataType::LargeList(f) => (
+                    vec![zeroed((len + 1) * 8)],
+                    vec![ArrayData::new_empty(f.data_type())],
+                    true,
+                ),
+                DataType::FixedSizeList(f, list_len) => (
+                    vec![],
+                    vec![ArrayData::new_null(f.data_type(), *list_len as usize * len)],
+                    true,
+                ),
+                DataType::Struct(fields) => (
+                    vec![],
+                    fields
+                        .iter()
+                        .map(|f| Self::new_null(f.data_type(), len))
+                        .collect(),
+                    true,
+                ),
+                DataType::Dictionary(k, v) => (
+                    vec![zeroed(k.primitive_width().unwrap() * len)],
+                    vec![ArrayData::new_empty(v.as_ref())],
+                    true,
+                ),
+                DataType::Union(f, i, mode) => {
+                    let ids = Buffer::from_iter(std::iter::repeat(i[0]).take(len));
+                    let buffers = match mode {
+                        UnionMode::Sparse => vec![ids],
+                        UnionMode::Dense => {
+                            let end_offset = i32::from_usize(len).unwrap();
+                            vec![ids, Buffer::from_iter(0_i32..end_offset)]
+                        }
+                    };
+
+                    let children = f
+                        .iter()
+                        .map(|f| Self::new_null(f.data_type(), len))
+                        .collect();
+
+                    (buffers, children, false)
+                }
+                DataType::RunEndEncoded(r, v) => {
+                    let runs = match r.data_type() {
+                        DataType::Int16 => {
+                            let i = i16::from_usize(len).expect("run overflow");
+                            Buffer::from_slice_ref([i])
+                        }
+                        DataType::Int32 => {
+                            let i = i32::from_usize(len).expect("run overflow");
+                            Buffer::from_slice_ref([i])
+                        }
+                        DataType::Int64 => {
+                            let i = i64::from_usize(len).expect("run overflow");
+                            Buffer::from_slice_ref([i])
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    let builder = ArrayData::builder(r.data_type().clone())
+                        .len(2)
+                        .buffers(vec![runs]);
+
+                    // SAFETY:
+                    // Valid by construction
+                    let runs = unsafe { builder.build_unchecked() };
+                    (
+                        vec![],
+                        vec![runs, ArrayData::new_null(v.data_type(), 1)],
+                        false,
+                    )
+                }
+                d => unreachable!("{d}"),
+            },
         };
 
-        // Data was constructed correctly above
-        unsafe {
-            Self::new_unchecked(
-                data_type.clone(),
-                0,
-                Some(0),
-                None,
-                0,
-                buffers,
-                child_data,
-            )
+        let mut builder = ArrayDataBuilder::new(data_type.clone())
+            .len(len)
+            .buffers(buffers)
+            .child_data(child_data);
+
+        if has_nulls {
+            builder = builder.null_count(len).null_bit_buffer(Some(zeroed(len)))
         }
+
+        // SAFETY:
+        // Data valid by construction
+        unsafe { builder.build_unchecked() }
+    }
+
+    /// Returns a new empty [ArrayData] valid for `data_type`.
+    pub fn new_empty(data_type: &DataType) -> Self {
+        Self::new_null(data_type, 0)
     }
 
     /// "cheap" validation of an `ArrayData`. Ensures buffers are
@@ -1578,30 +1538,24 @@ pub fn layout(data_type: &DataType) -> DataTypeLayout {
             buffers: vec![BufferSpec::BitMap],
             can_contain_null_mask: true,
         },
-        DataType::Int8 => DataTypeLayout::new_fixed_width(size_of::<i8>()),
-        DataType::Int16 => DataTypeLayout::new_fixed_width(size_of::<i16>()),
-        DataType::Int32 => DataTypeLayout::new_fixed_width(size_of::<i32>()),
-        DataType::Int64 => DataTypeLayout::new_fixed_width(size_of::<i64>()),
-        DataType::UInt8 => DataTypeLayout::new_fixed_width(size_of::<u8>()),
-        DataType::UInt16 => DataTypeLayout::new_fixed_width(size_of::<u16>()),
-        DataType::UInt32 => DataTypeLayout::new_fixed_width(size_of::<u32>()),
-        DataType::UInt64 => DataTypeLayout::new_fixed_width(size_of::<u64>()),
-        DataType::Float16 => DataTypeLayout::new_fixed_width(size_of::<f16>()),
-        DataType::Float32 => DataTypeLayout::new_fixed_width(size_of::<f32>()),
-        DataType::Float64 => DataTypeLayout::new_fixed_width(size_of::<f64>()),
-        DataType::Timestamp(_, _) => DataTypeLayout::new_fixed_width(size_of::<i64>()),
-        DataType::Date32 => DataTypeLayout::new_fixed_width(size_of::<i32>()),
-        DataType::Date64 => DataTypeLayout::new_fixed_width(size_of::<i64>()),
-        DataType::Time32(_) => DataTypeLayout::new_fixed_width(size_of::<i32>()),
-        DataType::Time64(_) => DataTypeLayout::new_fixed_width(size_of::<i64>()),
-        DataType::Interval(IntervalUnit::YearMonth) => {
-            DataTypeLayout::new_fixed_width(size_of::<i32>())
-        }
-        DataType::Interval(IntervalUnit::DayTime) => {
-            DataTypeLayout::new_fixed_width(size_of::<i64>())
-        }
-        DataType::Interval(IntervalUnit::MonthDayNano) => {
-            DataTypeLayout::new_fixed_width(size_of::<i128>())
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Interval(_) => {
+            DataTypeLayout::new_fixed_width(data_type.primitive_width().unwrap())
         }
         DataType::Duration(_) => DataTypeLayout::new_fixed_width(size_of::<i64>()),
         DataType::Binary => DataTypeLayout::new_binary(size_of::<i32>()),

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -410,6 +410,39 @@ impl DataType {
         }
     }
 
+    /// Returns the bit width of this type if it is a primitive type
+    ///
+    /// Returns `None` if not a primitive type
+    #[inline]
+    pub fn primitive_width(&self) -> Option<usize> {
+        match self {
+            DataType::Null => None,
+            DataType::Boolean => None,
+            DataType::Int8 | DataType::UInt8 => Some(1),
+            DataType::Int16 | DataType::UInt16 | DataType::Float16 => Some(2),
+            DataType::Int32 | DataType::UInt32 | DataType::Float32 => Some(4),
+            DataType::Int64 | DataType::UInt64 | DataType::Float64 => Some(8),
+            DataType::Timestamp(_, _) => Some(8),
+            DataType::Date32 | DataType::Time32(_) => Some(4),
+            DataType::Date64 | DataType::Time64(_) => Some(8),
+            DataType::Duration(_) => Some(8),
+            DataType::Interval(IntervalUnit::YearMonth) => Some(4),
+            DataType::Interval(IntervalUnit::DayTime) => Some(8),
+            DataType::Interval(IntervalUnit::MonthDayNano) => Some(16),
+            DataType::Decimal128(_, _) => Some(16),
+            DataType::Decimal256(_, _) => Some(32),
+            DataType::Utf8 | DataType::LargeUtf8 => None,
+            DataType::Binary | DataType::LargeBinary => None,
+            DataType::FixedSizeBinary(_) => None,
+            DataType::List(_) | DataType::LargeList(_) | DataType::Map(_, _) => None,
+            DataType::FixedSizeList(_, _) => None,
+            DataType::Struct(_) => None,
+            DataType::Union(_, _, _) => None,
+            DataType::Dictionary(_, _) => None,
+            DataType::RunEndEncoded(_, _) => None,
+        }
+    }
+
     /// Return size of this instance in bytes.
     ///
     /// Includes the size of `Self`.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This makes it easier to create a null array of a concrete type, adds support for more types of null array (e.g. UnionArray and RunArray), and reduces some code duplication

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
