### PR TITLE
fix: take_run benchmark parameter

### DIFF
--- a/arrow/benches/primitive_run_take.rs
+++ b/arrow/benches/primitive_run_take.rs
@@ -24,14 +24,14 @@ use arrow_array::UInt32Array;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
-fn create_random_index(size: usize, null_density: f32) -> UInt32Array {
+fn create_random_index(size: usize, null_density: f32, max_value: usize) -> UInt32Array {
     let mut rng = seedable_rng();
     let mut builder = UInt32Builder::with_capacity(size);
     for _ in 0..size {
         if rng.gen::<f32>() < null_density {
             builder.append_null();
         } else {
-            let value = rng.gen_range::<u32, _>(0u32..size as u32);
+            let value = rng.gen_range::<u32, _>(0u32..max_value as u32);
             builder.append_value(value);
         }
     }
@@ -48,7 +48,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             logical_array_len,
             physical_array_len,
         );
-        let indices = create_random_index(take_len, 0.0);
+        let indices = create_random_index(take_len, 0.0, logical_array_len);
         group.bench_function(
             format!(
                 "(run_array_len:{logical_array_len}, physical_array_len:{physical_array_len}, take_len:{take_len})"),


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

I recently noticed an issue with the parameters in the benchmark `primitive_run_take`. The benchmark was not taking indices across the entire logical array but rather constrained to the length of take array.  I updated the parameters to take indices across the entire logical array. There is performance regression because more values are taken from the array. I have furnished the performance differences below

<details>
<summary><h4>Benchmark results</h4></summary>

```
primitive_run_take/(run_array_len:512, physical_array_len:64, take_len:512)
                        time:   [23.347 µs 23.508 µs 23.713 µs]
                        change: [-1.5238% +0.0502% +1.6099%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  3 (3.00%) high mild
  14 (14.00%) high severe
primitive_run_take/(run_array_len:512, physical_array_len:128, take_len:512)
                        time:   [23.477 µs 23.616 µs 23.804 µs]
                        change: [-1.2725% +0.2827% +1.9661%] (p = 0.75 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe
primitive_run_take/(run_array_len:1024, physical_array_len:256, take_len:512)
                        time:   [23.653 µs 23.778 µs 23.975 µs]
                        change: [-1.3315% +0.3299% +2.0635%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
primitive_run_take/(run_array_len:1024, physical_array_len:256, take_len:1024)
                        time:   [47.861 µs 48.179 µs 48.621 µs]
                        change: [-0.3026% +1.4710% +3.2931%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
primitive_run_take/(run_array_len:2048, physical_array_len:512, take_len:512)
                        time:   [24.226 µs 24.287 µs 24.356 µs]
                        change: [+0.7574% +3.6336% +7.6136%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
primitive_run_take/(run_array_len:2048, physical_array_len:512, take_len:1024)
                        time:   [53.774 µs 54.093 µs 54.615 µs]
                        change: [+12.948% +15.613% +18.678%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
primitive_run_take/(run_array_len:4096, physical_array_len:1024, take_len:512)
                        time:   [25.297 µs 25.365 µs 25.440 µs]
                        change: [+4.7053% +7.0111% +9.3052%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
primitive_run_take/(run_array_len:4096, physical_array_len:1024, take_len:1024)
                        time:   [59.299 µs 59.752 µs 60.351 µs]
                        change: [+21.297% +23.389% +25.448%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) high mild
  8 (8.00%) high severe
```

</details>

# What changes are included in this PR?

# Are there any user-facing changes?

