### PR TITLE
Cleanup FFI interface (#3684) (#3683)

### DIFF
--- a/arrow/src/array/mod.rs
+++ b/arrow/src/array/mod.rs
@@ -34,6 +34,7 @@ pub use arrow_data::{
 pub use arrow_data::transform::{Capacities, MutableArrayData};
 
 #[cfg(feature = "ffi")]
+#[allow(deprecated)]
 pub use self::ffi::{export_array_into_raw, make_array_from_raw};
 
 // --------------------- Array's values comparison ---------------------

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -68,16 +68,18 @@
 //! struct ForeignArray {};
 //!
 //! impl ForeignArray {
-//!     /// Export to C Data interface
-//!     fn export(&self, array: *mut FFI_ArrowArray, schema: *mut FFI_ArrowSchema) {
+//!     /// Export from foreign array representation to C Data interface
+//!     /// e.g. <https://github.com/apache/arrow/blob/fc1f9ebbc4c3ae77d5cfc2f9322f4373d3d19b8a/python/pyarrow/array.pxi#L1552>
+//!     fn export_to_c(&self, array: *mut FFI_ArrowArray, schema: *mut FFI_ArrowSchema) {
 //!         // ...
 //!     }
 //! }
 //!
-//! fn import_from_python(foreign: &ForeignArray) -> Result<ArrayRef, ArrowError> {
+//! /// Import an [`ArrayRef`] from a [`ForeignArray`]
+//! fn import_array(foreign: &ForeignArray) -> Result<ArrayRef, ArrowError> {
 //!     let mut schema = FFI_ArrowSchema::empty();
 //!     let mut array = FFI_ArrowArray::empty();
-//!     foreign.export(addr_of_mut!(array), addr_of_mut!(schema));
+//!     foreign.export_to_c(addr_of_mut!(array), addr_of_mut!(schema));
 //!     Ok(make_array(ArrowArray::new(array, schema).try_into()?))
 //! }
 //! ```

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -24,68 +24,61 @@
 //! The second interface maps native Rust types to the Rust-specific implementation of Arrow such as `format` to `Datatype`,
 //! `Buffer`, etc. This is handled by `ArrowArray`.
 //!
+//!
+//! Export to FFI
+//!
 //! ```rust
 //! # use std::sync::Arc;
-//! # use arrow::array::{Int32Array, Array, ArrayData, export_array_into_raw, make_array, make_array_from_raw};
-//! # use arrow::error::{Result, ArrowError};
+//! # use arrow::array::{Int32Array, Array, ArrayData, make_array};
+//! # use arrow::error::Result;
 //! # use arrow::compute::kernels::arithmetic;
 //! # use arrow::ffi::{ArrowArray, FFI_ArrowArray, FFI_ArrowSchema};
-//! # use std::convert::TryFrom;
 //! # fn main() -> Result<()> {
 //! // create an array natively
 //! let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+//! let data = array.into_data();
 //!
-//! // export it
-//!
-//! let ffi_array = ArrowArray::try_new(array.data().clone())?;
-//! let (array_ptr, schema_ptr) = ArrowArray::into_raw(ffi_array);
-//!
-//! // consumed and used by something else...
+//! // Export it
+//! let out_array = FFI_ArrowArray::new(&data);
+//! let out_schema = FFI_ArrowSchema::try_from(data.data_type())?;
 //!
 //! // import it
-//! let array = unsafe { make_array_from_raw(array_ptr, schema_ptr)? };
+//! let array = ArrowArray::new(out_array, out_schema);
+//! let array = Int32Array::from(ArrayData::try_from(array)?);
 //!
 //! // perform some operation
-//! let array = array.as_any().downcast_ref::<Int32Array>().ok_or(
-//!     ArrowError::ParseError("Expects an int32".to_string()),
-//! )?;
 //! let array = arithmetic::add(&array, &array)?;
 //!
 //! // verify
 //! assert_eq!(array, Int32Array::from(vec![Some(2), None, Some(6)]));
+//! #
+//! # Ok(())
+//! # }
+//! ```
 //!
-//! // Simulate if raw pointers are provided by consumer
-//! let array = make_array(Int32Array::from(vec![Some(1), None, Some(3)]).into_data());
+//! Import from FFI
 //!
-//! let out_array = Box::new(FFI_ArrowArray::empty());
-//! let out_schema = Box::new(FFI_ArrowSchema::empty());
-//! let out_array_ptr = Box::into_raw(out_array);
-//! let out_schema_ptr = Box::into_raw(out_schema);
+//! ```
+//! # use std::ptr::addr_of_mut;
+//! # use arrow::ffi::{ArrowArray, FFI_ArrowArray, FFI_ArrowSchema};
+//! # use arrow_array::{ArrayRef, make_array};
+//! # use arrow_schema::ArrowError;
+//! #
+//! /// A foreign data container that can export to C Data interface
+//! struct ForeignArray {};
 //!
-//! // export array into raw pointers from consumer
-//! unsafe { export_array_into_raw(array, out_array_ptr, out_schema_ptr)?; };
-//!
-//! // import it
-//! let array = unsafe { make_array_from_raw(out_array_ptr, out_schema_ptr)? };
-//!
-//! // perform some operation
-//! let array = array.as_any().downcast_ref::<Int32Array>().ok_or(
-//!     ArrowError::ParseError("Expects an int32".to_string()),
-//! )?;
-//! let array = arithmetic::add(&array, &array)?;
-//!
-//! // verify
-//! assert_eq!(array, Int32Array::from(vec![Some(2), None, Some(6)]));
-//!
-//! // (drop/release)
-//! unsafe {
-//!     Box::from_raw(out_array_ptr);
-//!     Box::from_raw(out_schema_ptr);
-//!     Arc::from_raw(array_ptr);
-//!     Arc::from_raw(schema_ptr);
+//! impl ForeignArray {
+//!     /// Export to C Data interface
+//!     fn export(&self, array: *mut FFI_ArrowArray, schema: *mut FFI_ArrowSchema) {
+//!         // ...
+//!     }
 //! }
 //!
-//! Ok(())
+//! fn import_from_python(foreign: &ForeignArray) -> Result<ArrayRef, ArrowError> {
+//!     let mut schema = FFI_ArrowSchema::empty();
+//!     let mut array = FFI_ArrowArray::empty();
+//!     foreign.export(addr_of_mut!(array), addr_of_mut!(schema));
+//!     Ok(make_array(ArrowArray::new(array, schema).try_into()?))
 //! }
 //! ```
 
@@ -139,7 +132,15 @@ bitflags! {
 
 /// ABI-compatible struct for `ArrowSchema` from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
-/// This was created by bindgen
+///
+/// ```
+/// # use arrow::ffi::FFI_ArrowSchema;
+/// # use arrow_data::ArrayData;
+/// fn array_schema(data: &ArrayData) -> FFI_ArrowSchema {
+///     FFI_ArrowSchema::try_from(data.data_type()).unwrap()
+/// }
+/// ```
+///
 #[repr(C)]
 #[derive(Debug)]
 pub struct FFI_ArrowSchema {
@@ -394,7 +395,14 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
 
 /// ABI-compatible struct for ArrowArray from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
-/// This was created by bindgen
+///
+/// ```
+/// # use arrow::ffi::FFI_ArrowArray;
+/// # use arrow_array::Array;
+/// fn export_array(array: &dyn Array) -> FFI_ArrowArray {
+///     FFI_ArrowArray::new(array.data())
+/// }
+/// ```
 #[repr(C)]
 #[derive(Debug)]
 pub struct FFI_ArrowArray {
@@ -859,6 +867,14 @@ impl<'a> ArrowArrayRef for ArrowArrayChild<'a> {
 }
 
 impl ArrowArray {
+    /// Creates a new [`ArrowArray`] from the provided array and schema
+    pub fn new(array: FFI_ArrowArray, schema: FFI_ArrowSchema) -> Self {
+        Self {
+            array: Arc::new(array),
+            schema: Arc::new(schema),
+        }
+    }
+
     /// creates a new `ArrowArray`. This is used to export to the C Data Interface.
     ///
     /// # Memory Leaks
@@ -878,6 +894,7 @@ impl ArrowArray {
     /// on managing the allocation of the structs by themselves.
     /// # Error
     /// Errors if any of the pointers is null
+    #[deprecated(note = "Use ArrowArray::new")]
     pub unsafe fn try_from_raw(
         array: *const FFI_ArrowArray,
         schema: *const FFI_ArrowSchema,
@@ -911,6 +928,7 @@ impl ArrowArray {
     }
 
     /// exports [ArrowArray] to the C Data Interface
+    #[deprecated(note = "Use FFI_ArrowArray and FFI_ArrowSchema directly")]
     pub fn into_raw(this: ArrowArray) -> (*const FFI_ArrowArray, *const FFI_ArrowSchema) {
         (Arc::into_raw(this.array), Arc::into_raw(this.schema))
     }
@@ -946,6 +964,7 @@ mod tests {
     use arrow_array::types::{Float64Type, Int32Type};
     use arrow_array::{Float64Array, UnionArray};
     use std::convert::TryFrom;
+    use std::ptr::addr_of_mut;
 
     #[test]
     fn test_round_trip() -> Result<()> {
@@ -1424,31 +1443,28 @@ mod tests {
         let array = make_array(Int32Array::from(vec![1, 2, 3]).into_data());
 
         // Assume two raw pointers provided by the consumer
-        let out_array = Box::new(FFI_ArrowArray::empty());
-        let out_schema = Box::new(FFI_ArrowSchema::empty());
-        let out_array_ptr = Box::into_raw(out_array);
-        let out_schema_ptr = Box::into_raw(out_schema);
+        let mut out_array = FFI_ArrowArray::empty();
+        let mut out_schema = FFI_ArrowSchema::empty();
 
-        unsafe {
-            export_array_into_raw(array, out_array_ptr, out_schema_ptr)?;
+        {
+            let out_array_ptr = addr_of_mut!(out_array);
+            let out_schema_ptr = addr_of_mut!(out_schema);
+            unsafe {
+                export_array_into_raw(array, out_array_ptr, out_schema_ptr)?;
+            }
         }
 
         // (simulate consumer) import it
-        unsafe {
-            let array = ArrowArray::try_from_raw(out_array_ptr, out_schema_ptr).unwrap();
-            let data = ArrayData::try_from(array)?;
-            let array = make_array(data);
+        let array = ArrowArray::new(out_array, out_schema);
+        let data = ArrayData::try_from(array)?;
+        let array = make_array(data);
 
-            // perform some operation
-            let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
-            let array = kernels::arithmetic::add(array, array).unwrap();
+        // perform some operation
+        let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        let array = kernels::arithmetic::add(array, array).unwrap();
 
-            // verify
-            assert_eq!(array, Int32Array::from(vec![2, 4, 6]));
-
-            drop(Box::from_raw(out_array_ptr));
-            drop(Box::from_raw(out_schema_ptr));
-        }
+        // verify
+        assert_eq!(array, Int32Array::from(vec![2, 4, 6]));
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3684
Closes #3683

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The current interface is very hard to use correctly, with it being incredibly easy to accidentally leak memory. This reworks the interface to avoid this, and make better use of Rust's ownership semantics.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
