### PR TITLE
perf: Remove sorting to yield sorted_rank

### DIFF
--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -486,8 +486,10 @@ where
 fn sorted_rank(sorted_value_indices: &UInt32Array) -> Vec<u32> {
     assert_eq!(sorted_value_indices.null_count(), 0);
     let sorted_indices = sorted_value_indices.values();
-    let mut out: Vec<_> = (0..sorted_indices.len() as u32).collect();
-    out.sort_unstable_by_key(|x| sorted_indices[*x as usize]);
+    let mut out: Vec<_> = vec![0_u32; sorted_indices.len()];
+    for (ix, val) in sorted_indices.iter().enumerate() {
+        out[*val as usize] = ix as u32;
+    }
     out
 }
 


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change
I was looking through `arrow_ord` module for adding run array. I noticed the function `sorted_rank` was doing unnecessary sorting. The function can do its job in `O(N)` time. The changes resulted in non-trivial performance improvement in `sort_kernel` for dictionary.

```
dict string 2^12        time:   [33.434 µs 33.549 µs 33.695 µs]
                        change: [-13.791% -11.994% -10.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
``` 

Note: Thanks to the documentation of the function. Wouldn't have noticed this otherwise.
https://github.com/apache/arrow-rs/blob/526100928d62e1c16ac41bbef9b966ac59b3324a/arrow-ord/src/sort.rs#L485

# What changes are included in this PR?
Remove unnecessary sorting in `sorted_rank` function.

# Are there any user-facing changes?
No.