### PR TITLE
feat: Sort kernel for `RunArray`

### DIFF
--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -112,15 +112,35 @@ impl<R: RunEndIndexType> RunArray<R> {
 
     /// Returns a reference to run_ends array
     ///
-    /// Note: any slicing of this array is not applied to the returned array
+    /// Note: any slicing of this [`RunArray`] array is not applied to the returned array
     /// and must be handled separately
     pub fn run_ends(&self) -> &PrimitiveArray<R> {
         &self.run_ends
     }
 
     /// Returns a reference to values array
+    ///
+    /// Note: any slicing of this [`RunArray`] array is not applied to the returned array
+    /// and must be handled separately
     pub fn values(&self) -> &ArrayRef {
         &self.values
+    }
+
+    /// Returns the physical index of offset.
+    pub fn get_offset_physical_index(&self) -> usize {
+        if self.offset() == 0 {
+            return 0;
+        }
+        self.get_zero_offset_physical_index(self.offset()).unwrap()
+    }
+
+    /// Returns the physical index at which the array slice ends.
+    pub fn get_slice_end_physical_index(&self) -> usize {
+        if self.offset() + self.len() == Self::logical_len(&self.run_ends) {
+            return self.run_ends.len() - 1;
+        }
+        self.get_zero_offset_physical_index(self.offset() + self.len() - 1)
+            .unwrap()
     }
 
     /// Downcast this [`RunArray`] to a [`TypedRunArray`]
@@ -230,11 +250,7 @@ impl<R: RunEndIndexType> RunArray<R> {
         }
 
         // Skip some physical indices based on offset.
-        let skip_value = if self.offset() > 0 {
-            self.get_zero_offset_physical_index(self.offset()).unwrap()
-        } else {
-            0
-        };
+        let skip_value = self.get_offset_physical_index();
 
         let mut physical_indices = vec![0; indices_len];
 

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -472,6 +472,11 @@ impl<'a, R: RunEndIndexType, V> TypedRunArray<'a, R, V> {
     pub fn values(&self) -> &'a V {
         self.values
     }
+
+    /// Returns the run array of this [`TypedRunArray`]
+    pub fn run_array(&self) -> &'a RunArray<R> {
+        self.run_array
+    }
 }
 
 impl<'a, R: RunEndIndexType, V: Sync> Array for TypedRunArray<'a, R, V> {

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -126,7 +126,7 @@ impl<R: RunEndIndexType> RunArray<R> {
         &self.values
     }
 
-    /// Returns the physical at which the array slice starts.
+    /// Returns the physical index at which the array slice starts.
     pub fn get_start_physical_index(&self) -> usize {
         if self.offset() == 0 {
             return 0;

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -126,8 +126,8 @@ impl<R: RunEndIndexType> RunArray<R> {
         &self.values
     }
 
-    /// Returns the physical index of offset.
-    pub fn get_offset_physical_index(&self) -> usize {
+    /// Returns the physical at which the array slice starts.
+    pub fn get_start_physical_index(&self) -> usize {
         if self.offset() == 0 {
             return 0;
         }
@@ -135,7 +135,7 @@ impl<R: RunEndIndexType> RunArray<R> {
     }
 
     /// Returns the physical index at which the array slice ends.
-    pub fn get_slice_end_physical_index(&self) -> usize {
+    pub fn get_end_physical_index(&self) -> usize {
         if self.offset() + self.len() == Self::logical_len(&self.run_ends) {
             return self.run_ends.len() - 1;
         }
@@ -250,7 +250,7 @@ impl<R: RunEndIndexType> RunArray<R> {
         }
 
         // Skip some physical indices based on offset.
-        let skip_value = self.get_offset_physical_index();
+        let skip_value = self.get_start_physical_index();
 
         let mut physical_indices = vec![0; indices_len];
 

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -57,8 +57,8 @@ where
 {
     /// create a new iterator
     pub fn new(array: TypedRunArray<'a, R, V>) -> Self {
-        let current_front_physical: usize = array.run_array().get_start_physical_index();
-        let current_back_physical: usize = array.run_array().get_end_physical_index() + 1;
+        let current_front_physical = array.run_array().get_start_physical_index();
+        let current_back_physical = array.run_array().get_end_physical_index() + 1;
         RunArrayIter {
             array,
             current_front_logical: array.offset(),

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -19,9 +19,7 @@
 
 use arrow_buffer::ArrowNativeType;
 
-use crate::{
-    array::ArrayAccessor, types::RunEndIndexType, Array, TypedRunArray,
-};
+use crate::{array::ArrayAccessor, types::RunEndIndexType, Array, TypedRunArray};
 
 /// The [`RunArrayIter`] provides an idiomatic way to iterate over the run array.
 /// It returns Some(T) if there is a value or None if the value is null.
@@ -59,12 +57,8 @@ where
 {
     /// create a new iterator
     pub fn new(array: TypedRunArray<'a, R, V>) -> Self {
-        let current_front_physical: usize =
-            array.run_array().get_start_physical_index();
-        let current_back_physical: usize = array
-            .run_array()
-            .get_end_physical_index()
-            + 1;
+        let current_front_physical: usize = array.run_array().get_start_physical_index();
+        let current_back_physical: usize = array.run_array().get_end_physical_index() + 1;
         RunArrayIter {
             array,
             current_front_logical: array.offset(),

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -20,7 +20,7 @@
 use arrow_buffer::ArrowNativeType;
 
 use crate::{
-    array::ArrayAccessor, types::RunEndIndexType, Array, RunArray, TypedRunArray,
+    array::ArrayAccessor, types::RunEndIndexType, Array, TypedRunArray,
 };
 
 /// The [`RunArrayIter`] provides an idiomatic way to iterate over the run array.
@@ -60,11 +60,10 @@ where
     /// create a new iterator
     pub fn new(array: TypedRunArray<'a, R, V>) -> Self {
         let current_front_physical: usize =
-            array.run_array().get_physical_index(0).unwrap();
+            array.run_array().get_start_physical_index();
         let current_back_physical: usize = array
             .run_array()
-            .get_physical_index(array.len() - 1)
-            .unwrap()
+            .get_end_physical_index()
             + 1;
         RunArrayIter {
             array,

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -19,7 +19,9 @@
 
 use arrow_buffer::ArrowNativeType;
 
-use crate::{array::ArrayAccessor, types::RunEndIndexType, Array, TypedRunArray};
+use crate::{
+    array::ArrayAccessor, types::RunEndIndexType, Array, RunArray, TypedRunArray,
+};
 
 /// The [`RunArrayIter`] provides an idiomatic way to iterate over the run array.
 /// It returns Some(T) if there is a value or None if the value is null.
@@ -42,10 +44,10 @@ where
     <&'a V as ArrayAccessor>::Item: Default,
 {
     array: TypedRunArray<'a, R, V>,
-    current_logical: usize,
-    current_physical: usize,
-    current_end_logical: usize,
-    current_end_physical: usize,
+    current_front_logical: usize,
+    current_front_physical: usize,
+    current_back_logical: usize,
+    current_back_physical: usize,
 }
 
 impl<'a, R, V> RunArrayIter<'a, R, V>
@@ -57,14 +59,31 @@ where
 {
     /// create a new iterator
     pub fn new(array: TypedRunArray<'a, R, V>) -> Self {
-        let logical_len = array.len();
-        let physical_len: usize = array.values().len();
+        let current_front_physical: usize = if array.offset() > 0 {
+            array
+                .run_array()
+                .get_zero_offset_physical_index(array.offset())
+                .unwrap()
+        } else {
+            0
+        };
+        let sliced_end: usize = array.offset() + array.len();
+        let current_back_physical: usize =
+            if sliced_end == RunArray::<R>::logical_len(array.run_ends()) {
+                array.run_ends().len()
+            } else {
+                array
+                    .run_array()
+                    .get_zero_offset_physical_index(sliced_end - 1)
+                    .unwrap()
+                    + 1
+            };
         RunArrayIter {
             array,
-            current_logical: 0,
-            current_physical: 0,
-            current_end_logical: logical_len,
-            current_end_physical: physical_len,
+            current_front_logical: array.offset(),
+            current_front_physical,
+            current_back_logical: sliced_end,
+            current_back_physical,
         }
     }
 }
@@ -80,35 +99,37 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_logical == self.current_end_logical {
+        if self.current_front_logical == self.current_back_logical {
             return None;
         }
         // If current logical index is greater than current run end index then increment
         // the physical index.
-        if self.current_logical
+        if self.current_front_logical
             >= self
                 .array
                 .run_ends()
-                .value(self.current_physical)
+                .value(self.current_front_physical)
                 .as_usize()
         {
             // As the run_ends is expected to be strictly increasing, there
             // should be at least one logical entry in one physical entry. Because of this
             // reason the next value can be accessed by incrementing physical index once.
-            self.current_physical += 1;
+            self.current_front_physical += 1;
         }
-        if self.array.values().is_null(self.current_physical) {
-            self.current_logical += 1;
+        if self.array.values().is_null(self.current_front_physical) {
+            self.current_front_logical += 1;
             Some(None)
         } else {
-            self.current_logical += 1;
+            self.current_front_logical += 1;
             // Safety:
             // The self.current_physical is kept within bounds of self.current_logical.
             // The self.current_logical will not go out of bounds because of the check
             // `self.current_logical = self.current_end_logical` above.
             unsafe {
                 Some(Some(
-                    self.array.values().value_unchecked(self.current_physical),
+                    self.array
+                        .values()
+                        .value_unchecked(self.current_front_physical),
                 ))
             }
         }
@@ -116,8 +137,8 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (
-            self.current_end_logical - self.current_logical,
-            Some(self.current_end_logical - self.current_logical),
+            self.current_back_logical - self.current_front_logical,
+            Some(self.current_back_logical - self.current_front_logical),
         )
     }
 }
@@ -130,26 +151,26 @@ where
     <&'a V as ArrayAccessor>::Item: Default,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.current_end_logical == self.current_logical {
+        if self.current_back_logical == self.current_front_logical {
             return None;
         }
 
-        self.current_end_logical -= 1;
+        self.current_back_logical -= 1;
 
-        if self.current_end_physical > 0
-            && self.current_end_logical
+        if self.current_back_physical > 0
+            && self.current_back_logical
                 < self
                     .array
                     .run_ends()
-                    .value(self.current_end_physical - 1)
+                    .value(self.current_back_physical - 1)
                     .as_usize()
         {
             // As the run_ends is expected to be strictly increasing, there
             // should be at least one logical entry in one physical entry. Because of this
             // reason the next value can be accessed by decrementing physical index once.
-            self.current_end_physical -= 1;
+            self.current_back_physical -= 1;
         }
-        Some(if self.array.values().is_null(self.current_end_physical) {
+        Some(if self.array.values().is_null(self.current_back_physical) {
             None
         } else {
             // Safety:
@@ -160,7 +181,7 @@ where
                 Some(
                     self.array
                         .values()
-                        .value_unchecked(self.current_end_physical),
+                        .value_unchecked(self.current_back_physical),
                 )
             }
         })
@@ -184,8 +205,8 @@ mod tests {
     use crate::{
         array::{Int32Array, StringArray},
         builder::PrimitiveRunBuilder,
-        types::Int32Type,
-        Int64RunArray,
+        types::{Int16Type, Int32Type},
+        Array, Int64RunArray, PrimitiveArray, RunArray,
     };
 
     fn build_input_array(size: usize) -> Vec<Option<i32>> {
@@ -344,5 +365,51 @@ mod tests {
         ];
 
         assert_eq!(expected_vec, result_asref);
+    }
+
+    #[test]
+    fn test_sliced_run_array_iterator() {
+        let total_len = 80;
+        let input_array = build_input_array(total_len);
+
+        // Encode the input_array to run array
+        let mut builder =
+            PrimitiveRunBuilder::<Int16Type, Int32Type>::with_capacity(input_array.len());
+        builder.extend(input_array.iter().copied());
+        let run_array = builder.finish();
+
+        // test for all slice lengths.
+        for slice_len in 1..=total_len {
+            // test for offset = 0, slice length = slice_len
+            let sliced_run_array: RunArray<Int16Type> =
+                run_array.slice(0, slice_len).into_data().into();
+            let sliced_typed_run_array = sliced_run_array
+                .downcast::<PrimitiveArray<Int32Type>>()
+                .unwrap();
+
+            // Iterate on sliced typed run array
+            let actual: Vec<Option<i32>> = sliced_typed_run_array.into_iter().collect();
+            let expected: Vec<Option<i32>> =
+                input_array.iter().take(slice_len).copied().collect();
+            assert_eq!(expected, actual);
+
+            // test for offset = total_len - slice_len, length = slice_len
+            let sliced_run_array: RunArray<Int16Type> = run_array
+                .slice(total_len - slice_len, slice_len)
+                .into_data()
+                .into();
+            let sliced_typed_run_array = sliced_run_array
+                .downcast::<PrimitiveArray<Int32Type>>()
+                .unwrap();
+
+            // Iterate on sliced typed run array
+            let actual: Vec<Option<i32>> = sliced_typed_run_array.into_iter().collect();
+            let expected: Vec<Option<i32>> = input_array
+                .iter()
+                .skip(total_len - slice_len)
+                .copied()
+                .collect();
+            assert_eq!(expected, actual);
+        }
     }
 }

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -776,7 +776,7 @@ fn sort_run_to_indices<R: RunEndIndexType>(
         let physical_index = physical_index.unwrap() as usize + start_physical_index;
 
         // calculate the run length and logical index of sorted values
-        let (run_length, logical_index) = unsafe {
+        let (run_length, logical_index_start) = unsafe {
             // Safety:
             // The index will be within bounds as its in bounds of start_physical_index
             // and len, both of which are within bounds of run_array
@@ -803,7 +803,9 @@ fn sort_run_to_indices<R: RunEndIndexType>(
             }
         };
         let new_run_length = run_length.min(remaining_len);
-        result.resize(result.len() + new_run_length, logical_index as u32);
+        result.extend(
+            logical_index_start as u32..(logical_index_start + new_run_length) as u32,
+        );
         remaining_len -= new_run_length;
 
         if remaining_len == 0 {

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -649,8 +649,8 @@ fn sort_run_downcasted<R: RunEndIndexType>(
     let run_array = values.as_any().downcast_ref::<RunArray<R>>().unwrap();
 
     // slice the run_array.values based on offset and length.
-    let start_physical_index = run_array.get_offset_physical_index();
-    let end_physical_index = run_array.get_slice_end_physical_index();
+    let start_physical_index = run_array.get_start_physical_index();
+    let end_physical_index = run_array.get_end_physical_index();
     let physical_len = end_physical_index - start_physical_index + 1;
     let run_values = run_array.values().slice(start_physical_index, physical_len);
 
@@ -749,8 +749,8 @@ fn sort_run_to_indices<R: RunEndIndexType>(
     let run_array = values.as_any().downcast_ref::<RunArray<R>>().unwrap();
 
     // slice the run_array.values based on offset and length.
-    let start_physical_index = run_array.get_offset_physical_index();
-    let end_physical_index = run_array.get_slice_end_physical_index();
+    let start_physical_index = run_array.get_start_physical_index();
+    let end_physical_index = run_array.get_end_physical_index();
     let physical_len = end_physical_index - start_physical_index + 1;
     let run_values = run_array.values().slice(start_physical_index, physical_len);
 

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -357,6 +357,16 @@ pub fn sort_to_indices(
             sort_binary::<i32>(values, v, n, &options, limit)
         }
         DataType::LargeBinary => sort_binary::<i64>(values, v, n, &options, limit),
+        DataType::RunEndEncoded(run_ends_field, _) => match run_ends_field.data_type() {
+            DataType::Int16 => sort_run_to_indices::<Int16Type>(values, &options, limit),
+            DataType::Int32 => sort_run_to_indices::<Int32Type>(values, &options, limit),
+            DataType::Int64 => sort_run_to_indices::<Int64Type>(values, &options, limit),
+            dt => {
+                return Err(ArrowError::ComputeError(format!(
+                    "Inavlid run end data type: {dt}"
+                )))
+            }
+        },
         t => {
             return Err(ArrowError::ComputeError(format!(
                 "Sort not supported for data type {t:?}"
@@ -595,6 +605,69 @@ fn insert_valid_values<T>(result_slice: &mut [u32], offset: usize, valids: &[(u3
     };
 
     append_valids(&mut result_slice[offset..offset + valids.len()]);
+}
+
+// Sort to indices for run encoded array
+fn sort_run_to_indices<R: RunEndIndexType>(
+    values: &ArrayRef,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> UInt32Array {
+    let run_array = values.as_any().downcast_ref::<RunArray<R>>().unwrap();
+
+    // slice the run_array.values based on offset and length.
+    let start_physical_index = run_array.get_offset_physical_index();
+    let end_physical_index = run_array.get_slice_end_physical_index();
+    let physical_len = end_physical_index - start_physical_index + 1;
+    let run_values = run_array.values().slice(start_physical_index, physical_len);
+
+    // All the values have to be sorted irrespective of input limit.
+    let values_indices = sort_to_indices(&run_values, Some(*options), None).unwrap();
+
+    let mut len = if let Some(limit) = limit {
+        limit.min(run_array.len())
+    } else {
+        run_array.len()
+    };
+
+    let mut result: Vec<u32> = Vec::with_capacity(len);
+
+    // calculate new_run_length for sorted run_array.value indices and add them to output.
+    let run_ends = run_array.run_ends();
+    let mut indices_iter = values_indices.into_iter();
+    while len > 0 {
+        // as values indices are indexed on sliced run_array.values, the start_physical_index has to
+        // be added back to get physical index relative to run_array.values.
+        let index = indices_iter.next().unwrap().unwrap() as usize + start_physical_index;
+        let (run_length, logical_index) = unsafe {
+            // Safety:
+            // The index will be within bounds as its in bounds of start_physical_index
+            // and len both of which are withing bounds of run_array
+            if index == start_physical_index {
+                (
+                    run_ends.value_unchecked(index).as_usize() - run_array.offset(),
+                    0,
+                )
+            } else if index == end_physical_index {
+                (
+                    run_array.offset() + run_array.len()
+                        - run_ends.value_unchecked(index - 1).as_usize(),
+                    run_array.len() - 1,
+                )
+            } else {
+                (
+                    run_ends.value_unchecked(index).as_usize()
+                        - run_ends.value_unchecked(index - 1).as_usize(),
+                    run_ends.value_unchecked(index - 1).as_usize() - run_array.offset(),
+                )
+            }
+        };
+        let new_run_length = run_length.min(len);
+        result.resize(result.len() + new_run_length, logical_index as u32);
+        len -= new_run_length;
+    }
+
+    UInt32Array::from(result)
 }
 
 /// Sort strings
@@ -1055,6 +1128,7 @@ fn sort_valids_array<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_array::builder::PrimitiveRunBuilder;
     use arrow_buffer::i256;
     use rand::rngs::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
@@ -2878,6 +2952,97 @@ mod tests {
             Some(2),
             vec![Some("def"), None],
         );
+    }
+
+    #[test]
+    fn test_sort_run_to_indices() {
+        // Create an input array for testing
+        let total_len = 80;
+        let vals: Vec<Option<i32>> =
+            vec![Some(1), None, Some(2), Some(3), Some(4), None, Some(5)];
+        let repeats: Vec<usize> = vec![1, 3, 2, 4];
+        let mut input_array: Vec<Option<i32>> = Vec::with_capacity(total_len);
+        for ix in 0_usize..32 {
+            let repeat: usize = repeats[ix % repeats.len()];
+            let val: Option<i32> = vals[ix % vals.len()];
+            input_array.resize(input_array.len() + repeat, val);
+        }
+
+        // create run array using input_array
+        // Encode the input_array to run array
+        let mut builder =
+            PrimitiveRunBuilder::<Int16Type, Int32Type>::with_capacity(input_array.len());
+        builder.extend(input_array.iter().copied());
+        let run_array = builder.finish();
+
+        // slice lengths that are tested
+        let slice_lens = [
+            1, 2, 3, 4, 5, 6, 7, 37, 38, 39, 40, 41, 42, 43, 74, 75, 76, 77, 78, 79, 80,
+        ];
+        for slice_len in slice_lens {
+            test_sort_run_to_indices_inner(
+                input_array.as_slice(),
+                &run_array,
+                0,
+                slice_len,
+                None,
+            );
+            test_sort_run_to_indices_inner(
+                input_array.as_slice(),
+                &run_array,
+                total_len - slice_len,
+                slice_len,
+                None,
+            );
+            // Test with non zero limit
+            if slice_len > 1 {
+                test_sort_run_to_indices_inner(
+                    input_array.as_slice(),
+                    &run_array,
+                    0,
+                    slice_len,
+                    Some(slice_len / 2),
+                );
+                test_sort_run_to_indices_inner(
+                    input_array.as_slice(),
+                    &run_array,
+                    total_len - slice_len,
+                    slice_len,
+                    Some(slice_len / 2),
+                );
+            }
+        }
+    }
+
+    fn test_sort_run_to_indices_inner(
+        input_array: &[Option<i32>],
+        run_array: &RunArray<Int16Type>,
+        offset: usize,
+        length: usize,
+        limit: Option<usize>,
+    ) {
+        // Run the sort and build actual result
+        let sliced_array = run_array.slice(offset, length);
+        let sorted_sliced_array = sort_limit(&sliced_array, None, limit).unwrap();
+        let sorted_run_array = sorted_sliced_array
+            .as_any()
+            .downcast_ref::<RunArray<Int16Type>>()
+            .unwrap();
+        let typed_run_array = sorted_run_array
+            .downcast::<PrimitiveArray<Int32Type>>()
+            .unwrap();
+        let actual: Vec<Option<i32>> = typed_run_array.into_iter().collect();
+
+        // build expected result.
+        let mut sliced_input = input_array[offset..(offset + length)].to_owned();
+        sliced_input.sort();
+        let expected = if let Some(limit) = limit {
+            sliced_input.iter().take(limit).copied().collect()
+        } else {
+            sliced_input
+        };
+
+        assert_eq!(expected, actual)
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?
Part of #3520 

# Rationale for this change
See issue description 

# What changes are included in this PR?
Built on top to yet to be merged PR #3681 
- `sort_run_to_indices` for `RunArray`
- `sort_run` for `RunArray`
- Include sort run and sort run to indices in `sort_kernel` benchmark

Sorting run array to indices is very slow if the intention is to get output run array. The sorted indices are logical indices which has to be encoded back to run array. The function `sort_run` will rearrange runs based on sorted values and hence will be faster to get output run array. 

#### How much faster is `sort_run` compared to `sort_run_to_indices`?
Below benchmark result shows `sort_run` produces the output run array using same time taken by `sort_run_to_indices` to produce indices.

```
sort primitive run to indices 2^12
                        time:   [11.023 µs 11.054 µs 11.096 µs]
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

sort primitive run to run 2^12
                        time:   [10.165 µs 10.267 µs 10.410 µs]
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
```

#### What's the catch?
The `sort_run` will only rearrange the runs and not re-encode them for efficiency.  For e.g. an input `RunArray { run_ends = [2,4,6,8], values = [1,2,1,2] }` will result in output `RunArray { run_ends = [2,4,6,8], values = [1,1,2,2] }` and not `RunArray { run_ends = [4,8], values = [1,2] }`. The output of `sort_run_to_indices` can be used to re-encode the `RunArray`.


# Are there any user-facing changes?
Users will get a new sort function for `RunArray`
