### PR TITLE
object_store: azure cli authorization

### DIFF
--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -190,7 +190,7 @@ impl AzureClient {
                     .context(AuthorizationSnafu)?;
                 Ok(AzureCredential::AuthorizationToken(
                     // we do the conversion to a HeaderValue here, since it is fallible
-                    // and we wna to use it in an infallible function
+                    // and we want to use it in an infallible function
                     HeaderValue::from_str(&format!("Bearer {token}")).map_err(|err| {
                         crate::Error::Generic {
                             store: "MicrosoftAzure",

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -172,7 +172,7 @@ impl AzureClient {
             CredentialProvider::BearerToken(token) => {
                 Ok(AzureCredential::AuthorizationToken(
                     // we do the conversion to a HeaderValue here, since it is fallible
-                    // and we wna to use it in an infallible function
+                    // and we want to use it in an infallible function
                     HeaderValue::from_str(&format!("Bearer {token}")).map_err(|err| {
                         crate::Error::Generic {
                             store: "MicrosoftAzure",

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -169,6 +169,18 @@ impl AzureClient {
             CredentialProvider::AccessKey(key) => {
                 Ok(AzureCredential::AccessKey(key.to_owned()))
             }
+            CredentialProvider::BearerToken(token) => {
+                Ok(AzureCredential::AuthorizationToken(
+                    // we do the conversion to a HeaderValue here, since it is fallible
+                    // and we wna to use it in an infallible function
+                    HeaderValue::from_str(&format!("Bearer {token}")).map_err(|err| {
+                        crate::Error::Generic {
+                            store: "MicrosoftAzure",
+                            source: Box::new(err),
+                        }
+                    })?,
+                ))
+            }
             CredentialProvider::TokenCredential(cache, cred) => {
                 let token = cache
                     .get_or_insert_with(|| {

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -69,6 +69,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub enum CredentialProvider {
     AccessKey(String),
+    BearerToken(String),
     SASToken(Vec<(String, String)>),
     TokenCredential(TokenCache<String>, Box<dyn TokenCredential>),
 }

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -584,6 +584,12 @@ pub struct AzureCliCredential {
     _private: (),
 }
 
+impl AzureCliCredential {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 #[async_trait::async_trait]
 impl TokenCredential for AzureCliCredential {
     /// Fetch a token

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -901,6 +901,7 @@ impl MicrosoftAzureBuilder {
     }
 
     /// Set if the Azure Cli should be used for acquiring access token
+    /// <https://learn.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az-account-get-access-token>
     pub fn with_use_azure_cli(mut self, use_azure_cli: bool) -> Self {
         self.use_azure_cli = use_azure_cli;
         self

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -971,7 +971,7 @@ impl MicrosoftAzureBuilder {
             } else if self.use_azure_cli {
                 credential::CredentialProvider::TokenCredential(
                     TokenCache::default(),
-                    Box::new(credential::AzureCliCredential::default()),
+                    Box::new(credential::AzureCliCredential::new()),
                 )
             } else {
                 let client =

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -916,7 +916,7 @@ impl MicrosoftAzureBuilder {
             let url = Url::parse(&account_url)
                 .context(UnableToParseUrlSnafu { url: account_url })?;
             let credential = if let Some(bearer_token) = self.bearer_token {
-                credential::CredentialProvider::AccessKey(bearer_token)
+                credential::CredentialProvider::BearerToken(bearer_token)
             } else if let Some(access_key) = self.access_key {
                 credential::CredentialProvider::AccessKey(access_key)
             } else if let (Some(client_id), Some(tenant_id), Some(federated_token_file)) =


### PR DESCRIPTION
# Which issue does this PR close?

closes #3696
closes #3697

# Rationale for this change
 
see #3697

# What changes are included in this PR?

Fix passing bearer token in azure store directly to authorization header. Add a new `TokenCredential` that uses the azure CLI for acquiring an access token.

One problem with this PR is the lack of additional tests. I validated that is works locally, but was unsure how to write a meaningful test to use in CI.

P.S: In the meantime I also validated that the workload identity credential works as expected.

# Are there any user-facing changes?

users can now use bearer tokens and azure cli for authorization against azure object stores.
