### PR TITLE
perf: `take_run` improvements

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -866,7 +866,7 @@ where
 
     let take_value_indices: PrimitiveArray<I> = unsafe {
         // Safety:
-        // The function builds a valid run_ends array and hence need not be validated.
+        // The function builds a valid take_value_indices array and hence need not be validated.
         ArrayDataBuilder::new(I::DATA_TYPE)
             .len(new_physical_len)
             .null_count(0)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -2167,24 +2167,24 @@ mod tests {
 
     #[test]
     fn test_take_runs() {
-        let logical_array: Vec<i32> = vec![1_i32, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2];
+        let logical_array: Vec<i32> = vec![1_i32, 1, 2, 2, 1, 1, 1, 2, 2, 1, 1, 2, 2];
 
         let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
         builder.extend(logical_array.into_iter().map(Some));
         let run_array = builder.finish();
 
         let take_indices: PrimitiveArray<Int32Type> =
-            vec![7, 2, 3, 7, 10].into_iter().collect();
+            vec![7, 2, 3, 7, 11, 4, 6].into_iter().collect();
 
         let take_out = take_run(&run_array, &take_indices).unwrap();
 
-        assert_eq!(take_out.len(), 5);
+        assert_eq!(take_out.len(), 7);
 
-        assert_eq!(take_out.run_ends().len(), 4);
-        assert_eq!(take_out.run_ends().values(), &[1_i32, 3, 4, 5]);
+        assert_eq!(take_out.run_ends().len(), 5);
+        assert_eq!(take_out.run_ends().values(), &[1_i32, 3, 4, 5, 7]);
 
         let take_out_values = as_primitive_array::<Int32Type>(take_out.values());
-        assert_eq!(take_out_values.values(), &[2, 2, 2, 2]);
+        assert_eq!(take_out_values.values(), &[2, 2, 2, 2, 1]);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3701 
Part of #3520 

# Rationale for this change
See issue description #3701.

# What changes are included in this PR?

Update the `take_run` function to do the below
 1 Take physical_indices for the given logical indices.
 2 Run encode the physical_indices while keeping track of physical indices that needs to be taken.
 3 take values from run_array.values based on physical indices from the step 2.
 4 Build a new run array using run_ends from step 2 and values from step 3.

The performance of benchmark `primitive_take_run` has improved by approx 15%

<details><summary>Benchmark result</summary>

```
Primitive_run_take/(run_array_len:512, physical_array_len:64, take_len:512)
                        time:   [14.263 µs 14.289 µs 14.314 µs]
                        change: [-16.324% -15.022% -13.604%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
primitive_run_take/(run_array_len:512, physical_array_len:128, take_len:512)
                        time:   [14.299 µs 14.320 µs 14.344 µs]
                        change: [-17.510% -16.083% -14.660%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
primitive_run_take/(run_array_len:1024, physical_array_len:256, take_len:512)
                        time:   [14.672 µs 14.689 µs 14.706 µs]
                        change: [-17.290% -15.772% -14.314%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
primitive_run_take/(run_array_len:1024, physical_array_len:256, take_len:1024)
                        time:   [29.943 µs 29.972 µs 30.002 µs]
                        change: [-18.529% -17.130% -15.819%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  7 (7.00%) high severe
primitive_run_take/(run_array_len:2048, physical_array_len:512, take_len:512)
                        time:   [15.864 µs 15.896 µs 15.928 µs]
                        change: [-15.176% -13.517% -11.892%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
primitive_run_take/(run_array_len:2048, physical_array_len:512, take_len:1024)
                        time:   [34.206 µs 34.275 µs 34.347 µs]
                        change: [-15.092% -13.950% -12.743%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
primitive_run_take/(run_array_len:4096, physical_array_len:1024, take_len:512)
                        time:   [18.066 µs 18.094 µs 18.121 µs]
                        change: [-14.902% -13.842% -12.604%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
primitive_run_take/(run_array_len:4096, physical_array_len:1024, take_len:1024)
                        time:   [37.529 µs 37.571 µs 37.612 µs]
                        change: [-17.016% -15.749% -14.471%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high severe

```

</details>

# Are there any user-facing changes?
No
