### PR TITLE
feat: add StringArray.raw_value()

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -723,4 +723,14 @@ mod tests {
 
         assert_eq!(s, sa);
     }
+
+    #[test]
+    fn test_raw_values() {
+        let data = vec!["a", "b"];
+        let s = StringArray::from_iter_values(data.clone());
+        let b = BinaryArray::from(s.clone());
+        let values = vec![b.raw_value(0), b.raw_value(1)];
+        let expected: Vec<&[u8]> = data.iter().map(|&v| v.as_bytes()).collect();
+        assert_eq!(values, expected);
+    }
 }

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -719,4 +719,13 @@ mod tests {
         let err_return = array.into_builder().unwrap_err();
         assert_eq!(&err_return, &shared_array);
     }
+
+    #[test]
+    fn test_raw_values() {
+        let data = vec!["a", "b"];
+        let s = StringArray::from_iter_values(data.clone());
+        let values = vec![s.raw_value(0), s.raw_value(1)];
+        let expected: Vec<&[u8]> = data.iter().map(|&v| v.as_bytes()).collect();
+        assert_eq!(values, expected);
+    }
 }


### PR DESCRIPTION
This gives a reference to underlying bytes. As far as I can tell `BinaryArray::from` can't do the same thing because it needs to own the `StringArray`; this works with a reference to one.