### PR TITLE
Fix pyarrow integration test

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -34,6 +34,3 @@ crate-type = ["cdylib"]
 [dependencies]
 arrow = { path = "../arrow", version = "33.0.0", features = ["pyarrow"] }
 pyo3 = { version = "0.18", features = ["extension-module"] }
-
-[package.metadata.maturin]
-requires-dist = ["pyarrow>=1"]

--- a/arrow-pyarrow-integration-testing/pyproject.toml
+++ b/arrow-pyarrow-integration-testing/pyproject.toml
@@ -18,3 +18,5 @@
 [build-system]
 requires = ["maturin"]
 build-backend = "maturin"
+
+dependencies = ["pyarrow>=1"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Maturin has deprecated specifying dependencies using Cargo.toml, instead needing them to be provided by pyproject.toml

See https://github.com/apache/arrow-rs/actions/runs/4158175288/jobs/7193205193

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
