### PR TITLE
Add `into_primitive_dict_builder` to `DictionaryArray`

### DIFF
--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -1017,16 +1017,12 @@ mod tests {
             DictionaryArray::<Int8Type>::from(boxed.data().clone());
         let err = col.into_primitive_dict_builder::<Int32Type>();
 
-        match err {
-            Ok(_) => panic!("Should not get builder from cloned array"),
-            Err(returned) => {
-                let values = Int32Array::from_iter_values([10_i32, 12, 15]);
-                let keys = Int8Array::from_iter_values([1_i8, 0, 2, 0]);
+        let returned = err.unwrap_err();
 
-                let expected =
-                    DictionaryArray::<Int8Type>::try_new(&keys, &values).unwrap();
-                assert_eq!(expected, returned)
-            }
-        }
+        let values = Int32Array::from_iter_values([10_i32, 12, 15]);
+        let keys = Int8Array::from_iter_values([1_i8, 0, 2, 0]);
+
+        let expected = DictionaryArray::<Int8Type>::try_new(&keys, &values).unwrap();
+        assert_eq!(expected, returned);
     }
 }

--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -118,7 +118,7 @@ where
     /// # Panics
     ///
     /// This method panics if `keys_builder` or `values_builder` is not empty.
-    pub fn new_from_builders(
+    pub fn new_from_empty_builders(
         keys_builder: PrimitiveBuilder<K>,
         values_builder: PrimitiveBuilder<V>,
     ) -> Self {
@@ -130,6 +130,30 @@ where
             keys_builder,
             values_builder,
             map: HashMap::new(),
+        }
+    }
+
+    /// Creates a new `PrimitiveDictionaryBuilder` from existing `PrimitiveBuilder`s of keys and values.
+    ///
+    /// # Safety
+    ///
+    /// caller must ensure that the passed in builders are valid for DictionaryArray.
+    pub unsafe fn new_from_builders(
+        keys_builder: PrimitiveBuilder<K>,
+        values_builder: PrimitiveBuilder<V>,
+    ) -> Self {
+        let keys = keys_builder.values_slice();
+        let values = values_builder.values_slice();
+        let mut map = HashMap::with_capacity(values.len());
+
+        keys.iter().zip(values.iter()).for_each(|(key, value)| {
+            map.insert(Value(*value), K::Native::to_usize(*key).unwrap());
+        });
+
+        Self {
+            keys_builder,
+            values_builder,
+            map,
         }
     }
 
@@ -276,6 +300,16 @@ where
 
         DictionaryArray::from(unsafe { builder.build_unchecked() })
     }
+
+    /// Returns the current dictionary values buffer as a slice
+    pub fn values_slice(&self) -> &[V::Native] {
+        self.values_builder.values_slice()
+    }
+
+    /// Returns the current dictionary values buffer as a mutable slice
+    pub fn values_slice_mut(&mut self) -> &mut [V::Native] {
+        self.values_builder.values_slice_mut()
+    }
 }
 
 impl<K: ArrowPrimitiveType, P: ArrowPrimitiveType> Extend<Option<P::Native>>
@@ -357,7 +391,7 @@ mod tests {
         let values_builder =
             Decimal128Builder::new().with_data_type(DataType::Decimal128(1, 2));
         let mut builder =
-            PrimitiveDictionaryBuilder::<Int32Type, Decimal128Type>::new_from_builders(
+            PrimitiveDictionaryBuilder::<Int32Type, Decimal128Type>::new_from_empty_builders(
                 keys_builder,
                 values_builder,
             );


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3710.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Similar to `into_builder` of `PrimitiveArray`, `into_primitive_dict_builder` is for cow support for `DictionaryArray`. 

With this API, it is easy to add `unary_dict_mut`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added `into_primitive_dict_builder` API to `DictionaryArray` for mutating its keys and values.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
