### PR TITLE
feat: impl `Ord`/`PartialOrd` for `SortOptions`

### DIFF
--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -30,7 +30,7 @@ pub use schema::*;
 pub mod ffi;
 
 /// Options that define the sort order of a given column
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Makes it easier to use `SortOptions` in other code bases (esp. you can auto-derive `Ord` for other types that use `SortOptions`).

# What changes are included in this PR?
Auto-derive `Ord`/`PartialOrd` for `SortOptions`.

# Are there any user-facing changes?
\-
