### PR TITLE
fix: encoding batch with no columns

### DIFF
--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -511,7 +511,7 @@ mod tests {
         )
         .expect("cannot create record batch");
 
-        prepare_batch_for_flight(&batch, batch.schema().clone())
+        prepare_batch_for_flight(&batch, batch.schema())
             .expect("failed to optimize");
     }
 

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -18,7 +18,7 @@
 use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 
 use crate::{error::Result, FlightData, SchemaAsIpc};
-use arrow_array::{ArrayRef, RecordBatch};
+use arrow_array::{ArrayRef, RecordBatch, RecordBatchOptions};
 use arrow_ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use bytes::Bytes;
@@ -422,8 +422,11 @@ fn prepare_batch_for_flight(
         .iter()
         .map(hydrate_dictionary)
         .collect::<Result<Vec<_>>>()?;
+    let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
 
-    Ok(RecordBatch::try_new(schema, columns)?)
+    Ok(RecordBatch::try_new_with_options(
+        schema, columns, &options,
+    )?)
 }
 
 /// Hydrates a dictionary to its underlying type
@@ -497,6 +500,19 @@ mod tests {
             baseline_flight_batch.data_body.len()
                 > optimized_small_flight_batch.data_body.len()
         );
+    }
+
+    #[test]
+    fn test_encode_no_column_batch() {
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(10)),
+        )
+        .expect("cannot create record batch");
+
+        prepare_batch_for_flight(&batch, batch.schema().clone())
+            .expect("failed to optimize");
     }
 
     pub fn make_flight_data(

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -511,8 +511,7 @@ mod tests {
         )
         .expect("cannot create record batch");
 
-        prepare_batch_for_flight(&batch, batch.schema())
-            .expect("failed to optimize");
+        prepare_batch_for_flight(&batch, batch.schema()).expect("failed to optimize");
     }
 
     pub fn make_flight_data(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

When encoding a `RecordBatch` with no columns, the `FlightDataEncoder` will return an error:
```
Arrow(InvalidArgumentError("must either specify a row count or at least one column"))
```

This PR fixes this problem.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use `RecordBatch::try_new_with_options` to allow constructing a batch with no columns.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

No
