### PR TITLE
Enable to write NaN and Infinity of float as json string

### DIFF
--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -71,18 +71,45 @@ impl JsonSerializable for i128 {
 
 impl JsonSerializable for f16 {
     fn into_json_value(self) -> Option<Value> {
+        if self.is_nan() {
+            return Some(Value::String("NaN".to_owned()));
+        } else if self.is_infinite() {
+            if self.is_sign_positive() {
+                return Some(Value::String("Infinity".to_owned()));
+            } else {
+                return Some(Value::String("-Infinity".to_owned()));
+            }
+        }
         Number::from_f64(f64::round(f64::from(self) * 1000.0) / 1000.0).map(Value::Number)
     }
 }
 
 impl JsonSerializable for f32 {
     fn into_json_value(self) -> Option<Value> {
+        if self.is_nan() {
+            return Some(Value::String("NaN".to_owned()));
+        } else if self.is_infinite() {
+            if self.is_sign_positive() {
+                return Some(Value::String("Infinity".to_owned()));
+            } else {
+                return Some(Value::String("-Infinity".to_owned()));
+            }
+        }
         Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0).map(Value::Number)
     }
 }
 
 impl JsonSerializable for f64 {
     fn into_json_value(self) -> Option<Value> {
+        if self.is_nan() {
+            return Some(Value::String("NaN".to_owned()));
+        } else if self.is_infinite() {
+            if self.is_sign_positive() {
+                return Some(Value::String("Infinity".to_owned()));
+            } else {
+                return Some(Value::String("-Infinity".to_owned()));
+            }
+        }
         Number::from_f64(self).map(Value::Number)
     }
 }
@@ -116,6 +143,35 @@ mod tests {
             Some(VNumber(Number::from_f64(0.01f64).unwrap())),
             0.01f64.into_json_value()
         );
-        assert_eq!(None, f32::NAN.into_json_value());
+
+        assert_eq!(Some(VString("NaN".to_string())), f16::NAN.into_json_value());
+        assert_eq!(Some(VString("NaN".to_string())), f32::NAN.into_json_value());
+        assert_eq!(Some(VString("NaN".to_string())), f64::NAN.into_json_value());
+
+        assert_eq!(
+            Some(VString("Infinity".to_string())),
+            f16::INFINITY.into_json_value()
+        );
+        assert_eq!(
+            Some(VString("Infinity".to_string())),
+            f32::INFINITY.into_json_value()
+        );
+        assert_eq!(
+            Some(VString("Infinity".to_string())),
+            f64::INFINITY.into_json_value()
+        );
+
+        assert_eq!(
+            Some(VString("-Infinity".to_string())),
+            f16::NEG_INFINITY.into_json_value()
+        );
+        assert_eq!(
+            Some(VString("-Infinity".to_string())),
+            f32::NEG_INFINITY.into_json_value()
+        );
+        assert_eq!(
+            Some(VString("-Infinity".to_string())),
+            f64::NEG_INFINITY.into_json_value()
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change
 Now if the `RecordBatch` has float64array including f64 constants like `NaN`, `Infinity`, `-Infinity`, the json output is `{}`.
This PR enables `writer.write_batches()` to output them as string.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
