### PR TITLE
replace for loop by try_for_each

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -869,20 +869,20 @@ fn parse_decimal_with_parameter<T: DecimalType>(
         bytes[0..offset]
             .iter()
             .rev()
-            .try_for_each::<_, Result<(), ArrowError>>(|&byte| match byte {
-                b'-' => {
-                    negative = true;
-                    Ok(())
+            .try_for_each::<_, Result<(), ArrowError>>(|&byte| {
+                match byte {
+                    b'-' => {
+                        negative = true;
+                    }
+                    b'0'..=b'9' => {
+                        let add = T::Native::usize_as((byte - b'0') as usize)
+                            .mul_checked(base)?;
+                        result = result.add_checked(add)?;
+                        base = base.mul_checked(T::Native::usize_as(10))?;
+                    }
+                    _ => (),
                 }
-                b'0'..=b'9' => {
-                    let add =
-                        T::Native::usize_as((byte - b'0') as usize).mul_checked(base)?;
-                    result = result.add_checked(add)?;
-                    base = base.mul_checked(T::Native::usize_as(10))?;
-                    Ok(())
-                }
-                // because of the PARSE_DECIMAL_RE, bytes just contains digit、'-' and '.'.
-                _ => Ok(()),
+                Ok(())
             })?;
 
         if negative {

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -880,6 +880,7 @@ fn parse_decimal_with_parameter<T: DecimalType>(
                         result = result.add_checked(add)?;
                         base = base.mul_checked(T::Native::usize_as(10))?;
                     }
+                    // because of the PARSE_DECIMAL_RE, bytes just contains digit、'-' and '.'.
                     _ => (),
                 }
                 Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 In the previously submitted merge request, to return `Error` in the closure of the `for_each`, change the code from iter to for loop:
```rust
    for byte in bytes[0..offset].iter().rev() {
            match byte {
                b'-' => {
                    negative = true;
                }
                b'0'..=b'9' => {
                    let add =
                        T::Native::usize_as((byte - b'0') as usize).mul_checked(base)?;
                    result = result.add_checked(add)?;
                    base = base.mul_checked(T::Native::usize_as(10))?;
                }
                // because of the PARSE_DECIMAL_RE, bytes just contains digit、'-' and '.'.
                _ => {}
            }
        }
```
I later found out that it was possible to return error using `try_for_each`, like this:
```rust
   bytes[0..offset]
            .iter()
            .rev()
            .try_for_each::<_, Result<(), ArrowError>>(|&byte| match byte {
                b'-' => {
                    negative = true;
                    Ok(())
                }
                b'0'..=b'9' => {
                    let add =
                        T::Native::usize_as((byte - b'0') as usize).mul_checked(base)?;
                    result = result.add_checked(add)?;
                    base = base.mul_checked(T::Native::usize_as(10))?;
                    Ok(())
                }
                // because of the PARSE_DECIMAL_RE, bytes just contains digit、'-' and '.'.
                _ => Ok(()),
            })?;
```
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
replace for loop by try_for_each

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
