### PR TITLE
Support String Coercion in Raw JSON Reader

### DIFF
--- a/arrow-json/src/raw/list_array.rs
+++ b/arrow-json/src/raw/list_array.rs
@@ -31,13 +31,21 @@ pub struct ListArrayDecoder<O> {
 }
 
 impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
-    pub fn new(data_type: DataType, is_nullable: bool) -> Result<Self, ArrowError> {
+    pub fn new(
+        data_type: DataType,
+        coerce_primitive: bool,
+        is_nullable: bool,
+    ) -> Result<Self, ArrowError> {
         let field = match &data_type {
             DataType::List(f) if !O::IS_LARGE => f,
             DataType::LargeList(f) if O::IS_LARGE => f,
             _ => unreachable!(),
         };
-        let decoder = make_decoder(field.data_type().clone(), field.is_nullable())?;
+        let decoder = make_decoder(
+            field.data_type().clone(),
+            coerce_primitive,
+            field.is_nullable(),
+        )?;
 
         Ok(Self {
             data_type,

--- a/arrow-json/src/raw/map_array.rs
+++ b/arrow-json/src/raw/map_array.rs
@@ -30,7 +30,11 @@ pub struct MapArrayDecoder {
 }
 
 impl MapArrayDecoder {
-    pub fn new(data_type: DataType, is_nullable: bool) -> Result<Self, ArrowError> {
+    pub fn new(
+        data_type: DataType,
+        coerce_primitive: bool,
+        is_nullable: bool,
+    ) -> Result<Self, ArrowError> {
         let fields = match &data_type {
             DataType::Map(_, true) => {
                 return Err(ArrowError::NotYetImplemented(
@@ -48,9 +52,16 @@ impl MapArrayDecoder {
             _ => unreachable!(),
         };
 
-        let keys = make_decoder(fields[0].data_type().clone(), fields[0].is_nullable())?;
-        let values =
-            make_decoder(fields[1].data_type().clone(), fields[1].is_nullable())?;
+        let keys = make_decoder(
+            fields[0].data_type().clone(),
+            coerce_primitive,
+            fields[0].is_nullable(),
+        )?;
+        let values = make_decoder(
+            fields[1].data_type().clone(),
+            coerce_primitive,
+            fields[1].is_nullable(),
+        )?;
 
         Ok(Self {
             data_type,

--- a/arrow-json/src/raw/mod.rs
+++ b/arrow-json/src/raw/mod.rs
@@ -43,6 +43,7 @@ mod tape;
 /// A builder for [`RawReader`] and [`RawDecoder`]
 pub struct RawReaderBuilder {
     batch_size: usize,
+    coerce_primitive: bool,
 
     schema: SchemaRef,
 }
@@ -58,6 +59,7 @@ impl RawReaderBuilder {
     pub fn new(schema: SchemaRef) -> Self {
         Self {
             batch_size: 1024,
+            coerce_primitive: false,
             schema,
         }
     }
@@ -65,6 +67,14 @@ impl RawReaderBuilder {
     /// Sets the batch size in rows to read
     pub fn with_batch_size(self, batch_size: usize) -> Self {
         Self { batch_size, ..self }
+    }
+
+    /// Sets if the decoder should coerce primitive values (bool and number) into string when the Schema's column is Utf8 or LargeUtf8.
+    pub fn coerce_primitive(self, coerce_primitive: bool) -> Self {
+        Self {
+            coerce_primitive,
+            ..self
+        }
     }
 
     /// Create a [`RawReader`] with the provided [`BufRead`]
@@ -82,7 +92,11 @@ impl RawReaderBuilder {
 
         Ok(RawDecoder {
             decoder,
-            tape_decoder: TapeDecoder::new(self.batch_size, num_fields),
+            tape_decoder: TapeDecoder::new(
+                self.batch_size,
+                self.coerce_primitive,
+                num_fields,
+            ),
             batch_size: self.batch_size,
             schema: self.schema,
         })
@@ -311,13 +325,19 @@ mod tests {
     use std::io::{BufReader, Cursor, Seek};
     use std::sync::Arc;
 
-    fn do_read(buf: &str, batch_size: usize, schema: SchemaRef) -> Vec<RecordBatch> {
+    fn do_read(
+        buf: &str,
+        batch_size: usize,
+        coerce_primitive: bool,
+        schema: SchemaRef,
+    ) -> Vec<RecordBatch> {
         let mut unbuffered = vec![];
 
         // Test with different batch sizes to test for boundary conditions
         for batch_size in [1, 3, 100, batch_size] {
             unbuffered = RawReaderBuilder::new(schema.clone())
                 .with_batch_size(batch_size)
+                .coerce_primitive(coerce_primitive)
                 .build(Cursor::new(buf.as_bytes()))
                 .unwrap()
                 .collect::<Result<Vec<_>, _>>()
@@ -331,6 +351,7 @@ mod tests {
             for b in [1, 3, 5] {
                 let buffered = RawReaderBuilder::new(schema.clone())
                     .with_batch_size(batch_size)
+                    .coerce_primitive(coerce_primitive)
                     .build(BufReader::with_capacity(b, Cursor::new(buf.as_bytes())))
                     .unwrap()
                     .collect::<Result<Vec<_>, _>>()
@@ -360,7 +381,7 @@ mod tests {
             Field::new("c", DataType::Boolean, true),
         ]));
 
-        let batches = do_read(buf, 1024, schema);
+        let batches = do_read(buf, 1024, false, schema);
         assert_eq!(batches.len(), 1);
 
         let col1 = as_primitive_array::<Int64Type>(batches[0].column(0));
@@ -397,7 +418,7 @@ mod tests {
             Field::new("b", DataType::LargeUtf8, true),
         ]));
 
-        let batches = do_read(buf, 1024, schema);
+        let batches = do_read(buf, 1024, false, schema);
         assert_eq!(batches.len(), 1);
 
         let col1 = as_string_array(batches[0].column(0));
@@ -454,7 +475,7 @@ mod tests {
             ),
         ]));
 
-        let batches = do_read(buf, 1024, schema);
+        let batches = do_read(buf, 1024, false, schema);
         assert_eq!(batches.len(), 1);
 
         let list = as_list_array(batches[0].column(0).as_ref());
@@ -517,7 +538,7 @@ mod tests {
             ),
         ]));
 
-        let batches = do_read(buf, 1024, schema);
+        let batches = do_read(buf, 1024, false, schema);
         assert_eq!(batches.len(), 1);
 
         let nested = as_struct_array(batches[0].column(0).as_ref());
@@ -561,7 +582,7 @@ mod tests {
         let map = DataType::Map(Box::new(Field::new("entries", entries, true)), false);
         let schema = Arc::new(Schema::new(vec![Field::new("map", map, true)]));
 
-        let batches = do_read(buf, 1024, schema);
+        let batches = do_read(buf, 1024, false, schema);
         assert_eq!(batches.len(), 1);
 
         let map = as_map_array(batches[0].column(0).as_ref());
@@ -611,5 +632,85 @@ mod tests {
 
             assert_eq!(a_result, b_result);
         }
+    }
+
+    #[test]
+    fn test_not_coercing_primitive_into_string_without_flag() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
+
+        let buf = r#"{"a": 1}"#;
+        let result = RawReaderBuilder::new(schema.clone())
+            .with_batch_size(1024)
+            .build(Cursor::new(buf.as_bytes()))
+            .unwrap()
+            .read();
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Json error: expected string got number".to_string()
+        );
+
+        let buf = r#"{"a": true}"#;
+        let result = RawReaderBuilder::new(schema)
+            .with_batch_size(1024)
+            .build(Cursor::new(buf.as_bytes()))
+            .unwrap()
+            .read();
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Json error: expected string got true".to_string()
+        );
+    }
+
+    #[test]
+    fn test_coercing_primitive_into_string() {
+        let buf = r#"
+        {"a": 1, "b": 2, "c": true}
+        {"a": 2E0, "b": 4, "c": false}
+
+        {"b": 6, "a": 2.0}
+        {"b": "5", "a": 2}
+        {"b": 4e0}
+        {"b": 7, "a": null}
+        "#;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::Utf8, true),
+        ]));
+
+        let batches = do_read(buf, 1024, true, schema);
+        assert_eq!(batches.len(), 1);
+
+        let col1 = as_string_array(batches[0].column(0));
+        assert_eq!(col1.null_count(), 2);
+        assert_eq!(col1.value(0), "1");
+        assert_eq!(col1.value(1), "2E0");
+        assert_eq!(col1.value(2), "2.0");
+        assert_eq!(col1.value(3), "2");
+        assert!(col1.is_null(4));
+        assert!(col1.is_null(5));
+
+        let col2 = as_string_array(batches[0].column(1));
+        assert_eq!(col2.null_count(), 0);
+        assert_eq!(col2.value(0), "2");
+        assert_eq!(col2.value(1), "4");
+        assert_eq!(col2.value(2), "6");
+        assert_eq!(col2.value(3), "5");
+        assert_eq!(col2.value(4), "4e0");
+        assert_eq!(col2.value(5), "7");
+
+        let col3 = as_string_array(batches[0].column(2));
+        assert_eq!(col3.null_count(), 4);
+        assert_eq!(col3.value(0), "true");
+        assert_eq!(col3.value(1), "false");
+        assert!(col3.is_null(2));
+        assert!(col3.is_null(3));
+        assert!(col3.is_null(4));
+        assert!(col3.is_null(5));
     }
 }

--- a/arrow-json/src/raw/string_array.rs
+++ b/arrow-json/src/raw/string_array.rs
@@ -27,14 +27,23 @@ use crate::raw::{tape_error, ArrayDecoder};
 const TRUE: &str = "true";
 const FALSE: &str = "false";
 
-#[derive(Default)]
 pub struct StringArrayDecoder<O: OffsetSizeTrait> {
+    coerce_primitive: bool,
     phantom: PhantomData<O>,
+}
+
+impl<O: OffsetSizeTrait> StringArrayDecoder<O> {
+    pub fn new(coerce_primitive: bool) -> Self {
+        Self {
+            coerce_primitive,
+            phantom: Default::default(),
+        }
+    }
 }
 
 impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayData, ArrowError> {
-        let coerce_primitive = tape.coerce_primitive();
+        let coerce_primitive = self.coerce_primitive;
 
         let mut data_capacity = 0;
         for p in pos {

--- a/arrow-json/src/raw/struct_array.rs
+++ b/arrow-json/src/raw/struct_array.rs
@@ -28,10 +28,16 @@ pub struct StructArrayDecoder {
 }
 
 impl StructArrayDecoder {
-    pub fn new(data_type: DataType, is_nullable: bool) -> Result<Self, ArrowError> {
+    pub fn new(
+        data_type: DataType,
+        coerce_primitive: bool,
+        is_nullable: bool,
+    ) -> Result<Self, ArrowError> {
         let decoders = struct_fields(&data_type)
             .iter()
-            .map(|f| make_decoder(f.data_type().clone(), f.is_nullable()))
+            .map(|f| {
+                make_decoder(f.data_type().clone(), coerce_primitive, f.is_nullable())
+            })
             .collect::<Result<Vec<_>, ArrowError>>()?;
 
         Ok(Self {

--- a/arrow-json/src/raw/tape.rs
+++ b/arrow-json/src/raw/tape.rs
@@ -91,7 +91,6 @@ pub struct Tape<'a> {
     elements: &'a [TapeElement],
     strings: &'a str,
     string_offsets: &'a [usize],
-    coerce_primitive: bool,
     num_rows: usize,
 }
 
@@ -109,12 +108,6 @@ impl<'a> Tape<'a> {
     /// Returns the tape element at `idx`
     pub fn get(&self, idx: u32) -> TapeElement {
         self.elements[idx as usize]
-    }
-
-    /// Returns whether it should coerce primitive values into string or not.
-    #[inline]
-    pub fn coerce_primitive(&self) -> bool {
-        self.coerce_primitive
     }
 
     /// Returns the index of the next field at the same level as `cur_idx`
@@ -230,9 +223,6 @@ pub struct TapeDecoder {
     /// Number of rows to read per batch
     batch_size: usize,
 
-    /// Whether it should coerce primitive values (bool and number) into string or not.
-    coerce_primitive: bool,
-
     /// A buffer of parsed string data
     ///
     /// Note: if part way through a record, i.e. `stack` is not empty,
@@ -249,7 +239,7 @@ pub struct TapeDecoder {
 impl TapeDecoder {
     /// Create a new [`TapeDecoder`] with the provided batch size
     /// and an estimated number of fields in each row
-    pub fn new(batch_size: usize, coerce_primitive: bool, num_fields: usize) -> Self {
+    pub fn new(batch_size: usize, num_fields: usize) -> Self {
         let tokens_per_row = 2 + num_fields * 2;
         let mut offsets = Vec::with_capacity(batch_size * (num_fields * 2) + 1);
         offsets.push(0);
@@ -261,7 +251,6 @@ impl TapeDecoder {
             offsets,
             elements,
             batch_size,
-            coerce_primitive,
             num_rows: 0,
             bytes: Vec::with_capacity(num_fields * 2 * 8),
             stack: Vec::with_capacity(10),
@@ -502,7 +491,6 @@ impl TapeDecoder {
             strings,
             elements: &self.elements,
             string_offsets: &self.offsets,
-            coerce_primitive: self.coerce_primitive,
             num_rows: self.num_rows,
         })
     }
@@ -642,7 +630,7 @@ mod tests {
 
         {"a": ["", "foo", ["bar", "c"]], "b": {"1": []}, "c": {"2": [1, 2, 3]} }
         "#;
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(a.as_bytes()).unwrap();
 
         let finished = decoder.finish().unwrap();
@@ -745,21 +733,21 @@ mod tests {
     #[test]
     fn test_invalid() {
         // Test invalid
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         let err = decoder.decode(b"hello").unwrap_err().to_string();
         assert_eq!(
             err,
             "Json error: Encountered unexpected 'h' whilst trimming leading whitespace"
         );
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         let err = decoder.decode(b"{\"hello\": }").unwrap_err().to_string();
         assert_eq!(
             err,
             "Json error: Encountered unexpected '}' whilst parsing value"
         );
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         let err = decoder
             .decode(b"{\"hello\": [ false, tru ]}")
             .unwrap_err()
@@ -769,7 +757,7 @@ mod tests {
             "Json error: Encountered unexpected ' ' whilst parsing literal"
         );
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         let err = decoder
             .decode(b"{\"hello\": \"\\ud8\"}")
             .unwrap_err()
@@ -780,7 +768,7 @@ mod tests {
         );
 
         // Missing surrogate pair
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         let err = decoder
             .decode(b"{\"hello\": \"\\ud83d\"}")
             .unwrap_err()
@@ -791,38 +779,38 @@ mod tests {
         );
 
         // Test truncation
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"he").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading string");
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"hello\" : ").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading value");
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"hello\" : [").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading list");
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"hello\" : tru").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading true");
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"hello\" : nu").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading null");
 
         // Test invalid UTF-8
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"hello\" : \"world\xFF\"}").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Encountered non-UTF-8 data");
 
-        let mut decoder = TapeDecoder::new(16, false, 2);
+        let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"\xe2\" : \"\x96\xa1\"}").unwrap();
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Encountered truncated UTF-8 sequence");


### PR DESCRIPTION
# Which issue does this PR close?
None. This is a feature request.

# Rationale for this change
`infer_json_schema` coerces primitive values into string, and it couldn't work when reading the same json with the given schema.

```
        let schema = Schema::new(vec![
            Field::new("c1", DataType::Utf8, true),
            Field::new("c2", DataType::Utf8, true),
        ]);

        let inferred_schema = infer_json_schema_from_iterator(
            vec![
                Ok(serde_json::json!({"c1": 1, "c2": 1})),
                Ok(serde_json::json!({"c1": "a", "c2": 0})),
                Ok(serde_json::json!({"c1": true, "c2": "ok"})),
            ]
            .into_iter(),
        )
        .unwrap();

        assert_eq!(inferred_schema, schema);
```

# What changes are included in this PR?
Add flag to make `RawReader` behave the same as `infer_json_schema`.

# Are there any user-facing changes?
Yes, the user can opt-in a `coerce_primitive` flag.
