### PR TITLE
Make dictionary kernels optional for comparison benchmark

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -160,7 +160,7 @@ required-features = ["test_utils"]
 [[bench]]
 name = "comparison_kernels"
 harness = false
-required-features = ["test_utils", "dyn_cmp_dict"]
+required-features = ["test_utils"]
 
 [[bench]]
 name = "filter_kernels"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The dictionary kernels are very slow to compile, and requiring them for the comparison_kernel benchmarks therefore makes for very slow iteration cycles. This PR reworks them to instead be optional.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
