### PR TITLE
[minor] In ipc reader init hashMap with capacity

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -865,7 +865,7 @@ impl<R: Read + Seek> FileReader<R> {
         let schema = crate::convert::fb_to_schema(ipc_schema);
 
         // Create an array of optional dictionary value arrays, one per field.
-        let mut dictionaries_by_id = HashMap::new();
+        let mut dictionaries_by_id = HashMap::with_capacity(schema.fields().len());
         if let Some(dictionaries) = footer.dictionaries() {
             for block in dictionaries {
                 // read length from end of offset
@@ -1112,7 +1112,7 @@ impl<R: Read> StreamReader<R> {
         let schema = crate::convert::fb_to_schema(ipc_schema);
 
         // Create an array of optional dictionary value arrays, one per field.
-        let dictionaries_by_id = HashMap::new();
+        let dictionaries_by_id = HashMap::with_capacity(schema.fields().len());
 
         let projection = match projection {
             Some(projection_indices) => {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
use `new`: The hash map is initially created with a capacity of 0, so it will not allocate until it.
use `with_capacity` avoid reallocating
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
