### PR TITLE
Update MIRI for split crates (#2594)

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -14,4 +14,7 @@ cargo miri setup
 cargo clean
 
 echo "Starting Arrow MIRI run..."
-cargo miri test -p arrow -- --skip csv --skip ipc --skip json
+cargo miri test -p arrow-buffer
+cargo miri test -p arrow-data --features ffi
+cargo miri test -p arrow-schema --features ffi
+cargo miri test -p arrow-array

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -542,6 +542,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_true_false_count() {
         let mut rng = thread_rng();
 

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -881,6 +881,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_get_physical_indices() {
         // Test for logical lengths starting from 10 to 250 increasing by 10
         for logical_len in (0..250).step_by(10) {
@@ -917,6 +918,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_get_physical_indices_sliced() {
         let total_len = 80;
         let input_array = build_input_array(total_len);

--- a/arrow-array/src/run_iterator.rs
+++ b/arrow-array/src/run_iterator.rs
@@ -349,6 +349,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_sliced_run_array_iterator() {
         let total_len = 80;
         let input_array = build_input_array(total_len);

--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -549,7 +549,7 @@ impl ToPrimitive for i256 {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))] // llvm.x86.subborrow.64 not supported by MIRI
 mod tests {
     use super::*;
     use num::{BigInt, FromPrimitive, Signed, ToPrimitive};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2594

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Since splitting the crates, we were only running MIRI on what remained in the top-level crate (very little).

This PR updates the MIRI CI to run on just the low-level crates, where UB is most likely to manifest. We could cover all the crates, but figured I'd just get the baseline coverage back, whilst still keeping CI times down.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
