### PR TITLE
update object_store deps to patch potential security vulnerabilities

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -37,7 +37,7 @@ itertools = "0.10.1"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = "0.7"
-tokio = { version = "1.18", features = ["sync", "macros", "rt", "time", "io-util"] }
+tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"
@@ -72,4 +72,4 @@ dotenv = "0.15.0"
 tempfile = "3.1.0"
 futures-test = "0.3"
 rand = "0.8"
-hyper = { version = "0.14", features = ["server"] }
+hyper = { version = "0.14.24", features = ["server"] }


### PR DESCRIPTION
# Rationale for this change
 
As per issue #3760 there are potential security vulnerabilities with object_store https://deps.rs/crate/object_store/0.5.4. Upgrading tokio and hyper to the latest versions shouldn't introduce any breaking changes and should patch these security vulnerabilities.