### PR TITLE
object-store: fix handling of AWS profile credentials without expiry

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -1249,7 +1249,7 @@ mod tests {
             "ﬀkoß",
             "😃sadlksFFkoSSsh😃klF", // Original was case insensitive "😃sadlksffkosSsh😃klF"
             "😱slgFFkoSSsh😃klF",    // Original was case insensitive "😱slgffkosSsh😃klF"
-            "FFkoSS",                // "FFKoSS"
+            "FFkoSS",                    // "FFKoSS"
         ],
         "FFkoSS",
         contains_utf8_scalar,

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -1249,7 +1249,7 @@ mod tests {
             "ﬀkoß",
             "😃sadlksFFkoSSsh😃klF", // Original was case insensitive "😃sadlksffkosSsh😃klF"
             "😱slgFFkoSSsh😃klF",    // Original was case insensitive "😱slgffkosSsh😃klF"
-            "FFkoSS",                    // "FFKoSS"
+            "FFkoSS",                // "FFKoSS"
         ],
         "FFkoSS",
         contains_utf8_scalar,

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -554,10 +554,9 @@ mod profile {
                             source: Box::new(source),
                         })?;
                 let t_now = SystemTime::now();
-                let expiry = match c.expiry().and_then(|e| e.duration_since(t_now).ok()) {
-                    Some(ttl) => Some(Instant::now() + ttl),
-                    None => None
-                };
+                let expiry = c.expiry().
+                    and_then(|e| e.duration_since(t_now).ok()).
+                    map(|ttl| Instant::now() + ttl);
 
                 Ok(TemporaryToken {
                     token: Arc::new(AwsCredential {

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -520,7 +520,7 @@ mod profile {
     use aws_config::provider_config::ProviderConfig;
     use aws_credential_types::provider::ProvideCredentials;
     use aws_types::region::Region;
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime};
 
     #[derive(Debug)]
     pub struct ProfileProvider {
@@ -553,18 +553,7 @@ mod profile {
                             store: "S3",
                             source: Box::new(source),
                         })?;
-
-                let t_now = SystemTime::now();
-                let expiry = match c.expiry().and_then(|e| e.duration_since(t_now).ok()) {
-                    Some(ttl) => Instant::now() + ttl,
-                    None => {
-                        return Err(crate::Error::Generic {
-                            store: "S3",
-                            source: "Invalid expiry".into(),
-                        })
-                    }
-                };
-
+                let expiry = Instant::now() + Duration::from_secs(3600);
                 Ok(TemporaryToken {
                     token: Arc::new(AwsCredential {
                         key_id: c.access_key_id().to_string(),

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -520,7 +520,7 @@ mod profile {
     use aws_config::provider_config::ProviderConfig;
     use aws_credential_types::provider::ProvideCredentials;
     use aws_types::region::Region;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     #[derive(Debug)]
     pub struct ProfileProvider {

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -554,9 +554,10 @@ mod profile {
                             source: Box::new(source),
                         })?;
                 let t_now = SystemTime::now();
-                let expiry = c.expiry().
-                    and_then(|e| e.duration_since(t_now).ok()).
-                    map(|ttl| Instant::now() + ttl);
+                let expiry = c
+                    .expiry()
+                    .and_then(|e| e.duration_since(t_now).ok())
+                    .map(|ttl| Instant::now() + ttl);
 
                 Ok(TemporaryToken {
                     token: Arc::new(AwsCredential {

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -360,7 +360,7 @@ impl TokenCredential for ClientSecretOAuthProvider {
 
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
 
         Ok(token)
@@ -467,7 +467,7 @@ impl TokenCredential for ImdsManagedIdentityOAuthProvider {
 
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
 
         Ok(token)
@@ -541,7 +541,7 @@ impl TokenCredential for WorkloadIdentityOAuthProvider {
 
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
 
         Ok(token)
@@ -640,10 +640,10 @@ impl TokenCredential for AzureCliCredential {
                     - chrono::Local::now().naive_local();
                 Ok(TemporaryToken {
                     token: token_response.access_token,
-                    expiry: Instant::now()
+                    expiry: Some(Instant::now()
                         + duration.to_std().map_err(|_| Error::AzureCli {
                             message: "az returned invalid lifetime".to_string(),
-                        })?,
+                        })?),
                 })
             }
             Ok(az_output) => {

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -640,10 +640,12 @@ impl TokenCredential for AzureCliCredential {
                     - chrono::Local::now().naive_local();
                 Ok(TemporaryToken {
                     token: token_response.access_token,
-                    expiry: Some(Instant::now()
-                        + duration.to_std().map_err(|_| Error::AzureCli {
-                            message: "az returned invalid lifetime".to_string(),
-                        })?),
+                    expiry: Some(
+                        Instant::now()
+                            + duration.to_std().map_err(|_| Error::AzureCli {
+                                message: "az returned invalid lifetime".to_string(),
+                            })?,
+                    ),
                 })
             }
             Ok(az_output) => {

--- a/object_store/src/client/token.rs
+++ b/object_store/src/client/token.rs
@@ -55,9 +55,15 @@ impl<T: Clone + Send> TokenCache<T> {
 
         if let Some(cached) = locked.as_ref() {
             match cached.expiry {
-                Some(ttl) if ttl.checked_duration_since(now).unwrap_or_default().as_secs() > 300 => {
+                Some(ttl)
+                    if ttl
+                        .checked_duration_since(now)
+                        .unwrap_or_default()
+                        .as_secs()
+                        > 300 =>
+                {
                     return Ok(cached.token.clone());
-                },
+                }
                 None => return Ok(cached.token.clone()),
                 _ => (),
             }

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -220,7 +220,7 @@ impl TokenProvider for OAuthProvider {
 
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
 
         Ok(token)
@@ -393,7 +393,7 @@ impl TokenProvider for InstanceCredentialProvider {
                 .await?;
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
         Ok(token)
     }
@@ -467,7 +467,7 @@ impl TokenProvider for ApplicationDefaultCredentials {
             .context(TokenResponseBodySnafu)?;
         let token = TemporaryToken {
             token: response.access_token,
-            expiry: Instant::now() + Duration::from_secs(response.expires_in),
+            expiry: Some(Instant::now() + Duration::from_secs(response.expires_in)),
         };
         Ok(token)
     }


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/arrow-rs/issues/3765. ( `c.expiry()` will always return `None` )
 
# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Modify `TemporaryToken` to support `None` for expiry, allowing for infinite expiry.

Aligning with [expires_after](https://github.com/awslabs/smithy-rs/blob/76ee00eb1737964ce240ae817f573980920f0607/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs#L36) field from aws SDK 



