### PR TITLE
refactor: assorted `FlightSqlServiceClient` improvements

### DIFF
--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -61,9 +61,6 @@ jobs:
           cargo test -p arrow-flight --all-features
       - name: Test --examples
         run: |
-          cargo test -p arrow-flight  --features=flight-sql-experimental --examples
-      - name: Test --examples with TLS
-        run: |
           cargo test -p arrow-flight  --features=flight-sql-experimental,tls --examples
       - name: Verify workspace clean
         run: git diff --exit-code

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -64,4 +64,4 @@ tonic-build = { version = "=0.8.4", default-features = false, features = ["trans
 
 [[example]]
 name = "flight_sql_server"
-required-features = ["flight-sql-experimental"]
+required-features = ["flight-sql-experimental", "tls"]

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -580,12 +580,14 @@ mod tests {
             let key = std::fs::read_to_string("examples/data/client1.key").unwrap();
             let server_ca = std::fs::read_to_string("examples/data/ca.pem").unwrap();
 
-            let mut client = FlightSqlServiceClient::new_with_endpoint(
-                Identity::from_pem(cert, key),
-                Certificate::from_pem(&server_ca),
-                "localhost",
+            let tls_config = ClientTlsConfig::new()
+                .domain_name("localhost")
+                .ca_certificate(Certificate::from_pem(&server_ca))
+                .identity(Identity::from_pem(cert, key));
+            let mut client = FlightSqlServiceClient::new_with_tls_endpoint(
                 "127.0.0.1",
                 50051,
+                tls_config,
             )
             .await
             .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Assorted `FlightSqlServiceClient` improvements:

- **TLS config:** Do NOT alter existing method signatures if the TLS feature is enabled. Features should be purely additive in Rust. Instead use a new method to pass TLS configs. The config is now passed as `ClientTlsConfig` to allow more flexibility, e.g. just to use TLS w/o any client certs.
- **token handlng:** Allow the token to be passed in from an external source. The [auth spec] is super flexibility ("application-defined") and we cannot derive a way to determine the token in all cases. The current handshake-based mechanism is OK though. Also make sure the token is used in all relevant methods.
- **headers:** Allow users to pass in additional headers. This is helpful for certain applications.

[auth spec]: https://arrow.apache.org/docs/format/Flight.html#authentication

# What changes are included in this PR?
See list above.

# Are there any user-facing changes?
**Breaking** slight changes in the `FlightSqlServiceClient` interface.
