### PR TITLE
object_store: (GCP) Add support for Workload Identity Federation from AWS

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run clippy with aws_profile feature
         run: cargo clippy -p object_store --features aws_profile -- -D warnings
       - name: Run clippy with gcp feature
-        run: cargo clippy -p object_store --features gcp -- -D warnings
+        run: cargo clippy -p object_store --features gcp,aws -- -D warnings
       - name: Run clippy with azure feature
         run: cargo clippy -p object_store --features azure -- -D warnings
       - name: Run clippy with all features

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"
+urlencoding = {version ="2.1", optional = true }
 
 # Cloud storage support
 base64 = { version = "0.21", default-features = false, features = ["std"], optional = true }
@@ -60,7 +61,7 @@ aws-config = { version = "0.54", optional = true }
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
-gcp = ["cloud", "rustls-pemfile"]
+gcp = ["cloud", "rustls-pemfile", "urlencoding"]
 aws = ["cloud"]
 http = ["cloud"]
 

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -68,12 +68,12 @@ impl AwsCredential {
     }
 }
 
-struct RequestSigner<'a> {
-    date: DateTime<Utc>,
-    credential: &'a AwsCredential,
-    service: &'a str,
-    region: &'a str,
-    sign_payload: bool,
+pub(crate) struct RequestSigner<'a> {
+    pub(crate) date: DateTime<Utc>,
+    pub(crate) credential: &'a AwsCredential,
+    pub(crate) service: &'a str,
+    pub(crate) region: &'a str,
+    pub(crate) sign_payload: bool,
 }
 
 const DATE_HEADER: &str = "x-amz-date";
@@ -84,7 +84,7 @@ const AUTH_HEADER: &str = "authorization";
 const ALL_HEADERS: &[&str; 4] = &[DATE_HEADER, HASH_HEADER, TOKEN_HEADER, AUTH_HEADER];
 
 impl<'a> RequestSigner<'a> {
-    fn sign(&self, request: &mut Request) {
+    pub(crate) fn sign(&self, request: &mut Request, include_payload_hash: bool) {
         if let Some(ref token) = self.credential.token {
             let token_val = HeaderValue::from_str(token).unwrap();
             request.headers_mut().insert(TOKEN_HEADER, token_val);
@@ -105,12 +105,15 @@ impl<'a> RequestSigner<'a> {
                 None => EMPTY_SHA256_HASH.to_string(),
                 Some(body) => hex_digest(body.as_bytes().unwrap()),
             }
+        } else if !include_payload_hash {
+            EMPTY_SHA256_HASH.to_string()
         } else {
             UNSIGNED_PAYLOAD_LITERAL.to_string()
         };
-
-        let header_digest = HeaderValue::from_str(&digest).unwrap();
-        request.headers_mut().insert(HASH_HEADER, header_digest);
+        if include_payload_hash {
+            let header_digest = HeaderValue::from_str(&digest).unwrap();
+            request.headers_mut().insert(HASH_HEADER, header_digest);
+        }
 
         let (signed_headers, canonical_headers) = canonicalize_headers(request.headers());
         let canonical_query = canonicalize_query(request.url());
@@ -193,7 +196,7 @@ impl CredentialExt for RequestBuilder {
             sign_payload,
         };
 
-        signer.sign(&mut request);
+        signer.sign(&mut request, true);
 
         for header in ALL_HEADERS {
             if let Some(val) = request.headers_mut().remove(*header) {
@@ -627,7 +630,7 @@ mod tests {
             sign_payload: true,
         };
 
-        signer.sign(&mut request);
+        signer.sign(&mut request, true);
         assert_eq!(request.headers().get(AUTH_HEADER).unwrap(), "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20220806/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=a3c787a7ed37f7fdfbfd2d7056a3d7c9d85e6d52a2bfbec73793c0be6e7862d4")
     }
 
@@ -665,7 +668,7 @@ mod tests {
             sign_payload: false,
         };
 
-        signer.sign(&mut request);
+        signer.sign(&mut request, true);
         assert_eq!(request.headers().get(AUTH_HEADER).unwrap(), "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20220806/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=653c3d8ea261fd826207df58bc2bb69fbb5003e9eb3c0ef06e4a51f2a81d8699")
     }
 
@@ -702,7 +705,7 @@ mod tests {
             sign_payload: true,
         };
 
-        signer.sign(&mut request);
+        signer.sign(&mut request, true);
         assert_eq!(request.headers().get(AUTH_HEADER).unwrap(), "AWS4-HMAC-SHA256 Credential=H20ABqCkLZID4rLe/20220809/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=9ebf2f92872066c99ac94e573b4e1b80f4dbb8a32b1e8e23178318746e7d1b4d")
     }
 

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -60,7 +60,7 @@ use crate::{
 };
 
 mod client;
-mod credential;
+pub(crate) mod credential;
 
 // http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 //


### PR DESCRIPTION
Signed-off-by: 🐼 Samrose Ahmed 🐼 <samroseahmed@gmail.com>

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3797.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Need to support GCP Workload Identity Federation to be able to access GCS from AWS.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add a TokenProvider for Workload Identity Federation for AWS
* Needed to add `urlencoding` crate dependency (optional, only for gcp)

### Notes

* I tested this locally, I have to take a look at y'alls testing setup, any tips on how this should be tested, it calls the GCP STS APIs to exchange credentials.

# Are there any user-facing changes?

No API change, but semantically, AWS Workload Identity Federation Application Default Credentials files are now supported, whereas previously an error would be thrown.


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
