### PR TITLE
fix: Ensure Flight schema includes parent metadata

### DIFF
--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -453,7 +453,6 @@ fn hydrate_dictionary(array: &ArrayRef) -> Result<ArrayRef> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use arrow::{
         array::{UInt32Array, UInt8Array},
         compute::concat_batches,
@@ -462,6 +461,7 @@ mod tests {
     use arrow_array::{
         DictionaryArray, Int16Array, Int32Array, Int64Array, StringArray, UInt64Array,
     };
+    use std::collections::HashMap;
 
     use super::*;
 
@@ -505,9 +505,10 @@ mod tests {
 
     #[test]
     fn test_schema_metadata_encoded() {
-        let schema = Schema::new(vec![
-            Field::new("data", DataType::Int32, false),
-        ]).with_metadata(HashMap::from([("some_key".to_owned(), "some_value".to_owned())]));
+        let schema =
+            Schema::new(vec![Field::new("data", DataType::Int32, false)]).with_metadata(
+                HashMap::from([("some_key".to_owned(), "some_value".to_owned())]),
+            );
 
         let got = prepare_schema_for_flight(&schema);
         assert!(got.metadata().contains_key("some_key"));

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -17,7 +17,7 @@
 
 //! Tests for round trip encoding / decoding
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow::{compute::concat_batches, datatypes::Int32Type};
 use arrow_array::{ArrayRef, DictionaryArray, Float64Array, RecordBatch, UInt8Array};
@@ -60,6 +60,18 @@ async fn test_error() {
 #[tokio::test]
 async fn test_primative_one() {
     roundtrip(vec![make_primative_batch(5)]).await;
+}
+
+#[tokio::test]
+async fn test_schema_metadata() {
+    let batch = make_primative_batch(5);
+    let metadata = HashMap::from([("some_key".to_owned(), "some_value".to_owned())]);
+
+    // create a batch that has schema level metadata
+    let schema = Arc::new(batch.schema().as_ref().clone().with_metadata(metadata));
+    let batch = RecordBatch::try_new(schema, batch.columns().to_vec()).unwrap();
+
+    roundtrip(vec![batch]).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3779

# Rationale for this change
 
Ensures that schema-level metadata is included when encoding the schema for a Flight response.

# What changes are included in this PR?

The `prepare_schema_for_flight` function in the `encode` module of the `arrow-flight` crate was amended to include the schema from the parent.

# Are there any user-facing changes?

No