### PR TITLE
Restrict DictionaryArray to ArrowDictionaryKeyType

### DIFF
--- a/arrow-arith/src/arithmetic.rs
+++ b/arrow-arith/src/arithmetic.rs
@@ -525,7 +525,7 @@ fn math_op_dict<K, T, F>(
     op: F,
 ) -> Result<PrimitiveArray<T>, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowNumericType,
     F: Fn(T::Native, T::Native) -> T::Native,
 {
@@ -580,7 +580,7 @@ fn math_checked_op_dict<K, T, F>(
     op: F,
 ) -> Result<PrimitiveArray<T>, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowNumericType,
     F: Fn(T::Native, T::Native) -> Result<T::Native, ArrowError>,
 {
@@ -613,7 +613,7 @@ fn math_divide_checked_op_dict<K, T, F>(
     op: F,
 ) -> Result<PrimitiveArray<T>, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowNumericType,
     F: Fn(T::Native, T::Native) -> Result<T::Native, ArrowError>,
 {
@@ -666,7 +666,7 @@ fn math_divide_safe_op_dict<K, T, F>(
     op: F,
 ) -> Result<ArrayRef, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowNumericType,
     F: Fn(T::Native, T::Native) -> Option<T::Native>,
 {

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -19,6 +19,7 @@
 
 use arrow_array::builder::BufferBuilder;
 use arrow_array::iterator::ArrayIter;
+use arrow_array::types::ArrowDictionaryKeyType;
 use arrow_array::*;
 use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
 use arrow_buffer::{Buffer, MutableBuffer};
@@ -96,7 +97,7 @@ where
 /// A helper function that applies an infallible unary function to a dictionary array with primitive value type.
 fn unary_dict<K, F, T>(array: &DictionaryArray<K>, op: F) -> Result<ArrayRef, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowPrimitiveType,
     F: Fn(T::Native) -> T::Native,
 {
@@ -111,7 +112,7 @@ fn try_unary_dict<K, F, T>(
     op: F,
 ) -> Result<ArrayRef, ArrowError>
 where
-    K: ArrowNumericType,
+    K: ArrowDictionaryKeyType + ArrowNumericType,
     T: ArrowPrimitiveType,
     F: Fn(T::Native) -> Result<T::Native, ArrowError>,
 {

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -424,7 +424,7 @@ impl<T: ArrowPrimitiveType> PartialEq for PrimitiveArray<T> {
     }
 }
 
-impl<K: ArrowPrimitiveType> PartialEq for DictionaryArray<K> {
+impl<K: ArrowDictionaryKeyType> PartialEq for DictionaryArray<K> {
     fn eq(&self, other: &Self) -> bool {
         self.data().eq(other.data())
     }

--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::builder::{ArrayBuilder, PrimitiveBuilder};
+use crate::types::ArrowDictionaryKeyType;
 use crate::{Array, ArrayRef, ArrowPrimitiveType, DictionaryArray};
 use arrow_buffer::{ArrowNativeType, ToByteSlice};
 use arrow_schema::{ArrowError, DataType};
@@ -172,7 +173,7 @@ where
 
 impl<K, V> ArrayBuilder for PrimitiveDictionaryBuilder<K, V>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     V: ArrowPrimitiveType,
 {
     /// Returns the builder as an non-mutable `Any` reference.
@@ -213,7 +214,7 @@ where
 
 impl<K, V> PrimitiveDictionaryBuilder<K, V>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     V: ArrowPrimitiveType,
 {
     /// Append a primitive value to the array. Return an existing index
@@ -312,7 +313,7 @@ where
     }
 }
 
-impl<K: ArrowPrimitiveType, P: ArrowPrimitiveType> Extend<Option<P::Native>>
+impl<K: ArrowDictionaryKeyType, P: ArrowPrimitiveType> Extend<Option<P::Native>>
     for PrimitiveDictionaryBuilder<K, P>
 {
     #[inline]

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -2035,7 +2035,7 @@ fn cmp_dict_primitive<K, T, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     T: ArrowPrimitiveType + Sync + Send,
     F: Fn(T::Native, T::Native) -> bool,
 {
@@ -2055,7 +2055,7 @@ fn cmp_dict_string_array<K, OffsetSize: OffsetSizeTrait, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(&str, &str) -> bool,
 {
     compare_op(
@@ -2078,7 +2078,7 @@ fn cmp_dict_boolean_array<K, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(bool, bool) -> bool,
 {
     compare_op(
@@ -2097,7 +2097,7 @@ fn cmp_dict_binary_array<K, OffsetSize: OffsetSizeTrait, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(&[u8], &[u8]) -> bool,
 {
     compare_op(
@@ -2121,7 +2121,7 @@ pub fn cmp_dict<K, T, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     T: ArrowPrimitiveType + Sync + Send,
     F: Fn(T::Native, T::Native) -> bool,
 {
@@ -2141,7 +2141,7 @@ pub fn cmp_dict_bool<K, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(bool, bool) -> bool,
 {
     compare_op(
@@ -2160,7 +2160,7 @@ pub fn cmp_dict_utf8<K, OffsetSize: OffsetSizeTrait, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(&str, &str) -> bool,
 {
     compare_op(
@@ -2182,7 +2182,7 @@ pub fn cmp_dict_binary<K, OffsetSize: OffsetSizeTrait, F>(
     op: F,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     F: Fn(&[u8], &[u8]) -> bool,
 {
     compare_op(

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -1253,7 +1253,7 @@ fn unpack_dict_comparison<K>(
     dict_comparison: BooleanArray,
 ) -> Result<BooleanArray, ArrowError>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
     K::Native: num::ToPrimitive,
 {
     // TODO: Use take_boolean (#2967)

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow_array::builder::BooleanBufferBuilder;
 use arrow_array::cast::{as_generic_binary_array, as_largestring_array, as_string_array};
-use arrow_array::types::ByteArrayType;
+use arrow_array::types::{ArrowDictionaryKeyType, ByteArrayType};
 use arrow_array::*;
 use arrow_buffer::bit_util;
 use arrow_buffer::{buffer::buffer_bin_and, Buffer, MutableBuffer};
@@ -671,7 +671,7 @@ fn filter_dict<T>(
     predicate: &FilterPredicate,
 ) -> DictionaryArray<T>
 where
-    T: ArrowPrimitiveType,
+    T: ArrowDictionaryKeyType,
     T::Native: num::Num,
 {
     let builder = filter_primitive::<T>(array.keys(), predicate)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -770,7 +770,7 @@ fn take_dict<T, I>(
     indices: &PrimitiveArray<I>,
 ) -> Result<DictionaryArray<T>, ArrowError>
 where
-    T: ArrowPrimitiveType,
+    T: ArrowDictionaryKeyType,
     T::Native: num::Num,
     I: ArrowPrimitiveType,
     I::Native: ToPrimitive,

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -201,7 +201,7 @@ macro_rules! dict_function {
 ///
 /// See the documentation on [`like_utf8`] for more details.
 #[cfg(feature = "dyn_cmp_dict")]
-fn $fn_name<K: ArrowPrimitiveType>(
+fn $fn_name<K: arrow_array::types::ArrowDictionaryKeyType>(
     left: &DictionaryArray<K>,
     right: &DictionaryArray<K>,
 ) -> Result<BooleanArray, ArrowError> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #1799 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

DictionaryArray should only be constructible for valid dictionary indexes, this is strictly enforced by the move to structured ArrayData, and so we need to enforce this strictly for the array type also.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A few call-sites, including the DictionaryArray definition weren't restricted to `ArrowDictionaryKeyType`, they now are

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
