### PR TITLE
Add ArrayDataLayout, port validation (#1799)

### DIFF
--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -140,7 +140,7 @@ impl BooleanBuffer {
         &self.buffer
     }
 
-    /// Returns the inner [`Buffer`]
+    /// Returns the inner [`Buffer`], consuming self
     pub fn into_inner(self) -> Buffer {
         self.buffer
     }

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -139,4 +139,9 @@ impl BooleanBuffer {
     pub fn inner(&self) -> &Buffer {
         &self.buffer
     }
+
+    /// Returns the inner [`Buffer`]
+    pub fn into_inner(self) -> Buffer {
+        self.buffer
+    }
 }

--- a/arrow-buffer/src/buffer/offset.rs
+++ b/arrow-buffer/src/buffer/offset.rs
@@ -39,6 +39,21 @@ impl<O: ArrowNativeType> OffsetBuffer<O> {
         let buffer = MutableBuffer::from_len_zeroed(std::mem::size_of::<O>());
         Self(buffer.into_buffer().into())
     }
+
+    /// Returns the inner [`ScalarBuffer`]
+    pub fn inner(&self) -> &ScalarBuffer<O> {
+        &self.0
+    }
+
+    /// Returns the inner [`Buffer`]
+    pub fn into_inner(self) -> ScalarBuffer<O> {
+        self.0
+    }
+
+    /// Returns a zero-copy slice of this buffer with length `len` and starting at `offset`
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        Self(self.0.slice(offset, len.saturating_add(1)))
+    }
 }
 
 impl<T: ArrowNativeType> Deref for OffsetBuffer<T> {

--- a/arrow-buffer/src/buffer/offset.rs
+++ b/arrow-buffer/src/buffer/offset.rs
@@ -45,7 +45,7 @@ impl<O: ArrowNativeType> OffsetBuffer<O> {
         &self.0
     }
 
-    /// Returns the inner [`ScalarBuffer`]
+    /// Returns the inner [`ScalarBuffer`], consuming self
     pub fn into_inner(self) -> ScalarBuffer<O> {
         self.0
     }

--- a/arrow-buffer/src/buffer/offset.rs
+++ b/arrow-buffer/src/buffer/offset.rs
@@ -45,7 +45,7 @@ impl<O: ArrowNativeType> OffsetBuffer<O> {
         &self.0
     }
 
-    /// Returns the inner [`Buffer`]
+    /// Returns the inner [`ScalarBuffer`]
     pub fn into_inner(self) -> ScalarBuffer<O> {
         self.0
     }

--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -203,7 +203,7 @@ where
         &self.run_ends
     }
 
-    /// Returns the inner [`ScalarBuffer`]
+    /// Returns the inner [`ScalarBuffer`], consuming self
     pub fn into_inner(self) -> ScalarBuffer<E> {
         self.run_ends
     }

--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -197,4 +197,14 @@ where
             len,
         }
     }
+
+    /// Returns the inner [`ScalarBuffer`]
+    pub fn inner(&self) -> &ScalarBuffer<E> {
+        &self.run_ends
+    }
+
+    /// Returns the inner [`ScalarBuffer`]
+    pub fn into_inner(self) -> ScalarBuffer<E> {
+        self.run_ends
+    }
 }

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -61,7 +61,7 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
         &self.buffer
     }
 
-    /// Returns the inner [`Buffer`]
+    /// Returns the inner [`Buffer`], consuming self
     pub fn into_inner(self) -> Buffer {
         self.buffer
     }

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -50,6 +50,21 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
         let byte_len = len.checked_mul(size).expect("length overflow");
         buffer.slice_with_length(byte_offset, byte_len).into()
     }
+
+    /// Returns a zero-copy slice of this buffer with length `len` and starting at `offset`
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        Self::new(self.buffer.clone(), offset, len)
+    }
+
+    /// Returns the inner [`Buffer`]
+    pub fn inner(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    /// Returns the inner [`Buffer`]
+    pub fn into_inner(self) -> Buffer {
+        self.buffer
+    }
 }
 
 impl<T: ArrowNativeType> Deref for ScalarBuffer<T> {

--- a/arrow-data/src/data/boolean.rs
+++ b/arrow-data/src/data/boolean.rs
@@ -35,7 +35,7 @@ impl BooleanArrayData {
     ///
     /// Panics if
     /// - `nulls` and `values` are different lengths
-    /// - `data_type` is not compatible with `T`
+    /// - `PhysicalType::from(&data_type) != PhysicalType::Boolean`
     pub fn new(
         data_type: DataType,
         values: BooleanBuffer,

--- a/arrow-data/src/data/boolean.rs
+++ b/arrow-data/src/data/boolean.rs
@@ -15,71 +15,82 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::data::types::PhysicalType;
 use crate::data::ArrayDataLayout;
-use crate::{ArrayData, ArrayDataBuilder, Buffers};
-use arrow_buffer::buffer::NullBuffer;
+use crate::{ArrayDataBuilder, Buffers};
+use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
 use arrow_schema::DataType;
 
-/// ArrayData for [struct arrays](https://arrow.apache.org/docs/format/Columnar.html#struct-layout)
 #[derive(Debug, Clone)]
-pub struct StructArrayData {
+pub struct BooleanArrayData {
     data_type: DataType,
-    len: usize,
+    values: BooleanBuffer,
     nulls: Option<NullBuffer>,
-    children: Vec<ArrayData>,
 }
 
-impl StructArrayData {
-    /// Create a new [`StructArrayData`]
+impl BooleanArrayData {
+    /// Create a new [`BooleanArrayData`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if
+    /// - `nulls` and `values` are different lengths
+    /// - `data_type` is not compatible with `T`
+    pub fn new(
+        data_type: DataType,
+        values: BooleanBuffer,
+        nulls: Option<NullBuffer>,
+    ) -> Self {
+        let physical = PhysicalType::from(&data_type);
+        assert_eq!(
+            physical, PhysicalType::Boolean,
+            "Illegal physical type for BooleanArrayData of datatype {:?}, expected {:?} got {:?}",
+            data_type,
+            PhysicalType::Boolean,
+            physical
+        );
+
+        if let Some(n) = nulls.as_ref() {
+            assert_eq!(values.len(), n.len())
+        }
+        Self {
+            data_type,
+            values,
+            nulls,
+        }
+    }
+
+    /// Create a new [`BooleanArrayData`]
     ///
     /// # Safety
     ///
-    /// - data_type must be a StructArray with fields matching `child_data`
-    /// - all child data and nulls must have length matching `len`
+    /// - `nulls` and `values` are the same lengths
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Boolean`
     pub unsafe fn new_unchecked(
         data_type: DataType,
-        len: usize,
+        values: BooleanBuffer,
         nulls: Option<NullBuffer>,
-        children: Vec<ArrayData>,
     ) -> Self {
         Self {
             data_type,
-            len,
+            values,
             nulls,
-            children,
         }
     }
 
-    /// Creates a new [`StructArrayData`] from raw buffers
+    /// Creates a new [`BooleanArrayData`] from raw buffers
     ///
     /// # Safety
     ///
-    /// See [`StructArrayData::new_unchecked`]
+    /// See [`BooleanArrayData::new_unchecked`]
     pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
-        let children = builder
-            .child_data
-            .into_iter()
-            .map(|x| x.slice(builder.offset, builder.len))
-            .collect();
-
+        let values = builder.buffers.into_iter().next().unwrap();
+        let values = BooleanBuffer::new(values, builder.offset, builder.len);
         Self {
+            values,
             data_type: builder.data_type,
-            len: builder.len,
             nulls: builder.nulls,
-            children,
         }
-    }
-
-    /// Returns the length of this [`StructArrayData`]
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Returns `true` if this [`StructArrayData`] has zero length
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
     }
 
     /// Returns the null buffer if any
@@ -88,10 +99,10 @@ impl StructArrayData {
         self.nulls.as_ref()
     }
 
-    /// Returns the primitive values
+    /// Returns the boolean values
     #[inline]
-    pub fn children(&self) -> &[ArrayData] {
-        &self.children
+    pub fn values(&self) -> &BooleanBuffer {
+        &self.values
     }
 
     /// Returns the data type of this array
@@ -100,18 +111,17 @@ impl StructArrayData {
         &self.data_type
     }
 
-    /// Returns the underlying parts of this [`StructArrayData`]
-    pub fn into_parts(self) -> (DataType, Option<NullBuffer>, Vec<ArrayData>) {
-        (self.data_type, self.nulls, self.children)
+    /// Returns the underlying parts of this [`BooleanArrayData`]
+    pub fn into_parts(self) -> (DataType, BooleanBuffer, Option<NullBuffer>) {
+        (self.data_type, self.values, self.nulls)
     }
 
     /// Returns a zero-copy slice of this array
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         Self {
-            len,
             data_type: self.data_type.clone(),
+            values: self.values.slice(offset, len),
             nulls: self.nulls.as_ref().map(|x| x.slice(offset, len)),
-            children: self.children.iter().map(|c| c.slice(offset, len)).collect(),
         }
     }
 
@@ -119,11 +129,11 @@ impl StructArrayData {
     pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
         ArrayDataLayout {
             data_type: &self.data_type,
-            len: self.len,
-            offset: 0,
+            len: self.values.len(),
+            offset: self.values.offset(),
             nulls: self.nulls.as_ref(),
-            buffers: Buffers::default(),
-            child_data: &self.children,
+            buffers: Buffers::one(self.values().inner()),
+            child_data: &[],
         }
     }
 }

--- a/arrow-data/src/data/buffers.rs
+++ b/arrow-data/src/data/buffers.rs
@@ -25,13 +25,22 @@ pub struct Buffers<'a>([Option<&'a Buffer>; 2]);
 
 impl<'a> Buffers<'a> {
     /// Temporary will be removed once ArrayData does not store `Vec<Buffer>` directly (#3769)
-    #[inline]
     pub(crate) fn from_slice(a: &'a [Buffer]) -> Self {
         match a.len() {
             0 => Self([None, None]),
             1 => Self([Some(&a[0]), None]),
             _ => Self([Some(&a[0]), Some(&a[1])]),
         }
+    }
+
+    #[inline]
+    pub(crate) fn one(b: &'a Buffer) -> Self {
+        Self([Some(b), None])
+    }
+
+    #[inline]
+    pub(crate) fn two(a: &'a Buffer, b: &'a Buffer) -> Self {
+        Self([Some(a), Some(b)])
     }
 
     /// Returns the number of [`Buffer`] in this collection

--- a/arrow-data/src/data/bytes.rs
+++ b/arrow-data/src/data/bytes.rs
@@ -197,7 +197,6 @@ impl private::BytesOffsetSealed for i64 {
 }
 
 /// Applies op to each variant of [`ArrayDataBytes`]
-#[macro_export]
 macro_rules! bytes_op {
     ($array:ident, $op:block) => {
         match $array {

--- a/arrow-data/src/data/bytes.rs
+++ b/arrow-data/src/data/bytes.rs
@@ -328,7 +328,7 @@ impl<O: BytesOffset, B: Bytes + ?Sized> BytesArrayData<O, B> {
     ///
     /// - Each consecutive window of `offsets` must identify a valid slice of `values`
     /// - `nulls.len() == offsets.len() - 1`
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Bytes(O::TYPE, B::TYPE)`
     pub unsafe fn new_unchecked(
         data_type: DataType,
         offsets: OffsetBuffer<O>,
@@ -454,7 +454,7 @@ impl FixedSizeBinaryArrayData {
     ///
     /// # Safety
     ///
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::FixedSizeBinary(element_size)`
     /// - `nulls.len() == values.len() / element_size == len`
     pub unsafe fn new_unchecked(
         data_type: DataType,

--- a/arrow-data/src/data/dictionary.rs
+++ b/arrow-data/src/data/dictionary.rs
@@ -87,7 +87,6 @@ dictionary!(u32, UInt32);
 dictionary!(u64, UInt64);
 
 /// Applies op to each variant of [`ArrayDataDictionary`]
-#[macro_export]
 macro_rules! dictionary_op {
     ($array:ident, $op:block) => {
         match $array {

--- a/arrow-data/src/data/dictionary.rs
+++ b/arrow-data/src/data/dictionary.rs
@@ -148,7 +148,7 @@ impl ArrayDataDictionary {
     ///
     /// # Safety
     ///
-    /// See [`Self::new_unchecked`]
+    /// See [`DictionaryArrayData::new_unchecked`]
     pub(crate) unsafe fn from_raw(
         builder: ArrayDataBuilder,
         key: DictionaryKeyType,

--- a/arrow-data/src/data/dictionary.rs
+++ b/arrow-data/src/data/dictionary.rs
@@ -187,7 +187,7 @@ impl<K: DictionaryKey> DictionaryArrayData<K> {
     ///
     /// # Safety
     ///
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Dictionary(K::TYPE)`
     /// - child must have a type matching `data_type`
     /// - all values in `keys` must be `0 < v < child.len()` or be a null according to `nulls`
     /// - `nulls` must have the same length as `child`

--- a/arrow-data/src/data/list.rs
+++ b/arrow-data/src/data/list.rs
@@ -193,9 +193,9 @@ impl<O: ListOffset> ListArrayData<O> {
     ///
     /// # Safety
     ///
+    /// - `PhysicalType::from(&data_type) == PhysicalType::List(O::TYPE)`
     /// - Each consecutive window of `offsets` must identify a valid slice of `child`
     /// - `nulls.len() == offsets.len() - 1`
-    /// - `data_type` must be valid for this layout
     pub unsafe fn new_unchecked(
         data_type: DataType,
         offsets: OffsetBuffer<O>,
@@ -317,7 +317,7 @@ impl FixedSizeListArrayData {
     ///
     /// # Safety
     ///
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::FixedSizeList(element_size)`
     /// - `nulls.len() == values.len() / element_size == len`
     pub unsafe fn new_unchecked(
         data_type: DataType,

--- a/arrow-data/src/data/list.rs
+++ b/arrow-data/src/data/list.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use crate::data::types::OffsetType;
-use crate::ArrayData;
-use arrow_buffer::buffer::{NullBuffer, ScalarBuffer};
-use arrow_buffer::{ArrowNativeType, Buffer};
+use crate::data::ArrayDataLayout;
+use crate::{ArrayData, ArrayDataBuilder, Buffers};
+use arrow_buffer::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_buffer::ArrowNativeType;
 use arrow_schema::DataType;
 
 mod private {
@@ -113,6 +114,17 @@ impl private::ListOffsetSealed for i64 {
     }
 }
 
+/// Applies op to each variant of [`ListArrayData`]
+#[macro_export]
+macro_rules! list_op {
+    ($array:ident, $op:block) => {
+        match $array {
+            ArrayDataList::Small($array) => $op
+            ArrayDataList::Large($array) => $op
+        }
+    };
+}
+
 /// An enumeration of the types of [`ListArrayData`]
 #[derive(Debug, Clone)]
 pub enum ArrayDataList {
@@ -130,6 +142,36 @@ impl ArrayDataList {
     pub fn downcast<O: ListOffset>(self) -> Option<ListArrayData<O>> {
         O::downcast(self)
     }
+
+    /// Returns the values of this [`ArrayDataList`]
+    pub fn values(&self) -> &ArrayData {
+        let s = self;
+        list_op!(s, { s.values() })
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        let s = self;
+        list_op!(s, { s.slice(offset, len).into() })
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        let s = self;
+        list_op!(s, { s.layout() })
+    }
+
+    /// Creates a new [`ArrayDataList`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`ListArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder, offset: OffsetType) -> Self {
+        match offset {
+            OffsetType::Int32 => Self::Small(ListArrayData::from_raw(builder)),
+            OffsetType::Int64 => Self::Large(ListArrayData::from_raw(builder)),
+        }
+    }
 }
 
 impl<O: ListOffset> From<ListArrayData<O>> for ArrayDataList {
@@ -143,8 +185,8 @@ impl<O: ListOffset> From<ListArrayData<O>> for ArrayDataList {
 pub struct ListArrayData<O: ListOffset> {
     data_type: DataType,
     nulls: Option<NullBuffer>,
-    offsets: ScalarBuffer<O>,
-    child: Box<ArrayData>,
+    offsets: OffsetBuffer<O>,
+    values: Box<ArrayData>,
 }
 
 impl<O: ListOffset> ListArrayData<O> {
@@ -157,16 +199,54 @@ impl<O: ListOffset> ListArrayData<O> {
     /// - `data_type` must be valid for this layout
     pub unsafe fn new_unchecked(
         data_type: DataType,
-        offsets: ScalarBuffer<O>,
+        offsets: OffsetBuffer<O>,
         nulls: Option<NullBuffer>,
-        child: ArrayData,
+        values: ArrayData,
     ) -> Self {
         Self {
             data_type,
             nulls,
             offsets,
-            child: Box::new(child),
+            values: Box::new(values),
         }
+    }
+
+    /// Creates a new [`ListArrayData`] from an [`ArrayDataBuilder`]
+    ///
+    /// # Safety
+    ///
+    /// See [`Self::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
+        let offsets = builder.buffers.into_iter().next().unwrap();
+        let values = builder.child_data.into_iter().next().unwrap();
+
+        let offsets = match builder.len {
+            0 => OffsetBuffer::new_empty(),
+            _ => OffsetBuffer::new_unchecked(ScalarBuffer::new(
+                offsets,
+                builder.offset,
+                builder.len + 1,
+            )),
+        };
+
+        Self {
+            offsets,
+            data_type: builder.data_type,
+            nulls: builder.nulls,
+            values: Box::new(values),
+        }
+    }
+
+    /// Returns the length
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.offsets.len().wrapping_sub(1)
+    }
+
+    /// Returns true if this array is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.offsets.len() <= 1
     }
 
     /// Returns the null buffer if any
@@ -177,14 +257,14 @@ impl<O: ListOffset> ListArrayData<O> {
 
     /// Returns the offsets
     #[inline]
-    pub fn offsets(&self) -> &[O] {
+    pub fn offsets(&self) -> &OffsetBuffer<O> {
         &self.offsets
     }
 
-    /// Returns the child data
+    /// Returns the values of this [`ListArrayData`]
     #[inline]
-    pub fn child(&self) -> &ArrayData {
-        self.child.as_ref()
+    pub fn values(&self) -> &ArrayData {
+        self.values.as_ref()
     }
 
     /// Returns the data type of this array
@@ -192,12 +272,43 @@ impl<O: ListOffset> ListArrayData<O> {
     pub fn data_type(&self) -> &DataType {
         &self.data_type
     }
+
+    /// Returns the underlying parts of this [`ListArrayData`]
+    pub fn into_parts(
+        self,
+    ) -> (DataType, OffsetBuffer<O>, Option<NullBuffer>, ArrayData) {
+        (self.data_type, self.offsets, self.nulls, *self.values)
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            nulls: self.nulls.as_ref().map(|x| x.slice(offset, len)),
+            offsets: self.offsets.slice(offset, len),
+            values: self.values.clone(),
+        }
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        ArrayDataLayout {
+            data_type: &self.data_type,
+            len: self.len(),
+            offset: 0,
+            nulls: self.nulls.as_ref(),
+            buffers: Buffers::one(self.offsets.inner().inner()),
+            child_data: std::slice::from_ref(self.values.as_ref()),
+        }
+    }
 }
 
 /// ArrayData for [fixed-size list arrays](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-list-layout)
 #[derive(Debug, Clone)]
 pub struct FixedSizeListArrayData {
     data_type: DataType,
+    len: usize,
+    element_size: usize,
     nulls: Option<NullBuffer>,
     child: Box<ArrayData>,
 }
@@ -208,17 +319,56 @@ impl FixedSizeListArrayData {
     /// # Safety
     ///
     /// - `data_type` must be valid for this layout
-    /// - `nulls.len() == values.len() / element_size`
+    /// - `nulls.len() == values.len() / element_size == len`
     pub unsafe fn new_unchecked(
         data_type: DataType,
+        len: usize,
+        element_size: usize,
         nulls: Option<NullBuffer>,
         child: ArrayData,
     ) -> Self {
         Self {
             data_type,
+            len,
+            element_size,
             nulls,
             child: Box::new(child),
         }
+    }
+
+    /// Creates a new [`FixedSizeListArrayData`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`FixedSizeListArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder, size: usize) -> Self {
+        let child =
+            builder.child_data[0].slice(builder.offset * size, builder.len * size);
+        Self {
+            data_type: builder.data_type,
+            len: builder.len,
+            element_size: size,
+            nulls: builder.nulls,
+            child: Box::new(child),
+        }
+    }
+
+    /// Returns the length
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if this array is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the size of each element
+    #[inline]
+    pub fn element_size(&self) -> usize {
+        self.element_size
     }
 
     /// Returns the null buffer if any
@@ -237,5 +387,37 @@ impl FixedSizeListArrayData {
     #[inline]
     pub fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    /// Returns the underlying parts of this [`FixedSizeListArrayData`]
+    pub fn into_parts(self) -> (DataType, Option<NullBuffer>, ArrayData) {
+        (self.data_type, self.nulls, *self.child)
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        let offset_element = offset.checked_mul(self.element_size).expect("overflow");
+        let len_element = len.checked_mul(self.element_size).expect("overflow");
+        let child = self.child.slice(offset_element, len_element);
+
+        Self {
+            len,
+            data_type: self.data_type.clone(),
+            element_size: self.element_size,
+            nulls: self.nulls.as_ref().map(|x| x.slice(offset, len)),
+            child: Box::new(child),
+        }
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        ArrayDataLayout {
+            data_type: &self.data_type,
+            len: self.len,
+            offset: 0,
+            nulls: self.nulls.as_ref(),
+            buffers: Buffers::default(),
+            child_data: std::slice::from_ref(self.child.as_ref()),
+        }
     }
 }

--- a/arrow-data/src/data/list.rs
+++ b/arrow-data/src/data/list.rs
@@ -115,7 +115,6 @@ impl private::ListOffsetSealed for i64 {
 }
 
 /// Applies op to each variant of [`ListArrayData`]
-#[macro_export]
 macro_rules! list_op {
     ($array:ident, $op:block) => {
         match $array {

--- a/arrow-data/src/data/mod.rs
+++ b/arrow-data/src/data/mod.rs
@@ -595,7 +595,7 @@ impl ArrayData {
     /// * the buffer is not byte-aligned with type T, or
     /// * the datatype is `Boolean` (it corresponds to a bit-packed buffer where the offset is not applicable)
     pub fn buffer<T: ArrowNativeType>(&self, buffer: usize) -> &[T] {
-        self.buffers()[buffer].typed_data()
+        &self.buffers()[buffer].typed_data()[self.offset..]
     }
 
     /// Returns a new [`ArrayData`] valid for `data_type` containing `len` null values

--- a/arrow-data/src/data/mod.rs
+++ b/arrow-data/src/data/mod.rs
@@ -33,25 +33,25 @@ use crate::equal;
 mod buffers;
 pub use buffers::*;
 
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod boolean;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod bytes;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod dictionary;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod list;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod null;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod primitive;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod run;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod r#struct;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod types;
-#[allow(unused)] // Private until ready (#1176)
+#[allow(unused)] // Private until ready (#1799)
 mod union;
 
 #[inline]

--- a/arrow-data/src/data/null.rs
+++ b/arrow-data/src/data/null.rs
@@ -32,7 +32,7 @@ impl NullArrayData {
     ///
     /// # Panic
     ///
-    /// - `data_type` is not compatible with `T`
+    /// - `PhysicalType::from(&data_type) != PhysicalType::Null`
     pub fn new(data_type: DataType, len: usize) -> Self {
         assert_eq!(
             PhysicalType::from(&data_type),
@@ -83,7 +83,7 @@ impl NullArrayData {
     /// Returns a zero-copy slice of this array
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         let new_len = offset.saturating_add(len);
-        assert!(new_len <= self.len,);
+        assert!(new_len <= self.len);
         Self {
             data_type: self.data_type.clone(),
             len,

--- a/arrow-data/src/data/null.rs
+++ b/arrow-data/src/data/null.rs
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::data::types::PhysicalType;
+use crate::data::ArrayDataLayout;
+use crate::{ArrayDataBuilder, Buffers};
+use arrow_schema::DataType;
+
+/// ArrayData for [null arrays](https://arrow.apache.org/docs/format/Columnar.html#null-layout)
+#[derive(Debug, Clone)]
+pub struct NullArrayData {
+    data_type: DataType,
+    len: usize,
+}
+
+impl NullArrayData {
+    /// Create a new [`NullArrayData`]
+    ///
+    /// # Panic
+    ///
+    /// - `data_type` is not compatible with `T`
+    pub fn new(data_type: DataType, len: usize) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data_type),
+            PhysicalType::Null,
+            "Illegal physical type for NullArrayData of datatype {data_type:?}",
+        );
+        Self { data_type, len }
+    }
+
+    /// Create a new [`NullArrayData`]
+    ///
+    /// # Safety
+    ///
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Null`
+    pub unsafe fn new_unchecked(data_type: DataType, len: usize) -> Self {
+        Self { data_type, len }
+    }
+
+    /// Creates a new [`NullArrayData`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`NullArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
+        Self {
+            data_type: builder.data_type,
+            len: builder.len,
+        }
+    }
+
+    /// Returns the data type of this array
+    #[inline]
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Returns the length of this array
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the [`DataType`] and length of this [`NullArrayData`]
+    pub fn into_parts(self) -> (DataType, usize) {
+        (self.data_type, self.len)
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        let new_len = offset.saturating_add(len);
+        assert!(new_len <= self.len,);
+        Self {
+            data_type: self.data_type.clone(),
+            len,
+        }
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        ArrayDataLayout {
+            data_type: &self.data_type,
+            len: self.len,
+            offset: 0,
+            nulls: None,
+            buffers: Buffers::default(),
+            child_data: &[],
+        }
+    }
+}

--- a/arrow-data/src/data/primitive.rs
+++ b/arrow-data/src/data/primitive.rs
@@ -225,11 +225,29 @@ impl<T: Primitive> PrimitiveArrayData<T> {
         }
     }
 
+    /// Create a new [`PrimitiveArrayData`]
+    ///
+    /// # Safety
+    ///
+    /// - `nulls` and `values` must be the same length
+    /// - `data_type` must be compatible with `T`
+    pub unsafe fn new_unchecked(
+        data_type: DataType,
+        values: ScalarBuffer<T>,
+        nulls: Option<NullBuffer>,
+    ) -> Self {
+        Self {
+            data_type,
+            values,
+            nulls,
+        }
+    }
+
     /// Creates a new [`PrimitiveArrayData`] from an [`ArrayDataBuilder`]
     ///
     /// # Safety
     ///
-    /// See [`Self::new_unchecked`]
+    /// See [`PrimitiveArrayData::new_unchecked`]
     pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
         let values = builder.buffers.into_iter().next().unwrap();
         let values = ScalarBuffer::new(values, builder.offset, builder.len);

--- a/arrow-data/src/data/primitive.rs
+++ b/arrow-data/src/data/primitive.rs
@@ -201,8 +201,8 @@ impl<T: Primitive> PrimitiveArrayData<T> {
     /// # Panics
     ///
     /// Panics if
+    /// - `PhysicalType::from(&data_type) != PhysicalType::Primitive(T::TYPE)`
     /// - `nulls` and `values` are different lengths
-    /// - `data_type` is not compatible with `T`
     pub fn new(
         data_type: DataType,
         values: ScalarBuffer<T>,
@@ -229,8 +229,8 @@ impl<T: Primitive> PrimitiveArrayData<T> {
     ///
     /// # Safety
     ///
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Primitive(T::TYPE)`
     /// - `nulls` and `values` must be the same length
-    /// - `data_type` must be compatible with `T`
     pub unsafe fn new_unchecked(
         data_type: DataType,
         values: ScalarBuffer<T>,

--- a/arrow-data/src/data/primitive.rs
+++ b/arrow-data/src/data/primitive.rs
@@ -49,7 +49,6 @@ pub trait Primitive: private::PrimitiveSealed + ArrowNativeType {
 }
 
 /// Applies op to each variant of [`ArrayDataPrimitive`]
-#[macro_export]
 macro_rules! primitive_op {
     ($array:ident, $op:block) => {
         match $array {

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -84,7 +84,6 @@ run_end!(i32, Int32);
 run_end!(i64, Int64);
 
 /// Applies op to each variant of [`ArrayDataRun`]
-#[macro_export]
 macro_rules! run_op {
     ($array:ident, $op:block) => {
         match $array {

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -169,7 +169,7 @@ impl<E: RunEnd> RunArrayData<E> {
     ///
     /// # Safety
     ///
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Run(E::TYPE)`
     /// - `run_ends` must contain monotonically increasing, positive values `<= len`
     /// - `run_ends.len() == child.len()`
     pub unsafe fn new_unchecked(

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -158,9 +158,11 @@ impl<E: RunEnd> From<RunArrayData<E>> for ArrayDataRun {
 pub struct RunArrayData<E: RunEnd> {
     data_type: DataType,
     run_ends: RunEndBuffer<E>,
-    /// The children of this RunArrayData
+    /// The children of this RunArrayData:
     /// 1: the run ends
     /// 2: the values
+    ///
+    /// We store an array so that a slice can be returned in [`RunArrayData::layout`]
     children: Box<[ArrayData; 2]>,
 }
 
@@ -171,7 +173,7 @@ impl<E: RunEnd> RunArrayData<E> {
     ///
     /// - `PhysicalType::from(&data_type) == PhysicalType::Run(E::TYPE)`
     /// - `run_ends` must contain monotonically increasing, positive values `<= len`
-    /// - `run_ends.len() == child.len()`
+    /// - `run_ends.get_end_physical_index() < values.len()`
     pub unsafe fn new_unchecked(
         data_type: DataType,
         run_ends: RunEndBuffer<E>,

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -15,17 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::data::primitive::{Primitive, PrimitiveArrayData};
 use crate::data::types::RunEndType;
-use crate::ArrayData;
-use arrow_buffer::buffer::ScalarBuffer;
+use crate::data::ArrayDataLayout;
+use crate::{ArrayData, ArrayDataBuilder, Buffers};
+use arrow_buffer::buffer::{RunEndBuffer, ScalarBuffer};
 use arrow_buffer::ArrowNativeType;
 use arrow_schema::DataType;
-use std::marker::PhantomData;
 
 mod private {
     use super::*;
 
     pub trait RunEndSealed {
+        const ENDS_TYPE: DataType;
+
         /// Downcast [`ArrayDataRun`] to `[RunArrayData`]
         fn downcast_ref(data: &ArrayDataRun) -> Option<&RunArrayData<Self>>
         where
@@ -43,7 +46,7 @@ mod private {
     }
 }
 
-pub trait RunEnd: private::RunEndSealed + ArrowNativeType {
+pub trait RunEnd: private::RunEndSealed + ArrowNativeType + Primitive {
     const TYPE: RunEndType;
 }
 
@@ -53,6 +56,8 @@ macro_rules! run_end {
             const TYPE: RunEndType = RunEndType::$v;
         }
         impl private::RunEndSealed for $t {
+            const ENDS_TYPE: DataType = DataType::$v;
+
             fn downcast_ref(data: &ArrayDataRun) -> Option<&RunArrayData<Self>> {
                 match data {
                     ArrayDataRun::$v(v) => Some(v),
@@ -78,7 +83,20 @@ run_end!(i16, Int16);
 run_end!(i32, Int32);
 run_end!(i64, Int64);
 
+/// Applies op to each variant of [`ArrayDataRun`]
+#[macro_export]
+macro_rules! run_op {
+    ($array:ident, $op:block) => {
+        match $array {
+            ArrayDataRun::Int16($array) => $op
+            ArrayDataRun::Int32($array) => $op
+            ArrayDataRun::Int64($array) => $op
+        }
+    };
+}
+
 /// An enumeration of the types of [`RunArrayData`]
+#[derive(Debug, Clone)]
 pub enum ArrayDataRun {
     Int16(RunArrayData<i16>),
     Int32(RunArrayData<i32>),
@@ -88,26 +106,63 @@ pub enum ArrayDataRun {
 impl ArrayDataRun {
     /// Downcast this [`ArrayDataRun`] to the corresponding [`RunArrayData`]
     pub fn downcast_ref<E: RunEnd>(&self) -> Option<&RunArrayData<E>> {
-        E::downcast_ref(self)
+        <E as private::RunEndSealed>::downcast_ref(self)
     }
 
     /// Downcast this [`ArrayDataRun`] to the corresponding [`RunArrayData`]
     pub fn downcast<E: RunEnd>(self) -> Option<RunArrayData<E>> {
-        E::downcast(self)
+        <E as private::RunEndSealed>::downcast(self)
+    }
+
+    /// Returns the values of this [`ArrayDataRun`]
+    #[inline]
+    pub fn values(&self) -> &ArrayData {
+        let s = self;
+        run_op!(s, { s.values() })
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        let s = self;
+        run_op!(s, { s.slice(offset, len).into() })
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        let s = self;
+        run_op!(s, { s.layout() })
+    }
+
+    /// Creates a new [`ArrayDataRun`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`RunArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder, run: RunEndType) -> Self {
+        use RunEndType::*;
+        match run {
+            Int16 => Self::Int16(RunArrayData::from_raw(builder)),
+            Int32 => Self::Int32(RunArrayData::from_raw(builder)),
+            Int64 => Self::Int64(RunArrayData::from_raw(builder)),
+        }
     }
 }
 
 impl<E: RunEnd> From<RunArrayData<E>> for ArrayDataRun {
     fn from(value: RunArrayData<E>) -> Self {
-        E::upcast(value)
+        <E as private::RunEndSealed>::upcast(value)
     }
 }
 
 /// ArrayData for [run-end encoded arrays](https://arrow.apache.org/docs/format/Columnar.html#run-end-encoded-layout)
+#[derive(Debug, Clone)]
 pub struct RunArrayData<E: RunEnd> {
     data_type: DataType,
-    run_ends: ScalarBuffer<E>,
-    child: Box<ArrayData>,
+    run_ends: RunEndBuffer<E>,
+    /// The children of this RunArrayData
+    /// 1: the run ends
+    /// 2: the values
+    children: Box<[ArrayData; 2]>,
 }
 
 impl<E: RunEnd> RunArrayData<E> {
@@ -116,22 +171,67 @@ impl<E: RunEnd> RunArrayData<E> {
     /// # Safety
     ///
     /// - `data_type` must be valid for this layout
-    /// - `run_ends` must contain monotonically increasing, positive values `<= child.len()`
+    /// - `run_ends` must contain monotonically increasing, positive values `<= len`
+    /// - `run_ends.len() == child.len()`
     pub unsafe fn new_unchecked(
         data_type: DataType,
-        run_ends: ScalarBuffer<E>,
-        child: ArrayData,
+        run_ends: RunEndBuffer<E>,
+        values: ArrayData,
     ) -> Self {
+        let inner = run_ends.inner();
+        let child = ArrayDataBuilder::new(E::ENDS_TYPE)
+            .len(inner.len())
+            .buffers(vec![inner.inner().clone()])
+            .build_unchecked();
+
         Self {
             data_type,
             run_ends,
-            child: Box::new(child),
+            children: Box::new([child, values]),
         }
+    }
+
+    /// Creates a new [`RunArrayData`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`RunArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
+        let mut iter = builder.child_data.into_iter();
+        let child1 = iter.next().unwrap();
+        let child2 = iter.next().unwrap();
+
+        let p = ScalarBuffer::new(child1.buffers[0].clone(), child1.offset, child1.len);
+        let run_ends = RunEndBuffer::new_unchecked(p, builder.offset, builder.len);
+
+        Self {
+            run_ends,
+            data_type: builder.data_type,
+            children: Box::new([child1, child2]),
+        }
+    }
+
+    /// Returns the length
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.run_ends.len()
+    }
+
+    /// Returns the offset
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.run_ends.offset()
+    }
+
+    /// Returns true if this array is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.run_ends.is_empty()
     }
 
     /// Returns the run ends
     #[inline]
-    pub fn run_ends(&self) -> &[E] {
+    pub fn run_ends(&self) -> &RunEndBuffer<E> {
         &self.run_ends
     }
 
@@ -143,7 +243,34 @@ impl<E: RunEnd> RunArrayData<E> {
 
     /// Returns the child data
     #[inline]
-    pub fn child(&self) -> &ArrayData {
-        self.child.as_ref()
+    pub fn values(&self) -> &ArrayData {
+        &self.children[1]
+    }
+
+    /// Returns the underlying parts of this [`RunArrayData`]
+    pub fn into_parts(self) -> (DataType, RunEndBuffer<E>, ArrayData) {
+        let child = self.children.into_iter().nth(1).unwrap();
+        (self.data_type, self.run_ends, child)
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            run_ends: self.run_ends.slice(offset, len),
+            children: self.children.clone(),
+        }
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        ArrayDataLayout {
+            data_type: &self.data_type,
+            len: self.run_ends.len(),
+            offset: self.run_ends.offset(),
+            nulls: None,
+            buffers: Buffers::default(),
+            child_data: self.children.as_ref(),
+        }
     }
 }

--- a/arrow-data/src/data/struct.rs
+++ b/arrow-data/src/data/struct.rs
@@ -34,7 +34,7 @@ impl StructArrayData {
     ///
     /// # Safety
     ///
-    /// - data_type must be a StructArray with fields matching `child_data`
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Struct`
     /// - all child data and nulls must have length matching `len`
     pub unsafe fn new_unchecked(
         data_type: DataType,

--- a/arrow-data/src/data/union.rs
+++ b/arrow-data/src/data/union.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::ArrayData;
+use crate::data::ArrayDataLayout;
+use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::ScalarBuffer;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, UnionMode};
 
 /// ArrayData for [union arrays](https://arrow.apache.org/docs/format/Columnar.html#union-layout)
 #[derive(Debug, Clone)]
@@ -51,16 +52,62 @@ impl UnionArrayData {
         }
     }
 
+    /// Creates a new [`StructArrayData`] from raw buffers
+    ///
+    /// # Safety
+    ///
+    /// See [`UnionArrayData::new_unchecked`]
+    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder, mode: UnionMode) -> Self {
+        match mode {
+            UnionMode::Sparse => {
+                let type_ids = builder.buffers.into_iter().next().unwrap();
+                let type_ids = ScalarBuffer::new(type_ids, builder.offset, builder.len);
+                let children = builder
+                    .child_data
+                    .into_iter()
+                    .map(|x| x.slice(builder.offset, builder.len))
+                    .collect();
+
+                Self {
+                    type_ids,
+                    children,
+                    data_type: builder.data_type,
+                    offsets: None,
+                }
+            }
+            UnionMode::Dense => {
+                let mut iter = builder.buffers.into_iter();
+                let type_ids = iter.next().unwrap();
+                let offsets = iter.next().unwrap();
+                let type_ids = ScalarBuffer::new(type_ids, builder.offset, builder.len);
+                let offsets = ScalarBuffer::new(offsets, builder.offset, builder.len);
+
+                Self {
+                    type_ids,
+                    data_type: builder.data_type,
+                    offsets: Some(offsets),
+                    children: builder.child_data,
+                }
+            }
+        }
+    }
+
+    /// Returns the length of this array
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.type_ids.len()
+    }
+
     /// Returns the type ids for this array
     #[inline]
-    pub fn type_ids(&self) -> &[i8] {
+    pub fn type_ids(&self) -> &ScalarBuffer<i8> {
         &self.type_ids
     }
 
     /// Returns the offsets for this array if this is a dense union
     #[inline]
-    pub fn offsets(&self) -> Option<&[i32]> {
-        self.offsets.as_deref()
+    pub fn offsets(&self) -> Option<&ScalarBuffer<i32>> {
+        self.offsets.as_ref()
     }
 
     /// Returns the children of this array
@@ -73,5 +120,51 @@ impl UnionArrayData {
     #[inline]
     pub fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    /// Returns the underlying parts of this [`UnionArrayData`]
+    pub fn into_parts(
+        self,
+    ) -> (
+        DataType,
+        ScalarBuffer<i8>,
+        Option<ScalarBuffer<i32>>,
+        Vec<ArrayData>,
+    ) {
+        (self.data_type, self.type_ids, self.offsets, self.children)
+    }
+
+    /// Returns a zero-copy slice of this array
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        let (offsets, children) = match &self.offsets {
+            Some(offsets) => (Some(offsets.slice(offset, len)), self.children.clone()),
+            None => (
+                None,
+                self.children.iter().map(|c| c.slice(offset, len)).collect(),
+            ),
+        };
+        Self {
+            data_type: self.data_type.clone(),
+            type_ids: self.type_ids.slice(offset, len),
+            offsets,
+            children,
+        }
+    }
+
+    /// Returns an [`ArrayDataLayout`] representation of this
+    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
+        let buffers = match &self.offsets {
+            Some(offsets) => Buffers::two(self.type_ids.inner(), offsets.inner()),
+            None => Buffers::one(self.type_ids.inner()),
+        };
+
+        ArrayDataLayout {
+            data_type: &self.data_type,
+            len: self.type_ids.len(),
+            offset: 0,
+            nulls: None,
+            buffers,
+            child_data: &self.children,
+        }
     }
 }

--- a/arrow-data/src/data/union.rs
+++ b/arrow-data/src/data/union.rs
@@ -34,7 +34,8 @@ impl UnionArrayData {
     ///
     /// # Safety
     ///
-    /// - `data_type` must be valid for this layout
+    /// - `PhysicalType::from(&data_type) == PhysicalType::Union(mode)`
+    /// - `offsets` is `Some` iff the above `mode == UnionMode::Sparse`
     /// - `type_ids` must only contain values corresponding to a field in `data_type`
     /// - `children` must match the field definitions in `data_type`
     /// - For each value id in type_ids, the corresponding offset, must be in bounds for the child

--- a/arrow-data/src/data/union.rs
+++ b/arrow-data/src/data/union.rs
@@ -52,7 +52,7 @@ impl UnionArrayData {
         }
     }
 
-    /// Creates a new [`StructArrayData`] from raw buffers
+    /// Creates a new [`UnionArrayData`] from raw buffers
     ///
     /// # Safety
     ///


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Switching to the ArrayData enumeration requires a substantial amount of glue logic to convert between the `struct` and `enum` layouts. This PR therefore adds

* An ArrayDataLayout that can be used to get a `struct` view of the enum variants, for the purposes of validation, etc..
* Methods to create the enum variants from ArrayDataBuilder
* Methods to slice array data variants

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
