### PR TITLE
[ObjectStore] Add `append` API impl for `LocalFileSystem`

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -194,7 +194,7 @@ impl<W: Write> Writer<W> {
 }
 
 /// A CSV writer builder
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct WriterBuilder {
     /// Optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -37,7 +37,7 @@ itertools = "0.10.1"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = "0.7"
-tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
+tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -37,7 +37,6 @@ itertools = "0.10.1"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = "0.7"
-tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"
@@ -56,6 +55,12 @@ rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 aws-types = { version = "0.54", optional = true }
 aws-credential-types = { version = "0.54", optional = true }
 aws-config = { version = "0.54", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3740 and closes #3742 since we go down a different path.

# Rationale for this change

This PR adds the `LocalFileSystem` implementation for the "append" API. 

# What changes are included in this PR?

- Append API implementation for `LocalFileSystem`.

However, to simplify things, we used the `tokio::fs` feature which is not supported on `wasm32`. There is another implementation on https://github.com/synnada-ai/arrow-rs/pull/5 that alters the `LocalUpload` struct to support both staged and unstaged file writings.

# Are there any user-facing changes?

No.