### PR TITLE
Make dictionary preservation optional in row encoding

### DIFF
--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -97,12 +97,14 @@ fn row_bench(c: &mut Criterion) {
     let cols =
         vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 100)) as ArrayRef];
     do_bench(c, "4096 string_dictionary(100, 0)", cols.clone(), true);
-    do_bench(c, "4096 string_dictionary_hydrate(100, 0)", cols, false);
+    let name = "4096 string_dictionary_non_preserving(100, 0)";
+    do_bench(c, name, cols, false);
 
     let cols =
         vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0.5, 100)) as ArrayRef];
     do_bench(c, "4096 string_dictionary(100, 0.5)", cols.clone(), true);
-    do_bench(c, "4096 string_dictionary_hydrate(100, 0.5)", cols, false);
+    let name = "4096 string_dictionary_non_preserving(100, 0.5)";
+    do_bench(c, name, cols, false);
 
     let cols = vec![
         Arc::new(create_string_array_with_len::<i32>(4096, 0.5, 20)) as ArrayRef,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

As discussed on https://github.com/apache/arrow-datafusion/issues/4973#issuecomment-1460990408 the dictionary preserving row encoding is particularly expensive to compute and may not be appropriate for all use-cases. This PR therefore adds an option to instead encode the dictionary values directly, instead of constructing an order preserving dictionary.

```
convert_columns 4096 string_dictionary(100, 0)
                        time:   [637.45 µs 637.75 µs 638.08 µs]

convert_columns_prepared 4096 string_dictionary(100, 0)
                        time:   [141.49 µs 141.54 µs 141.60 µs]

convert_columns 4096 string_dictionary_hydrate(100, 0)
                        time:   [89.498 µs 89.546 µs 89.594 µs]

convert_columns_prepared 4096 string_dictionary_hydrate(100, 0)
                        time:   [87.264 µs 87.292 µs 87.323 µs]
```

This can be significantly faster, especially when seeing values for the first time (the unprepared case above), however, does come with the potential downside of a significantly less efficient encoding, which in turn needs more memory and may make comparisons slower.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
