### PR TITLE
Add as_any() to the ObjectStore to make it able to identify which ObjectStore is using for the related trait object

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -39,6 +39,7 @@ use futures::TryStreamExt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::any::Any;
 use std::collections::BTreeSet;
 use std::ops::Range;
 use std::str::FromStr;
@@ -169,6 +170,10 @@ impl std::fmt::Display for AmazonS3 {
 
 #[async_trait]
 impl ObjectStore for AmazonS3 {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.client.put_request(location, Some(bytes), &()).await?;
         Ok(())

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -43,6 +43,7 @@ use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::io;
 use std::ops::Range;
@@ -176,6 +177,10 @@ impl std::fmt::Display for MicrosoftAzure {
 
 #[async_trait]
 impl ObjectStore for MicrosoftAzure {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.client
             .put_request(location, Some(bytes), false, &())

--- a/object_store/src/chunked.rs
+++ b/object_store/src/chunked.rs
@@ -17,6 +17,7 @@
 
 //! A [`ChunkedStore`] that can be used to test streaming behaviour
 
+use std::any::Any;
 use std::fmt::{Debug, Display, Formatter};
 use std::io::{BufReader, Read};
 use std::ops::Range;
@@ -62,6 +63,10 @@ impl Display for ChunkedStore {
 
 #[async_trait]
 impl ObjectStore for ChunkedStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.inner.put(location, bytes).await
     }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -29,6 +29,7 @@
 //! to abort the upload and drop those unneeded parts. In addition, you may wish to
 //! consider implementing automatic clean up of unused parts that are older than one
 //! week.
+use std::any::Any;
 use std::collections::BTreeSet;
 use std::io;
 use std::ops::Range;
@@ -628,6 +629,10 @@ impl CloudMultiPartUploadImpl for GCSMultipartUpload {
 
 #[async_trait]
 impl ObjectStore for GoogleCloudStorage {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.client.put_request(location, bytes).await
     }

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -31,14 +31,14 @@
 //! [rfc2518]: https://datatracker.ietf.org/doc/html/rfc2518
 //! [WebDAV]: https://en.wikipedia.org/wiki/WebDAV
 
-use std::ops::Range;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use snafu::{OptionExt, ResultExt, Snafu};
+use std::any::Any;
+use std::ops::Range;
 use tokio::io::AsyncWrite;
 use url::Url;
 
@@ -100,6 +100,10 @@ impl std::fmt::Display for HttpStore {
 
 #[async_trait]
 impl ObjectStore for HttpStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.client.put(location, bytes).await
     }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -260,6 +260,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use snafu::Snafu;
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{Read, Seek, SeekFrom};
@@ -278,6 +279,10 @@ pub type MultipartId = String;
 /// Universal API to multiple object store services.
 #[async_trait]
 pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
+    /// Returns the object store as [`Any`](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
     /// Save the provided bytes to the specified location
     ///
     /// The operation is guaranteed to be atomic, it will either successfully

--- a/object_store/src/limit.rs
+++ b/object_store/src/limit.rs
@@ -24,6 +24,7 @@ use crate::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
+use std::any::Any;
 use std::io::{Error, IoSlice};
 use std::ops::Range;
 use std::pin::Pin;
@@ -72,6 +73,10 @@ impl<T: ObjectStore> std::fmt::Display for LimitStore<T> {
 
 #[async_trait]
 impl<T: ObjectStore> ObjectStore for LimitStore<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.put(location, bytes).await

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -27,6 +27,7 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use futures::{stream::BoxStream, StreamExt};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
+use std::any::Any;
 use std::fs::{metadata, symlink_metadata, File, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::ops::Range;
@@ -267,6 +268,10 @@ impl Config {
 
 #[async_trait]
 impl ObjectStore for LocalFileSystem {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         let path = self.config.path_to_filesystem(location)?;
 

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -24,6 +24,7 @@ use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use parking_lot::RwLock;
 use snafu::{ensure, OptionExt, Snafu};
+use std::any::Any;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::io;
@@ -87,6 +88,10 @@ impl std::fmt::Display for InMemory {
 
 #[async_trait]
 impl ObjectStore for InMemory {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         self.storage
             .write()

--- a/object_store/src/prefix.rs
+++ b/object_store/src/prefix.rs
@@ -18,6 +18,7 @@
 //! An object store wrapper handling a constant path prefix
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use std::any::Any;
 use std::ops::Range;
 use tokio::io::AsyncWrite;
 
@@ -62,6 +63,10 @@ impl<T: ObjectStore> PrefixObjectStore<T> {
 
 #[async_trait::async_trait]
 impl<T: ObjectStore> ObjectStore for PrefixObjectStore<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     /// Save the provided bytes to the specified location.
     async fn put(&self, location: &Path, bytes: Bytes) -> ObjectStoreResult<()> {
         let full_path = self.full_path(location);

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -25,6 +25,7 @@ use crate::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
+use std::any::Any;
 use std::time::Duration;
 use tokio::io::AsyncWrite;
 
@@ -145,6 +146,10 @@ impl<T: ObjectStore> std::fmt::Display for ThrottledStore<T> {
 
 #[async_trait]
 impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
         sleep(self.config().wait_put_per_call).await;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3838.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
