### PR TITLE
Support compression levels

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -20,6 +20,7 @@
 
 use std::{fmt, str};
 
+use crate::compression::ZstdLevel;
 use crate::format as parquet;
 
 use crate::errors::{ParquetError, Result};
@@ -290,7 +291,7 @@ pub enum Compression {
     LZO,
     BROTLI,
     LZ4,
-    ZSTD,
+    ZSTD(ZstdLevel),
     LZ4_RAW,
 }
 
@@ -834,7 +835,7 @@ impl TryFrom<parquet::CompressionCodec> for Compression {
             parquet::CompressionCodec::LZO => Compression::LZO,
             parquet::CompressionCodec::BROTLI => Compression::BROTLI,
             parquet::CompressionCodec::LZ4 => Compression::LZ4,
-            parquet::CompressionCodec::ZSTD => Compression::ZSTD,
+            parquet::CompressionCodec::ZSTD => Compression::ZSTD(Default::default()),
             parquet::CompressionCodec::LZ4_RAW => Compression::LZ4_RAW,
             _ => {
                 return Err(general_err!(
@@ -855,7 +856,7 @@ impl From<Compression> for parquet::CompressionCodec {
             Compression::LZO => parquet::CompressionCodec::LZO,
             Compression::BROTLI => parquet::CompressionCodec::BROTLI,
             Compression::LZ4 => parquet::CompressionCodec::LZ4,
-            Compression::ZSTD => parquet::CompressionCodec::ZSTD,
+            Compression::ZSTD(_) => parquet::CompressionCodec::ZSTD,
             Compression::LZ4_RAW => parquet::CompressionCodec::LZ4_RAW,
         }
     }
@@ -1787,7 +1788,7 @@ mod tests {
         assert_eq!(Compression::LZO.to_string(), "LZO");
         assert_eq!(Compression::BROTLI.to_string(), "BROTLI");
         assert_eq!(Compression::LZ4.to_string(), "LZ4");
-        assert_eq!(Compression::ZSTD.to_string(), "ZSTD");
+        assert_eq!(Compression::ZSTD(Default::default()).to_string(), "ZSTD");
     }
 
     #[test]
@@ -1818,7 +1819,7 @@ mod tests {
         );
         assert_eq!(
             Compression::try_from(parquet::CompressionCodec::ZSTD).unwrap(),
-            Compression::ZSTD
+            Compression::ZSTD(Default::default())
         );
     }
 
@@ -1839,7 +1840,10 @@ mod tests {
             Compression::BROTLI.into()
         );
         assert_eq!(parquet::CompressionCodec::LZ4, Compression::LZ4.into());
-        assert_eq!(parquet::CompressionCodec::ZSTD, Compression::ZSTD.into());
+        assert_eq!(
+            parquet::CompressionCodec::ZSTD,
+            Compression::ZSTD(Default::default()).into()
+        );
     }
 
     #[test]

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -1784,11 +1784,17 @@ mod tests {
     fn test_display_compression() {
         assert_eq!(Compression::UNCOMPRESSED.to_string(), "UNCOMPRESSED");
         assert_eq!(Compression::SNAPPY.to_string(), "SNAPPY");
-        assert_eq!(Compression::GZIP(Default::default()).to_string(), "GZIP");
+        assert_eq!(
+            Compression::GZIP(Default::default()).to_string(),
+            "GZIP(GzipLevel(6))"
+        );
         assert_eq!(Compression::LZO.to_string(), "LZO");
         assert_eq!(Compression::BROTLI.to_string(), "BROTLI");
         assert_eq!(Compression::LZ4.to_string(), "LZ4");
-        assert_eq!(Compression::ZSTD(Default::default()).to_string(), "ZSTD");
+        assert_eq!(
+            Compression::ZSTD(Default::default()).to_string(),
+            "ZSTD(ZstdLevel(1))"
+        );
     }
 
     #[test]
@@ -1833,7 +1839,10 @@ mod tests {
             parquet::CompressionCodec::SNAPPY,
             Compression::SNAPPY.into()
         );
-        assert_eq!(parquet::CompressionCodec::GZIP, Compression::GZIP.into());
+        assert_eq!(
+            parquet::CompressionCodec::GZIP,
+            Compression::GZIP(Default::default()).into()
+        );
         assert_eq!(parquet::CompressionCodec::LZO, Compression::LZO.into());
         assert_eq!(
             parquet::CompressionCodec::BROTLI,

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -20,7 +20,7 @@
 
 use std::{fmt, str};
 
-use crate::compression::{GzipLevel, ZstdLevel};
+use crate::compression::{BrotliLevel, GzipLevel, ZstdLevel};
 use crate::format as parquet;
 
 use crate::errors::{ParquetError, Result};
@@ -289,7 +289,7 @@ pub enum Compression {
     SNAPPY,
     GZIP(GzipLevel),
     LZO,
-    BROTLI,
+    BROTLI(BrotliLevel),
     LZ4,
     ZSTD(ZstdLevel),
     LZ4_RAW,
@@ -833,7 +833,7 @@ impl TryFrom<parquet::CompressionCodec> for Compression {
             parquet::CompressionCodec::SNAPPY => Compression::SNAPPY,
             parquet::CompressionCodec::GZIP => Compression::GZIP(Default::default()),
             parquet::CompressionCodec::LZO => Compression::LZO,
-            parquet::CompressionCodec::BROTLI => Compression::BROTLI,
+            parquet::CompressionCodec::BROTLI => Compression::BROTLI(Default::default()),
             parquet::CompressionCodec::LZ4 => Compression::LZ4,
             parquet::CompressionCodec::ZSTD => Compression::ZSTD(Default::default()),
             parquet::CompressionCodec::LZ4_RAW => Compression::LZ4_RAW,
@@ -854,7 +854,7 @@ impl From<Compression> for parquet::CompressionCodec {
             Compression::SNAPPY => parquet::CompressionCodec::SNAPPY,
             Compression::GZIP(_) => parquet::CompressionCodec::GZIP,
             Compression::LZO => parquet::CompressionCodec::LZO,
-            Compression::BROTLI => parquet::CompressionCodec::BROTLI,
+            Compression::BROTLI(_) => parquet::CompressionCodec::BROTLI,
             Compression::LZ4 => parquet::CompressionCodec::LZ4,
             Compression::ZSTD(_) => parquet::CompressionCodec::ZSTD,
             Compression::LZ4_RAW => parquet::CompressionCodec::LZ4_RAW,
@@ -1789,7 +1789,10 @@ mod tests {
             "GZIP(GzipLevel(6))"
         );
         assert_eq!(Compression::LZO.to_string(), "LZO");
-        assert_eq!(Compression::BROTLI.to_string(), "BROTLI");
+        assert_eq!(
+            Compression::BROTLI(Default::default()).to_string(),
+            "BROTLI(BrotliLevel(1))"
+        );
         assert_eq!(Compression::LZ4.to_string(), "LZ4");
         assert_eq!(
             Compression::ZSTD(Default::default()).to_string(),
@@ -1817,7 +1820,7 @@ mod tests {
         );
         assert_eq!(
             Compression::try_from(parquet::CompressionCodec::BROTLI).unwrap(),
-            Compression::BROTLI
+            Compression::BROTLI(Default::default())
         );
         assert_eq!(
             Compression::try_from(parquet::CompressionCodec::LZ4).unwrap(),
@@ -1846,7 +1849,7 @@ mod tests {
         assert_eq!(parquet::CompressionCodec::LZO, Compression::LZO.into());
         assert_eq!(
             parquet::CompressionCodec::BROTLI,
-            Compression::BROTLI.into()
+            Compression::BROTLI(Default::default()).into()
         );
         assert_eq!(parquet::CompressionCodec::LZ4, Compression::LZ4.into());
         assert_eq!(

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -20,7 +20,7 @@
 
 use std::{fmt, str};
 
-use crate::compression::ZstdLevel;
+use crate::compression::{GzipLevel, ZstdLevel};
 use crate::format as parquet;
 
 use crate::errors::{ParquetError, Result};
@@ -287,7 +287,7 @@ pub enum Encoding {
 pub enum Compression {
     UNCOMPRESSED,
     SNAPPY,
-    GZIP,
+    GZIP(GzipLevel),
     LZO,
     BROTLI,
     LZ4,
@@ -831,7 +831,7 @@ impl TryFrom<parquet::CompressionCodec> for Compression {
         Ok(match value {
             parquet::CompressionCodec::UNCOMPRESSED => Compression::UNCOMPRESSED,
             parquet::CompressionCodec::SNAPPY => Compression::SNAPPY,
-            parquet::CompressionCodec::GZIP => Compression::GZIP,
+            parquet::CompressionCodec::GZIP => Compression::GZIP(Default::default()),
             parquet::CompressionCodec::LZO => Compression::LZO,
             parquet::CompressionCodec::BROTLI => Compression::BROTLI,
             parquet::CompressionCodec::LZ4 => Compression::LZ4,
@@ -852,7 +852,7 @@ impl From<Compression> for parquet::CompressionCodec {
         match value {
             Compression::UNCOMPRESSED => parquet::CompressionCodec::UNCOMPRESSED,
             Compression::SNAPPY => parquet::CompressionCodec::SNAPPY,
-            Compression::GZIP => parquet::CompressionCodec::GZIP,
+            Compression::GZIP(_) => parquet::CompressionCodec::GZIP,
             Compression::LZO => parquet::CompressionCodec::LZO,
             Compression::BROTLI => parquet::CompressionCodec::BROTLI,
             Compression::LZ4 => parquet::CompressionCodec::LZ4,
@@ -1784,7 +1784,7 @@ mod tests {
     fn test_display_compression() {
         assert_eq!(Compression::UNCOMPRESSED.to_string(), "UNCOMPRESSED");
         assert_eq!(Compression::SNAPPY.to_string(), "SNAPPY");
-        assert_eq!(Compression::GZIP.to_string(), "GZIP");
+        assert_eq!(Compression::GZIP(Default::default()).to_string(), "GZIP");
         assert_eq!(Compression::LZO.to_string(), "LZO");
         assert_eq!(Compression::BROTLI.to_string(), "BROTLI");
         assert_eq!(Compression::LZ4.to_string(), "LZ4");
@@ -1803,7 +1803,7 @@ mod tests {
         );
         assert_eq!(
             Compression::try_from(parquet::CompressionCodec::GZIP).unwrap(),
-            Compression::GZIP
+            Compression::GZIP(Default::default())
         );
         assert_eq!(
             Compression::try_from(parquet::CompressionCodec::LZO).unwrap(),

--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -213,11 +213,11 @@ fn compression_from_str(cmp: &str) -> Result<Compression, String> {
     match cmp.to_uppercase().as_str() {
         "UNCOMPRESSED" => Ok(Compression::UNCOMPRESSED),
         "SNAPPY" => Ok(Compression::SNAPPY),
-        "GZIP" => Ok(Compression::GZIP),
+        "GZIP" => Ok(Compression::GZIP(Default::default())),
         "LZO" => Ok(Compression::LZO),
-        "BROTLI" => Ok(Compression::BROTLI),
+        "BROTLI" => Ok(Compression::BROTLI(Default::default())),
         "LZ4" => Ok(Compression::LZ4),
-        "ZSTD" => Ok(Compression::ZSTD),
+        "ZSTD" => Ok(Compression::ZSTD(Default::default())),
         v => Err(
             format!("Unknown compression {v} : possible values UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, LZ4, ZSTD \n\nFor more information try --help")
         )
@@ -507,15 +507,24 @@ mod tests {
         let args = parse_args(vec!["--parquet-compression", "snappy"]).unwrap();
         assert_eq!(args.parquet_compression, Compression::SNAPPY);
         let args = parse_args(vec!["--parquet-compression", "gzip"]).unwrap();
-        assert_eq!(args.parquet_compression, Compression::GZIP);
+        assert_eq!(
+            args.parquet_compression,
+            Compression::GZIP(Default::default())
+        );
         let args = parse_args(vec!["--parquet-compression", "lzo"]).unwrap();
         assert_eq!(args.parquet_compression, Compression::LZO);
         let args = parse_args(vec!["--parquet-compression", "lz4"]).unwrap();
         assert_eq!(args.parquet_compression, Compression::LZ4);
         let args = parse_args(vec!["--parquet-compression", "brotli"]).unwrap();
-        assert_eq!(args.parquet_compression, Compression::BROTLI);
+        assert_eq!(
+            args.parquet_compression,
+            Compression::BROTLI(Default::default())
+        );
         let args = parse_args(vec!["--parquet-compression", "zstd"]).unwrap();
-        assert_eq!(args.parquet_compression, Compression::ZSTD);
+        assert_eq!(
+            args.parquet_compression,
+            Compression::ZSTD(Default::default())
+        );
     }
 
     #[test]

--- a/parquet/src/bin/parquet-layout.rs
+++ b/parquet/src/bin/parquet-layout.rs
@@ -184,11 +184,11 @@ fn compression(compression: Compression) -> Option<&'static str> {
     match compression {
         Compression::UNCOMPRESSED => None,
         Compression::SNAPPY => Some("snappy"),
-        Compression::GZIP => Some("gzip"),
+        Compression::GZIP(_) => Some("gzip"),
         Compression::LZO => Some("lzo"),
-        Compression::BROTLI => Some("brotli"),
+        Compression::BROTLI(_) => Some("brotli"),
         Compression::LZ4 => Some("lz4"),
-        Compression::ZSTD => Some("zstd"),
+        Compression::ZSTD(_) => Some("zstd"),
         Compression::LZ4_RAW => Some("lz4_raw"),
     }
 }

--- a/parquet/src/bin/parquet-rewrite.rs
+++ b/parquet/src/bin/parquet-rewrite.rs
@@ -79,11 +79,11 @@ impl From<CompressionArgs> for Compression {
         match value {
             CompressionArgs::None => Self::UNCOMPRESSED,
             CompressionArgs::Snappy => Self::SNAPPY,
-            CompressionArgs::Gzip => Self::GZIP,
+            CompressionArgs::Gzip => Self::GZIP(Default::default()),
             CompressionArgs::Lzo => Self::LZO,
-            CompressionArgs::Brotli => Self::BROTLI,
+            CompressionArgs::Brotli => Self::BROTLI(Default::default()),
             CompressionArgs::Lz4 => Self::LZ4,
-            CompressionArgs::Zstd => Self::ZSTD,
+            CompressionArgs::Zstd => Self::ZSTD(Default::default()),
             CompressionArgs::Lz4Raw => Self::LZ4_RAW,
         }
     }

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -829,8 +829,8 @@ mod tests {
 
     #[test]
     fn test_codec_gzip() {
-        test_codec_with_size(CodecType::GZIP);
-        test_codec_without_size(CodecType::GZIP);
+        test_codec_with_size(CodecType::GZIP(Default::default()));
+        test_codec_without_size(CodecType::GZIP(Default::default()));
     }
 
     #[test]

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -861,14 +861,20 @@ mod tests {
 
     #[test]
     fn test_codec_gzip() {
-        test_codec_with_size(CodecType::GZIP(Default::default()));
-        test_codec_without_size(CodecType::GZIP(Default::default()));
+        for level in GzipLevel::MINIMUM_LEVEL..=GzipLevel::MAXIMUM_LEVEL {
+            let level = GzipLevel::try_new(level).unwrap();
+            test_codec_with_size(CodecType::GZIP(level));
+            test_codec_without_size(CodecType::GZIP(level));
+        }
     }
 
     #[test]
     fn test_codec_brotli() {
-        test_codec_with_size(CodecType::BROTLI(Default::default()));
-        test_codec_without_size(CodecType::BROTLI(Default::default()));
+        for level in BrotliLevel::MINIMUM_LEVEL..=BrotliLevel::MAXIMUM_LEVEL {
+            let level = BrotliLevel::try_new(level).unwrap();
+            test_codec_with_size(CodecType::BROTLI(level));
+            test_codec_without_size(CodecType::BROTLI(level));
+        }
     }
 
     #[test]
@@ -878,8 +884,11 @@ mod tests {
 
     #[test]
     fn test_codec_zstd() {
-        test_codec_with_size(CodecType::ZSTD(Default::default()));
-        test_codec_without_size(CodecType::ZSTD(Default::default()));
+        for level in ZstdLevel::MINIMUM_LEVEL..=ZstdLevel::MAXIMUM_LEVEL {
+            let level = ZstdLevel::try_new(level).unwrap();
+            test_codec_with_size(CodecType::ZSTD(level));
+            test_codec_without_size(CodecType::ZSTD(level));
+        }
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -937,7 +937,7 @@ mod tests {
             )]))
             // global column settings
             .set_encoding(Encoding::DELTA_BINARY_PACKED)
-            .set_compression(Compression::GZIP)
+            .set_compression(Compression::GZIP(Default::default()))
             .set_dictionary_enabled(false)
             .set_statistics_enabled(EnabledStatistics::None)
             .set_max_statistics_size(50)
@@ -972,7 +972,10 @@ mod tests {
             props.encoding(&ColumnPath::from("a")),
             Some(Encoding::DELTA_BINARY_PACKED)
         );
-        assert_eq!(props.compression(&ColumnPath::from("a")), Compression::GZIP);
+        assert_eq!(
+            props.compression(&ColumnPath::from("a")),
+            Compression::GZIP(Default::default())
+        );
         assert!(!props.dictionary_enabled(&ColumnPath::from("a")));
         assert_eq!(
             props.statistics_enabled(&ColumnPath::from("a")),
@@ -1004,7 +1007,7 @@ mod tests {
     fn test_writer_properties_builder_partial_defaults() {
         let props = WriterProperties::builder()
             .set_encoding(Encoding::DELTA_BINARY_PACKED)
-            .set_compression(Compression::GZIP)
+            .set_compression(Compression::GZIP(Default::default()))
             .set_bloom_filter_enabled(true)
             .set_column_encoding(ColumnPath::from("col"), Encoding::RLE)
             .build();
@@ -1015,7 +1018,7 @@ mod tests {
         );
         assert_eq!(
             props.compression(&ColumnPath::from("col")),
-            Compression::GZIP
+            Compression::GZIP(Default::default())
         );
         assert_eq!(
             props.dictionary_enabled(&ColumnPath::from("col")),


### PR DESCRIPTION
This code has been almost completely copied from `parquet2`.

# Which issue does this PR close?

Closes #3844.

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

The compression enum got variants.

# Other ways I have thought of

Another way to make this non breaking would be, to include another enum `CompressionOptions` that has all the codes with their supported arguments, which can be set with the `WriterPropertiesBuilder`.