### PR TITLE
Faster time parsing (~93% faster)

### DIFF
--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -63,3 +63,7 @@ half = { version = "2.1", default-features = false }
 [[bench]]
 name = "parse_timestamp"
 harness = false
+
+[[bench]]
+name = "parse_time"
+harness = false

--- a/arrow-cast/benches/parse_time.rs
+++ b/arrow-cast/benches/parse_time.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_cast::parse::{string_to_time_nanoseconds, string_to_timestamp_nanos};
+use arrow_cast::parse::string_to_time_nanoseconds;
 use criterion::*;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/arrow-cast/benches/parse_time.rs
+++ b/arrow-cast/benches/parse_time.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_cast::parse::{string_to_time_nanoseconds, string_to_timestamp_nanos};
+use criterion::*;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let timestamps = [
+        "9:50",
+        "09:50",
+        "09:50 PM",
+        "9:50:12 AM",
+        "09:50:12 PM",
+        "09:50:12.123456789",
+        "9:50:12.123456789",
+        "09:50:12.123456789 PM",
+    ];
+
+    for timestamp in timestamps {
+        let t = black_box(timestamp);
+        c.bench_function(t, |b| {
+            b.iter(|| string_to_time_nanoseconds(t).unwrap());
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -1417,6 +1417,38 @@ mod tests {
     }
 
     #[test]
+    fn test_string_to_time_invalid() {
+        let cases = [
+            "25:00",
+            "9:00:",
+            "009:00",
+            "09:0:00",
+            "25:00:00",
+            "13:00 AM",
+            "13:00 PM",
+            "12:00. AM",
+        ];
+        for case in cases {
+            assert!(string_to_time(case).is_none(), "{case}");
+        }
+    }
+
+    #[test]
+    fn test_string_to_time_chrono() {
+        let cases = [
+            ("09:0:00", "%H:%M:%S%.f"),
+            ("09:01:0", "%H:%M:%S%.f"),
+            ("9:1:0", "%H:%M:%S%.f"),
+            ("09:01:1", "%H:%M:%S%.f")
+        ];
+        for (s, format) in cases {
+            let chrono = NaiveTime::parse_from_str(s, format).ok();
+            let custom = string_to_time(s);
+            assert_eq!(chrono, custom);
+        }
+    }
+
+    #[test]
     fn test_parse_interval() {
         assert_eq!(
             (1i32, 0i32, 0i64),

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -305,10 +305,12 @@ fn string_to_time(s: &str) -> Option<NaiveTime> {
     }
 
     let (am, bytes) = match bytes.get(bytes.len() - 3..) {
-        Some(b" AM") => (Some(true), &bytes[..bytes.len() - 3]),
-        Some(b" am") => (Some(true), &bytes[..bytes.len() - 3]),
-        Some(b" PM") => (Some(false), &bytes[..bytes.len() - 3]),
-        Some(b" pm") => (Some(false), &bytes[..bytes.len() - 3]),
+        Some(b" AM" | b" am" | b" Am" | b" aM") => {
+            (Some(true), &bytes[..bytes.len() - 3])
+        }
+        Some(b" PM" | b" pm" | b" pM" | b" Pm") => {
+            (Some(false), &bytes[..bytes.len() - 3])
+        }
         _ => (None, bytes),
     };
 
@@ -1447,6 +1449,10 @@ mod tests {
             "09:01:0",
             "1:00.123",
             "1:00:00.123f",
+            " 9:00:00",
+            ":09:00",
+            "T9:00:00",
+            "AM",
         ];
         for case in cases {
             assert!(string_to_time(case).is_none(), "{case}");
@@ -1474,14 +1480,22 @@ mod tests {
             ("1:00 PM", "%I:%M %P"),
             ("12:00 PM", "%I:%M %P"),
             ("13:00 PM", "%I:%M %P"),
+            ("1:00 pM", "%I:%M %P"),
+            ("1:00 Pm", "%I:%M %P"),
+            ("1:00 aM", "%I:%M %P"),
+            ("1:00 Am", "%I:%M %P"),
             ("1:00:30.123456 PM", "%I:%M:%S%.f %P"),
             ("1:00:30.123456789 PM", "%I:%M:%S%.f %P"),
             ("1:00:30.123456789123 PM", "%I:%M:%S%.f %P"),
+            ("1:00:30.1234 PM", "%I:%M:%S%.f %P"),
+            ("1:00:30.123456 PM", "%I:%M:%S%.f %P"),
+            ("1:00:30.123456789123456789 PM", "%I:%M:%S%.f %P"),
+            ("1:00:30.12F456 PM", "%I:%M:%S%.f %P"),
         ];
         for (s, format) in cases {
             let chrono = NaiveTime::parse_from_str(s, format).ok();
             let custom = string_to_time(s);
-            assert_eq!(chrono, custom);
+            assert_eq!(chrono, custom, "{s}");
         }
     }
 

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -356,7 +356,7 @@ fn string_to_time(s: &str) -> Option<NaiveTime> {
     }
 
     // Strip decimal if any
-    let nanoseconds = match bytes.get(0) {
+    let nanoseconds = match bytes.first() {
         Some(b'.') => {
             let decimal = &bytes[1..];
             if decimal.iter().any(|x| !x.is_ascii_digit()) {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Faster time parsing

```
9:50                    time:   [5.1079 ns 5.1315 ns 5.1503 ns]
                        change: [-92.180% -92.146% -92.111%] (p = 0.00 < 0.05)
                        Performance has improved.

09:50                   time:   [5.1957 ns 5.2014 ns 5.2086 ns]
                        change: [-92.186% -92.139% -92.077%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  16 (16.00%) high severe

09:50 PM                time:   [6.0355 ns 6.0371 ns 6.0387 ns]
                        change: [-93.754% -93.746% -93.739%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

9:50:12 AM              time:   [6.0481 ns 6.0591 ns 6.0733 ns]
                        change: [-95.110% -95.105% -95.098%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

09:50:12 PM             time:   [6.4839 ns 6.4934 ns 6.5036 ns]
                        change: [-94.865% -94.853% -94.838%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

09:50:12.123456789      time:   [10.475 ns 10.503 ns 10.526 ns]
                        change: [-92.510% -92.485% -92.459%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 27 outliers among 100 measurements (27.00%)
  23 (23.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

9:50:12.123456789       time:   [9.9941 ns 10.036 ns 10.082 ns]
                        change: [-92.728% -92.701% -92.673%] (p = 0.00 < 0.05)
                        Performance has improved.

09:50:12.123456789 PM   time:   [11.016 ns 11.037 ns 11.060 ns]
                        change: [-93.423% -93.410% -93.396%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
