### PR TITLE
Supporting metadata fetch without open file read mode

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 
-[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+[target.'cfg(target_family="unix")'.dev-dependencies]
 nix = "0.26.1"
 
 [features]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -62,6 +62,9 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+nix = "0.26.1"
+
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1468,7 +1468,8 @@ mod unix_test {
         let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
         unistd::mkfifo(&root.path().join(filename), stat::Mode::S_IRWXU).unwrap();
         let location = Path::from(filename);
-        if (timeout(Duration::from_millis(10), integration.head(&location)).await).is_err()
+        if (timeout(Duration::from_millis(10), integration.head(&location)).await)
+            .is_err()
         {
             panic!("Did not receive value within 10 ms");
         }

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1450,7 +1450,7 @@ mod not_wasm_tests {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family="unix")]
 #[cfg(test)]
 mod unix_test {
     use crate::local::LocalFileSystem;

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1450,7 +1450,7 @@ mod not_wasm_tests {
     }
 }
 
-#[cfg(target_family="unix")]
+#[cfg(target_family = "unix")]
 #[cfg(test)]
 mod unix_test {
     use crate::local::LocalFileSystem;

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1468,8 +1468,7 @@ mod unix_test {
         let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
         unistd::mkfifo(&root.path().join(filename), stat::Mode::S_IRWXU).unwrap();
         let location = Path::from(filename);
-        if let Err(_) =
-            timeout(Duration::from_millis(10), integration.head(&location)).await
+        if (timeout(Duration::from_millis(10), integration.head(&location)).await).is_err()
         {
             panic!("Did not receive value within 10 ms");
         }


### PR DESCRIPTION
# Which issue does this PR close?

Did not open an issue since it is a basic enhancement.

# Rationale for this change
 
It is possible to retrieve metadata without opening the file, which means that FIFO files can also be supported without any additional effort.

# What changes are included in this PR?

`std::file::metadata()` converted into `std::fs::metadata(file_path)`. A test is added for a dummy FIFO file since opening a FIFO file is blocking.

# Are there any user-facing changes?

No
