### PR TITLE
Rework Strongly Typed ArrayData Abstractions

### DIFF
--- a/arrow-data/src/data/boolean.rs
+++ b/arrow-data/src/data/boolean.rs
@@ -112,6 +112,7 @@ impl BooleanArrayData {
 
 impl From<ArrayData> for BooleanArrayData {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(PhysicalType::from(&data.data_type), PhysicalType::Boolean);
         let values = data.buffers.into_iter().next().unwrap();
         let values = BooleanBuffer::new(values, data.offset, data.len);
         Self {

--- a/arrow-data/src/data/buffers.rs
+++ b/arrow-data/src/data/buffers.rs
@@ -33,16 +33,6 @@ impl<'a> Buffers<'a> {
         }
     }
 
-    #[inline]
-    pub(crate) fn one(b: &'a Buffer) -> Self {
-        Self([Some(b), None])
-    }
-
-    #[inline]
-    pub(crate) fn two(a: &'a Buffer, b: &'a Buffer) -> Self {
-        Self([Some(a), Some(b)])
-    }
-
     /// Returns the number of [`Buffer`] in this collection
     #[inline]
     pub fn len(&self) -> usize {

--- a/arrow-data/src/data/bytes.rs
+++ b/arrow-data/src/data/bytes.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::data::types::{BytesType, OffsetType};
+use crate::data::types::{BytesType, OffsetType, PhysicalType};
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_buffer::{ArrowNativeType, Buffer};
@@ -178,6 +178,10 @@ impl<O: BytesOffset, B: Bytes + ?Sized> BytesArrayData<O, B> {
 
 impl<O: BytesOffset, B: Bytes + ?Sized> From<ArrayData> for BytesArrayData<O, B> {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data.data_type),
+            PhysicalType::Bytes(O::TYPE, B::TYPE)
+        );
         let mut iter = data.buffers.into_iter();
         let offsets = iter.next().unwrap();
         let values = iter.next().unwrap();

--- a/arrow-data/src/data/dictionary.rs
+++ b/arrow-data/src/data/dictionary.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::data::types::DictionaryKeyType;
+use crate::data::types::{DictionaryKeyType, PhysicalType};
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{NullBuffer, ScalarBuffer};
 use arrow_buffer::ArrowNativeType;
@@ -136,6 +136,10 @@ impl<K: DictionaryKey> DictionaryArrayData<K> {
 
 impl<K: DictionaryKey> From<ArrayData> for DictionaryArrayData<K> {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data.data_type),
+            PhysicalType::Dictionary(K::TYPE)
+        );
         let keys = data.buffers.into_iter().next().unwrap();
         let keys = ScalarBuffer::new(keys, data.offset, data.len);
         let values = data.child_data.into_iter().next().unwrap();

--- a/arrow-data/src/data/list.rs
+++ b/arrow-data/src/data/list.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::data::types::OffsetType;
+use crate::data::types::{OffsetType, PhysicalType};
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_buffer::ArrowNativeType;
@@ -129,6 +129,10 @@ impl<O: ListOffset> ListArrayData<O> {
 
 impl<O: ListOffset> From<ArrayData> for ListArrayData<O> {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data.data_type),
+            PhysicalType::List(O::TYPE)
+        );
         let offsets = data.buffers.into_iter().next().unwrap();
         let values = data.child_data.into_iter().next().unwrap();
 

--- a/arrow-data/src/data/null.rs
+++ b/arrow-data/src/data/null.rs
@@ -79,10 +79,11 @@ impl NullArrayData {
 }
 
 impl From<ArrayData> for NullArrayData {
-    fn from(value: ArrayData) -> Self {
+    fn from(data: ArrayData) -> Self {
+        assert_eq!(PhysicalType::from(&data.data_type), PhysicalType::Null);
         Self {
-            data_type: value.data_type,
-            len: value.len + value.offset,
+            data_type: data.data_type,
+            len: data.len + data.offset,
         }
     }
 }

--- a/arrow-data/src/data/null.rs
+++ b/arrow-data/src/data/null.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use crate::data::types::PhysicalType;
-use crate::data::ArrayDataLayout;
-use crate::{ArrayDataBuilder, Buffers};
+use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_schema::DataType;
 
 /// ArrayData for [null arrays](https://arrow.apache.org/docs/format/Columnar.html#null-layout)
@@ -51,18 +50,6 @@ impl NullArrayData {
         Self { data_type, len }
     }
 
-    /// Creates a new [`NullArrayData`] from raw buffers
-    ///
-    /// # Safety
-    ///
-    /// See [`NullArrayData::new_unchecked`]
-    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
-        Self {
-            data_type: builder.data_type,
-            len: builder.len,
-        }
-    }
-
     /// Returns the data type of this array
     #[inline]
     pub fn data_type(&self) -> &DataType {
@@ -89,16 +76,26 @@ impl NullArrayData {
             len,
         }
     }
+}
 
-    /// Returns an [`ArrayDataLayout`] representation of this
-    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
-        ArrayDataLayout {
-            data_type: &self.data_type,
-            len: self.len,
+impl From<ArrayData> for NullArrayData {
+    fn from(value: ArrayData) -> Self {
+        Self {
+            data_type: value.data_type,
+            len: value.len + value.offset,
+        }
+    }
+}
+
+impl From<NullArrayData> for ArrayData {
+    fn from(value: NullArrayData) -> Self {
+        Self {
+            data_type: value.data_type,
+            len: value.len,
             offset: 0,
+            buffers: vec![],
+            child_data: vec![],
             nulls: None,
-            buffers: Buffers::default(),
-            child_data: &[],
         }
     }
 }

--- a/arrow-data/src/data/primitive.rs
+++ b/arrow-data/src/data/primitive.rs
@@ -144,6 +144,11 @@ impl<T: Primitive> PrimitiveArrayData<T> {
 
 impl<T: Primitive> From<ArrayData> for PrimitiveArrayData<T> {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data.data_type),
+            PhysicalType::Primitive(T::TYPE)
+        );
+
         let values = data.buffers.into_iter().next().unwrap();
         let values = ScalarBuffer::new(values, data.offset, data.len);
         Self {

--- a/arrow-data/src/data/primitive.rs
+++ b/arrow-data/src/data/primitive.rs
@@ -16,57 +16,18 @@
 // under the License.
 
 use crate::data::types::{PhysicalType, PrimitiveType};
-use crate::data::ArrayDataLayout;
-use crate::{ArrayDataBuilder, Buffers};
+use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{NullBuffer, ScalarBuffer};
 use arrow_buffer::{i256, ArrowNativeType};
 use arrow_schema::DataType;
 use half::f16;
 
 mod private {
-    use super::*;
-
-    pub trait PrimitiveSealed {
-        /// Downcast [`ArrayDataPrimitive`] to `[PrimitiveArrayData`]
-        fn downcast_ref(data: &ArrayDataPrimitive) -> Option<&PrimitiveArrayData<Self>>
-        where
-            Self: Primitive;
-
-        /// Downcast [`ArrayDataPrimitive`] to `[PrimitiveArrayData`]
-        fn downcast(data: ArrayDataPrimitive) -> Option<PrimitiveArrayData<Self>>
-        where
-            Self: Primitive;
-
-        /// Cast [`ArrayDataPrimitive`] to [`ArrayDataPrimitive`]
-        fn upcast(v: PrimitiveArrayData<Self>) -> ArrayDataPrimitive
-        where
-            Self: Primitive;
-    }
+    pub trait PrimitiveSealed {}
 }
 
 pub trait Primitive: private::PrimitiveSealed + ArrowNativeType {
     const TYPE: PrimitiveType;
-}
-
-/// Applies op to each variant of [`ArrayDataPrimitive`]
-macro_rules! primitive_op {
-    ($array:ident, $op:block) => {
-        match $array {
-            ArrayDataPrimitive::Int8($array) => $op
-            ArrayDataPrimitive::Int16($array) => $op
-            ArrayDataPrimitive::Int32($array) => $op
-            ArrayDataPrimitive::Int64($array) => $op
-            ArrayDataPrimitive::Int128($array) => $op
-            ArrayDataPrimitive::Int256($array) => $op
-            ArrayDataPrimitive::UInt8($array) => $op
-            ArrayDataPrimitive::UInt16($array) => $op
-            ArrayDataPrimitive::UInt32($array) => $op
-            ArrayDataPrimitive::UInt64($array) => $op
-            ArrayDataPrimitive::Float16($array) => $op
-            ArrayDataPrimitive::Float32($array) => $op
-            ArrayDataPrimitive::Float64($array) => $op
-        }
-    };
 }
 
 macro_rules! primitive {
@@ -74,27 +35,7 @@ macro_rules! primitive {
         impl Primitive for $t {
             const TYPE: PrimitiveType = PrimitiveType::$v;
         }
-        impl private::PrimitiveSealed for $t {
-            fn downcast_ref(
-                data: &ArrayDataPrimitive,
-            ) -> Option<&PrimitiveArrayData<Self>> {
-                match data {
-                    ArrayDataPrimitive::$v(v) => Some(v),
-                    _ => None,
-                }
-            }
-
-            fn downcast(data: ArrayDataPrimitive) -> Option<PrimitiveArrayData<Self>> {
-                match data {
-                    ArrayDataPrimitive::$v(v) => Some(v),
-                    _ => None,
-                }
-            }
-
-            fn upcast(v: PrimitiveArrayData<Self>) -> ArrayDataPrimitive {
-                ArrayDataPrimitive::$v(v)
-            }
-        }
+        impl private::PrimitiveSealed for $t {}
     };
 }
 
@@ -111,81 +52,6 @@ primitive!(u64, UInt64);
 primitive!(f16, Float16);
 primitive!(f32, Float32);
 primitive!(f64, Float64);
-
-/// An enumeration of the types of [`PrimitiveArrayData`]
-#[derive(Debug, Clone)]
-pub enum ArrayDataPrimitive {
-    Int8(PrimitiveArrayData<i8>),
-    Int16(PrimitiveArrayData<i16>),
-    Int32(PrimitiveArrayData<i32>),
-    Int64(PrimitiveArrayData<i64>),
-    Int128(PrimitiveArrayData<i128>),
-    Int256(PrimitiveArrayData<i256>),
-    UInt8(PrimitiveArrayData<u8>),
-    UInt16(PrimitiveArrayData<u16>),
-    UInt32(PrimitiveArrayData<u32>),
-    UInt64(PrimitiveArrayData<u64>),
-    Float16(PrimitiveArrayData<f16>),
-    Float32(PrimitiveArrayData<f32>),
-    Float64(PrimitiveArrayData<f64>),
-}
-
-impl ArrayDataPrimitive {
-    /// Downcast this [`ArrayDataPrimitive`] to the corresponding [`PrimitiveArrayData`]
-    pub fn downcast_ref<P: Primitive>(&self) -> Option<&PrimitiveArrayData<P>> {
-        P::downcast_ref(self)
-    }
-
-    /// Downcast this [`ArrayDataPrimitive`] to the corresponding [`PrimitiveArrayData`]
-    pub fn downcast<P: Primitive>(self) -> Option<PrimitiveArrayData<P>> {
-        P::downcast(self)
-    }
-
-    /// Returns a zero-copy slice of this array
-    pub fn slice(&self, offset: usize, len: usize) -> Self {
-        let s = self;
-        primitive_op!(s, { s.slice(offset, len).into() })
-    }
-
-    /// Returns an [`ArrayDataLayout`] representation of this
-    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
-        let s = self;
-        primitive_op!(s, { s.layout() })
-    }
-
-    /// Creates a new [`ArrayDataPrimitive`] from raw buffers
-    ///
-    /// # Safety
-    ///
-    /// See [`PrimitiveArrayData::new_unchecked`]
-    pub(crate) unsafe fn from_raw(
-        builder: ArrayDataBuilder,
-        primitive: PrimitiveType,
-    ) -> Self {
-        use PrimitiveType::*;
-        match primitive {
-            Int8 => Self::Int8(PrimitiveArrayData::from_raw(builder)),
-            Int16 => Self::Int16(PrimitiveArrayData::from_raw(builder)),
-            Int32 => Self::Int32(PrimitiveArrayData::from_raw(builder)),
-            Int64 => Self::Int64(PrimitiveArrayData::from_raw(builder)),
-            Int128 => Self::Int128(PrimitiveArrayData::from_raw(builder)),
-            Int256 => Self::Int256(PrimitiveArrayData::from_raw(builder)),
-            UInt8 => Self::UInt8(PrimitiveArrayData::from_raw(builder)),
-            UInt16 => Self::UInt16(PrimitiveArrayData::from_raw(builder)),
-            UInt32 => Self::UInt32(PrimitiveArrayData::from_raw(builder)),
-            UInt64 => Self::UInt64(PrimitiveArrayData::from_raw(builder)),
-            Float16 => Self::Float16(PrimitiveArrayData::from_raw(builder)),
-            Float32 => Self::Float32(PrimitiveArrayData::from_raw(builder)),
-            Float64 => Self::Float64(PrimitiveArrayData::from_raw(builder)),
-        }
-    }
-}
-
-impl<P: Primitive> From<PrimitiveArrayData<P>> for ArrayDataPrimitive {
-    fn from(value: PrimitiveArrayData<P>) -> Self {
-        P::upcast(value)
-    }
-}
 
 /// ArrayData for [fixed size arrays](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout) of [`Primitive`]
 #[derive(Debug, Clone)]
@@ -243,21 +109,6 @@ impl<T: Primitive> PrimitiveArrayData<T> {
         }
     }
 
-    /// Creates a new [`PrimitiveArrayData`] from an [`ArrayDataBuilder`]
-    ///
-    /// # Safety
-    ///
-    /// See [`PrimitiveArrayData::new_unchecked`]
-    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
-        let values = builder.buffers.into_iter().next().unwrap();
-        let values = ScalarBuffer::new(values, builder.offset, builder.len);
-        Self {
-            values,
-            data_type: builder.data_type,
-            nulls: builder.nulls,
-        }
-    }
-
     /// Returns the null buffer if any
     #[inline]
     pub fn nulls(&self) -> Option<&NullBuffer> {
@@ -289,16 +140,29 @@ impl<T: Primitive> PrimitiveArrayData<T> {
             nulls: self.nulls.as_ref().map(|x| x.slice(offset, len)),
         }
     }
+}
 
-    /// Returns an [`ArrayDataLayout`] representation of this
-    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
-        ArrayDataLayout {
-            data_type: &self.data_type,
-            len: self.values.len(),
+impl<T: Primitive> From<ArrayData> for PrimitiveArrayData<T> {
+    fn from(data: ArrayData) -> Self {
+        let values = data.buffers.into_iter().next().unwrap();
+        let values = ScalarBuffer::new(values, data.offset, data.len);
+        Self {
+            values,
+            data_type: data.data_type,
+            nulls: data.nulls,
+        }
+    }
+}
+
+impl<T: Primitive> From<PrimitiveArrayData<T>> for ArrayData {
+    fn from(value: PrimitiveArrayData<T>) -> Self {
+        Self {
+            data_type: value.data_type,
+            len: value.values.len(),
             offset: 0,
-            nulls: self.nulls.as_ref(),
-            buffers: Buffers::one(self.values.inner()),
-            child_data: &[],
+            buffers: vec![value.values.into_inner()],
+            child_data: vec![],
+            nulls: value.nulls,
         }
     }
 }

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::data::primitive::{Primitive, PrimitiveArrayData};
-use crate::data::types::RunEndType;
+use crate::data::types::{PhysicalType, RunEndType};
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{RunEndBuffer, ScalarBuffer};
 use arrow_buffer::ArrowNativeType;
@@ -83,12 +83,6 @@ impl<E: RunEnd> RunArrayData<E> {
         self.run_ends.len()
     }
 
-    /// Returns the offset
-    #[inline]
-    pub fn offset(&self) -> usize {
-        self.run_ends.offset()
-    }
-
     /// Returns true if this array is empty
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -130,6 +124,10 @@ impl<E: RunEnd> RunArrayData<E> {
 
 impl<E: RunEnd> From<ArrayData> for RunArrayData<E> {
     fn from(data: ArrayData) -> Self {
+        assert_eq!(
+            PhysicalType::from(&data.data_type),
+            PhysicalType::Run(E::TYPE)
+        );
         let mut iter = data.child_data.into_iter();
         let child1 = iter.next().unwrap();
         let child2 = iter.next().unwrap();

--- a/arrow-data/src/data/run.rs
+++ b/arrow-data/src/data/run.rs
@@ -17,7 +17,6 @@
 
 use crate::data::primitive::{Primitive, PrimitiveArrayData};
 use crate::data::types::RunEndType;
-use crate::data::ArrayDataLayout;
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::{RunEndBuffer, ScalarBuffer};
 use arrow_buffer::ArrowNativeType;
@@ -28,25 +27,10 @@ mod private {
 
     pub trait RunEndSealed {
         const ENDS_TYPE: DataType;
-
-        /// Downcast [`ArrayDataRun`] to `[RunArrayData`]
-        fn downcast_ref(data: &ArrayDataRun) -> Option<&RunArrayData<Self>>
-        where
-            Self: RunEnd;
-
-        /// Downcast [`ArrayDataRun`] to `[RunArrayData`]
-        fn downcast(data: ArrayDataRun) -> Option<RunArrayData<Self>>
-        where
-            Self: RunEnd;
-
-        /// Cast [`RunArrayData`] to [`ArrayDataRun`]
-        fn upcast(v: RunArrayData<Self>) -> ArrayDataRun
-        where
-            Self: RunEnd;
     }
 }
 
-pub trait RunEnd: private::RunEndSealed + ArrowNativeType + Primitive {
+pub trait RunEnd: private::RunEndSealed + ArrowNativeType {
     const TYPE: RunEndType;
 }
 
@@ -57,24 +41,6 @@ macro_rules! run_end {
         }
         impl private::RunEndSealed for $t {
             const ENDS_TYPE: DataType = DataType::$v;
-
-            fn downcast_ref(data: &ArrayDataRun) -> Option<&RunArrayData<Self>> {
-                match data {
-                    ArrayDataRun::$v(v) => Some(v),
-                    _ => None,
-                }
-            }
-
-            fn downcast(data: ArrayDataRun) -> Option<RunArrayData<Self>> {
-                match data {
-                    ArrayDataRun::$v(v) => Some(v),
-                    _ => None,
-                }
-            }
-
-            fn upcast(v: RunArrayData<Self>) -> ArrayDataRun {
-                ArrayDataRun::$v(v)
-            }
         }
     };
 }
@@ -83,87 +49,12 @@ run_end!(i16, Int16);
 run_end!(i32, Int32);
 run_end!(i64, Int64);
 
-/// Applies op to each variant of [`ArrayDataRun`]
-macro_rules! run_op {
-    ($array:ident, $op:block) => {
-        match $array {
-            ArrayDataRun::Int16($array) => $op
-            ArrayDataRun::Int32($array) => $op
-            ArrayDataRun::Int64($array) => $op
-        }
-    };
-}
-
-/// An enumeration of the types of [`RunArrayData`]
-#[derive(Debug, Clone)]
-pub enum ArrayDataRun {
-    Int16(RunArrayData<i16>),
-    Int32(RunArrayData<i32>),
-    Int64(RunArrayData<i64>),
-}
-
-impl ArrayDataRun {
-    /// Downcast this [`ArrayDataRun`] to the corresponding [`RunArrayData`]
-    pub fn downcast_ref<E: RunEnd>(&self) -> Option<&RunArrayData<E>> {
-        <E as private::RunEndSealed>::downcast_ref(self)
-    }
-
-    /// Downcast this [`ArrayDataRun`] to the corresponding [`RunArrayData`]
-    pub fn downcast<E: RunEnd>(self) -> Option<RunArrayData<E>> {
-        <E as private::RunEndSealed>::downcast(self)
-    }
-
-    /// Returns the values of this [`ArrayDataRun`]
-    #[inline]
-    pub fn values(&self) -> &ArrayData {
-        let s = self;
-        run_op!(s, { s.values() })
-    }
-
-    /// Returns a zero-copy slice of this array
-    pub fn slice(&self, offset: usize, len: usize) -> Self {
-        let s = self;
-        run_op!(s, { s.slice(offset, len).into() })
-    }
-
-    /// Returns an [`ArrayDataLayout`] representation of this
-    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
-        let s = self;
-        run_op!(s, { s.layout() })
-    }
-
-    /// Creates a new [`ArrayDataRun`] from raw buffers
-    ///
-    /// # Safety
-    ///
-    /// See [`RunArrayData::new_unchecked`]
-    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder, run: RunEndType) -> Self {
-        use RunEndType::*;
-        match run {
-            Int16 => Self::Int16(RunArrayData::from_raw(builder)),
-            Int32 => Self::Int32(RunArrayData::from_raw(builder)),
-            Int64 => Self::Int64(RunArrayData::from_raw(builder)),
-        }
-    }
-}
-
-impl<E: RunEnd> From<RunArrayData<E>> for ArrayDataRun {
-    fn from(value: RunArrayData<E>) -> Self {
-        <E as private::RunEndSealed>::upcast(value)
-    }
-}
-
 /// ArrayData for [run-end encoded arrays](https://arrow.apache.org/docs/format/Columnar.html#run-end-encoded-layout)
 #[derive(Debug, Clone)]
 pub struct RunArrayData<E: RunEnd> {
     data_type: DataType,
     run_ends: RunEndBuffer<E>,
-    /// The children of this RunArrayData:
-    /// 1: the run ends
-    /// 2: the values
-    ///
-    /// We store an array so that a slice can be returned in [`RunArrayData::layout`]
-    children: Box<[ArrayData; 2]>,
+    values: ArrayData,
 }
 
 impl<E: RunEnd> RunArrayData<E> {
@@ -179,36 +70,10 @@ impl<E: RunEnd> RunArrayData<E> {
         run_ends: RunEndBuffer<E>,
         values: ArrayData,
     ) -> Self {
-        let inner = run_ends.inner();
-        let child = ArrayDataBuilder::new(E::ENDS_TYPE)
-            .len(inner.len())
-            .buffers(vec![inner.inner().clone()])
-            .build_unchecked();
-
         Self {
             data_type,
             run_ends,
-            children: Box::new([child, values]),
-        }
-    }
-
-    /// Creates a new [`RunArrayData`] from raw buffers
-    ///
-    /// # Safety
-    ///
-    /// See [`RunArrayData::new_unchecked`]
-    pub(crate) unsafe fn from_raw(builder: ArrayDataBuilder) -> Self {
-        let mut iter = builder.child_data.into_iter();
-        let child1 = iter.next().unwrap();
-        let child2 = iter.next().unwrap();
-
-        let p = ScalarBuffer::new(child1.buffers[0].clone(), child1.offset, child1.len);
-        let run_ends = RunEndBuffer::new_unchecked(p, builder.offset, builder.len);
-
-        Self {
-            run_ends,
-            data_type: builder.data_type,
-            children: Box::new([child1, child2]),
+            values,
         }
     }
 
@@ -245,13 +110,12 @@ impl<E: RunEnd> RunArrayData<E> {
     /// Returns the child data
     #[inline]
     pub fn values(&self) -> &ArrayData {
-        &self.children[1]
+        &self.values
     }
 
     /// Returns the underlying parts of this [`RunArrayData`]
     pub fn into_parts(self) -> (DataType, RunEndBuffer<E>, ArrayData) {
-        let child = self.children.into_iter().nth(1).unwrap();
-        (self.data_type, self.run_ends, child)
+        (self.data_type, self.run_ends, self.values)
     }
 
     /// Returns a zero-copy slice of this array
@@ -259,19 +123,54 @@ impl<E: RunEnd> RunArrayData<E> {
         Self {
             data_type: self.data_type.clone(),
             run_ends: self.run_ends.slice(offset, len),
-            children: self.children.clone(),
+            values: self.values.clone(),
         }
     }
+}
 
-    /// Returns an [`ArrayDataLayout`] representation of this
-    pub(crate) fn layout(&self) -> ArrayDataLayout<'_> {
-        ArrayDataLayout {
-            data_type: &self.data_type,
-            len: self.run_ends.len(),
-            offset: self.run_ends.offset(),
+impl<E: RunEnd> From<ArrayData> for RunArrayData<E> {
+    fn from(data: ArrayData) -> Self {
+        let mut iter = data.child_data.into_iter();
+        let child1 = iter.next().unwrap();
+        let child2 = iter.next().unwrap();
+
+        let run_ends = child1.buffers.into_iter().next().unwrap();
+        let run_ends = ScalarBuffer::new(run_ends, child1.offset, child1.len);
+        // Safety:
+        // ArrayData must be valid
+        let run_ends =
+            unsafe { RunEndBuffer::new_unchecked(run_ends, data.offset, data.len) };
+
+        Self {
+            run_ends,
+            values: child2,
+            data_type: data.data_type,
+        }
+    }
+}
+
+impl<E: RunEnd> From<RunArrayData<E>> for ArrayData {
+    fn from(value: RunArrayData<E>) -> Self {
+        let len = value.run_ends.len();
+        let offset = value.run_ends.offset();
+        let inner = value.run_ends.into_inner();
+
+        // Safety:
+        // Valid by construction
+        let child1 = unsafe {
+            ArrayDataBuilder::new(E::ENDS_TYPE)
+                .len(inner.len())
+                .buffers(vec![inner.into_inner()])
+                .build_unchecked()
+        };
+
+        Self {
+            data_type: value.data_type,
+            len,
+            offset,
+            buffers: vec![],
+            child_data: vec![child1, value.values],
             nulls: None,
-            buffers: Buffers::default(),
-            child_data: self.children.as_ref(),
         }
     }
 }

--- a/arrow-data/src/data/struct.rs
+++ b/arrow-data/src/data/struct.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::data::types::PhysicalType;
 use crate::{ArrayData, ArrayDataBuilder, Buffers};
 use arrow_buffer::buffer::NullBuffer;
 use arrow_schema::DataType;
@@ -96,18 +97,14 @@ impl StructArrayData {
 }
 
 impl From<ArrayData> for StructArrayData {
-    fn from(data: ArrayData) -> Self {
-        let children = data
-            .child_data
-            .into_iter()
-            .map(|x| x.slice(data.offset, data.len))
-            .collect();
-
+    fn from(mut data: ArrayData) -> Self {
+        assert_eq!(PhysicalType::from(&data.data_type), PhysicalType::Struct);
         Self {
             data_type: data.data_type,
             len: data.len,
             nulls: data.nulls,
-            children,
+            // Don't slice children as assume offset already applied (#1750)
+            children: data.child_data,
         }
     }
 }

--- a/arrow-data/src/data/types.rs
+++ b/arrow-data/src/data/types.rs
@@ -76,12 +76,12 @@ pub enum PhysicalType {
     Null,
     Boolean,
     Primitive(PrimitiveType),
-    FixedSizeBinary(usize),
+    FixedSizeBinary,
     Bytes(OffsetType, BytesType),
-    FixedSizeList(usize),
+    FixedSizeList,
     List(OffsetType),
     Struct,
-    Union(UnionMode),
+    Union,
     Dictionary(DictionaryKeyType),
     Run(RunEndType),
 }
@@ -119,16 +119,16 @@ impl From<&DataType> for PhysicalType {
             DataType::Interval(IntervalUnit::MonthDayNano) => {
                 Self::Primitive(PrimitiveType::Int128)
             }
-            DataType::FixedSizeBinary(size) => Self::FixedSizeBinary(*size as usize),
+            DataType::FixedSizeBinary(_) => Self::FixedSizeBinary,
             DataType::Binary => Self::Bytes(OffsetType::Int32, BytesType::Binary),
             DataType::LargeBinary => Self::Bytes(OffsetType::Int64, BytesType::Binary),
             DataType::Utf8 => Self::Bytes(OffsetType::Int32, BytesType::Utf8),
             DataType::LargeUtf8 => Self::Bytes(OffsetType::Int64, BytesType::Utf8),
             DataType::List(_) => Self::List(OffsetType::Int32),
-            DataType::FixedSizeList(_, size) => Self::FixedSizeList(*size as usize),
+            DataType::FixedSizeList(_, _) => Self::FixedSizeList,
             DataType::LargeList(_) => Self::List(OffsetType::Int64),
             DataType::Struct(_) => Self::Struct,
-            DataType::Union(_, _, mode) => Self::Union(*mode),
+            DataType::Union(_, _, _) => Self::Union,
             DataType::Dictionary(k, _) => match k.as_ref() {
                 DataType::Int8 => Self::Dictionary(DictionaryKeyType::Int8),
                 DataType::Int16 => Self::Dictionary(DictionaryKeyType::Int16),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #1799 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See https://github.com/apache/arrow-rs/issues/1799#issuecomment-1472437840

In particular:

* Moves `from_raw` to `From<ArrayData>`
* Moves `layout` to `From<_> for ArrayData`
* Removes `ArrayDataLayout`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
