### PR TITLE
Added support for byte vectors and slices to parquet_derive (#3864)

### DIFF
--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -199,6 +199,16 @@ impl From<Vec<u8>> for ByteArray {
     }
 }
 
+impl<'a> From<&'a [u8]> for ByteArray {
+    fn from(b: &'a [u8]) -> ByteArray {
+        let mut v = Vec::new();
+        v.extend_from_slice(b);
+        Self {
+            data: Some(ByteBufferPtr::new(v)),
+        }
+    }
+}
+
 impl<'a> From<&'a str> for ByteArray {
     fn from(s: &'a str) -> ByteArray {
         let mut v = Vec::new();

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -42,6 +42,11 @@ struct ACompleteRecord<'a> {
     pub borrowed_maybe_a_string: &'a Option<String>,
     pub borrowed_maybe_a_str: &'a Option<&'a str>,
     pub now: chrono::NaiveDateTime,
+    pub byte_vec: Vec<u8>,
+    pub maybe_byte_vec: Option<Vec<u8>>,
+    pub borrowed_byte_vec: &'a [u8],
+    pub borrowed_maybe_byte_vec: &'a Option<Vec<u8>>,
+    pub borrowed_maybe_borrowed_byte_vec: &'a Option<&'a [u8]>,
 }
 
 #[cfg(test)]
@@ -84,6 +89,11 @@ mod tests {
             OPTIONAL BINARY          borrowed_maybe_a_string (STRING);
             OPTIONAL BINARY          borrowed_maybe_a_str (STRING);
             REQUIRED INT64           now (TIMESTAMP_MILLIS);
+            REQUIRED BINARY          byte_vec;
+            OPTIONAL BINARY          maybe_byte_vec;
+            REQUIRED BINARY          borrowed_byte_vec;
+            OPTIONAL BINARY          borrowed_maybe_byte_vec;
+            OPTIONAL BINARY          borrowed_maybe_borrowed_byte_vec;
         }";
 
         let schema = Arc::new(parse_message_type(schema_str).unwrap());
@@ -92,6 +102,9 @@ mod tests {
         let a_borrowed_string = "cool news".to_owned();
         let maybe_a_string = Some("it's true, I'm a string".to_owned());
         let maybe_a_str = Some(&a_str[..]);
+        let borrowed_byte_vec = vec![0x68, 0x69, 0x70];
+        let borrowed_maybe_byte_vec = Some(vec![0x71, 0x72]);
+        let borrowed_maybe_borrowed_byte_vec = Some(&borrowed_byte_vec[..]);
 
         let drs: Vec<ACompleteRecord> = vec![ACompleteRecord {
             a_bool: true,
@@ -115,6 +128,11 @@ mod tests {
             borrowed_maybe_a_string: &maybe_a_string,
             borrowed_maybe_a_str: &maybe_a_str,
             now: chrono::Utc::now().naive_local(),
+            byte_vec: vec![0x65, 0x66, 0x67],
+            maybe_byte_vec: Some(vec![0x88, 0x89, 0x90]),
+            borrowed_byte_vec: &borrowed_byte_vec,
+            borrowed_maybe_byte_vec: &borrowed_maybe_byte_vec,
+            borrowed_maybe_borrowed_byte_vec: &borrowed_maybe_borrowed_byte_vec,
         }];
 
         let generated_schema = drs.as_slice().schema().unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3864.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`parquet_derive` was missing some code to be able to handle byte vectors and slices in structs. The readme even currently states that `Vec<u8>` is supported even though it doesn't currently work.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This change enables support for `Vec<u8>`, `Option<Vec<u8>>`, `&Option<Vec<u8>>`, `&[u8]`, and `&Option<&[u8]>` in `parquet_derive`. All of these cases have been added to the integration test in `parquet_derive_test`.

This fix required adding a `Slice` variant to the `parquet_derive::parquet_field::Type` enum as well as implementing `From<&[u8]>` for `parquet::data_type::ByteArray`.

# Are there any user-facing changes?

No
