### PR TITLE
Use BooleanBuffer in BooleanArray (#3879)

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -96,9 +96,7 @@ impl BooleanArray {
         BooleanBuilder::with_capacity(capacity)
     }
 
-    /// Returns the underlying [`BooleanBuffer`] holding all the values of this array.
-    ///
-    /// Note this doesn't take the offset of this array into account.
+    /// Returns the underlying [`BooleanBuffer`] holding all the values of this array
     pub fn values(&self) -> &BooleanBuffer {
         &self.values
     }

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -19,7 +19,7 @@ use crate::array::print_long_array;
 use crate::builder::BooleanBuilder;
 use crate::iterator::BooleanIter;
 use crate::{Array, ArrayAccessor, ArrayRef};
-use arrow_buffer::{bit_util, Buffer, MutableBuffer, NullBuffer};
+use arrow_buffer::{bit_util, BooleanBuffer, Buffer, MutableBuffer, NullBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::DataType;
 use std::any::Any;
@@ -67,7 +67,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct BooleanArray {
     data: ArrayData,
-    raw_values: Buffer,
+    values: BooleanBuffer,
 }
 
 impl std::fmt::Debug for BooleanArray {
@@ -96,11 +96,11 @@ impl BooleanArray {
         BooleanBuilder::with_capacity(capacity)
     }
 
-    /// Returns a `Buffer` holding all the values of this array.
+    /// Returns the underlying [`BooleanBuffer`] holding all the values of this array.
     ///
     /// Note this doesn't take the offset of this array into account.
-    pub fn values(&self) -> &Buffer {
-        &self.raw_values
+    pub fn values(&self) -> &BooleanBuffer {
+        &self.values
     }
 
     /// Returns the number of non null, true values within this array
@@ -108,7 +108,7 @@ impl BooleanArray {
         match self.data.nulls() {
             Some(nulls) => {
                 let null_chunks = nulls.inner().bit_chunks();
-                let value_chunks = self.values().bit_chunks(self.offset(), self.len());
+                let value_chunks = self.values().bit_chunks();
                 null_chunks
                     .iter()
                     .zip(value_chunks.iter())
@@ -119,9 +119,7 @@ impl BooleanArray {
                     .map(|(a, b)| (a & b).count_ones() as usize)
                     .sum()
             }
-            None => self
-                .values()
-                .count_set_bits_offset(self.offset(), self.len()),
+            None => self.values().count_set_bits(),
         }
     }
 
@@ -135,8 +133,7 @@ impl BooleanArray {
     /// # Safety
     /// This doesn't check bounds, the caller must ensure that index < self.len()
     pub unsafe fn value_unchecked(&self, i: usize) -> bool {
-        let offset = i + self.offset();
-        bit_util::get_bit_raw(self.raw_values.as_ptr(), offset)
+        self.values.value_unchecked(i)
     }
 
     /// Returns the boolean value at index `i`.
@@ -329,8 +326,10 @@ impl From<ArrayData> for BooleanArray {
             1,
             "BooleanArray data should contain a single buffer only (values buffer)"
         );
-        let raw_values = data.buffers()[0].clone();
-        Self { data, raw_values }
+        let values =
+            BooleanBuffer::new(data.buffers()[0].clone(), data.offset(), data.len());
+
+        Self { data, values }
     }
 }
 
@@ -424,7 +423,7 @@ mod tests {
     fn test_boolean_array_from_vec() {
         let buf = Buffer::from([10_u8]);
         let arr = BooleanArray::from(vec![false, true, false, true]);
-        assert_eq!(&buf, arr.values());
+        assert_eq!(&buf, arr.values().inner());
         assert_eq!(4, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -439,7 +438,7 @@ mod tests {
     fn test_boolean_array_from_vec_option() {
         let buf = Buffer::from([10_u8]);
         let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
-        assert_eq!(&buf, arr.values());
+        assert_eq!(&buf, arr.values().inner());
         assert_eq!(4, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(1, arr.null_count());
@@ -501,7 +500,7 @@ mod tests {
             .build()
             .unwrap();
         let arr = BooleanArray::from(data);
-        assert_eq!(&buf2, arr.values());
+        assert_eq!(&buf2, arr.values().inner());
         assert_eq!(5, arr.len());
         assert_eq!(2, arr.offset());
         assert_eq!(0, arr.null_count());

--- a/arrow-array/src/builder/boolean_builder.rs
+++ b/arrow-array/src/builder/boolean_builder.rs
@@ -240,7 +240,7 @@ mod tests {
         }
 
         let arr = builder.finish();
-        assert_eq!(&buf, arr.values());
+        assert_eq!(&buf, arr.values().inner());
         assert_eq!(10, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -448,7 +448,7 @@ mod tests {
         }
 
         let arr = builder.finish();
-        assert_eq!(&buf, arr.values());
+        assert_eq!(&buf, arr.values().inner());
         assert_eq!(10, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use crate::bit_chunk_iterator::BitChunks;
-use crate::{bit_util, buffer_bin_and, buffer_bin_or, Buffer};
-use std::ops::{BitAnd, BitOr};
+use crate::{bit_util, buffer_bin_and, buffer_bin_or, buffer_unary_not, Buffer};
+use std::ops::{BitAnd, BitOr, Not};
 
 /// A slice-able [`Buffer`] containing bit-packed booleans
 #[derive(Debug, Clone, Eq)]
@@ -77,9 +77,9 @@ impl BooleanBuffer {
     ///
     /// Panics if `i >= self.len()`
     #[inline]
+    #[deprecated(note = "use BooleanBuffer::value")]
     pub fn is_set(&self, i: usize) -> bool {
-        assert!(i < self.len);
-        unsafe { bit_util::get_bit_raw(self.buffer.as_ptr(), i + self.offset) }
+        self.value(i)
     }
 
     /// Returns the offset of this [`BooleanBuffer`] in bits
@@ -98,6 +98,25 @@ impl BooleanBuffer {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
+    }
+
+    /// Returns the boolean value at index `i`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`
+    pub fn value(&self, idx: usize) -> bool {
+        assert!(idx < self.len);
+        unsafe { self.value_unchecked(idx) }
+    }
+
+    /// Returns the boolean value at index `i`.
+    ///
+    /// # Safety
+    /// This doesn't check bounds, the caller must ensure that index < self.len()
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> bool {
+        unsafe { bit_util::get_bit_raw(self.buffer.as_ptr(), i + self.offset) }
     }
 
     /// Returns the packed values of this [`BooleanBuffer`] not including any offset
@@ -144,6 +163,18 @@ impl BooleanBuffer {
     /// Returns the inner [`Buffer`], consuming self
     pub fn into_inner(self) -> Buffer {
         self.buffer
+    }
+}
+
+impl Not for &BooleanBuffer {
+    type Output = BooleanBuffer;
+
+    fn not(self) -> Self::Output {
+        BooleanBuffer {
+            buffer: buffer_unary_not(&self.buffer, self.offset, self.len),
+            offset: 0,
+            len: self.len,
+        }
     }
 }
 

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -94,7 +94,7 @@ impl NullBuffer {
     /// Returns `true` if the value at `idx` is not null
     #[inline]
     pub fn is_valid(&self, idx: usize) -> bool {
-        self.buffer.is_set(idx)
+        self.buffer.value(idx)
     }
 
     /// Returns `true` if the value at `idx` is null

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -26,7 +26,6 @@
 use arrow_array::cast::*;
 use arrow_array::types::*;
 use arrow_array::*;
-use arrow_buffer::buffer::buffer_unary_not;
 use arrow_buffer::{bit_util, Buffer, MutableBuffer};
 use arrow_data::bit_mask::combine_option_bitmap;
 use arrow_data::ArrayData;
@@ -196,23 +195,19 @@ pub fn eq_bool_scalar(
     left: &BooleanArray,
     right: bool,
 ) -> Result<BooleanArray, ArrowError> {
-    let len = left.len();
-    let left_offset = left.offset();
-
-    let values = if right {
-        left.values().bit_slice(left_offset, len)
-    } else {
-        buffer_unary_not(left.values(), left.offset(), left.len())
+    let values = match right {
+        true => left.values().clone(),
+        false => !left.values(),
     };
 
     let data = unsafe {
         ArrayData::new_unchecked(
             DataType::Boolean,
-            len,
+            values.len(),
             None,
             left.nulls().map(|b| b.inner().sliced()),
-            0,
-            vec![values],
+            values.offset(),
+            vec![values.into_inner()],
             vec![],
         )
     };

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -524,7 +524,7 @@ where
     IndexType: ArrowPrimitiveType,
     IndexType::Native: ToPrimitive,
 {
-    let val_buf = take_bits(values.values(), values.offset(), indices)?;
+    let val_buf = take_bits(values.values().inner(), values.offset(), indices)?;
     let null_buf = match values.nulls() {
         Some(nulls) if nulls.null_count() > 0 => {
             Some(take_bits(nulls.buffer(), nulls.offset(), indices)?)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3879

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Continues the process of making arrays wrappers around strongly typed buffer abstractions.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, it changes the return type of `BooleanArray::values`. I opted to just break this API instead of deprecating, as I wanted to keep the name the same, and the method is rarely used in downstreams, DataFusion doesn't call it at all, likely because it is hard to use correctly (something this PR improves).

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
