### PR TITLE
Return ScalarBuffer from PrimitiveArray::values (#3879)

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -277,7 +277,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
     /// Returns a slice of the values of this array
     #[inline]
-    pub fn values(&self) -> &[T::Native] {
+    pub fn values(&self) -> &ScalarBuffer<T::Native> {
         &self.raw_values
     }
 

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -114,6 +114,39 @@ impl<T: ArrowNativeType> From<Vec<T>> for ScalarBuffer<T> {
     }
 }
 
+impl<'a, T: ArrowNativeType> IntoIterator for &'a ScalarBuffer<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_ref().iter()
+    }
+}
+
+impl<T: ArrowNativeType, S: AsRef<[T]> + ?Sized> PartialEq<S> for ScalarBuffer<T> {
+    fn eq(&self, other: &S) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<T: ArrowNativeType, const N: usize> PartialEq<ScalarBuffer<T>> for [T; N] {
+    fn eq(&self, other: &ScalarBuffer<T>) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<T: ArrowNativeType> PartialEq<ScalarBuffer<T>> for [T] {
+    fn eq(&self, other: &ScalarBuffer<T>) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl<T: ArrowNativeType> PartialEq<ScalarBuffer<T>> for Vec<T> {
+    fn eq(&self, other: &ScalarBuffer<T>) -> bool {
+        self.as_slice().eq(other.as_ref())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3879

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Continues the process of making arrays wrappers around strongly typed buffer abstractions, in a similar vein to #3895

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, it changes the return type of PrimitiveArray::values. I opted to just break this API instead of deprecating, as I wanted to keep the name the same. 

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
