### PR TITLE
Fix parsing timestamps of exactly 32 characters

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -206,7 +206,7 @@ pub fn string_to_datetime<T: TimeZone>(
 
     if tz_offset == 32 {
         // Decimal overrun
-        while bytes[tz_offset].is_ascii_digit() && tz_offset < bytes.len() {
+        while tz_offset < bytes.len() && bytes[tz_offset].is_ascii_digit() {
             tz_offset += 1;
         }
     }
@@ -1080,6 +1080,21 @@ mod tests {
 
             let custom = string_to_datetime(&Utc, case).unwrap();
             assert_eq!(chrono_utc, custom)
+        }
+    }
+
+    #[test]
+    fn string_to_timestamp_naive() {
+        let cases = [
+            "2018-11-13T17:11:10.011375885995",
+            "2030-12-04T17:11:10.123",
+            "2030-12-04T17:11:10.1234",
+            "2030-12-04T17:11:10.123456",
+        ];
+        for case in cases {
+            let chrono = NaiveDateTime::parse_from_str(case, "%Y-%m-%dT%H:%M:%S%.f").unwrap();
+            let custom = string_to_datetime(&Utc, case).unwrap();
+            assert_eq!(chrono, custom.naive_utc())
         }
     }
 

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -1092,7 +1092,8 @@ mod tests {
             "2030-12-04T17:11:10.123456",
         ];
         for case in cases {
-            let chrono = NaiveDateTime::parse_from_str(case, "%Y-%m-%dT%H:%M:%S%.f").unwrap();
+            let chrono =
+                NaiveDateTime::parse_from_str(case, "%Y-%m-%dT%H:%M:%S%.f").unwrap();
             let custom = string_to_datetime(&Utc, case).unwrap();
             assert_eq!(chrono, custom.naive_utc())
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

related to #3801  

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Parsing `2018-11-13T17:11:10.011375885995` would panic with an out of range error

Found by https://github.com/apache/arrow-datafusion/pull/5685

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
