### PR TITLE
Re-export parquet compression level structs

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -20,7 +20,7 @@
 
 use std::{fmt, str};
 
-use crate::compression::{BrotliLevel, GzipLevel, ZstdLevel};
+pub use crate::compression::{BrotliLevel, GzipLevel, ZstdLevel};
 use crate::format as parquet;
 
 use crate::errors::{ParquetError, Result};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

These were added by #3847 but in the experimental compression module, this meant that users not enabling experimental features could only set them to `Default::default()`, which is confusing and not easily discoverable. Re-exporting them allows them to be used outside of the crate

FYI @spebern

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
