### PR TITLE
Improve ScalarBuffer debug output

### DIFF
--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -17,6 +17,7 @@
 
 use crate::buffer::Buffer;
 use crate::native::ArrowNativeType;
+use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
@@ -26,11 +27,17 @@ use std::ops::Deref;
 ///
 /// All [`ArrowNativeType`] are valid for all possible backing byte representations, and as
 /// a result they are "trivially safely transmutable".
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ScalarBuffer<T: ArrowNativeType> {
     /// Underlying data buffer
     buffer: Buffer,
     phantom: PhantomData<T>,
+}
+
+impl<T: ArrowNativeType> std::fmt::Debug for ScalarBuffer<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ScalarBuffer").field(&self.as_ref()).finish()
+    }
 }
 
 impl<T: ArrowNativeType> ScalarBuffer<T> {
@@ -166,6 +173,12 @@ mod tests {
 
         let typed = ScalarBuffer::<i32>::new(buffer, 3, 0);
         assert!(typed.is_empty());
+    }
+
+    #[test]
+    fn test_debug() {
+        let buffer = ScalarBuffer::from(vec![1, 2, 3]);
+        assert_eq!(format!("{buffer:?}"), "ScalarBuffer([1, 2, 3])");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Before the output was

```
ScalarBuffer { buffer: Buffer { data: Bytes { ptr: 0x7f96bc000d10, len: 12, data: [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0] }, ptr: 0x7f96bc000d10, length: 12 }, phantom: PhantomData<i32> }
```

After this change it is

```
ScalarBuffer([1, 2, 3])
```

This makes it significantly easier to interpret

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
