### PR TITLE
Cleanup uses of Array::data_ref (#3880)

### DIFF
--- a/arrow-arith/src/arithmetic.rs
+++ b/arrow-arith/src/arithmetic.rs
@@ -103,8 +103,7 @@ fn math_checked_divide_op_on_iters<T, F>(
     left: impl Iterator<Item = Option<T::Native>>,
     right: impl Iterator<Item = Option<T::Native>>,
     op: F,
-    len: usize,
-    null_bit_buffer: Option<arrow_buffer::Buffer>,
+    nulls: Option<NullBuffer>,
 ) -> Result<PrimitiveArray<T>, ArrowError>
 where
     T: ArrowNumericType,
@@ -130,18 +129,7 @@ where
         unsafe { arrow_buffer::Buffer::try_from_trusted_len_iter(values) }
     }?;
 
-    let data = unsafe {
-        arrow_data::ArrayData::new_unchecked(
-            T::DATA_TYPE,
-            len,
-            None,
-            null_bit_buffer,
-            0,
-            vec![buffer],
-            vec![],
-        )
-    };
-    Ok(PrimitiveArray::<T>::from(data))
+    Ok(PrimitiveArray::new(T::DATA_TYPE, buffer.into(), nulls))
 }
 
 /// Calculates the modulus operation `left % right` on two SIMD inputs.
@@ -284,10 +272,7 @@ where
     }
 
     // Create the combined `Bitmap`
-    let null_bit_buffer = arrow_data::bit_mask::combine_option_bitmap(
-        &[left.data_ref(), right.data_ref()],
-        left.len(),
-    );
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
 
     let lanes = T::lanes();
     let buffer_size = left.len() * std::mem::size_of::<T::Native>();
@@ -372,18 +357,7 @@ where
         }
     }
 
-    let data = unsafe {
-        arrow_data::ArrayData::new_unchecked(
-            T::DATA_TYPE,
-            left.len(),
-            None,
-            null_bit_buffer,
-            0,
-            vec![result.into()],
-            vec![],
-        )
-    };
-    Ok(PrimitiveArray::<T>::from(data))
+    Ok(PrimitiveArray::new(T::DATA_TYPE, result.into(), nulls))
 }
 
 /// Applies $OP to $LEFT and $RIGHT which are two dictionaries which have (the same) key type $KT
@@ -628,10 +602,7 @@ where
         )));
     }
 
-    let null_bit_buffer = arrow_data::bit_mask::combine_option_bitmap(
-        &[left.data_ref(), right.data_ref()],
-        left.len(),
-    );
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
 
     // Safety justification: Since the inputs are valid Arrow arrays, all values are
     // valid indexes into the dictionary (which is verified during construction)
@@ -653,13 +624,7 @@ where
             .take_iter_unchecked(right.keys_iter())
     };
 
-    math_checked_divide_op_on_iters(
-        left_iter,
-        right_iter,
-        op,
-        left.len(),
-        null_bit_buffer,
-    )
+    math_checked_divide_op_on_iters(left_iter, right_iter, op, nulls)
 }
 
 #[cfg(feature = "dyn_arith_dict")]

--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -335,7 +335,7 @@ pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
 pub fn is_not_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
     let len = input.len();
 
-    let output = match input.data_ref().nulls() {
+    let output = match input.nulls() {
         None => {
             let len_bytes = ceil(len, 8);
             MutableBuffer::new(len_bytes)

--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -294,7 +294,7 @@ impl<K: ArrowDictionaryKeyType> DictionaryArray<K> {
 
     /// Returns a clone of the value type of this list.
     pub fn value_type(&self) -> DataType {
-        self.values.data_ref().data_type().clone()
+        self.values.data_type().clone()
     }
 
     /// The length of the dictionary is the length of the keys array.

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -425,7 +425,7 @@ impl From<FixedSizeListArray> for FixedSizeBinaryArray {
             .len(v.len())
             .offset(v.offset())
             .add_buffer(child_data.buffers()[0].slice(child_data.offset()))
-            .nulls(v.data_ref().nulls().cloned());
+            .nulls(v.nulls().cloned());
 
         let data = unsafe { builder.build_unchecked() };
         Self::from(data)

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -76,7 +76,7 @@ impl FixedSizeListArray {
 
     /// Returns a clone of the value type of this list.
     pub fn value_type(&self) -> DataType {
-        self.values.data_ref().data_type().clone()
+        self.values.data_type().clone()
     }
 
     /// Returns ith value of this list array.

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -85,7 +85,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
 
     /// Returns a clone of the value type of this list.
     pub fn value_type(&self) -> DataType {
-        self.values.data_ref().data_type().clone()
+        self.values.data_type().clone()
     }
 
     /// Returns ith value of this list array.

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -97,7 +97,7 @@ impl Array for NullArray {
     /// Returns the total number of null values in this array.
     /// The null count of a `NullArray` always equals its length.
     fn null_count(&self) -> usize {
-        self.data_ref().len()
+        self.len()
     }
 }
 

--- a/arrow/benches/mutable_array.rs
+++ b/arrow/benches/mutable_array.rs
@@ -39,7 +39,8 @@ fn create_slices(size: usize) -> Vec<(usize, usize)> {
 }
 
 fn bench<T: Array>(v1: &T, slices: &[(usize, usize)]) {
-    let mut mutable = MutableArrayData::new(vec![v1.data_ref()], false, 5);
+    let data = v1.to_data();
+    let mut mutable = MutableArrayData::new(vec![&data], false, 5);
     for (start, end) in slices {
         mutable.extend(0, *start, *end)
     }

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -856,7 +856,7 @@ fn test_struct_equal_null() {
     )]))
     .null_bit_buffer(Some(Buffer::from(vec![0b00011110])))
     .len(5)
-    .add_child_data(a.data_ref().clone())
+    .add_child_data(a.to_data())
     .build()
     .unwrap();
     let a = make_array(a);
@@ -920,7 +920,7 @@ fn test_struct_equal_null_variable_size() {
     )]))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001010])))
     .len(5)
-    .add_child_data(strings1.data_ref().clone())
+    .add_child_data(strings1.to_data())
     .build()
     .unwrap();
     let a = make_array(a);
@@ -932,7 +932,7 @@ fn test_struct_equal_null_variable_size() {
     )]))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001010])))
     .len(5)
-    .add_child_data(strings2.data_ref().clone())
+    .add_child_data(strings2.to_data())
     .build()
     .unwrap();
     let b = make_array(b);

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(
             vec![true, false, false, false, false],
             (0..5)
-                .map(|idx| struct_array.data_ref().is_null(idx))
+                .map(|idx| struct_array.is_null(idx))
                 .collect::<Vec<bool>>()
         );
         assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3880

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The first of likely multiple PRs to gradually remove the direct usage of `ArrayData::data_ref` from the kernels

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
