### PR TITLE
Add Zero-Copy Conversion between Vec and MutableBuffer

### DIFF
--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -843,7 +843,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "memory is not aligned")]
     fn test_primitive_array_alignment() {
-        let buf = Buffer::from_slice_ref(&[0_u64]);
+        let buf = Buffer::from_slice_ref([0_u64]);
         let buf2 = buf.slice(1);
         let array_data = ArrayData::builder(DataType::Int32)
             .add_buffer(buf2)
@@ -858,7 +858,7 @@ mod tests {
     // https://github.com/apache/arrow-rs/issues/1545
     #[cfg(not(feature = "force_validate"))]
     fn test_list_array_alignment() {
-        let buf = Buffer::from_slice_ref(&[0_u64]);
+        let buf = Buffer::from_slice_ref([0_u64]);
         let buf2 = buf.slice(1);
 
         let values: [i32; 8] = [0; 8];

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -842,10 +842,8 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "memory is not aligned")]
-    #[allow(deprecated)]
     fn test_primitive_array_alignment() {
-        let ptr = arrow_buffer::alloc::allocate_aligned(8);
-        let buf = unsafe { Buffer::from_raw_parts(ptr, 8, 8) };
+        let buf = Buffer::from_slice_ref(&[0_u64]);
         let buf2 = buf.slice(1);
         let array_data = ArrayData::builder(DataType::Int32)
             .add_buffer(buf2)
@@ -859,10 +857,8 @@ mod tests {
     // Different error messages, so skip for now
     // https://github.com/apache/arrow-rs/issues/1545
     #[cfg(not(feature = "force_validate"))]
-    #[allow(deprecated)]
     fn test_list_array_alignment() {
-        let ptr = arrow_buffer::alloc::allocate_aligned(8);
-        let buf = unsafe { Buffer::from_raw_parts(ptr, 8, 8) };
+        let buf = Buffer::from_slice_ref(&[0_u64]);
         let buf2 = buf.slice(1);
 
         let values: [i32; 8] = [0; 8];

--- a/arrow-buffer/src/alloc/mod.rs
+++ b/arrow-buffer/src/alloc/mod.rs
@@ -18,116 +18,14 @@
 //! Defines memory-related functions, such as allocate/deallocate/reallocate memory
 //! regions, cache and allocation alignments.
 
-use std::alloc::{handle_alloc_error, Layout};
+use std::alloc::Layout;
 use std::fmt::{Debug, Formatter};
 use std::panic::RefUnwindSafe;
-use std::ptr::NonNull;
 use std::sync::Arc;
 
 mod alignment;
 
 pub use alignment::ALIGNMENT;
-
-/// Returns an aligned non null pointer similar to [`NonNull::dangling`]
-///
-/// Note that the pointer value may potentially represent a valid pointer, which means
-/// this must not be used as a "not yet initialized" sentinel value.
-///
-/// Types that lazily allocate must track initialization by some other means.
-#[inline]
-fn dangling_ptr() -> NonNull<u8> {
-    // SAFETY: ALIGNMENT is a non-zero usize which is then casted
-    // to a *mut T. Therefore, `ptr` is not null and the conditions for
-    // calling new_unchecked() are respected.
-    unsafe { NonNull::new_unchecked(ALIGNMENT as *mut u8) }
-}
-
-/// Allocates a cache-aligned memory region of `size` bytes with uninitialized values.
-/// This is more performant than using [allocate_aligned_zeroed] when all bytes will have
-/// an unknown or non-zero value and is semantically similar to `malloc`.
-#[deprecated(note = "Use Vec")]
-pub fn allocate_aligned(size: usize) -> NonNull<u8> {
-    unsafe {
-        if size == 0 {
-            dangling_ptr()
-        } else {
-            let layout = Layout::from_size_align_unchecked(size, ALIGNMENT);
-            let raw_ptr = std::alloc::alloc(layout);
-            NonNull::new(raw_ptr).unwrap_or_else(|| handle_alloc_error(layout))
-        }
-    }
-}
-
-/// Allocates a cache-aligned memory region of `size` bytes with `0` on all of them.
-/// This is more performant than using [allocate_aligned] and setting all bytes to zero
-/// and is semantically similar to `calloc`.
-#[deprecated(note = "Use Vec")]
-pub fn allocate_aligned_zeroed(size: usize) -> NonNull<u8> {
-    unsafe {
-        if size == 0 {
-            dangling_ptr()
-        } else {
-            let layout = Layout::from_size_align_unchecked(size, ALIGNMENT);
-            let raw_ptr = std::alloc::alloc_zeroed(layout);
-            NonNull::new(raw_ptr).unwrap_or_else(|| handle_alloc_error(layout))
-        }
-    }
-}
-
-/// # Safety
-///
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-///
-/// * ptr must denote a block of memory currently allocated via this allocator,
-///
-/// * size must be the same size that was used to allocate that block of memory,
-#[deprecated(note = "Use Vec")]
-pub unsafe fn free_aligned(ptr: NonNull<u8>, size: usize) {
-    if size != 0 {
-        std::alloc::dealloc(
-            ptr.as_ptr() as *mut u8,
-            Layout::from_size_align_unchecked(size, ALIGNMENT),
-        );
-    }
-}
-
-/// # Safety
-///
-/// This function is unsafe because undefined behavior can result if the caller does not ensure all
-/// of the following:
-///
-/// * ptr must be currently allocated via this allocator,
-///
-/// * new_size must be greater than zero.
-///
-/// * new_size, when rounded up to the nearest multiple of [ALIGNMENT], must not overflow (i.e.,
-/// the rounded value must be less than usize::MAX).
-#[deprecated(note = "Use Vec")]
-#[allow(deprecated)]
-pub unsafe fn reallocate(
-    ptr: NonNull<u8>,
-    old_size: usize,
-    new_size: usize,
-) -> NonNull<u8> {
-    if old_size == 0 {
-        return allocate_aligned(new_size);
-    }
-
-    if new_size == 0 {
-        free_aligned(ptr, old_size);
-        return dangling_ptr();
-    }
-
-    let raw_ptr = std::alloc::realloc(
-        ptr.as_ptr() as *mut u8,
-        Layout::from_size_align_unchecked(old_size, ALIGNMENT),
-        new_size,
-    );
-    NonNull::new(raw_ptr).unwrap_or_else(|| {
-        handle_alloc_error(Layout::from_size_align_unchecked(new_size, ALIGNMENT))
-    })
-}
 
 /// The owner of an allocation.
 /// The trait implementation is responsible for dropping the allocations once no more references exist.

--- a/arrow-buffer/src/bytes.rs
+++ b/arrow-buffer/src/bytes.rs
@@ -30,8 +30,8 @@ use crate::alloc::Deallocation;
 /// This structs' API is inspired by the `bytes::Bytes`, but it is not limited to using rust's
 /// global allocator nor u8 alignment.
 ///
-/// In the most common case, this buffer is allocated using [`allocate_aligned`](crate::alloc::allocate_aligned)
-/// and deallocated accordingly [`free_aligned`](crate::alloc::free_aligned).
+/// In the most common case, this buffer is allocated using [`alloc`](std::alloc::alloc)
+/// with an alignment of [`ALIGNMENT`](crate::alloc::ALIGNMENT)
 ///
 /// When the region is allocated by a different allocator, [Deallocation::Custom], this calls the
 /// custom deallocator to deallocate the region when it is no longer needed.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3516

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

https://github.com/apache/arrow-rs/pull/3756 only added zero-copy conversion between `Vec` and `Buffer` in order to keep the scope of the change down. Unfortunately as discovered in #3917 this causes issues for the APIs that allow converting an Array back into a builder, as the builders use MutableBuffer and therefore are restricted by the alignment expectations of `MutableBuffer`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds zero-copy conversion to `MutableBuffer` by storing the `Layout` inline.

# Are there any user-facing changes?

This changes what can and can't be converted to a MutableBuffer, and removes some low-level deprecated APIs. Downstream impact is likely to be extremely marginal.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
