### PR TITLE
fix: Specify content length for gcp copy request

### DIFF
--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -437,6 +437,8 @@ impl GoogleCloudStorageClient {
 
         builder
             .bearer_auth(token)
+            // Needed if reqwest is compiled with native-tls instead of rustls-tls
+            // See https://github.com/apache/arrow-rs/pull/3921
             .header(header::CONTENT_LENGTH, 0)
             .send_retry(&self.retry_config)
             .await

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -437,6 +437,7 @@ impl GoogleCloudStorageClient {
 
         builder
             .bearer_auth(token)
+            .header(header::CONTENT_LENGTH, 0)
             .send_retry(&self.retry_config)
             .await
             .map_err(|err| {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

This fixes an issue where copy requests for the GCS object store would error due to a missing `content-length` header.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We hit "Error 411 (Length Required)" on the copyTo endpoint when calling `copy_if_not_exists` for the GCS object store.

An example error response that we get:

```
"Generic GCS error: Error performing copy request databases/00000000-0000-0000-0000-000000000000/tmp/299e25c3-a5f5-445c-97ca-28f37f64fb29/lease: response error \"<!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n  <meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n  <title>Error 411 (Length Required)!!1</title>\n  <style>\n    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n  </style>\n  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n  <p><b>411.</b> <ins>That’s an error.</ins>\n  <p>POST requests require a <code>Content-length</code> header.  <ins>That’s all we know.</ins>\n\", after 0 retries: HTTP status client error (411 Length Required) for url (https://storage.googleapis.com/storage/v1/b/sean-test-glaredb/o/databases/00000000-0000-0000-0000-000000000000/tmp/299e25c3-a5f5-445c-97ca-28f37f64fb29/lease/copyTo/b/sean-test-glaredb/o/databases/00000000-0000-0000-0000-000000000000/visible/lease?ifGenerationMatch=0)"
```

Getting a reproducible test case for this has been incredibly tricky. We believe that it comes down to whether or not the `object_store` crate gets compiled with `native-tls` or `rust-tls`. See https://github.com/RustomMS/test-object-store for our best shot at reproducing.

I also believe that this change would fix this issue https://github.com/delta-io/delta-rs/issues/878.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Explicitly sets content-length to 0 for GCS copyTo request.

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
