### PR TITLE
feat: add take for MapArray

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::array::{get_offsets, print_long_array};
-use crate::{make_array, Array, ArrayRef, StringArray, StructArray, ListArray};
+use crate::{make_array, Array, ArrayRef, ListArray, StringArray, StructArray};
 use arrow_buffer::{ArrowNativeType, Buffer, NullBuffer, OffsetBuffer, ToByteSlice};
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType, Field};
@@ -251,65 +251,16 @@ impl std::fmt::Debug for MapArray {
     }
 }
 
-impl TryFrom<&ListArray> for MapArray {
-    type Error = ArrowError;
-    fn try_from(value: &ListArray) -> Result<Self, Self::Error> {
+impl From<MapArray> for ListArray {
+    fn from(value: MapArray) -> Self {
         let field = match value.data_type() {
-            DataType::List(field) => {
-                if let DataType::Struct(fields) = field.data_type() {
-                    if fields.len() != 2 {
-                        Err(ArrowError::InvalidArgumentError(
-                            "List item must be a struct type with two fields".to_string(),
-                        ))
-                    } else {
-                        Ok(field)
-                    }
-                } else {
-                    Err(ArrowError::InvalidArgumentError(
-                        "List item must be a struct type to convert to a list"
-                            .to_string(),
-                    ))
-                }
-            }
-            _ => unreachable!("This should be a list type."),
-        }?;
-        let old_data = value.to_data();
-        let array_data = unsafe {
-            ArrayData::new_unchecked(
-                DataType::Map(field.clone(), false),
-                old_data.len(),
-                Some(old_data.null_count()),
-                old_data.nulls().map(|nulls|nulls.buffer().clone()),
-                old_data.offset(),
-                old_data.buffers().to_vec(),
-                old_data.child_data().to_vec(),
-            )
+            DataType::Map(field, _) => field,
+            _ => unreachable!("This should be a map type."),
         };
-        Ok(MapArray::from(array_data))
-    }
-}
+        let data_type = DataType::List(field.clone());
+        let builder = value.into_data().into_builder().data_type(data_type);
+        let array_data = unsafe { builder.build_unchecked() };
 
-impl From<&MapArray> for ListArray {
-    fn from(value: &MapArray) -> Self {
-        let field = match value.data_type() {
-            DataType::Map(field, _) => {
-                field
-            },
-            _ => unreachable!("This should be a map type.")
-        };
-
-        let old_data = value.to_data();
-        let array_data = unsafe {
-            ArrayData::new_unchecked(
-                DataType::List(field.clone()),
-                old_data.len(),
-                Some(old_data.null_count()),
-                old_data.nulls().map(|nulls|nulls.buffer().clone()),
-                old_data.offset(),
-                old_data.buffers().to_vec(),
-                old_data.child_data().to_vec(),
-            )
-        };
         ListArray::from(array_data)
     }
 }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -151,9 +151,10 @@ where
             )?))
         }
         DataType::Map(_, _) => {
-            let list_arr = ListArray::from(values.as_map());
+            let list_arr = ListArray::from(values.as_map().clone());
             let list_data = take_list::<_, Int32Type>(&list_arr, indices)?;
-            Ok(Arc::new(MapArray::try_from(&list_data)?))
+            let builder = list_data.into_data().into_builder().data_type(values.data_type().clone());
+            Ok(Arc::new(MapArray::from(unsafe { builder.build_unchecked() })))
         }
         DataType::Struct(fields) => {
             let struct_: &StructArray =

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -150,6 +150,11 @@ where
                 *length as u32,
             )?))
         }
+        DataType::Map(_, _) => {
+            let list_arr = ListArray::from(values.as_map());
+            let list_data = take_list::<_, Int32Type>(&list_arr, indices)?;
+            Ok(Arc::new(MapArray::try_from(&list_data)?))
+        }
         DataType::Struct(fields) => {
             let struct_: &StructArray =
                 values.as_any().downcast_ref::<StructArray>().unwrap();
@@ -1917,6 +1922,30 @@ mod tests {
         // A panic is expected here since we have not supplied the check_bounds
         // option.
         take(&list_array, &index, None).unwrap();
+    }
+
+    #[test]
+    fn test_take_map() {
+        let values = Int32Array::from(vec![1, 2, 3, 4]);
+        let array = MapArray::new_from_strings(
+            vec!["a", "b", "c", "a"].into_iter(),
+            &values,
+            &[0, 3, 4],
+        )
+        .unwrap();
+
+        let index = UInt32Array::from(vec![0]);
+
+        let result = take(&array, &index, None).unwrap();
+        let expected: ArrayRef = Arc::new(
+            MapArray::new_from_strings(
+                vec!["a", "b", "c"].into_iter(),
+                &values.slice(0, 3),
+                &[0, 3],
+            )
+            .unwrap(),
+        );
+        assert_eq!(&expected, &result);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3875

# Rationale for this change
 
This seems to be one of the only array types that isn't supported by this function.

# What changes are included in this PR?

Adds an easy conversion between `MapArray` and `ListArray`, which allows us to reuse kernels that support `ListArray`.

# Are there any user-facing changes?

No breaking changes.