### PR TITLE
Add Strongly Typed Array Slice (#3929)

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1264,13 +1264,12 @@ mod tests {
             .into_iter()
             .collect();
         let sliced_input = sliced_input.slice(4, 2);
-        let sliced_input = sliced_input.as_string::<i32>();
 
-        assert_eq!(sliced_input, &input);
+        assert_eq!(&sliced_input, &input);
 
-        let actual = min_string(sliced_input);
+        let actual = min_string(&sliced_input);
         assert_eq!(actual, expected);
-        let actual = max_string(sliced_input);
+        let actual = max_string(&sliced_input);
         assert_eq!(actual, expected);
     }
 
@@ -1287,13 +1286,12 @@ mod tests {
             .into_iter()
             .collect();
         let sliced_input = sliced_input.slice(4, 2);
-        let sliced_input = sliced_input.as_binary::<i32>();
 
-        assert_eq!(sliced_input, &input);
+        assert_eq!(&sliced_input, &input);
 
-        let actual = min_binary(sliced_input);
+        let actual = min_binary(&sliced_input);
         assert_eq!(actual, expected);
-        let actual = max_binary(sliced_input);
+        let actual = max_binary(&sliced_input);
         assert_eq!(actual, expected);
     }
 

--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1219,13 +1219,12 @@ mod tests {
             .into_iter()
             .collect();
         let sliced_input = sliced_input.slice(4, 2);
-        let sliced_input = sliced_input.as_primitive::<Float64Type>();
 
-        assert_eq!(sliced_input, &input);
+        assert_eq!(&sliced_input, &input);
 
-        let actual = min(sliced_input);
+        let actual = min(&sliced_input);
         assert_eq!(actual, expected);
-        let actual = max(sliced_input);
+        let actual = max(&sliced_input);
         assert_eq!(actual, expected);
     }
 

--- a/arrow-arith/src/arithmetic.rs
+++ b/arrow-arith/src/arithmetic.rs
@@ -2043,7 +2043,7 @@ mod tests {
     fn test_primitive_array_add_scalar_sliced() {
         let a = Int32Array::from(vec![Some(15), None, Some(9), Some(8), None]);
         let a = a.slice(1, 4);
-        let actual = add_scalar(a.as_primitive(), 3).unwrap();
+        let actual = add_scalar(&a, 3).unwrap();
         let expected = Int32Array::from(vec![None, Some(12), Some(11), None]);
         assert_eq!(actual, expected);
     }
@@ -2073,7 +2073,7 @@ mod tests {
     fn test_primitive_array_subtract_scalar_sliced() {
         let a = Int32Array::from(vec![Some(15), None, Some(9), Some(8), None]);
         let a = a.slice(1, 4);
-        let actual = subtract_scalar(a.as_primitive(), 3).unwrap();
+        let actual = subtract_scalar(&a, 3).unwrap();
         let expected = Int32Array::from(vec![None, Some(6), Some(5), None]);
         assert_eq!(actual, expected);
     }
@@ -2103,7 +2103,7 @@ mod tests {
     fn test_primitive_array_multiply_scalar_sliced() {
         let a = Int32Array::from(vec![Some(15), None, Some(9), Some(8), None]);
         let a = a.slice(1, 4);
-        let actual = multiply_scalar(a.as_primitive(), 3).unwrap();
+        let actual = multiply_scalar(&a, 3).unwrap();
         let expected = Int32Array::from(vec![None, Some(27), Some(24), None]);
         assert_eq!(actual, expected);
     }
@@ -2223,7 +2223,7 @@ mod tests {
     fn test_primitive_array_divide_scalar_sliced() {
         let a = Int32Array::from(vec![Some(15), None, Some(9), Some(8), None]);
         let a = a.slice(1, 4);
-        let actual = divide_scalar(a.as_primitive(), 3).unwrap();
+        let actual = divide_scalar(&a, 3).unwrap();
         let expected = Int32Array::from(vec![None, Some(3), Some(2), None]);
         assert_eq!(actual, expected);
     }
@@ -2246,12 +2246,11 @@ mod tests {
     fn test_int_array_modulus_scalar_sliced() {
         let a = Int32Array::from(vec![Some(15), None, Some(9), Some(8), None]);
         let a = a.slice(1, 4);
-        let a = a.as_primitive();
-        let actual = modulus_scalar(a, 3).unwrap();
+        let actual = modulus_scalar(&a, 3).unwrap();
         let expected = Int32Array::from(vec![None, Some(0), Some(2), None]);
         assert_eq!(actual, expected);
 
-        let actual = modulus_scalar_dyn::<Int32Type>(a, 3).unwrap();
+        let actual = modulus_scalar_dyn::<Int32Type>(&a, 3).unwrap();
         let actual = actual.as_primitive::<Int32Type>();
         let expected = Int32Array::from(vec![None, Some(0), Some(2), None]);
         assert_eq!(actual, &expected);

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -499,7 +499,6 @@ where
 mod tests {
     use super::*;
     use arrow_array::builder::*;
-    use arrow_array::cast::*;
     use arrow_array::types::*;
 
     #[test]
@@ -507,14 +506,13 @@ mod tests {
         let input =
             Float64Array::from(vec![Some(5.1f64), None, Some(6.8), None, Some(7.2)]);
         let input_slice = input.slice(1, 4);
-        let input_slice: &Float64Array = input_slice.as_primitive();
-        let result = unary(input_slice, |n| n.round());
+        let result = unary(&input_slice, |n| n.round());
         assert_eq!(
             result,
             Float64Array::from(vec![None, Some(7.0), None, Some(7.0)])
         );
 
-        let result = unary_dyn::<_, Float64Type>(input_slice, |n| n + 1.0).unwrap();
+        let result = unary_dyn::<_, Float64Type>(&input_slice, |n| n + 1.0).unwrap();
 
         assert_eq!(
             result.as_any().downcast_ref::<Float64Array>().unwrap(),

--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -775,7 +775,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1]);
         let a = a.slice(8, 4);
 
-        let res = is_null(a.as_ref()).unwrap();
+        let res = is_null(&a).unwrap();
 
         let expected = BooleanArray::from(vec![false, false, false, false]);
 
@@ -800,7 +800,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1]);
         let a = a.slice(8, 4);
 
-        let res = is_not_null(a.as_ref()).unwrap();
+        let res = is_not_null(&a).unwrap();
 
         let expected = BooleanArray::from(vec![true, true, true, true]);
 
@@ -843,7 +843,7 @@ mod tests {
         ]);
         let a = a.slice(8, 4);
 
-        let res = is_null(a.as_ref()).unwrap();
+        let res = is_null(&a).unwrap();
 
         let expected = BooleanArray::from(vec![false, true, false, true]);
 
@@ -886,7 +886,7 @@ mod tests {
         ]);
         let a = a.slice(8, 4);
 
-        let res = is_not_null(a.as_ref()).unwrap();
+        let res = is_not_null(&a).unwrap();
 
         let expected = BooleanArray::from(vec![true, false, true, false]);
 

--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -134,6 +134,12 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         ArrayIter::new(self)
     }
 
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
+
     /// Returns `GenericByteBuilder` of this byte array for mutating its values if the underlying
     /// offset and data buffers are not shared by others.
     pub fn into_builder(self) -> Result<GenericByteBuilder<T>, Self> {
@@ -247,8 +253,7 @@ impl<T: ByteArrayType> Array for GenericByteArray<T> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -110,6 +110,12 @@ impl FixedSizeBinaryArray {
         self.data.buffers()[0].clone()
     }
 
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
+
     /// Create an array from an iterable argument of sparse byte slices.
     /// Sparsity means that items returned by the iterator are optional, i.e input argument can
     /// contain `None` items.
@@ -473,8 +479,7 @@ impl Array for FixedSizeBinaryArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -106,6 +106,12 @@ impl FixedSizeListArray {
         i as i32 * self.length
     }
 
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
+
     /// Creates a [`FixedSizeListArray`] from an iterator of primitive values
     /// # Example
     /// ```
@@ -216,8 +222,7 @@ impl Array for FixedSizeListArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -132,6 +132,12 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
         }
     }
 
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
+
     /// Creates a [`GenericListArray`] from an iterator of primitive values
     /// # Example
     /// ```
@@ -253,8 +259,7 @@ impl<OffsetSize: OffsetSizeTrait> Array for GenericListArray<OffsetSize> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -95,6 +95,12 @@ impl MapArray {
         let offsets = self.value_offsets();
         offsets[i + 1] - offsets[i]
     }
+
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
 }
 
 impl From<ArrayData> for MapArray {
@@ -222,8 +228,7 @@ impl Array for MapArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -141,7 +141,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// // Make slice over the values [2, 3, 4]
     /// let array_slice = array.slice(1, 3);
     ///
-    /// assert_eq!(array_slice.as_ref(), &Int32Array::from(vec![2, 3, 4]));
+    /// assert_eq!(&array_slice, &Int32Array::from(vec![2, 3, 4]));
     /// ```
     fn slice(&self, offset: usize, length: usize) -> ArrayRef;
 

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -54,6 +54,12 @@ impl NullArray {
         let array_data = unsafe { array_data.build_unchecked() };
         NullArray::from(array_data)
     }
+
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
 }
 
 impl Array for NullArray {
@@ -74,8 +80,7 @@ impl Array for NullArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -408,6 +408,12 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         indexes.map(|opt_index| opt_index.map(|index| self.value_unchecked(index)))
     }
 
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
+
     /// Reinterprets this array's contents as a different data type without copying
     ///
     /// This can be used to efficiently convert between primitive arrays with the
@@ -706,8 +712,7 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -253,6 +253,12 @@ impl<R: RunEndIndexType> RunArray<R> {
         }
         Ok(physical_indices)
     }
+
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
 }
 
 impl<R: RunEndIndexType> From<ArrayData> for RunArray<R> {
@@ -307,8 +313,7 @@ impl<T: RunEndIndexType> Array for RunArray<T> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
@@ -505,7 +510,7 @@ impl<'a, R: RunEndIndexType, V: Sync> Array for TypedRunArray<'a, R, V> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        self.run_array.slice(offset, length)
+        Arc::new(self.run_array.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -100,6 +100,12 @@ impl StructArray {
             .position(|c| c == &column_name)
             .map(|pos| self.column(pos))
     }
+
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
 }
 
 impl From<ArrayData> for StructArray {
@@ -205,8 +211,7 @@ impl Array for StructArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        // TODO: Slice buffers directly (#3880)
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -287,6 +287,12 @@ impl UnionArray {
             _ => unreachable!("Union array's data type is not a union!"),
         }
     }
+
+    /// Returns a zero-copy slice of this array with the indicated offset and length.
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        // TODO: Slice buffers directly (#3880)
+        self.data.slice(offset, length).into()
+    }
 }
 
 impl From<ArrayData> for UnionArray {
@@ -328,7 +334,7 @@ impl Array for UnionArray {
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
-        Arc::new(Self::from(self.data.slice(offset, length)))
+        Arc::new(self.slice(offset, length))
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -2024,15 +2024,11 @@ mod tests {
         );
 
         let sliced = array.slice(1, 2);
-        let read_sliced: &UInt32Array = sliced.as_primitive();
-        assert_eq!(
-            vec![Some(2), Some(3)],
-            read_sliced.iter().collect::<Vec<_>>()
-        );
+        assert_eq!(vec![Some(2), Some(3)], sliced.iter().collect::<Vec<_>>());
 
         let batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new("a", DataType::UInt32, true)])),
-            vec![sliced],
+            vec![Arc::new(sliced)],
         )
         .expect("new batch");
 

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -3796,14 +3796,13 @@ mod tests {
             vec![Some("hi"), None, Some("hello"), Some("world"), Some("")],
         );
         let a = a.slice(1, 4);
-        let a = a.as_string::<i32>();
-        let a_eq = eq_utf8_scalar(a, "hello").unwrap();
+        let a_eq = eq_utf8_scalar(&a, "hello").unwrap();
         assert_eq!(
             a_eq,
             BooleanArray::from(vec![None, Some(true), Some(false), Some(false)])
         );
 
-        let a_eq2 = eq_utf8_scalar(a, "").unwrap();
+        let a_eq2 = eq_utf8_scalar(&a, "").unwrap();
 
         assert_eq!(
             a_eq2,

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -2858,7 +2858,7 @@ mod tests {
             // slice and test if the dynamic array works
             let a = a.slice(0, a.len());
             let b = b.slice(0, b.len());
-            let c = $DYN_KERNEL(a.as_ref(), b.as_ref()).unwrap();
+            let c = $DYN_KERNEL(&a, &b).unwrap();
             assert_eq!(BooleanArray::from($EXPECTED), c);
 
             // test with a larger version of the same data to ensure we cover the chunked part of the comparison
@@ -2995,8 +2995,7 @@ mod tests {
     fn test_primitive_array_eq_scalar_with_slice() {
         let a = Int32Array::from(vec![Some(1), None, Some(2), Some(3)]);
         let a = a.slice(1, 3);
-        let a: &Int32Array = a.as_primitive();
-        let a_eq = eq_scalar(a, 2).unwrap();
+        let a_eq = eq_scalar(&a, 2).unwrap();
         assert_eq!(
             a_eq,
             BooleanArray::from(vec![None, Some(true), Some(false)])

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -426,8 +426,7 @@ mod tests {
         let input_1 = StringArray::from(vec!["hello", "A", "B", "C"]);
         let input_2 = StringArray::from(vec!["world", "D", "E", "Z"]);
 
-        let arr = concat(&[input_1.slice(1, 3).as_ref(), input_2.slice(1, 2).as_ref()])
-            .unwrap();
+        let arr = concat(&[&input_1.slice(1, 3), &input_2.slice(1, 2)]).unwrap();
 
         let expected_output = StringArray::from(vec!["A", "B", "C", "D", "E"]);
 
@@ -440,8 +439,7 @@ mod tests {
         let input_1 = StringArray::from(vec![Some("hello"), None, Some("A"), Some("C")]);
         let input_2 = StringArray::from(vec![None, Some("world"), Some("D"), None]);
 
-        let arr = concat(&[input_1.slice(1, 3).as_ref(), input_2.slice(1, 2).as_ref()])
-            .unwrap();
+        let arr = concat(&[&input_1.slice(1, 3), &input_2.slice(1, 2)]).unwrap();
 
         let expected_output =
             StringArray::from(vec![None, Some("A"), Some("C"), Some("world"), Some("D")]);

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -243,7 +243,7 @@ mod tests {
             None,
         ])
         .slice(1, 3);
-        let arr = concat(&[input_1.as_ref(), input_2.as_ref()]).unwrap();
+        let arr = concat(&[&input_1, &input_2]).unwrap();
 
         let expected_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
             Some(-1),

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -399,11 +399,8 @@ mod tests {
             ]));
         let input_struct_2 = StructArray::from(vec![(field, input_primitive_2)]);
 
-        let arr = concat(&[
-            input_struct_1.slice(1, 3).as_ref(),
-            input_struct_2.slice(1, 2).as_ref(),
-        ])
-        .unwrap();
+        let arr =
+            concat(&[&input_struct_1.slice(1, 3), &input_struct_2.slice(1, 2)]).unwrap();
 
         let expected_primitive_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
             Some(-1),

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -764,13 +764,12 @@ mod tests {
 
     #[test]
     fn test_filter_array_slice() {
-        let a_slice = Int32Array::from(vec![5, 6, 7, 8, 9]).slice(1, 4);
-        let a = a_slice.as_ref();
+        let a = Int32Array::from(vec![5, 6, 7, 8, 9]).slice(1, 4);
         let b = BooleanArray::from(vec![true, false, false, true]);
         // filtering with sliced filter array is not currently supported
         // let b_slice = BooleanArray::from(vec![true, false, false, true, false]).slice(1, 4);
         // let b = b_slice.as_any().downcast_ref().unwrap();
-        let c = filter(a, &b).unwrap();
+        let c = filter(&a, &b).unwrap();
         let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(2, d.len());
         assert_eq!(6, d.value(0));
@@ -868,14 +867,13 @@ mod tests {
 
     #[test]
     fn test_filter_array_slice_with_null() {
-        let a_slice =
+        let a =
             Int32Array::from(vec![Some(5), None, Some(7), Some(8), Some(9)]).slice(1, 4);
-        let a = a_slice.as_ref();
         let b = BooleanArray::from(vec![true, false, false, true]);
         // filtering with sliced filter array is not currently supported
         // let b_slice = BooleanArray::from(vec![true, false, false, true, false]).slice(1, 4);
         // let b = b_slice.as_any().downcast_ref().unwrap();
-        let c = filter(a, &b).unwrap();
+        let c = filter(&a, &b).unwrap();
         let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(2, d.len());
         assert!(d.is_null(0));
@@ -996,7 +994,7 @@ mod tests {
 
         let mask1 = BooleanArray::from(vec![Some(true), Some(true), None]);
         let out = filter(&a, &mask1).unwrap();
-        assert_eq!(&out, &a.slice(0, 2));
+        assert_eq!(out.as_ref(), &a.slice(0, 2));
     }
 
     #[test]

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -500,7 +500,6 @@ mod tests {
 
             for (a_offset, a_length) in a_slices {
                 let a = a.slice(a_offset, a_length);
-                let a = a.as_primitive::<Int32Type>();
 
                 for i in 1..65 {
                     let b_start_offset = rng.gen_range(0..i);
@@ -512,7 +511,7 @@ mod tests {
                     let b = b.slice(b_start_offset, a_length);
                     let b = b.as_boolean();
 
-                    test_nullif(a, b);
+                    test_nullif(&a, b);
                 }
             }
         }

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -210,7 +210,7 @@ mod tests {
         let s = s.slice(2, 3);
         let select = select.slice(1, 3);
         let select = select.as_boolean();
-        let a = nullif(s.as_ref(), select).unwrap();
+        let a = nullif(&s, select).unwrap();
         let r: Vec<_> = a.as_string::<i32>().iter().collect();
         assert_eq!(r, vec![None, Some("a"), None]);
     }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1561,14 +1561,8 @@ mod tests {
             StringArray::from(vec![Some("hello"), None, Some("world"), None, Some("hi")]);
         let indices = Int32Array::from(vec![Some(0), Some(1), None, Some(0), Some(2)]);
         let indices_slice = indices.slice(1, 4);
-        let indices_slice = indices_slice
-            .as_ref()
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap();
-
         let expected = StringArray::from(vec![None, None, Some("hello"), Some("world")]);
-        let result = take(&strings, indices_slice, None).unwrap();
+        let result = take(&strings, &indices_slice, None).unwrap();
         assert_eq!(result.as_ref(), &expected);
     }
 

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -426,7 +426,7 @@ mod tests {
     fn length_offsets_string() {
         let a = StringArray::from(vec![Some("hello"), Some(" "), Some("world"), None]);
         let b = a.slice(1, 3);
-        let result = length(b.as_ref()).unwrap();
+        let result = length(&b).unwrap();
         let result: &Int32Array = result.as_primitive();
 
         let expected = Int32Array::from(vec![Some(1), Some(5), None]);
@@ -439,7 +439,7 @@ mod tests {
             vec![Some(b"hello"), Some(b" "), Some(&[0xff, 0xf8]), None];
         let a = BinaryArray::from(value);
         let b = a.slice(1, 3);
-        let result = length(b.as_ref()).unwrap();
+        let result = length(&b).unwrap();
         let result: &Int32Array = result.as_primitive();
 
         let expected = Int32Array::from(vec![Some(1), Some(2), None]);
@@ -581,7 +581,7 @@ mod tests {
     fn bit_length_offsets_string() {
         let a = StringArray::from(vec![Some("hello"), Some(" "), Some("world"), None]);
         let b = a.slice(1, 3);
-        let result = bit_length(b.as_ref()).unwrap();
+        let result = bit_length(&b).unwrap();
         let result: &Int32Array = result.as_primitive();
 
         let expected = Int32Array::from(vec![Some(8), Some(40), None]);
@@ -594,7 +594,7 @@ mod tests {
             vec![Some(b"hello"), Some(&[]), Some(b"world"), None];
         let a = BinaryArray::from(value);
         let b = a.slice(1, 3);
-        let result = bit_length(b.as_ref()).unwrap();
+        let result = bit_length(&b).unwrap();
         let result: &Int32Array = result.as_primitive();
 
         let expected = Int32Array::from(vec![Some(0), Some(40), None]);

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -941,9 +941,7 @@ fn test_try_new_sliced_struct() {
 
     let struct_array = builder.finish();
     let struct_array_slice = struct_array.slice(1, 3);
-    let struct_array_data = struct_array_slice.data();
-
-    let cloned = make_array(struct_array_data.clone());
+    let cloned = struct_array_slice.clone();
     assert_eq!(&struct_array_slice, &cloned);
 }
 

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -401,10 +401,10 @@ mod tests {
         let expected_2 = expected.slice(2, 2);
 
         let actual = l1.next_batch(2).unwrap();
-        assert_eq!(expected_1.as_ref(), actual.as_ref());
+        assert_eq!(actual.as_ref(), &expected_1);
 
         let actual = l1.next_batch(1024).unwrap();
-        assert_eq!(expected_2.as_ref(), actual.as_ref());
+        assert_eq!(actual.as_ref(), &expected_2);
     }
 
     fn test_required_list<OffsetSize: OffsetSizeTrait>() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3880
Closes #3929

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

This is a breaking change, as calling `slice` on a concrete array will now return the concrete array. This change could be made as a non-breaking change, but I want to flush out the redundant downcasting.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
