### PR TITLE
feat: add etag for objectMeta

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -58,9 +58,11 @@ aws-config = { version = "0.54", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
+ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
+ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = "0.26.1"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -58,11 +58,9 @@ aws-config = { version = "0.54", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = "0.26.1"

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -165,7 +165,7 @@ pub struct ListContents {
     pub size: usize,
     pub last_modified: DateTime<Utc>,
     #[serde(rename = "ETag")]
-    pub e_tag: String,
+    pub e_tag: Option<String>,
 }
 
 impl TryFrom<ListContents> for ObjectMeta {

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -37,7 +37,6 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
-use std::hash::Hasher;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -165,22 +164,19 @@ pub struct ListContents {
     pub key: String,
     pub size: usize,
     pub last_modified: DateTime<Utc>,
+    #[serde(rename = "ETag")]
+    pub e_tag: String,
 }
 
 impl TryFrom<ListContents> for ObjectMeta {
     type Error = crate::Error;
 
     fn try_from(value: ListContents) -> Result<Self> {
-        let nanos = value.last_modified.clone().timestamp_nanos();
-        let mut hasher = ahash::AHasher::default();
-        hasher.write_i64(nanos);
-        let e_tag = hasher.finish().to_string();
-
         Ok(Self {
             location: Path::parse(value.key)?,
             last_modified: value.last_modified,
             size: value.size,
-            e_tag,
+            e_tag: value.e_tag,
         })
     }
 }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -259,13 +259,12 @@ impl ObjectStore for AmazonS3 {
 
         let e_tag = headers.get(ETAG).context(MissingEtagSnafu)?;
         let e_tag = e_tag.to_str().context(BadHeaderSnafu)?;
-        let e_tag = e_tag.to_string();
 
         Ok(ObjectMeta {
             location: location.clone(),
             last_modified,
             size: content_length,
-            e_tag,
+            e_tag: Some(e_tag.to_string()),
         })
     }
 

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -502,7 +502,6 @@ impl TryFrom<Blob> for ObjectMeta {
 struct BlobProperties {
     #[serde(deserialize_with = "deserialize_rfc1123", rename = "Last-Modified")]
     pub last_modified: DateTime<Utc>,
-    pub etag: String,
     #[serde(rename = "Content-Length")]
     pub content_length: u64,
     #[serde(rename = "Content-Type")]
@@ -511,7 +510,7 @@ struct BlobProperties {
     pub content_encoding: Option<String>,
     #[serde(rename = "Content-Language")]
     pub content_language: Option<String>,
-    #[serde(rename = "ETag")]
+    #[serde(rename = "Etag")]
     pub e_tag: String,
 }
 

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -511,7 +511,7 @@ struct BlobProperties {
     #[serde(rename = "Content-Language")]
     pub content_language: Option<String>,
     #[serde(rename = "Etag")]
-    pub e_tag: String,
+    pub e_tag: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -44,6 +44,7 @@ use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::fmt::{Debug, Formatter};
+use std::hash::Hasher;
 use std::io;
 use std::ops::Range;
 use std::sync::Arc;
@@ -257,10 +258,16 @@ impl ObjectStore for MicrosoftAzure {
             .parse()
             .context(InvalidContentLengthSnafu { content_length })?;
 
+        let nanos = last_modified.clone().timestamp_nanos();
+        let mut hasher = ahash::AHasher::default();
+        hasher.write_i64(nanos);
+        let e_tag = hasher.finish().to_string();
+
         Ok(ObjectMeta {
             location: location.clone(),
             last_modified,
             size: content_length,
+            e_tag,
         })
     }
 

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -265,13 +265,12 @@ impl ObjectStore for MicrosoftAzure {
             .ok_or(Error::MissingEtag)?
             .to_str()
             .context(BadHeaderSnafu)?;
-        let e_tag = e_tag.to_string();
 
         Ok(ObjectMeta {
             location: location.clone(),
             last_modified,
             size: content_length,
-            e_tag,
+            e_tag: Some(e_tag.to_string()),
         })
     }
 

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -196,7 +196,7 @@ struct Object {
     name: String,
     size: String,
     updated: DateTime<Utc>,
-    #[serde(rename = "ETag")]
+    #[serde(rename = "etag")]
     e_tag: String,
 }
 
@@ -211,7 +211,6 @@ struct InitiateMultipartUploadResult {
 struct MultipartPart {
     #[serde(rename = "PartNumber")]
     part_number: usize,
-    #[serde(rename = "ETag")]
     e_tag: String,
 }
 

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -197,7 +197,7 @@ struct Object {
     size: String,
     updated: DateTime<Utc>,
     #[serde(rename = "etag")]
-    e_tag: String,
+    e_tag: Option<String>,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -30,7 +30,6 @@
 //! consider implementing automatic clean up of unused parts that are older than one
 //! week.
 use std::collections::BTreeSet;
-use std::hash::Hasher;
 use std::io;
 use std::ops::Range;
 use std::str::FromStr;
@@ -197,6 +196,8 @@ struct Object {
     name: String,
     size: String,
     updated: DateTime<Utc>,
+    #[serde(rename = "ETag")]
+    e_tag: String,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -1171,11 +1172,7 @@ fn convert_object_meta(object: &Object) -> Result<ObjectMeta> {
     let location = Path::parse(&object.name)?;
     let last_modified = object.updated;
     let size = object.size.parse().context(InvalidSizeSnafu)?;
-
-    let nanos = last_modified.clone().timestamp_nanos();
-    let mut hasher = ahash::AHasher::default();
-    hasher.write_i64(nanos);
-    let e_tag = hasher.finish().to_string();
+    let e_tag = object.e_tag.clone();
 
     Ok(ObjectMeta {
         location,

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -30,6 +30,7 @@
 //! consider implementing automatic clean up of unused parts that are older than one
 //! week.
 use std::collections::BTreeSet;
+use std::hash::Hasher;
 use std::io;
 use std::ops::Range;
 use std::str::FromStr;
@@ -1171,10 +1172,16 @@ fn convert_object_meta(object: &Object) -> Result<ObjectMeta> {
     let last_modified = object.updated;
     let size = object.size.parse().context(InvalidSizeSnafu)?;
 
+    let nanos = last_modified.clone().timestamp_nanos();
+    let mut hasher = ahash::AHasher::default();
+    hasher.write_i64(nanos);
+    let e_tag = hasher.finish().to_string();
+
     Ok(ObjectMeta {
         location,
         last_modified,
         size,
+        e_tag,
     })
 }
 

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -26,7 +26,6 @@ use reqwest::header::{CONTENT_TYPE, RANGE};
 use reqwest::{Method, Response, StatusCode};
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::hash::Hasher;
 use std::ops::Range;
 use url::Url;
 
@@ -338,10 +337,7 @@ impl MultiStatusResponse {
     pub fn object_meta(&self, base_url: &Url) -> Result<ObjectMeta> {
         let last_modified = self.prop_stat.prop.last_modified;
 
-        let nanos = last_modified.clone().timestamp_nanos();
-        let mut hasher = ahash::AHasher::default();
-        hasher.write_i64(nanos);
-        let e_tag = hasher.finish().to_string();
+        let e_tag = self.prop_stat.prop.e_tag.clone();
 
         Ok(ObjectMeta {
             location: self.path(base_url)?,
@@ -373,6 +369,9 @@ pub struct Prop {
 
     #[serde(rename = "resourcetype")]
     resource_type: ResourceType,
+
+    #[serde(rename = "ETag")]
+    e_tag: String,
 }
 
 #[derive(Deserialize)]

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -370,7 +370,7 @@ pub struct Prop {
     #[serde(rename = "resourcetype")]
     resource_type: ResourceType,
 
-    #[serde(rename = "ETag")]
+    #[serde(rename = "getetag")]
     e_tag: String,
 }
 

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -336,14 +336,11 @@ impl MultiStatusResponse {
     /// Returns this objects metadata as [`ObjectMeta`]
     pub fn object_meta(&self, base_url: &Url) -> Result<ObjectMeta> {
         let last_modified = self.prop_stat.prop.last_modified;
-
-        let e_tag = self.prop_stat.prop.e_tag.clone();
-
         Ok(ObjectMeta {
             location: self.path(base_url)?,
             last_modified,
             size: self.size()?,
-            e_tag,
+            e_tag: self.prop_stat.prop.e_tag.clone(),
         })
     }
 
@@ -371,7 +368,7 @@ pub struct Prop {
     resource_type: ResourceType,
 
     #[serde(rename = "getetag")]
-    e_tag: String,
+    e_tag: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -519,7 +519,7 @@ pub struct ObjectMeta {
     /// The size in bytes of the object
     pub size: usize,
     /// The unique identifier for the object
-    pub e_tag: String,
+    pub e_tag: Option<String>,
 }
 
 /// Result for a get request

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -518,6 +518,8 @@ pub struct ObjectMeta {
     pub last_modified: DateTime<Utc>,
     /// The size in bytes of the object
     pub size: usize,
+    /// The unique identifier for the object
+    pub e_tag: String,
 }
 
 /// Result for a get request

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -28,6 +28,7 @@ use futures::future::BoxFuture;
 use futures::FutureExt;
 use futures::{stream::BoxStream, StreamExt};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
+use std::fs::{metadata, symlink_metadata, File, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::pin::Pin;
@@ -35,10 +36,6 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::{collections::BTreeSet, convert::TryFrom, io};
 use std::{collections::VecDeque, path::PathBuf};
-use std::{
-    fs::{metadata, symlink_metadata, File, OpenOptions},
-    hash::Hasher,
-};
 use tokio::io::AsyncWrite;
 use url::Url;
 use walkdir::{DirEntry, WalkDir};
@@ -900,16 +897,11 @@ fn convert_metadata(metadata: std::fs::Metadata, location: Path) -> Result<Objec
         path: location.as_ref(),
     })?;
 
-    let nanos = last_modified.clone().timestamp_nanos();
-    let mut hasher = ahash::AHasher::default();
-    hasher.write_i64(nanos);
-    let e_tag = hasher.finish().to_string();
-
     Ok(ObjectMeta {
         location,
         last_modified,
         size,
-        e_tag,
+        e_tag: None,
     })
 }
 

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -26,7 +26,6 @@ use parking_lot::RwLock;
 use snafu::{ensure, OptionExt, Snafu};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::hash::Hasher;
 use std::io;
 use std::ops::Range;
 use std::pin::Pin;
@@ -153,16 +152,11 @@ impl ObjectStore for InMemory {
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let entry = self.entry(location).await?;
 
-        let nanos = entry.1.clone().timestamp_nanos();
-        let mut hasher = ahash::AHasher::default();
-        hasher.write_i64(nanos);
-        let e_tag = hasher.finish().to_string();
-
         Ok(ObjectMeta {
             location: location.clone(),
             last_modified: entry.1,
             size: entry.0.len(),
-            e_tag,
+            e_tag: None,
         })
     }
 
@@ -189,16 +183,11 @@ impl ObjectStore for InMemory {
                     .unwrap_or(false)
             })
             .map(|(key, value)| {
-                let nanos = value.1.clone().timestamp_nanos();
-                let mut hasher = ahash::AHasher::default();
-                hasher.write_i64(nanos);
-                let e_tag = hasher.finish().to_string();
-
                 Ok(ObjectMeta {
                     location: key.clone(),
                     last_modified: value.1,
                     size: value.0.len(),
-                    e_tag,
+                    e_tag: None,
                 })
             })
             .collect();
@@ -238,16 +227,11 @@ impl ObjectStore for InMemory {
             if parts.next().is_some() {
                 common_prefixes.insert(prefix.child(common_prefix));
             } else {
-                let nanos = v.1.clone().timestamp_nanos();
-                let mut hasher = ahash::AHasher::default();
-                hasher.write_i64(nanos);
-                let e_tag = hasher.finish().to_string();
-
                 let object = ObjectMeta {
                     location: k.clone(),
                     last_modified: v.1,
                     size: v.0.len(),
-                    e_tag,
+                    e_tag: None,
                 };
                 objects.push(object);
             }

--- a/object_store/src/prefix.rs
+++ b/object_store/src/prefix.rs
@@ -108,6 +108,7 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
             last_modified: meta.last_modified,
             size: meta.size,
             location: self.strip_prefix(&meta.location).unwrap_or(meta.location),
+            e_tag: meta.e_tag,
         })
     }
 
@@ -128,6 +129,7 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
                 last_modified: meta.last_modified,
                 size: meta.size,
                 location: self.strip_prefix(&meta.location).unwrap_or(meta.location),
+                e_tag: meta.e_tag,
             })
             .boxed())
     }
@@ -155,6 +157,7 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
                             last_modified: meta.last_modified,
                             size: meta.size,
                             location: self.strip_prefix(&meta.location)?,
+                            e_tag: meta.e_tag.clone(),
                         })
                     })
                     .collect(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2240

# Rationale for this change
Add `Etag` for `objectMeta` as a unique identifier, which is a hash value by `last_modified`.


<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
