### PR TITLE
Fix: FlightSqlClient panic when execute_update.

### DIFF
--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -473,7 +473,7 @@ where
             let record_count = self.do_put_statement_update(token, request).await?;
             let result = DoPutUpdateResult { record_count };
             let output = futures::stream::iter(vec![Ok(PutResult {
-                app_metadata: result.encode_to_vec().into(),
+                app_metadata: result.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
         }
@@ -494,7 +494,7 @@ where
                 .await?;
             let result = DoPutUpdateResult { record_count };
             let output = futures::stream::iter(vec![Ok(PutResult {
-                app_metadata: result.encode_to_vec().into(),
+                app_metadata: result.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
         }


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change
 
 missing '.as_any()' when encoding DoPutUpdateResult, which results in empty Bytes, 
then FlightSqlClient will panic when  [unpack()?.unwrap()](https://github.com/apache/arrow-rs/blob/71ecc39f36c8f38a5fc93bc3878a607c831b2f12/arrow-flight/src/sql/client.rs#L194)


# What changes are included in this PR?


# Are there any user-facing changes?

