### PR TITLE
feat: enable metadata import/export through C data interface

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -138,6 +138,12 @@ def test_field_roundtrip(pyarrow_type):
         field = rust.round_trip_field(pyarrow_field)
         assert field == pyarrow_field
 
+def test_field_metadata_roundtrip():
+    metadata = {"hello": "World! 😊", "x": "2"}
+    pyarrow_field = pa.field("test", pa.int32(), metadata=metadata)
+    field = rust.round_trip_field(pyarrow_field)
+    assert field == pyarrow_field
+    assert field.metadata == pyarrow_field.metadata
 
 def test_schema_roundtrip():
     pyarrow_fields = zip(string.ascii_lowercase, _supported_pyarrow_types)

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -36,7 +36,10 @@
 
 use crate::{ArrowError, DataType, Field, Schema, TimeUnit, UnionMode};
 use bitflags::bitflags;
-use std::ffi::{c_char, c_void, CStr, CString};
+use std::{
+    collections::HashMap,
+    ffi::{c_char, c_void, CStr, CString},
+};
 
 bitflags! {
     pub struct Flags: i64 {
@@ -74,6 +77,7 @@ pub struct FFI_ArrowSchema {
 struct SchemaPrivateData {
     children: Box<[*mut FFI_ArrowSchema]>,
     dictionary: *mut FFI_ArrowSchema,
+    metadata: Option<Vec<u8>>,
 }
 
 // callback used to drop [FFI_ArrowSchema] when it is exported.
@@ -130,6 +134,7 @@ impl FFI_ArrowSchema {
         let mut private_data = Box::new(SchemaPrivateData {
             children: children_ptr,
             dictionary: dictionary_ptr,
+            metadata: None,
         });
 
         // intentionally set from private_data (see https://github.com/apache/arrow-rs/issues/580)
@@ -149,6 +154,46 @@ impl FFI_ArrowSchema {
 
     pub fn with_flags(mut self, flags: Flags) -> Result<Self, ArrowError> {
         self.flags = flags.bits();
+        Ok(self)
+    }
+
+    pub fn with_metadata(
+        mut self,
+        metadata: Option<&HashMap<String, String>>,
+    ) -> Result<Self, ArrowError> {
+        let new_metadata = if let Some(metadata) = metadata {
+            if metadata.len() > 0 {
+                let mut metadata_serialized: Vec<u8> = Vec::new();
+                metadata_serialized.extend((metadata.len() as i32).to_ne_bytes());
+
+                for (key, value) in metadata.into_iter() {
+                    let key_len = key.len() as i32;
+                    let value_len = value.len() as i32;
+
+                    metadata_serialized.extend(key_len.to_ne_bytes());
+                    metadata_serialized.extend_from_slice(key.as_bytes());
+                    metadata_serialized.extend(value_len.to_ne_bytes());
+                    metadata_serialized.extend_from_slice(value.as_bytes());
+                }
+
+                self.metadata = metadata_serialized.as_ptr() as *const c_char;
+                Some(metadata_serialized)
+            } else {
+                self.metadata = std::ptr::null_mut();
+                None
+            }
+        } else {
+            self.metadata = std::ptr::null_mut();
+            None
+        };
+
+        unsafe {
+            let mut private_data =
+                Box::from_raw(self.private_data as *mut SchemaPrivateData);
+            private_data.metadata = new_metadata;
+            self.private_data = Box::into_raw(private_data) as *mut c_void;
+        }
+
         Ok(self)
     }
 
@@ -211,6 +256,55 @@ impl FFI_ArrowSchema {
 
     pub fn dictionary_ordered(&self) -> bool {
         self.flags & 0b00000001 != 0
+    }
+
+    pub fn metadata(&self) -> Result<HashMap<String, String>, ArrowError> {
+        if self.metadata.is_null() {
+            Ok(HashMap::new())
+        } else {
+            let mut pos = 0;
+            let buffer: *const u8 = self.metadata as *const u8;
+
+            fn next_four_bytes(buffer: *const u8, pos: &mut isize) -> [u8; 4] {
+                let out = unsafe {
+                    [
+                        *buffer.offset(*pos),
+                        *buffer.offset(*pos + 1),
+                        *buffer.offset(*pos + 2),
+                        *buffer.offset(*pos + 3),
+                    ]
+                };
+                *pos += 4;
+                out
+            }
+
+            fn next_n_bytes(buffer: *const u8, pos: &mut isize, n: i32) -> &[u8] {
+                let out = unsafe {
+                    std::slice::from_raw_parts(buffer.offset(*pos), n.try_into().unwrap())
+                };
+                *pos += isize::try_from(n).unwrap();
+                out
+            }
+
+            let num_entries = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+            let mut metadata = HashMap::with_capacity(
+                num_entries.try_into().expect("Too many metadata entries"),
+            );
+
+            for _ in 0..num_entries {
+                let key_length = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+                let key = String::from_utf8(
+                    next_n_bytes(buffer, &mut pos, key_length).to_vec(),
+                )?;
+                let value_length = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+                let value = String::from_utf8(
+                    next_n_bytes(buffer, &mut pos, value_length).to_vec(),
+                )?;
+                metadata.insert(key, value);
+            }
+
+            Ok(metadata)
+        }
     }
 }
 
@@ -421,7 +515,8 @@ impl TryFrom<&FFI_ArrowSchema> for Field {
 
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self, ArrowError> {
         let dtype = DataType::try_from(c_schema)?;
-        let field = Field::new(c_schema.name(), dtype, c_schema.nullable());
+        let mut field = Field::new(c_schema.name(), dtype, c_schema.nullable());
+        field.set_metadata(c_schema.metadata()?);
         Ok(field)
     }
 }
@@ -433,7 +528,7 @@ impl TryFrom<&FFI_ArrowSchema> for Schema {
         // interpret it as a struct type then extract its fields
         let dtype = DataType::try_from(c_schema)?;
         if let DataType::Struct(fields) = dtype {
-            Ok(Schema::new(fields))
+            Ok(Schema::new(fields).with_metadata(c_schema.metadata()?))
         } else {
             Err(ArrowError::CDataInterface(
                 "Unable to interpret C data struct as a Schema".to_string(),
@@ -558,7 +653,8 @@ impl TryFrom<&Field> for FFI_ArrowSchema {
 
         FFI_ArrowSchema::try_from(field.data_type())?
             .with_name(field.name())?
-            .with_flags(flags)
+            .with_flags(flags)?
+            .with_metadata(Some(field.metadata()))
     }
 }
 
@@ -567,7 +663,8 @@ impl TryFrom<&Schema> for FFI_ArrowSchema {
 
     fn try_from(schema: &Schema) -> Result<Self, ArrowError> {
         let dtype = DataType::Struct(schema.fields().clone());
-        let c_schema = FFI_ArrowSchema::try_from(&dtype)?;
+        let c_schema =
+            FFI_ArrowSchema::try_from(&dtype)?.with_metadata(Some(&schema.metadata))?;
         Ok(c_schema)
     }
 }
@@ -655,7 +752,9 @@ mod tests {
             Field::new("name", DataType::Utf8, false),
             Field::new("address", DataType::Utf8, false),
             Field::new("priority", DataType::UInt8, false),
-        ]);
+        ])
+        .with_metadata([("hello".to_string(), "world".to_string())].into());
+
         round_trip_schema(schema);
 
         // test that we can interpret struct types as schema
@@ -699,5 +798,37 @@ mod tests {
 
         let arrow_schema = FFI_ArrowSchema::try_from(schema).unwrap();
         assert!(arrow_schema.child(0).dictionary_ordered());
+    }
+
+    #[test]
+    fn test_set_field_metadata() {
+        let metadata_cases: Vec<Option<HashMap<String, String>>> = vec![
+            Some([].into()),
+            Some([("key".to_string(), "value".to_string())].into()),
+            Some(
+                [
+                    ("key".to_string(), "".to_string()),
+                    ("ascii123".to_string(), "你好".to_string()),
+                    ("".to_string(), "value".to_string()),
+                ]
+                .into(),
+            ),
+            None,
+        ];
+
+        let mut schema = FFI_ArrowSchema::try_new("b", vec![], None)
+            .unwrap()
+            .with_name("test")
+            .unwrap();
+
+        for metadata in metadata_cases {
+            schema = schema.with_metadata(metadata.as_ref()).unwrap();
+            let field = Field::try_from(&schema).unwrap();
+            if let Some(metadata) = metadata {
+                assert_eq!(field.metadata(), &metadata);
+            } else {
+                assert!(field.metadata().is_empty());
+            }
+        }
     }
 }

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -162,11 +162,11 @@ impl FFI_ArrowSchema {
         metadata: Option<&HashMap<String, String>>,
     ) -> Result<Self, ArrowError> {
         let new_metadata = if let Some(metadata) = metadata {
-            if metadata.len() > 0 {
+            if !metadata.is_empty() {
                 let mut metadata_serialized: Vec<u8> = Vec::new();
                 metadata_serialized.extend((metadata.len() as i32).to_ne_bytes());
 
-                for (key, value) in metadata.into_iter() {
+                for (key, value) in metadata.iter() {
                     let key_len = key.len() as i32;
                     let value_len = value.len() as i32;
 

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -161,6 +161,7 @@ impl FFI_ArrowSchema {
         mut self,
         metadata: Option<&HashMap<String, String>>,
     ) -> Result<Self, ArrowError> {
+        // https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema.metadata
         let new_metadata = if let Some(metadata) = metadata {
             if !metadata.is_empty() {
                 let mut metadata_serialized: Vec<u8> = Vec::new();

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -288,16 +288,32 @@ impl FFI_ArrowSchema {
             }
 
             let num_entries = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+            if num_entries < 0 {
+                return Err(ArrowError::CDataInterface(
+                    "Negative number of metadata entries".to_string(),
+                ));
+            }
+
             let mut metadata = HashMap::with_capacity(
                 num_entries.try_into().expect("Too many metadata entries"),
             );
 
             for _ in 0..num_entries {
                 let key_length = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+                if key_length < 0 {
+                    return Err(ArrowError::CDataInterface(
+                        "Negative key length in metadata".to_string(),
+                    ));
+                }
                 let key = String::from_utf8(
                     next_n_bytes(buffer, &mut pos, key_length).to_vec(),
                 )?;
                 let value_length = i32::from_ne_bytes(next_four_bytes(buffer, &mut pos));
+                if value_length < 0 {
+                    return Err(ArrowError::CDataInterface(
+                        "Negative value length in metadata".to_string(),
+                    ));
+                }
                 let value = String::from_utf8(
                     next_n_bytes(buffer, &mut pos, value_length).to_vec(),
                 )?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #478.

# Rationale for this change
 
Metadata is used in extension types to communicate additional information. For example, the [geoarrow specification](https://github.com/geoarrow/geoarrow/blob/main/extension-types.md) uses field metadata to communicate extension types and coordinate systems for geospatial arrays. 

# What changes are included in this PR?

Adds metadata round tripping for fields and schemas.

# Are there any user-facing changes?

Fields and schemas brought through the C data interface will now have their metadata preserved.
