### PR TITLE
Faster i256 parsing

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -42,6 +42,11 @@ num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false }
 
 [dev-dependencies]
+criterion = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 
 [build-dependencies]
+
+[[bench]]
+name = "i256"
+harness = false

--- a/arrow-buffer/benches/i256.rs
+++ b/arrow-buffer/benches/i256.rs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_buffer::i256;
+use criterion::*;
+use std::str::FromStr;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let numbers = vec![
+        i256::ZERO,
+        i256::ONE,
+        i256::MINUS_ONE,
+        i256::from_i128(1233456789),
+        i256::from_i128(-1233456789),
+        i256::from_i128(i128::MAX),
+        i256::from_i128(i128::MIN),
+        i256::MIN,
+        i256::MAX,
+    ];
+
+    for number in numbers {
+        let t = black_box(number.to_string());
+        c.bench_function(&format!("i256_parse({t})"), |b| {
+            b.iter(|| i256::from_str(&t).unwrap());
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

```
i256_parse(0)           time:   [10.874 ns 10.877 ns 10.881 ns]
                        change: [-87.518% -87.503% -87.489%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

i256_parse(1)           time:   [10.876 ns 10.880 ns 10.884 ns]
                        change: [-88.017% -88.007% -87.998%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

i256_parse(-1)          time:   [10.921 ns 10.925 ns 10.930 ns]
                        change: [-88.083% -88.072% -88.061%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

i256_parse(1233456789)  time:   [13.636 ns 13.639 ns 13.643 ns]
                        change: [-86.694% -86.676% -86.658%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

i256_parse(-1233456789) time:   [14.703 ns 14.706 ns 14.710 ns]
                        change: [-86.286% -86.265% -86.245%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

i256_parse(170141183460469231731687303715884105727)
                        time:   [84.374 ns 84.410 ns 84.449 ns]
                        change: [-49.734% -49.609% -49.489%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

i256_parse(-170141183460469231731687303715884105728)
                        time:   [84.513 ns 84.830 ns 85.273 ns]
                        change: [-53.629% -53.463% -53.294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

i256_parse(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
                        time:   [161.48 ns 161.58 ns 161.71 ns]
                        change: [-41.546% -41.437% -41.329%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

i256_parse(57896044618658097711785492504343953926634992332820282019728792003956564819967)
                        time:   [161.24 ns 161.32 ns 161.41 ns]
                        change: [-35.107% -34.939% -34.776%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
