### PR TITLE
Panic instead of discarding nulls converting StructArray to RecordBatch -  (#3951)

### DIFF
--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -24,6 +24,28 @@ use std::{any::Any, ops::Index};
 
 /// A nested array type where each child (called *field*) is represented by a separate
 /// array.
+///
+///
+/// # Comparison with [RecordBatch]
+///
+/// Both [`RecordBatch`] and [`StructArray`] represent a collection of columns / arrays with the
+/// same length.
+///
+/// However, there are a couple of key differences:
+///
+/// * [`StructArray`] can be nested within other [`Array`], including itself
+/// * [`RecordBatch`] can contain top-level metadata on its associated [`Schema`][arrow_schema::Schema]
+/// * [`StructArray`] can contain top-level nulls, i.e. `null`
+/// * [`RecordBatch`] can only represent nulls in its child columns, i.e. `{"field": null}`
+///
+/// [`StructArray`] is therefore a more general data container than [`RecordBatch`], and as such
+/// code that needs to handle both will typically share an implementation in terms of
+/// [`StructArray`] and convert to/from [`RecordBatch`] as necessary.
+///
+/// [`From`] implementations are provided to facilitate this conversion, however, converting
+/// from a [`StructArray`] containing top-level nulls to a [`RecordBatch`] will panic, as there
+/// is no way to preserve them.
+///
 /// # Example: Create an array from a vector of fields
 ///
 /// ```

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -89,6 +89,14 @@ impl StructArray {
         }
     }
 
+    /// Returns the [`Field`] of this [`StructArray`]
+    pub fn fields(&self) -> &[Field] {
+        match self.data_type() {
+            DataType::Struct(f) => f,
+            _ => unreachable!(),
+        }
+    }
+
     /// Return child array whose field name equals to column_name
     ///
     /// Note: A schema can currently have duplicate field names, in which case

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -451,7 +451,7 @@ impl From<StructArray> for RecordBatch {
         assert_eq!(
             value.null_count(),
             0,
-            "Cannot convert nullable StructArray to RecordBatch"
+            "Cannot convert nullable StructArray to RecordBatch, see StructArray documentation"
         );
         let row_count = value.len();
         let schema = Arc::new(Schema::new(value.fields().clone()));

--- a/arrow/src/ffi_stream.rs
+++ b/arrow/src/ffi_stream.rs
@@ -373,7 +373,7 @@ impl Iterator for ArrowArrayStreamReader {
             .to_data()
             .ok()?;
 
-            let record_batch = RecordBatch::from(&StructArray::from(data));
+            let record_batch = RecordBatch::from(StructArray::from(data));
 
             Some(Ok(record_batch))
         } else {
@@ -492,7 +492,7 @@ mod tests {
             .to_data()
             .unwrap();
 
-            let record_batch = RecordBatch::from(&StructArray::from(array));
+            let record_batch = RecordBatch::from(StructArray::from(array));
             produced_batches.push(record_batch);
         }
 

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -217,6 +217,7 @@ mod tests {
     use crate::arrow::array_reader::ListArrayReader;
     use arrow::buffer::Buffer;
     use arrow::datatypes::Field;
+    use arrow_array::cast::AsArray;
     use arrow_array::{Array, Int32Array, ListArray};
 
     #[test]
@@ -251,7 +252,7 @@ mod tests {
         );
 
         let struct_array = struct_array_reader.next_batch(5).unwrap();
-        let struct_array = struct_array.as_any().downcast_ref::<StructArray>().unwrap();
+        let struct_array = struct_array.as_struct();
 
         assert_eq!(5, struct_array.len());
         assert_eq!(
@@ -327,7 +328,7 @@ mod tests {
         );
 
         let actual = struct_reader.next_batch(1024).unwrap();
-        let actual = actual.as_any().downcast_ref::<StructArray>().unwrap();
+        let actual = actual.as_struct();
         assert_eq!(actual, &expected)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3952

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Discarding the null buffer could potentially unmask nulls in non-nullable children, which would be ill-formed.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Technically this may change the behaviour of code that was relying on the null buffers silently being discarded, in practice this code was ill-formed.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
