### PR TITLE
Add Fields abstraction (#3955)

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -256,6 +256,7 @@ mod tests {
     use crate::cast::AsArray;
     use crate::types::UInt32Type;
     use crate::{Int32Array, UInt32Array};
+    use arrow_schema::Fields;
     use std::sync::Arc;
 
     use super::*;
@@ -496,10 +497,10 @@ mod tests {
     fn test_from_array_data_validation() {
         // A DictionaryArray has similar buffer layout to a MapArray
         // but the meaning of the values differs
-        let struct_t = DataType::Struct(vec![
+        let struct_t = DataType::Struct(Fields::from(vec![
             Field::new("keys", DataType::Int32, true),
             Field::new("values", DataType::UInt32, true),
-        ]);
+        ]));
         let dict_t = DataType::Dictionary(Box::new(DataType::Int32), Box::new(struct_t));
         let _ = MapArray::from(ArrayData::new_empty(&dict_t));
     }

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -731,7 +731,7 @@ mod tests {
     use crate::cast::{as_union_array, downcast_array};
     use crate::downcast_run_array;
     use arrow_buffer::{Buffer, MutableBuffer};
-    use arrow_schema::{Field, UnionMode};
+    use arrow_schema::{Field, Fields, UnionMode};
 
     #[test]
     fn test_empty_primitive() {
@@ -785,7 +785,7 @@ mod tests {
         // It is possible to create a null struct containing a non-nullable child
         // see https://github.com/apache/arrow-rs/pull/3244 for details
         let struct_type =
-            DataType::Struct(vec![Field::new("data", DataType::Int64, false)]);
+            DataType::Struct(vec![Field::new("data", DataType::Int64, false)].into());
         let array = new_null_array(&struct_type, 9);
 
         let a = array.as_any().downcast_ref::<StructArray>().unwrap();
@@ -828,10 +828,10 @@ mod tests {
         let data_type = DataType::Map(
             Box::new(Field::new(
                 "entry",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("key", DataType::Utf8, false),
                     Field::new("value", DataType::Int32, true),
-                ]),
+                ])),
                 false,
             )),
             false,

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -188,7 +188,7 @@ impl StructBuilder {
         }
     }
 
-    /// Creates a new `StructBuilder` from vector of [`Field`] with `capacity`
+    /// Creates a new `StructBuilder` from [`Fields`] and `capacity`
     pub fn from_fields(fields: Fields, capacity: usize) -> Self {
         let mut builders = Vec::with_capacity(fields.len());
         for field in &fields {

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -19,7 +19,7 @@
 //! [schema](arrow_schema::Schema).
 
 use crate::{new_empty_array, Array, ArrayRef, StructArray};
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaBuilder, SchemaRef};
 use std::ops::Index;
 use std::sync::Arc;
 
@@ -387,19 +387,18 @@ impl RecordBatch {
         I: IntoIterator<Item = (F, ArrayRef, bool)>,
         F: AsRef<str>,
     {
-        // TODO: implement `TryFrom` trait, once
-        // https://github.com/rust-lang/rust/issues/50133 is no longer an
-        // issue
-        let (fields, columns) = value
-            .into_iter()
-            .map(|(field_name, array, nullable)| {
-                let field_name = field_name.as_ref();
-                let field = Field::new(field_name, array.data_type().clone(), nullable);
-                (field, array)
-            })
-            .unzip();
+        let iter = value.into_iter();
+        let capacity = iter.size_hint().0;
+        let mut schema = SchemaBuilder::with_capacity(capacity);
+        let mut columns = Vec::with_capacity(capacity);
 
-        let schema = Arc::new(Schema::new(fields));
+        for (field_name, array, nullable) in iter {
+            let field_name = field_name.as_ref();
+            schema.push(Field::new(field_name, array.data_type().clone(), nullable));
+            columns.push(array);
+        }
+
+        let schema = Arc::new(schema.finish());
         RecordBatch::try_new(schema, columns)
     }
 
@@ -464,19 +463,6 @@ impl From<&StructArray> for RecordBatch {
         } else {
             unreachable!("unable to get datatype as struct")
         }
-    }
-}
-
-impl From<RecordBatch> for StructArray {
-    fn from(batch: RecordBatch) -> Self {
-        batch
-            .schema
-            .fields
-            .iter()
-            .zip(batch.columns.iter())
-            .map(|t| (t.0.clone(), t.1.clone()))
-            .collect::<Vec<(Field, ArrayRef)>>()
-            .into()
     }
 }
 
@@ -573,6 +559,7 @@ mod tests {
     };
     use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_data::ArrayDataBuilder;
+    use arrow_schema::Fields;
 
     #[test]
     fn create_record_batch() {
@@ -653,7 +640,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "assertion failed: (offset + length) <= self.num_rows()")]
     fn create_record_batch_slice_empty_batch() {
-        let schema = Schema::new(vec![]);
+        let schema = Schema::empty();
 
         let record_batch = RecordBatch::new_empty(Arc::new(schema));
 
@@ -729,7 +716,7 @@ mod tests {
                 false,
             ),
         ];
-        let struct_type = DataType::Struct(struct_fields);
+        let struct_type = DataType::Struct(struct_fields.into());
         let schema = Arc::new(Schema::new(vec![Field::new("a", struct_type, true)]));
 
         let a1: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
@@ -745,10 +732,10 @@ mod tests {
         .build()
         .unwrap();
         let a2: ArrayRef = Arc::new(ListArray::from(a2));
-        let a = ArrayDataBuilder::new(DataType::Struct(vec![
+        let a = ArrayDataBuilder::new(DataType::Struct(Fields::from(vec![
             Field::new("aa1", DataType::Int32, false),
             Field::new("a2", a2.data_type().clone(), false),
-        ]))
+        ])))
         .add_child_data(a1.into_data())
         .add_child_data(a2.into_data())
         .len(2)
@@ -801,7 +788,7 @@ mod tests {
         assert_eq!(4, batch.num_rows());
         assert_eq!(
             struct_array.data_type(),
-            &DataType::Struct(batch.schema().fields().to_vec())
+            &DataType::Struct(batch.schema().fields().clone())
         );
         assert_eq!(batch.column(0).as_ref(), boolean.as_ref());
         assert_eq!(batch.column(1).as_ref(), int.as_ref());
@@ -1024,7 +1011,7 @@ mod tests {
 
     #[test]
     fn test_no_column_record_batch() {
-        let schema = Arc::new(Schema::new(vec![]));
+        let schema = Arc::new(Schema::empty());
 
         let err = RecordBatch::try_new(schema.clone(), vec![]).unwrap_err();
         assert!(err

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -6993,10 +6993,10 @@ mod tests {
         let data_type = DataType::Map(
             Box::new(Field::new(
                 "entry",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("key", DataType::Utf8, false),
                     Field::new("value", DataType::Int32, true),
-                ]),
+                ])),
                 false,
             )),
             false,
@@ -7025,7 +7025,7 @@ mod tests {
 
         // Cast null from and to struct
         let data_type =
-            DataType::Struct(vec![Field::new("data", DataType::Int64, false)]);
+            DataType::Struct(vec![Field::new("data", DataType::Int64, false)].into());
         cast_from_null_to_other(&data_type);
     }
 

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -635,14 +635,16 @@ mod tests {
         let schema = Schema::new(vec![
             Field::new(
                 "c1",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
-                        DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                        DataType::Struct(
+                            vec![Field::new("c121", DataType::Utf8, false)].into(),
+                        ),
                         false,
                     ),
-                ]),
+                ])),
                 false,
             ),
             Field::new("c2", DataType::Utf8, false),
@@ -656,7 +658,9 @@ mod tests {
             (
                 Field::new(
                     "c12",
-                    DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                    DataType::Struct(
+                        vec![Field::new("c121", DataType::Utf8, false)].into(),
+                    ),
                     false,
                 ),
                 Arc::new(StructArray::from(vec![(

--- a/arrow-data/src/data/mod.rs
+++ b/arrow-data/src/data/mod.rs
@@ -1874,7 +1874,8 @@ mod tests {
         )
         .unwrap();
 
-        let data_type = DataType::Struct(vec![Field::new("x", DataType::Int32, true)]);
+        let field = Arc::new(Field::new("x", DataType::Int32, true));
+        let data_type = DataType::Struct(vec![field].into());
 
         let arr_data = ArrayData::builder(data_type)
             .len(5)

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -20,7 +20,7 @@ use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 use crate::{error::Result, FlightData, SchemaAsIpc};
 use arrow_array::{ArrayRef, RecordBatch, RecordBatchOptions};
 use arrow_ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use bytes::Bytes;
 use futures::{ready, stream::BoxStream, Stream, StreamExt};
 
@@ -309,7 +309,7 @@ impl Stream for FlightDataEncoder {
 ///
 /// See hydrate_dictionary for more information
 fn prepare_schema_for_flight(schema: &Schema) -> Schema {
-    let fields = schema
+    let fields: Fields = schema
         .fields()
         .iter()
         .map(|field| match field.data_type() {
@@ -319,7 +319,7 @@ fn prepare_schema_for_flight(schema: &Schema) -> Schema {
                 field.is_nullable(),
             )
             .with_metadata(field.metadata().clone()),
-            _ => field.clone(),
+            _ => field.as_ref().clone(),
         })
         .collect();
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -27,7 +27,7 @@ use arrow_flight::{
     encode::FlightDataEncoderBuilder,
     error::FlightError,
 };
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
 
@@ -484,7 +484,7 @@ async fn roundtrip_with_encoder(
 
 /// Workaround for https://github.com/apache/arrow-rs/issues/1206
 fn prepare_schema_for_flight(schema: &Schema) -> Schema {
-    let fields = schema
+    let fields: Fields = schema
         .fields()
         .iter()
         .map(|field| match field.data_type() {
@@ -494,7 +494,7 @@ fn prepare_schema_for_flight(schema: &Schema) -> Schema {
                 field.is_nullable(),
             )
             .with_metadata(field.metadata().clone()),
-            _ => field.clone(),
+            _ => field.as_ref().clone(),
         })
         .collect();
 

--- a/arrow-integration-test/src/datatype.rs
+++ b/arrow-integration-test/src/datatype.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit, UnionMode};
+use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit, UnionMode};
 use arrow::error::{ArrowError, Result};
 
 /// Parse a data type from a JSON representation.
@@ -206,7 +206,7 @@ pub fn data_type_from_json(json: &serde_json::Value) -> Result<DataType> {
             }
             Some(s) if s == "struct" => {
                 // return an empty `struct` type as its children aren't defined in the map
-                Ok(DataType::Struct(vec![]))
+                Ok(DataType::Struct(Fields::empty()))
             }
             Some(s) if s == "map" => {
                 if let Some(Value::Bool(keys_sorted)) = map.get("keysSorted") {

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -81,6 +81,12 @@ pub struct ArrowJsonField {
     pub metadata: Option<Value>,
 }
 
+impl From<&FieldRef> for ArrowJsonField {
+    fn from(value: &FieldRef) -> Self {
+        Self::from(value.as_ref())
+    }
+}
+
 impl From<&Field> for ArrowJsonField {
     fn from(field: &Field) -> Self {
         let metadata_value = match field.metadata().is_empty() {
@@ -1183,10 +1189,10 @@ mod tests {
             ),
             Field::new(
                 "structs",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("int32s", DataType::Int32, true),
                     Field::new("utf8s", DataType::Utf8, true),
-                ]),
+                ])),
                 true,
             ),
         ]);
@@ -1265,10 +1271,10 @@ mod tests {
 
         let structs_int32s = Int32Array::from(vec![None, Some(-2), None]);
         let structs_utf8s = StringArray::from(vec![None, None, Some("aaaaaa")]);
-        let struct_data_type = DataType::Struct(vec![
+        let struct_data_type = DataType::Struct(Fields::from(vec![
             Field::new("int32s", DataType::Int32, true),
             Field::new("utf8s", DataType::Utf8, true),
-        ]);
+        ]));
         let struct_data = ArrayData::builder(struct_data_type)
             .len(3)
             .add_child_data(structs_int32s.into_data())

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -183,7 +183,7 @@ fn create_array(
                 )?;
                 node_index = triple.1;
                 buffer_index = triple.2;
-                struct_arrays.push((struct_field.clone(), triple.0));
+                struct_arrays.push((struct_field.as_ref().clone(), triple.0));
             }
             let null_count = struct_node.null_count() as usize;
             let struct_array = if null_count > 0 {
@@ -736,10 +736,8 @@ pub fn read_dictionary(
     let dictionary_values: ArrayRef = match first_field.data_type() {
         DataType::Dictionary(_, ref value_type) => {
             // Make a fake schema for the dictionary batch.
-            let schema = Schema {
-                fields: vec![Field::new("", value_type.as_ref().clone(), true)],
-                metadata: HashMap::new(),
-            };
+            let value = value_type.as_ref().clone();
+            let schema = Schema::new(vec![Field::new("", value, true)]);
             // Read a single column
             let record_batch = read_record_batch(
                 buf,
@@ -1272,14 +1270,14 @@ mod tests {
         ];
         let union_data_type = DataType::Union(union_fileds, vec![0, 1], UnionMode::Dense);
 
-        let struct_fields = vec![
+        let struct_fields = Fields::from(vec![
             Field::new("id", DataType::Int32, false),
             Field::new(
                 "list",
                 DataType::List(Box::new(Field::new("item", DataType::Int8, true))),
                 false,
             ),
-        ];
+        ]);
         let struct_data_type = DataType::Struct(struct_fields);
 
         let run_encoded_data_type = DataType::RunEndEncoded(
@@ -1817,7 +1815,7 @@ mod tests {
 
     #[test]
     fn test_no_columns_batch() {
-        let schema = Arc::new(Schema::new(vec![]));
+        let schema = Arc::new(Schema::empty());
         let options = RecordBatchOptions::new()
             .with_match_field_names(true)
             .with_row_count(Some(10));

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -937,7 +937,7 @@ impl<W: Write> StreamWriter<W> {
     ///     255, 255, 255, 255,   0,   0,   0,   0
     /// ];
     ///
-    /// let schema = Schema::new(vec![]);
+    /// let schema = Schema::empty();
     /// let buffer: Vec<u8> = Vec::new();
     /// let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5)?;
     /// let stream_writer = StreamWriter::try_new_with_options(buffer, &schema, options)?;

--- a/arrow-json/src/raw/mod.rs
+++ b/arrow-json/src/raw/mod.rs
@@ -362,7 +362,7 @@ mod tests {
     use arrow_array::{Array, StructArray};
     use arrow_buffer::ArrowNativeType;
     use arrow_cast::display::{ArrayFormatter, FormatOptions};
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Fields, Schema};
     use std::fs::File;
     use std::io::{BufReader, Cursor, Seek};
     use std::sync::Arc;
@@ -510,23 +510,25 @@ mod tests {
             ),
             Field::new(
                 "nested",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("a", DataType::Int32, true),
                     Field::new("b", DataType::Int32, true),
-                ]),
+                ])),
                 true,
             ),
             Field::new(
                 "nested_list",
-                DataType::Struct(vec![Field::new(
+                DataType::Struct(Fields::from(vec![Field::new(
                     "list2",
                     DataType::List(Box::new(Field::new(
                         "element",
-                        DataType::Struct(vec![Field::new("c", DataType::Int32, false)]),
+                        DataType::Struct(
+                            vec![Field::new("c", DataType::Int32, false)].into(),
+                        ),
                         false,
                     ))),
                     true,
-                )]),
+                )])),
                 true,
             ),
         ]));
@@ -582,20 +584,22 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 "nested",
-                DataType::Struct(vec![Field::new("a", DataType::Int32, false)]),
+                DataType::Struct(vec![Field::new("a", DataType::Int32, false)].into()),
                 true,
             ),
             Field::new(
                 "nested_list",
-                DataType::Struct(vec![Field::new(
+                DataType::Struct(Fields::from(vec![Field::new(
                     "list2",
                     DataType::List(Box::new(Field::new(
                         "element",
-                        DataType::Struct(vec![Field::new("d", DataType::Int32, true)]),
+                        DataType::Struct(
+                            vec![Field::new("d", DataType::Int32, true)].into(),
+                        ),
                         false,
                     ))),
                     true,
-                )]),
+                )])),
                 true,
             ),
         ]));
@@ -636,10 +640,10 @@ mod tests {
            {"map": {"c": null, "a": ["baz"]}}
         "#;
         let list = DataType::List(Box::new(Field::new("element", DataType::Utf8, true)));
-        let entries = DataType::Struct(vec![
+        let entries = DataType::Struct(Fields::from(vec![
             Field::new("key", DataType::Utf8, false),
             Field::new("value", list, true),
-        ]);
+        ]));
 
         let map = DataType::Map(Box::new(Field::new("entries", entries, true)), false);
         let schema = Arc::new(Schema::new(vec![Field::new("map", map, true)]));
@@ -1008,29 +1012,29 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 "protocol",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("minReaderVersion", DataType::Int32, true),
                     Field::new("minWriterVersion", DataType::Int32, true),
-                ]),
+                ])),
                 true,
             ),
             Field::new(
                 "add",
-                DataType::Struct(vec![Field::new(
+                DataType::Struct(Fields::from(vec![Field::new(
                     "partitionValues",
                     DataType::Map(
                         Box::new(Field::new(
                             "key_value",
-                            DataType::Struct(vec![
+                            DataType::Struct(Fields::from(vec![
                                 Field::new("key", DataType::Utf8, false),
                                 Field::new("value", DataType::Utf8, true),
-                            ]),
+                            ])),
                             false,
                         )),
                         false,
                     ),
                     false,
-                )]),
+                )])),
                 true,
             ),
         ]));
@@ -1054,7 +1058,7 @@ mod tests {
             let non_null = r#"{"foo": {}}"#;
             let schema = Arc::new(Schema::new(vec![Field::new(
                 "foo",
-                DataType::Struct(vec![Field::new("bar", child, false)]),
+                DataType::Struct(vec![Field::new("bar", child, false)].into()),
                 true,
             )]));
             let mut reader = RawReaderBuilder::new(schema.clone())

--- a/arrow-json/src/raw/struct_array.rs
+++ b/arrow-json/src/raw/struct_array.rs
@@ -20,7 +20,7 @@ use crate::raw::{make_decoder, tape_error, ArrayDecoder};
 use arrow_array::builder::BooleanBufferBuilder;
 use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
-use arrow_schema::{ArrowError, DataType, Field};
+use arrow_schema::{ArrowError, DataType, Fields};
 
 pub struct StructArrayDecoder {
     data_type: DataType,
@@ -142,7 +142,7 @@ impl ArrayDecoder for StructArrayDecoder {
     }
 }
 
-fn struct_fields(data_type: &DataType) -> &[Field] {
+fn struct_fields(data_type: &DataType) -> &Fields {
     match &data_type {
         DataType::Struct(f) => f,
         _ => unreachable!(),

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -997,14 +997,16 @@ mod tests {
         let schema = Schema::new(vec![
             Field::new(
                 "c1",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
-                        DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                        DataType::Struct(
+                            vec![Field::new("c121", DataType::Utf8, false)].into(),
+                        ),
                         false,
                     ),
-                ]),
+                ])),
                 false,
             ),
             Field::new("c2", DataType::Utf8, false),
@@ -1018,7 +1020,9 @@ mod tests {
             (
                 Field::new(
                     "c12",
-                    DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                    DataType::Struct(
+                        vec![Field::new("c121", DataType::Utf8, false)].into(),
+                    ),
                     false,
                 ),
                 Arc::new(StructArray::from(vec![(
@@ -1158,14 +1162,16 @@ mod tests {
             "c1",
             DataType::List(Box::new(Field::new(
                 "s",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("c11", DataType::Int32, true),
                     Field::new(
                         "c12",
-                        DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                        DataType::Struct(
+                            vec![Field::new("c121", DataType::Utf8, false)].into(),
+                        ),
                         false,
                     ),
-                ]),
+                ])),
                 false,
             ))),
             true,
@@ -1181,7 +1187,9 @@ mod tests {
             (
                 Field::new(
                     "c12",
-                    DataType::Struct(vec![Field::new("c121", DataType::Utf8, false)]),
+                    DataType::Struct(
+                        vec![Field::new("c121", DataType::Utf8, false)].into(),
+                    ),
                     false,
                 ),
                 Arc::new(StructArray::from(vec![(
@@ -1316,7 +1324,7 @@ mod tests {
         {"list": [null]}
         "#;
         let ints_struct =
-            DataType::Struct(vec![Field::new("ints", DataType::Int32, true)]);
+            DataType::Struct(vec![Field::new("ints", DataType::Int32, true)].into());
         let list_type = DataType::List(Box::new(Field::new("item", ints_struct, true)));
         let list_field = Field::new("list", list_type, true);
         let schema = Arc::new(Schema::new(vec![list_field]));

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::{Field, FieldRef};
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// A cheaply cloneable, owned slice of [`FieldRef`]
+///
+/// Similar to `Arc<Vec<FieldPtr>>` or `Arc<[FieldPtr]>`
+///
+/// Can be constructed in a number of ways
+///
+/// ```
+/// # use std::sync::Arc;
+/// # use arrow_schema::{DataType, Field, Fields};
+/// // Can be constructed from Vec<Field>
+/// Fields::from(vec![Field::new("a", DataType::Boolean, false)]);
+/// // Can be constructed from Vec<FieldRef>
+/// Fields::from(vec![Arc::new(Field::new("a", DataType::Boolean, false))]);
+/// // Can be constructed from an iterator of Field
+/// std::iter::once(Field::new("a", DataType::Boolean, false)).collect::<Fields>();
+/// // Can be constructed from an iterator of FieldRef
+/// std::iter::once(Arc::new(Field::new("a", DataType::Boolean, false))).collect::<Fields>();
+/// ```
+///
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Fields(Arc<[FieldRef]>);
+
+impl std::fmt::Debug for Fields {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.as_ref().fmt(f)
+    }
+}
+
+impl Fields {
+    /// Returns a new empty [`Fields`]
+    pub fn empty() -> Self {
+        Self(Arc::new([]))
+    }
+
+    /// Return size of this instance in bytes.
+    pub fn size(&self) -> usize {
+        self.iter().map(|field| field.size()).sum()
+    }
+
+    /// Searches for a field by name, returning it along with its index if found
+    pub fn find(&self, name: &str) -> Option<(usize, &FieldRef)> {
+        self.0.iter().enumerate().find(|(_, b)| b.name() == name)
+    }
+}
+
+impl Default for Fields {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl FromIterator<Field> for Fields {
+    fn from_iter<T: IntoIterator<Item = Field>>(iter: T) -> Self {
+        iter.into_iter().map(Arc::new).collect()
+    }
+}
+
+impl FromIterator<FieldRef> for Fields {
+    fn from_iter<T: IntoIterator<Item = FieldRef>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl From<Vec<Field>> for Fields {
+    fn from(value: Vec<Field>) -> Self {
+        value.into_iter().collect()
+    }
+}
+
+impl From<Vec<FieldRef>> for Fields {
+    fn from(value: Vec<FieldRef>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&[FieldRef]> for Fields {
+    fn from(value: &[FieldRef]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<const N: usize> From<[FieldRef; N]> for Fields {
+    fn from(value: [FieldRef; N]) -> Self {
+        Self(Arc::new(value))
+    }
+}
+
+impl Deref for Fields {
+    type Target = [FieldRef];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> IntoIterator for &'a Fields {
+    type Item = &'a FieldRef;
+    type IntoIter = std::slice::Iter<'a, FieldRef>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+// Manually implement to avoid needing serde rc feature
+#[cfg(feature = "serde")]
+impl serde::Serialize for Fields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for e in self.iter() {
+            seq.serialize_element(e.as_ref())?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Fields {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Vec::<Field>::deserialize(deserializer)?.into())
+    }
+}

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -23,6 +23,8 @@ mod error;
 pub use error::*;
 mod field;
 pub use field::*;
+mod fields;
+pub use fields::*;
 mod schema;
 pub use schema::*;
 use std::ops;

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -18,12 +18,65 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use crate::error::ArrowError;
 use crate::field::Field;
+use crate::{FieldRef, Fields};
+
+/// A builder to facilitate building a [`Schema`] from iteratively from [`FieldRef`]
+#[derive(Debug, Default)]
+pub struct SchemaBuilder {
+    fields: Vec<FieldRef>,
+}
+
+impl SchemaBuilder {
+    /// Creates a new empty [`SchemaBuilder`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new empty [`SchemaBuilder`] with space for `capacity` fields
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            fields: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Appends a [`FieldRef`] to this [`SchemaBuilder`] without checking for collision
+    pub fn push(&mut self, field: impl Into<FieldRef>) {
+        self.fields.push(field.into())
+    }
+
+    /// Appends a [`FieldRef`] to this [`SchemaBuilder`] checking for collision
+    ///
+    /// If an existing field exists with the same name, calls [`Field::try_merge`]
+    pub fn try_merge(&mut self, field: &FieldRef) -> Result<(), ArrowError> {
+        // This could potentially be sped up with a HashMap or similar
+        let existing = self.fields.iter_mut().find(|f| f.name() == field.name());
+        match existing {
+            Some(e) if Arc::ptr_eq(e, field) => {} // Nothing to do
+            Some(e) => match Arc::get_mut(e) {
+                Some(e) => e.try_merge(field.as_ref())?,
+                None => {
+                    let mut t = e.as_ref().clone();
+                    t.try_merge(field)?;
+                    *e = Arc::new(t)
+                }
+            },
+            None => self.fields.push(field.clone()),
+        }
+        Ok(())
+    }
+
+    /// Consume this [`SchemaBuilder`] yielding the final [`Schema`]
+    pub fn finish(self) -> Schema {
+        Schema::new(self.fields)
+    }
+}
 
 /// A reference-counted reference to a [`Schema`].
-pub type SchemaRef = std::sync::Arc<Schema>;
+pub type SchemaRef = Arc<Schema>;
 
 /// Describes the meta-data of an ordered sequence of relative types.
 ///
@@ -32,7 +85,7 @@ pub type SchemaRef = std::sync::Arc<Schema>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Schema {
-    pub fields: Vec<Field>,
+    pub fields: Fields,
     /// A map of key-value pairs containing additional meta data.
     pub metadata: HashMap<String, String>,
 }
@@ -41,7 +94,7 @@ impl Schema {
     /// Creates an empty `Schema`
     pub fn empty() -> Self {
         Self {
-            fields: vec![],
+            fields: Default::default(),
             metadata: HashMap::new(),
         }
     }
@@ -57,7 +110,7 @@ impl Schema {
     ///
     /// let schema = Schema::new(vec![field_a, field_b]);
     /// ```
-    pub fn new(fields: Vec<Field>) -> Self {
+    pub fn new(fields: impl Into<Fields>) -> Self {
         Self::new_with_metadata(fields, HashMap::new())
     }
 
@@ -79,11 +132,14 @@ impl Schema {
     /// let schema = Schema::new_with_metadata(vec![field_a, field_b], metadata);
     /// ```
     #[inline]
-    pub const fn new_with_metadata(
-        fields: Vec<Field>,
+    pub fn new_with_metadata(
+        fields: impl Into<Fields>,
         metadata: HashMap<String, String>,
     ) -> Self {
-        Self { fields, metadata }
+        Self {
+            fields: fields.into(),
+            metadata,
+        }
     }
 
     /// Sets the metadata of this `Schema` to be `metadata` and returns self
@@ -141,39 +197,34 @@ impl Schema {
     pub fn try_merge(
         schemas: impl IntoIterator<Item = Self>,
     ) -> Result<Self, ArrowError> {
-        schemas
-            .into_iter()
-            .try_fold(Self::empty(), |mut merged, schema| {
-                let Schema { metadata, fields } = schema;
-                for (key, value) in metadata.into_iter() {
-                    // merge metadata
-                    if let Some(old_val) = merged.metadata.get(&key) {
-                        if old_val != &value {
-                            return Err(ArrowError::SchemaError(format!(
-                                "Fail to merge schema due to conflicting metadata. \
+        let mut out_meta = HashMap::new();
+        let mut out_fields = SchemaBuilder::new();
+        for schema in schemas {
+            let Schema { metadata, fields } = schema;
+
+            // merge metadata
+            for (key, value) in metadata.into_iter() {
+                if let Some(old_val) = out_meta.get(&key) {
+                    if old_val != &value {
+                        return Err(ArrowError::SchemaError(format!(
+                            "Fail to merge schema due to conflicting metadata. \
                                          Key '{key}' has different values '{old_val}' and '{value}'"
-                            )));
-                        }
-                    }
-                    merged.metadata.insert(key, value);
-                }
-                // merge fields
-                for field in fields.into_iter() {
-                    let merged_field =
-                        merged.fields.iter_mut().find(|f| f.name() == field.name());
-                    match merged_field {
-                        Some(merged_field) => merged_field.try_merge(&field)?,
-                        // found a new field, add to field list
-                        None => merged.fields.push(field),
+                        )));
                     }
                 }
-                Ok(merged)
-            })
+                out_meta.insert(key, value);
+            }
+
+            // merge fields
+            fields.iter().try_for_each(|x| out_fields.try_merge(x))?
+        }
+
+        Ok(out_fields.finish().with_metadata(out_meta))
     }
 
     /// Returns an immutable reference of the vector of `Field` instances.
     #[inline]
-    pub const fn fields(&self) -> &Vec<Field> {
+    pub const fn fields(&self) -> &Fields {
         &self.fields
     }
 
@@ -205,15 +256,13 @@ impl Schema {
 
     /// Find the index of the column with the given name.
     pub fn index_of(&self, name: &str) -> Result<usize, ArrowError> {
-        (0..self.fields.len())
-            .find(|idx| self.fields[*idx].name() == name)
-            .ok_or_else(|| {
-                let valid_fields: Vec<String> =
-                    self.fields.iter().map(|f| f.name().clone()).collect();
-                ArrowError::SchemaError(format!(
-                    "Unable to get field named \"{name}\". Valid fields: {valid_fields:?}"
-                ))
-            })
+        let (idx, _) = self.fields().find(name).ok_or_else(|| {
+            let valid_fields: Vec<_> = self.fields.iter().map(|f| f.name()).collect();
+            ArrowError::SchemaError(format!(
+                "Unable to get field named \"{name}\". Valid fields: {valid_fields:?}"
+            ))
+        })?;
+        Ok(idx)
     }
 
     /// Returns an immutable reference to the Map of custom metadata key-value pairs.
@@ -225,10 +274,8 @@ impl Schema {
     /// Look up a column by name and return a immutable reference to the column along with
     /// its index.
     pub fn column_with_name(&self, name: &str) -> Option<(usize, &Field)> {
-        self.fields
-            .iter()
-            .enumerate()
-            .find(|&(_, c)| c.name() == name)
+        let (idx, field) = self.fields.find(name)?;
+        Some((idx, field.as_ref()))
     }
 
     /// Check to see if `self` is a superset of `other` schema. Here are the comparison rules:
@@ -281,9 +328,10 @@ impl Hash for Schema {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::datatype::DataType;
     use crate::{TimeUnit, UnionMode};
+
+    use super::*;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -525,10 +573,10 @@ mod tests {
             Field::new("last_name", DataType::Utf8, false),
             Field::new(
                 "address",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("street", DataType::Utf8, false),
                     Field::new("zip", DataType::UInt16, false),
-                ]),
+                ])),
                 false,
             ),
             Field::new_dict(
@@ -634,7 +682,9 @@ mod tests {
                 Field::new("last_name", DataType::Utf8, false),
                 Field::new(
                     "address",
-                    DataType::Struct(vec![Field::new("zip", DataType::UInt16, false)]),
+                    DataType::Struct(
+                        vec![Field::new("zip", DataType::UInt16, false)].into(),
+                    ),
                     false,
                 ),
             ]),
@@ -644,12 +694,12 @@ mod tests {
                     Field::new("last_name", DataType::Utf8, true),
                     Field::new(
                         "address",
-                        DataType::Struct(vec![
+                        DataType::Struct(Fields::from(vec![
                             // add new nested field
                             Field::new("street", DataType::Utf8, false),
                             // nullable merge on nested field
                             Field::new("zip", DataType::UInt16, true),
-                        ]),
+                        ])),
                         false,
                     ),
                     // new field
@@ -671,10 +721,10 @@ mod tests {
                     Field::new("last_name", DataType::Utf8, true),
                     Field::new(
                         "address",
-                        DataType::Struct(vec![
+                        DataType::Struct(Fields::from(vec![
                             Field::new("zip", DataType::UInt16, true),
                             Field::new("street", DataType::Utf8, false),
-                        ]),
+                        ])),
                         false,
                     ),
                     Field::new("number", DataType::Utf8, true),

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -75,6 +75,42 @@ impl SchemaBuilder {
     }
 }
 
+impl From<&Fields> for SchemaBuilder {
+    fn from(value: &Fields) -> Self {
+        Self {
+            fields: value.to_vec(),
+        }
+    }
+}
+
+impl From<Fields> for SchemaBuilder {
+    fn from(value: Fields) -> Self {
+        Self {
+            fields: value.to_vec(),
+        }
+    }
+}
+
+impl Extend<FieldRef> for SchemaBuilder {
+    fn extend<T: IntoIterator<Item = FieldRef>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.fields.reserve(iter.size_hint().0);
+        for f in iter {
+            self.push(f)
+        }
+    }
+}
+
+impl Extend<Field> for SchemaBuilder {
+    fn extend<T: IntoIterator<Item = Field>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.fields.reserve(iter.size_hint().0);
+        for f in iter {
+            self.push(f)
+        }
+    }
+}
+
 /// A reference-counted reference to a [`Schema`].
 pub type SchemaRef = Arc<Schema>;
 

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -128,7 +128,7 @@ mod tests {
     use arrow_array::types::Int32Type;
     use arrow_array::{Int32Array, StringArray, StructArray};
     use arrow_data::ArrayData;
-    use arrow_schema::{DataType, Field};
+    use arrow_schema::{DataType, Field, Fields};
     use rand::{thread_rng, Rng};
 
     #[test]
@@ -376,10 +376,10 @@ mod tests {
     /// also need the top level is_valid bits to be correct.
     fn create_foo_struct(values: Vec<Foo>) -> StructArray {
         let mut struct_array = StructBuilder::new(
-            vec![
+            Fields::from(vec![
                 Field::new("a", DataType::Int32, true),
                 Field::new("b", DataType::Boolean, true),
-            ],
+            ]),
             vec![
                 Box::new(Int32Builder::with_capacity(values.len())),
                 Box::new(BooleanBuilder::with_capacity(values.len())),

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -151,23 +151,21 @@ where
             )?))
         }
         DataType::Struct(fields) => {
-            let struct_: &StructArray =
-                values.as_any().downcast_ref::<StructArray>().unwrap();
-            let arrays: Result<Vec<ArrayRef>, _> = struct_
+            let array: &StructArray = values.as_struct();
+            let arrays  = array
                 .columns()
                 .iter()
                 .map(|a| take_impl(a.as_ref(), indices, Some(options.clone())))
-                .collect();
-            let arrays = arrays?;
+                .collect::<Result<Vec<ArrayRef>, _>>()?;
             let fields: Vec<(Field, ArrayRef)> =
-                fields.clone().into_iter().zip(arrays).collect();
+                fields.iter().map(|f| f.as_ref().clone()).zip(arrays).collect();
 
             // Create the null bit buffer.
             let is_valid: Buffer = indices
                 .iter()
                 .map(|index| {
                     if let Some(index) = index {
-                        struct_.is_valid(index.to_usize().unwrap())
+                        array.is_valid(index.to_usize().unwrap())
                     } else {
                         false
                     }
@@ -962,7 +960,7 @@ where
 mod tests {
     use super::*;
     use arrow_array::builder::*;
-    use arrow_schema::TimeUnit;
+    use arrow_schema::{Fields, TimeUnit};
 
     fn test_take_decimal_arrays(
         data: Vec<Option<i128>>,
@@ -1060,10 +1058,10 @@ mod tests {
         values: Vec<Option<(Option<bool>, Option<i32>)>>,
     ) -> StructArray {
         let mut struct_builder = StructBuilder::new(
-            vec![
+            Fields::from(vec![
                 Field::new("a", DataType::Boolean, true),
                 Field::new("b", DataType::Int32, true),
-            ],
+            ]),
             vec![
                 Box::new(BooleanBuilder::with_capacity(values.len())),
                 Box::new(Int32Builder::with_capacity(values.len())),

--- a/arrow/examples/dynamic_types.rs
+++ b/arrow/examples/dynamic_types.rs
@@ -27,6 +27,7 @@ use arrow::record_batch::*;
 
 #[cfg(feature = "prettyprint")]
 use arrow::util::pretty::print_batches;
+use arrow_schema::Fields;
 
 fn main() -> Result<()> {
     // define schema
@@ -34,11 +35,11 @@ fn main() -> Result<()> {
         Field::new("id", DataType::Int32, false),
         Field::new(
             "nested",
-            DataType::Struct(vec![
+            DataType::Struct(Fields::from(vec![
                 Field::new("a", DataType::Utf8, false),
                 Field::new("b", DataType::Float64, false),
                 Field::new("c", DataType::Float64, false),
-            ]),
+            ])),
             false,
         ),
     ]);

--- a/arrow/src/compute/kernels/limit.rs
+++ b/arrow/src/compute/kernels/limit.rs
@@ -161,7 +161,7 @@ mod tests {
             Field::new("a", DataType::Boolean, true),
             Field::new("b", DataType::Int32, true),
         ];
-        let struct_array_data = ArrayData::builder(DataType::Struct(field_types))
+        let struct_array_data = ArrayData::builder(DataType::Struct(field_types.into()))
             .len(5)
             .add_child_data(boolean_data.clone())
             .add_child_data(int_data.clone())

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -29,7 +29,8 @@ pub use arrow_array::{
 pub use arrow_buffer::{i256, ArrowNativeType, ToByteSlice};
 pub use arrow_data::decimal::*;
 pub use arrow_schema::{
-    DataType, Field, IntervalUnit, Schema, SchemaRef, TimeUnit, UnionMode,
+    DataType, Field, FieldRef, Fields, IntervalUnit, Schema, SchemaBuilder, SchemaRef,
+    TimeUnit, UnionMode,
 };
 
 #[cfg(feature = "ffi")]

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -249,6 +249,7 @@ fn create_random_null_buffer(size: usize, null_density: f32) -> Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_schema::Fields;
 
     #[test]
     fn test_create_batch() {
@@ -298,7 +299,7 @@ mod tests {
     #[test]
     fn test_create_struct_array() {
         let size = 32;
-        let struct_fields = vec![
+        let struct_fields = Fields::from(vec![
             Field::new("b", DataType::Boolean, true),
             Field::new(
                 "c",
@@ -315,14 +316,14 @@ mod tests {
             ),
             Field::new(
                 "d",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("d_x", DataType::Int32, true),
                     Field::new("d_y", DataType::Float32, false),
                     Field::new("d_z", DataType::Binary, true),
-                ]),
+                ])),
                 true,
             ),
-        ];
+        ]);
         let field = Field::new("struct", DataType::Struct(struct_fields), true);
         let array = create_random_array(&field, size, 0.2, 0.5).unwrap();
 

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -40,7 +40,9 @@ use arrow_buffer::{i256, Buffer};
 use arrow_cast::pretty::pretty_format_columns;
 use arrow_cast::{can_cast_types, cast};
 use arrow_data::ArrayData;
-use arrow_schema::{ArrowError, DataType, Field, IntervalUnit, TimeUnit, UnionMode};
+use arrow_schema::{
+    ArrowError, DataType, Field, Fields, IntervalUnit, TimeUnit, UnionMode,
+};
 use half::f16;
 use std::sync::Arc;
 
@@ -398,10 +400,10 @@ fn get_all_types() -> Vec<DataType> {
         FixedSizeList(Box::new(Field::new("item", DataType::Utf8, false)), 10),
         LargeList(Box::new(Field::new("item", DataType::Int8, true))),
         LargeList(Box::new(Field::new("item", DataType::Utf8, false))),
-        Struct(vec![
+        Struct(Fields::from(vec![
             Field::new("f1", DataType::Int32, true),
             Field::new("f2", DataType::Utf8, true),
-        ]),
+        ])),
         Union(
             vec![
                 Field::new("f1", DataType::Int32, false),

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -1226,10 +1226,10 @@ fn make_struct(
     elements: Vec<Option<(Option<&'static str>, Option<i32>)>>,
 ) -> StructArray {
     let mut builder = StructBuilder::new(
-        Fields::from(vec![
+        vec![
             Field::new("f1", DataType::Utf8, true),
             Field::new("f2", DataType::Int32, true),
-        ]),
+        ],
         vec![
             Box::new(StringBuilder::new()),
             Box::new(Int32Builder::new()),

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -26,7 +26,7 @@ use arrow_array::builder::{StringBuilder, StructBuilder};
 use arrow_array::{DictionaryArray, FixedSizeListArray};
 use arrow_buffer::{Buffer, ToByteSlice};
 use arrow_data::{ArrayData, ArrayDataBuilder};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Fields};
 use std::sync::Arc;
 
 #[test]
@@ -806,10 +806,10 @@ fn test_struct_equal_null() {
     ]));
     let ints_non_null: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 0]));
 
-    let a = ArrayData::builder(DataType::Struct(vec![
+    let a = ArrayData::builder(DataType::Struct(Fields::from(vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Int32, true),
-    ]))
+    ])))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001011])))
     .len(5)
     .add_child_data(strings.to_data())
@@ -818,10 +818,10 @@ fn test_struct_equal_null() {
     .unwrap();
     let a = make_array(a);
 
-    let b = ArrayData::builder(DataType::Struct(vec![
+    let b = ArrayData::builder(DataType::Struct(Fields::from(vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Int32, true),
-    ]))
+    ])))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001011])))
     .len(5)
     .add_child_data(strings.to_data())
@@ -834,10 +834,10 @@ fn test_struct_equal_null() {
 
     // test with arrays that are not equal
     let c_ints_non_null: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 0, 4]));
-    let c = ArrayData::builder(DataType::Struct(vec![
+    let c = ArrayData::builder(DataType::Struct(Fields::from(vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Int32, true),
-    ]))
+    ])))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001011])))
     .len(5)
     .add_child_data(strings.to_data())
@@ -849,11 +849,9 @@ fn test_struct_equal_null() {
     test_equal(&a, &c, false);
 
     // test a nested struct
-    let a = ArrayData::builder(DataType::Struct(vec![Field::new(
-        "f3",
-        a.data_type().clone(),
-        true,
-    )]))
+    let a = ArrayData::builder(DataType::Struct(
+        vec![Field::new("f3", a.data_type().clone(), true)].into(),
+    ))
     .null_bit_buffer(Some(Buffer::from(vec![0b00011110])))
     .len(5)
     .add_child_data(a.to_data())
@@ -869,10 +867,10 @@ fn test_struct_equal_null() {
         Some("mark"),
         Some("doe"),
     ]));
-    let b = ArrayData::builder(DataType::Struct(vec![
+    let b = ArrayData::builder(DataType::Struct(Fields::from(vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Int32, true),
-    ]))
+    ])))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001011])))
     .len(5)
     .add_child_data(strings.to_data())
@@ -880,11 +878,9 @@ fn test_struct_equal_null() {
     .build()
     .unwrap();
 
-    let b = ArrayData::builder(DataType::Struct(vec![Field::new(
-        "f3",
-        b.data_type().clone(),
-        true,
-    )]))
+    let b = ArrayData::builder(DataType::Struct(
+        vec![Field::new("f3", b.data_type().clone(), true)].into(),
+    ))
     .null_bit_buffer(Some(Buffer::from(vec![0b00011110])))
     .len(5)
     .add_child_data(b)
@@ -913,11 +909,9 @@ fn test_struct_equal_null_variable_size() {
         Some("doe"),
     ]));
 
-    let a = ArrayData::builder(DataType::Struct(vec![Field::new(
-        "f1",
-        DataType::Utf8,
-        true,
-    )]))
+    let a = ArrayData::builder(DataType::Struct(
+        vec![Field::new("f1", DataType::Utf8, true)].into(),
+    ))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001010])))
     .len(5)
     .add_child_data(strings1.to_data())
@@ -925,11 +919,9 @@ fn test_struct_equal_null_variable_size() {
     .unwrap();
     let a = make_array(a);
 
-    let b = ArrayData::builder(DataType::Struct(vec![Field::new(
-        "f1",
-        DataType::Utf8,
-        true,
-    )]))
+    let b = ArrayData::builder(DataType::Struct(
+        vec![Field::new("f1", DataType::Utf8, true)].into(),
+    ))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001010])))
     .len(5)
     .add_child_data(strings2.to_data())
@@ -947,11 +939,9 @@ fn test_struct_equal_null_variable_size() {
         Some("doe"),
         Some("joe"),
     ]));
-    let c = ArrayData::builder(DataType::Struct(vec![Field::new(
-        "f1",
-        DataType::Utf8,
-        true,
-    )]))
+    let c = ArrayData::builder(DataType::Struct(
+        vec![Field::new("f1", DataType::Utf8, true)].into(),
+    ))
     .null_bit_buffer(Some(Buffer::from(vec![0b00001011])))
     .len(5)
     .add_child_data(strings3.to_data())
@@ -1236,10 +1226,10 @@ fn make_struct(
     elements: Vec<Option<(Option<&'static str>, Option<i32>)>>,
 ) -> StructArray {
     let mut builder = StructBuilder::new(
-        vec![
+        Fields::from(vec![
             Field::new("f1", DataType::Utf8, true),
             Field::new("f2", DataType::Int32, true),
-        ],
+        ]),
         vec![
             Box::new(StringBuilder::new()),
             Box::new(Int32Builder::new()),

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::Int16Type;
 use arrow_buffer::Buffer;
 use arrow_data::transform::MutableArrayData;
 use arrow_data::ArrayData;
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Fields};
 use std::sync::Arc;
 
 fn create_decimal_array(
@@ -778,10 +778,10 @@ fn test_map_nulls_append() {
         DataType::Map(
             Box::new(Field::new(
                 "entries",
-                DataType::Struct(vec![
+                DataType::Struct(Fields::from(vec![
                     Field::new("keys", DataType::Int64, false),
                     Field::new("values", DataType::Int64, true),
-                ]),
+                ])),
                 false,
             )),
             false,

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -23,7 +23,7 @@ use arrow::array::{
 use arrow_array::Decimal128Array;
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_data::ArrayData;
-use arrow_schema::{DataType, Field, UnionMode};
+use arrow_schema::{DataType, Field, Fields, UnionMode};
 use std::ptr::NonNull;
 use std::sync::Arc;
 
@@ -387,7 +387,7 @@ fn test_validate_struct_child_type() {
 
     // validate the the type of struct fields matches child fields
     ArrayData::try_new(
-        DataType::Struct(vec![Field::new("field1", DataType::Int64, true)]),
+        DataType::Struct(vec![Field::new("field1", DataType::Int64, true)].into()),
         3,
         None,
         0,
@@ -408,7 +408,7 @@ fn test_validate_struct_child_length() {
         .collect::<Int32Array>();
 
     ArrayData::try_new(
-        DataType::Struct(vec![Field::new("field1", DataType::Int32, true)]),
+        DataType::Struct(vec![Field::new("field1", DataType::Int32, true)].into()),
         6,
         None,
         0,
@@ -874,10 +874,10 @@ fn test_validate_union_dense_with_bad_len() {
 #[test]
 fn test_try_new_sliced_struct() {
     let mut builder = StructBuilder::new(
-        vec![
+        Fields::from(vec![
             Field::new("a", DataType::Int32, true),
             Field::new("b", DataType::Boolean, true),
-        ],
+        ]),
         vec![
             Box::new(Int32Builder::with_capacity(5)),
             Box::new(BooleanBuilder::with_capacity(5)),

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -23,7 +23,7 @@ use arrow::array::{
 use arrow_array::Decimal128Array;
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_data::ArrayData;
-use arrow_schema::{DataType, Field, Fields, UnionMode};
+use arrow_schema::{DataType, Field, UnionMode};
 use std::ptr::NonNull;
 use std::sync::Arc;
 
@@ -874,10 +874,10 @@ fn test_validate_union_dense_with_bad_len() {
 #[test]
 fn test_try_new_sliced_struct() {
     let mut builder = StructBuilder::new(
-        Fields::from(vec![
+        vec![
             Field::new("a", DataType::Int32, true),
             Field::new("b", DataType::Boolean, true),
-        ]),
+        ],
         vec![
             Box::new(Int32Builder::with_capacity(5)),
             Box::new(BooleanBuilder::with_capacity(5)),

--- a/arrow/tests/schema.rs
+++ b/arrow/tests/schema.rs
@@ -29,18 +29,19 @@ fn schema_destructure() {
     let field = Field::new("c1", DataType::Utf8, false);
     let schema = Schema::new(vec![field]).with_metadata(meta);
 
-    // Destructuring a Schema allows rewriting fields and metadata
+    // Destructuring a Schema allows rewriting metadata
     // without copying
     //
     // Model this usecase below:
 
     let Schema {
-        mut fields,
-        metadata,
+        fields,
+        mut metadata,
     } = schema;
-    fields.push(Field::new("c2", DataType::Utf8, false));
+
+    metadata.insert("foo".to_string(), "bar".to_string());
 
     let new_schema = Schema::new(fields).with_metadata(metadata);
 
-    assert_eq!(new_schema.fields().len(), 2);
+    assert_eq!(new_schema.metadata.get("foo").unwrap(), "bar");
 }

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -233,25 +233,25 @@ fn _create_nested_bench_batch(
     let fields = vec![
         Field::new(
             "_1",
-            DataType::Struct(vec![
+            DataType::Struct(Fields::from(vec![
                 Field::new("_1", DataType::Int8, true),
                 Field::new(
                     "_2",
-                    DataType::Struct(vec![
+                    DataType::Struct(Fields::from(vec![
                         Field::new("_1", DataType::Int8, true),
                         Field::new(
                             "_1",
-                            DataType::Struct(vec![
+                            DataType::Struct(Fields::from(vec![
                                 Field::new("_1", DataType::Int8, true),
                                 Field::new("_2", DataType::Utf8, true),
-                            ]),
+                            ])),
                             true,
                         ),
                         Field::new("_2", DataType::UInt8, true),
-                    ]),
+                    ])),
                     true,
                 ),
-            ]),
+            ])),
             true,
         ),
         Field::new(
@@ -260,14 +260,14 @@ fn _create_nested_bench_batch(
                 "item",
                 DataType::List(Box::new(Field::new(
                     "item",
-                    DataType::Struct(vec![
+                    DataType::Struct(Fields::from(vec![
                         Field::new(
                             "_1",
-                            DataType::Struct(vec![
+                            DataType::Struct(Fields::from(vec![
                                 Field::new("_1", DataType::Int8, true),
                                 Field::new("_2", DataType::Int16, true),
                                 Field::new("_3", DataType::Int32, true),
-                            ]),
+                            ])),
                             true,
                         ),
                         Field::new(
@@ -279,7 +279,7 @@ fn _create_nested_bench_batch(
                             ))),
                             true,
                         ),
-                    ]),
+                    ])),
                     true,
                 ))),
                 true,

--- a/parquet/src/arrow/array_reader/empty_array.rs
+++ b/parquet/src/arrow/array_reader/empty_array.rs
@@ -17,7 +17,7 @@
 
 use crate::arrow::array_reader::ArrayReader;
 use crate::errors::Result;
-use arrow_schema::DataType as ArrowType;
+use arrow_schema::{DataType as ArrowType, Fields};
 use arrow_array::{ArrayRef, StructArray};
 use arrow_data::ArrayDataBuilder;
 use std::any::Any;
@@ -40,7 +40,7 @@ struct EmptyArrayReader {
 impl EmptyArrayReader {
     pub fn new(row_count: usize) -> Self {
         Self {
-            data_type: ArrowType::Struct(vec![]),
+            data_type: ArrowType::Struct(Fields::empty()),
             remaining_rows: row_count,
             need_consume_records: 0,
         }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -261,6 +261,7 @@ mod tests {
     use arrow::datatypes::{Field, Int32Type as ArrowInt32, Int32Type};
     use arrow_array::{Array, PrimitiveArray};
     use arrow_data::ArrayDataBuilder;
+    use arrow_schema::Fields;
     use std::sync::Arc;
 
     fn list_type<OffsetSize: OffsetSizeTrait>(
@@ -581,15 +582,17 @@ mod tests {
         assert_eq!(batch.data_type(), array_reader.get_data_type());
         assert_eq!(
             batch.data_type(),
-            &ArrowType::Struct(vec![Field::new(
+            &ArrowType::Struct(Fields::from(vec![Field::new(
                 "table_info",
                 ArrowType::List(Box::new(Field::new(
                     "table_info",
-                    ArrowType::Struct(vec![Field::new("name", ArrowType::Binary, false)]),
+                    ArrowType::Struct(
+                        vec![Field::new("name", ArrowType::Binary, false)].into()
+                    ),
                     false
                 ))),
                 false
-            )])
+            )]))
         );
         assert_eq!(batch.len(), 0);
     }

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -129,6 +129,7 @@ mod tests {
     use arrow_array::builder::{MapBuilder, PrimitiveBuilder, StringBuilder};
     use arrow_array::cast::*;
     use arrow_array::RecordBatch;
+    use arrow_schema::Fields;
     use bytes::Bytes;
 
     #[test]
@@ -150,10 +151,10 @@ mod tests {
             ArrowType::Map(
                 Box::new(Field::new(
                     "entries",
-                    ArrowType::Struct(vec![
+                    ArrowType::Struct(Fields::from(vec![
                         Field::new("keys", ArrowType::Utf8, false),
                         Field::new("values", ArrowType::Int32, true),
-                    ]),
+                    ])),
                     false,
                 )),
                 false, // Map field not sorted

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -218,6 +218,7 @@ mod tests {
     use arrow::buffer::Buffer;
     use arrow::datatypes::Field;
     use arrow_array::{Array, Int32Array, ListArray};
+    use arrow_schema::Fields;
 
     #[test]
     fn test_struct_array_reader() {
@@ -237,10 +238,10 @@ mod tests {
             Some(vec![0, 1, 1, 1, 1]),
         );
 
-        let struct_type = ArrowType::Struct(vec![
+        let struct_type = ArrowType::Struct(Fields::from(vec![
             Field::new("f1", array_1.data_type().clone(), true),
             Field::new("f2", array_2.data_type().clone(), true),
-        ]);
+        ]));
 
         let mut struct_array_reader = StructArrayReader::new(
             struct_type,

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -704,7 +704,7 @@ mod tests {
     use arrow_array::{RecordBatch, RecordBatchReader};
     use arrow_buffer::Buffer;
     use arrow_data::ArrayDataBuilder;
-    use arrow_schema::{DataType as ArrowDataType, Field, Schema};
+    use arrow_schema::{DataType as ArrowDataType, Field, Fields, Schema};
 
     use crate::arrow::arrow_reader::{
         ArrowPredicateFn, ArrowReaderOptions, ParquetRecordBatchReader,
@@ -1104,16 +1104,17 @@ mod tests {
     fn test_decimal_nullable_struct() {
         let decimals = Decimal128Array::from_iter_values([1, 2, 3, 4, 5, 6, 7, 8]);
 
-        let data = ArrayDataBuilder::new(ArrowDataType::Struct(vec![Field::new(
-            "decimals",
-            decimals.data_type().clone(),
-            false,
-        )]))
-        .len(8)
-        .null_bit_buffer(Some(Buffer::from(&[0b11101111])))
-        .child_data(vec![decimals.into_data()])
-        .build()
-        .unwrap();
+        let data =
+            ArrayDataBuilder::new(ArrowDataType::Struct(Fields::from(vec![Field::new(
+                "decimals",
+                decimals.data_type().clone(),
+                false,
+            )])))
+            .len(8)
+            .null_bit_buffer(Some(Buffer::from(&[0b11101111])))
+            .child_data(vec![decimals.into_data()])
+            .build()
+            .unwrap();
 
         let written = RecordBatch::try_from_iter([(
             "struct",
@@ -1140,16 +1141,17 @@ mod tests {
     #[test]
     fn test_int32_nullable_struct() {
         let int32 = Int32Array::from_iter_values([1, 2, 3, 4, 5, 6, 7, 8]);
-        let data = ArrayDataBuilder::new(ArrowDataType::Struct(vec![Field::new(
-            "int32",
-            int32.data_type().clone(),
-            false,
-        )]))
-        .len(8)
-        .null_bit_buffer(Some(Buffer::from(&[0b11101111])))
-        .child_data(vec![int32.into_data()])
-        .build()
-        .unwrap();
+        let data =
+            ArrayDataBuilder::new(ArrowDataType::Struct(Fields::from(vec![Field::new(
+                "int32",
+                int32.data_type().clone(),
+                false,
+            )])))
+            .len(8)
+            .null_bit_buffer(Some(Buffer::from(&[0b11101111])))
+            .child_data(vec![int32.into_data()])
+            .build()
+            .unwrap();
 
         let written = RecordBatch::try_from_iter([(
             "struct",
@@ -1867,19 +1869,19 @@ mod tests {
         let expected_schema = Schema::new(vec![
             Field::new(
                 "roll_num",
-                ArrowDataType::Struct(vec![Field::new(
+                ArrowDataType::Struct(Fields::from(vec![Field::new(
                     "count",
                     ArrowDataType::UInt64,
                     false,
-                )]),
+                )])),
                 false,
             ),
             Field::new(
                 "PC_CUR",
-                ArrowDataType::Struct(vec![
+                ArrowDataType::Struct(Fields::from(vec![
                     Field::new("mean", ArrowDataType::Int64, false),
                     Field::new("sum", ArrowDataType::Int64, false),
-                ]),
+                ])),
                 false,
             ),
         ]);
@@ -1947,11 +1949,13 @@ mod tests {
 
         let reader = builder.with_projection(mask).build().unwrap();
 
-        let expected_schema = Schema::new(vec![Field::new(
+        let expected_schema = Schema::new(Fields::from(vec![Field::new(
             "group",
-            ArrowDataType::Struct(vec![Field::new("leaf", ArrowDataType::Int32, false)]),
+            ArrowDataType::Struct(
+                vec![Field::new("leaf", ArrowDataType::Int32, false)].into(),
+            ),
             true,
-        )]);
+        )]));
 
         let batch = reader.into_iter().next().unwrap().unwrap();
         assert_eq!(batch.schema().as_ref(), &expected_schema);

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -486,7 +486,7 @@ mod tests {
     use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_cast::display::array_value_to_string;
     use arrow_data::ArrayDataBuilder;
-    use arrow_schema::Schema;
+    use arrow_schema::{Fields, Schema};
 
     #[test]
     fn test_calculate_array_levels_twitter_example() {
@@ -947,7 +947,7 @@ mod tests {
         );
         let struct_field_e = Field::new(
             "e",
-            DataType::Struct(vec![struct_field_f.clone(), struct_field_g.clone()]),
+            DataType::Struct(vec![struct_field_f.clone(), struct_field_g.clone()].into()),
             true,
         );
         let schema = Schema::new(vec![
@@ -955,7 +955,9 @@ mod tests {
             Field::new("b", DataType::Int32, true),
             Field::new(
                 "c",
-                DataType::Struct(vec![struct_field_d.clone(), struct_field_e.clone()]),
+                DataType::Struct(
+                    vec![struct_field_d.clone(), struct_field_e.clone()].into(),
+                ),
                 true, // https://github.com/apache/arrow-rs/issues/245
             ),
         ]);
@@ -1067,7 +1069,7 @@ mod tests {
         let offset_field = Field::new("offset", DataType::Int32, true);
         let schema = Schema::new(vec![Field::new(
             "some_nested_object",
-            DataType::Struct(vec![offset_field.clone()]),
+            DataType::Struct(vec![offset_field.clone()].into()),
             false,
         )]);
 
@@ -1090,7 +1092,7 @@ mod tests {
         let offset_field = Field::new("offset", DataType::Int32, true);
         let schema = Schema::new(vec![Field::new(
             "some_nested_object",
-            DataType::Struct(vec![offset_field.clone()]),
+            DataType::Struct(vec![offset_field.clone()].into()),
             true,
         )]);
 
@@ -1122,10 +1124,10 @@ mod tests {
         {"stocks":{"long": "$CCC", "short": null}}
         {"stocks":{"hedged": "$YYY", "long": null, "short": "$D"}}
         "#;
-        let entries_struct_type = DataType::Struct(vec![
+        let entries_struct_type = DataType::Struct(Fields::from(vec![
             Field::new("key", DataType::Utf8, false),
             Field::new("value", DataType::Utf8, true),
-        ]);
+        ]));
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
@@ -1182,13 +1184,12 @@ mod tests {
     fn test_list_of_struct() {
         // define schema
         let int_field = Field::new("a", DataType::Int32, true);
-        let item_field =
-            Field::new("item", DataType::Struct(vec![int_field.clone()]), true);
+        let fields = Fields::from([Arc::new(int_field)]);
+        let item_field = Field::new("item", DataType::Struct(fields.clone()), true);
         let list_field = Field::new("list", DataType::List(Box::new(item_field)), true);
 
         let int_builder = Int32Builder::with_capacity(10);
-        let struct_builder =
-            StructBuilder::new(vec![int_field], vec![Box::new(int_builder)]);
+        let struct_builder = StructBuilder::new(fields, vec![Box::new(int_builder)]);
         let mut list_builder = ListBuilder::new(struct_builder);
 
         // [{a: 1}], [], null, [null, null], [{a: null}], [{a: 2}]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2094,7 +2094,7 @@ mod tests {
         let int_builder2 = Int32Builder::with_capacity(10);
 
         let struct_builder = StructBuilder::new(
-            vec![int_field, int_field2].into(),
+            vec![int_field, int_field2],
             vec![Box::new(int_builder), Box::new(int_builder2)],
         );
         let mut list_builder = ListBuilder::new(struct_builder);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3955 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This adds a cheaply cloneable `Fields` abstraction, that internally contains `FieldRef` within a reference counted slice.

This achieves a couple of things:

* The use of `FieldRef` allows projecting / reconstructing schema without needing to copy `Field`
* The use of `Arc<[FieldRef]>` allows cheap cloning of `DataType`, construction of `DataType::Struct`, etc...
* Allows cheap pointer comparisons between `Schema` and `DataType`
* Provides a potential extension point for faster field name lookups

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, this makes a fundamental change to the schema representation
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
