### PR TITLE
fix: remove unused type parameters.

### DIFF
--- a/arrow-ord/src/ord.rs
+++ b/arrow-ord/src/ord.rs
@@ -45,10 +45,7 @@ fn compare_boolean(left: &dyn Array, right: &dyn Array) -> DynComparator {
     Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
-fn compare_string<T>(left: &dyn Array, right: &dyn Array) -> DynComparator
-where
-    T: OffsetSizeTrait,
-{
+fn compare_string(left: &dyn Array, right: &dyn Array) -> DynComparator {
     let left: StringArray = StringArray::from(left.data().clone());
     let right: StringArray = StringArray::from(right.data().clone());
 
@@ -229,8 +226,8 @@ pub fn build_compare(
         (Duration(Nanosecond), Duration(Nanosecond)) => {
             compare_primitives::<DurationNanosecondType>(left, right)
         }
-        (Utf8, Utf8) => compare_string::<i32>(left, right),
-        (LargeUtf8, LargeUtf8) => compare_string::<i64>(left, right),
+        (Utf8, Utf8) => compare_string(left, right),
+        (LargeUtf8, LargeUtf8) => compare_string(left, right),
         (
             Dictionary(key_type_lhs, value_type_lhs),
             Dictionary(key_type_rhs, value_type_rhs),

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -271,62 +271,38 @@ pub fn sort_to_indices(
         }
         DataType::Utf8 => sort_string::<i32>(values, v, n, &options, limit),
         DataType::LargeUtf8 => sort_string::<i64>(values, v, n, &options, limit),
-        DataType::List(field) | DataType::FixedSizeList(field, _) => match field
-            .data_type()
-        {
-            DataType::Int8 => sort_list::<i32, Int8Type>(values, v, n, &options, limit),
-            DataType::Int16 => sort_list::<i32, Int16Type>(values, v, n, &options, limit),
-            DataType::Int32 => sort_list::<i32, Int32Type>(values, v, n, &options, limit),
-            DataType::Int64 => sort_list::<i32, Int64Type>(values, v, n, &options, limit),
-            DataType::UInt8 => sort_list::<i32, UInt8Type>(values, v, n, &options, limit),
-            DataType::UInt16 => {
-                sort_list::<i32, UInt16Type>(values, v, n, &options, limit)
+        DataType::List(field) | DataType::FixedSizeList(field, _) => {
+            match field.data_type() {
+                DataType::Int8 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Int16 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Int32 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Int64 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::UInt8 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::UInt16 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::UInt32 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::UInt64 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Float16 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Float32 => sort_list::<i32>(values, v, n, &options, limit),
+                DataType::Float64 => sort_list::<i32>(values, v, n, &options, limit),
+                t => {
+                    return Err(ArrowError::ComputeError(format!(
+                        "Sort not supported for list type {t:?}"
+                    )));
+                }
             }
-            DataType::UInt32 => {
-                sort_list::<i32, UInt32Type>(values, v, n, &options, limit)
-            }
-            DataType::UInt64 => {
-                sort_list::<i32, UInt64Type>(values, v, n, &options, limit)
-            }
-            DataType::Float16 => {
-                sort_list::<i32, Float16Type>(values, v, n, &options, limit)
-            }
-            DataType::Float32 => {
-                sort_list::<i32, Float32Type>(values, v, n, &options, limit)
-            }
-            DataType::Float64 => {
-                sort_list::<i32, Float64Type>(values, v, n, &options, limit)
-            }
-            t => {
-                return Err(ArrowError::ComputeError(format!(
-                    "Sort not supported for list type {t:?}"
-                )));
-            }
-        },
+        }
         DataType::LargeList(field) => match field.data_type() {
-            DataType::Int8 => sort_list::<i64, Int8Type>(values, v, n, &options, limit),
-            DataType::Int16 => sort_list::<i64, Int16Type>(values, v, n, &options, limit),
-            DataType::Int32 => sort_list::<i64, Int32Type>(values, v, n, &options, limit),
-            DataType::Int64 => sort_list::<i64, Int64Type>(values, v, n, &options, limit),
-            DataType::UInt8 => sort_list::<i64, UInt8Type>(values, v, n, &options, limit),
-            DataType::UInt16 => {
-                sort_list::<i64, UInt16Type>(values, v, n, &options, limit)
-            }
-            DataType::UInt32 => {
-                sort_list::<i64, UInt32Type>(values, v, n, &options, limit)
-            }
-            DataType::UInt64 => {
-                sort_list::<i64, UInt64Type>(values, v, n, &options, limit)
-            }
-            DataType::Float16 => {
-                sort_list::<i64, Float16Type>(values, v, n, &options, limit)
-            }
-            DataType::Float32 => {
-                sort_list::<i64, Float32Type>(values, v, n, &options, limit)
-            }
-            DataType::Float64 => {
-                sort_list::<i64, Float64Type>(values, v, n, &options, limit)
-            }
+            DataType::Int8 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Int16 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Int32 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Int64 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::UInt8 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::UInt16 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::UInt32 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::UInt64 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Float16 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Float32 => sort_list::<i64>(values, v, n, &options, limit),
+            DataType::Float64 => sort_list::<i64>(values, v, n, &options, limit),
             t => {
                 return Err(ArrowError::ComputeError(format!(
                     "Sort not supported for list type {t:?}"
@@ -901,7 +877,7 @@ where
     }
 }
 
-fn sort_list<S, T>(
+fn sort_list<S>(
     values: &dyn Array,
     value_indices: Vec<u32>,
     null_indices: Vec<u32>,
@@ -910,8 +886,6 @@ fn sort_list<S, T>(
 ) -> UInt32Array
 where
     S: OffsetSizeTrait,
-    T: ArrowPrimitiveType,
-    T::Native: PartialOrd,
 {
     sort_list_inner::<S>(values, value_indices, null_indices, options, limit)
 }


### PR DESCRIPTION
receive warning from cargo clippy.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

```
cargo clippy --future-incompat-report


warning: type parameter goes unused in function definition
  --> arrow-ord/src/ord.rs:48:18
   |
48 | fn compare_string<T>(left: &dyn Array, right: &dyn Array) -> DynComparator
   |                  ^^^
   |
   = help: consider removing the parameter
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_type_parameters
   = note: `#[warn(clippy::extra_unused_type_parameters)]` on by default

warning: type parameter goes unused in function definition
   --> arrow-ord/src/sort.rs:904:17
    |
904 | fn sort_list<S, T>(
    |                 ^
    |
    = help: consider removing the parameter
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_type_parameters

```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
