### PR TITLE
Handle precision overflow when casting from integer to decimal

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -8158,11 +8158,31 @@ mod tests {
         assert!(casted_array.is_ok());
         assert!(casted_array.unwrap().is_null(0));
 
-        let casted_array = cast_with_options(
+        let err = cast_with_options(
             &array,
             &DataType::Decimal128(7, 3),
             &CastOptions { safe: false },
         );
-        assert!(casted_array.is_err());
+        assert_eq!("Invalid argument error: 1234567000 is too large to store in a Decimal128 of precision 7. Max is 9999999", err.unwrap_err().to_string());
+    }
+
+    #[test]
+    fn test_cast_numeric_to_decimal256_precision_overflow() {
+        let array = Int64Array::from(vec![1234567]);
+        let array = Arc::new(array) as ArrayRef;
+        let casted_array = cast_with_options(
+            &array,
+            &DataType::Decimal256(7, 3),
+            &CastOptions { safe: true },
+        );
+        assert!(casted_array.is_ok());
+        assert!(casted_array.unwrap().is_null(0));
+
+        let err = cast_with_options(
+            &array,
+            &DataType::Decimal256(7, 3),
+            &CastOptions { safe: false },
+        );
+        assert_eq!("Invalid argument error: 1234567000 is too large to store in a Decimal256 of precision 7. Max is 9999999", err.unwrap_err().to_string());
     }
 }

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -4391,8 +4391,7 @@ mod tests {
         assert!(casted_array.is_ok());
         let array = casted_array.unwrap();
         let array: &Decimal128Array = array.as_primitive();
-        let err = array.validate_decimal_precision(3);
-        assert_eq!("Invalid argument error: 1000 is too large to store in a Decimal128 of precision 3. Max is 999", err.unwrap_err().to_string());
+        assert!(array.is_null(4));
 
         // test i8 to decimal type with overflow the result type
         // the 100 will be converted to 1000_i128, but it is out of range for max value in the precision 3.
@@ -4401,8 +4400,7 @@ mod tests {
         assert!(casted_array.is_ok());
         let array = casted_array.unwrap();
         let array: &Decimal128Array = array.as_primitive();
-        let err = array.validate_decimal_precision(3);
-        assert_eq!("Invalid argument error: 1000 is too large to store in a Decimal128 of precision 3. Max is 999", err.unwrap_err().to_string());
+        assert!(array.is_null(4));
 
         // test f32 to decimal type
         let array = Float32Array::from(vec![
@@ -4560,8 +4558,7 @@ mod tests {
         assert!(casted_array.is_ok());
         let array = casted_array.unwrap();
         let array: &Decimal256Array = array.as_primitive();
-        let err = array.validate_decimal_precision(3);
-        assert_eq!("Invalid argument error: 1000 is too large to store in a Decimal256 of precision 3. Max is 999", err.unwrap_err().to_string());
+        assert!(array.is_null(4));
 
         // test f32 to decimal type
         let array = Float32Array::from(vec![

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -364,9 +364,9 @@ where
                 })
             }),
             false => array.try_unary::<_, D, _>(|v| {
-                v.as_().div_checked(scale_factor).and_then(|v| {
-                    D::validate_decimal_precision(v, precision).and_then(|_| Ok(v))
-                })
+                v.as_()
+                    .div_checked(scale_factor)
+                    .and_then(|v| D::validate_decimal_precision(v, precision).map(|_| v))
             })?,
         }
     } else {
@@ -377,9 +377,9 @@ where
                 })
             }),
             false => array.try_unary::<_, D, _>(|v| {
-                v.as_().mul_checked(scale_factor).and_then(|v| {
-                    D::validate_decimal_precision(v, precision).and_then(|_| Ok(v))
-                })
+                v.as_()
+                    .mul_checked(scale_factor)
+                    .and_then(|v| D::validate_decimal_precision(v, precision).map(|_| v))
             })?,
         }
     };


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3995.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Although `cast` kernel checks if division or multiplication overflows in such cast operation, it doesn't check precision overflow. This is somehow related to decimal operation convention in arrow-rs, that is let user handle invalid values in decimal arrays. But for `cast` kernel, because it provides `CastOptions` which defines null behavior for invalid case, the behavior of not checking precision overflow becomes a bit inconsistent.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
