### PR TITLE
Deprecate combine_option_bitmap

### DIFF
--- a/arrow-data/src/bit_mask.rs
+++ b/arrow-data/src/bit_mask.rs
@@ -68,6 +68,7 @@ pub fn set_bits(
 /// Combines the null bitmaps of multiple arrays using a bitwise `and` operation.
 ///
 /// This function is useful when implementing operations on higher level arrays.
+#[deprecated(note = "Use NullBuffer::union")]
 pub fn combine_option_bitmap(
     arrays: &[&ArrayData],
     len_in_bits: usize,
@@ -247,6 +248,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_combine_option_bitmap() {
         let none_bitmap = make_data_with_null_bit_buffer(8, 0, None);
         let some_bitmap =
@@ -298,6 +300,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_combine_option_bitmap_with_offsets() {
         let none_bitmap = make_data_with_null_bit_buffer(8, 0, None);
         let bitmap0 =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3880

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`NullBuffer::union` is both more flexible and concise. As an added bonus it can avoid needing to slice the null buffer if not necessary

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
