### PR TITLE
Add FlightSQL module docs and links to `arrow-flight` crates

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -36,6 +36,7 @@ arrow-schema = { workspace = true }
 base64 = { version = "0.21", default-features = false, features = ["std"] }
 tonic = { version = "0.9", default-features = false, features = ["transport", "codegen", "prost"] }
 bytes = { version = "1", default-features = false }
+paste = { version = "1.0" }
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -30,6 +30,11 @@
 //!
 //! 2. Low level [tonic] generated [`flight_service_client`] and
 //! [`flight_service_server`].
+//!
+//! 3. Experimental support for [Flight SQL]rec in [`sql`]. Requires the
+//! `flight-sql-experimental` feature of this crate to be activated.
+//!
+//! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
 #![allow(rustdoc::invalid_html_tags)]
 
 use arrow_ipc::{convert, writer, writer::EncodedData, writer::IpcWriteOptions};

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -31,7 +31,7 @@
 //! 2. Low level [tonic] generated [`flight_service_client`] and
 //! [`flight_service_server`].
 //!
-//! 3. Experimental support for [Flight SQL]rec in [`sql`]. Requires the
+//! 3. Experimental support for [Flight SQL] in [`sql`]. Requires the
 //! `flight-sql-experimental` feature of this crate to be activated.
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! A FlightSQL Client [`FlightSqlServiceClient`]
+
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Bytes;

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -27,7 +27,7 @@
 //! and [`FlightService::do_get`](crate::flight_service_server::FlightService::do_get)
 //!
 //! This module contains:
-//! 1. The [tonic] generated protobuf definitions for FlightSQL messages such as [`CommandStatementQuery`]
+//! 1. The [prost] generated structs for FlightSQL messages such as [`CommandStatementQuery`]
 //! 2. Helpers for for encoding and decoding such messages: [`Any`] and [`Command`]
 //! 3. A [`FlightSqlServiceClient`](client::FlightSqlServiceClient) for interacting with FlightSQL servers.
 //! 4. A [`FlightSqlService`](server::FlightSqlService) to help building FlightSQL servers from [`FlightService`](crate::flight_service_server::FlightService).

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -18,23 +18,24 @@
 //! Support for execute SQL queries using [Apache Arrow] [Flight SQL].
 //!
 //! [Flight SQL] is built on top of Arrow Flight RPC framework, by
-//! defining specific messages, encoded using the protobuf format, sent
-//! in the
-//! [`FlightDescriptor::cmd`](crate::FlightDescriptor::cmd)
-//! field to [`FlightService`](crate::flight_service_server::FlightService) endpoints
-//! such as
-//! [`FlightService::get_flight_info`](crate::flight_service_server::FlightService::get_flight_info)
-//! and [`FlightService::do_get`](crate::flight_service_server::FlightService::do_get)
+//! defining specific messages, encoded using the protobuf format,
+//! sent in the[`FlightDescriptor::cmd`] field to [`FlightService`]
+//! endpoints such as[`get_flight_info`] and [`do_get`].
 //!
 //! This module contains:
-//! 1. The [prost] generated structs for FlightSQL messages such as [`CommandStatementQuery`]
-//! 2. Helpers for for encoding and decoding such messages: [`Any`] and [`Command`]
-//! 3. A [`FlightSqlServiceClient`](client::FlightSqlServiceClient) for interacting with FlightSQL servers.
-//! 4. A [`FlightSqlService`](server::FlightSqlService) to help building FlightSQL servers from [`FlightService`](crate::flight_service_server::FlightService).
+//! 1. [prost] generated structs for FlightSQL messages such as [`CommandStatementQuery`]
+//! 2. Helpers for encoding and decoding FlightSQL messages: [`Any`] and [`Command`]
+//! 3. A [`FlightSqlServiceClient`] for interacting with FlightSQL servers.
+//! 4. A [`FlightSqlService`] to help building FlightSQL servers from [`FlightService`].
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
 //! [Apache Arrow]: https://arrow.apache.org
-
+//! [`FlightDescriptor::cmd`]: crate::FlightDescriptor::cmd
+//! [`FlightService`]: crate::flight_service_server::FlightService
+//! [`get_flight_info`]: crate::flight_service_server::FlightService::get_flight_info
+//! [`do_get`]: crate::flight_service_server::FlightService::do_get
+//! [`FlightSqlServiceClient`]: client::FlightSqlServiceClient
+//! [`FlightSqlService`]: server::FlightSqlService
 use arrow_schema::ArrowError;
 use bytes::Bytes;
 use paste::paste;

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -15,6 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Support for execute SQL queries using [Apache Arrow] [Flight SQL].
+//!
+//! [Flight SQL] is built on top of Arrow Flight RPC framework, by
+//! defining specific message, encoded using the protobuf format, sent
+//! in the
+//! [`FlightDescriptor::cmd`](crate::FlightDescriptor::cmd)
+//! field to [`FlightService`](crate::flight_service_server::FlightService) endpoints
+//! such as
+//! [`FlightService::get_flight_info`](crate::flight_service_server::FlightService::get_flight_info)
+//! and [`FlightService::do_get`](crate::flight_service_server::FlightService::do_get)
+//!
+//! This module contains:
+//! 1. The [tonic] generated protobuf definitions for FlightSQL messages such as [`CommandStatementQuery`]
+//! 2. Helpers for for encoding and decoding such messages: [`Any`] and [`Command`]
+//! 3. A [`FlightSqlServiceClient`](client::FlightSqlServiceClient) for interacting with FlightSQL servers.
+//! 4. A [`FlightSqlService`](server::FlightSqlService) to help building FlightSQL servers from [`FlightService`](crate::flight_service_server::FlightService).
+//!
+//! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
+//! [Apache Arrow]: https://arrow.apache.org
+
 use arrow_schema::ArrowError;
 use bytes::Bytes;
 use paste::paste;
@@ -90,8 +110,8 @@ macro_rules! prost_message_ext {
             )*
 
                 as_item! {
-                /// Helper to convert to/from protobuf [`Any`]
-                /// to a strongly typed enum.
+                /// Helper to convert to/from protobuf [`Any`] message
+                /// to a specific FlightSQL command message.
                 ///
                 /// # Example
                 /// ```rust

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Helper trait [`FlightSqlService`] for implementing a [`FlightService`] that implements FlightSQL.
+
 use std::pin::Pin;
 
 use crate::sql::{Any, Command};


### PR DESCRIPTION
# Which issue does this PR close?

re https://github.com/apache/arrow-rs/pull/3887

# Rationale for this change
 
While waiting for CI to run on https://github.com/apache/arrow-rs/pull/3887 I spent some time writing docs to make it easier to understand what is going on / what we have in this crate. 

# What changes are included in this PR?

1. Add a breadcrumb to `arrow-flight` to point at the `sql` feature. 
2. Add module documentation to arrow-flight sql with some orienting text and pointers

# Are there any user-facing changes?

more docs