### PR TITLE
fix: f16::ZERO and f16::ONE are mixed up

### DIFF
--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -377,6 +377,6 @@ macro_rules! native_type_float_op {
     };
 }
 
-native_type_float_op!(f16, f16::ONE, f16::ZERO);
+native_type_float_op!(f16, f16::ZERO, f16::ONE);
 native_type_float_op!(f32, 0., 1.);
 native_type_float_op!(f64, 0., 1.);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4016

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes
