### PR TITLE
Minor: add methods "is_positive" and "signum" to i256

### DIFF
--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -322,7 +322,7 @@ impl i256 {
     #[inline]
     pub fn checked_add(self, other: Self) -> Option<Self> {
         let r = self.wrapping_add(other);
-        ((other.is_negative() && r < self) || (!other.is_negative() && r >= self))
+        ((other.is_negative() && r < self) || (other.is_positive() && r >= self))
             .then_some(r)
     }
 
@@ -338,7 +338,7 @@ impl i256 {
     #[inline]
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         let r = self.wrapping_sub(other);
-        ((other.is_negative() && r > self) || (!other.is_negative() && r <= self))
+        ((other.is_negative() && r > self) || (other.is_positive() && r <= self))
             .then_some(r)
     }
 
@@ -487,6 +487,12 @@ impl i256 {
     #[inline]
     pub const fn is_negative(self) -> bool {
         self.high.is_negative()
+    }
+
+    /// Returns `true` if this [`i256`] is positive
+    #[inline]
+    pub const fn is_positive(self) -> bool {
+        self.high.is_positive()
     }
 }
 

--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -483,6 +483,21 @@ impl i256 {
         acc.wrapping_mul(base)
     }
 
+    /// Returns a number [`i256`] representing sign of this [`i256`].
+    ///
+    /// 0 if the number is zero
+    /// 1 if the number is positive
+    /// -1 if the number is negative
+    pub const fn signum(self) -> Self {
+        if self.is_positive() {
+            i256::from_i128(1)
+        } else if self.is_negative() {
+            i256::from_i128(-1)
+        } else {
+            i256::from_i128(0)
+        }
+    }
+
     /// Returns `true` if this [`i256`] is negative
     #[inline]
     pub const fn is_negative(self) -> bool {
@@ -490,9 +505,8 @@ impl i256 {
     }
 
     /// Returns `true` if this [`i256`] is positive
-    #[inline]
     pub const fn is_positive(self) -> bool {
-        self.high.is_positive()
+        self.high.is_positive() || self.high == 0 && self.low != 0
     }
 }
 
@@ -921,6 +935,24 @@ mod tests {
                 test_ops(il, ir)
             }
         }
+    }
+
+    #[test]
+    fn test_signed_ops() {
+        // signum
+        assert_eq!(i256::from_i128(1).signum(), i256::from_i128(1));
+        assert_eq!(i256::from_i128(0).signum(), i256::from_i128(0));
+        assert_eq!(i256::from_i128(-1).signum(), i256::from_i128(-1));
+
+        // is_positive
+        assert!(i256::from_i128(1).is_positive());
+        assert!(!i256::from_i128(0).is_positive());
+        assert!(!i256::from_i128(-1).is_positive());
+
+        // is_negative
+        assert!(!i256::from_i128(1).is_negative());
+        assert!(!i256::from_i128(0).is_negative());
+        assert!(i256::from_i128(-1).is_negative());
     }
 
     #[test]

--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -322,7 +322,7 @@ impl i256 {
     #[inline]
     pub fn checked_add(self, other: Self) -> Option<Self> {
         let r = self.wrapping_add(other);
-        ((other.is_negative() && r < self) || (other.is_positive() && r >= self))
+        ((other.is_negative() && r < self) || (!other.is_negative() && r >= self))
             .then_some(r)
     }
 
@@ -338,7 +338,7 @@ impl i256 {
     #[inline]
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         let r = self.wrapping_sub(other);
-        ((other.is_negative() && r > self) || (other.is_positive() && r <= self))
+        ((other.is_negative() && r > self) || (!other.is_negative() && r <= self))
             .then_some(r)
     }
 

--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -490,11 +490,11 @@ impl i256 {
     /// -1 if the number is negative
     pub const fn signum(self) -> Self {
         if self.is_positive() {
-            i256::from_i128(1)
+            i256::ONE
         } else if self.is_negative() {
-            i256::from_i128(-1)
+            i256::MINUS_ONE
         } else {
-            i256::from_i128(0)
+            i256::ZERO
         }
     }
 
@@ -940,18 +940,21 @@ mod tests {
     #[test]
     fn test_signed_ops() {
         // signum
-        assert_eq!(i256::from_i128(1).signum(), i256::from_i128(1));
-        assert_eq!(i256::from_i128(0).signum(), i256::from_i128(0));
-        assert_eq!(i256::from_i128(-1).signum(), i256::from_i128(-1));
+        assert_eq!(i256::from_i128(1).signum(), i256::ONE);
+        assert_eq!(i256::from_i128(0).signum(), i256::ZERO);
+        assert_eq!(i256::from_i128(-0).signum(), i256::ZERO);
+        assert_eq!(i256::from_i128(-1).signum(), i256::MINUS_ONE);
 
         // is_positive
         assert!(i256::from_i128(1).is_positive());
         assert!(!i256::from_i128(0).is_positive());
+        assert!(!i256::from_i128(-0).is_positive());
         assert!(!i256::from_i128(-1).is_positive());
 
         // is_negative
         assert!(!i256::from_i128(1).is_negative());
         assert!(!i256::from_i128(0).is_negative());
+        assert!(!i256::from_i128(-0).is_negative());
         assert!(i256::from_i128(-1).is_negative());
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change
All signed numbers have these methods ("is_positive" and "signum") in Rust (i8, i16, i32, i64, i128). It would be convenient for users to use them.

# What changes are included in this PR?
The implementation "is_positive" and "signum" methods for i256.

# Are there any user-facing changes?
Yes
