### PR TITLE
Add get_config_value to AWS/Azure/GCP Builders

### DIFF
--- a/object_store/src/aws/checksum.rs
+++ b/object_store/src/aws/checksum.rs
@@ -42,7 +42,7 @@ impl Checksum {
 impl std::fmt::Display for Checksum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            Checksum::SHA256 => write!(f, "sha256"),
+            Self::SHA256 => write!(f, "sha256"),
         }
     }
 }

--- a/object_store/src/aws/checksum.rs
+++ b/object_store/src/aws/checksum.rs
@@ -39,11 +39,19 @@ impl Checksum {
     }
 }
 
+impl std::fmt::Display for Checksum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Checksum::SHA256 => write!(f, "sha256"),
+        }
+    }
+}
+
 impl TryFrom<&String> for Checksum {
     type Error = ();
 
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        match value.as_str() {
+        match value.to_lowercase().as_str() {
             "sha256" => Ok(Self::SHA256),
             _ => Err(()),
         }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -401,35 +401,35 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
 #[derive(Debug, Default, Clone)]
 pub struct AmazonS3Builder {
     /// Access key id
-    pub access_key_id: Option<String>,
+    access_key_id: Option<String>,
     /// Secret access_key
-    pub secret_access_key: Option<String>,
+    secret_access_key: Option<String>,
     /// Region
-    pub region: Option<String>,
+    region: Option<String>,
     /// Bucket name
-    pub bucket_name: Option<String>,
+    bucket_name: Option<String>,
     /// Endpoint for communicating with AWS S3
-    pub endpoint: Option<String>,
+    endpoint: Option<String>,
     /// Token to use for requests
-    pub token: Option<String>,
+    token: Option<String>,
     /// Url
-    pub url: Option<String>,
+    url: Option<String>,
     /// Retry config
-    pub retry_config: RetryConfig,
+    retry_config: RetryConfig,
     /// When set to true, fallback to IMDSv1
-    pub imdsv1_fallback: bool,
+    imdsv1_fallback: bool,
     /// When set to true, virtual hosted style request has to be used
-    pub virtual_hosted_style_request: bool,
+    virtual_hosted_style_request: bool,
     /// When set to true, unsigned payload option has to be used
-    pub unsigned_payload: bool,
+    unsigned_payload: bool,
     /// Checksum algorithm which has to be used for object integrity check during upload
-    pub checksum_algorithm: Option<Checksum>,
+    checksum_algorithm: Option<Checksum>,
     /// Metadata endpoint, see <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html>
-    pub metadata_endpoint: Option<String>,
+    metadata_endpoint: Option<String>,
     /// Profile name, see <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html>
-    pub profile: Option<String>,
+    profile: Option<String>,
     /// Client options
-    pub client_options: ClientOptions,
+    client_options: ClientOptions,
 }
 
 /// Configuration keys for [`AmazonS3Builder`]
@@ -764,6 +764,38 @@ impl AmazonS3Builder {
             self = self.try_with_option(key, value)?;
         }
         Ok(self)
+    }
+
+    /// Get config value via a [`AmazonS3ConfigKey`].
+    ///
+    /// # Example
+    /// ```
+    /// use object_store::aws::{AmazonS3Builder, AmazonS3ConfigKey};
+    ///
+    /// let builder = AmazonS3Builder::from_env()
+    ///     .with_bucket_name("foo");
+    /// let bucket_name = builder.get_config_value(&AmazonS3ConfigKey::Bucket).unwrap_or_default();
+    /// assert_eq!("foo", &bucket_name);
+    /// ```
+    pub fn get_config_value(&self, key: &AmazonS3ConfigKey) -> Option<String> {
+        match key {
+            AmazonS3ConfigKey::AccessKeyId => self.access_key_id.clone(),
+            AmazonS3ConfigKey::SecretAccessKey => self.secret_access_key.clone(),
+            AmazonS3ConfigKey::Region | AmazonS3ConfigKey::DefaultRegion => {
+                self.region.clone()
+            }
+            AmazonS3ConfigKey::Bucket => self.bucket_name.clone(),
+            AmazonS3ConfigKey::Endpoint => self.endpoint.clone(),
+            AmazonS3ConfigKey::Token => self.token.clone(),
+            AmazonS3ConfigKey::ImdsV1Fallback => Some(self.imdsv1_fallback.to_string()),
+            AmazonS3ConfigKey::VirtualHostedStyleRequest => {
+                Some(self.virtual_hosted_style_request.to_string())
+            }
+            AmazonS3ConfigKey::MetadataEndpoint => self.metadata_endpoint.clone(),
+            AmazonS3ConfigKey::Profile => self.profile.clone(),
+            AmazonS3ConfigKey::UnsignedPayload => Some(self.unsigned_payload.to_string()),
+            AmazonS3ConfigKey::Checksum => self.checksum_algorithm.map(|v| v.to_string()),
+        }
     }
 
     /// Sets properties on this builder based on a URL
@@ -1285,6 +1317,62 @@ mod tests {
         assert_eq!(builder.endpoint.unwrap(), aws_endpoint);
         assert_eq!(builder.token.unwrap(), aws_session_token);
         assert!(builder.unsigned_payload);
+    }
+
+    #[test]
+    fn s3_test_config_get_value() {
+        let aws_access_key_id = "object_store:fake_access_key_id".to_string();
+        let aws_secret_access_key = "object_store:fake_secret_key".to_string();
+        let aws_default_region = "object_store:fake_default_region".to_string();
+        let aws_endpoint = "object_store:fake_endpoint".to_string();
+        let aws_session_token = "object_store:fake_session_token".to_string();
+        let options = HashMap::from([
+            (AmazonS3ConfigKey::AccessKeyId, aws_access_key_id.clone()),
+            (
+                AmazonS3ConfigKey::SecretAccessKey,
+                aws_secret_access_key.clone(),
+            ),
+            (AmazonS3ConfigKey::DefaultRegion, aws_default_region.clone()),
+            (AmazonS3ConfigKey::Endpoint, aws_endpoint.clone()),
+            (AmazonS3ConfigKey::Token, aws_session_token.clone()),
+            (AmazonS3ConfigKey::UnsignedPayload, "true".to_string()),
+        ]);
+
+        let builder = AmazonS3Builder::new().try_with_options(&options).unwrap();
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::AccessKeyId)
+                .unwrap(),
+            aws_access_key_id
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::SecretAccessKey)
+                .unwrap(),
+            aws_secret_access_key
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::DefaultRegion)
+                .unwrap(),
+            aws_default_region
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::Endpoint)
+                .unwrap(),
+            aws_endpoint
+        );
+        assert_eq!(
+            builder.get_config_value(&AmazonS3ConfigKey::Token).unwrap(),
+            aws_session_token
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&AmazonS3ConfigKey::UnsignedPayload)
+                .unwrap(),
+            "true"
+        );
     }
 
     #[test]

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -400,21 +400,36 @@ impl CloudMultiPartUploadImpl for S3MultiPartUpload {
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct AmazonS3Builder {
-    access_key_id: Option<String>,
-    secret_access_key: Option<String>,
-    region: Option<String>,
-    bucket_name: Option<String>,
-    endpoint: Option<String>,
-    token: Option<String>,
-    url: Option<String>,
-    retry_config: RetryConfig,
-    imdsv1_fallback: bool,
-    virtual_hosted_style_request: bool,
-    unsigned_payload: bool,
-    checksum_algorithm: Option<Checksum>,
-    metadata_endpoint: Option<String>,
-    profile: Option<String>,
-    client_options: ClientOptions,
+    /// Access key id
+    pub access_key_id: Option<String>,
+    /// Secret access_key
+    pub secret_access_key: Option<String>,
+    /// Region
+    pub region: Option<String>,
+    /// Bucket name
+    pub bucket_name: Option<String>,
+    /// Endpoint for communicating with AWS S3
+    pub endpoint: Option<String>,
+    /// Token to use for requests
+    pub token: Option<String>,
+    /// Url
+    pub url: Option<String>,
+    /// Retry config
+    pub retry_config: RetryConfig,
+    /// When set to true, fallback to IMDSv1
+    pub imdsv1_fallback: bool,
+    /// When set to true, virtual hosted style request has to be used
+    pub virtual_hosted_style_request: bool,
+    /// When set to true, unsigned payload option has to be used
+    pub unsigned_payload: bool,
+    /// Checksum algorithm which has to be used for object integrity check during upload
+    pub checksum_algorithm: Option<Checksum>,
+    /// Metadata endpoint, see <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html>
+    pub metadata_endpoint: Option<String>,
+    /// Profile name, see <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html>
+    pub profile: Option<String>,
+    /// Client options
+    pub client_options: ClientOptions,
 }
 
 /// Configuration keys for [`AmazonS3Builder`]

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -395,43 +395,43 @@ impl CloudMultiPartUploadImpl for AzureMultiPartUpload {
 #[derive(Default, Clone)]
 pub struct MicrosoftAzureBuilder {
     /// Account name
-    pub account_name: Option<String>,
+    account_name: Option<String>,
     /// Access key
-    pub access_key: Option<String>,
+    access_key: Option<String>,
     /// Container name
-    pub container_name: Option<String>,
+    container_name: Option<String>,
     /// Bearer token
-    pub bearer_token: Option<String>,
+    bearer_token: Option<String>,
     /// Client id
-    pub client_id: Option<String>,
+    client_id: Option<String>,
     /// Client secret
-    pub client_secret: Option<String>,
+    client_secret: Option<String>,
     /// Tenant id
-    pub tenant_id: Option<String>,
+    tenant_id: Option<String>,
     /// Query pairs for shared access signature authorization
-    pub sas_query_pairs: Option<Vec<(String, String)>>,
+    sas_query_pairs: Option<Vec<(String, String)>>,
     /// Shared access signature
-    pub sas_key: Option<String>,
+    sas_key: Option<String>,
     /// Authority host
-    pub authority_host: Option<String>,
+    authority_host: Option<String>,
     /// Url
-    pub url: Option<String>,
+    url: Option<String>,
     /// When set to true, azurite storage emulator has to be used
-    pub use_emulator: bool,
+    use_emulator: bool,
     /// Msi endpoint for acquiring managed identity token
-    pub msi_endpoint: Option<String>,
+    msi_endpoint: Option<String>,
     /// Object id for use with managed identity authentication
-    pub object_id: Option<String>,
+    object_id: Option<String>,
     /// Msi resource id for use with managed identity authentication
-    pub msi_resource_id: Option<String>,
+    msi_resource_id: Option<String>,
     /// File containing token for Azure AD workload identity federation
-    pub federated_token_file: Option<String>,
+    federated_token_file: Option<String>,
     /// When set to true, azure cli has to be used for acquiring access token
-    pub use_azure_cli: bool,
+    use_azure_cli: bool,
     /// Retry config
-    pub retry_config: RetryConfig,
+    retry_config: RetryConfig,
     /// Client options
-    pub client_options: ClientOptions,
+    client_options: ClientOptions,
 }
 
 /// Configuration keys for [`MicrosoftAzureBuilder`]
@@ -764,6 +764,35 @@ impl MicrosoftAzureBuilder {
             self = self.try_with_option(key, value)?;
         }
         Ok(self)
+    }
+
+    /// Get config value via a [`AzureConfigKey`].
+    ///
+    /// # Example
+    /// ```
+    /// use object_store::azure::{MicrosoftAzureBuilder, AzureConfigKey};
+    ///
+    /// let builder = MicrosoftAzureBuilder::from_env()
+    ///     .with_account("foo");
+    /// let account_name = builder.get_config_value(&AzureConfigKey::AccountName).unwrap_or_default();
+    /// assert_eq!("foo", &account_name);
+    /// ```
+    pub fn get_config_value(&self, key: &AzureConfigKey) -> Option<String> {
+        match key {
+            AzureConfigKey::AccountName => self.account_name.clone(),
+            AzureConfigKey::AccessKey => self.access_key.clone(),
+            AzureConfigKey::ClientId => self.client_id.clone(),
+            AzureConfigKey::ClientSecret => self.client_secret.clone(),
+            AzureConfigKey::AuthorityId => self.tenant_id.clone(),
+            AzureConfigKey::SasKey => self.sas_key.clone(),
+            AzureConfigKey::Token => self.bearer_token.clone(),
+            AzureConfigKey::UseEmulator => Some(self.use_emulator.to_string()),
+            AzureConfigKey::MsiEndpoint => self.msi_endpoint.clone(),
+            AzureConfigKey::ObjectId => self.object_id.clone(),
+            AzureConfigKey::MsiResourceId => self.msi_resource_id.clone(),
+            AzureConfigKey::FederatedTokenFile => self.federated_token_file.clone(),
+            AzureConfigKey::UseAzureCli => Some(self.use_azure_cli.to_string()),
+        }
     }
 
     /// Sets properties on this builder based on a URL
@@ -1269,6 +1298,39 @@ mod tests {
         assert_eq!(builder.client_id.unwrap(), azure_client_id);
         assert_eq!(builder.account_name.unwrap(), azure_storage_account_name);
         assert_eq!(builder.bearer_token.unwrap(), azure_storage_token);
+    }
+
+    #[test]
+    fn azure_test_config_get_value() {
+        let azure_client_id = "object_store:fake_access_key_id".to_string();
+        let azure_storage_account_name = "object_store:fake_secret_key".to_string();
+        let azure_storage_token = "object_store:fake_default_region".to_string();
+        let options = HashMap::from([
+            (AzureConfigKey::ClientId, azure_client_id.clone()),
+            (
+                AzureConfigKey::AccountName,
+                azure_storage_account_name.clone(),
+            ),
+            (AzureConfigKey::Token, azure_storage_token.clone()),
+        ]);
+
+        let builder = MicrosoftAzureBuilder::new()
+            .try_with_options(&options)
+            .unwrap();
+        assert_eq!(
+            builder.get_config_value(&AzureConfigKey::ClientId).unwrap(),
+            azure_client_id
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&AzureConfigKey::AccountName)
+                .unwrap(),
+            azure_storage_account_name
+        );
+        assert_eq!(
+            builder.get_config_value(&AzureConfigKey::Token).unwrap(),
+            azure_storage_token
+        );
     }
 
     #[test]

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -394,25 +394,44 @@ impl CloudMultiPartUploadImpl for AzureMultiPartUpload {
 /// ```
 #[derive(Default, Clone)]
 pub struct MicrosoftAzureBuilder {
-    account_name: Option<String>,
-    access_key: Option<String>,
-    container_name: Option<String>,
-    bearer_token: Option<String>,
-    client_id: Option<String>,
-    client_secret: Option<String>,
-    tenant_id: Option<String>,
-    sas_query_pairs: Option<Vec<(String, String)>>,
-    sas_key: Option<String>,
-    authority_host: Option<String>,
-    url: Option<String>,
-    use_emulator: bool,
-    msi_endpoint: Option<String>,
-    object_id: Option<String>,
-    msi_resource_id: Option<String>,
-    federated_token_file: Option<String>,
-    use_azure_cli: bool,
-    retry_config: RetryConfig,
-    client_options: ClientOptions,
+    /// Account name
+    pub account_name: Option<String>,
+    /// Access key
+    pub access_key: Option<String>,
+    /// Container name
+    pub container_name: Option<String>,
+    /// Bearer token
+    pub bearer_token: Option<String>,
+    /// Client id
+    pub client_id: Option<String>,
+    /// Client secret
+    pub client_secret: Option<String>,
+    /// Tenant id
+    pub tenant_id: Option<String>,
+    /// Query pairs for shared access signature authorization
+    pub sas_query_pairs: Option<Vec<(String, String)>>,
+    /// Shared access signature
+    pub sas_key: Option<String>,
+    /// Authority host
+    pub authority_host: Option<String>,
+    /// Url
+    pub url: Option<String>,
+    /// When set to true, azurite storage emulator has to be used
+    pub use_emulator: bool,
+    /// Msi endpoint for acquiring managed identity token
+    pub msi_endpoint: Option<String>,
+    /// Object id for use with managed identity authentication
+    pub object_id: Option<String>,
+    /// Msi resource id for use with managed identity authentication
+    pub msi_resource_id: Option<String>,
+    /// File containing token for Azure AD workload identity federation
+    pub federated_token_file: Option<String>,
+    /// When set to true, azure cli has to be used for acquiring access token
+    pub use_azure_cli: bool,
+    /// Retry config
+    pub retry_config: RetryConfig,
+    /// Client options
+    pub client_options: ClientOptions,
 }
 
 /// Configuration keys for [`MicrosoftAzureBuilder`]

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -768,13 +768,20 @@ impl ObjectStore for GoogleCloudStorage {
 /// ```
 #[derive(Debug, Clone)]
 pub struct GoogleCloudStorageBuilder {
-    bucket_name: Option<String>,
-    url: Option<String>,
-    service_account_path: Option<String>,
-    service_account_key: Option<String>,
-    application_credentials_path: Option<String>,
-    retry_config: RetryConfig,
-    client_options: ClientOptions,
+    /// Bucket name
+    pub bucket_name: Option<String>,
+    /// Url
+    pub url: Option<String>,
+    /// Path to the service account file
+    pub service_account_path: Option<String>,
+    /// The serialized service account key
+    pub service_account_key: Option<String>,
+    /// Path to the application credentials file.
+    pub application_credentials_path: Option<String>,
+    /// Retry config
+    pub retry_config: RetryConfig,
+    /// Client options
+    pub client_options: ClientOptions,
 }
 
 /// Configuration keys for [`GoogleCloudStorageBuilder`]

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -769,19 +769,19 @@ impl ObjectStore for GoogleCloudStorage {
 #[derive(Debug, Clone)]
 pub struct GoogleCloudStorageBuilder {
     /// Bucket name
-    pub bucket_name: Option<String>,
+    bucket_name: Option<String>,
     /// Url
-    pub url: Option<String>,
+    url: Option<String>,
     /// Path to the service account file
-    pub service_account_path: Option<String>,
+    service_account_path: Option<String>,
     /// The serialized service account key
-    pub service_account_key: Option<String>,
+    service_account_key: Option<String>,
     /// Path to the application credentials file.
-    pub application_credentials_path: Option<String>,
+    application_credentials_path: Option<String>,
     /// Retry config
-    pub retry_config: RetryConfig,
+    retry_config: RetryConfig,
     /// Client options
-    pub client_options: ClientOptions,
+    client_options: ClientOptions,
 }
 
 /// Configuration keys for [`GoogleCloudStorageBuilder`]
@@ -988,6 +988,28 @@ impl GoogleCloudStorageBuilder {
             self = self.try_with_option(key, value)?;
         }
         Ok(self)
+    }
+
+    /// Get config value via a [`GoogleConfigKey`].
+    ///
+    /// # Example
+    /// ```
+    /// use object_store::gcp::{GoogleCloudStorageBuilder, GoogleConfigKey};
+    ///
+    /// let builder = GoogleCloudStorageBuilder::from_env()
+    ///     .with_service_account_key("foo");
+    /// let service_account_key = builder.get_config_value(&GoogleConfigKey::ServiceAccountKey).unwrap_or_default();
+    /// assert_eq!("foo", &service_account_key);
+    /// ```
+    pub fn get_config_value(&self, key: &GoogleConfigKey) -> Option<String> {
+        match key {
+            GoogleConfigKey::ServiceAccount => self.service_account_path.clone(),
+            GoogleConfigKey::ServiceAccountKey => self.service_account_key.clone(),
+            GoogleConfigKey::Bucket => self.bucket_name.clone(),
+            GoogleConfigKey::ApplicationCredentials => {
+                self.application_credentials_path.clone()
+            }
+        }
     }
 
     /// Sets properties on this builder based on a URL
@@ -1457,6 +1479,33 @@ mod test {
             google_service_account.as_str()
         );
         assert_eq!(builder.bucket_name.unwrap(), google_bucket_name.as_str());
+    }
+
+    #[test]
+    fn gcs_test_config_get_value() {
+        let google_service_account = "object_store:fake_service_account".to_string();
+        let google_bucket_name = "object_store:fake_bucket".to_string();
+        let options = HashMap::from([
+            (
+                GoogleConfigKey::ServiceAccount,
+                google_service_account.clone(),
+            ),
+            (GoogleConfigKey::Bucket, google_bucket_name.clone()),
+        ]);
+
+        let builder = GoogleCloudStorageBuilder::new()
+            .try_with_options(&options)
+            .unwrap();
+        assert_eq!(
+            builder
+                .get_config_value(&GoogleConfigKey::ServiceAccount)
+                .unwrap(),
+            google_service_account
+        );
+        assert_eq!(
+            builder.get_config_value(&GoogleConfigKey::Bucket).unwrap(),
+            google_bucket_name
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4021 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See #4021 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- make struct fields of `AmazonS3Builder`, `MicrosoftAzureBuilder`, `GoogleCloudStorageBuilder` to pub

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
