### PR TITLE
Split object_store into separate workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@
 # under the License.
 
 [workspace]
+
 members = [
     "arrow",
     "arrow-arith",
@@ -35,7 +36,6 @@ members = [
     "arrow-schema",
     "arrow-select",
     "arrow-string",
-    "object_store",
     "parquet",
     "parquet_derive",
     "parquet_derive_test",
@@ -51,10 +51,14 @@ members = [
 #
 resolver = "2"
 
-# this package is excluded because it requires different compilation flags, thereby significantly changing
-# how it is compiled within the workspace, causing the whole workspace to be compiled from scratch
-# this way, this is a stand-alone package that compiles independently of the others.
-exclude = ["arrow-pyarrow-integration-testing"]
+exclude = [
+    # arrow-pyarrow-integration-testing is excluded because it requires different compilation flags, thereby
+    # significantly changing how it is compiled within the workspace, causing the whole workspace to be compiled from
+    # scratch this way, this is a stand-alone package that compiles independently of the others.
+    "arrow-pyarrow-integration-testing",
+    # object_store is excluded because it follows a separate release cycle from the other arrow crates
+    "object_store"
+]
 
 [workspace.package]
 version = "37.0.0"

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -117,14 +117,11 @@ echo "---------------------------------------------------------"
 
 # create <tarball> containing the files in git at $release_hash
 # the files in the tarball are prefixed with {tag} (e.g. 4.0.1)
-# use --delete to filter out:
-# 1. `object_store` files
-# 2. Workspace `Cargo.toml` file (which refers to object_store)
+# use --delete to filter out `object_store` files
 mkdir -p ${distdir}
 (cd "${SOURCE_TOP_DIR}" && \
      git archive ${release_hash} --prefix ${release}/ \
          | $tar --delete ${release}/'object_store' \
-         | $tar --delete ${release}/'Cargo.toml' \
          | gzip > ${tarball})
 
 echo "Running rat license checker on ${tarball}"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -105,10 +105,7 @@ test_source_distribution() {
 
   # raises on any formatting errors
   rustup component add rustfmt --toolchain stable
-  (cd arrow && cargo fmt --check)
-  (cd arrow-flight && cargo fmt --check)
-  (cd parquet && cargo fmt --check)
-  (cd parquet_derive && cargo fmt --check)
+  cargo fmt --all -- --check
 
   # Clone testing repositories if not cloned already
   git clone https://github.com/apache/arrow-testing.git arrow-testing-data
@@ -116,15 +113,7 @@ test_source_distribution() {
   export ARROW_TEST_DATA=$PWD/arrow-testing-data/data
   export PARQUET_TEST_DATA=$PWD/parquet-testing-data/data
 
-  (cd arrow && cargo build && cargo test)
-  (cd arrow-flight && cargo build && cargo test)
-  # To avoid https://github.com/apache/arrow-rs/issues/3410,
-  # remove path reference from parquet:
-  # object_store = { version = "0.5", path = "../object_store", default-features = false, optional = true }
-  # object_store = { version = "0.5", default-features = false, optional = true }
-  sed -i -e 's/\(^object_store.*\)\(path = ".*", \)/\1/g' parquet/Cargo.toml
-  (cd parquet && cargo build && cargo test)
-  (cd parquet_derive && cargo build && cargo test)
+  cargo test --all
 
   # verify that the leaf crates can be published to crates.io
   # we can't verify crates that depend on others

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -43,7 +43,8 @@ arrow-data = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
 arrow-select = { workspace = true, optional = true }
 arrow-ipc = { workspace = true, optional = true }
-object_store = { version = "0.5", path = "../object_store", default-features = false, optional = true }
+# Intentionally not a path dependency as object_store is released separately
+object_store = { version = "0.5", default-features = false, optional = true }
 
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #4030
Closes #3414

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`object_store` follows a separate release cycle and is distributed independently, having it in the same workspace creates friction and requires workarounds that then cause their own issues. Simpler to just keep it separate.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Splits object_store into its own workspace

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
