### PR TITLE
Add with_tokio_runtime to HTTP stores

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -19,13 +19,13 @@ use crate::aws::checksum::Checksum;
 use crate::aws::credential::{AwsCredential, CredentialExt, CredentialProvider};
 use crate::aws::STRICT_PATH_ENCODE_SET;
 use crate::client::pagination::stream_paginated;
-use crate::client::retry::RetryExt;
+use crate::client::retry::{ClientConfig, RetryExt};
 use crate::multipart::UploadPart;
 use crate::path::DELIMITER;
 use crate::util::{format_http_range, format_prefix};
 use crate::{
     BoxStream, ClientOptions, ListResult, MultipartId, ObjectMeta, Path, Result,
-    RetryConfig, StreamExt,
+    StreamExt,
 };
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
@@ -208,7 +208,7 @@ pub struct S3Config {
     pub bucket: String,
     pub bucket_endpoint: String,
     pub credentials: Box<dyn CredentialProvider>,
-    pub retry_config: RetryConfig,
+    pub client_config: ClientConfig,
     pub client_options: ClientOptions,
     pub sign_payload: bool,
     pub checksum: Option<Checksum>,
@@ -271,7 +271,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(GetRequestSnafu {
                 path: path.as_ref(),
@@ -317,7 +317,7 @@ impl S3Client {
                 self.config.sign_payload,
                 payload_sha256,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(PutRequestSnafu {
                 path: path.as_ref(),
@@ -345,7 +345,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(DeleteRequestSnafu {
                 path: path.as_ref(),
@@ -370,7 +370,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(CopyRequestSnafu {
                 path: from.as_ref(),
@@ -422,7 +422,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(ListRequestSnafu)?
             .bytes()
@@ -476,7 +476,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(CreateMultipartRequestSnafu)?
             .bytes()
@@ -521,7 +521,7 @@ impl S3Client {
                 self.config.sign_payload,
                 None,
             )
-            .send_retry(&self.config.retry_config)
+            .send_retry(&self.config.client_config)
             .await
             .context(CompleteMultipartRequestSnafu)?;
 

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -1297,8 +1297,8 @@ mod tests {
         assert!(builder.is_err());
     }
 
-    #[tokio::test]
-    async fn s3_test() {
+    #[test]
+    fn s3_test() {
         let builder = maybe_skip_integration!();
         let is_local = matches!(&builder.endpoint, Some(e) if e.starts_with("http://"));
 

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -21,10 +21,7 @@ use crate::client::pagination::stream_paginated;
 use crate::client::retry::{ClientConfig, RetryExt};
 use crate::path::DELIMITER;
 use crate::util::{deserialize_rfc1123, format_http_range, format_prefix};
-use crate::{
-    BoxStream, ClientOptions, ListResult, ObjectMeta, Path, Result,
-    StreamExt,
-};
+use crate::{BoxStream, ClientOptions, ListResult, ObjectMeta, Path, Result, StreamExt};
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::{Buf, Bytes};

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -1137,8 +1137,8 @@ mod tests {
         }};
     }
 
-    #[tokio::test]
-    async fn azure_blob_test() {
+    #[test]
+    fn azure_blob_test() {
         let builder = maybe_skip_integration!();
         let test = |integration| async move {
             put_get_delete_list_opts(&integration, false).await;

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -283,6 +283,14 @@ mod tests {
 
     use super::*;
 
+    /// Deletes any directories left behind from previous tests
+    async fn cleanup_directories(integration: &HttpStore) {
+        let result = integration.list_with_delimiter(None).await.unwrap();
+        for r in result.common_prefixes {
+            integration.delete(&r).await.unwrap();
+        }
+    }
+
     #[test]
     fn http_test() {
         dotenv::dotenv().ok();
@@ -300,6 +308,7 @@ mod tests {
         let (handle, shutdown) = dedicated_tokio();
 
         let test = |integration| async move {
+            cleanup_directories(&integration).await;
             put_get_delete_list_opts(&integration, false).await;
             list_uses_directories_correctly(&integration).await;
             list_with_delimiter(&integration).await;

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -981,7 +981,7 @@ mod tests {
     }
 
     #[test]
-    fn test_non_tokio() {
+    fn local_non_tokio() {
         let root = TempDir::new().unwrap();
         let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
         futures::executor::block_on(async move {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This allows isolating IO into a separate pool, allowing using object_store outside of a tokio context

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
