### PR TITLE
Use BufRead for JSON Schema Inference

### DIFF
--- a/arrow-json/src/reader.rs
+++ b/arrow-json/src/reader.rs
@@ -187,17 +187,17 @@ fn generate_schema(spec: HashMap<String, InferredType>) -> Result<Schema, ArrowE
 /// }
 /// ```
 #[derive(Debug)]
-pub struct ValueIter<'a, R: Read> {
-    reader: &'a mut BufReader<R>,
+pub struct ValueIter<'a, R: BufRead> {
+    reader: &'a mut R,
     max_read_records: Option<usize>,
     record_count: usize,
     // reuse line buffer to avoid allocation on each record
     line_buf: String,
 }
 
-impl<'a, R: Read> ValueIter<'a, R> {
+impl<'a, R: BufRead> ValueIter<'a, R> {
     /// Creates a new `ValueIter`
-    pub fn new(reader: &'a mut BufReader<R>, max_read_records: Option<usize>) -> Self {
+    pub fn new(reader: &'a mut R, max_read_records: Option<usize>) -> Self {
         Self {
             reader,
             max_read_records,
@@ -207,7 +207,7 @@ impl<'a, R: Read> ValueIter<'a, R> {
     }
 }
 
-impl<'a, R: Read> Iterator for ValueIter<'a, R> {
+impl<'a, R: BufRead> Iterator for ValueIter<'a, R> {
     type Item = Result<Value, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -303,8 +303,8 @@ pub fn infer_json_schema_from_seekable<R: Read + Seek>(
 /// // seek back to start so that the original file is usable again
 /// file.seek(SeekFrom::Start(0)).unwrap();
 /// ```
-pub fn infer_json_schema<R: Read>(
-    reader: &mut BufReader<R>,
+pub fn infer_json_schema<R: BufRead>(
+    reader: &mut R,
     max_read_records: Option<usize>,
 ) -> Result<Schema, ArrowError> {
     infer_json_schema_from_iterator(ValueIter::new(reader, max_read_records))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

Enhance API flexibility.

In our use case, we have a `SyncIoBridge` which implements the `Read` and `BufRead` traits, and it works well with `arrow::csv::reader::infer_reader_schema`.

```rust
        let reader = SyncIoBridge::new(decoded);

        let (schema, _records_read) = arrow::csv::reader::infer_reader_schema(
            reader,
            self.delimiter,
            self.schema_infer_max_record,
            self.has_header,
        )
```

However, the  `ValueIter::new` only accepts the type of `BufReader<Reader>`  argument. If changing `BufReader<Read>` to `BufRead,` We can call the API without the `BufReader` wrapped outside.


```rust
        let mut reader = BufReader::new(SyncIoBridge::new(decoded));
        let iter = ValueIter::new(&mut reader, self.schema_infer_max_record);
```


<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Refactor `infer_json_scheam's` reader type from BufReader<Read> to BufRead

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
