### PR TITLE
Add offsets accessors to variable length arrays (#3879)

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -68,12 +68,18 @@ impl<T: ByteArrayType> GenericByteArray<T> {
     }
 
     /// Returns a reference to the offsets of this array
+    ///
+    /// Unlike [`Self::value_offsets`] this returns the [`OffsetBuffer`]
+    /// allowing for zero-copy cloning
     #[inline]
     pub fn offsets(&self) -> &OffsetBuffer<T::Offset> {
         &self.value_offsets
     }
 
     /// Returns the values of this array
+    ///
+    /// Unlike [`Self::value_data`] this returns the [`Buffer`]
+    /// allowing for zero-copy cloning
     #[inline]
     pub fn values(&self) -> &Buffer {
         &self.value_data

--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -67,6 +67,18 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         offsets[i + 1] - offsets[i]
     }
 
+    /// Returns a reference to the offsets of this array
+    #[inline]
+    pub fn offsets(&self) -> &OffsetBuffer<T::Offset> {
+        &self.value_offsets
+    }
+
+    /// Returns the values of this array
+    #[inline]
+    pub fn values(&self) -> &Buffer {
+        &self.value_data
+    }
+
     /// Returns the raw value data
     pub fn value_data(&self) -> &[u8] {
         self.value_data.as_slice()

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -78,7 +78,14 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
         DataType::List
     };
 
-    /// Returns a reference to the values of this list.
+    /// Returns a reference to the offsets of this list
+    #[inline]
+    pub fn offsets(&self) -> &OffsetBuffer<OffsetSize> {
+        &self.value_offsets
+    }
+
+    /// Returns a reference to the values of this list
+    #[inline]
     pub fn values(&self) -> &ArrayRef {
         &self.values
     }

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -79,6 +79,9 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     };
 
     /// Returns a reference to the offsets of this list
+    ///
+    /// Unlike [`Self::value_offsets`] this returns the [`OffsetBuffer`]
+    /// allowing for zero-copy cloning
     #[inline]
     pub fn offsets(&self) -> &OffsetBuffer<OffsetSize> {
         &self.value_offsets

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -43,6 +43,9 @@ pub struct MapArray {
 
 impl MapArray {
     /// Returns a reference to the offsets of this map
+    ///
+    /// Unlike [`Self::value_offsets`] this returns the [`OffsetBuffer`]
+    /// allowing for zero-copy cloning
     #[inline]
     pub fn offsets(&self) -> &OffsetBuffer<i32> {
         &self.value_offsets

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -42,12 +42,18 @@ pub struct MapArray {
 }
 
 impl MapArray {
-    /// Returns a reference to the keys of this map.
+    /// Returns a reference to the offsets of this map
+    #[inline]
+    pub fn offsets(&self) -> &OffsetBuffer<i32> {
+        &self.value_offsets
+    }
+
+    /// Returns a reference to the keys of this map
     pub fn keys(&self) -> &ArrayRef {
         &self.keys
     }
 
-    /// Returns a reference to the values of this map.
+    /// Returns a reference to the values of this map
     pub fn values(&self) -> &ArrayRef {
         &self.values
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3879

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This provides access to the typed buffer abstractions, which allows for destructing of arrays. I opted to add new functions, instead of changing the return types of `value_data` and `value_offsets` to reduce code churn, and also because the value prefix is a tad redundant. I expect we may eventually deprecate and remove the old methods.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
