### PR TITLE
Shutdown parquet async writer

### DIFF
--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -129,6 +129,7 @@ impl<W: AsyncWrite + Unpin + Send> AsyncArrowWriter<W> {
 
         // Force to flush the remaining data.
         Self::try_flush(&mut self.shared_buffer, &mut self.async_writer, true).await?;
+        self.async_writer.shutdown().await?;
 
         Ok(metadata)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4058 

# Rationale for this change

I have tried to use the new parquet AsyncArrowWriter by writing files to S3 using the object_store multipart upload. However, for the upload to complete, the inner writer needs to be `shutdown` and this writer does not do that.

# What changes are included in this PR?

Just line to shut down writer when running the `close` method.

# Are there any user-facing changes?
No