### PR TITLE
Remove ArrayData from Array (#3880)

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1241,13 +1241,12 @@ mod tests {
             .into_iter()
             .collect();
         let sliced_input = sliced_input.slice(4, 2);
-        let sliced_input = sliced_input.as_boolean();
 
-        assert_eq!(sliced_input, &input);
+        assert_eq!(sliced_input, input);
 
-        let actual = min_boolean(sliced_input);
+        let actual = min_boolean(&sliced_input);
         assert_eq!(actual, expected);
-        let actual = max_boolean(sliced_input);
+        let actual = max_boolean(&sliced_input);
         assert_eq!(actual, expected);
     }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -29,7 +29,7 @@ use arrow_buffer::{
     i256, ArrowNativeType, BooleanBuffer, Buffer, NullBuffer, ScalarBuffer,
 };
 use arrow_data::bit_iterator::try_for_each_valid_idx;
-use arrow_data::ArrayData;
+use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};
 use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use half::f16;
@@ -248,17 +248,18 @@ pub use crate::types::ArrowPrimitiveType;
 /// }
 /// ```
 pub struct PrimitiveArray<T: ArrowPrimitiveType> {
-    /// Underlying ArrayData
-    data: ArrayData,
+    data_type: DataType,
     /// Values data
     values: ScalarBuffer<T::Native>,
+    nulls: Option<NullBuffer>,
 }
 
 impl<T: ArrowPrimitiveType> Clone for PrimitiveArray<T> {
     fn clone(&self) -> Self {
         Self {
-            data: self.data.clone(),
+            data_type: self.data_type.clone(),
             values: self.values.clone(),
+            nulls: self.nulls.clone(),
         }
     }
 }
@@ -282,15 +283,19 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         }
 
         // TODO: Don't store ArrayData inside arrays (#3880)
-        let data = unsafe {
-            ArrayData::builder(data_type)
-                .len(values.len())
-                .nulls(nulls)
-                .buffers(vec![values.inner().clone()])
-                .build_unchecked()
-        };
+        // let data = unsafe {
+        //     ArrayData::builder(data_type)
+        //         .len(values.len())
+        //         .nulls(nulls)
+        //         .buffers(vec![values.inner().clone()])
+        //         .build_unchecked()
+        // };
 
-        Self { data, values }
+        Self {
+            data_type,
+            values,
+            nulls,
+        }
     }
 
     /// Asserts that `data_type` is compatible with `Self`
@@ -306,12 +311,12 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Returns the length of this array.
     #[inline]
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.values.len()
     }
 
     /// Returns whether this array is empty.
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.values.is_empty()
     }
 
     /// Returns the values of this array
@@ -410,8 +415,11 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        // TODO: Slice buffers directly (#3880)
-        self.data.slice(offset, length).into()
+        Self {
+            data_type: self.data_type.clone(),
+            values: self.values.slice(offset, length),
+            nulls: self.nulls.as_ref().map(|n| n.slice(offset, length)),
+        }
     }
 
     /// Reinterprets this array's contents as a different data type without copying
@@ -436,7 +444,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     where
         K: ArrowPrimitiveType<Native = T::Native>,
     {
-        let d = self.data.clone().into_builder().data_type(K::DATA_TYPE);
+        let d = self.to_data().into_builder().data_type(K::DATA_TYPE);
 
         // SAFETY:
         // Native type is the same
@@ -629,14 +637,14 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// data buffer is not shared by others.
     pub fn into_builder(self) -> Result<PrimitiveBuilder<T>, Self> {
         let len = self.len();
-        let null_bit_buffer = self.data.nulls().map(|b| b.inner().sliced());
+        let data = self.into_data();
+        let null_bit_buffer = data.nulls().map(|b| b.inner().sliced());
 
         let element_len = std::mem::size_of::<T::Native>();
-        let buffer = self.data.buffers()[0]
-            .slice_with_length(self.data.offset() * element_len, len * element_len);
+        let buffer = data.buffers()[0]
+            .slice_with_length(data.offset() * element_len, len * element_len);
 
-        drop(self.data);
-        drop(self.values);
+        drop(data);
 
         let try_mutable_null_buffer = match null_bit_buffer {
             None => Ok(None),
@@ -686,7 +694,12 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
 impl<T: ArrowPrimitiveType> From<PrimitiveArray<T>> for ArrayData {
     fn from(array: PrimitiveArray<T>) -> Self {
-        array.data
+        let builder = ArrayDataBuilder::new(array.data_type)
+            .len(array.values.len())
+            .nulls(array.nulls)
+            .buffers(vec![array.values.into_inner()]);
+
+        unsafe { builder.build_unchecked() }
     }
 }
 
@@ -695,24 +708,48 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
         self
     }
 
-    fn data(&self) -> &ArrayData {
-        &self.data
-    }
-
     fn to_data(&self) -> ArrayData {
-        self.data.clone()
+        self.clone().into()
     }
 
     fn into_data(self) -> ArrayData {
         self.into()
     }
 
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
         Arc::new(self.slice(offset, length))
     }
 
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    fn offset(&self) -> usize {
+        0
+    }
+
     fn nulls(&self) -> Option<&NullBuffer> {
-        self.data.nulls()
+        self.nulls.as_ref()
+    }
+
+    fn get_buffer_memory_size(&self) -> usize {
+        let mut size = self.values.inner().capacity();
+        if let Some(n) = self.nulls.as_ref() {
+            size += n.buffer().capacity();
+        }
+        size
+    }
+
+    fn get_array_memory_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.get_buffer_memory_size()
     }
 }
 
@@ -1061,8 +1098,7 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
     /// Construct a timestamp array with an optional timezone
     pub fn with_timezone_opt<S: Into<Arc<str>>>(&self, timezone: Option<S>) -> Self {
         let array_data = unsafe {
-            self.data
-                .clone()
+            self.to_data()
                 .into_builder()
                 .data_type(DataType::Timestamp(T::UNIT, timezone.map(Into::into)))
                 .build_unchecked()
@@ -1083,7 +1119,11 @@ impl<T: ArrowPrimitiveType> From<ArrayData> for PrimitiveArray<T> {
 
         let values =
             ScalarBuffer::new(data.buffers()[0].clone(), data.offset(), data.len());
-        Self { data, values }
+        Self {
+            data_type: data.data_type().clone(),
+            values,
+            nulls: data.nulls().cloned(),
+        }
     }
 }
 
@@ -1108,12 +1148,10 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
         self.validate_precision_scale(precision, scale)?;
 
         // safety: self.data is valid DataType::Decimal as checked above
-        let new_data_type = T::TYPE_CONSTRUCTOR(precision, scale);
-        let data = self.data.into_builder().data_type(new_data_type);
-
-        // SAFETY
-        // Validated data above
-        Ok(unsafe { data.build_unchecked().into() })
+        Ok(Self {
+            data_type: T::TYPE_CONSTRUCTOR(precision, scale),
+            ..self
+        })
     }
 
     // validate that the new precision and scale are valid or not
@@ -1244,7 +1282,7 @@ mod tests {
     fn test_primitive_array_from_vec() {
         let buf = Buffer::from_slice_ref([0, 1, 2, 3, 4]);
         let arr = Int32Array::from(vec![0, 1, 2, 3, 4]);
-        assert_eq!(buf, *arr.data.buffers()[0]);
+        assert_eq!(&buf, arr.values.inner());
         assert_eq!(5, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(0, arr.null_count());
@@ -1484,7 +1522,6 @@ mod tests {
 
         let arr2 = arr.slice(2, 5);
         assert_eq!(5, arr2.len());
-        assert_eq!(2, arr2.offset());
         assert_eq!(1, arr2.null_count());
 
         for i in 0..arr2.len() {
@@ -1497,7 +1534,6 @@ mod tests {
 
         let arr3 = arr2.slice(2, 3);
         assert_eq!(3, arr3.len());
-        assert_eq!(4, arr3.offset());
         assert_eq!(0, arr3.null_count());
 
         let int_arr3 = arr3.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -1742,7 +1778,7 @@ mod tests {
     fn test_primitive_array_builder() {
         // Test building a primitive array with ArrayData builder and offset
         let buf = Buffer::from_slice_ref([0i32, 1, 2, 3, 4, 5, 6]);
-        let buf2 = buf.clone();
+        let buf2 = buf.slice_with_length(8, 20);
         let data = ArrayData::builder(DataType::Int32)
             .len(5)
             .offset(2)
@@ -1750,7 +1786,7 @@ mod tests {
             .build()
             .unwrap();
         let arr = Int32Array::from(data);
-        assert_eq!(buf2, *arr.data.buffers()[0]);
+        assert_eq!(&buf2, arr.values.inner());
         assert_eq!(5, arr.len());
         assert_eq!(0, arr.null_count());
         for i in 0..3 {

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -299,7 +299,9 @@ impl UnionArray {
     /// Returns a zero-copy slice of this array with the indicated offset and length.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         let (offsets, fields) = match self.offsets.as_ref() {
+            // If dense union, slice offsets
             Some(offsets) => (Some(offsets.slice(offset, length)), self.fields.clone()),
+            // Otherwise need to slice sparse children
             None => {
                 let fields = self
                     .fields

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -474,7 +474,7 @@ impl From<StructArray> for RecordBatch {
         );
         let row_count = value.len();
         let schema = Arc::new(Schema::new(value.fields().clone()));
-        let columns = value.boxed_fields;
+        let columns = value.fields;
 
         RecordBatch {
             schema,
@@ -614,7 +614,7 @@ mod tests {
         let record_batch =
             RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])
                 .unwrap();
-        assert_eq!(record_batch.get_array_memory_size(), 564);
+        assert_eq!(record_batch.get_array_memory_size(), 364);
     }
 
     fn check_batch(record_batch: RecordBatch, num_rows: usize) {

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -4667,10 +4667,8 @@ mod tests {
         let array = Int32Array::from(vec![-5, 6, -7, 8, 100000000]);
         assert_eq!(0, array.offset());
         let array = array.slice(2, 3);
-        assert_eq!(2, array.offset());
         let b = cast(&array, &DataType::UInt8).unwrap();
         assert_eq!(3, b.len());
-        assert_eq!(0, b.offset());
         let c = b.as_any().downcast_ref::<UInt8Array>().unwrap();
         assert!(!c.is_valid(0));
         assert_eq!(8, c.value(1));

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -24,11 +24,11 @@ use std::cmp::min;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 
-use arrow_array::types::{Int16Type, Int32Type, Int64Type, RunEndIndexType};
 use flatbuffers::FlatBufferBuilder;
 
 use arrow_array::builder::BufferBuilder;
 use arrow_array::cast::*;
+use arrow_array::types::{Int16Type, Int32Type, Int64Type, RunEndIndexType};
 use arrow_array::*;
 use arrow_buffer::bit_util;
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer};
@@ -1107,94 +1107,29 @@ fn get_buffer_element_width(spec: &BufferSpec) -> usize {
     }
 }
 
-/// Returns byte width for binary value_offset buffer spec.
-#[inline]
-fn get_value_offset_byte_width(data_type: &DataType) -> usize {
-    match data_type {
-        DataType::Binary | DataType::Utf8 => 4,
-        DataType::LargeBinary | DataType::LargeUtf8 => 8,
-        _ => unreachable!(),
+/// Returns the values and offsets [`Buffer`] for a ByteArray with offset type `O`
+fn get_byte_array_buffers<O: OffsetSizeTrait>(data: &ArrayData) -> (Buffer, Buffer) {
+    if data.is_empty() {
+        return (MutableBuffer::new(0).into(), MutableBuffer::new(0).into());
     }
-}
 
-/// Returns the number of total bytes in base binary arrays.
-fn get_binary_buffer_len(array_data: &ArrayData) -> usize {
-    if array_data.is_empty() {
-        return 0;
-    }
-    match array_data.data_type() {
-        DataType::Binary => {
-            let array: BinaryArray = array_data.clone().into();
-            let offsets = array.value_offsets();
-            (offsets[array_data.len()] - offsets[0]) as usize
-        }
-        DataType::LargeBinary => {
-            let array: LargeBinaryArray = array_data.clone().into();
-            let offsets = array.value_offsets();
-            (offsets[array_data.len()] - offsets[0]) as usize
-        }
-        DataType::Utf8 => {
-            let array: StringArray = array_data.clone().into();
-            let offsets = array.value_offsets();
-            (offsets[array_data.len()] - offsets[0]) as usize
-        }
-        DataType::LargeUtf8 => {
-            let array: LargeStringArray = array_data.clone().into();
-            let offsets = array.value_offsets();
-            (offsets[array_data.len()] - offsets[0]) as usize
-        }
-        _ => unreachable!(),
-    }
-}
+    let buffers = data.buffers();
+    let offsets: &[O] = buffers[0].typed_data::<O>();
+    let offset_slice = &offsets[data.offset()..data.offset() + data.len() + 1];
 
-/// Rebase value offsets for given ArrayData to zero-based.
-fn get_zero_based_value_offsets<OffsetSize: OffsetSizeTrait>(
-    array_data: &ArrayData,
-) -> Buffer {
-    match array_data.data_type() {
-        DataType::Binary | DataType::LargeBinary => {
-            let array: GenericBinaryArray<OffsetSize> = array_data.clone().into();
-            let offsets = array.value_offsets();
-            let start_offset = offsets[0];
+    let start_offset = offset_slice.first().unwrap();
+    let end_offset = offset_slice.last().unwrap();
 
-            let mut builder = BufferBuilder::<OffsetSize>::new(array_data.len() + 1);
-            for x in offsets {
-                builder.append(*x - start_offset);
-            }
+    let offsets = match start_offset.as_usize() {
+        0 => buffers[0].clone(),
+        _ => offset_slice.iter().map(|x| *x - *start_offset).collect(),
+    };
 
-            builder.finish()
-        }
-        DataType::Utf8 | DataType::LargeUtf8 => {
-            let array: GenericStringArray<OffsetSize> = array_data.clone().into();
-            let offsets = array.value_offsets();
-            let start_offset = offsets[0];
-
-            let mut builder = BufferBuilder::<OffsetSize>::new(array_data.len() + 1);
-            for x in offsets {
-                builder.append(*x - start_offset);
-            }
-
-            builder.finish()
-        }
-        _ => unreachable!(),
-    }
-}
-
-/// Returns the start offset of base binary array.
-fn get_buffer_offset<OffsetSize: OffsetSizeTrait>(array_data: &ArrayData) -> OffsetSize {
-    match array_data.data_type() {
-        DataType::Binary | DataType::LargeBinary => {
-            let array: GenericBinaryArray<OffsetSize> = array_data.clone().into();
-            let offsets = array.value_offsets();
-            offsets[0]
-        }
-        DataType::Utf8 | DataType::LargeUtf8 => {
-            let array: GenericStringArray<OffsetSize> = array_data.clone().into();
-            let offsets = array.value_offsets();
-            offsets[0]
-        }
-        _ => unreachable!(),
-    }
+    let values = buffers[1].slice_with_length(
+        start_offset.as_usize(),
+        end_offset.as_usize() - start_offset.as_usize(),
+    );
+    (offsets, values)
 }
 
 /// Write array data to a vector of bytes
@@ -1241,65 +1176,27 @@ fn write_array_data(
     }
 
     let data_type = array_data.data_type();
-    if matches!(
-        data_type,
-        DataType::Binary | DataType::LargeBinary | DataType::Utf8 | DataType::LargeUtf8
-    ) {
-        let offset_buffer = &array_data.buffers()[0];
-        let value_offset_byte_width = get_value_offset_byte_width(data_type);
-        let min_length = (array_data.len() + 1) * value_offset_byte_width;
-        if buffer_need_truncate(
-            array_data.offset(),
-            offset_buffer,
-            &BufferSpec::FixedWidth {
-                byte_width: value_offset_byte_width,
-            },
-            min_length,
-        ) {
-            // Rebase offsets and truncate values
-            let (new_offsets, byte_offset) =
-                if matches!(data_type, DataType::Binary | DataType::Utf8) {
-                    (
-                        get_zero_based_value_offsets::<i32>(array_data),
-                        get_buffer_offset::<i32>(array_data) as usize,
-                    )
-                } else {
-                    (
-                        get_zero_based_value_offsets::<i64>(array_data),
-                        get_buffer_offset::<i64>(array_data) as usize,
-                    )
-                };
-
+    if matches!(data_type, DataType::Binary | DataType::Utf8) {
+        let (offsets, values) = get_byte_array_buffers::<i32>(array_data);
+        for buffer in [offsets, values] {
             offset = write_buffer(
-                new_offsets.as_slice(),
+                buffer.as_slice(),
                 buffers,
                 arrow_data,
                 offset,
                 compression_codec,
             )?;
-
-            let total_bytes = get_binary_buffer_len(array_data);
-            let value_buffer = &array_data.buffers()[1];
-            let buffer_length = min(total_bytes, value_buffer.len() - byte_offset);
-            let buffer_slice =
-                &value_buffer.as_slice()[byte_offset..(byte_offset + buffer_length)];
+        }
+    } else if matches!(data_type, DataType::LargeBinary | DataType::LargeUtf8) {
+        let (offsets, values) = get_byte_array_buffers::<i64>(array_data);
+        for buffer in [offsets, values] {
             offset = write_buffer(
-                buffer_slice,
+                buffer.as_slice(),
                 buffers,
                 arrow_data,
                 offset,
                 compression_codec,
             )?;
-        } else {
-            for buffer in array_data.buffers() {
-                offset = write_buffer(
-                    buffer.as_slice(),
-                    buffers,
-                    arrow_data,
-                    offset,
-                    compression_codec,
-                )?;
-            }
         }
     } else if DataType::is_numeric(data_type)
         || DataType::is_temporal(data_type)
@@ -1445,19 +1342,19 @@ fn pad_to_8(len: u32) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::Cursor;
     use std::io::Seek;
     use std::sync::Arc;
 
-    use crate::MetadataVersion;
-
-    use crate::reader::*;
     use arrow_array::builder::PrimitiveRunBuilder;
     use arrow_array::builder::UnionBuilder;
     use arrow_array::types::*;
     use arrow_schema::DataType;
+
+    use crate::reader::*;
+    use crate::MetadataVersion;
+
+    use super::*;
 
     #[test]
     #[cfg(feature = "lz4")]

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1108,6 +1108,10 @@ fn get_buffer_element_width(spec: &BufferSpec) -> usize {
 }
 
 /// Returns the values and offsets [`Buffer`] for a ByteArray with offset type `O`
+///
+/// In particular, this handles re-encoding the offsets if they don't start at `0`,
+/// slicing the values buffer as appropriate. This helps reduce the encoded
+/// size of sliced arrays, as values that have been sliced away are not encoded
 fn get_byte_array_buffers<O: OffsetSizeTrait>(data: &ArrayData) -> (Buffer, Buffer) {
     if data.is_empty() {
         return (MutableBuffer::new(0).into(), MutableBuffer::new(0).into());

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -52,7 +52,7 @@ fn double(array: &PyAny, py: Python) -> PyResult<PyObject> {
     let array = kernels::arithmetic::add(array, array).map_err(to_py_err)?;
 
     // export
-    array.data().to_pyarrow(py)
+    array.to_data().to_pyarrow(py)
 }
 
 /// calls a lambda function that receives and returns an array
@@ -64,7 +64,7 @@ fn double_py(lambda: &PyAny, py: Python) -> PyResult<bool> {
     let expected = Arc::new(Int64Array::from(vec![Some(2), None, Some(6)])) as ArrayRef;
 
     // to py
-    let pyarray = array.data().to_pyarrow(py)?;
+    let pyarray = array.to_data().to_pyarrow(py)?;
     let pyarray = lambda.call1((pyarray,))?;
     let array = make_array(ArrayData::from_pyarrow(pyarray)?);
 
@@ -75,7 +75,7 @@ fn double_py(lambda: &PyAny, py: Python) -> PyResult<bool> {
 fn make_empty_array(datatype: PyArrowType<DataType>, py: Python) -> PyResult<PyObject> {
     let array = new_empty_array(&datatype.0);
 
-    array.data().to_pyarrow(py)
+    array.to_data().to_pyarrow(py)
 }
 
 /// Returns the substring
@@ -90,7 +90,7 @@ fn substring(
     // substring
     let array = kernels::substring::substring(array.as_ref(), start, None).map_err(to_py_err)?;
 
-    Ok(array.data().to_owned().into())
+    Ok(array.to_data().into())
 }
 
 /// Returns the concatenate
@@ -101,7 +101,7 @@ fn concatenate(array: PyArrowType<ArrayData>, py: Python) -> PyResult<PyObject> 
     // concat
     let array = kernels::concat::concat(&[array.as_ref(), array.as_ref()]).map_err(to_py_err)?;
 
-    array.data().to_pyarrow(py)
+    array.to_data().to_pyarrow(py)
 }
 
 #[pyfunction]

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -208,8 +208,7 @@ mod tests {
 
         let s = s.slice(2, 3);
         let select = select.slice(1, 3);
-        let select = select.as_boolean();
-        let a = nullif(&s, select).unwrap();
+        let a = nullif(&s, &select).unwrap();
         let r: Vec<_> = a.as_string::<i32>().iter().collect();
         assert_eq!(r, vec![None, Some("a"), None]);
     }
@@ -509,9 +508,8 @@ mod tests {
                         .map(|_| rng.gen_bool(0.5).then(|| rng.gen_bool(0.5)))
                         .collect();
                     let b = b.slice(b_start_offset, a_length);
-                    let b = b.as_boolean();
 
-                    test_nullif(&a, b);
+                    test_nullif(&a, &b);
                 }
             }
         }

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -322,7 +322,7 @@
 //! Advanced users may wish to interact with the underlying buffers of an [`Array`], for example,
 //! for FFI or high-performance conversion from other formats. This interface is provided by
 //! [`ArrayData`] which stores the [`Buffer`] comprising an [`Array`], and can be accessed
-//! with [`Array::data`](array::Array::data)
+//! with [`Array::to_data`](array::Array::to_data)
 //!
 //! The APIs for constructing [`ArrayData`] come in safe, and unsafe variants, with the former
 //! performing extensive, but potentially expensive validation to ensure the buffers are well-formed.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3880

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See ticket

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, this inherently changes the way that slicing behaves

It also adds a statically typed BooleanArray::slice that somehow was missed in #3930

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
