### PR TITLE
Serialize numeric to tape (#4069)

### DIFF
--- a/arrow-json/src/reader/serializer.rs
+++ b/arrow-json/src/reader/serializer.rs
@@ -68,6 +68,13 @@ impl<'a> TapeSerializer<'a> {
             offsets,
         }
     }
+
+    fn serialize_number(&mut self, v: &[u8]) {
+        self.bytes.extend_from_slice(v);
+        let idx = self.offsets.len() - 1;
+        self.elements.push(TapeElement::Number(idx as _));
+        self.offsets.push(self.bytes.len());
+    }
 }
 
 /// The tape stores all values as strings, and so must serialize numeric types
@@ -81,7 +88,8 @@ macro_rules! serialize_numeric {
     ($s:ident, $t:ty, $v:ident) => {{
         let mut buffer = [0_u8; <$t>::FORMATTED_SIZE];
         let s = lexical_core::write($v, &mut buffer);
-        $s.serialize_bytes(s)
+        $s.serialize_number(s);
+        Ok(())
     }};
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4069

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Certain types such as timestamps handle numbers and strings differently, it is important to preserve this distinction when serializing to a tape

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
