### PR TITLE
Improve JSON decoder errors (#4076)

### DIFF
--- a/arrow-json/src/reader/boolean_array.rs
+++ b/arrow-json/src/reader/boolean_array.rs
@@ -21,7 +21,7 @@ use arrow_data::ArrayData;
 use arrow_schema::ArrowError;
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{tape_error, ArrayDecoder};
+use crate::reader::ArrayDecoder;
 
 #[derive(Default)]
 pub struct BooleanArrayDecoder {}
@@ -34,7 +34,7 @@ impl ArrayDecoder for BooleanArrayDecoder {
                 TapeElement::Null => builder.append_null(),
                 TapeElement::True => builder.append_value(true),
                 TapeElement::False => builder.append_value(false),
-                d => return Err(tape_error(d, "boolean")),
+                _ => return Err(tape.error(*p, "boolean")),
             }
         }
 

--- a/arrow-json/src/reader/decimal_array.rs
+++ b/arrow-json/src/reader/decimal_array.rs
@@ -25,7 +25,7 @@ use arrow_data::ArrayData;
 use arrow_schema::ArrowError;
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{tape_error, ArrayDecoder};
+use crate::reader::ArrayDecoder;
 
 pub struct DecimalArrayDecoder<D: DecimalType> {
     precision: u8,
@@ -64,7 +64,7 @@ where
                     let value = parse_decimal::<D>(s, self.precision, self.scale)?;
                     builder.append_value(value)
                 }
-                d => return Err(tape_error(d, "decimal")),
+                _ => return Err(tape.error(*p, "decimal")),
             }
         }
 

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{make_decoder, tape_error, ArrayDecoder};
+use crate::reader::{make_decoder, ArrayDecoder};
 use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
@@ -78,7 +78,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for ListArrayDecoder<O> {
                     nulls.append(false);
                     *p + 1
                 }
-                (d, _) => return Err(tape_error(d, "[")),
+                _ => return Err(tape.error(*p, "[")),
             };
 
             let mut cur_idx = *p + 1;
@@ -86,9 +86,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for ListArrayDecoder<O> {
                 child_pos.push(cur_idx);
 
                 // Advance to next field
-                cur_idx = tape
-                    .next(cur_idx)
-                    .map_err(|d| tape_error(d, "list value"))?;
+                cur_idx = tape.next(cur_idx, "list value")?;
             }
 
             let offset = O::from_usize(child_pos.len()).ok_or_else(|| {

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{make_decoder, tape_error, ArrayDecoder};
+use crate::reader::{make_decoder, ArrayDecoder};
 use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder};
 use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
 use arrow_buffer::ArrowNativeType;
@@ -104,14 +104,14 @@ impl ArrayDecoder for MapArrayDecoder {
                     nulls.append(false);
                     p + 1
                 }
-                (d, _) => return Err(tape_error(d, "{")),
+                _ => return Err(tape.error(p, "{")),
             };
 
             let mut cur_idx = p + 1;
             while cur_idx < end_idx {
                 let key = cur_idx;
-                let value = tape.next(key).map_err(|d| tape_error(d, "map key"))?;
-                cur_idx = tape.next(value).map_err(|d| tape_error(d, "map value"))?;
+                let value = tape.next(key, "map key")?;
+                cur_idx = tape.next(value, "map value")?;
 
                 key_pos.push(key);
                 value_pos.push(value);

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -963,8 +963,7 @@ mod tests {
             .build(Cursor::new(buf.as_bytes()))
             .unwrap()
             .read()
-            .unwrap_err()
-            .to_string();
+            .unwrap_err();
 
         assert_eq!(
             err.to_string(),

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -632,10 +632,6 @@ fn make_decoder(
     }
 }
 
-fn tape_error(d: TapeElement, expected: &str) -> ArrowError {
-    ArrowError::JsonError(format!("expected {expected} got {d}"))
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs::File;
@@ -962,29 +958,30 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
 
         let buf = r#"{"a": 1}"#;
-        let result = ReaderBuilder::new(schema.clone())
+        let err = ReaderBuilder::new(schema.clone())
             .with_batch_size(1024)
             .build(Cursor::new(buf.as_bytes()))
             .unwrap()
-            .read();
+            .read()
+            .unwrap_err()
+            .to_string();
 
-        assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
-            "Json error: expected string got number".to_string()
+            err.to_string(),
+            "Json error: whilst decoding field 'a': expected string got 1"
         );
 
         let buf = r#"{"a": true}"#;
-        let result = ReaderBuilder::new(schema)
+        let err = ReaderBuilder::new(schema)
             .with_batch_size(1024)
             .build(Cursor::new(buf.as_bytes()))
             .unwrap()
-            .read();
+            .read()
+            .unwrap_err();
 
-        assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
-            "Json error: expected string got true".to_string()
+            err.to_string(),
+            "Json error: whilst decoding field 'a': expected string got true"
         );
     }
 
@@ -1865,5 +1862,96 @@ mod tests {
         assert_eq!(12, sum_num_rows);
         assert_eq!(3, num_batches);
         assert_eq!(100000000000011, sum_a);
+    }
+
+    #[test]
+    fn test_decoder_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new_struct(
+            "a",
+            vec![Field::new("child", DataType::Int32, false)],
+            true,
+        )]));
+
+        let parse_err = |s: &str| {
+            ReaderBuilder::new(schema.clone())
+                .build(Cursor::new(s.as_bytes()))
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+        };
+
+        let err = parse_err(r#"{"a": 123}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': expected { got 123"
+        );
+
+        let err = parse_err(r#"{"a": ["bar"]}"#);
+        assert_eq!(
+            err,
+            r#"Json error: whilst decoding field 'a': expected { got ["bar"]"#
+        );
+
+        let err = parse_err(r#"{"a": []}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': expected { got []"
+        );
+
+        let err = parse_err(r#"{"a": [{"child": 234}]}"#);
+        assert_eq!(
+            err,
+            r#"Json error: whilst decoding field 'a': expected { got [{"child": 234}]"#
+        );
+
+        let err = parse_err(r#"{"a": [{"child": {"foo": [{"foo": ["bar"]}]}}]}"#);
+        assert_eq!(
+            err,
+            r#"Json error: whilst decoding field 'a': expected { got [{"child": {"foo": [{"foo": ["bar"]}]}}]"#
+        );
+
+        let err = parse_err(r#"{"a": true}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': expected { got true"
+        );
+
+        let err = parse_err(r#"{"a": false}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': expected { got false"
+        );
+
+        let err = parse_err(r#"{"a": "foo"}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': expected { got \"foo\""
+        );
+
+        let err = parse_err(r#"{"a": {"child": false}}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': whilst decoding field 'child': expected primitive got false"
+        );
+
+        let err = parse_err(r#"{"a": {"child": []}}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': whilst decoding field 'child': expected primitive got []"
+        );
+
+        let err = parse_err(r#"{"a": {"child": [123]}}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': whilst decoding field 'child': expected primitive got [123]"
+        );
+
+        let err = parse_err(r#"{"a": {"child": [123, 3465346]}}"#);
+        assert_eq!(
+            err,
+            "Json error: whilst decoding field 'a': whilst decoding field 'child': expected primitive got [123, 3465346]"
+        );
     }
 }

--- a/arrow-json/src/reader/primitive_array.rs
+++ b/arrow-json/src/reader/primitive_array.rs
@@ -25,7 +25,7 @@ use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType};
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{tape_error, ArrayDecoder};
+use crate::reader::ArrayDecoder;
 
 /// A trait for JSON-specific primitive parsing logic
 ///
@@ -116,7 +116,7 @@ where
 
                     builder.append_value(value)
                 }
-                d => return Err(tape_error(d, "primitive")),
+                _ => return Err(tape.error(*p, "primitive")),
             }
         }
 

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -22,7 +22,7 @@ use arrow_schema::ArrowError;
 use std::marker::PhantomData;
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{tape_error, ArrayDecoder};
+use crate::reader::ArrayDecoder;
 
 const TRUE: &str = "true";
 const FALSE: &str = "false";
@@ -61,7 +61,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
                 TapeElement::Number(idx) if coerce_primitive => {
                     data_capacity += tape.get_string(idx).len();
                 }
-                d => return Err(tape_error(d, "string")),
+                _ => return Err(tape.error(*p, "string")),
             }
         }
 

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -97,8 +97,7 @@ impl<'a> Tape<'a> {
 
     /// Returns the index of the next field at the same level as `cur_idx`
     ///
-    /// Return an error containing the [`TapeElement`] at `cur_idx` if it
-    /// is not the start of a field
+    /// Return an error if `cur_idx` is not the start of a field
     pub fn next(&self, cur_idx: u32, expected: &str) -> Result<u32, ArrowError> {
         match self.get(cur_idx) {
             TapeElement::String(_)

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -18,7 +18,6 @@
 use crate::reader::serializer::TapeSerializer;
 use arrow_schema::ArrowError;
 use serde::Serialize;
-use std::fmt::{Display, Formatter};
 
 /// We decode JSON to a flattened tape representation,
 /// allowing for efficient traversal of the JSON data
@@ -63,22 +62,6 @@ pub enum TapeElement {
     Null,
 }
 
-impl Display for TapeElement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TapeElement::StartObject(_) => write!(f, "{{"),
-            TapeElement::EndObject(_) => write!(f, "}}"),
-            TapeElement::StartList(_) => write!(f, "["),
-            TapeElement::EndList(_) => write!(f, "]"),
-            TapeElement::String(_) => write!(f, "string"),
-            TapeElement::Number(_) => write!(f, "number"),
-            TapeElement::True => write!(f, "true"),
-            TapeElement::False => write!(f, "false"),
-            TapeElement::Null => write!(f, "null"),
-        }
-    }
-}
-
 /// A decoded JSON tape
 ///
 /// String and numeric data is stored alongside an array of [`TapeElement`]
@@ -116,7 +99,7 @@ impl<'a> Tape<'a> {
     ///
     /// Return an error containing the [`TapeElement`] at `cur_idx` if it
     /// is not the start of a field
-    pub fn next(&self, cur_idx: u32) -> Result<u32, TapeElement> {
+    pub fn next(&self, cur_idx: u32, expected: &str) -> Result<u32, ArrowError> {
         match self.get(cur_idx) {
             TapeElement::String(_)
             | TapeElement::Number(_)
@@ -125,13 +108,61 @@ impl<'a> Tape<'a> {
             | TapeElement::Null => Ok(cur_idx + 1),
             TapeElement::StartList(end_idx) => Ok(end_idx + 1),
             TapeElement::StartObject(end_idx) => Ok(end_idx + 1),
-            d => Err(d),
+            _ => Err(self.error(cur_idx, expected)),
         }
     }
 
     /// Returns the number of rows
     pub fn num_rows(&self) -> usize {
         self.num_rows
+    }
+
+    /// Serialize the tape element at index `idx` to `out` returning the next field index
+    fn serialize(&self, out: &mut String, idx: u32) -> u32 {
+        match self.get(idx) {
+            TapeElement::StartObject(end) => {
+                out.push('{');
+                let mut cur_idx = idx + 1;
+                while cur_idx < end {
+                    cur_idx = self.serialize(out, cur_idx);
+                    out.push_str(": ");
+                    cur_idx = self.serialize(out, cur_idx);
+                }
+                out.push('}');
+                return end + 1;
+            }
+            TapeElement::EndObject(_) => out.push('}'),
+            TapeElement::StartList(end) => {
+                out.push('[');
+                let mut cur_idx = idx + 1;
+                while cur_idx < end {
+                    cur_idx = self.serialize(out, cur_idx);
+                    if cur_idx < end {
+                        out.push_str(", ");
+                    }
+                }
+                out.push(']');
+                return end + 1;
+            }
+            TapeElement::EndList(_) => out.push(']'),
+            TapeElement::String(s) => {
+                out.push('"');
+                out.push_str(self.get_string(s));
+                out.push('"')
+            }
+            TapeElement::Number(n) => out.push_str(self.get_string(n)),
+            TapeElement::True => out.push_str("true"),
+            TapeElement::False => out.push_str("false"),
+            TapeElement::Null => out.push_str("null"),
+        }
+        idx + 1
+    }
+
+    /// Returns an error reading index `idx`
+    pub fn error(&self, idx: u32, expected: &str) -> ArrowError {
+        let mut out = String::with_capacity(64);
+        self.serialize(&mut out, idx);
+        ArrowError::JsonError(format!("expected {expected} got {out}"))
     }
 }
 

--- a/arrow-json/src/reader/timestamp_array.rs
+++ b/arrow-json/src/reader/timestamp_array.rs
@@ -27,7 +27,7 @@ use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType, TimeUnit};
 
 use crate::reader::tape::{Tape, TapeElement};
-use crate::reader::{tape_error, ArrayDecoder};
+use crate::reader::ArrayDecoder;
 
 /// A specialized [`ArrayDecoder`] for timestamps
 pub struct TimestampArrayDecoder<P: ArrowTimestampType, Tz: TimeZone> {
@@ -90,7 +90,7 @@ where
 
                     builder.append_value(value)
                 }
-                d => return Err(tape_error(d, "primitive")),
+                _ => return Err(tape.error(*p, "primitive")),
             }
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4076

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This improves the error messages when decoding the tape, these are produced when the JSON input is valid, i.e. has successfully been decoded to a tape, but doesn't match the expected schema. Producing a more helpful error message is therefore useful for identifying what has gone wrong.

Unfortunately at this level rows don't really exist, but at the very least we can provide more context than a single byte :sweat_smile: 

The error messages for invalid JSON are still not brilliant, but given JSON validation is not "specialized", I'm not sure how important this is.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
