### PR TITLE
optimize cast for same decimal type and same scale

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -733,7 +733,7 @@ pub fn cast_with_options(
             cast_primitive_to_list::<i64>(array, to, to_type, cast_options)
         }
         (Decimal128(_, s1), Decimal128(p2, s2)) => {
-            cast_decimal_to_decimal::<Decimal128Type, Decimal128Type>(
+            cast_decimal_to_decimal_same_type::<Decimal128Type>(
                 array.as_primitive(),
                 *s1,
                 *p2,
@@ -742,7 +742,7 @@ pub fn cast_with_options(
             )
         }
         (Decimal256(_, s1), Decimal256(p2, s2)) => {
-            cast_decimal_to_decimal::<Decimal256Type, Decimal256Type>(
+            cast_decimal_to_decimal_same_type::<Decimal256Type>(
                 array.as_primitive(),
                 *s1,
                 *p2,
@@ -1174,16 +1174,16 @@ pub fn cast_with_options(
                 cast_string_to_time64nanosecond::<i32>(array, cast_options)
             }
             Timestamp(TimeUnit::Second, to_tz) => {
-                cast_string_to_timestamp::<i32, TimestampSecondType>(array, to_tz,cast_options)
+                cast_string_to_timestamp::<i32, TimestampSecondType>(array, to_tz, cast_options)
             }
             Timestamp(TimeUnit::Millisecond, to_tz) => {
                 cast_string_to_timestamp::<i32, TimestampMillisecondType>(array, to_tz, cast_options)
             }
             Timestamp(TimeUnit::Microsecond, to_tz) => {
-                cast_string_to_timestamp::<i32, TimestampMicrosecondType>(array, to_tz,cast_options)
+                cast_string_to_timestamp::<i32, TimestampMicrosecondType>(array, to_tz, cast_options)
             }
             Timestamp(TimeUnit::Nanosecond, to_tz) => {
-                cast_string_to_timestamp::<i32, TimestampNanosecondType>(array, to_tz,cast_options)
+                cast_string_to_timestamp::<i32, TimestampNanosecondType>(array, to_tz, cast_options)
             }
             Interval(IntervalUnit::YearMonth) => {
                 cast_string_to_year_month_interval::<i32>(array, cast_options)
@@ -1267,7 +1267,7 @@ pub fn cast_with_options(
                 cast_byte_container::<BinaryType, LargeBinaryType>(array)
             }
             FixedSizeBinary(size) => {
-                cast_binary_to_fixed_size_binary::<i32>(array,*size, cast_options)
+                cast_binary_to_fixed_size_binary::<i32>(array, *size, cast_options)
             }
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
@@ -1758,12 +1758,12 @@ pub fn cast_with_options(
                         })
                 }
                 false => {
-                            array.as_primitive::<TimestampSecondType>().try_unary::<_, Date64Type, _>(
-                                |x| {
-                                    x.mul_checked(MILLISECONDS)
-                                },
-                            )?
-                        }
+                    array.as_primitive::<TimestampSecondType>().try_unary::<_, Date64Type, _>(
+                        |x| {
+                            x.mul_checked(MILLISECONDS)
+                        },
+                    )?
+                }
             },
         )),
         (Timestamp(TimeUnit::Millisecond, _), Date64) => {
@@ -1804,10 +1804,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMillisecondType>()
                     .try_unary::<_, Time64MicrosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64us(as_time_res_with_timezone::<
-                        TimestampMillisecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64us(as_time_res_with_timezone::<
+                            TimestampMillisecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Millisecond, tz), Time64(TimeUnit::Nanosecond)) => {
@@ -1815,10 +1815,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMillisecondType>()
                     .try_unary::<_, Time64NanosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64ns(as_time_res_with_timezone::<
-                        TimestampMillisecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64ns(as_time_res_with_timezone::<
+                            TimestampMillisecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Microsecond, tz), Time64(TimeUnit::Microsecond)) => {
@@ -1826,10 +1826,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMicrosecondType>()
                     .try_unary::<_, Time64MicrosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64us(as_time_res_with_timezone::<
-                        TimestampMicrosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64us(as_time_res_with_timezone::<
+                            TimestampMicrosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Microsecond, tz), Time64(TimeUnit::Nanosecond)) => {
@@ -1837,10 +1837,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMicrosecondType>()
                     .try_unary::<_, Time64NanosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64ns(as_time_res_with_timezone::<
-                        TimestampMicrosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64ns(as_time_res_with_timezone::<
+                            TimestampMicrosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Nanosecond, tz), Time64(TimeUnit::Microsecond)) => {
@@ -1848,10 +1848,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampNanosecondType>()
                     .try_unary::<_, Time64MicrosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64us(as_time_res_with_timezone::<
-                        TimestampNanosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64us(as_time_res_with_timezone::<
+                            TimestampNanosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Nanosecond, tz), Time64(TimeUnit::Nanosecond)) => {
@@ -1859,10 +1859,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampNanosecondType>()
                     .try_unary::<_, Time64NanosecondType, ArrowError>(|x| {
-                    Ok(time_to_time64ns(as_time_res_with_timezone::<
-                        TimestampNanosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time64ns(as_time_res_with_timezone::<
+                            TimestampNanosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Second, tz), Time32(TimeUnit::Second)) => {
@@ -1903,10 +1903,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMillisecondType>()
                     .try_unary::<_, Time32MillisecondType, ArrowError>(|x| {
-                    Ok(time_to_time32ms(as_time_res_with_timezone::<
-                        TimestampMillisecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time32ms(as_time_res_with_timezone::<
+                            TimestampMillisecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Microsecond, tz), Time32(TimeUnit::Second)) => {
@@ -1925,10 +1925,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampMicrosecondType>()
                     .try_unary::<_, Time32MillisecondType, ArrowError>(|x| {
-                    Ok(time_to_time32ms(as_time_res_with_timezone::<
-                        TimestampMicrosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time32ms(as_time_res_with_timezone::<
+                            TimestampMicrosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
         (Timestamp(TimeUnit::Nanosecond, tz), Time32(TimeUnit::Second)) => {
@@ -1947,10 +1947,10 @@ pub fn cast_with_options(
             Ok(Arc::new(
                 array.as_primitive::<TimestampNanosecondType>()
                     .try_unary::<_, Time32MillisecondType, ArrowError>(|x| {
-                    Ok(time_to_time32ms(as_time_res_with_timezone::<
-                        TimestampNanosecondType,
-                    >(x, tz)?))
-                })?,
+                        Ok(time_to_time32ms(as_time_res_with_timezone::<
+                            TimestampNanosecondType,
+                        >(x, tz)?))
+                    })?,
             ))
         }
 
@@ -2081,6 +2081,87 @@ impl DecimalCast for i256 {
     }
 }
 
+fn cast_decimal_to_decimal_error<O>(
+    output_precision: u8,
+    output_scale: i8,
+) -> impl Fn(<O as ArrowPrimitiveType>::Native) -> ArrowError
+where
+    O: DecimalType,
+    O::Native: DecimalCast + ArrowNativeTypeOp,
+{
+    move |x: O::Native| {
+        ArrowError::CastError(format!(
+            "Cannot cast to {}({}, {}). Overflowing on {:?}",
+            O::PREFIX,
+            output_precision,
+            output_scale,
+            x
+        ))
+    }
+}
+
+fn cast_decimal_to_decimal_same_type<T>(
+    array: &PrimitiveArray<T>,
+    input_scale: i8,
+    output_precision: u8,
+    output_scale: i8,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef, ArrowError>
+where
+    T: DecimalType,
+    T::Native: DecimalCast + ArrowNativeTypeOp,
+{
+    let error = cast_decimal_to_decimal_error::<T>(output_precision, output_scale);
+
+    let array: PrimitiveArray<T> = if input_scale == output_scale {
+        // the scale doesn't change, the native value don't need to be changed
+        array.clone()
+    } else if input_scale > output_scale {
+        let div = T::Native::from_decimal(10_i128)
+            .unwrap()
+            .pow_checked((input_scale - output_scale) as u32)?;
+
+        let half = div.div_wrapping(T::Native::from_usize(2).unwrap());
+        let half_neg = half.neg_wrapping();
+
+        let f = |x: T::Native| {
+            // div is >= 10 and so this cannot overflow
+            let d = x.div_wrapping(div);
+            let r = x.mod_wrapping(div);
+
+            // Round result
+            let adjusted = match x >= T::Native::ZERO {
+                true if r >= half => d.add_wrapping(T::Native::ONE),
+                false if r <= half_neg => d.sub_wrapping(T::Native::ONE),
+                _ => d,
+            };
+            Some(adjusted)
+        };
+
+        match cast_options.safe {
+            true => array.unary_opt(f),
+            false => array.try_unary(|x| f(x).ok_or_else(|| error(x)))?,
+        }
+    } else {
+        // input_scale > output_scale
+        let mul = T::Native::from_decimal(10_i128)
+            .unwrap()
+            .pow_checked((output_scale - input_scale) as u32)?;
+
+        let f = |x| T::Native::from_decimal(x).and_then(|x| x.mul_checked(mul).ok());
+
+        match cast_options.safe {
+            true => array.unary_opt(f),
+            false => array.try_unary(|x| f(x).ok_or_else(|| error(x)))?,
+        }
+    };
+
+    Ok(Arc::new(array.with_precision_and_scale(
+        output_precision,
+        output_scale,
+    )?))
+}
+
 fn cast_decimal_to_decimal<I, O>(
     array: &PrimitiveArray<I>,
     input_scale: i8,
@@ -2094,15 +2175,7 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    let error = |x| {
-        ArrowError::CastError(format!(
-            "Cannot cast to {}({}, {}). Overflowing on {:?}",
-            O::PREFIX,
-            output_precision,
-            output_scale,
-            x
-        ))
-    };
+    let error = cast_decimal_to_decimal_error::<I>(output_precision, output_scale);
 
     let array: PrimitiveArray<O> = if input_scale > output_scale {
         let div = I::Native::from_decimal(10_i128)
@@ -7680,7 +7753,7 @@ mod tests {
             Decimal128Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal128Type>("12345", 2).unwrap(),
                 38,
-                2
+                2,
             ),
             "12345.00"
         );
@@ -7688,7 +7761,7 @@ mod tests {
             Decimal128Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal128Type>("0.12345", 2).unwrap(),
                 38,
-                2
+                2,
             ),
             "0.12"
         );
@@ -7696,7 +7769,7 @@ mod tests {
             Decimal128Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal128Type>(".12345", 2).unwrap(),
                 38,
-                2
+                2,
             ),
             "0.12"
         );
@@ -7704,7 +7777,7 @@ mod tests {
             Decimal128Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal128Type>(".1265", 2).unwrap(),
                 38,
-                2
+                2,
             ),
             "0.13"
         );
@@ -7712,7 +7785,7 @@ mod tests {
             Decimal128Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal128Type>(".1265", 2).unwrap(),
                 38,
-                2
+                2,
             ),
             "0.13"
         );
@@ -7721,7 +7794,7 @@ mod tests {
             Decimal256Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal256Type>("123.45", 3).unwrap(),
                 38,
-                3
+                3,
             ),
             "123.450"
         );
@@ -7729,7 +7802,7 @@ mod tests {
             Decimal256Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal256Type>("12345", 3).unwrap(),
                 38,
-                3
+                3,
             ),
             "12345.000"
         );
@@ -7737,7 +7810,7 @@ mod tests {
             Decimal256Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal256Type>("0.12345", 3).unwrap(),
                 38,
-                3
+                3,
             ),
             "0.123"
         );
@@ -7745,7 +7818,7 @@ mod tests {
             Decimal256Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal256Type>(".12345", 3).unwrap(),
                 38,
-                3
+                3,
             ),
             "0.123"
         );
@@ -7753,7 +7826,7 @@ mod tests {
             Decimal256Type::format_decimal(
                 parse_string_to_decimal_native::<Decimal256Type>(".1265", 3).unwrap(),
                 38,
-                3
+                3,
             ),
             "0.127"
         );

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -2102,7 +2102,7 @@ where
     }
 }
 
-fn convert_to_smaller_equal_scale_decimal<I, O>(
+fn convert_to_smaller_scale_decimal<I, O>(
     array: &PrimitiveArray<I>,
     input_scale: i8,
     output_precision: u8,
@@ -2143,7 +2143,7 @@ where
     })
 }
 
-fn convert_to_bigger_scale_decimal<I, O>(
+fn convert_to_bigger_or_equal_scale_decimal<I, O>(
     array: &PrimitiveArray<I>,
     input_scale: i8,
     output_precision: u8,
@@ -2186,7 +2186,7 @@ where
             // the scale doesn't change, the native value don't need to be changed
             array.clone()
         }
-        Ordering::Greater => convert_to_smaller_equal_scale_decimal::<T, T>(
+        Ordering::Greater => convert_to_smaller_scale_decimal::<T, T>(
             array,
             input_scale,
             output_precision,
@@ -2195,7 +2195,7 @@ where
         )?,
         Ordering::Less => {
             // input_scale < output_scale
-            convert_to_bigger_scale_decimal::<T, T>(
+            convert_to_bigger_or_equal_scale_decimal::<T, T>(
                 array,
                 input_scale,
                 output_precision,
@@ -2226,7 +2226,7 @@ where
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
     let array: PrimitiveArray<O> = if input_scale > output_scale {
-        convert_to_smaller_equal_scale_decimal::<I, O>(
+        convert_to_smaller_scale_decimal::<I, O>(
             array,
             input_scale,
             output_precision,
@@ -2234,7 +2234,7 @@ where
             cast_options,
         )?
     } else {
-        convert_to_bigger_scale_decimal::<I, O>(
+        convert_to_bigger_or_equal_scale_decimal::<I, O>(
             array,
             input_scale,
             output_precision,

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -230,6 +230,13 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast decimal256 to decimal256 512", |b| {
         b.iter(|| cast_array(&decimal256_array, DataType::Decimal256(50, 5)))
     });
+
+    c.bench_function("cast decimal128 to decimal128 512 with same scale", |b| {
+        b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(30, 3)))
+    });
+    c.bench_function("cast decimal256 to decimal256 512 with same scale", |b| {
+        b.iter(|| cast_array(&decimal256_array, DataType::Decimal256(60, 3)))
+    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

we are optimizing the TPCH query, and find some decimal cast is heavy such TPCH-1.



In the Sum Agg, the sum decimal type is (precision+10, scale). The scale is not changed, the array don't need to be converted.



# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

add two micro benchmark, and get the result:

```
cast decimal128 to decimal128 512 with same scale
                        time:   [213.91 ns 214.46 ns 215.11 ns]
                        change: [-96.673% -96.654% -96.628%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

cast decimal256 to decimal256 512 with same scale
                        time:   [212.81 ns 213.51 ns 214.28 ns]
                        change: [-98.529% -98.524% -98.519%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
