### PR TITLE
[Minor]: Add `Hash` trait to SortOptions.

### DIFF
--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -33,7 +33,7 @@ use std::ops;
 pub mod ffi;
 
 /// Options that define the sort order of a given column
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Hash, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 `SortOptions` doesn't implement `Hash` trait. This prevents us to use `HashSet`, `HashMap` with this type. (Or structs having field of this type).
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
This Pr adds `Hash` trait for `SortOptions` type.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
