### PR TITLE
Simplify reference to GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ a great place to meet other contributors and get guidance on where to contribute
 2. the [GitHub Discussions][discussions]
 3. the [Discord channel](https://discord.gg/YAb2TdazKQ)
 
-Unlike other parts of the Arrow ecosystem, the Rust implementation uses [GitHub issues][issues] as the system of record for new features
-and bug fixes and this plays a critical role in the release process.
+The Rust implementation uses [GitHub issues][issues] as the system of record for new features and bug fixes and
+this plays a critical role in the release process.
 
 For design discussions we generally collaborate on Google documents and file a GitHub issue linking to the document.
 


### PR DESCRIPTION
Most Arrow projects use GitHub issues

# Which issue does this PR close?
https://github.com/apache/arrow-rs/issues/4091
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4091 



# Are there any user-facing changes?
No


