### PR TITLE
Increase minimum chrono version to 0.4.24

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -44,7 +44,7 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-data = { workspace = true }
-chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.8", optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }


### PR DESCRIPTION
# Which issue does this PR close?
related to https://github.com/apache/arrow-rs/issues/3963

# Rationale for this change
 
https://github.com/apache/arrow-rs/pull/4038 from @Weijun-H  uses a chrono API introduced in ` 0.4.24`

# What changes are included in this PR?

Increase minimum chrono version to 0.4.24

# Are there any user-facing changes?

not really
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
