### PR TITLE
Remove DataType from PrimitiveArray constructors

### DIFF
--- a/arrow-arith/src/arithmetic.rs
+++ b/arrow-arith/src/arithmetic.rs
@@ -129,7 +129,7 @@ where
         unsafe { arrow_buffer::Buffer::try_from_trusted_len_iter(values) }
     }?;
 
-    Ok(PrimitiveArray::new(T::DATA_TYPE, buffer.into(), nulls))
+    Ok(PrimitiveArray::new(buffer.into(), nulls))
 }
 
 /// Calculates the modulus operation `left % right` on two SIMD inputs.
@@ -356,7 +356,7 @@ where
         }
     }
 
-    Ok(PrimitiveArray::new(T::DATA_TYPE, result.into(), nulls))
+    Ok(PrimitiveArray::new(result.into(), nulls))
 }
 
 /// Applies $OP to $LEFT and $RIGHT which are two dictionaries which have (the same) key type $KT

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -208,7 +208,7 @@ where
     //  Soundness
     //      `values` is an iterator with a known size from a PrimitiveArray
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
-    Ok(PrimitiveArray::new(O::DATA_TYPE, buffer.into(), nulls))
+    Ok(PrimitiveArray::new(buffer.into(), nulls))
 }
 
 /// Given two arrays of length `len`, calls `op(a[i], b[i])` for `i` in `0..len`, mutating
@@ -312,7 +312,7 @@ where
         })?;
 
         let values = buffer.finish().into();
-        Ok(PrimitiveArray::new(O::DATA_TYPE, values, Some(nulls)))
+        Ok(PrimitiveArray::new(values, Some(nulls)))
     }
 }
 
@@ -396,7 +396,7 @@ where
             buffer.push_unchecked(op(a.value_unchecked(idx), b.value_unchecked(idx))?);
         };
     }
-    Ok(PrimitiveArray::new(O::DATA_TYPE, buffer.into(), None))
+    Ok(PrimitiveArray::new(buffer.into(), None))
 }
 
 /// This intentional inline(never) attribute helps LLVM optimize the loop.

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -1120,7 +1120,7 @@ mod tests {
     #[test]
     fn test_try_new() {
         let offsets = OffsetBuffer::new(vec![0, 1, 4, 5].into());
-        let values = Int32Array::new(DataType::Int32, vec![1, 2, 3, 4, 5].into(), None);
+        let values = Int32Array::new(vec![1, 2, 3, 4, 5].into(), None);
         let values = Arc::new(values) as ArrayRef;
 
         let field = Arc::new(Field::new("element", DataType::Int32, false));
@@ -1151,7 +1151,7 @@ mod tests {
         );
 
         let nulls = NullBuffer::new_null(7);
-        let values = Int64Array::new(DataType::Int64, vec![0; 7].into(), Some(nulls));
+        let values = Int64Array::new(vec![0; 7].into(), Some(nulls));
         let values = Arc::new(values);
 
         let err = LargeListArray::try_new(field, offsets.clone(), values.clone(), None)
@@ -1165,7 +1165,7 @@ mod tests {
         let field = Arc::new(Field::new("element", DataType::Int64, true));
         LargeListArray::new(field.clone(), offsets.clone(), values, None);
 
-        let values = Int64Array::new(DataType::Int64, vec![0; 2].into(), None);
+        let values = Int64Array::new(vec![0; 2].into(), None);
         let err =
             LargeListArray::try_new(field, offsets, Arc::new(values), None).unwrap_err();
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -270,12 +270,8 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// # Panics
     ///
     /// Panics if [`Self::try_new`] returns an error
-    pub fn new(
-        data_type: DataType,
-        values: ScalarBuffer<T::Native>,
-        nulls: Option<NullBuffer>,
-    ) -> Self {
-        Self::try_new(data_type, values, nulls).unwrap()
+    pub fn new(values: ScalarBuffer<T::Native>, nulls: Option<NullBuffer>) -> Self {
+        Self::try_new(values, nulls).unwrap()
     }
 
     /// Create a new [`PrimitiveArray`] from the provided data_type, values, nulls
@@ -284,20 +280,10 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     ///
     /// Errors if:
     /// - `values.len() != nulls.len()`
-    /// - `!Self::is_compatible(data_type)`
     pub fn try_new(
-        data_type: DataType,
         values: ScalarBuffer<T::Native>,
         nulls: Option<NullBuffer>,
     ) -> Result<Self, ArrowError> {
-        if !Self::is_compatible(&data_type) {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "PrimitiveArray expected data type {} got {}",
-                T::DATA_TYPE,
-                data_type
-            )));
-        }
-
         if let Some(n) = nulls.as_ref() {
             if n.len() != values.len() {
                 return Err(ArrowError::InvalidArgumentError(format!(
@@ -309,7 +295,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         }
 
         Ok(Self {
-            data_type,
+            data_type: T::DATA_TYPE,
             values,
             nulls,
         })
@@ -318,6 +304,19 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Deconstruct this array into its constituent parts
     pub fn into_parts(self) -> (DataType, ScalarBuffer<T::Native>, Option<NullBuffer>) {
         (self.data_type, self.values, self.nulls)
+    }
+
+    /// Overrides the [`DataType`] of this [`PrimitiveArray`]
+    ///
+    /// Prefer using [`Self::with_timezone`] or [`Self::with_precision_and_scale`] where
+    /// the primitive type is suitably constrained, as these cannot panic
+    ///
+    /// # Panics
+    ///
+    /// Panics if ![Self::is_compatible]
+    pub fn with_data_type(self, data_type: DataType) -> Self {
+        Self::assert_compatible(&data_type);
+        Self { data_type, ..self }
     }
 
     /// Asserts that `data_type` is compatible with `Self`
@@ -406,7 +405,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     pub fn from_value(value: T::Native, count: usize) -> Self {
         unsafe {
             let val_buf = Buffer::from_trusted_len_iter((0..count).map(|_| value));
-            Self::new(T::DATA_TYPE, val_buf.into(), None)
+            Self::new(val_buf.into(), None)
         }
     }
 
@@ -498,7 +497,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         //  Soundness
         //      `values` is an iterator with a known size because arrays are sized.
         let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
-        PrimitiveArray::new(O::DATA_TYPE, buffer.into(), nulls)
+        PrimitiveArray::new(buffer.into(), nulls)
     }
 
     /// Applies an unary and infallible function to a mutable primitive array.
@@ -561,7 +560,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         }
 
         let values = buffer.finish().into();
-        Ok(PrimitiveArray::new(O::DATA_TYPE, values, nulls))
+        Ok(PrimitiveArray::new(values, nulls))
     }
 
     /// Applies an unary and fallible function to all valid values in a mutable primitive array.
@@ -646,7 +645,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let nulls = BooleanBuffer::new(null_builder.finish(), 0, len);
         let values = buffer.finish().into();
         let nulls = unsafe { NullBuffer::new_unchecked(nulls, out_null_count) };
-        PrimitiveArray::new(O::DATA_TYPE, values, Some(nulls))
+        PrimitiveArray::new(values, Some(nulls))
     }
 
     /// Returns `PrimitiveBuilder` of this primitive array for mutating its values if the underlying
@@ -1292,6 +1291,7 @@ mod tests {
     use crate::builder::{Decimal128Builder, Decimal256Builder};
     use crate::cast::downcast_array;
     use crate::{ArrayRef, BooleanArray};
+    use arrow_schema::TimeUnit;
     use std::sync::Arc;
 
     #[test]
@@ -2296,30 +2296,26 @@ mod tests {
 
     #[test]
     fn test_try_new() {
-        Int32Array::new(DataType::Int32, vec![1, 2, 3, 4].into(), None);
-        Int32Array::new(
-            DataType::Int32,
-            vec![1, 2, 3, 4].into(),
-            Some(NullBuffer::new_null(4)),
-        );
-        let err = Int32Array::try_new(DataType::Int64, vec![1, 2, 3, 4].into(), None)
-            .unwrap_err();
+        Int32Array::new(vec![1, 2, 3, 4].into(), None);
+        Int32Array::new(vec![1, 2, 3, 4].into(), Some(NullBuffer::new_null(4)));
 
-        assert_eq!(
-            err.to_string(),
-            "Invalid argument error: PrimitiveArray expected data type Int32 got Int64"
-        );
-
-        let err = Int32Array::try_new(
-            DataType::Int32,
-            vec![1, 2, 3, 4].into(),
-            Some(NullBuffer::new_null(3)),
-        )
-        .unwrap_err();
+        let err =
+            Int32Array::try_new(vec![1, 2, 3, 4].into(), Some(NullBuffer::new_null(3)))
+                .unwrap_err();
 
         assert_eq!(
             err.to_string(),
             "Invalid argument error: Incorrect length of null buffer for PrimitiveArray, expected 4 got 3"
         );
+
+        TimestampNanosecondArray::new(vec![1, 2, 3, 4].into(), None).with_data_type(
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("03:00".into())),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "PrimitiveArray expected data type Int32 got Date32")]
+    fn test_with_data_type() {
+        Int32Array::new(vec![1, 2, 3, 4].into(), None).with_data_type(DataType::Date32);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This makes the constructors more consistent with the other PrimitiveArray methods which default to `T::DATA_TYPE` requiring the user to manually override it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

This does change `PrimitiveArray::new` which was included in the last release. Given how new this API is, I don't anticipate any major issues.