### PR TITLE
Retry on Connection Errors

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -43,6 +43,7 @@ walkdir = "2"
 
 # Cloud storage support
 base64 = { version = "0.21", default-features = false, features = ["std"], optional = true }
+hyper = { version = "0.14", default-features = false, optional = true }
 quick-xml = { version = "0.28.0", features = ["serialize"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
@@ -66,7 +67,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 nix = "0.26.1"
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
+cloud = ["serde", "serde_json", "quick-xml",  "hyper", "reqwest", "reqwest/json","reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]


### PR DESCRIPTION
Request errors can happen intermittently for a variety of reasons i.e patchy internet, hyper holding on to request for too long, TLS errors, broken pipes.

This increases the types of issues that can be retried.

# Which issue does this PR close?

Closes #4119 

# Rationale for this change
 
Only certain request errors are retried currently, and I was experiencing very unreliable multipart uploads, because if a single chunk failed the whole upload would fail.  Mulitpart uploads caused more issues due to sometimes being a delay between the `put` requests for each chunk and hyper, sometimes using a dead connection, or having network issues.

# What changes are included in this PR?

Allow retries when reqwest fails due to request errors. 

# Are there any user-facing changes?

Fewer failures when getting or uploading data to object stores.