### PR TITLE
Make arrow_json::ReaderBuilder method names consistent

### DIFF
--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -193,8 +193,16 @@ impl ReaderBuilder {
         Self { batch_size, ..self }
     }
 
-    /// Sets if the decoder should coerce primitive values (bool and number) into string when the Schema's column is Utf8 or LargeUtf8.
+    /// Sets if the decoder should coerce primitive values (bool and number) into string
+    /// when the Schema's column is Utf8 or LargeUtf8.
+    #[deprecated(note = "Use with_coerce_primitive")]
     pub fn coerce_primitive(self, coerce_primitive: bool) -> Self {
+        self.with_coerce_primitive(coerce_primitive)
+    }
+
+    /// Sets if the decoder should coerce primitive values (bool and number) into string
+    /// when the Schema's column is Utf8 or LargeUtf8.
+    pub fn with_coerce_primitive(self, coerce_primitive: bool) -> Self {
         Self {
             coerce_primitive,
             ..self
@@ -666,7 +674,7 @@ mod tests {
         for batch_size in [1, 3, 100, batch_size] {
             unbuffered = ReaderBuilder::new(schema.clone())
                 .with_batch_size(batch_size)
-                .coerce_primitive(coerce_primitive)
+                .with_coerce_primitive(coerce_primitive)
                 .build(Cursor::new(buf.as_bytes()))
                 .unwrap()
                 .collect::<Result<Vec<_>, _>>()
@@ -680,7 +688,7 @@ mod tests {
             for b in [1, 3, 5] {
                 let buffered = ReaderBuilder::new(schema.clone())
                     .with_batch_size(batch_size)
-                    .coerce_primitive(coerce_primitive)
+                    .with_coerce_primitive(coerce_primitive)
                     .build(BufReader::with_capacity(b, Cursor::new(buf.as_bytes())))
                     .unwrap()
                     .collect::<Result<Vec<_>, _>>()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
We tend to use the `with` prefix for builder method names across arrow-csv, arrow-json and parquet. This helps to distinguish between constructor methods, and methods that return the currently set values.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
