### PR TITLE
docs: fix the wrong ln command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ If the file already exists, to avoid mistakenly **overriding**, you MAY have to 
 the link source or file content. Else if not exist, let's safely soft link [pre-commit.sh](pre-commit.sh) as file `.git/hooks/pre-commit`:
 
 ```bash
-ln -s  ../../rust/pre-commit.sh .git/hooks/pre-commit
+ln -s  ../../pre-commit.sh .git/hooks/pre-commit
 ```
 
 If sometimes you want to commit without checking, just run `git commit` with `--no-verify`:


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
`pre-commit.sh` is located in the project root, the path in that `ln -s` command should be `../../pre-commit.sh`


# What changes are included in this PR?
A shell command
# Are there any user-facing changes?
None
