### PR TITLE
Cleanup reading page index (#4149) (#4090)

### DIFF
--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -78,18 +78,16 @@
 use std::collections::VecDeque;
 use std::fmt::Formatter;
 
-use std::io::{Cursor, SeekFrom};
+use std::io::SeekFrom;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use crate::format::{OffsetIndex, PageLocation};
 use bytes::{Buf, Bytes};
 use futures::future::{BoxFuture, FutureExt};
 use futures::ready;
 use futures::stream::Stream;
-use thrift::protocol::{TCompactInputProtocol, TSerializable};
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
@@ -109,9 +107,13 @@ use crate::column::page::{PageIterator, PageReader};
 use crate::errors::{ParquetError, Result};
 use crate::file::footer::{decode_footer, decode_metadata};
 use crate::file::metadata::{ParquetMetaData, RowGroupMetaData};
+use crate::file::page_index::index::Index;
+use crate::file::page_index::index_reader::{
+    acc_range, decode_column_index, decode_offset_index,
+};
 use crate::file::reader::{ChunkReader, Length, SerializedPageReader};
+use crate::format::PageLocation;
 
-use crate::file::page_index::index_reader;
 use crate::file::FOOTER_SIZE;
 
 use crate::schema::types::{ColumnDescPtr, SchemaDescPtr};
@@ -121,6 +123,7 @@ pub use metadata::*;
 
 #[cfg(feature = "object_store")]
 mod store;
+
 #[cfg(feature = "object_store")]
 pub use store::*;
 
@@ -240,78 +243,53 @@ impl<T: AsyncFileReader + Send + 'static> ArrowReaderBuilder<AsyncReader<T>> {
             && metadata.column_index().is_none()
             && metadata.offset_index().is_none()
         {
-            let mut fetch_ranges = vec![];
-            let mut index_lengths: Vec<Vec<usize>> = vec![];
+            let fetch = metadata.row_groups().iter().flat_map(|r| r.columns()).fold(
+                None,
+                |a, c| {
+                    let a = acc_range(a, c.column_index_range());
+                    acc_range(a, c.offset_index_range())
+                },
+            );
 
-            for rg in metadata.row_groups() {
-                let (loc_offset, loc_length) =
-                    index_reader::get_location_offset_and_total_length(rg.columns())?;
+            if let Some(fetch) = fetch {
+                let bytes = input.get_bytes(fetch.clone()).await?;
+                let bytes = |r: Range<usize>| {
+                    &bytes[(r.start - fetch.start)..(r.end - fetch.start)]
+                };
 
-                let (idx_offset, idx_lengths) =
-                    index_reader::get_index_offset_and_lengths(rg.columns())?;
-                let idx_length = idx_lengths.iter().sum::<usize>();
+                let mut offset_index = Vec::with_capacity(metadata.num_row_groups());
+                let mut column_index = Vec::with_capacity(metadata.num_row_groups());
+                for rg in metadata.row_groups() {
+                    let columns = rg.columns();
+                    let mut rg_offset_index = Vec::with_capacity(columns.len());
+                    let mut rg_column_index = Vec::with_capacity(columns.len());
 
-                // If index data is missing, return without any indexes
-                if loc_length == 0 || idx_length == 0 {
-                    return Self::new_builder(AsyncReader(input), metadata, options);
+                    for chunk in rg.columns() {
+                        let t = chunk.column_type();
+                        let c = match chunk.column_index_range() {
+                            Some(range) => decode_column_index(bytes(range), t)?,
+                            None => Index::NONE,
+                        };
+
+                        let o = match chunk.offset_index_range() {
+                            Some(range) => decode_offset_index(bytes(range))?,
+                            None => return Err(general_err!("missing offset index")),
+                        };
+
+                        rg_column_index.push(c);
+                        rg_offset_index.push(o);
+                    }
+                    offset_index.push(rg_offset_index);
+                    column_index.push(rg_column_index);
                 }
 
-                fetch_ranges.push(loc_offset as usize..loc_offset as usize + loc_length);
-                fetch_ranges.push(idx_offset as usize..idx_offset as usize + idx_length);
-                index_lengths.push(idx_lengths);
+                metadata = Arc::new(ParquetMetaData::new_with_page_index(
+                    metadata.file_metadata().clone(),
+                    metadata.row_groups().to_vec(),
+                    Some(column_index),
+                    Some(offset_index),
+                ));
             }
-
-            let mut chunks = input.get_byte_ranges(fetch_ranges).await?.into_iter();
-            let mut index_lengths = index_lengths.into_iter();
-
-            let mut row_groups = metadata.row_groups().to_vec();
-
-            let mut columns_indexes = vec![];
-            let mut offset_indexes = vec![];
-
-            for rg in row_groups.iter_mut() {
-                let columns = rg.columns();
-
-                let location_data = chunks.next().unwrap();
-                let mut cursor = Cursor::new(location_data);
-                let mut offset_index = vec![];
-
-                for _ in 0..columns.len() {
-                    let mut prot = TCompactInputProtocol::new(&mut cursor);
-                    let offset = OffsetIndex::read_from_in_protocol(&mut prot)?;
-                    offset_index.push(offset.page_locations);
-                }
-
-                offset_indexes.push(offset_index);
-
-                let index_data = chunks.next().unwrap();
-                let index_lengths = index_lengths.next().unwrap();
-
-                let mut start = 0;
-                let data = index_lengths.into_iter().map(|length| {
-                    let r = index_data.slice(start..start + length);
-                    start += length;
-                    r
-                });
-
-                let indexes = rg
-                    .columns()
-                    .iter()
-                    .zip(data)
-                    .map(|(column, data)| {
-                        let column_type = column.column_type();
-                        index_reader::deserialize_column_index(&data, column_type)
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                columns_indexes.push(indexes);
-            }
-
-            metadata = Arc::new(ParquetMetaData::new_with_page_index(
-                metadata.file_metadata().clone(),
-                row_groups,
-                Some(columns_indexes),
-                Some(offset_indexes),
-            ));
         }
 
         Self::new_builder(AsyncReader(input), metadata, options)

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -253,7 +253,7 @@ impl<T: AsyncFileReader + Send + 'static> ArrowReaderBuilder<AsyncReader<T>> {
 
             if let Some(fetch) = fetch {
                 let bytes = input.get_bytes(fetch.clone()).await?;
-                let bytes = |r: Range<usize>| {
+                let get = |r: Range<usize>| {
                     &bytes[(r.start - fetch.start)..(r.end - fetch.start)]
                 };
 
@@ -267,12 +267,12 @@ impl<T: AsyncFileReader + Send + 'static> ArrowReaderBuilder<AsyncReader<T>> {
                     for chunk in rg.columns() {
                         let t = chunk.column_type();
                         let c = match chunk.column_index_range() {
-                            Some(range) => decode_column_index(bytes(range), t)?,
+                            Some(range) => decode_column_index(get(range), t)?,
                             None => Index::NONE,
                         };
 
                         let o = match chunk.offset_index_range() {
-                            Some(range) => decode_offset_index(bytes(range))?,
+                            Some(range) => decode_offset_index(get(range))?,
                             None => return Err(general_err!("missing offset index")),
                         };
 

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -33,6 +33,7 @@
 //! [`ColumnChunkMetaData`](struct.ColumnChunkMetaData.html) has information about column
 //! chunk (primitive leaf column), including encoding/compression, number of values, etc.
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use crate::format::{
@@ -565,6 +566,13 @@ impl ColumnChunkMetaData {
         self.column_index_length
     }
 
+    /// Returns the range for the offset index if any
+    pub(crate) fn column_index_range(&self) -> Option<Range<usize>> {
+        let offset = usize::try_from(self.column_index_offset?).ok()?;
+        let length = usize::try_from(self.column_index_length?).ok()?;
+        Some(offset..(offset + length))
+    }
+
     /// Returns the offset for the offset index.
     pub fn offset_index_offset(&self) -> Option<i64> {
         self.offset_index_offset
@@ -573,6 +581,13 @@ impl ColumnChunkMetaData {
     /// Returns the offset for the offset index length.
     pub fn offset_index_length(&self) -> Option<i32> {
         self.offset_index_length
+    }
+
+    /// Returns the range for the offset index if any
+    pub(crate) fn offset_index_range(&self) -> Option<Range<usize>> {
+        let offset = usize::try_from(self.offset_index_offset?).ok()?;
+        let length = usize::try_from(self.offset_index_length?).ok()?;
+        Some(offset..(offset + length))
     }
 
     /// Method to convert from Thrift.

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -28,7 +28,9 @@ use std::io::Cursor;
 use std::ops::Range;
 use thrift::protocol::{TCompactInputProtocol, TSerializable};
 
-/// Computes the aggregate range of two optional ranges
+/// Computes the covering range of two optional ranges
+///
+/// For example `acc_range(Some(7..9), Some(1..3)) = Some(1..9)`
 pub(crate) fn acc_range(
     a: Option<Range<usize>>,
     b: Option<Range<usize>>,

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -66,12 +66,12 @@ pub fn read_columns_indexes<R: ChunkReader>(
     };
 
     let bytes = reader.get_bytes(fetch.start as _, fetch.end - fetch.start)?;
-    let bytes = |r: Range<usize>| &bytes[(r.start - fetch.start)..(r.end - fetch.start)];
+    let get = |r: Range<usize>| &bytes[(r.start - fetch.start)..(r.end - fetch.start)];
 
     chunks
         .iter()
         .map(|c| match c.column_index_range() {
-            Some(r) => decode_column_index(bytes(r), c.column_type()),
+            Some(r) => decode_column_index(get(r), c.column_type()),
             None => Ok(Index::NONE),
         })
         .collect()
@@ -102,12 +102,12 @@ pub fn read_pages_locations<R: ChunkReader>(
     };
 
     let bytes = reader.get_bytes(fetch.start as _, fetch.end - fetch.start)?;
-    let bytes = |r: Range<usize>| &bytes[(r.start - fetch.start)..(r.end - fetch.start)];
+    let get = |r: Range<usize>| &bytes[(r.start - fetch.start)..(r.end - fetch.start)];
 
     chunks
         .iter()
         .map(|c| match c.offset_index_range() {
-            Some(r) => decode_offset_index(bytes(r)),
+            Some(r) => decode_offset_index(get(r)),
             None => Err(general_err!("missing offset index")),
         })
         .collect()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4149
Precursor to #4090

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This performs some cleanup on the logic for reading the page index, in preparation for adding an async API. It also eliminates the assumption of contiguous ranges (#4149).

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
