### PR TITLE
InMemory append API

### DIFF
--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -379,13 +379,9 @@ impl AsyncWrite for InMemoryAppend {
 
     fn poll_shutdown(
         self: Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), io::Error>> {
-        // does nothing different than flush
-        match self.poll_flush(_cx) {
-            Poll::Ready(_) => Poll::Ready(Ok(())),
-            Poll::Pending => Poll::Pending,
-        }
+        self.poll_flush(cx)
     }
 }
 

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -124,7 +124,7 @@ impl ObjectStore for InMemory {
         Ok(Box::new(InMemoryAppend {
             location: _location.clone(),
             data: Vec::<u8>::new(),
-            storage: self.storage.clone(),
+            storage: StorageType::clone(&self.storage),
         }))
     }
 
@@ -360,7 +360,7 @@ impl AsyncWrite for InMemoryAppend {
         mut self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), io::Error>> {
-        let storage = self.storage.clone();
+        let storage = StorageType::clone(&self.storage);
 
         let mut writer = storage.write();
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4152.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

InMemory implementation of ObjectStore can support append() now.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

append() returns an InMemoryAppend object, having the fields of location (where the data is stored in BTree), data appended, and the storage of the InMemory object. poll_write() writes the buffer, poll_flush() append the data to storage. There is no need to use poll_shutdown().

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
