### PR TITLE
Faster prefix match in object_store path handling

### DIFF
--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -227,14 +227,9 @@ impl Path {
 
     /// Returns the [`PathPart`] of this [`Path`]
     pub fn parts(&self) -> impl Iterator<Item = PathPart<'_>> {
-        match self.raw.is_empty() {
-            true => itertools::Either::Left(std::iter::empty()),
-            false => itertools::Either::Right(
-                self.raw
-                    .split(DELIMITER)
-                    .map(|s| PathPart { raw: s.into() }),
-            ),
-        }
+        self.raw
+            .split_terminator(DELIMITER)
+            .map(|s| PathPart { raw: s.into() })
     }
 
     /// Returns the last path segment containing the filename stored in this [`Path`]
@@ -447,6 +442,8 @@ mod tests {
 
         let prefix = existing_path.clone();
         assert_eq!(existing_path.prefix_match(&prefix).unwrap().count(), 0);
+
+        assert_eq!(Path::default().parts().count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Whilst working on https://github.com/apache/arrow-datafusion/pull/6183 realised there is faster way to achieve this

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
