### PR TITLE
Allow creating unbuffered streamreader

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1297,9 +1297,6 @@ impl<R: Read> RecordBatchReader for StreamReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::Cursor;
-
     use crate::writer::unslice_run_array;
 
     use super::*;
@@ -1515,8 +1512,7 @@ mod tests {
         file.rewind().unwrap();
 
         // read stream back
-        let reader =
-            StreamReader::<BufReader<&mut File>>::try_new(&mut file, None).unwrap();
+        let reader = StreamReader::try_new(&mut file, None).unwrap();
 
         reader.for_each(|batch| {
             let batch = batch.unwrap();
@@ -1575,11 +1571,8 @@ mod tests {
         drop(writer);
 
         let mut reader =
-            crate::reader::StreamReader::<BufReader<Cursor<Vec<u8>>>>::try_new(
-                std::io::Cursor::new(buf),
-                None,
-            )
-            .unwrap();
+            crate::reader::StreamReader::try_new(std::io::Cursor::new(buf), None)
+                .unwrap();
         reader.next().unwrap().unwrap()
     }
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1119,23 +1119,12 @@ impl<R: Read> StreamReader<BufReader<R>> {
     ) -> Result<Self, ArrowError> {
         Self::try_new_unbuffered(BufReader::new(reader), projection)
     }
-
-    /// Gets a reference to the underlying reader.
-    ///
-    /// It is inadvisable to directly read from the underlying reader.
-    pub fn get_ref(&self) -> &R {
-        self.reader.get_ref()
-    }
-
-    /// Gets a mutable reference to the underlying reader.
-    ///
-    /// It is inadvisable to directly read from the underlying reader.
-    pub fn get_mut(&mut self) -> &mut R {
-        self.reader.get_mut()
-    }
 }
 
 impl<R: Read> StreamReader<R> {
+    /// Try to create a new stream reader but do not wrap the reader in a BufReader.
+    ///
+    /// Unless you need the StreamReader to be unbuffered you likely want to use `StreamReader::try_new` instead.
     pub fn try_new_unbuffered(
         mut reader: R,
         projection: Option<Vec<usize>>,
@@ -1278,6 +1267,20 @@ impl<R: Read> StreamReader<R> {
                 format!("Reading types other than record batches not yet supported, unable to read {t:?} ")
             )),
         }
+    }
+
+    /// Gets a reference to the underlying reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    /// Gets a mutable reference to the underlying reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?


Closes #93

# Rationale for this change
 
Allows users to create a StreamReader without buffering. This is useful if you want to customize the buffer size of the BufReader manually or if you want reads to be unbuffered.

# What changes are included in this PR?

Adds a new try_new_unbuffered() function to StreamReader.

# Are there any user-facing changes?

Yes. get_ref()/get_mut() may now return a BufReader<R> instead of an R.