### PR TITLE
Minor: support new types in struct_builder.rs

### DIFF
--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -41,6 +41,8 @@ pub type UInt16Builder = PrimitiveBuilder<UInt16Type>;
 pub type UInt32Builder = PrimitiveBuilder<UInt32Type>;
 /// An usigned 64-bit integer array builder.
 pub type UInt64Builder = PrimitiveBuilder<UInt64Type>;
+/// A 16-bit floating point array builder.
+pub type Float16Builder = PrimitiveBuilder<Float16Type>;
 /// A 32-bit floating point array builder.
 pub type Float32Builder = PrimitiveBuilder<Float32Type>;
 /// A 64-bit floating point array builder.
@@ -180,7 +182,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     /// data type of the generated array.
     ///
     /// This method allows overriding the data type, to allow specifying timezones
-    /// for [`DataType::Timestamp`] or precision and scale for [`DataType::Decimal128`]
+    /// for [`DataType::Timestamp`] or precision and scale for [`DataType::Decimal128`] and [`DataType::Decimal256`]
     ///
     /// # Panics
     ///

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -109,9 +109,13 @@ pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<dyn ArrayBuilde
         DataType::UInt16 => Box::new(UInt16Builder::with_capacity(capacity)),
         DataType::UInt32 => Box::new(UInt32Builder::with_capacity(capacity)),
         DataType::UInt64 => Box::new(UInt64Builder::with_capacity(capacity)),
+        DataType::Float16 => Box::new(Float16Builder::with_capacity(capacity)),
         DataType::Float32 => Box::new(Float32Builder::with_capacity(capacity)),
         DataType::Float64 => Box::new(Float64Builder::with_capacity(capacity)),
         DataType::Binary => Box::new(BinaryBuilder::with_capacity(capacity, 1024)),
+        DataType::LargeBinary => {
+            Box::new(LargeBinaryBuilder::with_capacity(capacity, 1024))
+        }
         DataType::FixedSizeBinary(len) => {
             Box::new(FixedSizeBinaryBuilder::with_capacity(capacity, *len))
         }
@@ -119,7 +123,14 @@ pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<dyn ArrayBuilde
             Decimal128Builder::with_capacity(capacity)
                 .with_data_type(DataType::Decimal128(*p, *s)),
         ),
+        DataType::Decimal256(p, s) => Box::new(
+            Decimal256Builder::with_capacity(capacity)
+                .with_data_type(DataType::Decimal256(*p, *s)),
+        ),
         DataType::Utf8 => Box::new(StringBuilder::with_capacity(capacity, 1024)),
+        DataType::LargeUtf8 => {
+            Box::new(LargeStringBuilder::with_capacity(capacity, 1024))
+        }
         DataType::Date32 => Box::new(Date32Builder::with_capacity(capacity)),
         DataType::Date64 => Box::new(Date64Builder::with_capacity(capacity)),
         DataType::Time32(TimeUnit::Second) => {


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change
 Support new types in `struct_builder.rs`:
- Float16
- Decimal256
- LargeBinary
- LargeUtf8


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
