### PR TITLE
Parquet: Implement support for Encoding::BYTE_STREAM_SPLIT

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1313,6 +1313,9 @@ mod tests {
             | DataType::UInt32
             | DataType::UInt16
             | DataType::UInt8 => vec![Encoding::PLAIN, Encoding::DELTA_BINARY_PACKED],
+            DataType::Float32 | DataType::Float64 => {
+                vec![Encoding::PLAIN, Encoding::BYTE_STREAM_SPLIT]
+            }
             _ => vec![Encoding::PLAIN],
         };
 

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1096,7 +1096,6 @@ impl<T: DataType> Decoder<T> for DeltaByteArrayDecoder<T> {
 
 #[cfg(test)]
 mod tests {
-
     use super::{super::encoding::*, *};
 
     use std::f32::consts::PI as PI_f32;

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1097,8 +1097,6 @@ impl<T: DataType> Decoder<T> for DeltaByteArrayDecoder<T> {
 #[cfg(test)]
 mod tests {
 
-    use arrow::datatypes::Float64Type;
-
     use super::{super::encoding::*, *};
 
     use std::f32::consts::PI as PI_f32;
@@ -1892,8 +1890,18 @@ mod tests {
             ],
             vec![f32::from_le_bytes([0xA3, 0xB4, 0xC5, 0xD6])],
         ];
-        // let data = vec![vec![0.0f64], vec![1.0]];
         test_byte_stream_split_decode::<FloatType>(data);
+    }
+
+    #[test]
+    fn test_skip_byte_stream_split() {
+        let block_data = vec![0.3, 0.4, 0.1, 4.10];
+        test_skip::<FloatType>(block_data.clone(), Encoding::BYTE_STREAM_SPLIT, 2);
+        test_skip::<DoubleType>(
+            block_data.into_iter().map(|x| x as f64).collect(),
+            Encoding::BYTE_STREAM_SPLIT,
+            100,
+        );
     }
 
     fn test_rle_value_decode<T: DataType>(data: Vec<Vec<T::T>>) {

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -1,0 +1,117 @@
+use crate::data_type::{DataType, SliceAsBytes};
+use crate::{basic::Encoding, errors::Result};
+
+use super::Decoder;
+
+use crate::util::memory::ByteBufferPtr;
+
+use std::marker::PhantomData;
+
+pub struct ByteStreamSplitDecoder<T: DataType> {
+    _phantom: PhantomData<T>,
+    encoded_bytes: ByteBufferPtr,
+    total_num_values: usize,
+    cur_byte_idx: usize,
+}
+
+impl<T: DataType> ByteStreamSplitDecoder<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+            encoded_bytes: ByteBufferPtr::new(vec![]),
+            total_num_values: 0,
+            cur_byte_idx: 0,
+        }
+    }
+}
+
+impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
+    fn set_data(&mut self, data: ByteBufferPtr, num_values: usize) -> Result<()> {
+        self.encoded_bytes = data;
+        self.total_num_values = num_values;
+        self.cur_byte_idx = 0;
+
+        println!();
+        Ok(())
+    }
+
+    fn get(&mut self, buffer: &mut [<T as DataType>::T]) -> Result<usize> {
+        let total_remaining_values = self.values_left();
+        let num_values_to_decode = buffer.len().min(total_remaining_values);
+        dbg!(
+            self.total_num_values,
+            total_remaining_values,
+            self.cur_byte_idx,
+            num_values_to_decode,
+        );
+
+        let num_streams = T::get_type_size();
+
+        // TODO explain safety
+        let raw_out_bytes = unsafe { <T as DataType>::T::slice_as_bytes_mut(buffer) };
+
+        let byte_stride = num_values_to_decode;
+
+        let mut start = self.cur_byte_idx;
+
+        // For each value, compute a chunk that is the indexes into self.encoded_bytes to fetch and combine into the output byte
+
+        (0..12).cycle().chun(T::get_type_size())
+
+        for value_idx in 0..num_values_to_decode {
+            usize::
+            // go through each byte at a time of the value
+            for b_idx in 0..T::get_type_size() {
+                let encoded_byte_idx = 
+                raw_out_bytes[value_idx * T::get_type_size() + b_idx] =
+                    self.encoded_bytes[start + value_idx + (b_idx * T::get_type_size())];
+            }
+        }
+
+        // for out_index in (0..raw_out_bytes.len()).step_by(T::get_type_size()) {
+        //     for i in 0..T::get_type_size() {
+        //         raw_out_bytes[out_index + i] =
+        //             self.encoded_bytes[self.cur_byte_idx + (i * T::get_type_size())];
+        //     }
+        // }
+
+        // // TODO will it be better to take iterate stream first, because of locality?
+        // for i in self.cur_byte_idx..self.cur_byte_idx + num_values_to_decode {
+        //     for b in 0..num_streams {
+        //         // dbg!(byte_index);
+        //         // TODO avoid get_type_size mul every iteration
+        //         let encoded_byte_index = (b * byte_stride) + i;
+        //         let out_byte_index = i * num_streams + b;
+        //         // dbg!(encoded_byte_index, out_byte_index, b, byte_stride);
+        //         raw_out_bytes[out_byte_index] = self.encoded_bytes[encoded_byte_index];
+        //     }
+        // }
+
+        // TODO I think there's an inherent flaw in the design of Decoding, where the
+        // Or maybe we can actually do it by remember the byte we are at in self.buffer
+
+        self.cur_byte_idx += num_values_to_decode;
+
+        Ok(num_values_to_decode)
+    }
+
+    fn values_left(&self) -> usize {
+        self.total_num_values - self.cur_byte_idx
+    }
+
+    fn encoding(&self) -> Encoding {
+        Encoding::BYTE_STREAM_SPLIT
+    }
+
+    fn skip(&mut self, num_values: usize) -> Result<usize> {
+        todo!()
+        // let values_skipped = 0;
+        // let new = self.cur_value_idx + num_values;
+        // if new > self.num_values {
+        //     return Ok()
+        // }
+        // self.cur_value_idx.s + num_values
+        // self.cur_value_idx.a += num_values;
+        // Ok()
+    }
+}

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -117,14 +117,8 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
     }
 
     fn skip(&mut self, num_values: usize) -> Result<usize> {
-        todo!()
-        // let values_skipped = 0;
-        // let new = self.cur_value_idx + num_values;
-        // if new > self.num_values {
-        //     return Ok()
-        // }
-        // self.cur_value_idx.s + num_values
-        // self.cur_value_idx.a += num_values;
-        // Ok()
+        let to_skip = usize::min(self.values_left(), num_values);
+        self.values_decoded += to_skip;
+        Ok(to_skip)
     }
 }

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -11,7 +11,7 @@ pub struct ByteStreamSplitDecoder<T: DataType> {
     _phantom: PhantomData<T>,
     encoded_bytes: ByteBufferPtr,
     total_num_values: usize,
-    cur_byte_idx: usize,
+    values_decoded: usize,
 }
 
 impl<T: DataType> ByteStreamSplitDecoder<T> {
@@ -20,7 +20,7 @@ impl<T: DataType> ByteStreamSplitDecoder<T> {
             _phantom: PhantomData,
             encoded_bytes: ByteBufferPtr::new(vec![]),
             total_num_values: 0,
-            cur_byte_idx: 0,
+            values_decoded: 0,
         }
     }
 }
@@ -29,7 +29,7 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
     fn set_data(&mut self, data: ByteBufferPtr, num_values: usize) -> Result<()> {
         self.encoded_bytes = data;
         self.total_num_values = num_values;
-        self.cur_byte_idx = 0;
+        self.values_decoded = 0;
 
         println!();
         Ok(())
@@ -37,36 +37,49 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
 
     fn get(&mut self, buffer: &mut [<T as DataType>::T]) -> Result<usize> {
         let total_remaining_values = self.values_left();
-        let num_values_to_decode = buffer.len().min(total_remaining_values);
+        let num_values = buffer.len().min(total_remaining_values);
         dbg!(
             self.total_num_values,
             total_remaining_values,
-            self.cur_byte_idx,
-            num_values_to_decode,
+            self.values_decoded,
+            num_values,
         );
-
-        let num_streams = T::get_type_size();
 
         // TODO explain safety
         let raw_out_bytes = unsafe { <T as DataType>::T::slice_as_bytes_mut(buffer) };
 
-        let byte_stride = num_values_to_decode;
-
-        let mut start = self.cur_byte_idx;
-
         // For each value, compute a chunk that is the indexes into self.encoded_bytes to fetch and combine into the output byte
 
-        (0..12).cycle().chun(T::get_type_size())
+        // TODO it might be better to go through one byte stream at a time for memory locality
 
-        for value_idx in 0..num_values_to_decode {
-            usize::
-            // go through each byte at a time of the value
-            for b_idx in 0..T::get_type_size() {
-                let encoded_byte_idx = 
-                raw_out_bytes[value_idx * T::get_type_size() + b_idx] =
-                    self.encoded_bytes[start + value_idx + (b_idx * T::get_type_size())];
+        let num_values = num_values;
+        let num_streams = T::get_type_size();
+        let byte_stream_length = self.encoded_bytes.len() / num_streams;
+        let values_decoded = self.values_decoded;
+
+        // go through each value to decode
+        for out_value_idx in 0..num_values {
+            // go through each byte stream of that value
+            for byte_stream_idx in 0..num_streams {
+                let idx_in_encoded_data = (byte_stream_idx * byte_stream_length)
+                    + (values_decoded + out_value_idx);
+
+                raw_out_bytes[(out_value_idx * num_streams) + byte_stream_idx] =
+                    self.encoded_bytes[idx_in_encoded_data];
             }
         }
+
+        // let encoded_indices_iter = (0..num_values).cartesian_product(0..num_streams).map(
+        //     |(value_idx, byte_idx)| {
+        //         (start
+        //             + value_idx
+        //             + (byte_idx * (num_streams - 1)) % self.encoded_bytes.len())
+        //     },
+        // );
+        // for (out_byte_idx, encoded_idx) in (0..num_bytes).zip(encoded_indices_iter) {
+        //     println!("{out_byte_idx} {encoded_idx}");
+        //     raw_out_bytes[out_byte_idx] = self.encoded_bytes[encoded_idx];
+        // }
 
         // for out_index in (0..raw_out_bytes.len()).step_by(T::get_type_size()) {
         //     for i in 0..T::get_type_size() {
@@ -90,13 +103,13 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
         // TODO I think there's an inherent flaw in the design of Decoding, where the
         // Or maybe we can actually do it by remember the byte we are at in self.buffer
 
-        self.cur_byte_idx += num_values_to_decode;
+        self.values_decoded += num_values;
 
-        Ok(num_values_to_decode)
+        Ok(num_values)
     }
 
     fn values_left(&self) -> usize {
-        self.total_num_values - self.cur_byte_idx
+        self.total_num_values - self.values_decoded
     }
 
     fn encoding(&self) -> Encoding {

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -1,6 +1,6 @@
 use crate::basic::{Encoding, Type};
+use crate::data_type::DataType;
 use crate::data_type::SliceAsBytes;
-use crate::data_type::{AsBytes, DataType};
 use crate::util::memory::ByteBufferPtr;
 
 use crate::errors::Result;
@@ -16,7 +16,6 @@ pub struct ByteStreamSplitEncoder<T> {
 
 impl<T: DataType> ByteStreamSplitEncoder<T> {
     pub(crate) fn new() -> Self {
-        // println!("ByteStreamSplitEncoder constructed");
         Self {
             buffer: Vec::new(),
             _p: PhantomData,
@@ -26,20 +25,12 @@ impl<T: DataType> ByteStreamSplitEncoder<T> {
 
 impl<T: DataType> Encoder<T> for ByteStreamSplitEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
-        // println!("ByteStreamSplitEncoder.put");
-        // dbg!(values.len());
-        // println!("before self.buffer: {:x?}", self.buffer);
         self.buffer
             .extend(<T as DataType>::T::slice_as_bytes(values));
         ensure_phys_ty!(
             Type::FLOAT | Type::DOUBLE,
             "ByteStreamSplitEncoder only supports FloatType or DoubleType"
         );
-
-        // TODO should this instead use T::encode?
-
-        // TODO chunk to try to make compiler auto-vectorize
-        // println!("after self.buffer: {:x?}", self.buffer);
 
         Ok(())
     }

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -1,0 +1,69 @@
+use crate::basic::{Encoding, Type};
+use crate::data_type::SliceAsBytes;
+use crate::data_type::{AsBytes, DataType};
+use crate::util::memory::ByteBufferPtr;
+
+use crate::errors::Result;
+
+use super::Encoder;
+
+use std::marker::PhantomData;
+
+pub struct ByteStreamSplitEncoder<T> {
+    buffer: Vec<u8>,
+    _p: PhantomData<T>,
+}
+
+impl<T: DataType> ByteStreamSplitEncoder<T> {
+    pub(crate) fn new() -> Self {
+        // println!("ByteStreamSplitEncoder constructed");
+        Self {
+            buffer: Vec::new(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: DataType> Encoder<T> for ByteStreamSplitEncoder<T> {
+    fn put(&mut self, values: &[T::T]) -> Result<()> {
+        // println!("ByteStreamSplitEncoder.put");
+        // dbg!(values.len());
+        // println!("before self.buffer: {:x?}", self.buffer);
+        self.buffer
+            .extend(<T as DataType>::T::slice_as_bytes(values));
+        ensure_phys_ty!(
+            Type::FLOAT | Type::DOUBLE,
+            "ByteStreamSplitEncoder only supports FloatType or DoubleType"
+        );
+
+        // TODO should this instead use T::encode?
+
+        // TODO chunk to try to make compiler auto-vectorize
+        // println!("after self.buffer: {:x?}", self.buffer);
+
+        Ok(())
+    }
+
+    fn encoding(&self) -> Encoding {
+        Encoding::BYTE_STREAM_SPLIT
+    }
+
+    fn estimated_data_encoded_size(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn flush_buffer(&mut self) -> Result<ByteBufferPtr> {
+        let mut encoded = vec![0; self.buffer.len()];
+        // Have to do all work in flush buffer, as we need the whole byte stream
+        let num_streams = T::get_type_size();
+        let num_values = self.buffer.len() / T::get_type_size();
+        for i in 0..num_values {
+            for j in 0..num_streams {
+                let byte_in_value = self.buffer[i * num_streams + j];
+                encoded[j * num_values + i] = byte_in_value;
+            }
+        }
+        self.buffer.clear();
+        Ok(encoded.into())
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/4102.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Implements decoding and encoding of BYTE_STREAM_SPLIT for f32 and f64.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes, now the BYTE_STREAM_SPLIT will not error when used as an encoding for a column.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
