### PR TITLE
Add ObjectStoreScheme (#4047)

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -249,7 +249,10 @@ pub use client::{backoff::BackoffConfig, retry::RetryConfig};
 
 #[cfg(any(feature = "azure", feature = "aws", feature = "gcp"))]
 mod multipart;
+mod scheme;
 mod util;
+
+pub use scheme::ObjectStoreScheme;
 
 use crate::path::Path;
 #[cfg(not(target_arch = "wasm32"))]

--- a/object_store/src/scheme.rs
+++ b/object_store/src/scheme.rs
@@ -51,9 +51,9 @@ impl ObjectStoreScheme {
             }
             ("http", Some(_)) => Ok(Self::Http),
             ("https", Some(host)) => {
-                if host.ends_with("dfs.core.windows.net") {
-                    Ok(Self::MicrosoftAzure)
-                } else if host.ends_with("blob.core.windows.net") {
+                if host.ends_with("dfs.core.windows.net")
+                    || host.ends_with("blob.core.windows.net")
+                {
                     Ok(Self::MicrosoftAzure)
                 } else if host.ends_with("amazonaws.com") {
                     Ok(Self::AmazonS3)

--- a/object_store/src/scheme.rs
+++ b/object_store/src/scheme.rs
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::{Error, Result};
+use url::Url;
+
+/// Recognises various URL formats, identifying the relevant [`ObjectStore`](crate::ObjectStore)
+///
+/// This can be combined with the [with_url](crate::aws::AmazonS3Builder::with_url) methods
+/// on the corresponding builder to construct the relevant type of store
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ObjectStoreScheme {
+    /// Url corresponding to [`LocalFileSystem`](crate::local::LocalFileSystem)
+    Local,
+    /// Url corresponding to [`InMemory`](crate::memory::InMemory)
+    Memory,
+    /// Url corresponding to [`AmazonS3`](crate::aws::AmazonS3)
+    AmazonS3,
+    /// Url corresponding to [`GoogleCloudStorage`](crate::gcp::GoogleCloudStorage)
+    GoogleCloudStorage,
+    /// Url corresponding to [`MicrosoftAzure`](crate::azure::MicrosoftAzure)
+    MicrosoftAzure,
+    /// Url corresponding to [`HttpStore`](crate::http::HttpStore)
+    Http,
+}
+
+impl ObjectStoreScheme {
+    /// Create an [`ObjectStoreScheme`] from the provided [`Url`]
+    pub fn try_new(url: &Url) -> Result<Self> {
+        match (url.scheme(), url.host_str()) {
+            ("file", None) => Ok(Self::Local),
+            ("memory", None) => Ok(Self::Memory),
+            ("s3" | "s3a", Some(_)) => Ok(Self::AmazonS3),
+            ("gs", Some(_)) => Ok(Self::GoogleCloudStorage),
+            ("az" | "adl" | "azure" | "abfs" | "abfss", Some(_)) => {
+                Ok(Self::MicrosoftAzure)
+            }
+            ("http", Some(_)) => Ok(Self::Http),
+            ("https", Some(host)) => {
+                if host.ends_with("dfs.core.windows.net") {
+                    Ok(Self::MicrosoftAzure)
+                } else if host.ends_with("blob.core.windows.net") {
+                    Ok(Self::MicrosoftAzure)
+                } else if host.ends_with("amazonaws.com") {
+                    Ok(Self::AmazonS3)
+                } else {
+                    Ok(Self::Http)
+                }
+            }
+            _ => Err(Error::Generic {
+                store: "ObjectStoreScheme",
+                source: format!("Unrecognized URL: {url}").into(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scheme() {
+        let cases = [
+            ("file:/path", ObjectStoreScheme::Local),
+            ("file:///path", ObjectStoreScheme::Local),
+            ("memory:/foo", ObjectStoreScheme::Memory),
+            ("memory:///", ObjectStoreScheme::Memory),
+            ("s3://bucket/path", ObjectStoreScheme::AmazonS3),
+            ("s3a://bucket/path", ObjectStoreScheme::AmazonS3),
+            (
+                "https://s3.bucket.amazonaws.com",
+                ObjectStoreScheme::AmazonS3,
+            ),
+            (
+                "https://bucket.s3.region.amazonaws.com",
+                ObjectStoreScheme::AmazonS3,
+            ),
+            ("abfs://container/path", ObjectStoreScheme::MicrosoftAzure),
+            (
+                "abfs://file_system@account_name.dfs.core.windows.net/path",
+                ObjectStoreScheme::MicrosoftAzure,
+            ),
+            (
+                "abfss://file_system@account_name.dfs.core.windows.net/path",
+                ObjectStoreScheme::MicrosoftAzure,
+            ),
+            (
+                "https://account.dfs.core.windows.net",
+                ObjectStoreScheme::MicrosoftAzure,
+            ),
+            (
+                "https://account.blob.core.windows.net",
+                ObjectStoreScheme::MicrosoftAzure,
+            ),
+            ("gs://bucket/path", ObjectStoreScheme::GoogleCloudStorage),
+            ("http://mydomain/path", ObjectStoreScheme::Http),
+            ("https://mydomain/path", ObjectStoreScheme::Http),
+        ];
+
+        for (s, expected) in cases {
+            let url = Url::parse(s).unwrap();
+            assert_eq!(ObjectStoreScheme::try_new(&url).unwrap(), expected);
+        }
+
+        let neg_cases = [
+            "unix:/run/foo.socket",
+            "file://remote/path",
+            "memory://remote/",
+        ];
+        for s in neg_cases {
+            let url = Url::parse(s).unwrap();
+            assert!(ObjectStoreScheme::try_new(&url).is_err());
+        }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4047

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Inspired by the work in #4077 I started work on a generic `ObjectStoreBuilder`, however, this ran into a couple of challenges

* Different stores have different configuration APIs, e.g. S3 has ClientOptions, whereas LocalFilesystem has a prefix
* Some downstreams will want to use environment variables, and some will not
* Some downstreams will want to filter config to just match those expected by the store, others will want to error
* There are various valid ways LocalFileSystem and Memory URLs could be interpreted
* The feature flag plumbing was extremely fiddly, the fact we separate the different stores is a historical artifact from when they brought in different SDKs, downstreams shouldn't need to do this

Whilst this PR does to a certain extent punt the issue onto downstreams, I think this standardises the non-trivial URL recognition logic, whilst allowing downstreams to make their own opinionated decision w.r.t the above.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
