### PR TITLE
Remove powf_scalar kernel

### DIFF
--- a/arrow-arith/src/arithmetic.rs
+++ b/arrow-arith/src/arithmetic.rs
@@ -29,7 +29,6 @@ use arrow_array::*;
 use arrow_buffer::i256;
 use arrow_buffer::ArrowNativeType;
 use arrow_schema::*;
-use num::traits::Pow;
 use std::cmp::min;
 use std::sync::Arc;
 
@@ -1340,18 +1339,6 @@ pub fn negate_checked<T: ArrowNumericType>(
     array: &PrimitiveArray<T>,
 ) -> Result<PrimitiveArray<T>, ArrowError> {
     try_unary(array, |value| value.neg_checked())
-}
-
-/// Raise array with floating point values to the power of a scalar.
-pub fn powf_scalar<T>(
-    array: &PrimitiveArray<T>,
-    raise: T::Native,
-) -> Result<PrimitiveArray<T>, ArrowError>
-where
-    T: ArrowFloatNumericType,
-    T::Native: Pow<T::Native, Output = T::Native>,
-{
-    Ok(unary(array, |x| x.pow(raise)))
 }
 
 /// Perform `left * right` operation on two arrays. If either left or right value is null
@@ -3214,18 +3201,6 @@ mod tests {
         let actual: Vec<Option<u8>> = actual.iter().collect();
         let expected: Vec<Option<u8>> =
             (63..63_u8 + 65_u8).map(|i| Some(i + i)).collect();
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_primitive_array_raise_power_scalar() {
-        let a = Float64Array::from(vec![1.0, 2.0, 3.0]);
-        let actual = powf_scalar(&a, 2.0).unwrap();
-        let expected = Float64Array::from(vec![1.0, 4.0, 9.0]);
-        assert_eq!(expected, actual);
-        let a = Float64Array::from(vec![Some(1.0), None, Some(3.0)]);
-        let actual = powf_scalar(&a, 2.0).unwrap();
-        let expected = Float64Array::from(vec![Some(1.0), None, Some(9.0)]);
         assert_eq!(expected, actual);
     }
 

--- a/arrow-array/src/numeric.rs
+++ b/arrow-array/src/numeric.rs
@@ -558,35 +558,6 @@ impl ArrowNumericType for Decimal256Type {
     }
 }
 
-/// A subtype of primitive type that represents numeric float values
-#[cfg(feature = "simd")]
-pub trait ArrowFloatNumericType: ArrowNumericType {
-    /// SIMD version of pow
-    fn pow(base: Self::Simd, raise: Self::Simd) -> Self::Simd;
-}
-
-/// A subtype of primitive type that represents numeric float values
-#[cfg(not(feature = "simd"))]
-pub trait ArrowFloatNumericType: ArrowNumericType {}
-
-macro_rules! make_float_numeric_type {
-    ($impl_ty:ty, $simd_ty:ident) => {
-        #[cfg(feature = "simd")]
-        impl ArrowFloatNumericType for $impl_ty {
-            #[inline]
-            fn pow(base: Self::Simd, raise: Self::Simd) -> Self::Simd {
-                base.powf(raise)
-            }
-        }
-
-        #[cfg(not(feature = "simd"))]
-        impl ArrowFloatNumericType for $impl_ty {}
-    };
-}
-
-make_float_numeric_type!(Float32Type, f32x16);
-make_float_numeric_type!(Float64Type, f64x8);
-
 #[cfg(all(test, feature = "simd"))]
 mod tests {
     use super::*;

--- a/arrow/src/datatypes/mod.rs
+++ b/arrow/src/datatypes/mod.rs
@@ -23,9 +23,7 @@
 //!  * [`DataType`](crate::datatypes::DataType) to describe the type of a field.
 
 pub use arrow_array::types::*;
-pub use arrow_array::{
-    ArrowFloatNumericType, ArrowNativeTypeOp, ArrowNumericType, ArrowPrimitiveType,
-};
+pub use arrow_array::{ArrowNativeTypeOp, ArrowNumericType, ArrowPrimitiveType};
 pub use arrow_buffer::{i256, ArrowNativeType, ToByteSlice};
 pub use arrow_data::decimal::*;
 pub use arrow_schema::{


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to https://github.com/apache/arrow-rs/issues/4166
Relates to #3999 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This functionality is half-baked, with no checked, dyn variants, nor array variants

I have confirmed it isn't used by DataFusion, and any downstreams that notice its removal can easily use PrimitiveArray::unary

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
