### PR TITLE
Object Store (AWS): Support dynamically resolving S3 bucket region

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -149,13 +149,13 @@ enum Error {
     BucketNotFound { bucket: String },
 
     #[snafu(display("Failed to resolve region for bucket '{}'", bucket))]
-    ResolveRegionError {
+    ResolveRegion {
         bucket: String,
         source: reqwest::Error,
     },
 
     #[snafu(display("Failed to parse the region for bucket '{}'", bucket))]
-    RegionParseError { bucket: String },
+    RegionParse { bucket: String },
 }
 
 impl From<Error> for super::Error {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3213.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See #3213.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Added a new `aws::resolve_bucket_region` function that uses the [HeadBucket API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) to get the bucket region.


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
