### PR TITLE
Add implementation of `RecordBatchReader` for CSV reader

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -490,6 +490,12 @@ impl<R: BufRead> Iterator for BufReader<R> {
     }
 }
 
+impl<R: BufRead> RecordBatchReader for BufReader<R> {
+    fn schema(&self) -> SchemaRef {
+        self.decoder.schema.clone()
+    }
+}
+
 /// A push-based interface for decoding CSV data from an arbitrary byte stream
 ///
 /// See [`Reader`] for a higher-level interface for interface with [`Read`]


### PR DESCRIPTION
# Which issue does this PR close?

There's no issue associated with this PR. I can create one if needed.

# Rationale for this change
 
Implementations of `RecordBatchReader` for JSON, IPC and Parquet exist but not for CSV...

# What changes are included in this PR?

Implementation of `RecordBatchReader` for `arrow_csv::reader::BufReader`.

# Are there any user-facing changes?

No breaking changes are introduced with this PR and no documentation need to be added or updated.
