### PR TITLE
Add RecordBatchWriter trait and implement it for CSV, JSON, IPC and Parquet

### DIFF
--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -183,6 +183,7 @@ pub use array::*;
 mod record_batch;
 pub use record_batch::{
     RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader,
+    RecordBatchWriter,
 };
 
 mod arithmetic;

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -43,6 +43,12 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch, ArrowError>> {
     }
 }
 
+/// Trait for types that can write `RecordBatch`'s.
+pub trait RecordBatchWriter {
+    /// Write a single batch to the writer.
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
+}
+
 /// A two-dimensional batch of column-oriented data with a defined
 /// [schema](arrow_schema::Schema).
 ///

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -119,8 +119,16 @@ impl<W: Write> Writer<W> {
         }
     }
 
+    /// Unwraps this `Writer<W>`, returning the underlying writer.
+    pub fn into_inner(self) -> W {
+        // Safe to call `unwrap` since `write` always flushes the writer.
+        self.writer.into_inner().unwrap()
+    }
+}
+
+impl<W: Write> RecordBatchWriter for Writer<W> {
     /// Write a vector of record batches to a writable object
-    pub fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         let num_columns = batch.num_columns();
         if self.beginning {
             if self.has_headers {
@@ -184,12 +192,6 @@ impl<W: Write> Writer<W> {
         self.writer.flush()?;
 
         Ok(())
-    }
-
-    /// Unwraps this `Writer<W>`, returning the underlying writer.
-    pub fn into_inner(self) -> W {
-        // Safe to call `unwrap` since `write` always flushes the writer.
-        self.writer.into_inner().unwrap()
     }
 }
 

--- a/arrow-integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/arrow-integration-testing/src/bin/arrow-file-to-stream.rs
@@ -18,6 +18,7 @@
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::RecordBatchWriter;
 use clap::Parser;
 use std::fs::File;
 use std::io::{self, BufReader};

--- a/arrow-integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/arrow-integration-testing/src/bin/arrow-json-integration-test.rs
@@ -20,6 +20,7 @@ use arrow::datatypes::{Fields, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
+use arrow::record_batch::RecordBatchWriter;
 use arrow_integration_test::*;
 use arrow_integration_testing::read_json_file;
 use clap::Parser;

--- a/arrow-integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/arrow-integration-testing/src/bin/arrow-stream-to-file.rs
@@ -20,6 +20,7 @@ use std::io;
 use arrow::error::Result;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
+use arrow::record_batch::RecordBatchWriter;
 
 fn main() -> Result<()> {
     let mut arrow_stream_reader = StreamReader::try_new(io::stdin(), None)?;

--- a/arrow-integration-testing/tests/ipc_writer.rs
+++ b/arrow-integration-testing/tests/ipc_writer.rs
@@ -18,6 +18,7 @@
 use arrow::ipc;
 use arrow::ipc::reader::{FileReader, StreamReader};
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions, StreamWriter};
+use arrow::record_batch::RecordBatchWriter;
 use arrow::util::test_util::arrow_test_data;
 use arrow_integration_testing::read_gzip_json;
 use std::fs::File;

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -35,7 +35,7 @@
 //! let a = Int32Array::from(vec![1, 2, 3]);
 //! let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
 //!
-//! let json_rows = arrow_json::writer::record_batches_to_json_rows(&[batch]).unwrap();
+//! let json_rows = arrow_json::writer::record_batches_to_json_rows(&[&batch]).unwrap();
 //! assert_eq!(
 //!     serde_json::Value::Object(json_rows[1].clone()),
 //!     serde_json::json!({"a": 2}),
@@ -59,7 +59,7 @@
 //! // Write the record batch out as JSON
 //! let buf = Vec::new();
 //! let mut writer = arrow_json::LineDelimitedWriter::new(buf);
-//! writer.write_batches(&vec![batch]).unwrap();
+//! writer.write_batches(&vec![&batch]).unwrap();
 //! writer.finish().unwrap();
 //!
 //! // Get the underlying buffer back,
@@ -85,7 +85,7 @@
 //! // Write the record batch out as a JSON array
 //! let buf = Vec::new();
 //! let mut writer = arrow_json::ArrayWriter::new(buf);
-//! writer.write_batches(&vec![batch]).unwrap();
+//! writer.write_batches(&vec![&batch]).unwrap();
 //! writer.finish().unwrap();
 //!
 //! // Get the underlying buffer back,
@@ -390,7 +390,7 @@ fn set_column_for_json_rows(
 /// Converts an arrow [`RecordBatch`] into a `Vec` of Serde JSON
 /// [`JsonMap`]s (objects)
 pub fn record_batches_to_json_rows(
-    batches: &[RecordBatch],
+    batches: &[&RecordBatch],
 ) -> Result<Vec<JsonMap<String, Value>>, ArrowError> {
     let mut rows: Vec<JsonMap<String, Value>> = iter::repeat(JsonMap::new())
         .take(batches.iter().map(|b| b.num_rows()).sum())
@@ -553,16 +553,8 @@ where
         Ok(())
     }
 
-    /// Convert the `RecordBatch` into JSON rows, and write them to the output
-    pub fn write(&mut self, batch: RecordBatch) -> Result<(), ArrowError> {
-        for row in record_batches_to_json_rows(&[batch])? {
-            self.write_row(&Value::Object(row))?;
-        }
-        Ok(())
-    }
-
     /// Convert the [`RecordBatch`] into JSON rows, and write them to the output
-    pub fn write_batches(&mut self, batches: &[RecordBatch]) -> Result<(), ArrowError> {
+    pub fn write_batches(&mut self, batches: &[&RecordBatch]) -> Result<(), ArrowError> {
         for row in record_batches_to_json_rows(batches)? {
             self.write_row(&Value::Object(row))?;
         }
@@ -583,6 +575,20 @@ where
     /// Unwraps this `Writer<W>`, returning the underlying writer
     pub fn into_inner(self) -> W {
         self.writer
+    }
+}
+
+impl<W, F> RecordBatchWriter for Writer<W, F>
+where
+    W: Write,
+    F: JsonFormat,
+{
+    /// Convert the `RecordBatch` into JSON rows, and write them to the output
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        for row in record_batches_to_json_rows(&[batch])? {
+            self.write_row(&Value::Object(row))?;
+        }
+        Ok(())
     }
 }
 
@@ -631,7 +637,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -662,7 +668,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -704,7 +710,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -759,7 +765,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -818,7 +824,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -864,7 +870,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -907,7 +913,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -950,7 +956,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1010,7 +1016,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1053,7 +1059,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1113,7 +1119,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1192,7 +1198,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1217,7 +1223,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         let result = String::from_utf8(buf).unwrap();
@@ -1315,7 +1321,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         // NOTE: The last value should technically be {"list": [null]} but it appears
@@ -1378,7 +1384,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write_batches(&[batch]).unwrap();
+            writer.write_batches(&[&batch]).unwrap();
         }
 
         assert_json_eq(
@@ -1408,7 +1414,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut writer = LineDelimitedWriter::new(&mut buf);
-            writer.write(batch).unwrap();
+            writer.write(&batch).unwrap();
         }
 
         let result = String::from_utf8(buf).unwrap();
@@ -1445,7 +1451,7 @@ mod tests {
         let batch = reader.next().unwrap().unwrap();
 
         // test batches = an empty batch + 2 same batches, finally result should be eq to 2 same batches
-        let batches = [RecordBatch::new_empty(schema), batch.clone(), batch];
+        let batches = [&RecordBatch::new_empty(schema), &batch, &batch];
 
         let mut buf = Vec::new();
         {

--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -23,7 +23,7 @@ use criterion::*;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchWriter};
 use arrow::util::bench_util::{create_primitive_array, create_string_array_with_len};
 use std::io::Cursor;
 use std::sync::Arc;

--- a/arrow/benches/csv_writer.rs
+++ b/arrow/benches/csv_writer.rs
@@ -23,7 +23,7 @@ use criterion::*;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchWriter};
 use std::env;
 use std::fs::File;
 use std::sync::Arc;

--- a/arrow/benches/json_reader.rs
+++ b/arrow/benches/json_reader.rs
@@ -21,7 +21,7 @@ use arrow::datatypes::*;
 use arrow::util::bench_util::{
     create_primitive_array, create_string_array, create_string_array_with_len,
 };
-use arrow_array::RecordBatch;
+use arrow_array::{RecordBatch, RecordBatchWriter};
 use arrow_json::{LineDelimitedWriter, ReaderBuilder};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -92,7 +92,7 @@ fn large_bench_primitive(c: &mut Criterion) {
     .unwrap();
 
     let mut out = Vec::with_capacity(1024);
-    LineDelimitedWriter::new(&mut out).write(batch).unwrap();
+    LineDelimitedWriter::new(&mut out).write(&batch).unwrap();
 
     let json = std::str::from_utf8(&out).unwrap();
     do_bench(c, "large_bench_primitive", json, schema)

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -376,7 +376,9 @@ pub use arrow_json as json;
 pub mod pyarrow;
 
 pub mod record_batch {
-    pub use arrow_array::{RecordBatch, RecordBatchOptions, RecordBatchReader};
+    pub use arrow_array::{
+        RecordBatch, RecordBatchOptions, RecordBatchReader, RecordBatchWriter,
+    };
 }
 pub use arrow_array::temporal_conversions;
 pub use arrow_row as row;

--- a/arrow/src/util/string_writer.rs
+++ b/arrow/src/util/string_writer.rs
@@ -28,7 +28,7 @@
 //! use arrow::array::*;
 //! use arrow::csv;
 //! use arrow::datatypes::*;
-//! use arrow::record_batch::RecordBatch;
+//! use arrow::record_batch::{RecordBatch, RecordBatchWriter};
 //! use arrow::util::string_writer::StringWriter;
 //! use std::sync::Arc;
 //!

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -28,7 +28,10 @@ extern crate parquet;
 use std::sync::Arc;
 
 use arrow::datatypes::*;
-use arrow::{record_batch::RecordBatch, util::data_gen::*};
+use arrow::{
+    record_batch::{RecordBatch, RecordBatchWriter},
+    util::data_gen::*,
+};
 use parquet::file::properties::WriterProperties;
 use parquet::{arrow::ArrowWriter, errors::Result};
 

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -431,7 +431,7 @@ mod tests {
     use arrow_array::{Array, Decimal128Array, ListArray};
     use arrow::datatypes::Field;
     use arrow::error::Result as ArrowResult;
-    use arrow_array::RecordBatch;
+    use arrow_array::{RecordBatch, RecordBatchWriter};
     use bytes::Bytes;
     use std::sync::Arc;
 

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -128,7 +128,7 @@ mod tests {
     use arrow::datatypes::{Field, Int32Type, Schema};
     use arrow_array::builder::{MapBuilder, PrimitiveBuilder, StringBuilder};
     use arrow_array::cast::*;
-    use arrow_array::RecordBatch;
+    use arrow_array::{RecordBatch, RecordBatchWriter};
     use arrow_schema::Fields;
     use bytes::Bytes;
 

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -18,7 +18,7 @@
 //! Tests that the ArrowWriter correctly lays out values into multiple pages
 
 use arrow::array::{Int32Array, StringArray};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchWriter};
 use bytes::Bytes;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};
 use parquet::arrow::ArrowWriter;


### PR DESCRIPTION
# Which issue does this PR close?

This PR doesn't close any particular issue.

# Rationale for this change

I found myself needing to work generically with writers of record batches and I need a common interface for doing that.

Do you find this useful? Feel free to reject the PR if you don't see any use case for it.

# What changes are included in this PR?

A new trait is introduced and implemented for CSV, JSON, IPC and Parquet :

```rust
/// Trait for types that can write `RecordBatch`'s.
pub trait RecordBatchWriter {
    /// Write a single batch to the writer.
    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
}
```

# Are there any user-facing changes?

According to my analysis there are at least two breaking changes:

1. To use `write` clients now need to import `RecordBatchWriter`
2. `parquet::arrow_writer::ArrowWriter` now returns an `ArrowError` instead of `ParquetError`
