### PR TITLE
Add RecordBatchWriter trait and implement it for CSV, JSON, IPC and P…

### DIFF
--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -183,6 +183,7 @@ pub use array::*;
 mod record_batch;
 pub use record_batch::{
     RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader,
+    RecordBatchWriter,
 };
 
 mod arithmetic;

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -43,6 +43,12 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch, ArrowError>> {
     }
 }
 
+/// Trait for types that can write `RecordBatch`'s.
+pub trait RecordBatchWriter {
+    /// Write a single batch to the writer.
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
+}
+
 /// A two-dimensional batch of column-oriented data with a defined
 /// [schema](arrow_schema::Schema).
 ///

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -193,6 +193,12 @@ impl<W: Write> Writer<W> {
     }
 }
 
+impl<W: Write> RecordBatchWriter for Writer<W> {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        self.write(batch)
+    }
+}
+
 /// A CSV writer builder
 #[derive(Clone, Debug)]
 pub struct WriterBuilder {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -857,6 +857,12 @@ impl<W: Write> FileWriter<W> {
     }
 }
 
+impl<W: Write> RecordBatchWriter for FileWriter<W> {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        self.write(batch)
+    }
+}
+
 pub struct StreamWriter<W: Write> {
     /// The object to write to
     writer: BufWriter<W>,
@@ -988,6 +994,12 @@ impl<W: Write> StreamWriter<W> {
             self.finish()?;
         }
         self.writer.into_inner().map_err(ArrowError::from)
+    }
+}
+
+impl<W: Write> RecordBatchWriter for StreamWriter<W> {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        self.write(batch)
     }
 }
 

--- a/arrow/benches/json_reader.rs
+++ b/arrow/benches/json_reader.rs
@@ -92,7 +92,7 @@ fn large_bench_primitive(c: &mut Criterion) {
     .unwrap();
 
     let mut out = Vec::with_capacity(1024);
-    LineDelimitedWriter::new(&mut out).write(batch).unwrap();
+    LineDelimitedWriter::new(&mut out).write(&batch).unwrap();
 
     let json = std::str::from_utf8(&out).unwrap();
     do_bench(c, "large_bench_primitive", json, schema)

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::{Decimal128Type, Int32Type, Int64Type, UInt32Type, UInt64Type};
-use arrow_array::{types, Array, ArrayRef, RecordBatch};
-use arrow_schema::{DataType as ArrowDataType, IntervalUnit, SchemaRef};
+use arrow_array::{types, Array, ArrayRef, RecordBatch, RecordBatchWriter};
+use arrow_schema::{ArrowError, DataType as ArrowDataType, IntervalUnit, SchemaRef};
 
 use super::schema::{
     add_encoded_arrow_schema_to_metadata, arrow_to_parquet_schema,
@@ -243,6 +243,12 @@ impl<W: Write> ArrowWriter<W> {
     pub fn close(mut self) -> Result<crate::format::FileMetaData> {
         self.flush()?;
         self.writer.close()
+    }
+}
+
+impl<W: Write> RecordBatchWriter for ArrowWriter<W> {
+    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
+        self.write(batch).map_err(|e| e.into())
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

This PR doesn't close any particular issue.

# Rationale for this change

I found myself needing to work generically with writers of record batches and I need a common interface for doing that.

Do you find this useful? Feel free to reject the PR if you don't see any use case for it.

# What changes are included in this PR?

A new trait is introduced and implemented for CSV, JSON, IPC and Parquet :

```rust
/// Trait for types that can write `RecordBatch`'s.
pub trait RecordBatchWriter {
    /// Write a single batch to the writer.
    fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
}
```

# Are there any user-facing changes?

According to my analysis there are at least one breaking change:

Prototypes of `arrow_json::writer::Writer::write` and `arrow_json::writer::record_batches_to_json_rows` have changed and now takes a reference to the record batch instead of taking ownership of it.