### PR TITLE
Consistently use GCP XML API

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Configure Fake GCS Server (GCP emulation)
         run: |
-          docker run -d -p 4443:4443 fsouza/fake-gcs-server -scheme http
+          docker run -d -p 4443:4443 tustvold/fake-gcs-server -scheme http -backend memory -public-host localhost:4443
           # Give the container a moment to start up prior to configuring it
           sleep 1
           curl -v -X POST --data-binary '{"name":"test-bucket"}' -H "Content-Type: application/json" "http://localhost:4443/storage/v1/b"

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -95,6 +95,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure Fake GCS Server (GCP emulation)
+        # Custom image - see fsouza/fake-gcs-server#1164
         run: |
           docker run -d -p 4443:4443 tustvold/fake-gcs-server -scheme http -backend memory -public-host localhost:4443
           # Give the container a moment to start up prior to configuring it

--- a/object_store/CONTRIBUTING.md
+++ b/object_store/CONTRIBUTING.md
@@ -103,7 +103,7 @@ To test the GCS integration, we use [Fake GCS Server](https://github.com/fsouza/
 Startup the fake server:
 
 ```shell
-docker run -p 4443:4443 fsouza/fake-gcs-server -scheme http
+docker run -p 4443:4443 tustvold/fake-gcs-server -scheme http
 ```
 
 Configure the account:

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 nix = "0.26.1"
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml",  "hyper", "reqwest", "reqwest/json","reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
+cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -18,19 +18,19 @@
 use crate::aws::checksum::Checksum;
 use crate::aws::credential::{AwsCredential, CredentialExt, CredentialProvider};
 use crate::aws::STRICT_PATH_ENCODE_SET;
+use crate::client::list::ListResponse;
 use crate::client::pagination::stream_paginated;
 use crate::client::retry::RetryExt;
 use crate::multipart::UploadPart;
 use crate::path::DELIMITER;
 use crate::util::{format_http_range, format_prefix};
 use crate::{
-    BoxStream, ClientOptions, ListResult, MultipartId, ObjectMeta, Path, Result,
-    RetryConfig, StreamExt,
+    BoxStream, ClientOptions, ListResult, MultipartId, Path, Result, RetryConfig,
+    StreamExt,
 };
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::{Buf, Bytes};
-use chrono::{DateTime, Utc};
 use percent_encoding::{utf8_percent_encode, PercentEncode};
 use reqwest::{
     header::CONTENT_TYPE, Client as ReqwestClient, Method, Response, StatusCode,
@@ -115,69 +115,6 @@ impl From<Error> for crate::Error {
                 source: Box::new(err),
             },
         }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct ListResponse {
-    #[serde(default)]
-    pub contents: Vec<ListContents>,
-    #[serde(default)]
-    pub common_prefixes: Vec<ListPrefix>,
-    #[serde(default)]
-    pub next_continuation_token: Option<String>,
-}
-
-impl TryFrom<ListResponse> for ListResult {
-    type Error = crate::Error;
-
-    fn try_from(value: ListResponse) -> Result<Self> {
-        let common_prefixes = value
-            .common_prefixes
-            .into_iter()
-            .map(|x| Ok(Path::parse(x.prefix)?))
-            .collect::<Result<_>>()?;
-
-        let objects = value
-            .contents
-            .into_iter()
-            .map(TryFrom::try_from)
-            .collect::<Result<_>>()?;
-
-        Ok(Self {
-            common_prefixes,
-            objects,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct ListPrefix {
-    pub prefix: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct ListContents {
-    pub key: String,
-    pub size: usize,
-    pub last_modified: DateTime<Utc>,
-    #[serde(rename = "ETag")]
-    pub e_tag: Option<String>,
-}
-
-impl TryFrom<ListContents> for ObjectMeta {
-    type Error = crate::Error;
-
-    fn try_from(value: ListContents) -> Result<Self> {
-        Ok(Self {
-            location: Path::parse(value.key)?,
-            last_modified: value.last_modified,
-            size: value.size,
-            e_tag: value.e_tag,
-        })
     }
 }
 

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -38,7 +38,6 @@ use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Bytes;
-use chrono::{TimeZone, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
@@ -51,9 +50,9 @@ use std::{collections::BTreeSet, str::FromStr};
 use tokio::io::AsyncWrite;
 use url::Url;
 
+use crate::client::header::header_meta;
 use crate::client::ClientConfigKey;
 use crate::config::ConfigValue;
-use crate::util::RFC1123_FMT;
 pub use credential::authority_hosts;
 
 mod client;
@@ -74,24 +73,6 @@ const MSI_ENDPOINT_ENV_KEY: &str = "IDENTITY_ENDPOINT";
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
 enum Error {
-    #[snafu(display("Last-Modified Header missing from response"))]
-    MissingLastModified,
-
-    #[snafu(display("Content-Length Header missing from response"))]
-    MissingContentLength,
-
-    #[snafu(display("Invalid last modified '{}': {}", last_modified, source))]
-    InvalidLastModified {
-        last_modified: String,
-        source: chrono::ParseError,
-    },
-
-    #[snafu(display("Invalid content length '{}': {}", content_length, source))]
-    InvalidContentLength {
-        content_length: String,
-        source: std::num::ParseIntError,
-    },
-
     #[snafu(display("Received header containing non-ASCII data"))]
     BadHeader { source: reqwest::header::ToStrError },
 
@@ -145,6 +126,11 @@ enum Error {
 
     #[snafu(display("ETag Header missing from response"))]
     MissingEtag,
+
+    #[snafu(display("Failed to parse headers: {}", source))]
+    Header {
+        source: crate::client::header::Error,
+    },
 }
 
 impl From<Error> for super::Error {
@@ -237,43 +223,10 @@ impl ObjectStore for MicrosoftAzure {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        use reqwest::header::{CONTENT_LENGTH, ETAG, LAST_MODIFIED};
-
         // Extract meta from headers
         // https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-properties
         let response = self.client.get_request(location, None, true).await?;
-        let headers = response.headers();
-
-        let last_modified = headers
-            .get(LAST_MODIFIED)
-            .ok_or(Error::MissingLastModified)?
-            .to_str()
-            .context(BadHeaderSnafu)?;
-        let last_modified = Utc
-            .datetime_from_str(last_modified, RFC1123_FMT)
-            .context(InvalidLastModifiedSnafu { last_modified })?;
-
-        let content_length = headers
-            .get(CONTENT_LENGTH)
-            .ok_or(Error::MissingContentLength)?
-            .to_str()
-            .context(BadHeaderSnafu)?;
-        let content_length = content_length
-            .parse()
-            .context(InvalidContentLengthSnafu { content_length })?;
-
-        let e_tag = headers
-            .get(ETAG)
-            .ok_or(Error::MissingEtag)?
-            .to_str()
-            .context(BadHeaderSnafu)?;
-
-        Ok(ObjectMeta {
-            location: location.clone(),
-            last_modified,
-            size: content_length,
-            e_tag: Some(e_tag.to_string()),
-        })
+        Ok(header_meta(location, response.headers()).context(HeaderSnafu)?)
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Logic for extracting ObjectMeta from headers used by AWS, GCP and Azure
+
+use crate::path::Path;
+use crate::ObjectMeta;
+use chrono::{DateTime, Utc};
+use hyper::header::{CONTENT_LENGTH, ETAG, LAST_MODIFIED};
+use hyper::HeaderMap;
+use snafu::{OptionExt, ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("ETag Header missing from response"))]
+    MissingEtag,
+
+    #[snafu(display("Received header containing non-ASCII data"))]
+    BadHeader { source: reqwest::header::ToStrError },
+
+    #[snafu(display("Last-Modified Header missing from response"))]
+    MissingLastModified,
+
+    #[snafu(display("Content-Length Header missing from response"))]
+    MissingContentLength,
+
+    #[snafu(display("Invalid last modified '{}': {}", last_modified, source))]
+    InvalidLastModified {
+        last_modified: String,
+        source: chrono::ParseError,
+    },
+
+    #[snafu(display("Invalid content length '{}': {}", content_length, source))]
+    InvalidContentLength {
+        content_length: String,
+        source: std::num::ParseIntError,
+    },
+}
+
+/// Extracts [`ObjectMeta`] from the provided [`HeaderMap`]
+pub fn header_meta(location: &Path, headers: &HeaderMap) -> Result<ObjectMeta, Error> {
+    let last_modified = headers
+        .get(LAST_MODIFIED)
+        .context(MissingLastModifiedSnafu)?;
+
+    let content_length = headers
+        .get(CONTENT_LENGTH)
+        .context(MissingContentLengthSnafu)?;
+
+    let last_modified = last_modified.to_str().context(BadHeaderSnafu)?;
+    let last_modified = DateTime::parse_from_rfc2822(last_modified)
+        .context(InvalidLastModifiedSnafu { last_modified })?
+        .with_timezone(&Utc);
+
+    let content_length = content_length.to_str().context(BadHeaderSnafu)?;
+    let content_length = content_length
+        .parse()
+        .context(InvalidContentLengthSnafu { content_length })?;
+
+    let e_tag = headers.get(ETAG).context(MissingEtagSnafu)?;
+    let e_tag = e_tag.to_str().context(BadHeaderSnafu)?;
+
+    Ok(ObjectMeta {
+        location: location.clone(),
+        last_modified,
+        size: content_length,
+        e_tag: Some(e_tag.to_string()),
+    })
+}

--- a/object_store/src/client/list.rs
+++ b/object_store/src/client/list.rs
@@ -1,0 +1,85 @@
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! The list response format used by GCP and AWS
+
+use crate::path::Path;
+use crate::{ListResult, ObjectMeta, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListResponse {
+    #[serde(default)]
+    pub contents: Vec<ListContents>,
+    #[serde(default)]
+    pub common_prefixes: Vec<ListPrefix>,
+    #[serde(default)]
+    pub next_continuation_token: Option<String>,
+}
+
+impl TryFrom<ListResponse> for ListResult {
+    type Error = crate::Error;
+
+    fn try_from(value: ListResponse) -> Result<Self> {
+        let common_prefixes = value
+            .common_prefixes
+            .into_iter()
+            .map(|x| Ok(Path::parse(x.prefix)?))
+            .collect::<Result<_>>()?;
+
+        let objects = value
+            .contents
+            .into_iter()
+            .map(TryFrom::try_from)
+            .collect::<Result<_>>()?;
+
+        Ok(Self {
+            common_prefixes,
+            objects,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListPrefix {
+    pub prefix: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListContents {
+    pub key: String,
+    pub size: usize,
+    pub last_modified: DateTime<Utc>,
+    #[serde(rename = "ETag")]
+    pub e_tag: Option<String>,
+}
+
+impl TryFrom<ListContents> for ObjectMeta {
+    type Error = crate::Error;
+
+    fn try_from(value: ListContents) -> Result<Self> {
+        Ok(Self {
+            location: Path::parse(value.key)?,
+            last_modified: value.last_modified,
+            size: value.size,
+            e_tag: value.e_tag,
+        })
+    }
+}

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -26,6 +26,12 @@ pub mod retry;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub mod token;
 
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+pub mod header;
+
+#[cfg(any(feature = "aws", feature = "gcp"))]
+pub mod list;
+
 use crate::config::ConfigValue;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client, ClientBuilder, Proxy};

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -37,9 +37,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::{Buf, Bytes};
-use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
-use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{percent_encode, utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::RANGE;
 use reqwest::{header, Client, Method, Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -47,6 +46,8 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 use url::Url;
 
+use crate::client::header::header_meta;
+use crate::client::list::ListResponse;
 use crate::client::pagination::stream_paginated;
 use crate::client::retry::RetryExt;
 use crate::client::ClientConfigKey;
@@ -81,6 +82,9 @@ enum Error {
 
     #[snafu(display("Error getting list response body: {}", source))]
     ListResponseBody { source: reqwest::Error },
+
+    #[snafu(display("Got invalid list response: {}", source))]
+    InvalidListResponse { source: quick_xml::de::DeError },
 
     #[snafu(display("Error performing get request {}: {}", path, source))]
     GetRequest {
@@ -152,6 +156,11 @@ enum Error {
 
     #[snafu(display("Configuration key: '{}' is not known.", key))]
     UnknownConfigurationKey { key: String },
+
+    #[snafu(display("Failed to parse headers: {}", source))]
+    Header {
+        source: crate::client::header::Error,
+    },
 }
 
 impl From<Error> for super::Error {
@@ -180,25 +189,6 @@ impl From<Error> for super::Error {
             },
         }
     }
-}
-
-#[derive(serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct ListResponse {
-    next_page_token: Option<String>,
-    #[serde(default)]
-    prefixes: Vec<String>,
-    #[serde(default)]
-    items: Vec<Object>,
-}
-
-#[derive(serde::Deserialize, Debug)]
-struct Object {
-    name: String,
-    size: String,
-    updated: DateTime<Utc>,
-    #[serde(rename = "etag")]
-    e_tag: Option<String>,
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -268,15 +258,11 @@ impl GoogleCloudStorageClient {
     }
 
     fn object_url(&self, path: &Path) -> String {
-        let encoded =
-            percent_encoding::utf8_percent_encode(path.as_ref(), NON_ALPHANUMERIC);
-        format!(
-            "{}/storage/v1/b/{}/o/{}",
-            self.base_url, self.bucket_name_encoded, encoded
-        )
+        let encoded = utf8_percent_encode(path.as_ref(), NON_ALPHANUMERIC);
+        format!("{}/{}/{}", self.base_url, self.bucket_name_encoded, encoded)
     }
 
-    /// Perform a get request <https://cloud.google.com/storage/docs/json_api/v1/objects/get>
+    /// Perform a get request <https://cloud.google.com/storage/docs/xml-api/get-object-download>
     async fn get_request(
         &self,
         path: &Path,
@@ -286,20 +272,19 @@ impl GoogleCloudStorageClient {
         let token = self.get_token().await?;
         let url = self.object_url(path);
 
-        let mut builder = self.client.request(Method::GET, url);
+        let method = match head {
+            true => Method::HEAD,
+            false => Method::GET,
+        };
+
+        let mut builder = self.client.request(method, url);
 
         if let Some(range) = range {
             builder = builder.header(RANGE, format_http_range(range));
         }
 
-        let alt = match head {
-            true => "json",
-            false => "media",
-        };
-
         let response = builder
             .bearer_auth(token)
-            .query(&[("alt", alt)])
             .send_retry(&self.retry_config)
             .await
             .context(GetRequestSnafu {
@@ -309,13 +294,10 @@ impl GoogleCloudStorageClient {
         Ok(response)
     }
 
-    /// Perform a put request <https://cloud.google.com/storage/docs/json_api/v1/objects/insert>
+    /// Perform a put request <https://cloud.google.com/storage/docs/xml-api/put-object-upload>
     async fn put_request(&self, path: &Path, payload: Bytes) -> Result<()> {
         let token = self.get_token().await?;
-        let url = format!(
-            "{}/upload/storage/v1/b/{}/o",
-            self.base_url, self.bucket_name_encoded
-        );
+        let url = self.object_url(path);
 
         let content_type = self
             .client_options
@@ -323,11 +305,10 @@ impl GoogleCloudStorageClient {
             .unwrap_or("application/octet-stream");
 
         self.client
-            .request(Method::POST, url)
+            .request(Method::PUT, url)
             .bearer_auth(token)
             .header(header::CONTENT_TYPE, content_type)
             .header(header::CONTENT_LENGTH, payload.len())
-            .query(&[("uploadType", "media"), ("name", path.as_ref())])
             .body(payload)
             .send_retry(&self.retry_config)
             .await
@@ -392,7 +373,7 @@ impl GoogleCloudStorageClient {
         Ok(())
     }
 
-    /// Perform a delete request <https://cloud.google.com/storage/docs/json_api/v1/objects/delete>
+    /// Perform a delete request <https://cloud.google.com/storage/docs/xml-api/delete-object>
     async fn delete_request(&self, path: &Path) -> Result<()> {
         let token = self.get_token().await?;
         let url = self.object_url(path);
@@ -409,7 +390,7 @@ impl GoogleCloudStorageClient {
         Ok(())
     }
 
-    /// Perform a copy request <https://cloud.google.com/storage/docs/json_api/v1/objects/copy>
+    /// Perform a copy request <https://cloud.google.com/storage/docs/xml-api/put-object-copy>
     async fn copy_request(
         &self,
         from: &Path,
@@ -417,24 +398,18 @@ impl GoogleCloudStorageClient {
         if_not_exists: bool,
     ) -> Result<()> {
         let token = self.get_token().await?;
+        let url = self.object_url(to);
 
-        let source =
-            percent_encoding::utf8_percent_encode(from.as_ref(), NON_ALPHANUMERIC);
-        let destination =
-            percent_encoding::utf8_percent_encode(to.as_ref(), NON_ALPHANUMERIC);
-        let url = format!(
-            "{}/storage/v1/b/{}/o/{}/copyTo/b/{}/o/{}",
-            self.base_url,
-            self.bucket_name_encoded,
-            source,
-            self.bucket_name_encoded,
-            destination
-        );
+        let from = utf8_percent_encode(from.as_ref(), NON_ALPHANUMERIC);
+        let source = format!("{}/{}", self.bucket_name_encoded, from);
 
-        let mut builder = self.client.request(Method::POST, url);
+        let mut builder = self
+            .client
+            .request(Method::PUT, url)
+            .header("x-goog-copy-source", source);
 
         if if_not_exists {
-            builder = builder.query(&[("ifGenerationMatch", "0")]);
+            builder = builder.header("x-goog-if-generation-match", 0);
         }
 
         builder
@@ -465,7 +440,7 @@ impl GoogleCloudStorageClient {
         Ok(())
     }
 
-    /// Perform a list request <https://cloud.google.com/storage/docs/json_api/v1/objects/list>
+    /// Perform a list request <https://cloud.google.com/storage/docs/xml-api/get-bucket-list>
     async fn list_request(
         &self,
         prefix: Option<&str>,
@@ -473,13 +448,10 @@ impl GoogleCloudStorageClient {
         page_token: Option<&str>,
     ) -> Result<ListResponse> {
         let token = self.get_token().await?;
+        let url = format!("{}/{}", self.base_url, self.bucket_name_encoded);
 
-        let url = format!(
-            "{}/storage/v1/b/{}/o",
-            self.base_url, self.bucket_name_encoded
-        );
-
-        let mut query = Vec::with_capacity(4);
+        let mut query = Vec::with_capacity(5);
+        query.push(("list-type", "2"));
         if delimiter {
             query.push(("delimiter", DELIMITER))
         }
@@ -489,14 +461,14 @@ impl GoogleCloudStorageClient {
         }
 
         if let Some(page_token) = page_token {
-            query.push(("pageToken", page_token))
+            query.push(("continuation-token", page_token))
         }
 
         if let Some(max_results) = &self.max_list_results {
-            query.push(("maxResults", max_results))
+            query.push(("max-keys", max_results))
         }
 
-        let response: ListResponse = self
+        let response = self
             .client
             .request(Method::GET, url)
             .query(&query)
@@ -504,9 +476,12 @@ impl GoogleCloudStorageClient {
             .send_retry(&self.retry_config)
             .await
             .context(ListRequestSnafu)?
-            .json()
+            .bytes()
             .await
             .context(ListResponseBodySnafu)?;
+
+        let response: ListResponse = quick_xml::de::from_reader(response.reader())
+            .context(InvalidListResponseSnafu)?;
 
         Ok(response)
     }
@@ -516,14 +491,14 @@ impl GoogleCloudStorageClient {
         &self,
         prefix: Option<&Path>,
         delimiter: bool,
-    ) -> BoxStream<'_, Result<ListResponse>> {
+    ) -> BoxStream<'_, Result<ListResult>> {
         let prefix = format_prefix(prefix);
         stream_paginated(prefix, move |prefix, token| async move {
             let mut r = self
                 .list_request(prefix.as_deref(), delimiter, token.as_deref())
                 .await?;
-            let next_token = r.next_page_token.take();
-            Ok((r, prefix, next_token))
+            let next_token = r.next_continuation_token.take();
+            Ok((r.try_into()?, prefix, next_token))
         })
         .boxed()
     }
@@ -692,10 +667,7 @@ impl ObjectStore for GoogleCloudStorage {
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let response = self.client.get_request(location, None, true).await?;
-        let object = response.json().await.context(GetResponseBodySnafu {
-            path: location.as_ref(),
-        })?;
-        convert_object_meta(&object)
+        Ok(header_meta(location, response.headers()).context(HeaderSnafu)?)
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
@@ -709,11 +681,7 @@ impl ObjectStore for GoogleCloudStorage {
         let stream = self
             .client
             .list_paginated(prefix, false)
-            .map_ok(|r| {
-                futures::stream::iter(
-                    r.items.into_iter().map(|x| convert_object_meta(&x)),
-                )
-            })
+            .map_ok(|r| futures::stream::iter(r.objects.into_iter().map(Ok)))
             .try_flatten()
             .boxed();
 
@@ -728,15 +696,8 @@ impl ObjectStore for GoogleCloudStorage {
 
         while let Some(result) = stream.next().await {
             let response = result?;
-
-            for p in response.prefixes {
-                common_prefixes.insert(Path::parse(p)?);
-            }
-
-            objects.reserve(response.items.len());
-            for object in &response.items {
-                objects.push(convert_object_meta(object)?);
-            }
+            common_prefixes.extend(response.common_prefixes.into_iter());
+            objects.extend(response.objects.into_iter());
         }
 
         Ok(ListResult {
@@ -1200,20 +1161,6 @@ impl GoogleCloudStorageBuilder {
             }),
         })
     }
-}
-
-fn convert_object_meta(object: &Object) -> Result<ObjectMeta> {
-    let location = Path::parse(&object.name)?;
-    let last_modified = object.updated;
-    let size = object.size.parse().context(InvalidSizeSnafu)?;
-    let e_tag = object.e_tag.clone();
-
-    Ok(ObjectMeta {
-        location,
-        last_modified,
-        size,
-        e_tag,
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #2241
Relates to #3027
Closes #4209

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We currently use a mixture of the XML and JSON APIs. 

The XML API is more complete, supporting the full set of request preconditions, list offsets, etc... and so we should just switch over. As an added bonus this allows for code sharing between the implementations.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
