### PR TITLE
feat: Support bitwise and boolean aggregate functions

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -329,7 +329,6 @@ where
 
 macro_rules! bit_operation {
     ($NAME:ident, $OP:ident, $NATIVE:ident, $DEFAULT:expr, $DOC:expr) => {
-        #[cfg(not(feature = "simd"))]
         #[doc = $DOC]
         ///
         /// Returns `None` if the array is empty or only contains null values.
@@ -400,21 +399,21 @@ bit_operation!(
     bitand,
     BitAnd,
     -1,
-    "Returns the bitwise AND of all non-null input values."
+    "Returns the bitwise and of all non-null input values."
 );
 bit_operation!(
     bit_or,
     bitor,
     BitOr,
     0,
-    "Returns the bitwise OR of all non-null input values."
+    "Returns the bitwise or of all non-null input values."
 );
 bit_operation!(
     bit_xor,
     bitxor,
     BitXor,
     0,
-    "Returns the bitwise exclusive OR of all non-null input values."
+    "Returns the bitwise xor of all non-null input values."
 );
 
 /// Returns true if all non-null input values are true, otherwise false.

--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1086,13 +1086,13 @@ mod tests {
     #[test]
     fn test_primitive_array_bool_and() {
         let a = BooleanArray::from(vec![true, false, true, false, true]);
-        assert_eq!(false, bool_and(&a).unwrap());
+        assert!(!bool_and(&a).unwrap());
     }
 
     #[test]
     fn test_primitive_array_bool_and_with_nulls() {
         let a = BooleanArray::from(vec![None, Some(true), Some(true), None, Some(true)]);
-        assert_eq!(true, bool_and(&a).unwrap());
+        assert!(bool_and(&a).unwrap());
     }
 
     #[test]
@@ -1104,14 +1104,14 @@ mod tests {
     #[test]
     fn test_primitive_array_bool_or() {
         let a = BooleanArray::from(vec![true, false, true, false, true]);
-        assert_eq!(true, bool_or(&a).unwrap());
+        assert!(bool_or(&a).unwrap());
     }
 
     #[test]
     fn test_primitive_array_bool_or_with_nulls() {
         let a =
             BooleanArray::from(vec![None, Some(false), Some(false), None, Some(false)]);
-        assert_eq!(false, bool_or(&a).unwrap());
+        assert!(!bool_or(&a).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to [#6275](https://github.com/apache/arrow-datafusion/issues/6275)

# Rationale for this change
The implementation of these functions in `arrow-rs` was proposed by @alamb in the comment (See PR: https://github.com/apache/arrow-datafusion/pull/6276).
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
