### PR TITLE
Add finish method to RecordBatchWriter trait

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -47,6 +47,9 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch, ArrowError>> {
 pub trait RecordBatchWriter {
     /// Write a single batch to the writer.
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
+
+    /// TODO.
+    fn finish(&mut self) -> Result<(), ArrowError>;
 }
 
 /// A two-dimensional batch of column-oriented data with a defined

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -48,7 +48,9 @@ pub trait RecordBatchWriter {
     /// Write a single batch to the writer.
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
 
-    /// TODO.
+    /// Write footer or termination data, then mark the writer as done. After this 
+    /// function has been called, no more call to [`RecordBatchWriter::write`] should be 
+    /// made.
     fn finish(&mut self) -> Result<(), ArrowError>;
 }
 

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -197,6 +197,10 @@ impl<W: Write> RecordBatchWriter for Writer<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
     }
+
+    fn finish(&mut self) -> Result<(), ArrowError> {
+        Ok(())
+    }
 }
 
 /// A CSV writer builder

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -861,6 +861,10 @@ impl<W: Write> RecordBatchWriter for FileWriter<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
     }
+
+    fn finish(&mut self) -> Result<(), ArrowError> {
+        self.finish()
+    }
 }
 
 pub struct StreamWriter<W: Write> {
@@ -1000,6 +1004,10 @@ impl<W: Write> StreamWriter<W> {
 impl<W: Write> RecordBatchWriter for StreamWriter<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
+    }
+
+    fn finish(&mut self) -> Result<(), ArrowError> {
+        self.finish()
     }
 }
 

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -594,6 +594,10 @@ where
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
     }
+
+    fn finish(&mut self) -> Result<(), ArrowError> {
+        self.finish()
+    }
 }
 
 #[cfg(test)]

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -463,6 +463,7 @@ mod tests {
             ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let read = ParquetRecordBatchReader::try_new(Bytes::from(buffer), 3)
             .unwrap()

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -552,7 +552,7 @@ mod tests {
             .set_max_row_group_size(200)
             .build();
 
-        let writer = ArrowWriter::try_new(
+        let mut writer = ArrowWriter::try_new(
             file.try_clone().unwrap(),
             Arc::new(arrow_schema),
             Some(props),

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -194,6 +194,7 @@ mod tests {
             .expect("creat file writer");
         writer.write(&batch).expect("writing file");
         writer.close().expect("close writer");
+        drop(writer);
 
         // Read file
         let reader = Bytes::from(buffer);

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -712,6 +712,7 @@ mod tests {
 
         writer.write(&original).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let mut reader =
             ParquetRecordBatchReader::try_new(Bytes::from(buf), 1024).unwrap();
@@ -953,6 +954,7 @@ mod tests {
             ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let read = ParquetRecordBatchReader::try_new(Bytes::from(buffer), 3)
             .unwrap()
@@ -990,6 +992,7 @@ mod tests {
             ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let read = ParquetRecordBatchReader::try_new(Bytes::from(buffer), 3)
             .unwrap()
@@ -1030,6 +1033,7 @@ mod tests {
             ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let read = ParquetRecordBatchReader::try_new(Bytes::from(buffer), 3)
             .unwrap()
@@ -2092,6 +2096,7 @@ mod tests {
             writer.write(&batch).unwrap();
         }
         writer.close().unwrap();
+        drop(writer);
 
         let mut record_reader =
             ParquetRecordBatchReader::try_new(Bytes::from(buf), batch_size).unwrap();
@@ -2319,6 +2324,7 @@ mod tests {
         let rg_md = row_group_writer.close().unwrap();
         assert_eq!(rg_md.num_rows(), 1);
         writer.close().unwrap();
+        drop(writer);
 
         let bytes = Bytes::from(buf);
 
@@ -2492,6 +2498,7 @@ mod tests {
             ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let read = ParquetRecordBatchReader::try_new(Bytes::from(buffer), 8)
             .unwrap()

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -1658,7 +1658,7 @@ mod tests {
 
         // write to an empty parquet file so that schema is serialized
         let file = tempfile::tempfile().unwrap();
-        let writer = ArrowWriter::try_new(
+        let mut writer = ArrowWriter::try_new(
             file.try_clone().unwrap(),
             Arc::new(schema.clone()),
             None,
@@ -1718,7 +1718,7 @@ mod tests {
 
         // write to an empty parquet file so that schema is serialized
         let file = tempfile::tempfile().unwrap();
-        let writer = ArrowWriter::try_new(
+        let mut writer = ArrowWriter::try_new(
             file.try_clone().unwrap(),
             Arc::new(schema.clone()),
             None,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1735,6 +1735,7 @@ mod tests {
         c.close().unwrap();
         r.close().unwrap();
         writer.close().unwrap();
+        drop(writer);
 
         let b = Bytes::from(out);
         let options = ReadOptionsBuilder::new().with_page_index().build();

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -65,6 +65,7 @@ fn do_test(test: LayoutTest) {
         writer.write(&batch).unwrap();
     }
     writer.close().unwrap();
+    drop(writer);
     let b = Bytes::from(buf);
 
     // Re-read file to decode column index


### PR DESCRIPTION
# Which issue does this PR close?

This PR does not close any particular issue.

# Rationale for this change
 
After adding the `RecordBatchWriter` trait in #4206, I realized that one more method was needed to be able to work generically with writers. Almost every existing writers (except CSV) have some kind of method to close/finish the writer that must be called after all calls to `write` have been made.

# What changes are included in this PR?

Add `RecordBatchWriter::finish` method and implement it for CSV, JSON, IPC and Parquet.

# Are there any user-facing changes?

Yes. According to my analysis there are at least two breaking changes:

- `parquet::arrow::arrow_writer::ArrowWriter::close` now takes `&mut self` instead of `self`
- `parquet::file::writer::SerializedFileWriter::close` now takes `&mut self` instead of `self`
