### PR TITLE
Add close method to RecordBatchWriter trait

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -49,7 +49,7 @@ pub trait RecordBatchWriter {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
 
     /// Write footer or termination data, then mark the writer as done.
-    fn finish(self) -> Result<(), ArrowError>;
+    fn close(self) -> Result<(), ArrowError>;
 }
 
 /// A two-dimensional batch of column-oriented data with a defined

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -47,6 +47,9 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch, ArrowError>> {
 pub trait RecordBatchWriter {
     /// Write a single batch to the writer.
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError>;
+
+    /// Write footer or termination data, then mark the writer as done.
+    fn finish(self) -> Result<(), ArrowError>;
 }
 
 /// A two-dimensional batch of column-oriented data with a defined

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -197,6 +197,10 @@ impl<W: Write> RecordBatchWriter for Writer<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
     }
+
+    fn finish(self) -> Result<(), ArrowError> {
+        Ok(())
+    }
 }
 
 /// A CSV writer builder

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -198,7 +198,7 @@ impl<W: Write> RecordBatchWriter for Writer<W> {
         self.write(batch)
     }
 
-    fn finish(self) -> Result<(), ArrowError> {
+    fn close(self) -> Result<(), ArrowError> {
         Ok(())
     }
 }

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1510,6 +1510,8 @@ mod tests {
         stream_writer.write(&batch).unwrap();
         stream_writer.finish().unwrap();
 
+        drop(stream_writer);
+
         file.rewind().unwrap();
 
         // read stream back
@@ -1556,6 +1558,7 @@ mod tests {
             crate::writer::FileWriter::try_new(&mut buf, &rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
+        drop(writer);
 
         let mut reader =
             crate::reader::FileReader::try_new(std::io::Cursor::new(buf), None).unwrap();
@@ -1568,6 +1571,7 @@ mod tests {
             crate::writer::StreamWriter::try_new(&mut buf, &rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
+        drop(writer);
 
         let mut reader =
             crate::reader::StreamReader::try_new(std::io::Cursor::new(buf), None)
@@ -1587,6 +1591,7 @@ mod tests {
             writer.write_metadata(k, v);
         }
         writer.finish().unwrap();
+        drop(writer);
 
         let reader =
             crate::reader::FileReader::try_new(std::io::Cursor::new(buf), None).unwrap();

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1510,8 +1510,6 @@ mod tests {
         stream_writer.write(&batch).unwrap();
         stream_writer.finish().unwrap();
 
-        drop(stream_writer);
-
         file.rewind().unwrap();
 
         // read stream back
@@ -1558,7 +1556,6 @@ mod tests {
             crate::writer::FileWriter::try_new(&mut buf, &rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
-        drop(writer);
 
         let mut reader =
             crate::reader::FileReader::try_new(std::io::Cursor::new(buf), None).unwrap();
@@ -1571,7 +1568,6 @@ mod tests {
             crate::writer::StreamWriter::try_new(&mut buf, &rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
-        drop(writer);
 
         let mut reader =
             crate::reader::StreamReader::try_new(std::io::Cursor::new(buf), None)
@@ -1591,7 +1587,6 @@ mod tests {
             writer.write_metadata(k, v);
         }
         writer.finish().unwrap();
-        drop(writer);
 
         let reader =
             crate::reader::FileReader::try_new(std::io::Cursor::new(buf), None).unwrap();

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -851,7 +851,7 @@ impl<W: Write> FileWriter<W> {
     /// writer.
     pub fn into_inner(mut self) -> Result<W, ArrowError> {
         if !self.finished {
-            self.finish()?;
+            FileWriter::finish(&mut self)?;
         }
         self.writer.into_inner().map_err(ArrowError::from)
     }
@@ -860,6 +860,10 @@ impl<W: Write> FileWriter<W> {
 impl<W: Write> RecordBatchWriter for FileWriter<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
+    }
+
+    fn finish(mut self) -> Result<(), ArrowError> {
+        FileWriter::finish(&mut self)
     }
 }
 
@@ -991,7 +995,7 @@ impl<W: Write> StreamWriter<W> {
     /// ```
     pub fn into_inner(mut self) -> Result<W, ArrowError> {
         if !self.finished {
-            self.finish()?;
+            StreamWriter::finish(&mut self)?;
         }
         self.writer.into_inner().map_err(ArrowError::from)
     }
@@ -1000,6 +1004,10 @@ impl<W: Write> StreamWriter<W> {
 impl<W: Write> RecordBatchWriter for StreamWriter<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
+    }
+
+    fn finish(mut self) -> Result<(), ArrowError> {
+        StreamWriter::finish(&mut self)
     }
 }
 
@@ -1797,7 +1805,7 @@ mod tests {
         let buffer: Vec<u8> = Vec::new();
         let mut stream_writer = StreamWriter::try_new(buffer, &record.schema()).unwrap();
         stream_writer.write(record).unwrap();
-        stream_writer.finish().unwrap();
+        StreamWriter::finish(&mut stream_writer).unwrap();
         stream_writer.into_inner().unwrap()
     }
 
@@ -2053,7 +2061,7 @@ mod tests {
 
         let mut writer = StreamWriter::try_new(Vec::<u8>::new(), &schema).unwrap();
         writer.write(&batch).unwrap();
-        writer.finish().unwrap();
+        StreamWriter::finish(&mut writer).unwrap();
         let data = writer.into_inner().unwrap();
 
         let mut reader = StreamReader::try_new(Cursor::new(data), None).unwrap();
@@ -2146,7 +2154,7 @@ mod tests {
 
         let mut writer = FileWriter::try_new(Vec::<u8>::new(), &schema).unwrap();
         writer.write(&batch).unwrap();
-        writer.finish().unwrap();
+        FileWriter::finish(&mut writer).unwrap();
         let data = writer.into_inner().unwrap();
 
         let mut reader = FileReader::try_new(Cursor::new(data), None).unwrap();

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -851,7 +851,7 @@ impl<W: Write> FileWriter<W> {
     /// writer.
     pub fn into_inner(mut self) -> Result<W, ArrowError> {
         if !self.finished {
-            FileWriter::finish(&mut self)?;
+            self.finish()?;
         }
         self.writer.into_inner().map_err(ArrowError::from)
     }
@@ -862,7 +862,7 @@ impl<W: Write> RecordBatchWriter for FileWriter<W> {
         self.write(batch)
     }
 
-    fn finish(mut self) -> Result<(), ArrowError> {
+    fn close(mut self) -> Result<(), ArrowError> {
         FileWriter::finish(&mut self)
     }
 }
@@ -995,7 +995,7 @@ impl<W: Write> StreamWriter<W> {
     /// ```
     pub fn into_inner(mut self) -> Result<W, ArrowError> {
         if !self.finished {
-            StreamWriter::finish(&mut self)?;
+            self.finish()?;
         }
         self.writer.into_inner().map_err(ArrowError::from)
     }
@@ -1006,8 +1006,8 @@ impl<W: Write> RecordBatchWriter for StreamWriter<W> {
         self.write(batch)
     }
 
-    fn finish(mut self) -> Result<(), ArrowError> {
-        StreamWriter::finish(&mut self)
+    fn close(mut self) -> Result<(), ArrowError> {
+        self.finish()
     }
 }
 
@@ -1805,7 +1805,7 @@ mod tests {
         let buffer: Vec<u8> = Vec::new();
         let mut stream_writer = StreamWriter::try_new(buffer, &record.schema()).unwrap();
         stream_writer.write(record).unwrap();
-        StreamWriter::finish(&mut stream_writer).unwrap();
+        stream_writer.finish().unwrap();
         stream_writer.into_inner().unwrap()
     }
 
@@ -2061,7 +2061,7 @@ mod tests {
 
         let mut writer = StreamWriter::try_new(Vec::<u8>::new(), &schema).unwrap();
         writer.write(&batch).unwrap();
-        StreamWriter::finish(&mut writer).unwrap();
+        writer.finish().unwrap();
         let data = writer.into_inner().unwrap();
 
         let mut reader = StreamReader::try_new(Cursor::new(data), None).unwrap();
@@ -2154,7 +2154,7 @@ mod tests {
 
         let mut writer = FileWriter::try_new(Vec::<u8>::new(), &schema).unwrap();
         writer.write(&batch).unwrap();
-        FileWriter::finish(&mut writer).unwrap();
+        writer.finish().unwrap();
         let data = writer.into_inner().unwrap();
 
         let mut reader = FileReader::try_new(Cursor::new(data), None).unwrap();

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -863,7 +863,7 @@ impl<W: Write> RecordBatchWriter for FileWriter<W> {
     }
 
     fn close(mut self) -> Result<(), ArrowError> {
-        FileWriter::finish(&mut self)
+        self.finish()
     }
 }
 

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -594,6 +594,10 @@ where
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch)
     }
+
+    fn finish(mut self) -> Result<(), ArrowError> {
+        Writer::finish(&mut self)
+    }
 }
 
 #[cfg(test)]
@@ -1262,15 +1266,16 @@ mod tests {
     #[test]
     fn json_writer_empty() {
         let mut writer = ArrayWriter::new(vec![] as Vec<u8>);
-        writer.finish().unwrap();
+        ArrayWriter::finish(&mut writer).unwrap();
         assert_eq!(String::from_utf8(writer.into_inner()).unwrap(), "");
     }
+
     #[test]
     fn json_writer_one_row() {
         let mut writer = ArrayWriter::new(vec![] as Vec<u8>);
         let v = json!({ "an": "object" });
         writer.write_row(&v).unwrap();
-        writer.finish().unwrap();
+        ArrayWriter::finish(&mut writer).unwrap();
         assert_eq!(
             String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"}]"#
@@ -1284,7 +1289,7 @@ mod tests {
         writer.write_row(&v).unwrap();
         let v = json!({ "another": "object" });
         writer.write_row(&v).unwrap();
-        writer.finish().unwrap();
+        ArrayWriter::finish(&mut writer).unwrap();
         assert_eq!(
             String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"},{"another":"object"}]"#

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -595,8 +595,8 @@ where
         self.write(batch)
     }
 
-    fn finish(mut self) -> Result<(), ArrowError> {
-        Writer::finish(&mut self)
+    fn close(mut self) -> Result<(), ArrowError> {
+        self.finish()
     }
 }
 
@@ -1266,7 +1266,7 @@ mod tests {
     #[test]
     fn json_writer_empty() {
         let mut writer = ArrayWriter::new(vec![] as Vec<u8>);
-        ArrayWriter::finish(&mut writer).unwrap();
+        writer.finish().unwrap();
         assert_eq!(String::from_utf8(writer.into_inner()).unwrap(), "");
     }
 
@@ -1275,7 +1275,7 @@ mod tests {
         let mut writer = ArrayWriter::new(vec![] as Vec<u8>);
         let v = json!({ "an": "object" });
         writer.write_row(&v).unwrap();
-        ArrayWriter::finish(&mut writer).unwrap();
+        writer.finish().unwrap();
         assert_eq!(
             String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"}]"#
@@ -1289,7 +1289,7 @@ mod tests {
         writer.write_row(&v).unwrap();
         let v = json!({ "another": "object" });
         writer.write_row(&v).unwrap();
-        ArrayWriter::finish(&mut writer).unwrap();
+        writer.finish().unwrap();
         assert_eq!(
             String::from_utf8(writer.into_inner()).unwrap(),
             r#"[{"an":"object"},{"another":"object"}]"#

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -251,7 +251,7 @@ impl<W: Write> RecordBatchWriter for ArrowWriter<W> {
         self.write(batch).map_err(|e| e.into())
     }
 
-    fn finish(self) -> std::result::Result<(), ArrowError> {
+    fn close(self) -> std::result::Result<(), ArrowError> {
         self.close()?;
         Ok(())
     }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -250,6 +250,10 @@ impl<W: Write> RecordBatchWriter for ArrowWriter<W> {
     fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         self.write(batch).map_err(|e| e.into())
     }
+
+    fn finish(self) -> std::result::Result<(), ArrowError> {
+        self.close().map(|_| ()).map_err(ArrowError::from)
+    }
 }
 
 fn write_leaves<W: Write>(

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -252,7 +252,8 @@ impl<W: Write> RecordBatchWriter for ArrowWriter<W> {
     }
 
     fn finish(self) -> std::result::Result<(), ArrowError> {
-        self.close().map(|_| ()).map_err(ArrowError::from)
+        self.close()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

This PR does not close any particular issue. It is an alternative implementation of #4221 

# Rationale for this change
 
In #4221, the `finish` method takes `&mut self` whereas in this PR it takes `self`.

We are forced to use fully qualified method calls for `finish` where we want to call `finish` on the object itself because `RecordBatchWriter` is in scope (because we `use arrow_array::*`). What's your opinion on importing only needed items from `arrow_array` to avoid this?

# What changes are included in this PR?

Add `finish` method to `RecordBatchWriter` and implement it for CSV, JSON, IPC and Parquet writers.

# Are there any user-facing changes?

According to my analysis no breaking change is introduced in this PR.
