### PR TITLE
Return NotFound for directories in Head and Get (#4230)

### DIFF
--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -262,7 +262,7 @@ impl AzureClient {
                 Err(crate::Error::NotFound {
                     path: path.to_string(),
                     source: format!(
-                        "Not a directory, got x-ms-resource-type: {}",
+                        "Not a file, got x-ms-resource-type: {}",
                         String::from_utf8_lossy(resource.as_ref())
                     )
                     .into(),

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -257,7 +257,19 @@ impl AzureClient {
                 path: path.as_ref(),
             })?;
 
-        Ok(response)
+        match response.headers().get("x-ms-resource-type") {
+            Some(resource) if resource.as_ref() != b"file" => {
+                Err(crate::Error::NotFound {
+                    path: path.to_string(),
+                    source: format!(
+                        "Not a directory, got x-ms-resource-type: {}",
+                        String::from_utf8_lossy(resource.as_ref())
+                    )
+                    .into(),
+                })
+            }
+            _ => Ok(response),
+        }
     }
 
     /// Make an Azure Delete request <https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob>

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -238,10 +238,13 @@ impl Client {
             .send_retry(&self.retry_config)
             .await
             .map_err(|source| match source.status() {
-                Some(StatusCode::NOT_FOUND) => crate::Error::NotFound {
-                    source: Box::new(source),
-                    path: location.to_string(),
-                },
+                // Some stores return METHOD_NOT_ALLOWED for get on directories
+                Some(StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED) => {
+                    crate::Error::NotFound {
+                        source: Box::new(source),
+                        path: location.to_string(),
+                    }
+                }
                 _ => Error::Request { source }.into(),
             })
     }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -880,6 +880,14 @@ mod tests {
         assert_eq!(result.common_prefixes.len(), 1);
         assert_eq!(result.common_prefixes[0], Path::from("test_dir"));
 
+        // Should return not found
+        let err = storage.get(&Path::from("test_dir")).await.unwrap_err();
+        assert!(matches!(err, crate::Error::NotFound { .. }), "{}", err);
+
+        // Should return not found
+        let err = storage.head(&Path::from("test_dir")).await.unwrap_err();
+        assert!(matches!(err, crate::Error::NotFound { .. }), "{}", err);
+
         // List everything starting with a prefix that should return results
         let prefix = Path::from("test_dir");
         let content_list = flatten_list_stream(storage, Some(&prefix)).await.unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4230

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I spent a non-trivial amount of time helping diagnose an issue with https://github.com/apache/arrow-datafusion/pull/6183 that boiled down to a head request being made instead of a list request, because the `ListingTableUrl` didn't end with a `/`. Normally this would have returned a 404 NotFound which would have made the issue easy to identify, however, because it was an Azure hierarchical namespace this didn't occur.

LocalFileSystem also runs into a similar issue.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

LocalFileSystem and MicrosoftAzure will no longer return directories for get and head requests

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
