### PR TITLE
feat: update flight-sql to latest specs

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -513,7 +513,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionClosePreparedStatementRequest,
         _request: Request<Action>,
     ) -> Result<(), Status> {
-        unimplemented!("Implement do_action_close_prepared_statement")
+        Err(Status::unimplemented(
+            "Implement do_action_close_prepared_statement",
+        ))
     }
 
     async fn do_action_create_prepared_substrait_plan(
@@ -521,7 +523,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionCreatePreparedSubstraitPlanRequest,
         _request: Request<Action>,
     ) -> Result<ActionCreatePreparedStatementResult, Status> {
-        unimplemented!("Implement do_action_create_prepared_substrait_plan")
+        Err(Status::unimplemented(
+            "Implement do_action_create_prepared_substrait_plan",
+        ))
     }
 
     async fn do_action_begin_transaction(
@@ -529,7 +533,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionBeginTransactionRequest,
         _request: Request<Action>,
     ) -> Result<ActionBeginTransactionResult, Status> {
-        unimplemented!("Implement do_action_begin_transaction")
+        Err(Status::unimplemented(
+            "Implement do_action_begin_transaction",
+        ))
     }
 
     async fn do_action_end_transaction(
@@ -537,7 +543,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionEndTransactionRequest,
         _request: Request<Action>,
     ) -> Result<(), Status> {
-        unimplemented!("Implement do_action_end_transaction")
+        Err(Status::unimplemented("Implement do_action_end_transaction"))
     }
 
     async fn do_action_begin_savepoint(
@@ -545,7 +551,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionBeginSavepointRequest,
         _request: Request<Action>,
     ) -> Result<ActionBeginSavepointResult, Status> {
-        unimplemented!("Implement do_action_begin_savepoint")
+        Err(Status::unimplemented("Implement do_action_begin_savepoint"))
     }
 
     async fn do_action_end_savepoint(
@@ -553,7 +559,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionEndSavepointRequest,
         _request: Request<Action>,
     ) -> Result<(), Status> {
-        unimplemented!("Implement do_action_end_savepoint")
+        Err(Status::unimplemented("Implement do_action_end_savepoint"))
     }
 
     async fn do_action_cancel_query(
@@ -561,7 +567,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionCancelQueryRequest,
         _request: Request<Action>,
     ) -> Result<ActionCancelQueryResult, Status> {
-        unimplemented!("Implement do_action_cancel_query")
+        Err(Status::unimplemented("Implement do_action_cancel_query"))
     }
 
     async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -183,8 +183,21 @@ pub struct FlightInfo {
     /// In other words, an application can use multiple endpoints to
     /// represent partitioned data.
     ///
-    /// There is no ordering defined on endpoints. Hence, if the returned
-    /// data has an ordering, it should be returned in a single endpoint.
+    /// If the returned data has an ordering, an application can use
+    /// "FlightInfo.ordered = true" or should return the all data in a
+    /// single endpoint. Otherwise, there is no ordering defined on
+    /// endpoints or the data within.
+    ///
+    /// A client can read ordered data by reading data from returned
+    /// endpoints, in order, from front to back.
+    ///
+    /// Note that a client may ignore "FlightInfo.ordered = true". If an
+    /// ordering is important for an application, an application must
+    /// choose one of them:
+    ///
+    /// * An application requires that all clients must read data in
+    ///    returned endpoints order.
+    /// * An application must return the all data in a single endpoint.
     #[prost(message, repeated, tag = "3")]
     pub endpoint: ::prost::alloc::vec::Vec<FlightEndpoint>,
     /// Set these to -1 if unknown.
@@ -192,6 +205,10 @@ pub struct FlightInfo {
     pub total_records: i64,
     #[prost(int64, tag = "5")]
     pub total_bytes: i64,
+    ///
+    /// FlightEndpoints are in the same order as the data.
+    #[prost(bool, tag = "6")]
+    pub ordered: bool,
 }
 ///
 /// A particular stream or split associated with a flight.

--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -108,7 +108,10 @@ async fn main() {
     setup_logging();
     let mut client = setup_client(args.client_args).await.expect("setup client");
 
-    let info = client.execute(args.query).await.expect("prepare statement");
+    let info = client
+        .execute(args.query, None)
+        .await
+        .expect("prepare statement");
     info!("got flight info");
 
     let schema = Arc::new(Schema::try_from(info.clone()).expect("valid schema"));

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -424,6 +424,7 @@ impl FlightInfo {
         endpoint: Vec<FlightEndpoint>,
         total_records: i64,
         total_bytes: i64,
+        ordered: bool,
     ) -> Self {
         let IpcMessage(vals) = message;
         FlightInfo {
@@ -432,6 +433,7 @@ impl FlightInfo {
             endpoint,
             total_records,
             total_bytes,
+            ordered,
         }
     }
 

--- a/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
+++ b/arrow-flight/src/sql/arrow.flight.protocol.sql.rs
@@ -51,12 +51,12 @@ pub struct CommandGetSqlInfo {
 /// The returned schema will be:
 /// <
 ///    type_name: utf8 not null (The name of the data type, for example: VARCHAR, INTEGER, etc),
-///    data_type: int not null (The SQL data type),
-///    column_size: int (The maximum size supported by that column.
-///                      In case of exact numeric types, this represents the maximum precision.
-///                      In case of string types, this represents the character length.
-///                      In case of datetime data types, this represents the length in characters of the string representation.
-///                      NULL is returned for data types where column size is not applicable.),
+///    data_type: int32 not null (The SQL data type),
+///    column_size: int32 (The maximum size supported by that column.
+///                        In case of exact numeric types, this represents the maximum precision.
+///                        In case of string types, this represents the character length.
+///                        In case of datetime data types, this represents the length in characters of the string representation.
+///                        NULL is returned for data types where column size is not applicable.),
 ///    literal_prefix: utf8 (Character or characters used to prefix a literal, NULL is returned for
 ///                          data types where a literal prefix is not applicable.),
 ///    literal_suffix: utf8 (Character or characters used to terminate a literal,
@@ -65,11 +65,11 @@ pub struct CommandGetSqlInfo {
 ///                         (A list of keywords corresponding to which parameters can be used when creating
 ///                          a column for that specific type.
 ///                          NULL is returned if there are no parameters for the data type definition.),
-///    nullable: int not null (Shows if the data type accepts a NULL value. The possible values can be seen in the
-///                            Nullable enum.),
+///    nullable: int32 not null (Shows if the data type accepts a NULL value. The possible values can be seen in the
+///                              Nullable enum.),
 ///    case_sensitive: bool not null (Shows if a character data type is case-sensitive in collations and comparisons),
-///    searchable: int not null (Shows how the data type is used in a WHERE clause. The possible values can be seen in the
-///                              Searchable enum.),
+///    searchable: int32 not null (Shows how the data type is used in a WHERE clause. The possible values can be seen in the
+///                                Searchable enum.),
 ///    unsigned_attribute: bool (Shows if the data type is unsigned. NULL is returned if the attribute is
 ///                              not applicable to the data type or the data type is not numeric.),
 ///    fixed_prec_scale: bool not null (Shows if the data type has predefined fixed precision and scale.),
@@ -77,26 +77,26 @@ pub struct CommandGetSqlInfo {
 ///                          is not applicable to the data type or the data type is not numeric.),
 ///    local_type_name: utf8 (Localized version of the data source-dependent name of the data type. NULL
 ///                           is returned if a localized name is not supported by the data source),
-///    minimum_scale: int (The minimum scale of the data type on the data source.
-///                        If a data type has a fixed scale, the MINIMUM_SCALE and MAXIMUM_SCALE
-///                        columns both contain this value. NULL is returned if scale is not applicable.),
-///    maximum_scale: int (The maximum scale of the data type on the data source.
-///                        NULL is returned if scale is not applicable.),
-///    sql_data_type: int not null (The value of the SQL DATA TYPE which has the same values
-///                                 as data_type value. Except for interval and datetime, which
-///                                 uses generic values. More info about those types can be
-///                                 obtained through datetime_subcode. The possible values can be seen
-///                                 in the XdbcDataType enum.),
-///    datetime_subcode: int (Only used when the SQL DATA TYPE is interval or datetime. It contains
-///                           its sub types. For type different from interval and datetime, this value
-///                           is NULL. The possible values can be seen in the XdbcDatetimeSubcode enum.),
-///    num_prec_radix: int (If the data type is an approximate numeric type, this column contains
-///                         the value 2 to indicate that COLUMN_SIZE specifies a number of bits. For
-///                         exact numeric types, this column contains the value 10 to indicate that
-///                         column size specifies a number of decimal digits. Otherwise, this column is NULL.),
-///    interval_precision: int (If the data type is an interval data type, then this column contains the value
-///                             of the interval leading precision. Otherwise, this column is NULL. This fields
-///                             is only relevant to be used by ODBC).
+///    minimum_scale: int32 (The minimum scale of the data type on the data source.
+///                          If a data type has a fixed scale, the MINIMUM_SCALE and MAXIMUM_SCALE
+///                          columns both contain this value. NULL is returned if scale is not applicable.),
+///    maximum_scale: int32 (The maximum scale of the data type on the data source.
+///                          NULL is returned if scale is not applicable.),
+///    sql_data_type: int32 not null (The value of the SQL DATA TYPE which has the same values
+///                                   as data_type value. Except for interval and datetime, which
+///                                   uses generic values. More info about those types can be
+///                                   obtained through datetime_subcode. The possible values can be seen
+///                                   in the XdbcDataType enum.),
+///    datetime_subcode: int32 (Only used when the SQL DATA TYPE is interval or datetime. It contains
+///                             its sub types. For type different from interval and datetime, this value
+///                             is NULL. The possible values can be seen in the XdbcDatetimeSubcode enum.),
+///    num_prec_radix: int32 (If the data type is an approximate numeric type, this column contains
+///                           the value 2 to indicate that COLUMN_SIZE specifies a number of bits. For
+///                           exact numeric types, this column contains the value 10 to indicate that
+///                           column size specifies a number of decimal digits. Otherwise, this column is NULL.),
+///    interval_precision: int32 (If the data type is an interval data type, then this column contains the value
+///                               of the interval leading precision. Otherwise, this column is NULL. This fields
+///                               is only relevant to be used by ODBC).
 /// >
 /// The returned data should be ordered by data_type and then by type_name.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -246,7 +246,7 @@ pub struct CommandGetTableTypes {}
 ///   table_name: utf8 not null,
 ///   column_name: utf8 not null,
 ///   key_name: utf8,
-///   key_sequence: int not null
+///   key_sequence: int32 not null
 /// >
 /// The returned data should be ordered by catalog_name, db_schema_name, table_name, key_name, then key_sequence.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -285,11 +285,11 @@ pub struct CommandGetPrimaryKeys {
 ///   fk_db_schema_name: utf8,
 ///   fk_table_name: utf8 not null,
 ///   fk_column_name: utf8 not null,
-///   key_sequence: int not null,
+///   key_sequence: int32 not null,
 ///   fk_key_name: utf8,
 ///   pk_key_name: utf8,
-///   update_rule: uint1 not null,
-///   delete_rule: uint1 not null
+///   update_rule: uint8 not null,
+///   delete_rule: uint8 not null
 /// >
 /// The returned data should be ordered by fk_catalog_name, fk_db_schema_name, fk_table_name, fk_key_name, then key_sequence.
 /// update_rule and delete_rule returns a byte that is equivalent to actions declared on UpdateDeleteRules enum.
@@ -328,11 +328,11 @@ pub struct CommandGetExportedKeys {
 ///   fk_db_schema_name: utf8,
 ///   fk_table_name: utf8 not null,
 ///   fk_column_name: utf8 not null,
-///   key_sequence: int not null,
+///   key_sequence: int32 not null,
 ///   fk_key_name: utf8,
 ///   pk_key_name: utf8,
-///   update_rule: uint1 not null,
-///   delete_rule: uint1 not null
+///   update_rule: uint8 not null,
+///   delete_rule: uint8 not null
 /// >
 /// The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
 /// update_rule and delete_rule returns a byte that is equivalent to actions:
@@ -378,11 +378,11 @@ pub struct CommandGetImportedKeys {
 ///   fk_db_schema_name: utf8,
 ///   fk_table_name: utf8 not null,
 ///   fk_column_name: utf8 not null,
-///   key_sequence: int not null,
+///   key_sequence: int32 not null,
 ///   fk_key_name: utf8,
 ///   pk_key_name: utf8,
-///   update_rule: uint1 not null,
-///   delete_rule: uint1 not null
+///   update_rule: uint8 not null,
+///   delete_rule: uint8 not null
 /// >
 /// The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
 /// update_rule and delete_rule returns a byte that is equivalent to actions:
@@ -435,13 +435,49 @@ pub struct ActionCreatePreparedStatementRequest {
     /// The valid SQL string to create a prepared statement for.
     #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
+    /// Create/execute the prepared statement as part of this transaction (if
+    /// unset, executions of the prepared statement will be auto-committed).
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub transaction_id: ::core::option::Option<::prost::bytes::Bytes>,
 }
 ///
-/// Wrap the result of a "GetPreparedStatement" action.
+/// An embedded message describing a Substrait plan to execute.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubstraitPlan {
+    /// The serialized substrait.Plan to create a prepared statement for.
+    /// XXX(ARROW-16902): this is bytes instead of an embedded message
+    /// because Protobuf does not really support one DLL using Protobuf
+    /// definitions from another DLL.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub plan: ::prost::bytes::Bytes,
+    /// The Substrait release, e.g. "0.12.0". This information is not
+    /// tracked in the plan itself, so this is the only way for consumers
+    /// to potentially know if they can handle the plan.
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+}
+///
+/// Request message for the "CreatePreparedSubstraitPlan" action on a Flight SQL enabled backend.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionCreatePreparedSubstraitPlanRequest {
+    /// The serialized substrait.Plan to create a prepared statement for.
+    #[prost(message, optional, tag = "1")]
+    pub plan: ::core::option::Option<SubstraitPlan>,
+    /// Create/execute the prepared statement as part of this transaction (if
+    /// unset, executions of the prepared statement will be auto-committed).
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub transaction_id: ::core::option::Option<::prost::bytes::Bytes>,
+}
+///
+/// Wrap the result of a "CreatePreparedStatement" or "CreatePreparedSubstraitPlan" action.
 ///
 /// The resultant PreparedStatement can be closed either:
 /// - Manually, through the "ClosePreparedStatement" action;
 /// - Automatically, by a server timeout.
+///
+/// The result should be wrapped in a google.protobuf.Any message.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionCreatePreparedStatementResult {
@@ -468,6 +504,182 @@ pub struct ActionClosePreparedStatementRequest {
     pub prepared_statement_handle: ::prost::bytes::Bytes,
 }
 ///
+/// Request message for the "BeginTransaction" action.
+/// Begins a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionBeginTransactionRequest {}
+///
+/// Request message for the "BeginSavepoint" action.
+/// Creates a savepoint within a transaction.
+///
+/// Only supported if FLIGHT_SQL_TRANSACTION is
+/// FLIGHT_SQL_TRANSACTION_SUPPORT_SAVEPOINT.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionBeginSavepointRequest {
+    /// The transaction to which a savepoint belongs.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub transaction_id: ::prost::bytes::Bytes,
+    /// Name for the savepoint.
+    #[prost(string, tag = "2")]
+    pub name: ::prost::alloc::string::String,
+}
+///
+/// The result of a "BeginTransaction" action.
+///
+/// The transaction can be manipulated with the "EndTransaction" action, or
+/// automatically via server timeout. If the transaction times out, then it is
+/// automatically rolled back.
+///
+/// The result should be wrapped in a google.protobuf.Any message.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionBeginTransactionResult {
+    /// Opaque handle for the transaction on the server.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub transaction_id: ::prost::bytes::Bytes,
+}
+///
+/// The result of a "BeginSavepoint" action.
+///
+/// The transaction can be manipulated with the "EndSavepoint" action.
+/// If the associated transaction is committed, rolled back, or times
+/// out, then the savepoint is also invalidated.
+///
+/// The result should be wrapped in a google.protobuf.Any message.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionBeginSavepointResult {
+    /// Opaque handle for the savepoint on the server.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub savepoint_id: ::prost::bytes::Bytes,
+}
+///
+/// Request message for the "EndTransaction" action.
+///
+/// Commit (COMMIT) or rollback (ROLLBACK) the transaction.
+///
+/// If the action completes successfully, the transaction handle is
+/// invalidated, as are all associated savepoints.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionEndTransactionRequest {
+    /// Opaque handle for the transaction on the server.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub transaction_id: ::prost::bytes::Bytes,
+    /// Whether to commit/rollback the given transaction.
+    #[prost(enumeration = "action_end_transaction_request::EndTransaction", tag = "2")]
+    pub action: i32,
+}
+/// Nested message and enum types in `ActionEndTransactionRequest`.
+pub mod action_end_transaction_request {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum EndTransaction {
+        Unspecified = 0,
+        /// Commit the transaction.
+        Commit = 1,
+        /// Roll back the transaction.
+        Rollback = 2,
+    }
+    impl EndTransaction {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EndTransaction::Unspecified => "END_TRANSACTION_UNSPECIFIED",
+                EndTransaction::Commit => "END_TRANSACTION_COMMIT",
+                EndTransaction::Rollback => "END_TRANSACTION_ROLLBACK",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "END_TRANSACTION_UNSPECIFIED" => Some(Self::Unspecified),
+                "END_TRANSACTION_COMMIT" => Some(Self::Commit),
+                "END_TRANSACTION_ROLLBACK" => Some(Self::Rollback),
+                _ => None,
+            }
+        }
+    }
+}
+///
+/// Request message for the "EndSavepoint" action.
+///
+/// Release (RELEASE) the savepoint or rollback (ROLLBACK) to the
+/// savepoint.
+///
+/// Releasing a savepoint invalidates that savepoint.  Rolling back to
+/// a savepoint does not invalidate the savepoint, but invalidates all
+/// savepoints created after the current savepoint.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionEndSavepointRequest {
+    /// Opaque handle for the savepoint on the server.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub savepoint_id: ::prost::bytes::Bytes,
+    /// Whether to rollback/release the given savepoint.
+    #[prost(enumeration = "action_end_savepoint_request::EndSavepoint", tag = "2")]
+    pub action: i32,
+}
+/// Nested message and enum types in `ActionEndSavepointRequest`.
+pub mod action_end_savepoint_request {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum EndSavepoint {
+        Unspecified = 0,
+        /// Release the savepoint.
+        Release = 1,
+        /// Roll back to a savepoint.
+        Rollback = 2,
+    }
+    impl EndSavepoint {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EndSavepoint::Unspecified => "END_SAVEPOINT_UNSPECIFIED",
+                EndSavepoint::Release => "END_SAVEPOINT_RELEASE",
+                EndSavepoint::Rollback => "END_SAVEPOINT_ROLLBACK",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "END_SAVEPOINT_UNSPECIFIED" => Some(Self::Unspecified),
+                "END_SAVEPOINT_RELEASE" => Some(Self::Release),
+                "END_SAVEPOINT_ROLLBACK" => Some(Self::Rollback),
+                _ => None,
+            }
+        }
+    }
+}
+///
 /// Represents a SQL query. Used in the command member of FlightDescriptor
 /// for the following RPC calls:
 ///   - GetSchema: return the Arrow schema of the query.
@@ -489,6 +701,36 @@ pub struct CommandStatementQuery {
     /// The SQL syntax.
     #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
+    /// Include the query as part of this transaction (if unset, the query is auto-committed).
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub transaction_id: ::core::option::Option<::prost::bytes::Bytes>,
+}
+///
+/// Represents a Substrait plan. Used in the command member of FlightDescriptor
+/// for the following RPC calls:
+///   - GetSchema: return the Arrow schema of the query.
+///     Fields on this schema may contain the following metadata:
+///     - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+///     - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+///     - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+///     - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
+///     - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+///     - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
+///     - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+///     - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+///     - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+///     - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+///   - GetFlightInfo: execute the query.
+///   - DoPut: execute the query.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommandStatementSubstraitPlan {
+    /// A serialized substrait.Plan
+    #[prost(message, optional, tag = "1")]
+    pub plan: ::core::option::Option<SubstraitPlan>,
+    /// Include the query as part of this transaction (if unset, the query is auto-committed).
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub transaction_id: ::core::option::Option<::prost::bytes::Bytes>,
 }
 /// *
 /// Represents a ticket resulting from GetFlightInfo with a CommandStatementQuery.
@@ -533,6 +775,9 @@ pub struct CommandStatementUpdate {
     /// The SQL syntax.
     #[prost(string, tag = "1")]
     pub query: ::prost::alloc::string::String,
+    /// Include the query as part of this transaction (if unset, the query is auto-committed).
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub transaction_id: ::core::option::Option<::prost::bytes::Bytes>,
 }
 ///
 /// Represents a SQL update query. Used in the command member of FlightDescriptor
@@ -557,6 +802,93 @@ pub struct DoPutUpdateResult {
     #[prost(int64, tag = "1")]
     pub record_count: i64,
 }
+///
+/// Request message for the "CancelQuery" action.
+///
+/// Explicitly cancel a running query.
+///
+/// This lets a single client explicitly cancel work, no matter how many clients
+/// are involved/whether the query is distributed or not, given server support.
+/// The transaction/statement is not rolled back; it is the application's job to
+/// commit or rollback as appropriate. This only indicates the client no longer
+/// wishes to read the remainder of the query results or continue submitting
+/// data.
+///
+/// This command is idempotent.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionCancelQueryRequest {
+    /// The result of the GetFlightInfo RPC that initiated the query.
+    /// XXX(ARROW-16902): this must be a serialized FlightInfo, but is
+    /// rendered as bytes because Protobuf does not really support one
+    /// DLL using Protobuf definitions from another DLL.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub info: ::prost::bytes::Bytes,
+}
+///
+/// The result of cancelling a query.
+///
+/// The result should be wrapped in a google.protobuf.Any message.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionCancelQueryResult {
+    #[prost(enumeration = "action_cancel_query_result::CancelResult", tag = "1")]
+    pub result: i32,
+}
+/// Nested message and enum types in `ActionCancelQueryResult`.
+pub mod action_cancel_query_result {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum CancelResult {
+        /// The cancellation status is unknown. Servers should avoid using
+        /// this value (send a NOT_FOUND error if the requested query is
+        /// not known). Clients can retry the request.
+        Unspecified = 0,
+        /// The cancellation request is complete. Subsequent requests with
+        /// the same payload may return CANCELLED or a NOT_FOUND error.
+        Cancelled = 1,
+        /// The cancellation request is in progress. The client may retry
+        /// the cancellation request.
+        Cancelling = 2,
+        /// The query is not cancellable. The client should not retry the
+        /// cancellation request.
+        NotCancellable = 3,
+    }
+    impl CancelResult {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                CancelResult::Unspecified => "CANCEL_RESULT_UNSPECIFIED",
+                CancelResult::Cancelled => "CANCEL_RESULT_CANCELLED",
+                CancelResult::Cancelling => "CANCEL_RESULT_CANCELLING",
+                CancelResult::NotCancellable => "CANCEL_RESULT_NOT_CANCELLABLE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "CANCEL_RESULT_UNSPECIFIED" => Some(Self::Unspecified),
+                "CANCEL_RESULT_CANCELLED" => Some(Self::Cancelled),
+                "CANCEL_RESULT_CANCELLING" => Some(Self::Cancelling),
+                "CANCEL_RESULT_NOT_CANCELLABLE" => Some(Self::NotCancellable),
+                _ => None,
+            }
+        }
+    }
+}
 /// Options for CommandGetSqlInfo.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -574,6 +906,49 @@ pub enum SqlInfo {
     /// - false: if read-write
     /// - true: if read only
     FlightSqlServerReadOnly = 3,
+    ///
+    /// Retrieves a boolean value indicating whether the Flight SQL Server supports executing
+    /// SQL queries.
+    ///
+    /// Note that the absence of this info (as opposed to a false value) does not necessarily
+    /// mean that SQL is not supported, as this property was not originally defined.
+    FlightSqlServerSql = 4,
+    ///
+    /// Retrieves a boolean value indicating whether the Flight SQL Server supports executing
+    /// Substrait plans.
+    FlightSqlServerSubstrait = 5,
+    ///
+    /// Retrieves a string value indicating the minimum supported Substrait version, or null
+    /// if Substrait is not supported.
+    FlightSqlServerSubstraitMinVersion = 6,
+    ///
+    /// Retrieves a string value indicating the maximum supported Substrait version, or null
+    /// if Substrait is not supported.
+    FlightSqlServerSubstraitMaxVersion = 7,
+    ///
+    /// Retrieves an int32 indicating whether the Flight SQL Server supports the
+    /// BeginTransaction/EndTransaction/BeginSavepoint/EndSavepoint actions.
+    ///
+    /// Even if this is not supported, the database may still support explicit "BEGIN
+    /// TRANSACTION"/"COMMIT" SQL statements (see SQL_TRANSACTIONS_SUPPORTED); this property
+    /// is only about whether the server implements the Flight SQL API endpoints.
+    ///
+    /// The possible values are listed in `SqlSupportedTransaction`.
+    FlightSqlServerTransaction = 8,
+    ///
+    /// Retrieves a boolean value indicating whether the Flight SQL Server supports explicit
+    /// query cancellation (the CancelQuery action).
+    FlightSqlServerCancel = 9,
+    ///
+    /// Retrieves an int32 indicating the timeout (in milliseconds) for prepared statement handles.
+    ///
+    /// If 0, there is no timeout.  Servers should reset the timeout when the handle is used in a command.
+    FlightSqlServerStatementTimeout = 100,
+    ///
+    /// Retrieves an int32 indicating the timeout (in milliseconds) for transactions, since transactions are not tied to a connection.
+    ///
+    /// If 0, there is no timeout.  Servers should reset the timeout when the handle is used in a command.
+    FlightSqlServerTransactionTimeout = 101,
     ///
     /// Retrieves a boolean value indicating whether the Flight SQL Server supports CREATE and DROP of catalogs.
     ///
@@ -1125,6 +1500,22 @@ impl SqlInfo {
             SqlInfo::FlightSqlServerVersion => "FLIGHT_SQL_SERVER_VERSION",
             SqlInfo::FlightSqlServerArrowVersion => "FLIGHT_SQL_SERVER_ARROW_VERSION",
             SqlInfo::FlightSqlServerReadOnly => "FLIGHT_SQL_SERVER_READ_ONLY",
+            SqlInfo::FlightSqlServerSql => "FLIGHT_SQL_SERVER_SQL",
+            SqlInfo::FlightSqlServerSubstrait => "FLIGHT_SQL_SERVER_SUBSTRAIT",
+            SqlInfo::FlightSqlServerSubstraitMinVersion => {
+                "FLIGHT_SQL_SERVER_SUBSTRAIT_MIN_VERSION"
+            }
+            SqlInfo::FlightSqlServerSubstraitMaxVersion => {
+                "FLIGHT_SQL_SERVER_SUBSTRAIT_MAX_VERSION"
+            }
+            SqlInfo::FlightSqlServerTransaction => "FLIGHT_SQL_SERVER_TRANSACTION",
+            SqlInfo::FlightSqlServerCancel => "FLIGHT_SQL_SERVER_CANCEL",
+            SqlInfo::FlightSqlServerStatementTimeout => {
+                "FLIGHT_SQL_SERVER_STATEMENT_TIMEOUT"
+            }
+            SqlInfo::FlightSqlServerTransactionTimeout => {
+                "FLIGHT_SQL_SERVER_TRANSACTION_TIMEOUT"
+            }
             SqlInfo::SqlDdlCatalog => "SQL_DDL_CATALOG",
             SqlInfo::SqlDdlSchema => "SQL_DDL_SCHEMA",
             SqlInfo::SqlDdlTable => "SQL_DDL_TABLE",
@@ -1241,6 +1632,22 @@ impl SqlInfo {
             "FLIGHT_SQL_SERVER_VERSION" => Some(Self::FlightSqlServerVersion),
             "FLIGHT_SQL_SERVER_ARROW_VERSION" => Some(Self::FlightSqlServerArrowVersion),
             "FLIGHT_SQL_SERVER_READ_ONLY" => Some(Self::FlightSqlServerReadOnly),
+            "FLIGHT_SQL_SERVER_SQL" => Some(Self::FlightSqlServerSql),
+            "FLIGHT_SQL_SERVER_SUBSTRAIT" => Some(Self::FlightSqlServerSubstrait),
+            "FLIGHT_SQL_SERVER_SUBSTRAIT_MIN_VERSION" => {
+                Some(Self::FlightSqlServerSubstraitMinVersion)
+            }
+            "FLIGHT_SQL_SERVER_SUBSTRAIT_MAX_VERSION" => {
+                Some(Self::FlightSqlServerSubstraitMaxVersion)
+            }
+            "FLIGHT_SQL_SERVER_TRANSACTION" => Some(Self::FlightSqlServerTransaction),
+            "FLIGHT_SQL_SERVER_CANCEL" => Some(Self::FlightSqlServerCancel),
+            "FLIGHT_SQL_SERVER_STATEMENT_TIMEOUT" => {
+                Some(Self::FlightSqlServerStatementTimeout)
+            }
+            "FLIGHT_SQL_SERVER_TRANSACTION_TIMEOUT" => {
+                Some(Self::FlightSqlServerTransactionTimeout)
+            }
             "SQL_DDL_CATALOG" => Some(Self::SqlDdlCatalog),
             "SQL_DDL_SCHEMA" => Some(Self::SqlDdlSchema),
             "SQL_DDL_TABLE" => Some(Self::SqlDdlTable),
@@ -1350,6 +1757,43 @@ impl SqlInfo {
             "SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED" => {
                 Some(Self::SqlStoredFunctionsUsingCallSyntaxSupported)
             }
+            _ => None,
+        }
+    }
+}
+/// The level of support for Flight SQL transaction RPCs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SqlSupportedTransaction {
+    /// Unknown/not indicated/no support
+    None = 0,
+    /// Transactions, but not savepoints.
+    /// A savepoint is a mark within a transaction that can be individually
+    /// rolled back to. Not all databases support savepoints.
+    Transaction = 1,
+    /// Transactions and savepoints
+    Savepoint = 2,
+}
+impl SqlSupportedTransaction {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SqlSupportedTransaction::None => "SQL_SUPPORTED_TRANSACTION_NONE",
+            SqlSupportedTransaction::Transaction => {
+                "SQL_SUPPORTED_TRANSACTION_TRANSACTION"
+            }
+            SqlSupportedTransaction::Savepoint => "SQL_SUPPORTED_TRANSACTION_SAVEPOINT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SQL_SUPPORTED_TRANSACTION_NONE" => Some(Self::None),
+            "SQL_SUPPORTED_TRANSACTION_TRANSACTION" => Some(Self::Transaction),
+            "SQL_SUPPORTED_TRANSACTION_SAVEPOINT" => Some(Self::Savepoint),
             _ => None,
         }
     }

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -116,8 +116,15 @@ impl FlightSqlServiceClient<Channel> {
     }
 
     /// Execute a query on the server.
-    pub async fn execute(&mut self, query: String) -> Result<FlightInfo, ArrowError> {
-        let cmd = CommandStatementQuery { query };
+    pub async fn execute(
+        &mut self,
+        query: String,
+        transaction_id: Option<Bytes>,
+    ) -> Result<FlightInfo, ArrowError> {
+        let cmd = CommandStatementQuery {
+            query,
+            transaction_id,
+        };
         self.get_flight_info_for_command(cmd).await
     }
 
@@ -170,8 +177,15 @@ impl FlightSqlServiceClient<Channel> {
     }
 
     /// Execute a update query on the server, and return the number of records affected
-    pub async fn execute_update(&mut self, query: String) -> Result<i64, ArrowError> {
-        let cmd = CommandStatementUpdate { query };
+    pub async fn execute_update(
+        &mut self,
+        query: String,
+        transaction_id: Option<Bytes>,
+    ) -> Result<i64, ArrowError> {
+        let cmd = CommandStatementUpdate {
+            query,
+            transaction_id,
+        };
         let descriptor = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
         let req = self.set_request_headers(
             stream::iter(vec![FlightData {
@@ -325,8 +339,12 @@ impl FlightSqlServiceClient<Channel> {
     pub async fn prepare(
         &mut self,
         query: String,
+        transaction_id: Option<Bytes>,
     ) -> Result<PreparedStatement<Channel>, ArrowError> {
-        let cmd = ActionCreatePreparedStatementRequest { query };
+        let cmd = ActionCreatePreparedStatementRequest {
+            query,
+            transaction_id,
+        };
         let action = Action {
             r#type: CREATE_PREPARED_STATEMENT.to_string(),
             body: cmd.as_any().encode_to_vec().into(),

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -46,9 +46,18 @@ mod gen {
     include!("arrow.flight.protocol.sql.rs");
 }
 
+pub use gen::ActionBeginSavepointRequest;
+pub use gen::ActionBeginSavepointResult;
+pub use gen::ActionBeginTransactionRequest;
+pub use gen::ActionBeginTransactionResult;
+pub use gen::ActionCancelQueryRequest;
+pub use gen::ActionCancelQueryResult;
 pub use gen::ActionClosePreparedStatementRequest;
 pub use gen::ActionCreatePreparedStatementRequest;
 pub use gen::ActionCreatePreparedStatementResult;
+pub use gen::ActionCreatePreparedSubstraitPlanRequest;
+pub use gen::ActionEndSavepointRequest;
+pub use gen::ActionEndTransactionRequest;
 pub use gen::CommandGetCatalogs;
 pub use gen::CommandGetCrossReference;
 pub use gen::CommandGetDbSchemas;
@@ -62,6 +71,7 @@ pub use gen::CommandGetXdbcTypeInfo;
 pub use gen::CommandPreparedStatementQuery;
 pub use gen::CommandPreparedStatementUpdate;
 pub use gen::CommandStatementQuery;
+pub use gen::CommandStatementSubstraitPlan;
 pub use gen::CommandStatementUpdate;
 pub use gen::DoPutUpdateResult;
 pub use gen::SqlInfo;
@@ -120,6 +130,7 @@ macro_rules! prost_message_ext {
                 /// # use arrow_flight::sql::{Any, CommandStatementQuery, Command};
                 /// let flightsql_message = CommandStatementQuery {
                 ///   query: "SELECT * FROM foo".to_string(),
+                ///   transaction_id: None,
                 /// };
                 ///
                 /// // Given a packed FlightSQL Any message
@@ -203,9 +214,18 @@ macro_rules! prost_message_ext {
 
 // Implement ProstMessageExt for all structs defined in FlightSql.proto
 prost_message_ext!(
+    ActionBeginSavepointRequest,
+    ActionBeginSavepointResult,
+    ActionBeginTransactionRequest,
+    ActionBeginTransactionResult,
+    ActionCancelQueryRequest,
+    ActionCancelQueryResult,
     ActionClosePreparedStatementRequest,
     ActionCreatePreparedStatementRequest,
     ActionCreatePreparedStatementResult,
+    ActionCreatePreparedSubstraitPlanRequest,
+    ActionEndSavepointRequest,
+    ActionEndTransactionRequest,
     CommandGetCatalogs,
     CommandGetCrossReference,
     CommandGetDbSchemas,
@@ -219,6 +239,7 @@ prost_message_ext!(
     CommandPreparedStatementQuery,
     CommandPreparedStatementUpdate,
     CommandStatementQuery,
+    CommandStatementSubstraitPlan,
     CommandStatementUpdate,
     DoPutUpdateResult,
     TicketStatementQuery,
@@ -296,6 +317,7 @@ mod tests {
     fn test_prost_any_pack_unpack() {
         let query = CommandStatementQuery {
             query: "select 1".to_string(),
+            transaction_id: None,
         };
         let any = Any::pack(&query).unwrap();
         assert!(any.is::<CommandStatementQuery>());
@@ -307,6 +329,7 @@ mod tests {
     fn test_command() {
         let query = CommandStatementQuery {
             query: "select 1".to_string(),
+            transaction_id: None,
         };
         let any = Any::pack(&query).unwrap();
         let cmd: Command = any.try_into().unwrap();

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -30,17 +30,28 @@ use super::{
         FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
         PutResult, SchemaResult, Ticket,
     },
+    ActionBeginSavepointRequest, ActionBeginSavepointResult,
+    ActionBeginTransactionRequest, ActionBeginTransactionResult,
+    ActionCancelQueryRequest, ActionCancelQueryResult,
     ActionClosePreparedStatementRequest, ActionCreatePreparedStatementRequest,
-    ActionCreatePreparedStatementResult, CommandGetCatalogs, CommandGetCrossReference,
-    CommandGetDbSchemas, CommandGetExportedKeys, CommandGetImportedKeys,
-    CommandGetPrimaryKeys, CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables,
-    CommandGetXdbcTypeInfo, CommandPreparedStatementQuery,
-    CommandPreparedStatementUpdate, CommandStatementQuery, CommandStatementUpdate,
-    DoPutUpdateResult, ProstMessageExt, SqlInfo, TicketStatementQuery,
+    ActionCreatePreparedStatementResult, ActionCreatePreparedSubstraitPlanRequest,
+    ActionEndSavepointRequest, ActionEndTransactionRequest, CommandGetCatalogs,
+    CommandGetCrossReference, CommandGetDbSchemas, CommandGetExportedKeys,
+    CommandGetImportedKeys, CommandGetPrimaryKeys, CommandGetSqlInfo,
+    CommandGetTableTypes, CommandGetTables, CommandGetXdbcTypeInfo,
+    CommandPreparedStatementQuery, CommandPreparedStatementUpdate, CommandStatementQuery,
+    CommandStatementSubstraitPlan, CommandStatementUpdate, DoPutUpdateResult,
+    ProstMessageExt, SqlInfo, TicketStatementQuery,
 };
 
 pub(crate) static CREATE_PREPARED_STATEMENT: &str = "CreatePreparedStatement";
 pub(crate) static CLOSE_PREPARED_STATEMENT: &str = "ClosePreparedStatement";
+pub(crate) static CREATE_PREPARED_SUBSTRAIT_PLAN: &str = "CreatePreparedSubstraitPlan";
+pub(crate) static BEGIN_TRANSACTION: &str = "BeginTransaction";
+pub(crate) static END_TRANSACTION: &str = "EndTransaction";
+pub(crate) static BEGIN_SAVEPOINT: &str = "BeginSavepoint";
+pub(crate) static END_SAVEPOINT: &str = "EndSavepoint";
+pub(crate) static CANCEL_QUERY: &str = "CancelQuery";
 
 /// Implements FlightSqlService to handle the flight sql protocol
 #[tonic::async_trait]
@@ -78,6 +89,13 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     async fn get_flight_info_statement(
         &self,
         query: CommandStatementQuery,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status>;
+
+    /// Get a FlightInfo for executing a substrait plan.
+    async fn get_flight_info_substrait_plan(
+        &self,
+        query: CommandStatementSubstraitPlan,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status>;
 
@@ -267,6 +285,13 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
         request: Request<Streaming<FlightData>>,
     ) -> Result<i64, Status>;
 
+    /// Execute a substrait plan
+    async fn do_put_substrait_plan(
+        &self,
+        query: CommandStatementSubstraitPlan,
+        request: Request<Streaming<FlightData>>,
+    ) -> Result<i64, Status>;
+
     // do_action
 
     /// Create a prepared statement from given SQL statement.
@@ -281,7 +306,49 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
         &self,
         query: ActionClosePreparedStatementRequest,
         request: Request<Action>,
-    );
+    ) -> Result<(), Status>;
+
+    /// Create a prepared substrait plan.
+    async fn do_action_create_prepared_substrait_plan(
+        &self,
+        query: ActionCreatePreparedSubstraitPlanRequest,
+        request: Request<Action>,
+    ) -> Result<ActionCreatePreparedStatementResult, Status>;
+
+    /// Begin a transaction
+    async fn do_action_begin_transaction(
+        &self,
+        query: ActionBeginTransactionRequest,
+        request: Request<Action>,
+    ) -> Result<ActionBeginTransactionResult, Status>;
+
+    /// End a transaction
+    async fn do_action_end_transaction(
+        &self,
+        query: ActionEndTransactionRequest,
+        request: Request<Action>,
+    ) -> Result<(), Status>;
+
+    /// Begin a savepoint
+    async fn do_action_begin_savepoint(
+        &self,
+        query: ActionBeginSavepointRequest,
+        request: Request<Action>,
+    ) -> Result<ActionBeginSavepointResult, Status>;
+
+    /// End a savepoint
+    async fn do_action_end_savepoint(
+        &self,
+        query: ActionEndSavepointRequest,
+        request: Request<Action>,
+    ) -> Result<(), Status>;
+
+    /// Cancel a query
+    async fn do_action_cancel_query(
+        &self,
+        query: ActionCancelQueryRequest,
+        request: Request<Action>,
+    ) -> Result<ActionCancelQueryResult, Status>;
 
     /// Register a new SqlInfo result, making it available when calling GetSqlInfo.
     async fn register_sql_info(&self, id: i32, result: &SqlInfo);
@@ -338,6 +405,9 @@ where
             Command::CommandPreparedStatementQuery(handle) => {
                 self.get_flight_info_prepared_statement(handle, request)
                     .await
+            }
+            Command::CommandStatementSubstraitPlan(handle) => {
+                self.get_flight_info_substrait_plan(handle, request).await
             }
             Command::CommandGetCatalogs(token) => {
                 self.get_flight_info_catalogs(token, request).await
@@ -450,6 +520,14 @@ where
             Command::CommandPreparedStatementQuery(command) => {
                 self.do_put_prepared_statement_query(command, request).await
             }
+            Command::CommandStatementSubstraitPlan(command) => {
+                let record_count = self.do_put_substrait_plan(command, request).await?;
+                let result = DoPutUpdateResult { record_count };
+                let output = futures::stream::iter(vec![Ok(PutResult {
+                    app_metadata: result.as_any().encode_to_vec().into(),
+                })]);
+                Ok(Response::new(Box::pin(output)))
+            }
             Command::CommandPreparedStatementUpdate(command) => {
                 let record_count = self
                     .do_put_prepared_statement_update(command, request)
@@ -485,9 +563,58 @@ where
                 Response Message: N/A"
                 .into(),
         };
+        let create_prepared_substrait_plan_action_type = ActionType {
+            r#type: CREATE_PREPARED_SUBSTRAIT_PLAN.to_string(),
+            description:
+                "Creates a reusable prepared substrait plan resource on the server.\n
+                Request Message: ActionCreatePreparedSubstraitPlanRequest\n
+                Response Message: ActionCreatePreparedStatementResult"
+                    .into(),
+        };
+        let begin_transaction_action_type = ActionType {
+            r#type: BEGIN_TRANSACTION.to_string(),
+            description: "Begins a transaction.\n
+                Request Message: ActionBeginTransactionRequest\n
+                Response Message: ActionBeginTransactionResult"
+                .into(),
+        };
+        let end_transaction_action_type = ActionType {
+            r#type: END_TRANSACTION.to_string(),
+            description: "Ends a transaction\n
+                Request Message: ActionEndTransactionRequest\n
+                Response Message: N/A"
+                .into(),
+        };
+        let begin_savepoint_action_type = ActionType {
+            r#type: BEGIN_SAVEPOINT.to_string(),
+            description: "Begins a savepoint.\n
+                Request Message: ActionBeginSavepointRequest\n
+                Response Message: ActionBeginSavepointResult"
+                .into(),
+        };
+        let end_savepoint_action_type = ActionType {
+            r#type: END_SAVEPOINT.to_string(),
+            description: "Ends a savepoint\n
+                Request Message: ActionEndSavepointRequest\n
+                Response Message: N/A"
+                .into(),
+        };
+        let cancel_query_action_type = ActionType {
+            r#type: CANCEL_QUERY.to_string(),
+            description: "Cancels a query\n
+                Request Message: ActionCancelQueryRequest\n
+                Response Message: ActionCancelQueryResult"
+                .into(),
+        };
         let actions: Vec<Result<ActionType, Status>> = vec![
             Ok(create_prepared_statement_action_type),
             Ok(close_prepared_statement_action_type),
+            Ok(create_prepared_substrait_plan_action_type),
+            Ok(begin_transaction_action_type),
+            Ok(end_transaction_action_type),
+            Ok(begin_savepoint_action_type),
+            Ok(end_savepoint_action_type),
+            Ok(cancel_query_action_type),
         ];
         let output = futures::stream::iter(actions);
         Ok(Response::new(Box::pin(output) as Self::ListActionsStream))
@@ -529,8 +656,107 @@ where
                         "Unable to unpack ActionClosePreparedStatementRequest.",
                     )
                 })?;
-            self.do_action_close_prepared_statement(cmd, request).await;
+            self.do_action_close_prepared_statement(cmd, request)
+                .await?;
             return Ok(Response::new(Box::pin(futures::stream::empty())));
+        }
+        if request.get_ref().r#type == CREATE_PREPARED_SUBSTRAIT_PLAN {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionCreatePreparedSubstraitPlanRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument(
+                        "Unable to unpack ActionCreatePreparedSubstraitPlanRequest.",
+                    )
+                })?;
+            self.do_action_create_prepared_substrait_plan(cmd, request)
+                .await?;
+            return Ok(Response::new(Box::pin(futures::stream::empty())));
+        }
+        if request.get_ref().r#type == BEGIN_TRANSACTION {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionBeginTransactionRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument(
+                        "Unable to unpack ActionBeginTransactionRequest.",
+                    )
+                })?;
+            let stmt = self.do_action_begin_transaction(cmd, request).await?;
+            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+                body: stmt.as_any().encode_to_vec().into(),
+            })]);
+            return Ok(Response::new(Box::pin(output)));
+        }
+        if request.get_ref().r#type == END_TRANSACTION {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionEndTransactionRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument(
+                        "Unable to unpack ActionEndTransactionRequest.",
+                    )
+                })?;
+            self.do_action_end_transaction(cmd, request).await?;
+            return Ok(Response::new(Box::pin(futures::stream::empty())));
+        }
+        if request.get_ref().r#type == BEGIN_SAVEPOINT {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionBeginSavepointRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument(
+                        "Unable to unpack ActionBeginSavepointRequest.",
+                    )
+                })?;
+            let stmt = self.do_action_begin_savepoint(cmd, request).await?;
+            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+                body: stmt.as_any().encode_to_vec().into(),
+            })]);
+            return Ok(Response::new(Box::pin(output)));
+        }
+        if request.get_ref().r#type == END_SAVEPOINT {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionEndSavepointRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument(
+                        "Unable to unpack ActionEndSavepointRequest.",
+                    )
+                })?;
+            self.do_action_end_savepoint(cmd, request).await?;
+            return Ok(Response::new(Box::pin(futures::stream::empty())));
+        }
+        if request.get_ref().r#type == CANCEL_QUERY {
+            let any =
+                Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
+
+            let cmd: ActionCancelQueryRequest = any
+                .unpack()
+                .map_err(arrow_error_to_status)?
+                .ok_or_else(|| {
+                    Status::invalid_argument("Unable to unpack ActionCancelQueryRequest.")
+                })?;
+            let stmt = self.do_action_cancel_query(cmd, request).await?;
+            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+                body: stmt.as_any().encode_to_vec().into(),
+            })]);
+            return Ok(Response::new(Box::pin(output)));
         }
 
         Err(Status::invalid_argument(format!(

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -643,8 +643,7 @@ where
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
-        }
-        if request.get_ref().r#type == CLOSE_PREPARED_STATEMENT {
+        } else if request.get_ref().r#type == CLOSE_PREPARED_STATEMENT {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -659,8 +658,7 @@ where
             self.do_action_close_prepared_statement(cmd, request)
                 .await?;
             return Ok(Response::new(Box::pin(futures::stream::empty())));
-        }
-        if request.get_ref().r#type == CREATE_PREPARED_SUBSTRAIT_PLAN {
+        } else if request.get_ref().r#type == CREATE_PREPARED_SUBSTRAIT_PLAN {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -675,8 +673,7 @@ where
             self.do_action_create_prepared_substrait_plan(cmd, request)
                 .await?;
             return Ok(Response::new(Box::pin(futures::stream::empty())));
-        }
-        if request.get_ref().r#type == BEGIN_TRANSACTION {
+        } else if request.get_ref().r#type == BEGIN_TRANSACTION {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -693,8 +690,7 @@ where
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
-        }
-        if request.get_ref().r#type == END_TRANSACTION {
+        } else if request.get_ref().r#type == END_TRANSACTION {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -708,8 +704,7 @@ where
                 })?;
             self.do_action_end_transaction(cmd, request).await?;
             return Ok(Response::new(Box::pin(futures::stream::empty())));
-        }
-        if request.get_ref().r#type == BEGIN_SAVEPOINT {
+        } else if request.get_ref().r#type == BEGIN_SAVEPOINT {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -726,8 +721,7 @@ where
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
-        }
-        if request.get_ref().r#type == END_SAVEPOINT {
+        } else if request.get_ref().r#type == END_SAVEPOINT {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 
@@ -741,8 +735,7 @@ where
                 })?;
             self.do_action_end_savepoint(cmd, request).await?;
             return Ok(Response::new(Box::pin(futures::stream::empty())));
-        }
-        if request.get_ref().r#type == CANCEL_QUERY {
+        } else if request.get_ref().r#type == CANCEL_QUERY {
             let any =
                 Any::decode(&*request.get_ref().body).map_err(decode_error_to_status)?;
 

--- a/arrow-flight/tests/client.rs
+++ b/arrow-flight/tests/client.rs
@@ -104,6 +104,7 @@ fn test_flight_info(request: &FlightDescriptor) -> FlightInfo {
         flight_descriptor: Some(request.clone()),
         total_bytes: 123,
         total_records: 456,
+        ordered: false,
     }
 }
 

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -21,13 +21,17 @@ use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray};
 use arrow_flight::{
     flight_service_server::{FlightService, FlightServiceServer},
     sql::{
-        server::FlightSqlService, ActionClosePreparedStatementRequest,
-        ActionCreatePreparedStatementRequest, ActionCreatePreparedStatementResult, Any,
-        CommandGetCatalogs, CommandGetCrossReference, CommandGetDbSchemas,
-        CommandGetExportedKeys, CommandGetImportedKeys, CommandGetPrimaryKeys,
-        CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables,
-        CommandGetXdbcTypeInfo, CommandPreparedStatementQuery,
-        CommandPreparedStatementUpdate, CommandStatementQuery, CommandStatementUpdate,
+        server::FlightSqlService, ActionBeginSavepointRequest,
+        ActionBeginSavepointResult, ActionBeginTransactionRequest,
+        ActionBeginTransactionResult, ActionCancelQueryRequest, ActionCancelQueryResult,
+        ActionClosePreparedStatementRequest, ActionCreatePreparedStatementRequest,
+        ActionCreatePreparedStatementResult, ActionCreatePreparedSubstraitPlanRequest,
+        ActionEndSavepointRequest, ActionEndTransactionRequest, Any, CommandGetCatalogs,
+        CommandGetCrossReference, CommandGetDbSchemas, CommandGetExportedKeys,
+        CommandGetImportedKeys, CommandGetPrimaryKeys, CommandGetSqlInfo,
+        CommandGetTableTypes, CommandGetTables, CommandGetXdbcTypeInfo,
+        CommandPreparedStatementQuery, CommandPreparedStatementUpdate,
+        CommandStatementQuery, CommandStatementSubstraitPlan, CommandStatementUpdate,
         ProstMessageExt, SqlInfo, TicketStatementQuery,
     },
     utils::batches_to_flight_data,
@@ -197,6 +201,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
             ],
             total_records: batch.num_rows() as i64,
             total_bytes: batch.get_array_memory_size() as i64,
+            ordered: false,
         };
         let resp = Response::new(info);
         Ok(resp)
@@ -209,6 +214,16 @@ impl FlightSqlService for FlightSqlServiceImpl {
     ) -> Result<Response<FlightInfo>, Status> {
         Err(Status::unimplemented(
             "get_flight_info_prepared_statement not implemented",
+        ))
+    }
+
+    async fn get_flight_info_substrait_plan(
+        &self,
+        _query: CommandStatementSubstraitPlan,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
+        Err(Status::unimplemented(
+            "get_flight_info_substrait_plan not implemented",
         ))
     }
 
@@ -430,6 +445,16 @@ impl FlightSqlService for FlightSqlServiceImpl {
         ))
     }
 
+    async fn do_put_substrait_plan(
+        &self,
+        _ticket: CommandStatementSubstraitPlan,
+        _request: Request<Streaming<FlightData>>,
+    ) -> Result<i64, Status> {
+        Err(Status::unimplemented(
+            "do_put_substrait_plan not implemented",
+        ))
+    }
+
     async fn do_put_prepared_statement_query(
         &self,
         _query: CommandPreparedStatementQuery,
@@ -464,7 +489,56 @@ impl FlightSqlService for FlightSqlServiceImpl {
         &self,
         _query: ActionClosePreparedStatementRequest,
         _request: Request<Action>,
-    ) {
+    ) -> Result<(), Status> {
+        unimplemented!("Implement do_action_close_prepared_statement")
+    }
+
+    async fn do_action_create_prepared_substrait_plan(
+        &self,
+        _query: ActionCreatePreparedSubstraitPlanRequest,
+        _request: Request<Action>,
+    ) -> Result<ActionCreatePreparedStatementResult, Status> {
+        unimplemented!("Implement do_action_create_prepared_substrait_plan")
+    }
+
+    async fn do_action_begin_transaction(
+        &self,
+        _query: ActionBeginTransactionRequest,
+        _request: Request<Action>,
+    ) -> Result<ActionBeginTransactionResult, Status> {
+        unimplemented!("Implement do_action_begin_transaction")
+    }
+
+    async fn do_action_end_transaction(
+        &self,
+        _query: ActionEndTransactionRequest,
+        _request: Request<Action>,
+    ) -> Result<(), Status> {
+        unimplemented!("Implement do_action_end_transaction")
+    }
+
+    async fn do_action_begin_savepoint(
+        &self,
+        _query: ActionBeginSavepointRequest,
+        _request: Request<Action>,
+    ) -> Result<ActionBeginSavepointResult, Status> {
+        unimplemented!("Implement do_action_begin_savepoint")
+    }
+
+    async fn do_action_end_savepoint(
+        &self,
+        _query: ActionEndSavepointRequest,
+        _request: Request<Action>,
+    ) -> Result<(), Status> {
+        unimplemented!("Implement do_action_end_savepoint")
+    }
+
+    async fn do_action_cancel_query(
+        &self,
+        _query: ActionCancelQueryRequest,
+        _request: Request<Action>,
+    ) -> Result<ActionCancelQueryResult, Status> {
+        unimplemented!("Implement do_action_cancel_query")
     }
 
     async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -200,6 +200,7 @@ impl FlightService for FlightServiceImpl {
                     endpoint: vec![endpoint],
                     total_records: total_records as i64,
                     total_bytes: -1,
+                    ordered: false,
                 };
 
                 Ok(Response::new(info))

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -16,347 +16,365 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
+ syntax = "proto3";
 
-option java_package = "org.apache.arrow.flight.impl";
-option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
-option csharp_namespace = "Apache.Arrow.Flight.Protocol";
-
-package arrow.flight.protocol;
-
-/*
- * A flight service is an endpoint for retrieving or storing Arrow data. A
- * flight service can expose one or more predefined endpoints that can be
- * accessed using the Arrow Flight Protocol. Additionally, a flight service
- * can expose a set of actions that are available.
- */
-service FlightService {
-
-  /*
-   * Handshake between client and server. Depending on the server, the
-   * handshake may be required to determine the token that should be used for
-   * future operations. Both request and response are streams to allow multiple
-   * round-trips depending on auth mechanism.
-   */
-  rpc Handshake(stream HandshakeRequest) returns (stream HandshakeResponse) {}
-
-  /*
-   * Get a list of available streams given a particular criteria. Most flight
-   * services will expose one or more streams that are readily available for
-   * retrieval. This api allows listing the streams available for
-   * consumption. A user can also provide a criteria. The criteria can limit
-   * the subset of streams that can be listed via this interface. Each flight
-   * service allows its own definition of how to consume criteria.
-   */
-  rpc ListFlights(Criteria) returns (stream FlightInfo) {}
-
-  /*
-   * For a given FlightDescriptor, get information about how the flight can be
-   * consumed. This is a useful interface if the consumer of the interface
-   * already can identify the specific flight to consume. This interface can
-   * also allow a consumer to generate a flight stream through a specified
-   * descriptor. For example, a flight descriptor might be something that
-   * includes a SQL statement or a Pickled Python operation that will be
-   * executed. In those cases, the descriptor will not be previously available
-   * within the list of available streams provided by ListFlights but will be
-   * available for consumption for the duration defined by the specific flight
-   * service.
-   */
-  rpc GetFlightInfo(FlightDescriptor) returns (FlightInfo) {}
-
-  /*
-   * For a given FlightDescriptor, get the Schema as described in Schema.fbs::Schema
-   * This is used when a consumer needs the Schema of flight stream. Similar to
-   * GetFlightInfo this interface may generate a new flight that was not previously
-   * available in ListFlights.
-   */
-   rpc GetSchema(FlightDescriptor) returns (SchemaResult) {}
-
-  /*
-   * Retrieve a single stream associated with a particular descriptor
-   * associated with the referenced ticket. A Flight can be composed of one or
-   * more streams where each stream can be retrieved using a separate opaque
-   * ticket that the flight service uses for managing a collection of streams.
-   */
-  rpc DoGet(Ticket) returns (stream FlightData) {}
-
-  /*
-   * Push a stream to the flight service associated with a particular
-   * flight stream. This allows a client of a flight service to upload a stream
-   * of data. Depending on the particular flight service, a client consumer
-   * could be allowed to upload a single stream per descriptor or an unlimited
-   * number. In the latter, the service might implement a 'seal' action that
-   * can be applied to a descriptor once all streams are uploaded.
-   */
-  rpc DoPut(stream FlightData) returns (stream PutResult) {}
-
-  /*
-   * Open a bidirectional data channel for a given descriptor. This
-   * allows clients to send and receive arbitrary Arrow data and
-   * application-specific metadata in a single logical stream. In
-   * contrast to DoGet/DoPut, this is more suited for clients
-   * offloading computation (rather than storage) to a Flight service.
-   */
-  rpc DoExchange(stream FlightData) returns (stream FlightData) {}
-
-  /*
-   * Flight services can support an arbitrary number of simple actions in
-   * addition to the possible ListFlights, GetFlightInfo, DoGet, DoPut
-   * operations that are potentially available. DoAction allows a flight client
-   * to do a specific action against a flight service. An action includes
-   * opaque request and response objects that are specific to the type action
-   * being undertaken.
-   */
-  rpc DoAction(Action) returns (stream Result) {}
-
-  /*
-   * A flight service exposes all of the available action types that it has
-   * along with descriptions. This allows different flight consumers to
-   * understand the capabilities of the flight service.
-   */
-  rpc ListActions(Empty) returns (stream ActionType) {}
-
-}
-
-/*
- * The request that a client provides to a server on handshake.
- */
-message HandshakeRequest {
-
-  /*
-   * A defined protocol version
-   */
-  uint64 protocol_version = 1;
-
-  /*
-   * Arbitrary auth/handshake info.
-   */
-  bytes payload = 2;
-}
-
-message HandshakeResponse {
-
-  /*
-   * A defined protocol version
-   */
-  uint64 protocol_version = 1;
-
-  /*
-   * Arbitrary auth/handshake info.
-   */
-  bytes payload = 2;
-}
-
-/*
- * A message for doing simple auth.
- */
-message BasicAuth {
-  string username = 2;
-  string password = 3;
-}
-
-message Empty {}
-
-/*
- * Describes an available action, including both the name used for execution
- * along with a short description of the purpose of the action.
- */
-message ActionType {
-  string type = 1;
-  string description = 2;
-}
-
-/*
- * A service specific expression that can be used to return a limited set
- * of available Arrow Flight streams.
- */
-message Criteria {
-  bytes expression = 1;
-}
-
-/*
- * An opaque action specific for the service.
- */
-message Action {
-  string type = 1;
-  bytes body = 2;
-}
-
-/*
- * An opaque result returned after executing an action.
- */
-message Result {
-  bytes body = 1;
-}
-
-/*
- * Wrap the result of a getSchema call
- */
-message SchemaResult {
-  // The schema of the dataset in its IPC form:
-  //   4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
-  //   4 bytes - the byte length of the payload
-  //   a flatbuffer Message whose header is the Schema
-  bytes schema = 1;
-}
-
-/*
- * The name or tag for a Flight. May be used as a way to retrieve or generate
- * a flight or be used to expose a set of previously defined flights.
- */
-message FlightDescriptor {
-
-  /*
-   * Describes what type of descriptor is defined.
-   */
-  enum DescriptorType {
-
-    // Protobuf pattern, not used.
-    UNKNOWN = 0;
-
-    /*
-     * A named path that identifies a dataset. A path is composed of a string
-     * or list of strings describing a particular dataset. This is conceptually
-     *  similar to a path inside a filesystem.
-     */
-    PATH = 1;
-
-    /*
-     * An opaque command to generate a dataset.
-     */
-    CMD = 2;
-  }
-
-  DescriptorType type = 1;
-
-  /*
-   * Opaque value used to express a command. Should only be defined when
-   * type = CMD.
-   */
-  bytes cmd = 2;
-
-  /*
-   * List of strings identifying a particular dataset. Should only be defined
-   * when type = PATH.
-   */
-  repeated string path = 3;
-}
-
-/*
- * The access coordinates for retrieval of a dataset. With a FlightInfo, a
- * consumer is able to determine how to retrieve a dataset.
- */
-message FlightInfo {
-  // The schema of the dataset in its IPC form:
-  //   4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
-  //   4 bytes - the byte length of the payload
-  //   a flatbuffer Message whose header is the Schema
-  bytes schema = 1;
-
-  /*
-   * The descriptor associated with this info.
-   */
-  FlightDescriptor flight_descriptor = 2;
-
-  /*
-   * A list of endpoints associated with the flight. To consume the
-   * whole flight, all endpoints (and hence all Tickets) must be
-   * consumed. Endpoints can be consumed in any order.
-   *
-   * In other words, an application can use multiple endpoints to
-   * represent partitioned data.
-   *
-   * There is no ordering defined on endpoints. Hence, if the returned
-   * data has an ordering, it should be returned in a single endpoint.
-   */
-  repeated FlightEndpoint endpoint = 3;
-
-  // Set these to -1 if unknown.
-  int64 total_records = 4;
-  int64 total_bytes = 5;
-}
-
-/*
- * A particular stream or split associated with a flight.
- */
-message FlightEndpoint {
-
-  /*
-   * Token used to retrieve this stream.
-   */
-  Ticket ticket = 1;
-
-  /*
-   * A list of URIs where this ticket can be redeemed via DoGet().
-   *
-   * If the list is empty, the expectation is that the ticket can only
-   * be redeemed on the current service where the ticket was
-   * generated.
-   *
-   * If the list is not empty, the expectation is that the ticket can
-   * be redeemed at any of the locations, and that the data returned
-   * will be equivalent. In this case, the ticket may only be redeemed
-   * at one of the given locations, and not (necessarily) on the
-   * current service.
-   *
-   * In other words, an application can use multiple locations to
-   * represent redundant and/or load balanced services.
-   */
-  repeated Location location = 2;
-}
-
-/*
- * A location where a Flight service will accept retrieval of a particular
- * stream given a ticket.
- */
-message Location {
-  string uri = 1;
-}
-
-/*
- * An opaque identifier that the service can use to retrieve a particular
- * portion of a stream.
- *
- * Tickets are meant to be single use. It is an error/application-defined
- * behavior to reuse a ticket.
- */
-message Ticket {
-  bytes ticket = 1;
-}
-
-/*
- * A batch of Arrow data as part of a stream of batches.
- */
-message FlightData {
-
-  /*
-   * The descriptor of the data. This is only relevant when a client is
-   * starting a new DoPut stream.
-   */
-  FlightDescriptor flight_descriptor = 1;
-
-  /*
-   * Header for message data as described in Message.fbs::Message.
-   */
-  bytes data_header = 2;
-
-  /*
-   * Application-defined metadata.
-   */
-  bytes app_metadata = 3;
-
-  /*
-   * The actual batch of Arrow data. Preferably handled with minimal-copies
-   * coming last in the definition to help with sidecar patterns (it is
-   * expected that some implementations will fetch this field off the wire
-   * with specialized code to avoid extra memory copies).
-   */
-  bytes data_body = 1000;
-}
-
-/**
- * The response message associated with the submission of a DoPut.
- */
-message PutResult {
-  bytes app_metadata = 1;
-}
+ option java_package = "org.apache.arrow.flight.impl";
+ option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
+ option csharp_namespace = "Apache.Arrow.Flight.Protocol";
+ 
+ package arrow.flight.protocol;
+ 
+ /*
+  * A flight service is an endpoint for retrieving or storing Arrow data. A
+  * flight service can expose one or more predefined endpoints that can be
+  * accessed using the Arrow Flight Protocol. Additionally, a flight service
+  * can expose a set of actions that are available.
+  */
+ service FlightService {
+ 
+   /*
+    * Handshake between client and server. Depending on the server, the
+    * handshake may be required to determine the token that should be used for
+    * future operations. Both request and response are streams to allow multiple
+    * round-trips depending on auth mechanism.
+    */
+   rpc Handshake(stream HandshakeRequest) returns (stream HandshakeResponse) {}
+ 
+   /*
+    * Get a list of available streams given a particular criteria. Most flight
+    * services will expose one or more streams that are readily available for
+    * retrieval. This api allows listing the streams available for
+    * consumption. A user can also provide a criteria. The criteria can limit
+    * the subset of streams that can be listed via this interface. Each flight
+    * service allows its own definition of how to consume criteria.
+    */
+   rpc ListFlights(Criteria) returns (stream FlightInfo) {}
+ 
+   /*
+    * For a given FlightDescriptor, get information about how the flight can be
+    * consumed. This is a useful interface if the consumer of the interface
+    * already can identify the specific flight to consume. This interface can
+    * also allow a consumer to generate a flight stream through a specified
+    * descriptor. For example, a flight descriptor might be something that
+    * includes a SQL statement or a Pickled Python operation that will be
+    * executed. In those cases, the descriptor will not be previously available
+    * within the list of available streams provided by ListFlights but will be
+    * available for consumption for the duration defined by the specific flight
+    * service.
+    */
+   rpc GetFlightInfo(FlightDescriptor) returns (FlightInfo) {}
+ 
+   /*
+    * For a given FlightDescriptor, get the Schema as described in Schema.fbs::Schema
+    * This is used when a consumer needs the Schema of flight stream. Similar to
+    * GetFlightInfo this interface may generate a new flight that was not previously
+    * available in ListFlights.
+    */
+    rpc GetSchema(FlightDescriptor) returns (SchemaResult) {}
+ 
+   /*
+    * Retrieve a single stream associated with a particular descriptor
+    * associated with the referenced ticket. A Flight can be composed of one or
+    * more streams where each stream can be retrieved using a separate opaque
+    * ticket that the flight service uses for managing a collection of streams.
+    */
+   rpc DoGet(Ticket) returns (stream FlightData) {}
+ 
+   /*
+    * Push a stream to the flight service associated with a particular
+    * flight stream. This allows a client of a flight service to upload a stream
+    * of data. Depending on the particular flight service, a client consumer
+    * could be allowed to upload a single stream per descriptor or an unlimited
+    * number. In the latter, the service might implement a 'seal' action that
+    * can be applied to a descriptor once all streams are uploaded.
+    */
+   rpc DoPut(stream FlightData) returns (stream PutResult) {}
+ 
+   /*
+    * Open a bidirectional data channel for a given descriptor. This
+    * allows clients to send and receive arbitrary Arrow data and
+    * application-specific metadata in a single logical stream. In
+    * contrast to DoGet/DoPut, this is more suited for clients
+    * offloading computation (rather than storage) to a Flight service.
+    */
+   rpc DoExchange(stream FlightData) returns (stream FlightData) {}
+ 
+   /*
+    * Flight services can support an arbitrary number of simple actions in
+    * addition to the possible ListFlights, GetFlightInfo, DoGet, DoPut
+    * operations that are potentially available. DoAction allows a flight client
+    * to do a specific action against a flight service. An action includes
+    * opaque request and response objects that are specific to the type action
+    * being undertaken.
+    */
+   rpc DoAction(Action) returns (stream Result) {}
+ 
+   /*
+    * A flight service exposes all of the available action types that it has
+    * along with descriptions. This allows different flight consumers to
+    * understand the capabilities of the flight service.
+    */
+   rpc ListActions(Empty) returns (stream ActionType) {}
+ 
+ }
+ 
+ /*
+  * The request that a client provides to a server on handshake.
+  */
+ message HandshakeRequest {
+ 
+   /*
+    * A defined protocol version
+    */
+   uint64 protocol_version = 1;
+ 
+   /*
+    * Arbitrary auth/handshake info.
+    */
+   bytes payload = 2;
+ }
+ 
+ message HandshakeResponse {
+ 
+   /*
+    * A defined protocol version
+    */
+   uint64 protocol_version = 1;
+ 
+   /*
+    * Arbitrary auth/handshake info.
+    */
+   bytes payload = 2;
+ }
+ 
+ /*
+  * A message for doing simple auth.
+  */
+ message BasicAuth {
+   string username = 2;
+   string password = 3;
+ }
+ 
+ message Empty {}
+ 
+ /*
+  * Describes an available action, including both the name used for execution
+  * along with a short description of the purpose of the action.
+  */
+ message ActionType {
+   string type = 1;
+   string description = 2;
+ }
+ 
+ /*
+  * A service specific expression that can be used to return a limited set
+  * of available Arrow Flight streams.
+  */
+ message Criteria {
+   bytes expression = 1;
+ }
+ 
+ /*
+  * An opaque action specific for the service.
+  */
+ message Action {
+   string type = 1;
+   bytes body = 2;
+ }
+ 
+ /*
+  * An opaque result returned after executing an action.
+  */
+ message Result {
+   bytes body = 1;
+ }
+ 
+ /*
+  * Wrap the result of a getSchema call
+  */
+ message SchemaResult {
+   // The schema of the dataset in its IPC form:
+   //   4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
+   //   4 bytes - the byte length of the payload
+   //   a flatbuffer Message whose header is the Schema
+   bytes schema = 1;
+ }
+ 
+ /*
+  * The name or tag for a Flight. May be used as a way to retrieve or generate
+  * a flight or be used to expose a set of previously defined flights.
+  */
+ message FlightDescriptor {
+ 
+   /*
+    * Describes what type of descriptor is defined.
+    */
+   enum DescriptorType {
+ 
+     // Protobuf pattern, not used.
+     UNKNOWN = 0;
+ 
+     /*
+      * A named path that identifies a dataset. A path is composed of a string
+      * or list of strings describing a particular dataset. This is conceptually
+      *  similar to a path inside a filesystem.
+      */
+     PATH = 1;
+ 
+     /*
+      * An opaque command to generate a dataset.
+      */
+     CMD = 2;
+   }
+ 
+   DescriptorType type = 1;
+ 
+   /*
+    * Opaque value used to express a command. Should only be defined when
+    * type = CMD.
+    */
+   bytes cmd = 2;
+ 
+   /*
+    * List of strings identifying a particular dataset. Should only be defined
+    * when type = PATH.
+    */
+   repeated string path = 3;
+ }
+ 
+ /*
+  * The access coordinates for retrieval of a dataset. With a FlightInfo, a
+  * consumer is able to determine how to retrieve a dataset.
+  */
+ message FlightInfo {
+   // The schema of the dataset in its IPC form:
+   //   4 bytes - an optional IPC_CONTINUATION_TOKEN prefix
+   //   4 bytes - the byte length of the payload
+   //   a flatbuffer Message whose header is the Schema
+   bytes schema = 1;
+ 
+   /*
+    * The descriptor associated with this info.
+    */
+   FlightDescriptor flight_descriptor = 2;
+ 
+   /*
+    * A list of endpoints associated with the flight. To consume the
+    * whole flight, all endpoints (and hence all Tickets) must be
+    * consumed. Endpoints can be consumed in any order.
+    *
+    * In other words, an application can use multiple endpoints to
+    * represent partitioned data.
+    *
+    * If the returned data has an ordering, an application can use
+    * "FlightInfo.ordered = true" or should return the all data in a
+    * single endpoint. Otherwise, there is no ordering defined on
+    * endpoints or the data within.
+    *
+    * A client can read ordered data by reading data from returned
+    * endpoints, in order, from front to back.
+    *
+    * Note that a client may ignore "FlightInfo.ordered = true". If an
+    * ordering is important for an application, an application must
+    * choose one of them:
+    *
+    * * An application requires that all clients must read data in
+    *   returned endpoints order.
+    * * An application must return the all data in a single endpoint.
+    */
+   repeated FlightEndpoint endpoint = 3;
+ 
+   // Set these to -1 if unknown.
+   int64 total_records = 4;
+   int64 total_bytes = 5;
+ 
+   /*
+    * FlightEndpoints are in the same order as the data.
+    */
+   bool ordered = 6;
+ }
+ 
+ /*
+  * A particular stream or split associated with a flight.
+  */
+ message FlightEndpoint {
+ 
+   /*
+    * Token used to retrieve this stream.
+    */
+   Ticket ticket = 1;
+ 
+   /*
+    * A list of URIs where this ticket can be redeemed via DoGet().
+    *
+    * If the list is empty, the expectation is that the ticket can only
+    * be redeemed on the current service where the ticket was
+    * generated.
+    *
+    * If the list is not empty, the expectation is that the ticket can
+    * be redeemed at any of the locations, and that the data returned
+    * will be equivalent. In this case, the ticket may only be redeemed
+    * at one of the given locations, and not (necessarily) on the
+    * current service.
+    *
+    * In other words, an application can use multiple locations to
+    * represent redundant and/or load balanced services.
+    */
+   repeated Location location = 2;
+ }
+ 
+ /*
+  * A location where a Flight service will accept retrieval of a particular
+  * stream given a ticket.
+  */
+ message Location {
+   string uri = 1;
+ }
+ 
+ /*
+  * An opaque identifier that the service can use to retrieve a particular
+  * portion of a stream.
+  *
+  * Tickets are meant to be single use. It is an error/application-defined
+  * behavior to reuse a ticket.
+  */
+ message Ticket {
+   bytes ticket = 1;
+ }
+ 
+ /*
+  * A batch of Arrow data as part of a stream of batches.
+  */
+ message FlightData {
+ 
+   /*
+    * The descriptor of the data. This is only relevant when a client is
+    * starting a new DoPut stream.
+    */
+   FlightDescriptor flight_descriptor = 1;
+ 
+   /*
+    * Header for message data as described in Message.fbs::Message.
+    */
+   bytes data_header = 2;
+ 
+   /*
+    * Application-defined metadata.
+    */
+   bytes app_metadata = 3;
+ 
+   /*
+    * The actual batch of Arrow data. Preferably handled with minimal-copies
+    * coming last in the definition to help with sidecar patterns (it is
+    * expected that some implementations will fetch this field off the wire
+    * with specialized code to avoid extra memory copies).
+    */
+   bytes data_body = 1000;
+ }
+ 
+ /**
+  * The response message associated with the submission of a DoPut.
+  */
+ message PutResult {
+   bytes app_metadata = 1;
+ }

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -16,1540 +16,1832 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
-import "google/protobuf/descriptor.proto";
-
-option java_package = "org.apache.arrow.flight.sql.impl";
-option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
-package arrow.flight.protocol.sql;
-
-/*
- * Represents a metadata request. Used in the command member of FlightDescriptor
- * for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  info_name: uint32 not null,
- *  value: dense_union<
- *              string_value: utf8,
- *              bool_value: bool,
- *              bigint_value: int64,
- *              int32_bitmask: int32,
- *              string_list: list<string_data: utf8>
- *              int32_to_int32_list_map: map<key: int32, value: list<$data$: int32>>
- * >
- * where there is one row per requested piece of metadata information.
- */
-message CommandGetSqlInfo {
-  option (experimental) = true;
-
-  /*
-   * Values are modelled after ODBC's SQLGetInfo() function. This information is intended to provide
-   * Flight SQL clients with basic, SQL syntax and SQL functions related information.
-   * More information types can be added in future releases.
-   * E.g. more SQL syntax support types, scalar functions support, type conversion support etc.
-   *
-   * Note that the set of metadata may expand.
-   *
-   * Initially, Flight SQL will support the following information types:
-   * - Server Information - Range [0-500)
-   * - Syntax Information - Range [500-1000)
-   * Range [0-10,000) is reserved for defaults (see SqlInfo enum for default options).
-   * Custom options should start at 10,000.
-   *
-   * If omitted, then all metadata will be retrieved.
-   * Flight SQL Servers may choose to include additional metadata above and beyond the specified set, however they must
-   * at least return the specified set. IDs ranging from 0 to 10,000 (exclusive) are reserved for future use.
-   * If additional metadata is included, the metadata IDs should start from 10,000.
-   */
-  repeated uint32 info = 1;
-}
-
-// Options for CommandGetSqlInfo.
-enum SqlInfo {
-
-  // Server Information [0-500): Provides basic information about the Flight SQL Server.
-
-  // Retrieves a UTF-8 string with the name of the Flight SQL Server.
-  FLIGHT_SQL_SERVER_NAME = 0;
-
-  // Retrieves a UTF-8 string with the native version of the Flight SQL Server.
-  FLIGHT_SQL_SERVER_VERSION = 1;
-
-  // Retrieves a UTF-8 string with the Arrow format version of the Flight SQL Server.
-  FLIGHT_SQL_SERVER_ARROW_VERSION = 2;
-
-  /*
-   * Retrieves a boolean value indicating whether the Flight SQL Server is read only.
-   *
-   * Returns:
-   * - false: if read-write
-   * - true: if read only
-   */
-  FLIGHT_SQL_SERVER_READ_ONLY = 3;
-
-
-  // SQL Syntax Information [500-1000): provides information about SQL syntax supported by the Flight SQL Server.
-
-  /*
-   * Retrieves a boolean value indicating whether the Flight SQL Server supports CREATE and DROP of catalogs.
-   *
-   * Returns:
-   * - false: if it doesn't support CREATE and DROP of catalogs.
-   * - true: if it supports CREATE and DROP of catalogs.
-   */
-  SQL_DDL_CATALOG = 500;
-
-  /*
-   * Retrieves a boolean value indicating whether the Flight SQL Server supports CREATE and DROP of schemas.
-   *
-   * Returns:
-   * - false: if it doesn't support CREATE and DROP of schemas.
-   * - true: if it supports CREATE and DROP of schemas.
-   */
-  SQL_DDL_SCHEMA = 501;
-
-  /*
-   * Indicates whether the Flight SQL Server supports CREATE and DROP of tables.
-   *
-   * Returns:
-   * - false: if it doesn't support CREATE and DROP of tables.
-   * - true: if it supports CREATE and DROP of tables.
-   */
-  SQL_DDL_TABLE = 502;
-
-  /*
-   * Retrieves a int32 ordinal representing the case sensitivity of catalog, table, schema and table names.
-   *
-   * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
-   */
-  SQL_IDENTIFIER_CASE = 503;
-
-  // Retrieves a UTF-8 string with the supported character(s) used to surround a delimited identifier.
-  SQL_IDENTIFIER_QUOTE_CHAR = 504;
-
-  /*
-   * Retrieves a int32 describing the case sensitivity of quoted identifiers.
-   *
-   * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
-   */
-  SQL_QUOTED_IDENTIFIER_CASE = 505;
-
-  /*
-   * Retrieves a boolean value indicating whether all tables are selectable.
-   *
-   * Returns:
-   * - false: if not all tables are selectable or if none are;
-   * - true: if all tables are selectable.
-   */
-  SQL_ALL_TABLES_ARE_SELECTABLE = 506;
-
-  /*
-   * Retrieves the null ordering.
-   *
-   * Returns a int32 ordinal for the null ordering being used, as described in
-   * `arrow.flight.protocol.sql.SqlNullOrdering`.
-   */
-  SQL_NULL_ORDERING = 507;
-
-  // Retrieves a UTF-8 string list with values of the supported keywords.
-  SQL_KEYWORDS = 508;
-
-  // Retrieves a UTF-8 string list with values of the supported numeric functions.
-  SQL_NUMERIC_FUNCTIONS = 509;
-
-  // Retrieves a UTF-8 string list with values of the supported string functions.
-  SQL_STRING_FUNCTIONS = 510;
-
-  // Retrieves a UTF-8 string list with values of the supported system functions.
-  SQL_SYSTEM_FUNCTIONS = 511;
-
-  // Retrieves a UTF-8 string list with values of the supported datetime functions.
-  SQL_DATETIME_FUNCTIONS = 512;
-
-  /*
-   * Retrieves the UTF-8 string that can be used to escape wildcard characters.
-   * This is the string that can be used to escape '_' or '%' in the catalog search parameters that are a pattern
-   * (and therefore use one of the wildcard characters).
-   * The '_' character represents any single character; the '%' character represents any sequence of zero or more
-   * characters.
-   */
-  SQL_SEARCH_STRING_ESCAPE = 513;
-
-  /*
-   * Retrieves a UTF-8 string with all the "extra" characters that can be used in unquoted identifier names
-   * (those beyond a-z, A-Z, 0-9 and _).
-   */
-  SQL_EXTRA_NAME_CHARACTERS = 514;
-
-  /*
-   * Retrieves a boolean value indicating whether column aliasing is supported.
-   * If so, the SQL AS clause can be used to provide names for computed columns or to provide alias names for columns
-   * as required.
-   *
-   * Returns:
-   * - false: if column aliasing is unsupported;
-   * - true: if column aliasing is supported.
-   */
-  SQL_SUPPORTS_COLUMN_ALIASING = 515;
-
-  /*
-   * Retrieves a boolean value indicating whether concatenations between null and non-null values being
-   * null are supported.
-   *
-   * - Returns:
-   * - false: if concatenations between null and non-null values being null are unsupported;
-   * - true: if concatenations between null and non-null values being null are supported.
-   */
-  SQL_NULL_PLUS_NULL_IS_NULL = 516;
-
-  /*
-   * Retrieves a map where the key is the type to convert from and the value is a list with the types to convert to,
-   * indicating the supported conversions. Each key and each item on the list value is a value to a predefined type on
-   * SqlSupportsConvert enum.
-   * The returned map will be:  map<int32, list<int32>>
-   */
-  SQL_SUPPORTS_CONVERT = 517;
-
-  /*
-   * Retrieves a boolean value indicating whether, when table correlation names are supported,
-   * they are restricted to being different from the names of the tables.
-   *
-   * Returns:
-   * - false: if table correlation names are unsupported;
-   * - true: if table correlation names are supported.
-   */
-  SQL_SUPPORTS_TABLE_CORRELATION_NAMES = 518;
-
-  /*
-   * Retrieves a boolean value indicating whether, when table correlation names are supported,
-   * they are restricted to being different from the names of the tables.
-   *
-   * Returns:
-   * - false: if different table correlation names are unsupported;
-   * - true: if different table correlation names are supported
-   */
-  SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES = 519;
-
-  /*
-   * Retrieves a boolean value indicating whether expressions in ORDER BY lists are supported.
-   *
-   * Returns:
-   * - false: if expressions in ORDER BY are unsupported;
-   * - true: if expressions in ORDER BY are supported;
-   */
-  SQL_SUPPORTS_EXPRESSIONS_IN_ORDER_BY = 520;
-
-  /*
-   * Retrieves a boolean value indicating whether using a column that is not in the SELECT statement in a GROUP BY
-   * clause is supported.
-   *
-   * Returns:
-   * - false: if using a column that is not in the SELECT statement in a GROUP BY clause is unsupported;
-   * - true: if using a column that is not in the SELECT statement in a GROUP BY clause is supported.
-   */
-  SQL_SUPPORTS_ORDER_BY_UNRELATED = 521;
-
-  /*
-   * Retrieves the supported GROUP BY commands;
-   *
-   * Returns an int32 bitmask value representing the supported commands.
-   * The returned bitmask should be parsed in order to retrieve the supported commands.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (GROUP BY is unsupported);
-   * - return 1 (\b1)   => [SQL_GROUP_BY_UNRELATED];
-   * - return 2 (\b10)  => [SQL_GROUP_BY_BEYOND_SELECT];
-   * - return 3 (\b11)  => [SQL_GROUP_BY_UNRELATED, SQL_GROUP_BY_BEYOND_SELECT].
-   * Valid GROUP BY types are described under `arrow.flight.protocol.sql.SqlSupportedGroupBy`.
-   */
-  SQL_SUPPORTED_GROUP_BY = 522;
-
-  /*
-   * Retrieves a boolean value indicating whether specifying a LIKE escape clause is supported.
-   *
-   * Returns:
-   * - false: if specifying a LIKE escape clause is unsupported;
-   * - true: if specifying a LIKE escape clause is supported.
-   */
-  SQL_SUPPORTS_LIKE_ESCAPE_CLAUSE = 523;
-
-  /*
-   * Retrieves a boolean value indicating whether columns may be defined as non-nullable.
-   *
-   * Returns:
-   * - false: if columns cannot be defined as non-nullable;
-   * - true: if columns may be defined as non-nullable.
-   */
-  SQL_SUPPORTS_NON_NULLABLE_COLUMNS = 524;
-
-  /*
-   * Retrieves the supported SQL grammar level as per the ODBC specification.
-   *
-   * Returns an int32 bitmask value representing the supported SQL grammar level.
-   * The returned bitmask should be parsed in order to retrieve the supported grammar levels.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (SQL grammar is unsupported);
-   * - return 1 (\b1)   => [SQL_MINIMUM_GRAMMAR];
-   * - return 2 (\b10)  => [SQL_CORE_GRAMMAR];
-   * - return 3 (\b11)  => [SQL_MINIMUM_GRAMMAR, SQL_CORE_GRAMMAR];
-   * - return 4 (\b100) => [SQL_EXTENDED_GRAMMAR];
-   * - return 5 (\b101) => [SQL_MINIMUM_GRAMMAR, SQL_EXTENDED_GRAMMAR];
-   * - return 6 (\b110) => [SQL_CORE_GRAMMAR, SQL_EXTENDED_GRAMMAR];
-   * - return 7 (\b111) => [SQL_MINIMUM_GRAMMAR, SQL_CORE_GRAMMAR, SQL_EXTENDED_GRAMMAR].
-   * Valid SQL grammar levels are described under `arrow.flight.protocol.sql.SupportedSqlGrammar`.
-   */
-  SQL_SUPPORTED_GRAMMAR = 525;
-
-  /*
-   * Retrieves the supported ANSI92 SQL grammar level.
-   *
-   * Returns an int32 bitmask value representing the supported ANSI92 SQL grammar level.
-   * The returned bitmask should be parsed in order to retrieve the supported commands.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (ANSI92 SQL grammar is unsupported);
-   * - return 1 (\b1)   => [ANSI92_ENTRY_SQL];
-   * - return 2 (\b10)  => [ANSI92_INTERMEDIATE_SQL];
-   * - return 3 (\b11)  => [ANSI92_ENTRY_SQL, ANSI92_INTERMEDIATE_SQL];
-   * - return 4 (\b100) => [ANSI92_FULL_SQL];
-   * - return 5 (\b101) => [ANSI92_ENTRY_SQL, ANSI92_FULL_SQL];
-   * - return 6 (\b110) => [ANSI92_INTERMEDIATE_SQL, ANSI92_FULL_SQL];
-   * - return 7 (\b111) => [ANSI92_ENTRY_SQL, ANSI92_INTERMEDIATE_SQL, ANSI92_FULL_SQL].
-   * Valid ANSI92 SQL grammar levels are described under `arrow.flight.protocol.sql.SupportedAnsi92SqlGrammarLevel`.
-   */
-  SQL_ANSI92_SUPPORTED_LEVEL = 526;
-
-  /*
-   * Retrieves a boolean value indicating whether the SQL Integrity Enhancement Facility is supported.
-   *
-   * Returns:
-   * - false: if the SQL Integrity Enhancement Facility is supported;
-   * - true: if the SQL Integrity Enhancement Facility is supported.
-   */
-  SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY = 527;
-
-  /*
-   * Retrieves the support level for SQL OUTER JOINs.
-   *
-   * Returns a int32 ordinal for the SQL ordering being used, as described in
-   * `arrow.flight.protocol.sql.SqlOuterJoinsSupportLevel`.
-   */
-  SQL_OUTER_JOINS_SUPPORT_LEVEL = 528;
-
-  // Retrieves a UTF-8 string with the preferred term for "schema".
-  SQL_SCHEMA_TERM = 529;
-
-  // Retrieves a UTF-8 string with the preferred term for "procedure".
-  SQL_PROCEDURE_TERM = 530;
-
-  /*
-   * Retrieves a UTF-8 string with the preferred term for "catalog".
-   * If a empty string is returned its assumed that the server does NOT supports catalogs.
-   */
-  SQL_CATALOG_TERM = 531;
-
-  /*
-   * Retrieves a boolean value indicating whether a catalog appears at the start of a fully qualified table name.
-   *
-   * - false: if a catalog does not appear at the start of a fully qualified table name;
-   * - true: if a catalog appears at the start of a fully qualified table name.
-   */
-  SQL_CATALOG_AT_START = 532;
-
-  /*
-   * Retrieves the supported actions for a SQL schema.
-   *
-   * Returns an int32 bitmask value representing the supported actions for a SQL schema.
-   * The returned bitmask should be parsed in order to retrieve the supported actions for a SQL schema.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported actions for SQL schema);
-   * - return 1 (\b1)   => [SQL_ELEMENT_IN_PROCEDURE_CALLS];
-   * - return 2 (\b10)  => [SQL_ELEMENT_IN_INDEX_DEFINITIONS];
-   * - return 3 (\b11)  => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS];
-   * - return 4 (\b100) => [SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 5 (\b101) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 6 (\b110) => [SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 7 (\b111) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS].
-   * Valid actions for a SQL schema described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
-   */
-  SQL_SCHEMAS_SUPPORTED_ACTIONS = 533;
-
-  /*
-   * Retrieves the supported actions for a SQL schema.
-   *
-   * Returns an int32 bitmask value representing the supported actions for a SQL catalog.
-   * The returned bitmask should be parsed in order to retrieve the supported actions for a SQL catalog.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported actions for SQL catalog);
-   * - return 1 (\b1)   => [SQL_ELEMENT_IN_PROCEDURE_CALLS];
-   * - return 2 (\b10)  => [SQL_ELEMENT_IN_INDEX_DEFINITIONS];
-   * - return 3 (\b11)  => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS];
-   * - return 4 (\b100) => [SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 5 (\b101) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 6 (\b110) => [SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
-   * - return 7 (\b111) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS].
-   * Valid actions for a SQL catalog are described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
-   */
-  SQL_CATALOGS_SUPPORTED_ACTIONS = 534;
-
-  /*
-   * Retrieves the supported SQL positioned commands.
-   *
-   * Returns an int32 bitmask value representing the supported SQL positioned commands.
-   * The returned bitmask should be parsed in order to retrieve the supported SQL positioned commands.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported SQL positioned commands);
-   * - return 1 (\b1)   => [SQL_POSITIONED_DELETE];
-   * - return 2 (\b10)  => [SQL_POSITIONED_UPDATE];
-   * - return 3 (\b11)  => [SQL_POSITIONED_DELETE, SQL_POSITIONED_UPDATE].
-   * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlSupportedPositionedCommands`.
-   */
-  SQL_SUPPORTED_POSITIONED_COMMANDS = 535;
-
-  /*
-   * Retrieves a boolean value indicating whether SELECT FOR UPDATE statements are supported.
-   *
-   * Returns:
-   * - false: if SELECT FOR UPDATE statements are unsupported;
-   * - true: if SELECT FOR UPDATE statements are supported.
-   */
-  SQL_SELECT_FOR_UPDATE_SUPPORTED = 536;
-
-  /*
-   * Retrieves a boolean value indicating whether stored procedure calls that use the stored procedure escape syntax
-   * are supported.
-   *
-   * Returns:
-   * - false: if stored procedure calls that use the stored procedure escape syntax are unsupported;
-   * - true: if stored procedure calls that use the stored procedure escape syntax are supported.
-   */
-  SQL_STORED_PROCEDURES_SUPPORTED = 537;
-
-  /*
-   * Retrieves the supported SQL subqueries.
-   *
-   * Returns an int32 bitmask value representing the supported SQL subqueries.
-   * The returned bitmask should be parsed in order to retrieve the supported SQL subqueries.
-   *
-   * For instance:
-   * - return 0   (\b0)     => [] (no supported SQL subqueries);
-   * - return 1   (\b1)     => [SQL_SUBQUERIES_IN_COMPARISONS];
-   * - return 2   (\b10)    => [SQL_SUBQUERIES_IN_EXISTS];
-   * - return 3   (\b11)    => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS];
-   * - return 4   (\b100)   => [SQL_SUBQUERIES_IN_INS];
-   * - return 5   (\b101)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_INS];
-   * - return 6   (\b110)   => [SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_EXISTS];
-   * - return 7   (\b111)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS];
-   * - return 8   (\b1000)  => [SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 9   (\b1001)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 10  (\b1010)  => [SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 11  (\b1011)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 12  (\b1100)  => [SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 13  (\b1101)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 14  (\b1110)  => [SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - return 15  (\b1111)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
-   * - ...
-   * Valid SQL subqueries are described under `arrow.flight.protocol.sql.SqlSupportedSubqueries`.
-   */
-  SQL_SUPPORTED_SUBQUERIES = 538;
-
-  /*
-   * Retrieves a boolean value indicating whether correlated subqueries are supported.
-   *
-   * Returns:
-   * - false: if correlated subqueries are unsupported;
-   * - true: if correlated subqueries are supported.
-   */
-  SQL_CORRELATED_SUBQUERIES_SUPPORTED = 539;
-
-  /*
-   * Retrieves the supported SQL UNIONs.
-   *
-   * Returns an int32 bitmask value representing the supported SQL UNIONs.
-   * The returned bitmask should be parsed in order to retrieve the supported SQL UNIONs.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported SQL positioned commands);
-   * - return 1 (\b1)   => [SQL_UNION];
-   * - return 2 (\b10)  => [SQL_UNION_ALL];
-   * - return 3 (\b11)  => [SQL_UNION, SQL_UNION_ALL].
-   * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlSupportedUnions`.
-   */
-  SQL_SUPPORTED_UNIONS = 540;
-
-  // Retrieves a int64 value representing the maximum number of hex characters allowed in an inline binary literal.
-  SQL_MAX_BINARY_LITERAL_LENGTH = 541;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed for a character literal.
-  SQL_MAX_CHAR_LITERAL_LENGTH = 542;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed for a column name.
-  SQL_MAX_COLUMN_NAME_LENGTH = 543;
-
-  // Retrieves a int64 value representing the the maximum number of columns allowed in a GROUP BY clause.
-  SQL_MAX_COLUMNS_IN_GROUP_BY = 544;
-
-  // Retrieves a int64 value representing the maximum number of columns allowed in an index.
-  SQL_MAX_COLUMNS_IN_INDEX = 545;
-
-  // Retrieves a int64 value representing the maximum number of columns allowed in an ORDER BY clause.
-  SQL_MAX_COLUMNS_IN_ORDER_BY = 546;
-
-  // Retrieves a int64 value representing the maximum number of columns allowed in a SELECT list.
-  SQL_MAX_COLUMNS_IN_SELECT = 547;
-
-  // Retrieves a int64 value representing the maximum number of columns allowed in a table.
-  SQL_MAX_COLUMNS_IN_TABLE = 548;
-
-  // Retrieves a int64 value representing the maximum number of concurrent connections possible.
-  SQL_MAX_CONNECTIONS = 549;
-
-  // Retrieves a int64 value the maximum number of characters allowed in a cursor name.
-  SQL_MAX_CURSOR_NAME_LENGTH = 550;
-
-  /*
-   * Retrieves a int64 value representing the maximum number of bytes allowed for an index,
-   * including all of the parts of the index.
-   */
-  SQL_MAX_INDEX_LENGTH = 551;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed in a schema name.
-  SQL_DB_SCHEMA_NAME_LENGTH = 552;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed in a procedure name.
-  SQL_MAX_PROCEDURE_NAME_LENGTH = 553;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed in a catalog name.
-  SQL_MAX_CATALOG_NAME_LENGTH = 554;
-
-  // Retrieves a int64 value representing the maximum number of bytes allowed in a single row.
-  SQL_MAX_ROW_SIZE = 555;
-
-  /*
-   * Retrieves a boolean indicating whether the return value for the JDBC method getMaxRowSize includes the SQL
-   * data types LONGVARCHAR and LONGVARBINARY.
-   *
-   * Returns:
-   * - false: if return value for the JDBC method getMaxRowSize does
-   *          not include the SQL data types LONGVARCHAR and LONGVARBINARY;
-   * - true: if return value for the JDBC method getMaxRowSize includes
-   *         the SQL data types LONGVARCHAR and LONGVARBINARY.
-   */
-  SQL_MAX_ROW_SIZE_INCLUDES_BLOBS = 556;
-
-  /*
-   * Retrieves a int64 value representing the maximum number of characters allowed for an SQL statement;
-   * a result of 0 (zero) means that there is no limit or the limit is not known.
-   */
-  SQL_MAX_STATEMENT_LENGTH = 557;
-
-  // Retrieves a int64 value representing the maximum number of active statements that can be open at the same time.
-  SQL_MAX_STATEMENTS = 558;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed in a table name.
-  SQL_MAX_TABLE_NAME_LENGTH = 559;
-
-  // Retrieves a int64 value representing the maximum number of tables allowed in a SELECT statement.
-  SQL_MAX_TABLES_IN_SELECT = 560;
-
-  // Retrieves a int64 value representing the maximum number of characters allowed in a user name.
-  SQL_MAX_USERNAME_LENGTH = 561;
-
-  /*
-   * Retrieves this database's default transaction isolation level as described in
-   * `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
-   *
-   * Returns a int32 ordinal for the SQL transaction isolation level.
-   */
-  SQL_DEFAULT_TRANSACTION_ISOLATION = 562;
-
-  /*
-   * Retrieves a boolean value indicating whether transactions are supported. If not, invoking the method commit is a
-   * noop, and the isolation level is `arrow.flight.protocol.sql.SqlTransactionIsolationLevel.TRANSACTION_NONE`.
-   *
-   * Returns:
-   * - false: if transactions are unsupported;
-   * - true: if transactions are supported.
-   */
-  SQL_TRANSACTIONS_SUPPORTED = 563;
-
-  /*
-   * Retrieves the supported transactions isolation levels.
-   *
-   * Returns an int32 bitmask value representing the supported transactions isolation levels.
-   * The returned bitmask should be parsed in order to retrieve the supported transactions isolation levels.
-   *
-   * For instance:
-   * - return 0   (\b0)     => [] (no supported SQL transactions isolation levels);
-   * - return 1   (\b1)     => [SQL_TRANSACTION_NONE];
-   * - return 2   (\b10)    => [SQL_TRANSACTION_READ_UNCOMMITTED];
-   * - return 3   (\b11)    => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED];
-   * - return 4   (\b100)   => [SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 5   (\b101)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 6   (\b110)   => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 7   (\b111)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 8   (\b1000)  => [SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 9   (\b1001)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 10  (\b1010)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 11  (\b1011)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 12  (\b1100)  => [SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 13  (\b1101)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 14  (\b1110)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 15  (\b1111)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 16  (\b10000) => [SQL_TRANSACTION_SERIALIZABLE];
-   * - ...
-   * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
-   */
-  SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS = 564;
-
-  /*
-   * Retrieves a boolean value indicating whether a data definition statement within a transaction forces
-   * the transaction to commit.
-   *
-   * Returns:
-   * - false: if a data definition statement within a transaction does not force the transaction to commit;
-   * - true: if a data definition statement within a transaction forces the transaction to commit.
-   */
-  SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT = 565;
-
-  /*
-   * Retrieves a boolean value indicating whether a data definition statement within a transaction is ignored.
-   *
-   * Returns:
-   * - false: if a data definition statement within a transaction is taken into account;
-   * - true: a data definition statement within a transaction is ignored.
-   */
-  SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED = 566;
-
-  /*
-   * Retrieves an int32 bitmask value representing the supported result set types.
-   * The returned bitmask should be parsed in order to retrieve the supported result set types.
-   *
-   * For instance:
-   * - return 0   (\b0)     => [] (no supported result set types);
-   * - return 1   (\b1)     => [SQL_RESULT_SET_TYPE_UNSPECIFIED];
-   * - return 2   (\b10)    => [SQL_RESULT_SET_TYPE_FORWARD_ONLY];
-   * - return 3   (\b11)    => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_FORWARD_ONLY];
-   * - return 4   (\b100)   => [SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
-   * - return 5   (\b101)   => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
-   * - return 6   (\b110)   => [SQL_RESULT_SET_TYPE_FORWARD_ONLY, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
-   * - return 7   (\b111)   => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_FORWARD_ONLY, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
-   * - return 8   (\b1000)  => [SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE];
-   * - ...
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetType`.
-   */
-  SQL_SUPPORTED_RESULT_SET_TYPES = 567;
-
-  /*
-   * Returns an int32 bitmask value concurrency types supported for
-   * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_UNSPECIFIED`.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
-   * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
-   * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
-   */
-  SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_UNSPECIFIED = 568;
-
-  /*
-   * Returns an int32 bitmask value concurrency types supported for
-   * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_FORWARD_ONLY`.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
-   * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
-   * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
-   */
-  SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_FORWARD_ONLY = 569;
-
-  /*
-   * Returns an int32 bitmask value concurrency types supported for
-   * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE`.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
-   * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
-   * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
-   */
-  SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_SENSITIVE = 570;
-
-  /*
-   * Returns an int32 bitmask value concurrency types supported for
-   * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE`.
-   *
-   * For instance:
-   * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
-   * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
-   * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
-   * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
-   */
-  SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_INSENSITIVE = 571;
-
-  /*
-   * Retrieves a boolean value indicating whether this database supports batch updates.
-   *
-   * - false: if this database does not support batch updates;
-   * - true: if this database supports batch updates.
-   */
-  SQL_BATCH_UPDATES_SUPPORTED = 572;
-
-  /*
-   * Retrieves a boolean value indicating whether this database supports savepoints.
-   *
-   * Returns:
-   * - false: if this database does not support savepoints;
-   * - true: if this database supports savepoints.
-   */
-  SQL_SAVEPOINTS_SUPPORTED = 573;
-
-  /*
-   * Retrieves a boolean value indicating whether named parameters are supported in callable statements.
-   *
-   * Returns:
-   * - false: if named parameters in callable statements are unsupported;
-   * - true: if named parameters in callable statements are supported.
-   */
-  SQL_NAMED_PARAMETERS_SUPPORTED = 574;
-
-  /*
-   * Retrieves a boolean value indicating whether updates made to a LOB are made on a copy or directly to the LOB.
-   *
-   * Returns:
-   * - false: if updates made to a LOB are made directly to the LOB;
-   * - true: if updates made to a LOB are made on a copy.
-   */
-  SQL_LOCATORS_UPDATE_COPY = 575;
-
-  /*
-   * Retrieves a boolean value indicating whether invoking user-defined or vendor functions
-   * using the stored procedure escape syntax is supported.
-   *
-   * Returns:
-   * - false: if invoking user-defined or vendor functions using the stored procedure escape syntax is unsupported;
-   * - true: if invoking user-defined or vendor functions using the stored procedure escape syntax is supported.
-   */
-  SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED = 576;
-}
-
-enum SqlSupportedCaseSensitivity {
-  SQL_CASE_SENSITIVITY_UNKNOWN = 0;
-  SQL_CASE_SENSITIVITY_CASE_INSENSITIVE = 1;
-  SQL_CASE_SENSITIVITY_UPPERCASE = 2;
-  SQL_CASE_SENSITIVITY_LOWERCASE = 3;
-}
-
-enum SqlNullOrdering {
-  SQL_NULLS_SORTED_HIGH = 0;
-  SQL_NULLS_SORTED_LOW = 1;
-  SQL_NULLS_SORTED_AT_START = 2;
-  SQL_NULLS_SORTED_AT_END = 3;
-}
-
-enum SupportedSqlGrammar {
-  SQL_MINIMUM_GRAMMAR = 0;
-  SQL_CORE_GRAMMAR = 1;
-  SQL_EXTENDED_GRAMMAR = 2;
-}
-
-enum SupportedAnsi92SqlGrammarLevel {
-  ANSI92_ENTRY_SQL = 0;
-  ANSI92_INTERMEDIATE_SQL = 1;
-  ANSI92_FULL_SQL = 2;
-}
-
-enum SqlOuterJoinsSupportLevel {
-  SQL_JOINS_UNSUPPORTED = 0;
-  SQL_LIMITED_OUTER_JOINS = 1;
-  SQL_FULL_OUTER_JOINS = 2;
-}
-
-enum SqlSupportedGroupBy {
-  SQL_GROUP_BY_UNRELATED = 0;
-  SQL_GROUP_BY_BEYOND_SELECT = 1;
-}
-
-enum SqlSupportedElementActions {
-  SQL_ELEMENT_IN_PROCEDURE_CALLS = 0;
-  SQL_ELEMENT_IN_INDEX_DEFINITIONS = 1;
-  SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS = 2;
-}
-
-enum SqlSupportedPositionedCommands {
-  SQL_POSITIONED_DELETE = 0;
-  SQL_POSITIONED_UPDATE = 1;
-}
-
-enum SqlSupportedSubqueries {
-  SQL_SUBQUERIES_IN_COMPARISONS = 0;
-  SQL_SUBQUERIES_IN_EXISTS = 1;
-  SQL_SUBQUERIES_IN_INS = 2;
-  SQL_SUBQUERIES_IN_QUANTIFIEDS = 3;
-}
-
-enum SqlSupportedUnions {
-  SQL_UNION = 0;
-  SQL_UNION_ALL = 1;
-}
-
-enum SqlTransactionIsolationLevel {
-  SQL_TRANSACTION_NONE = 0;
-  SQL_TRANSACTION_READ_UNCOMMITTED = 1;
-  SQL_TRANSACTION_READ_COMMITTED = 2;
-  SQL_TRANSACTION_REPEATABLE_READ = 3;
-  SQL_TRANSACTION_SERIALIZABLE = 4;
-}
-
-enum SqlSupportedTransactions {
-  SQL_TRANSACTION_UNSPECIFIED = 0;
-  SQL_DATA_DEFINITION_TRANSACTIONS = 1;
-  SQL_DATA_MANIPULATION_TRANSACTIONS = 2;
-}
-
-enum SqlSupportedResultSetType {
-  SQL_RESULT_SET_TYPE_UNSPECIFIED = 0;
-  SQL_RESULT_SET_TYPE_FORWARD_ONLY = 1;
-  SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE = 2;
-  SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE = 3;
-}
-
-enum SqlSupportedResultSetConcurrency {
-  SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED = 0;
-  SQL_RESULT_SET_CONCURRENCY_READ_ONLY = 1;
-  SQL_RESULT_SET_CONCURRENCY_UPDATABLE = 2;
-}
-
-enum SqlSupportsConvert {
-  SQL_CONVERT_BIGINT = 0;
-  SQL_CONVERT_BINARY = 1;
-  SQL_CONVERT_BIT = 2;
-  SQL_CONVERT_CHAR = 3;
-  SQL_CONVERT_DATE = 4;
-  SQL_CONVERT_DECIMAL = 5;
-  SQL_CONVERT_FLOAT = 6;
-  SQL_CONVERT_INTEGER = 7;
-  SQL_CONVERT_INTERVAL_DAY_TIME = 8;
-  SQL_CONVERT_INTERVAL_YEAR_MONTH = 9;
-  SQL_CONVERT_LONGVARBINARY = 10;
-  SQL_CONVERT_LONGVARCHAR = 11;
-  SQL_CONVERT_NUMERIC = 12;
-  SQL_CONVERT_REAL = 13;
-  SQL_CONVERT_SMALLINT = 14;
-  SQL_CONVERT_TIME = 15;
-  SQL_CONVERT_TIMESTAMP = 16;
-  SQL_CONVERT_TINYINT = 17;
-  SQL_CONVERT_VARBINARY = 18;
-  SQL_CONVERT_VARCHAR = 19;
-}
-
-/**
- * The JDBC/ODBC-defined type of any object.
- * All the values here are the sames as in the JDBC and ODBC specs.
- */
-enum XdbcDataType {
-  XDBC_UNKNOWN_TYPE = 0;
-  XDBC_CHAR = 1;
-  XDBC_NUMERIC = 2;
-  XDBC_DECIMAL = 3;
-  XDBC_INTEGER = 4;
-  XDBC_SMALLINT = 5;
-  XDBC_FLOAT = 6;
-  XDBC_REAL = 7;
-  XDBC_DOUBLE = 8;
-  XDBC_DATETIME = 9;
-  XDBC_INTERVAL = 10;
-  XDBC_VARCHAR = 12;
-  XDBC_DATE = 91;
-  XDBC_TIME = 92;
-  XDBC_TIMESTAMP = 93;
-  XDBC_LONGVARCHAR = -1;
-  XDBC_BINARY = -2;
-  XDBC_VARBINARY = -3;
-  XDBC_LONGVARBINARY = -4;
-  XDBC_BIGINT = -5;
-  XDBC_TINYINT = -6;
-  XDBC_BIT = -7;
-  XDBC_WCHAR = -8;
-  XDBC_WVARCHAR = -9;
-}
-
-/**
- * Detailed subtype information for XDBC_TYPE_DATETIME and XDBC_TYPE_INTERVAL.
- */
-enum XdbcDatetimeSubcode {
-  option allow_alias = true;
-  XDBC_SUBCODE_UNKNOWN = 0;
-  XDBC_SUBCODE_YEAR = 1;
-  XDBC_SUBCODE_DATE = 1;
-  XDBC_SUBCODE_TIME = 2;
-  XDBC_SUBCODE_MONTH = 2;
-  XDBC_SUBCODE_TIMESTAMP = 3;
-  XDBC_SUBCODE_DAY = 3;
-  XDBC_SUBCODE_TIME_WITH_TIMEZONE = 4;
-  XDBC_SUBCODE_HOUR = 4;
-  XDBC_SUBCODE_TIMESTAMP_WITH_TIMEZONE = 5;
-  XDBC_SUBCODE_MINUTE = 5;
-  XDBC_SUBCODE_SECOND = 6;
-  XDBC_SUBCODE_YEAR_TO_MONTH = 7;
-  XDBC_SUBCODE_DAY_TO_HOUR = 8;
-  XDBC_SUBCODE_DAY_TO_MINUTE = 9;
-  XDBC_SUBCODE_DAY_TO_SECOND = 10;
-  XDBC_SUBCODE_HOUR_TO_MINUTE = 11;
-  XDBC_SUBCODE_HOUR_TO_SECOND = 12;
-  XDBC_SUBCODE_MINUTE_TO_SECOND = 13;
-  XDBC_SUBCODE_INTERVAL_YEAR = 101;
-  XDBC_SUBCODE_INTERVAL_MONTH = 102;
-  XDBC_SUBCODE_INTERVAL_DAY = 103;
-  XDBC_SUBCODE_INTERVAL_HOUR = 104;
-  XDBC_SUBCODE_INTERVAL_MINUTE = 105;
-  XDBC_SUBCODE_INTERVAL_SECOND = 106;
-  XDBC_SUBCODE_INTERVAL_YEAR_TO_MONTH = 107;
-  XDBC_SUBCODE_INTERVAL_DAY_TO_HOUR = 108;
-  XDBC_SUBCODE_INTERVAL_DAY_TO_MINUTE = 109;
-  XDBC_SUBCODE_INTERVAL_DAY_TO_SECOND = 110;
-  XDBC_SUBCODE_INTERVAL_HOUR_TO_MINUTE = 111;
-  XDBC_SUBCODE_INTERVAL_HOUR_TO_SECOND = 112;
-  XDBC_SUBCODE_INTERVAL_MINUTE_TO_SECOND = 113;
-}
-
-enum Nullable {
-  /**
-   * Indicates that the fields does not allow the use of null values.
-   */
-  NULLABILITY_NO_NULLS = 0;
-
-  /**
-   * Indicates that the fields allow the use of null values.
-   */
-  NULLABILITY_NULLABLE = 1;
-
-  /**
-   * Indicates that nullability of the fields can not be determined.
-   */
-  NULLABILITY_UNKNOWN = 2;
-}
-
-enum Searchable {
-  /**
-   * Indicates that column can not be used in a WHERE clause.
-   */
-  SEARCHABLE_NONE = 0;
-
-  /**
-   * Indicates that the column can be used in a WHERE clause if it is using a
-   * LIKE operator.
-   */
-  SEARCHABLE_CHAR = 1;
-
-  /**
-   * Indicates that the column can be used In a WHERE clause with any
-   * operator other than LIKE.
-   *
-   * - Allowed operators: comparison, quantified comparison, BETWEEN,
-   *                      DISTINCT, IN, MATCH, and UNIQUE.
-   */
-  SEARCHABLE_BASIC = 2;
-
-  /**
-   * Indicates that the column can be used in a WHERE clause using any operator.
-   */
-  SEARCHABLE_FULL = 3;
-}
-
-/*
- * Represents a request to retrieve information about data type supported on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned schema will be:
- * <
- *   type_name: utf8 not null (The name of the data type, for example: VARCHAR, INTEGER, etc),
- *   data_type: int not null (The SQL data type),
- *   column_size: int (The maximum size supported by that column.
- *                     In case of exact numeric types, this represents the maximum precision.
- *                     In case of string types, this represents the character length.
- *                     In case of datetime data types, this represents the length in characters of the string representation.
- *                     NULL is returned for data types where column size is not applicable.),
- *   literal_prefix: utf8 (Character or characters used to prefix a literal, NULL is returned for
- *                         data types where a literal prefix is not applicable.),
- *   literal_suffix: utf8 (Character or characters used to terminate a literal,
- *                         NULL is returned for data types where a literal suffix is not applicable.),
- *   create_params: list<utf8 not null>
- *                        (A list of keywords corresponding to which parameters can be used when creating
- *                         a column for that specific type.
- *                         NULL is returned if there are no parameters for the data type definition.),
- *   nullable: int not null (Shows if the data type accepts a NULL value. The possible values can be seen in the
- *                           Nullable enum.),
- *   case_sensitive: bool not null (Shows if a character data type is case-sensitive in collations and comparisons),
- *   searchable: int not null (Shows how the data type is used in a WHERE clause. The possible values can be seen in the
- *                             Searchable enum.),
- *   unsigned_attribute: bool (Shows if the data type is unsigned. NULL is returned if the attribute is
- *                             not applicable to the data type or the data type is not numeric.),
- *   fixed_prec_scale: bool not null (Shows if the data type has predefined fixed precision and scale.),
- *   auto_increment: bool (Shows if the data type is auto incremental. NULL is returned if the attribute
- *                         is not applicable to the data type or the data type is not numeric.),
- *   local_type_name: utf8 (Localized version of the data source-dependent name of the data type. NULL
- *                          is returned if a localized name is not supported by the data source),
- *   minimum_scale: int (The minimum scale of the data type on the data source.
- *                       If a data type has a fixed scale, the MINIMUM_SCALE and MAXIMUM_SCALE
- *                       columns both contain this value. NULL is returned if scale is not applicable.),
- *   maximum_scale: int (The maximum scale of the data type on the data source.
- *                       NULL is returned if scale is not applicable.),
- *   sql_data_type: int not null (The value of the SQL DATA TYPE which has the same values
- *                                as data_type value. Except for interval and datetime, which
- *                                uses generic values. More info about those types can be
- *                                obtained through datetime_subcode. The possible values can be seen
- *                                in the XdbcDataType enum.),
- *   datetime_subcode: int (Only used when the SQL DATA TYPE is interval or datetime. It contains
- *                          its sub types. For type different from interval and datetime, this value
- *                          is NULL. The possible values can be seen in the XdbcDatetimeSubcode enum.),
- *   num_prec_radix: int (If the data type is an approximate numeric type, this column contains
- *                        the value 2 to indicate that COLUMN_SIZE specifies a number of bits. For
- *                        exact numeric types, this column contains the value 10 to indicate that
- *                        column size specifies a number of decimal digits. Otherwise, this column is NULL.),
- *   interval_precision: int (If the data type is an interval data type, then this column contains the value
- *                            of the interval leading precision. Otherwise, this column is NULL. This fields
- *                            is only relevant to be used by ODBC).
- * >
- * The returned data should be ordered by data_type and then by type_name.
- */
-message CommandGetXdbcTypeInfo {
-  option (experimental) = true;
-
-  /*
-   * Specifies the data type to search for the info.
-   */
-  optional int32 data_type = 1;
-}
-
-/*
- * Represents a request to retrieve the list of catalogs on a Flight SQL enabled backend.
- * The definition of a catalog depends on vendor/implementation. It is usually the database itself
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  catalog_name: utf8 not null
- * >
- * The returned data should be ordered by catalog_name.
- */
-message CommandGetCatalogs {
-  option (experimental) = true;
-}
-
-/*
- * Represents a request to retrieve the list of database schemas on a Flight SQL enabled backend.
- * The definition of a database schema depends on vendor/implementation. It is usually a collection of tables.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  catalog_name: utf8,
- *  db_schema_name: utf8 not null
- * >
- * The returned data should be ordered by catalog_name, then db_schema_name.
- */
-message CommandGetDbSchemas {
-  option (experimental) = true;
-
-  /*
-   * Specifies the Catalog to search for the tables.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string catalog = 1;
-
-  /*
-   * Specifies a filter pattern for schemas to search for.
-   * When no db_schema_filter_pattern is provided, the pattern will not be used to narrow the search.
-   * In the pattern string, two special characters can be used to denote matching rules:
-   *    - "%" means to match any substring with 0 or more characters.
-   *    - "_" means to match any one character.
-   */
-  optional string db_schema_filter_pattern = 2;
-}
-
-/*
- * Represents a request to retrieve the list of tables, and optionally their schemas, on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  catalog_name: utf8,
- *  db_schema_name: utf8,
- *  table_name: utf8 not null,
- *  table_type: utf8 not null,
- *  [optional] table_schema: bytes not null (schema of the table as described in Schema.fbs::Schema,
- *                                           it is serialized as an IPC message.)
- * >
- * Fields on table_schema may contain the following metadata:
- *  - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
- *  - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
- *  - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *  - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
- *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
- *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
- *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
- *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
- *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
- *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
- */
-message CommandGetTables {
-  option (experimental) = true;
-
-  /*
-   * Specifies the Catalog to search for the tables.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string catalog = 1;
-
-  /*
-   * Specifies a filter pattern for schemas to search for.
-   * When no db_schema_filter_pattern is provided, all schemas matching other filters are searched.
-   * In the pattern string, two special characters can be used to denote matching rules:
-   *    - "%" means to match any substring with 0 or more characters.
-   *    - "_" means to match any one character.
-   */
-  optional string db_schema_filter_pattern = 2;
-
-  /*
-   * Specifies a filter pattern for tables to search for.
-   * When no table_name_filter_pattern is provided, all tables matching other filters are searched.
-   * In the pattern string, two special characters can be used to denote matching rules:
-   *    - "%" means to match any substring with 0 or more characters.
-   *    - "_" means to match any one character.
-   */
-  optional string table_name_filter_pattern = 3;
-
-  /*
-   * Specifies a filter of table types which must match.
-   * The table types depend on vendor/implementation. It is usually used to separate tables from views or system tables.
-   * TABLE, VIEW, and SYSTEM TABLE are commonly supported.
-   */
-  repeated string table_types = 4;
-
-  // Specifies if the Arrow schema should be returned for found tables.
-  bool include_schema = 5;
-}
-
-/*
- * Represents a request to retrieve the list of table types on a Flight SQL enabled backend.
- * The table types depend on vendor/implementation. It is usually used to separate tables from views or system tables.
- * TABLE, VIEW, and SYSTEM TABLE are commonly supported.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  table_type: utf8 not null
- * >
- * The returned data should be ordered by table_type.
- */
-message CommandGetTableTypes {
-  option (experimental) = true;
-}
-
-/*
- * Represents a request to retrieve the primary keys of a table on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  catalog_name: utf8,
- *  db_schema_name: utf8,
- *  table_name: utf8 not null,
- *  column_name: utf8 not null,
- *  key_name: utf8,
- *  key_sequence: int not null
- * >
- * The returned data should be ordered by catalog_name, db_schema_name, table_name, key_name, then key_sequence.
- */
-message CommandGetPrimaryKeys {
-  option (experimental) = true;
-
-  /*
-   * Specifies the catalog to search for the table.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string catalog = 1;
-
-  /*
-   * Specifies the schema to search for the table.
-   * An empty string retrieves those without a schema.
-   * If omitted the schema name should not be used to narrow the search.
-   */
-  optional string db_schema = 2;
-
-  // Specifies the table to get the primary keys for.
-  string table = 3;
-}
-
-enum UpdateDeleteRules {
-  CASCADE = 0;
-  RESTRICT = 1;
-  SET_NULL = 2;
-  NO_ACTION = 3;
-  SET_DEFAULT = 4;
-}
-
-/*
- * Represents a request to retrieve a description of the foreign key columns that reference the given table's
- * primary key columns (the foreign keys exported by a table) of a table on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  pk_catalog_name: utf8,
- *  pk_db_schema_name: utf8,
- *  pk_table_name: utf8 not null,
- *  pk_column_name: utf8 not null,
- *  fk_catalog_name: utf8,
- *  fk_db_schema_name: utf8,
- *  fk_table_name: utf8 not null,
- *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
- *  fk_key_name: utf8,
- *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
- * >
- * The returned data should be ordered by fk_catalog_name, fk_db_schema_name, fk_table_name, fk_key_name, then key_sequence.
- * update_rule and delete_rule returns a byte that is equivalent to actions declared on UpdateDeleteRules enum.
- */
-message CommandGetExportedKeys {
-  option (experimental) = true;
-
-  /*
-   * Specifies the catalog to search for the foreign key table.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string catalog = 1;
-
-  /*
-   * Specifies the schema to search for the foreign key table.
-   * An empty string retrieves those without a schema.
-   * If omitted the schema name should not be used to narrow the search.
-   */
-  optional string db_schema = 2;
-
-  // Specifies the foreign key table to get the foreign keys for.
-  string table = 3;
-}
-
-/*
- * Represents a request to retrieve the foreign keys of a table on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  pk_catalog_name: utf8,
- *  pk_db_schema_name: utf8,
- *  pk_table_name: utf8 not null,
- *  pk_column_name: utf8 not null,
- *  fk_catalog_name: utf8,
- *  fk_db_schema_name: utf8,
- *  fk_table_name: utf8 not null,
- *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
- *  fk_key_name: utf8,
- *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
- * >
- * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
- * update_rule and delete_rule returns a byte that is equivalent to actions:
- *    - 0 = CASCADE
- *    - 1 = RESTRICT
- *    - 2 = SET NULL
- *    - 3 = NO ACTION
- *    - 4 = SET DEFAULT
- */
-message CommandGetImportedKeys {
-  option (experimental) = true;
-
-  /*
-   * Specifies the catalog to search for the primary key table.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string catalog = 1;
-
-  /*
-   * Specifies the schema to search for the primary key table.
-   * An empty string retrieves those without a schema.
-   * If omitted the schema name should not be used to narrow the search.
-   */
-  optional string db_schema = 2;
-
-  // Specifies the primary key table to get the foreign keys for.
-  string table = 3;
-}
-
-/*
- * Represents a request to retrieve a description of the foreign key columns in the given foreign key table that
- * reference the primary key or the columns representing a unique constraint of the parent table (could be the same
- * or a different table) on a Flight SQL enabled backend.
- * Used in the command member of FlightDescriptor for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *  - GetFlightInfo: execute the catalog metadata request.
- *
- * The returned Arrow schema will be:
- * <
- *  pk_catalog_name: utf8,
- *  pk_db_schema_name: utf8,
- *  pk_table_name: utf8 not null,
- *  pk_column_name: utf8 not null,
- *  fk_catalog_name: utf8,
- *  fk_db_schema_name: utf8,
- *  fk_table_name: utf8 not null,
- *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
- *  fk_key_name: utf8,
- *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
- * >
- * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
- * update_rule and delete_rule returns a byte that is equivalent to actions:
- *    - 0 = CASCADE
- *    - 1 = RESTRICT
- *    - 2 = SET NULL
- *    - 3 = NO ACTION
- *    - 4 = SET DEFAULT
- */
-message CommandGetCrossReference {
-  option (experimental) = true;
-
-  /**
-   * The catalog name where the parent table is.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string pk_catalog = 1;
-
-  /**
-   * The Schema name where the parent table is.
-   * An empty string retrieves those without a schema.
-   * If omitted the schema name should not be used to narrow the search.
-   */
-  optional string pk_db_schema = 2;
-
-  /**
-   * The parent table name. It cannot be null.
-   */
-  string pk_table = 3;
-
-  /**
-   * The catalog name where the foreign table is.
-   * An empty string retrieves those without a catalog.
-   * If omitted the catalog name should not be used to narrow the search.
-   */
-  optional string fk_catalog = 4;
-
-  /**
-   * The schema name where the foreign table is.
-   * An empty string retrieves those without a schema.
-   * If omitted the schema name should not be used to narrow the search.
-   */
-  optional string fk_db_schema = 5;
-
-  /**
-   * The foreign table name. It cannot be null.
-   */
-  string fk_table = 6;
-}
-
-// SQL Execution Action Messages
-
-/*
- * Request message for the "CreatePreparedStatement" action on a Flight SQL enabled backend.
- */
-message ActionCreatePreparedStatementRequest {
-  option (experimental) = true;
-
-  // The valid SQL string to create a prepared statement for.
-  string query = 1;
-}
-
-/*
- * Wrap the result of a "GetPreparedStatement" action.
- *
- * The resultant PreparedStatement can be closed either:
- * - Manually, through the "ClosePreparedStatement" action;
- * - Automatically, by a server timeout.
- */
-message ActionCreatePreparedStatementResult {
-  option (experimental) = true;
-
-  // Opaque handle for the prepared statement on the server.
-  bytes prepared_statement_handle = 1;
-
-  // If a result set generating query was provided, dataset_schema contains the
-  // schema of the dataset as described in Schema.fbs::Schema, it is serialized as an IPC message.
-  bytes dataset_schema = 2;
-
-  // If the query provided contained parameters, parameter_schema contains the
-  // schema of the expected parameters as described in Schema.fbs::Schema, it is serialized as an IPC message.
-  bytes parameter_schema = 3;
-}
-
-/*
- * Request message for the "ClosePreparedStatement" action on a Flight SQL enabled backend.
- * Closes server resources associated with the prepared statement handle.
- */
-message ActionClosePreparedStatementRequest {
-  option (experimental) = true;
-
-  // Opaque handle for the prepared statement on the server.
-  bytes prepared_statement_handle = 1;
-}
-
-
-// SQL Execution Messages.
-
-/*
- * Represents a SQL query. Used in the command member of FlightDescriptor
- * for the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *    Fields on this schema may contain the following metadata:
- *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
- *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
- *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
- *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
- *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
- *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *  - GetFlightInfo: execute the query.
- */
-message CommandStatementQuery {
-  option (experimental) = true;
-
-  // The SQL syntax.
-  string query = 1;
-}
-
-/**
- * Represents a ticket resulting from GetFlightInfo with a CommandStatementQuery.
- * This should be used only once and treated as an opaque value, that is, clients should not attempt to parse this.
- */
-message TicketStatementQuery {
-  option (experimental) = true;
-
-  // Unique identifier for the instance of the statement to execute.
-  bytes statement_handle = 1;
-}
-
-/*
- * Represents an instance of executing a prepared statement. Used in the command member of FlightDescriptor for
- * the following RPC calls:
- *  - GetSchema: return the Arrow schema of the query.
- *    Fields on this schema may contain the following metadata:
- *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
- *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
- *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
- *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
- *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
- *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *  - DoPut: bind parameter values. All of the bound parameter sets will be executed as a single atomic execution.
- *  - GetFlightInfo: execute the prepared statement instance.
- */
-message CommandPreparedStatementQuery {
-  option (experimental) = true;
-
-  // Opaque handle for the prepared statement on the server.
-  bytes prepared_statement_handle = 1;
-}
-
-/*
- * Represents a SQL update query. Used in the command member of FlightDescriptor
- * for the the RPC call DoPut to cause the server to execute the included SQL update.
- */
-message CommandStatementUpdate {
-  option (experimental) = true;
-
-  // The SQL syntax.
-  string query = 1;
-}
-
-/*
- * Represents a SQL update query. Used in the command member of FlightDescriptor
- * for the the RPC call DoPut to cause the server to execute the included
- * prepared statement handle as an update.
- */
-message CommandPreparedStatementUpdate {
-  option (experimental) = true;
-
-  // Opaque handle for the prepared statement on the server.
-  bytes prepared_statement_handle = 1;
-}
-
-/*
- * Returned from the RPC call DoPut when a CommandStatementUpdate
- * CommandPreparedStatementUpdate was in the request, containing
- * results from the update.
- */
-message DoPutUpdateResult {
-  option (experimental) = true;
-
-  // The number of records updated. A return value of -1 represents
-  // an unknown updated record count.
-  int64 record_count = 1;
-}
-
-extend google.protobuf.MessageOptions {
-  bool experimental = 1000;
-}
+ syntax = "proto3";
+ import "google/protobuf/descriptor.proto";
+ 
+ option java_package = "org.apache.arrow.flight.sql.impl";
+ option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
+ package arrow.flight.protocol.sql;
+ 
+ /*
+  * Represents a metadata request. Used in the command member of FlightDescriptor
+  * for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  info_name: uint32 not null,
+  *  value: dense_union<
+  *              string_value: utf8,
+  *              bool_value: bool,
+  *              bigint_value: int64,
+  *              int32_bitmask: int32,
+  *              string_list: list<string_data: utf8>
+  *              int32_to_int32_list_map: map<key: int32, value: list<$data$: int32>>
+  * >
+  * where there is one row per requested piece of metadata information.
+  */
+ message CommandGetSqlInfo {
+   option (experimental) = true;
+ 
+   /*
+    * Values are modelled after ODBC's SQLGetInfo() function. This information is intended to provide
+    * Flight SQL clients with basic, SQL syntax and SQL functions related information.
+    * More information types can be added in future releases.
+    * E.g. more SQL syntax support types, scalar functions support, type conversion support etc.
+    *
+    * Note that the set of metadata may expand.
+    *
+    * Initially, Flight SQL will support the following information types:
+    * - Server Information - Range [0-500)
+    * - Syntax Information - Range [500-1000)
+    * Range [0-10,000) is reserved for defaults (see SqlInfo enum for default options).
+    * Custom options should start at 10,000.
+    *
+    * If omitted, then all metadata will be retrieved.
+    * Flight SQL Servers may choose to include additional metadata above and beyond the specified set, however they must
+    * at least return the specified set. IDs ranging from 0 to 10,000 (exclusive) are reserved for future use.
+    * If additional metadata is included, the metadata IDs should start from 10,000.
+    */
+   repeated uint32 info = 1;
+ }
+ 
+ // Options for CommandGetSqlInfo.
+ enum SqlInfo {
+ 
+   // Server Information [0-500): Provides basic information about the Flight SQL Server.
+ 
+   // Retrieves a UTF-8 string with the name of the Flight SQL Server.
+   FLIGHT_SQL_SERVER_NAME = 0;
+ 
+   // Retrieves a UTF-8 string with the native version of the Flight SQL Server.
+   FLIGHT_SQL_SERVER_VERSION = 1;
+ 
+   // Retrieves a UTF-8 string with the Arrow format version of the Flight SQL Server.
+   FLIGHT_SQL_SERVER_ARROW_VERSION = 2;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server is read only.
+    *
+    * Returns:
+    * - false: if read-write
+    * - true: if read only
+    */
+   FLIGHT_SQL_SERVER_READ_ONLY = 3;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server supports executing
+    * SQL queries.
+    *
+    * Note that the absence of this info (as opposed to a false value) does not necessarily
+    * mean that SQL is not supported, as this property was not originally defined.
+    */
+   FLIGHT_SQL_SERVER_SQL = 4;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server supports executing
+    * Substrait plans.
+    */
+   FLIGHT_SQL_SERVER_SUBSTRAIT = 5;
+ 
+   /*
+    * Retrieves a string value indicating the minimum supported Substrait version, or null
+    * if Substrait is not supported.
+    */
+   FLIGHT_SQL_SERVER_SUBSTRAIT_MIN_VERSION = 6;
+ 
+   /*
+    * Retrieves a string value indicating the maximum supported Substrait version, or null
+    * if Substrait is not supported.
+    */
+   FLIGHT_SQL_SERVER_SUBSTRAIT_MAX_VERSION = 7;
+ 
+   /*
+    * Retrieves an int32 indicating whether the Flight SQL Server supports the
+    * BeginTransaction/EndTransaction/BeginSavepoint/EndSavepoint actions.
+    *
+    * Even if this is not supported, the database may still support explicit "BEGIN
+    * TRANSACTION"/"COMMIT" SQL statements (see SQL_TRANSACTIONS_SUPPORTED); this property
+    * is only about whether the server implements the Flight SQL API endpoints.
+    *
+    * The possible values are listed in `SqlSupportedTransaction`.
+    */
+   FLIGHT_SQL_SERVER_TRANSACTION = 8;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server supports explicit
+    * query cancellation (the CancelQuery action).
+    */
+   FLIGHT_SQL_SERVER_CANCEL = 9;
+ 
+   /*
+    * Retrieves an int32 indicating the timeout (in milliseconds) for prepared statement handles.
+    *
+    * If 0, there is no timeout.  Servers should reset the timeout when the handle is used in a command.
+    */
+   FLIGHT_SQL_SERVER_STATEMENT_TIMEOUT = 100;
+ 
+   /*
+    * Retrieves an int32 indicating the timeout (in milliseconds) for transactions, since transactions are not tied to a connection.
+    *
+    * If 0, there is no timeout.  Servers should reset the timeout when the handle is used in a command.
+    */
+   FLIGHT_SQL_SERVER_TRANSACTION_TIMEOUT = 101;
+ 
+   // SQL Syntax Information [500-1000): provides information about SQL syntax supported by the Flight SQL Server.
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server supports CREATE and DROP of catalogs.
+    *
+    * Returns:
+    * - false: if it doesn't support CREATE and DROP of catalogs.
+    * - true: if it supports CREATE and DROP of catalogs.
+    */
+   SQL_DDL_CATALOG = 500;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the Flight SQL Server supports CREATE and DROP of schemas.
+    *
+    * Returns:
+    * - false: if it doesn't support CREATE and DROP of schemas.
+    * - true: if it supports CREATE and DROP of schemas.
+    */
+   SQL_DDL_SCHEMA = 501;
+ 
+   /*
+    * Indicates whether the Flight SQL Server supports CREATE and DROP of tables.
+    *
+    * Returns:
+    * - false: if it doesn't support CREATE and DROP of tables.
+    * - true: if it supports CREATE and DROP of tables.
+    */
+   SQL_DDL_TABLE = 502;
+ 
+   /*
+    * Retrieves a int32 ordinal representing the case sensitivity of catalog, table, schema and table names.
+    *
+    * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
+    */
+   SQL_IDENTIFIER_CASE = 503;
+ 
+   // Retrieves a UTF-8 string with the supported character(s) used to surround a delimited identifier.
+   SQL_IDENTIFIER_QUOTE_CHAR = 504;
+ 
+   /*
+    * Retrieves a int32 describing the case sensitivity of quoted identifiers.
+    *
+    * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
+    */
+   SQL_QUOTED_IDENTIFIER_CASE = 505;
+ 
+   /*
+    * Retrieves a boolean value indicating whether all tables are selectable.
+    *
+    * Returns:
+    * - false: if not all tables are selectable or if none are;
+    * - true: if all tables are selectable.
+    */
+   SQL_ALL_TABLES_ARE_SELECTABLE = 506;
+ 
+   /*
+    * Retrieves the null ordering.
+    *
+    * Returns a int32 ordinal for the null ordering being used, as described in
+    * `arrow.flight.protocol.sql.SqlNullOrdering`.
+    */
+   SQL_NULL_ORDERING = 507;
+ 
+   // Retrieves a UTF-8 string list with values of the supported keywords.
+   SQL_KEYWORDS = 508;
+ 
+   // Retrieves a UTF-8 string list with values of the supported numeric functions.
+   SQL_NUMERIC_FUNCTIONS = 509;
+ 
+   // Retrieves a UTF-8 string list with values of the supported string functions.
+   SQL_STRING_FUNCTIONS = 510;
+ 
+   // Retrieves a UTF-8 string list with values of the supported system functions.
+   SQL_SYSTEM_FUNCTIONS = 511;
+ 
+   // Retrieves a UTF-8 string list with values of the supported datetime functions.
+   SQL_DATETIME_FUNCTIONS = 512;
+ 
+   /*
+    * Retrieves the UTF-8 string that can be used to escape wildcard characters.
+    * This is the string that can be used to escape '_' or '%' in the catalog search parameters that are a pattern
+    * (and therefore use one of the wildcard characters).
+    * The '_' character represents any single character; the '%' character represents any sequence of zero or more
+    * characters.
+    */
+   SQL_SEARCH_STRING_ESCAPE = 513;
+ 
+   /*
+    * Retrieves a UTF-8 string with all the "extra" characters that can be used in unquoted identifier names
+    * (those beyond a-z, A-Z, 0-9 and _).
+    */
+   SQL_EXTRA_NAME_CHARACTERS = 514;
+ 
+   /*
+    * Retrieves a boolean value indicating whether column aliasing is supported.
+    * If so, the SQL AS clause can be used to provide names for computed columns or to provide alias names for columns
+    * as required.
+    *
+    * Returns:
+    * - false: if column aliasing is unsupported;
+    * - true: if column aliasing is supported.
+    */
+   SQL_SUPPORTS_COLUMN_ALIASING = 515;
+ 
+   /*
+    * Retrieves a boolean value indicating whether concatenations between null and non-null values being
+    * null are supported.
+    *
+    * - Returns:
+    * - false: if concatenations between null and non-null values being null are unsupported;
+    * - true: if concatenations between null and non-null values being null are supported.
+    */
+   SQL_NULL_PLUS_NULL_IS_NULL = 516;
+ 
+   /*
+    * Retrieves a map where the key is the type to convert from and the value is a list with the types to convert to,
+    * indicating the supported conversions. Each key and each item on the list value is a value to a predefined type on
+    * SqlSupportsConvert enum.
+    * The returned map will be:  map<int32, list<int32>>
+    */
+   SQL_SUPPORTS_CONVERT = 517;
+ 
+   /*
+    * Retrieves a boolean value indicating whether, when table correlation names are supported,
+    * they are restricted to being different from the names of the tables.
+    *
+    * Returns:
+    * - false: if table correlation names are unsupported;
+    * - true: if table correlation names are supported.
+    */
+   SQL_SUPPORTS_TABLE_CORRELATION_NAMES = 518;
+ 
+   /*
+    * Retrieves a boolean value indicating whether, when table correlation names are supported,
+    * they are restricted to being different from the names of the tables.
+    *
+    * Returns:
+    * - false: if different table correlation names are unsupported;
+    * - true: if different table correlation names are supported
+    */
+   SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES = 519;
+ 
+   /*
+    * Retrieves a boolean value indicating whether expressions in ORDER BY lists are supported.
+    *
+    * Returns:
+    * - false: if expressions in ORDER BY are unsupported;
+    * - true: if expressions in ORDER BY are supported;
+    */
+   SQL_SUPPORTS_EXPRESSIONS_IN_ORDER_BY = 520;
+ 
+   /*
+    * Retrieves a boolean value indicating whether using a column that is not in the SELECT statement in a GROUP BY
+    * clause is supported.
+    *
+    * Returns:
+    * - false: if using a column that is not in the SELECT statement in a GROUP BY clause is unsupported;
+    * - true: if using a column that is not in the SELECT statement in a GROUP BY clause is supported.
+    */
+   SQL_SUPPORTS_ORDER_BY_UNRELATED = 521;
+ 
+   /*
+    * Retrieves the supported GROUP BY commands;
+    *
+    * Returns an int32 bitmask value representing the supported commands.
+    * The returned bitmask should be parsed in order to retrieve the supported commands.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (GROUP BY is unsupported);
+    * - return 1 (\b1)   => [SQL_GROUP_BY_UNRELATED];
+    * - return 2 (\b10)  => [SQL_GROUP_BY_BEYOND_SELECT];
+    * - return 3 (\b11)  => [SQL_GROUP_BY_UNRELATED, SQL_GROUP_BY_BEYOND_SELECT].
+    * Valid GROUP BY types are described under `arrow.flight.protocol.sql.SqlSupportedGroupBy`.
+    */
+   SQL_SUPPORTED_GROUP_BY = 522;
+ 
+   /*
+    * Retrieves a boolean value indicating whether specifying a LIKE escape clause is supported.
+    *
+    * Returns:
+    * - false: if specifying a LIKE escape clause is unsupported;
+    * - true: if specifying a LIKE escape clause is supported.
+    */
+   SQL_SUPPORTS_LIKE_ESCAPE_CLAUSE = 523;
+ 
+   /*
+    * Retrieves a boolean value indicating whether columns may be defined as non-nullable.
+    *
+    * Returns:
+    * - false: if columns cannot be defined as non-nullable;
+    * - true: if columns may be defined as non-nullable.
+    */
+   SQL_SUPPORTS_NON_NULLABLE_COLUMNS = 524;
+ 
+   /*
+    * Retrieves the supported SQL grammar level as per the ODBC specification.
+    *
+    * Returns an int32 bitmask value representing the supported SQL grammar level.
+    * The returned bitmask should be parsed in order to retrieve the supported grammar levels.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (SQL grammar is unsupported);
+    * - return 1 (\b1)   => [SQL_MINIMUM_GRAMMAR];
+    * - return 2 (\b10)  => [SQL_CORE_GRAMMAR];
+    * - return 3 (\b11)  => [SQL_MINIMUM_GRAMMAR, SQL_CORE_GRAMMAR];
+    * - return 4 (\b100) => [SQL_EXTENDED_GRAMMAR];
+    * - return 5 (\b101) => [SQL_MINIMUM_GRAMMAR, SQL_EXTENDED_GRAMMAR];
+    * - return 6 (\b110) => [SQL_CORE_GRAMMAR, SQL_EXTENDED_GRAMMAR];
+    * - return 7 (\b111) => [SQL_MINIMUM_GRAMMAR, SQL_CORE_GRAMMAR, SQL_EXTENDED_GRAMMAR].
+    * Valid SQL grammar levels are described under `arrow.flight.protocol.sql.SupportedSqlGrammar`.
+    */
+   SQL_SUPPORTED_GRAMMAR = 525;
+ 
+   /*
+    * Retrieves the supported ANSI92 SQL grammar level.
+    *
+    * Returns an int32 bitmask value representing the supported ANSI92 SQL grammar level.
+    * The returned bitmask should be parsed in order to retrieve the supported commands.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (ANSI92 SQL grammar is unsupported);
+    * - return 1 (\b1)   => [ANSI92_ENTRY_SQL];
+    * - return 2 (\b10)  => [ANSI92_INTERMEDIATE_SQL];
+    * - return 3 (\b11)  => [ANSI92_ENTRY_SQL, ANSI92_INTERMEDIATE_SQL];
+    * - return 4 (\b100) => [ANSI92_FULL_SQL];
+    * - return 5 (\b101) => [ANSI92_ENTRY_SQL, ANSI92_FULL_SQL];
+    * - return 6 (\b110) => [ANSI92_INTERMEDIATE_SQL, ANSI92_FULL_SQL];
+    * - return 7 (\b111) => [ANSI92_ENTRY_SQL, ANSI92_INTERMEDIATE_SQL, ANSI92_FULL_SQL].
+    * Valid ANSI92 SQL grammar levels are described under `arrow.flight.protocol.sql.SupportedAnsi92SqlGrammarLevel`.
+    */
+   SQL_ANSI92_SUPPORTED_LEVEL = 526;
+ 
+   /*
+    * Retrieves a boolean value indicating whether the SQL Integrity Enhancement Facility is supported.
+    *
+    * Returns:
+    * - false: if the SQL Integrity Enhancement Facility is supported;
+    * - true: if the SQL Integrity Enhancement Facility is supported.
+    */
+   SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY = 527;
+ 
+   /*
+    * Retrieves the support level for SQL OUTER JOINs.
+    *
+    * Returns a int32 ordinal for the SQL ordering being used, as described in
+    * `arrow.flight.protocol.sql.SqlOuterJoinsSupportLevel`.
+    */
+   SQL_OUTER_JOINS_SUPPORT_LEVEL = 528;
+ 
+   // Retrieves a UTF-8 string with the preferred term for "schema".
+   SQL_SCHEMA_TERM = 529;
+ 
+   // Retrieves a UTF-8 string with the preferred term for "procedure".
+   SQL_PROCEDURE_TERM = 530;
+ 
+   /*
+    * Retrieves a UTF-8 string with the preferred term for "catalog".
+    * If a empty string is returned its assumed that the server does NOT supports catalogs.
+    */
+   SQL_CATALOG_TERM = 531;
+ 
+   /*
+    * Retrieves a boolean value indicating whether a catalog appears at the start of a fully qualified table name.
+    *
+    * - false: if a catalog does not appear at the start of a fully qualified table name;
+    * - true: if a catalog appears at the start of a fully qualified table name.
+    */
+   SQL_CATALOG_AT_START = 532;
+ 
+   /*
+    * Retrieves the supported actions for a SQL schema.
+    *
+    * Returns an int32 bitmask value representing the supported actions for a SQL schema.
+    * The returned bitmask should be parsed in order to retrieve the supported actions for a SQL schema.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported actions for SQL schema);
+    * - return 1 (\b1)   => [SQL_ELEMENT_IN_PROCEDURE_CALLS];
+    * - return 2 (\b10)  => [SQL_ELEMENT_IN_INDEX_DEFINITIONS];
+    * - return 3 (\b11)  => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS];
+    * - return 4 (\b100) => [SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 5 (\b101) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 6 (\b110) => [SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 7 (\b111) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS].
+    * Valid actions for a SQL schema described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
+    */
+   SQL_SCHEMAS_SUPPORTED_ACTIONS = 533;
+ 
+   /*
+    * Retrieves the supported actions for a SQL schema.
+    *
+    * Returns an int32 bitmask value representing the supported actions for a SQL catalog.
+    * The returned bitmask should be parsed in order to retrieve the supported actions for a SQL catalog.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported actions for SQL catalog);
+    * - return 1 (\b1)   => [SQL_ELEMENT_IN_PROCEDURE_CALLS];
+    * - return 2 (\b10)  => [SQL_ELEMENT_IN_INDEX_DEFINITIONS];
+    * - return 3 (\b11)  => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS];
+    * - return 4 (\b100) => [SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 5 (\b101) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 6 (\b110) => [SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
+    * - return 7 (\b111) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS].
+    * Valid actions for a SQL catalog are described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
+    */
+   SQL_CATALOGS_SUPPORTED_ACTIONS = 534;
+ 
+   /*
+    * Retrieves the supported SQL positioned commands.
+    *
+    * Returns an int32 bitmask value representing the supported SQL positioned commands.
+    * The returned bitmask should be parsed in order to retrieve the supported SQL positioned commands.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported SQL positioned commands);
+    * - return 1 (\b1)   => [SQL_POSITIONED_DELETE];
+    * - return 2 (\b10)  => [SQL_POSITIONED_UPDATE];
+    * - return 3 (\b11)  => [SQL_POSITIONED_DELETE, SQL_POSITIONED_UPDATE].
+    * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlSupportedPositionedCommands`.
+    */
+   SQL_SUPPORTED_POSITIONED_COMMANDS = 535;
+ 
+   /*
+    * Retrieves a boolean value indicating whether SELECT FOR UPDATE statements are supported.
+    *
+    * Returns:
+    * - false: if SELECT FOR UPDATE statements are unsupported;
+    * - true: if SELECT FOR UPDATE statements are supported.
+    */
+   SQL_SELECT_FOR_UPDATE_SUPPORTED = 536;
+ 
+   /*
+    * Retrieves a boolean value indicating whether stored procedure calls that use the stored procedure escape syntax
+    * are supported.
+    *
+    * Returns:
+    * - false: if stored procedure calls that use the stored procedure escape syntax are unsupported;
+    * - true: if stored procedure calls that use the stored procedure escape syntax are supported.
+    */
+   SQL_STORED_PROCEDURES_SUPPORTED = 537;
+ 
+   /*
+    * Retrieves the supported SQL subqueries.
+    *
+    * Returns an int32 bitmask value representing the supported SQL subqueries.
+    * The returned bitmask should be parsed in order to retrieve the supported SQL subqueries.
+    *
+    * For instance:
+    * - return 0   (\b0)     => [] (no supported SQL subqueries);
+    * - return 1   (\b1)     => [SQL_SUBQUERIES_IN_COMPARISONS];
+    * - return 2   (\b10)    => [SQL_SUBQUERIES_IN_EXISTS];
+    * - return 3   (\b11)    => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS];
+    * - return 4   (\b100)   => [SQL_SUBQUERIES_IN_INS];
+    * - return 5   (\b101)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_INS];
+    * - return 6   (\b110)   => [SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_EXISTS];
+    * - return 7   (\b111)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS];
+    * - return 8   (\b1000)  => [SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 9   (\b1001)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 10  (\b1010)  => [SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 11  (\b1011)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 12  (\b1100)  => [SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 13  (\b1101)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 14  (\b1110)  => [SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - return 15  (\b1111)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
+    * - ...
+    * Valid SQL subqueries are described under `arrow.flight.protocol.sql.SqlSupportedSubqueries`.
+    */
+   SQL_SUPPORTED_SUBQUERIES = 538;
+ 
+   /*
+    * Retrieves a boolean value indicating whether correlated subqueries are supported.
+    *
+    * Returns:
+    * - false: if correlated subqueries are unsupported;
+    * - true: if correlated subqueries are supported.
+    */
+   SQL_CORRELATED_SUBQUERIES_SUPPORTED = 539;
+ 
+   /*
+    * Retrieves the supported SQL UNIONs.
+    *
+    * Returns an int32 bitmask value representing the supported SQL UNIONs.
+    * The returned bitmask should be parsed in order to retrieve the supported SQL UNIONs.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported SQL positioned commands);
+    * - return 1 (\b1)   => [SQL_UNION];
+    * - return 2 (\b10)  => [SQL_UNION_ALL];
+    * - return 3 (\b11)  => [SQL_UNION, SQL_UNION_ALL].
+    * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlSupportedUnions`.
+    */
+   SQL_SUPPORTED_UNIONS = 540;
+ 
+   // Retrieves a int64 value representing the maximum number of hex characters allowed in an inline binary literal.
+   SQL_MAX_BINARY_LITERAL_LENGTH = 541;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed for a character literal.
+   SQL_MAX_CHAR_LITERAL_LENGTH = 542;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed for a column name.
+   SQL_MAX_COLUMN_NAME_LENGTH = 543;
+ 
+   // Retrieves a int64 value representing the the maximum number of columns allowed in a GROUP BY clause.
+   SQL_MAX_COLUMNS_IN_GROUP_BY = 544;
+ 
+   // Retrieves a int64 value representing the maximum number of columns allowed in an index.
+   SQL_MAX_COLUMNS_IN_INDEX = 545;
+ 
+   // Retrieves a int64 value representing the maximum number of columns allowed in an ORDER BY clause.
+   SQL_MAX_COLUMNS_IN_ORDER_BY = 546;
+ 
+   // Retrieves a int64 value representing the maximum number of columns allowed in a SELECT list.
+   SQL_MAX_COLUMNS_IN_SELECT = 547;
+ 
+   // Retrieves a int64 value representing the maximum number of columns allowed in a table.
+   SQL_MAX_COLUMNS_IN_TABLE = 548;
+ 
+   // Retrieves a int64 value representing the maximum number of concurrent connections possible.
+   SQL_MAX_CONNECTIONS = 549;
+ 
+   // Retrieves a int64 value the maximum number of characters allowed in a cursor name.
+   SQL_MAX_CURSOR_NAME_LENGTH = 550;
+ 
+   /*
+    * Retrieves a int64 value representing the maximum number of bytes allowed for an index,
+    * including all of the parts of the index.
+    */
+   SQL_MAX_INDEX_LENGTH = 551;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed in a schema name.
+   SQL_DB_SCHEMA_NAME_LENGTH = 552;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed in a procedure name.
+   SQL_MAX_PROCEDURE_NAME_LENGTH = 553;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed in a catalog name.
+   SQL_MAX_CATALOG_NAME_LENGTH = 554;
+ 
+   // Retrieves a int64 value representing the maximum number of bytes allowed in a single row.
+   SQL_MAX_ROW_SIZE = 555;
+ 
+   /*
+    * Retrieves a boolean indicating whether the return value for the JDBC method getMaxRowSize includes the SQL
+    * data types LONGVARCHAR and LONGVARBINARY.
+    *
+    * Returns:
+    * - false: if return value for the JDBC method getMaxRowSize does
+    *          not include the SQL data types LONGVARCHAR and LONGVARBINARY;
+    * - true: if return value for the JDBC method getMaxRowSize includes
+    *         the SQL data types LONGVARCHAR and LONGVARBINARY.
+    */
+   SQL_MAX_ROW_SIZE_INCLUDES_BLOBS = 556;
+ 
+   /*
+    * Retrieves a int64 value representing the maximum number of characters allowed for an SQL statement;
+    * a result of 0 (zero) means that there is no limit or the limit is not known.
+    */
+   SQL_MAX_STATEMENT_LENGTH = 557;
+ 
+   // Retrieves a int64 value representing the maximum number of active statements that can be open at the same time.
+   SQL_MAX_STATEMENTS = 558;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed in a table name.
+   SQL_MAX_TABLE_NAME_LENGTH = 559;
+ 
+   // Retrieves a int64 value representing the maximum number of tables allowed in a SELECT statement.
+   SQL_MAX_TABLES_IN_SELECT = 560;
+ 
+   // Retrieves a int64 value representing the maximum number of characters allowed in a user name.
+   SQL_MAX_USERNAME_LENGTH = 561;
+ 
+   /*
+    * Retrieves this database's default transaction isolation level as described in
+    * `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
+    *
+    * Returns a int32 ordinal for the SQL transaction isolation level.
+    */
+   SQL_DEFAULT_TRANSACTION_ISOLATION = 562;
+ 
+   /*
+    * Retrieves a boolean value indicating whether transactions are supported. If not, invoking the method commit is a
+    * noop, and the isolation level is `arrow.flight.protocol.sql.SqlTransactionIsolationLevel.TRANSACTION_NONE`.
+    *
+    * Returns:
+    * - false: if transactions are unsupported;
+    * - true: if transactions are supported.
+    */
+   SQL_TRANSACTIONS_SUPPORTED = 563;
+ 
+   /*
+    * Retrieves the supported transactions isolation levels.
+    *
+    * Returns an int32 bitmask value representing the supported transactions isolation levels.
+    * The returned bitmask should be parsed in order to retrieve the supported transactions isolation levels.
+    *
+    * For instance:
+    * - return 0   (\b0)     => [] (no supported SQL transactions isolation levels);
+    * - return 1   (\b1)     => [SQL_TRANSACTION_NONE];
+    * - return 2   (\b10)    => [SQL_TRANSACTION_READ_UNCOMMITTED];
+    * - return 3   (\b11)    => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED];
+    * - return 4   (\b100)   => [SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 5   (\b101)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 6   (\b110)   => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 7   (\b111)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 8   (\b1000)  => [SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 9   (\b1001)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 10  (\b1010)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 11  (\b1011)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 12  (\b1100)  => [SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 13  (\b1101)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 14  (\b1110)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 15  (\b1111)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
+    * - return 16  (\b10000) => [SQL_TRANSACTION_SERIALIZABLE];
+    * - ...
+    * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
+    */
+   SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS = 564;
+ 
+   /*
+    * Retrieves a boolean value indicating whether a data definition statement within a transaction forces
+    * the transaction to commit.
+    *
+    * Returns:
+    * - false: if a data definition statement within a transaction does not force the transaction to commit;
+    * - true: if a data definition statement within a transaction forces the transaction to commit.
+    */
+   SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT = 565;
+ 
+   /*
+    * Retrieves a boolean value indicating whether a data definition statement within a transaction is ignored.
+    *
+    * Returns:
+    * - false: if a data definition statement within a transaction is taken into account;
+    * - true: a data definition statement within a transaction is ignored.
+    */
+   SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED = 566;
+ 
+   /*
+    * Retrieves an int32 bitmask value representing the supported result set types.
+    * The returned bitmask should be parsed in order to retrieve the supported result set types.
+    *
+    * For instance:
+    * - return 0   (\b0)     => [] (no supported result set types);
+    * - return 1   (\b1)     => [SQL_RESULT_SET_TYPE_UNSPECIFIED];
+    * - return 2   (\b10)    => [SQL_RESULT_SET_TYPE_FORWARD_ONLY];
+    * - return 3   (\b11)    => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_FORWARD_ONLY];
+    * - return 4   (\b100)   => [SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
+    * - return 5   (\b101)   => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
+    * - return 6   (\b110)   => [SQL_RESULT_SET_TYPE_FORWARD_ONLY, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
+    * - return 7   (\b111)   => [SQL_RESULT_SET_TYPE_UNSPECIFIED, SQL_RESULT_SET_TYPE_FORWARD_ONLY, SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE];
+    * - return 8   (\b1000)  => [SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE];
+    * - ...
+    * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetType`.
+    */
+   SQL_SUPPORTED_RESULT_SET_TYPES = 567;
+ 
+   /*
+    * Returns an int32 bitmask value concurrency types supported for
+    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_UNSPECIFIED`.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
+    * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
+    * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+    */
+   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_UNSPECIFIED = 568;
+ 
+   /*
+    * Returns an int32 bitmask value concurrency types supported for
+    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_FORWARD_ONLY`.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
+    * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
+    * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+    */
+   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_FORWARD_ONLY = 569;
+ 
+   /*
+    * Returns an int32 bitmask value concurrency types supported for
+    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE`.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
+    * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
+    * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+    */
+   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_SENSITIVE = 570;
+ 
+   /*
+    * Returns an int32 bitmask value concurrency types supported for
+    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE`.
+    *
+    * For instance:
+    * - return 0 (\b0)   => [] (no supported concurrency types for this result set type)
+    * - return 1 (\b1)   => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED]
+    * - return 2 (\b10)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 3 (\b11)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY]
+    * - return 4 (\b100) => [SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
+    * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+    */
+   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_INSENSITIVE = 571;
+ 
+   /*
+    * Retrieves a boolean value indicating whether this database supports batch updates.
+    *
+    * - false: if this database does not support batch updates;
+    * - true: if this database supports batch updates.
+    */
+   SQL_BATCH_UPDATES_SUPPORTED = 572;
+ 
+   /*
+    * Retrieves a boolean value indicating whether this database supports savepoints.
+    *
+    * Returns:
+    * - false: if this database does not support savepoints;
+    * - true: if this database supports savepoints.
+    */
+   SQL_SAVEPOINTS_SUPPORTED = 573;
+ 
+   /*
+    * Retrieves a boolean value indicating whether named parameters are supported in callable statements.
+    *
+    * Returns:
+    * - false: if named parameters in callable statements are unsupported;
+    * - true: if named parameters in callable statements are supported.
+    */
+   SQL_NAMED_PARAMETERS_SUPPORTED = 574;
+ 
+   /*
+    * Retrieves a boolean value indicating whether updates made to a LOB are made on a copy or directly to the LOB.
+    *
+    * Returns:
+    * - false: if updates made to a LOB are made directly to the LOB;
+    * - true: if updates made to a LOB are made on a copy.
+    */
+   SQL_LOCATORS_UPDATE_COPY = 575;
+ 
+   /*
+    * Retrieves a boolean value indicating whether invoking user-defined or vendor functions
+    * using the stored procedure escape syntax is supported.
+    *
+    * Returns:
+    * - false: if invoking user-defined or vendor functions using the stored procedure escape syntax is unsupported;
+    * - true: if invoking user-defined or vendor functions using the stored procedure escape syntax is supported.
+    */
+   SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED = 576;
+ }
+ 
+ // The level of support for Flight SQL transaction RPCs.
+ enum SqlSupportedTransaction {
+   // Unknown/not indicated/no support
+   SQL_SUPPORTED_TRANSACTION_NONE = 0;
+   // Transactions, but not savepoints.
+   // A savepoint is a mark within a transaction that can be individually
+   // rolled back to. Not all databases support savepoints.
+   SQL_SUPPORTED_TRANSACTION_TRANSACTION = 1;
+   // Transactions and savepoints
+   SQL_SUPPORTED_TRANSACTION_SAVEPOINT = 2;
+ }
+ 
+ enum SqlSupportedCaseSensitivity {
+   SQL_CASE_SENSITIVITY_UNKNOWN = 0;
+   SQL_CASE_SENSITIVITY_CASE_INSENSITIVE = 1;
+   SQL_CASE_SENSITIVITY_UPPERCASE = 2;
+   SQL_CASE_SENSITIVITY_LOWERCASE = 3;
+ }
+ 
+ enum SqlNullOrdering {
+   SQL_NULLS_SORTED_HIGH = 0;
+   SQL_NULLS_SORTED_LOW = 1;
+   SQL_NULLS_SORTED_AT_START = 2;
+   SQL_NULLS_SORTED_AT_END = 3;
+ }
+ 
+ enum SupportedSqlGrammar {
+   SQL_MINIMUM_GRAMMAR = 0;
+   SQL_CORE_GRAMMAR = 1;
+   SQL_EXTENDED_GRAMMAR = 2;
+ }
+ 
+ enum SupportedAnsi92SqlGrammarLevel {
+   ANSI92_ENTRY_SQL = 0;
+   ANSI92_INTERMEDIATE_SQL = 1;
+   ANSI92_FULL_SQL = 2;
+ }
+ 
+ enum SqlOuterJoinsSupportLevel {
+   SQL_JOINS_UNSUPPORTED = 0;
+   SQL_LIMITED_OUTER_JOINS = 1;
+   SQL_FULL_OUTER_JOINS = 2;
+ }
+ 
+ enum SqlSupportedGroupBy {
+   SQL_GROUP_BY_UNRELATED = 0;
+   SQL_GROUP_BY_BEYOND_SELECT = 1;
+ }
+ 
+ enum SqlSupportedElementActions {
+   SQL_ELEMENT_IN_PROCEDURE_CALLS = 0;
+   SQL_ELEMENT_IN_INDEX_DEFINITIONS = 1;
+   SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS = 2;
+ }
+ 
+ enum SqlSupportedPositionedCommands {
+   SQL_POSITIONED_DELETE = 0;
+   SQL_POSITIONED_UPDATE = 1;
+ }
+ 
+ enum SqlSupportedSubqueries {
+   SQL_SUBQUERIES_IN_COMPARISONS = 0;
+   SQL_SUBQUERIES_IN_EXISTS = 1;
+   SQL_SUBQUERIES_IN_INS = 2;
+   SQL_SUBQUERIES_IN_QUANTIFIEDS = 3;
+ }
+ 
+ enum SqlSupportedUnions {
+   SQL_UNION = 0;
+   SQL_UNION_ALL = 1;
+ }
+ 
+ enum SqlTransactionIsolationLevel {
+   SQL_TRANSACTION_NONE = 0;
+   SQL_TRANSACTION_READ_UNCOMMITTED = 1;
+   SQL_TRANSACTION_READ_COMMITTED = 2;
+   SQL_TRANSACTION_REPEATABLE_READ = 3;
+   SQL_TRANSACTION_SERIALIZABLE = 4;
+ }
+ 
+ enum SqlSupportedTransactions {
+   SQL_TRANSACTION_UNSPECIFIED = 0;
+   SQL_DATA_DEFINITION_TRANSACTIONS = 1;
+   SQL_DATA_MANIPULATION_TRANSACTIONS = 2;
+ }
+ 
+ enum SqlSupportedResultSetType {
+   SQL_RESULT_SET_TYPE_UNSPECIFIED = 0;
+   SQL_RESULT_SET_TYPE_FORWARD_ONLY = 1;
+   SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE = 2;
+   SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE = 3;
+ }
+ 
+ enum SqlSupportedResultSetConcurrency {
+   SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED = 0;
+   SQL_RESULT_SET_CONCURRENCY_READ_ONLY = 1;
+   SQL_RESULT_SET_CONCURRENCY_UPDATABLE = 2;
+ }
+ 
+ enum SqlSupportsConvert {
+   SQL_CONVERT_BIGINT = 0;
+   SQL_CONVERT_BINARY = 1;
+   SQL_CONVERT_BIT = 2;
+   SQL_CONVERT_CHAR = 3;
+   SQL_CONVERT_DATE = 4;
+   SQL_CONVERT_DECIMAL = 5;
+   SQL_CONVERT_FLOAT = 6;
+   SQL_CONVERT_INTEGER = 7;
+   SQL_CONVERT_INTERVAL_DAY_TIME = 8;
+   SQL_CONVERT_INTERVAL_YEAR_MONTH = 9;
+   SQL_CONVERT_LONGVARBINARY = 10;
+   SQL_CONVERT_LONGVARCHAR = 11;
+   SQL_CONVERT_NUMERIC = 12;
+   SQL_CONVERT_REAL = 13;
+   SQL_CONVERT_SMALLINT = 14;
+   SQL_CONVERT_TIME = 15;
+   SQL_CONVERT_TIMESTAMP = 16;
+   SQL_CONVERT_TINYINT = 17;
+   SQL_CONVERT_VARBINARY = 18;
+   SQL_CONVERT_VARCHAR = 19;
+ }
+ 
+ /**
+  * The JDBC/ODBC-defined type of any object.
+  * All the values here are the sames as in the JDBC and ODBC specs.
+  */
+ enum XdbcDataType {
+   XDBC_UNKNOWN_TYPE = 0;
+   XDBC_CHAR = 1;
+   XDBC_NUMERIC = 2;
+   XDBC_DECIMAL = 3;
+   XDBC_INTEGER = 4;
+   XDBC_SMALLINT = 5;
+   XDBC_FLOAT = 6;
+   XDBC_REAL = 7;
+   XDBC_DOUBLE = 8;
+   XDBC_DATETIME = 9;
+   XDBC_INTERVAL = 10;
+   XDBC_VARCHAR = 12;
+   XDBC_DATE = 91;
+   XDBC_TIME = 92;
+   XDBC_TIMESTAMP = 93;
+   XDBC_LONGVARCHAR = -1;
+   XDBC_BINARY = -2;
+   XDBC_VARBINARY = -3;
+   XDBC_LONGVARBINARY = -4;
+   XDBC_BIGINT = -5;
+   XDBC_TINYINT = -6;
+   XDBC_BIT = -7;
+   XDBC_WCHAR = -8;
+   XDBC_WVARCHAR = -9;
+ }
+ 
+ /**
+  * Detailed subtype information for XDBC_TYPE_DATETIME and XDBC_TYPE_INTERVAL.
+  */
+ enum XdbcDatetimeSubcode {
+   option allow_alias = true;
+   XDBC_SUBCODE_UNKNOWN = 0;
+   XDBC_SUBCODE_YEAR = 1;
+   XDBC_SUBCODE_DATE = 1;
+   XDBC_SUBCODE_TIME = 2;
+   XDBC_SUBCODE_MONTH = 2;
+   XDBC_SUBCODE_TIMESTAMP = 3;
+   XDBC_SUBCODE_DAY = 3;
+   XDBC_SUBCODE_TIME_WITH_TIMEZONE = 4;
+   XDBC_SUBCODE_HOUR = 4;
+   XDBC_SUBCODE_TIMESTAMP_WITH_TIMEZONE = 5;
+   XDBC_SUBCODE_MINUTE = 5;
+   XDBC_SUBCODE_SECOND = 6;
+   XDBC_SUBCODE_YEAR_TO_MONTH = 7;
+   XDBC_SUBCODE_DAY_TO_HOUR = 8;
+   XDBC_SUBCODE_DAY_TO_MINUTE = 9;
+   XDBC_SUBCODE_DAY_TO_SECOND = 10;
+   XDBC_SUBCODE_HOUR_TO_MINUTE = 11;
+   XDBC_SUBCODE_HOUR_TO_SECOND = 12;
+   XDBC_SUBCODE_MINUTE_TO_SECOND = 13;
+   XDBC_SUBCODE_INTERVAL_YEAR = 101;
+   XDBC_SUBCODE_INTERVAL_MONTH = 102;
+   XDBC_SUBCODE_INTERVAL_DAY = 103;
+   XDBC_SUBCODE_INTERVAL_HOUR = 104;
+   XDBC_SUBCODE_INTERVAL_MINUTE = 105;
+   XDBC_SUBCODE_INTERVAL_SECOND = 106;
+   XDBC_SUBCODE_INTERVAL_YEAR_TO_MONTH = 107;
+   XDBC_SUBCODE_INTERVAL_DAY_TO_HOUR = 108;
+   XDBC_SUBCODE_INTERVAL_DAY_TO_MINUTE = 109;
+   XDBC_SUBCODE_INTERVAL_DAY_TO_SECOND = 110;
+   XDBC_SUBCODE_INTERVAL_HOUR_TO_MINUTE = 111;
+   XDBC_SUBCODE_INTERVAL_HOUR_TO_SECOND = 112;
+   XDBC_SUBCODE_INTERVAL_MINUTE_TO_SECOND = 113;
+ }
+ 
+ enum Nullable {
+   /**
+    * Indicates that the fields does not allow the use of null values.
+    */
+   NULLABILITY_NO_NULLS = 0;
+ 
+   /**
+    * Indicates that the fields allow the use of null values.
+    */
+   NULLABILITY_NULLABLE = 1;
+ 
+   /**
+    * Indicates that nullability of the fields can not be determined.
+    */
+   NULLABILITY_UNKNOWN = 2;
+ }
+ 
+ enum Searchable {
+   /**
+    * Indicates that column can not be used in a WHERE clause.
+    */
+   SEARCHABLE_NONE = 0;
+ 
+   /**
+    * Indicates that the column can be used in a WHERE clause if it is using a
+    * LIKE operator.
+    */
+   SEARCHABLE_CHAR = 1;
+ 
+   /**
+    * Indicates that the column can be used In a WHERE clause with any
+    * operator other than LIKE.
+    *
+    * - Allowed operators: comparison, quantified comparison, BETWEEN,
+    *                      DISTINCT, IN, MATCH, and UNIQUE.
+    */
+   SEARCHABLE_BASIC = 2;
+ 
+   /**
+    * Indicates that the column can be used in a WHERE clause using any operator.
+    */
+   SEARCHABLE_FULL = 3;
+ }
+ 
+ /*
+  * Represents a request to retrieve information about data type supported on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned schema will be:
+  * <
+  *   type_name: utf8 not null (The name of the data type, for example: VARCHAR, INTEGER, etc),
+  *   data_type: int32 not null (The SQL data type),
+  *   column_size: int32 (The maximum size supported by that column.
+  *                       In case of exact numeric types, this represents the maximum precision.
+  *                       In case of string types, this represents the character length.
+  *                       In case of datetime data types, this represents the length in characters of the string representation.
+  *                       NULL is returned for data types where column size is not applicable.),
+  *   literal_prefix: utf8 (Character or characters used to prefix a literal, NULL is returned for
+  *                         data types where a literal prefix is not applicable.),
+  *   literal_suffix: utf8 (Character or characters used to terminate a literal,
+  *                         NULL is returned for data types where a literal suffix is not applicable.),
+  *   create_params: list<utf8 not null>
+  *                        (A list of keywords corresponding to which parameters can be used when creating
+  *                         a column for that specific type.
+  *                         NULL is returned if there are no parameters for the data type definition.),
+  *   nullable: int32 not null (Shows if the data type accepts a NULL value. The possible values can be seen in the
+  *                             Nullable enum.),
+  *   case_sensitive: bool not null (Shows if a character data type is case-sensitive in collations and comparisons),
+  *   searchable: int32 not null (Shows how the data type is used in a WHERE clause. The possible values can be seen in the
+  *                               Searchable enum.),
+  *   unsigned_attribute: bool (Shows if the data type is unsigned. NULL is returned if the attribute is
+  *                             not applicable to the data type or the data type is not numeric.),
+  *   fixed_prec_scale: bool not null (Shows if the data type has predefined fixed precision and scale.),
+  *   auto_increment: bool (Shows if the data type is auto incremental. NULL is returned if the attribute
+  *                         is not applicable to the data type or the data type is not numeric.),
+  *   local_type_name: utf8 (Localized version of the data source-dependent name of the data type. NULL
+  *                          is returned if a localized name is not supported by the data source),
+  *   minimum_scale: int32 (The minimum scale of the data type on the data source.
+  *                         If a data type has a fixed scale, the MINIMUM_SCALE and MAXIMUM_SCALE
+  *                         columns both contain this value. NULL is returned if scale is not applicable.),
+  *   maximum_scale: int32 (The maximum scale of the data type on the data source.
+  *                         NULL is returned if scale is not applicable.),
+  *   sql_data_type: int32 not null (The value of the SQL DATA TYPE which has the same values
+  *                                  as data_type value. Except for interval and datetime, which
+  *                                  uses generic values. More info about those types can be
+  *                                  obtained through datetime_subcode. The possible values can be seen
+  *                                  in the XdbcDataType enum.),
+  *   datetime_subcode: int32 (Only used when the SQL DATA TYPE is interval or datetime. It contains
+  *                            its sub types. For type different from interval and datetime, this value
+  *                            is NULL. The possible values can be seen in the XdbcDatetimeSubcode enum.),
+  *   num_prec_radix: int32 (If the data type is an approximate numeric type, this column contains
+  *                          the value 2 to indicate that COLUMN_SIZE specifies a number of bits. For
+  *                          exact numeric types, this column contains the value 10 to indicate that
+  *                          column size specifies a number of decimal digits. Otherwise, this column is NULL.),
+  *   interval_precision: int32 (If the data type is an interval data type, then this column contains the value
+  *                              of the interval leading precision. Otherwise, this column is NULL. This fields
+  *                              is only relevant to be used by ODBC).
+  * >
+  * The returned data should be ordered by data_type and then by type_name.
+  */
+ message CommandGetXdbcTypeInfo {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the data type to search for the info.
+    */
+   optional int32 data_type = 1;
+ }
+ 
+ /*
+  * Represents a request to retrieve the list of catalogs on a Flight SQL enabled backend.
+  * The definition of a catalog depends on vendor/implementation. It is usually the database itself
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  catalog_name: utf8 not null
+  * >
+  * The returned data should be ordered by catalog_name.
+  */
+ message CommandGetCatalogs {
+   option (experimental) = true;
+ }
+ 
+ /*
+  * Represents a request to retrieve the list of database schemas on a Flight SQL enabled backend.
+  * The definition of a database schema depends on vendor/implementation. It is usually a collection of tables.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  catalog_name: utf8,
+  *  db_schema_name: utf8 not null
+  * >
+  * The returned data should be ordered by catalog_name, then db_schema_name.
+  */
+ message CommandGetDbSchemas {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the Catalog to search for the tables.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string catalog = 1;
+ 
+   /*
+    * Specifies a filter pattern for schemas to search for.
+    * When no db_schema_filter_pattern is provided, the pattern will not be used to narrow the search.
+    * In the pattern string, two special characters can be used to denote matching rules:
+    *    - "%" means to match any substring with 0 or more characters.
+    *    - "_" means to match any one character.
+    */
+   optional string db_schema_filter_pattern = 2;
+ }
+ 
+ /*
+  * Represents a request to retrieve the list of tables, and optionally their schemas, on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  catalog_name: utf8,
+  *  db_schema_name: utf8,
+  *  table_name: utf8 not null,
+  *  table_type: utf8 not null,
+  *  [optional] table_schema: bytes not null (schema of the table as described in Schema.fbs::Schema,
+  *                                           it is serialized as an IPC message.)
+  * >
+  * Fields on table_schema may contain the following metadata:
+  *  - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+  *  - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+  *  - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+  *  - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
+  *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+  *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
+  *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+  *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
+  */
+ message CommandGetTables {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the Catalog to search for the tables.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string catalog = 1;
+ 
+   /*
+    * Specifies a filter pattern for schemas to search for.
+    * When no db_schema_filter_pattern is provided, all schemas matching other filters are searched.
+    * In the pattern string, two special characters can be used to denote matching rules:
+    *    - "%" means to match any substring with 0 or more characters.
+    *    - "_" means to match any one character.
+    */
+   optional string db_schema_filter_pattern = 2;
+ 
+   /*
+    * Specifies a filter pattern for tables to search for.
+    * When no table_name_filter_pattern is provided, all tables matching other filters are searched.
+    * In the pattern string, two special characters can be used to denote matching rules:
+    *    - "%" means to match any substring with 0 or more characters.
+    *    - "_" means to match any one character.
+    */
+   optional string table_name_filter_pattern = 3;
+ 
+   /*
+    * Specifies a filter of table types which must match.
+    * The table types depend on vendor/implementation. It is usually used to separate tables from views or system tables.
+    * TABLE, VIEW, and SYSTEM TABLE are commonly supported.
+    */
+   repeated string table_types = 4;
+ 
+   // Specifies if the Arrow schema should be returned for found tables.
+   bool include_schema = 5;
+ }
+ 
+ /*
+  * Represents a request to retrieve the list of table types on a Flight SQL enabled backend.
+  * The table types depend on vendor/implementation. It is usually used to separate tables from views or system tables.
+  * TABLE, VIEW, and SYSTEM TABLE are commonly supported.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  table_type: utf8 not null
+  * >
+  * The returned data should be ordered by table_type.
+  */
+ message CommandGetTableTypes {
+   option (experimental) = true;
+ }
+ 
+ /*
+  * Represents a request to retrieve the primary keys of a table on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  catalog_name: utf8,
+  *  db_schema_name: utf8,
+  *  table_name: utf8 not null,
+  *  column_name: utf8 not null,
+  *  key_name: utf8,
+  *  key_sequence: int32 not null
+  * >
+  * The returned data should be ordered by catalog_name, db_schema_name, table_name, key_name, then key_sequence.
+  */
+ message CommandGetPrimaryKeys {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the catalog to search for the table.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string catalog = 1;
+ 
+   /*
+    * Specifies the schema to search for the table.
+    * An empty string retrieves those without a schema.
+    * If omitted the schema name should not be used to narrow the search.
+    */
+   optional string db_schema = 2;
+ 
+   // Specifies the table to get the primary keys for.
+   string table = 3;
+ }
+ 
+ enum UpdateDeleteRules {
+   CASCADE = 0;
+   RESTRICT = 1;
+   SET_NULL = 2;
+   NO_ACTION = 3;
+   SET_DEFAULT = 4;
+ }
+ 
+ /*
+  * Represents a request to retrieve a description of the foreign key columns that reference the given table's
+  * primary key columns (the foreign keys exported by a table) of a table on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  pk_catalog_name: utf8,
+  *  pk_db_schema_name: utf8,
+  *  pk_table_name: utf8 not null,
+  *  pk_column_name: utf8 not null,
+  *  fk_catalog_name: utf8,
+  *  fk_db_schema_name: utf8,
+  *  fk_table_name: utf8 not null,
+  *  fk_column_name: utf8 not null,
+  *  key_sequence: int32 not null,
+  *  fk_key_name: utf8,
+  *  pk_key_name: utf8,
+  *  update_rule: uint8 not null,
+  *  delete_rule: uint8 not null
+  * >
+  * The returned data should be ordered by fk_catalog_name, fk_db_schema_name, fk_table_name, fk_key_name, then key_sequence.
+  * update_rule and delete_rule returns a byte that is equivalent to actions declared on UpdateDeleteRules enum.
+  */
+ message CommandGetExportedKeys {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the catalog to search for the foreign key table.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string catalog = 1;
+ 
+   /*
+    * Specifies the schema to search for the foreign key table.
+    * An empty string retrieves those without a schema.
+    * If omitted the schema name should not be used to narrow the search.
+    */
+   optional string db_schema = 2;
+ 
+   // Specifies the foreign key table to get the foreign keys for.
+   string table = 3;
+ }
+ 
+ /*
+  * Represents a request to retrieve the foreign keys of a table on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  pk_catalog_name: utf8,
+  *  pk_db_schema_name: utf8,
+  *  pk_table_name: utf8 not null,
+  *  pk_column_name: utf8 not null,
+  *  fk_catalog_name: utf8,
+  *  fk_db_schema_name: utf8,
+  *  fk_table_name: utf8 not null,
+  *  fk_column_name: utf8 not null,
+  *  key_sequence: int32 not null,
+  *  fk_key_name: utf8,
+  *  pk_key_name: utf8,
+  *  update_rule: uint8 not null,
+  *  delete_rule: uint8 not null
+  * >
+  * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
+  * update_rule and delete_rule returns a byte that is equivalent to actions:
+  *    - 0 = CASCADE
+  *    - 1 = RESTRICT
+  *    - 2 = SET NULL
+  *    - 3 = NO ACTION
+  *    - 4 = SET DEFAULT
+  */
+ message CommandGetImportedKeys {
+   option (experimental) = true;
+ 
+   /*
+    * Specifies the catalog to search for the primary key table.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string catalog = 1;
+ 
+   /*
+    * Specifies the schema to search for the primary key table.
+    * An empty string retrieves those without a schema.
+    * If omitted the schema name should not be used to narrow the search.
+    */
+   optional string db_schema = 2;
+ 
+   // Specifies the primary key table to get the foreign keys for.
+   string table = 3;
+ }
+ 
+ /*
+  * Represents a request to retrieve a description of the foreign key columns in the given foreign key table that
+  * reference the primary key or the columns representing a unique constraint of the parent table (could be the same
+  * or a different table) on a Flight SQL enabled backend.
+  * Used in the command member of FlightDescriptor for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *  - GetFlightInfo: execute the catalog metadata request.
+  *
+  * The returned Arrow schema will be:
+  * <
+  *  pk_catalog_name: utf8,
+  *  pk_db_schema_name: utf8,
+  *  pk_table_name: utf8 not null,
+  *  pk_column_name: utf8 not null,
+  *  fk_catalog_name: utf8,
+  *  fk_db_schema_name: utf8,
+  *  fk_table_name: utf8 not null,
+  *  fk_column_name: utf8 not null,
+  *  key_sequence: int32 not null,
+  *  fk_key_name: utf8,
+  *  pk_key_name: utf8,
+  *  update_rule: uint8 not null,
+  *  delete_rule: uint8 not null
+  * >
+  * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
+  * update_rule and delete_rule returns a byte that is equivalent to actions:
+  *    - 0 = CASCADE
+  *    - 1 = RESTRICT
+  *    - 2 = SET NULL
+  *    - 3 = NO ACTION
+  *    - 4 = SET DEFAULT
+  */
+ message CommandGetCrossReference {
+   option (experimental) = true;
+ 
+   /**
+    * The catalog name where the parent table is.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string pk_catalog = 1;
+ 
+   /**
+    * The Schema name where the parent table is.
+    * An empty string retrieves those without a schema.
+    * If omitted the schema name should not be used to narrow the search.
+    */
+   optional string pk_db_schema = 2;
+ 
+   /**
+    * The parent table name. It cannot be null.
+    */
+   string pk_table = 3;
+ 
+   /**
+    * The catalog name where the foreign table is.
+    * An empty string retrieves those without a catalog.
+    * If omitted the catalog name should not be used to narrow the search.
+    */
+   optional string fk_catalog = 4;
+ 
+   /**
+    * The schema name where the foreign table is.
+    * An empty string retrieves those without a schema.
+    * If omitted the schema name should not be used to narrow the search.
+    */
+   optional string fk_db_schema = 5;
+ 
+   /**
+    * The foreign table name. It cannot be null.
+    */
+   string fk_table = 6;
+ }
+ 
+ // Query Execution Action Messages
+ 
+ /*
+  * Request message for the "CreatePreparedStatement" action on a Flight SQL enabled backend.
+  */
+ message ActionCreatePreparedStatementRequest {
+   option (experimental) = true;
+ 
+   // The valid SQL string to create a prepared statement for.
+   string query = 1;
+   // Create/execute the prepared statement as part of this transaction (if
+   // unset, executions of the prepared statement will be auto-committed).
+   optional bytes transaction_id = 2;
+ }
+ 
+ /*
+  * An embedded message describing a Substrait plan to execute.
+  */
+ message SubstraitPlan {
+   option (experimental) = true;
+ 
+   // The serialized substrait.Plan to create a prepared statement for.
+   // XXX(ARROW-16902): this is bytes instead of an embedded message
+   // because Protobuf does not really support one DLL using Protobuf
+   // definitions from another DLL.
+   bytes plan = 1;
+   // The Substrait release, e.g. "0.12.0". This information is not
+   // tracked in the plan itself, so this is the only way for consumers
+   // to potentially know if they can handle the plan.
+   string version = 2;
+ }
+ 
+ /*
+  * Request message for the "CreatePreparedSubstraitPlan" action on a Flight SQL enabled backend.
+  */
+ message ActionCreatePreparedSubstraitPlanRequest {
+   option (experimental) = true;
+ 
+   // The serialized substrait.Plan to create a prepared statement for.
+   SubstraitPlan plan = 1;
+   // Create/execute the prepared statement as part of this transaction (if
+   // unset, executions of the prepared statement will be auto-committed).
+   optional bytes transaction_id = 2;
+ }
+ 
+ /*
+  * Wrap the result of a "CreatePreparedStatement" or "CreatePreparedSubstraitPlan" action.
+  *
+  * The resultant PreparedStatement can be closed either:
+  * - Manually, through the "ClosePreparedStatement" action;
+  * - Automatically, by a server timeout.
+  *
+  * The result should be wrapped in a google.protobuf.Any message.
+  */
+ message ActionCreatePreparedStatementResult {
+   option (experimental) = true;
+ 
+   // Opaque handle for the prepared statement on the server.
+   bytes prepared_statement_handle = 1;
+ 
+   // If a result set generating query was provided, dataset_schema contains the
+   // schema of the dataset as described in Schema.fbs::Schema, it is serialized as an IPC message.
+   bytes dataset_schema = 2;
+ 
+   // If the query provided contained parameters, parameter_schema contains the
+   // schema of the expected parameters as described in Schema.fbs::Schema, it is serialized as an IPC message.
+   bytes parameter_schema = 3;
+ }
+ 
+ /*
+  * Request message for the "ClosePreparedStatement" action on a Flight SQL enabled backend.
+  * Closes server resources associated with the prepared statement handle.
+  */
+ message ActionClosePreparedStatementRequest {
+   option (experimental) = true;
+ 
+   // Opaque handle for the prepared statement on the server.
+   bytes prepared_statement_handle = 1;
+ }
+ 
+ /*
+  * Request message for the "BeginTransaction" action.
+  * Begins a transaction.
+  */
+ message ActionBeginTransactionRequest {
+   option (experimental) = true;
+ }
+ 
+ /*
+  * Request message for the "BeginSavepoint" action.
+  * Creates a savepoint within a transaction.
+  *
+  * Only supported if FLIGHT_SQL_TRANSACTION is
+  * FLIGHT_SQL_TRANSACTION_SUPPORT_SAVEPOINT.
+  */
+ message ActionBeginSavepointRequest {
+   option (experimental) = true;
+ 
+   // The transaction to which a savepoint belongs.
+   bytes transaction_id = 1;
+   // Name for the savepoint.
+   string name = 2;
+ }
+ 
+ /*
+  * The result of a "BeginTransaction" action.
+  *
+  * The transaction can be manipulated with the "EndTransaction" action, or
+  * automatically via server timeout. If the transaction times out, then it is
+  * automatically rolled back.
+  *
+  * The result should be wrapped in a google.protobuf.Any message.
+  */
+ message ActionBeginTransactionResult {
+   option (experimental) = true;
+ 
+   // Opaque handle for the transaction on the server.
+   bytes transaction_id = 1;
+ }
+ 
+ /*
+  * The result of a "BeginSavepoint" action.
+  *
+  * The transaction can be manipulated with the "EndSavepoint" action.
+  * If the associated transaction is committed, rolled back, or times
+  * out, then the savepoint is also invalidated.
+  *
+  * The result should be wrapped in a google.protobuf.Any message.
+  */
+ message ActionBeginSavepointResult {
+   option (experimental) = true;
+ 
+   // Opaque handle for the savepoint on the server.
+   bytes savepoint_id = 1;
+ }
+ 
+ /*
+  * Request message for the "EndTransaction" action.
+  *
+  * Commit (COMMIT) or rollback (ROLLBACK) the transaction.
+  *
+  * If the action completes successfully, the transaction handle is
+  * invalidated, as are all associated savepoints.
+  */
+ message ActionEndTransactionRequest {
+   option (experimental) = true;
+ 
+   enum EndTransaction {
+     END_TRANSACTION_UNSPECIFIED = 0;
+     // Commit the transaction.
+     END_TRANSACTION_COMMIT = 1;
+     // Roll back the transaction.
+     END_TRANSACTION_ROLLBACK = 2;
+   }
+   // Opaque handle for the transaction on the server.
+   bytes transaction_id = 1;
+   // Whether to commit/rollback the given transaction.
+   EndTransaction action = 2;
+ }
+ 
+ /*
+  * Request message for the "EndSavepoint" action.
+  *
+  * Release (RELEASE) the savepoint or rollback (ROLLBACK) to the
+  * savepoint.
+  *
+  * Releasing a savepoint invalidates that savepoint.  Rolling back to
+  * a savepoint does not invalidate the savepoint, but invalidates all
+  * savepoints created after the current savepoint.
+  */
+ message ActionEndSavepointRequest {
+   option (experimental) = true;
+ 
+   enum EndSavepoint {
+     END_SAVEPOINT_UNSPECIFIED = 0;
+     // Release the savepoint.
+     END_SAVEPOINT_RELEASE = 1;
+     // Roll back to a savepoint.
+     END_SAVEPOINT_ROLLBACK = 2;
+   }
+   // Opaque handle for the savepoint on the server.
+   bytes savepoint_id = 1;
+   // Whether to rollback/release the given savepoint.
+   EndSavepoint action = 2;
+ }
+ 
+ // Query Execution Messages.
+ 
+ /*
+  * Represents a SQL query. Used in the command member of FlightDescriptor
+  * for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *    Fields on this schema may contain the following metadata:
+  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+  *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
+  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
+  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+  *  - GetFlightInfo: execute the query.
+  */
+ message CommandStatementQuery {
+   option (experimental) = true;
+ 
+   // The SQL syntax.
+   string query = 1;
+   // Include the query as part of this transaction (if unset, the query is auto-committed).
+   optional bytes transaction_id = 2;
+ }
+ 
+ /*
+  * Represents a Substrait plan. Used in the command member of FlightDescriptor
+  * for the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *    Fields on this schema may contain the following metadata:
+  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+  *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
+  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
+  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+  *  - GetFlightInfo: execute the query.
+  *  - DoPut: execute the query.
+  */
+ message CommandStatementSubstraitPlan {
+   option (experimental) = true;
+ 
+   // A serialized substrait.Plan
+   SubstraitPlan plan = 1;
+   // Include the query as part of this transaction (if unset, the query is auto-committed).
+   optional bytes transaction_id = 2;
+ }
+ 
+ /**
+  * Represents a ticket resulting from GetFlightInfo with a CommandStatementQuery.
+  * This should be used only once and treated as an opaque value, that is, clients should not attempt to parse this.
+  */
+ message TicketStatementQuery {
+   option (experimental) = true;
+ 
+   // Unique identifier for the instance of the statement to execute.
+   bytes statement_handle = 1;
+ }
+ 
+ /*
+  * Represents an instance of executing a prepared statement. Used in the command member of FlightDescriptor for
+  * the following RPC calls:
+  *  - GetSchema: return the Arrow schema of the query.
+  *    Fields on this schema may contain the following metadata:
+  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+  *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
+  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
+  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+  *  - DoPut: bind parameter values. All of the bound parameter sets will be executed as a single atomic execution.
+  *  - GetFlightInfo: execute the prepared statement instance.
+  */
+ message CommandPreparedStatementQuery {
+   option (experimental) = true;
+ 
+   // Opaque handle for the prepared statement on the server.
+   bytes prepared_statement_handle = 1;
+ }
+ 
+ /*
+  * Represents a SQL update query. Used in the command member of FlightDescriptor
+  * for the the RPC call DoPut to cause the server to execute the included SQL update.
+  */
+ message CommandStatementUpdate {
+   option (experimental) = true;
+ 
+   // The SQL syntax.
+   string query = 1;
+   // Include the query as part of this transaction (if unset, the query is auto-committed).
+   optional bytes transaction_id = 2;
+ }
+ 
+ /*
+  * Represents a SQL update query. Used in the command member of FlightDescriptor
+  * for the the RPC call DoPut to cause the server to execute the included
+  * prepared statement handle as an update.
+  */
+ message CommandPreparedStatementUpdate {
+   option (experimental) = true;
+ 
+   // Opaque handle for the prepared statement on the server.
+   bytes prepared_statement_handle = 1;
+ }
+ 
+ /*
+  * Returned from the RPC call DoPut when a CommandStatementUpdate
+  * CommandPreparedStatementUpdate was in the request, containing
+  * results from the update.
+  */
+ message DoPutUpdateResult {
+   option (experimental) = true;
+ 
+   // The number of records updated. A return value of -1 represents
+   // an unknown updated record count.
+   int64 record_count = 1;
+ }
+ 
+ /*
+  * Request message for the "CancelQuery" action.
+  *
+  * Explicitly cancel a running query.
+  *
+  * This lets a single client explicitly cancel work, no matter how many clients
+  * are involved/whether the query is distributed or not, given server support.
+  * The transaction/statement is not rolled back; it is the application's job to
+  * commit or rollback as appropriate. This only indicates the client no longer
+  * wishes to read the remainder of the query results or continue submitting
+  * data.
+  *
+  * This command is idempotent.
+  */
+ message ActionCancelQueryRequest {
+   option (experimental) = true;
+ 
+   // The result of the GetFlightInfo RPC that initiated the query.
+   // XXX(ARROW-16902): this must be a serialized FlightInfo, but is
+   // rendered as bytes because Protobuf does not really support one
+   // DLL using Protobuf definitions from another DLL.
+   bytes info = 1;
+ }
+ 
+ /*
+  * The result of cancelling a query.
+  *
+  * The result should be wrapped in a google.protobuf.Any message.
+  */
+ message ActionCancelQueryResult {
+   option (experimental) = true;
+ 
+   enum CancelResult {
+     // The cancellation status is unknown. Servers should avoid using
+     // this value (send a NOT_FOUND error if the requested query is
+     // not known). Clients can retry the request.
+     CANCEL_RESULT_UNSPECIFIED = 0;
+     // The cancellation request is complete. Subsequent requests with
+     // the same payload may return CANCELLED or a NOT_FOUND error.
+     CANCEL_RESULT_CANCELLED = 1;
+     // The cancellation request is in progress. The client may retry
+     // the cancellation request.
+     CANCEL_RESULT_CANCELLING = 2;
+     // The query is not cancellable. The client should not retry the
+     // cancellation request.
+     CANCEL_RESULT_NOT_CANCELLABLE = 3;
+   }
+ 
+   CancelResult result = 1;
+ }
+ 
+ extend google.protobuf.MessageOptions {
+   bool experimental = 1000;
+ }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4249

# Rationale for this change
 
arrow-rs should keep up-to-date with the reference specs from apache/arrow.

# What changes are included in this PR?

* generate types based on latest proto files from apache/arrow
* update flight-sql server / client implementations

# Are there any user-facing changes?

New actions and statements are added. The flight sql server trait has corresponding handlers added.
