### PR TITLE
Strip leading whitespace from flight_sql_client custom header values

### DIFF
--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -49,7 +49,7 @@ where
         match parts.as_slice() {
             [key, value] => {
                 let key = K::from_str(key).map_err(|e| e.to_string())?;
-                let value = V::from_str(value).map_err(|e| e.to_string())?;
+                let value = V::from_str(value.trim_start()).map_err(|e| e.to_string())?;
                 Ok(Self { key, value })
             }
             _ => Err(format!(

--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -49,7 +49,7 @@ where
         match parts.as_slice() {
             [key, value] => {
                 let key = K::from_str(key).map_err(|e| e.to_string())?;
-                let value = V::from_str(value.trim_start()).map_err(|e| e.to_string())?;
+                let value = V::from_str(value.trim()).map_err(|e| e.to_string())?;
                 Ok(Self { key, value })
             }
             _ => Err(format!(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4270

# What changes are included in this PR?

This PR fixes the code that parses the `key: value` pairs when parsing the `--headers` flag