### PR TITLE
Add `Debug` impls for public structs in Parquet crate

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -322,6 +322,7 @@ impl ByteArrayDecoder {
 }
 
 /// Decoder from [`Encoding::PLAIN`] data to [`OffsetBuffer`]
+#[derive(Debug)]
 pub struct ByteArrayDecoderPlain {
     buf: ByteBufferPtr,
     offset: usize,
@@ -420,6 +421,7 @@ impl ByteArrayDecoderPlain {
 }
 
 /// Decoder from [`Encoding::DELTA_LENGTH_BYTE_ARRAY`] data to [`OffsetBuffer`]
+#[derive(Debug)]
 pub struct ByteArrayDecoderDeltaLength {
     lengths: Vec<i32>,
     data: ByteBufferPtr,
@@ -500,6 +502,7 @@ impl ByteArrayDecoderDeltaLength {
 }
 
 /// Decoder from [`Encoding::DELTA_BYTE_ARRAY`] to [`OffsetBuffer`]
+#[derive(Debug)]
 pub struct ByteArrayDecoderDelta {
     decoder: DeltaByteArrayDecoder,
     validate_utf8: bool,
@@ -537,6 +540,7 @@ impl ByteArrayDecoderDelta {
 }
 
 /// Decoder from [`Encoding::RLE_DICTIONARY`] to [`OffsetBuffer`]
+#[derive(Debug)]
 pub struct ByteArrayDecoderDictionary {
     decoder: DictIndexDecoder,
 }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -28,6 +28,7 @@ use arrow_data::{transform::MutableArrayData, ArrayData};
 use arrow_schema::DataType as ArrowType;
 use std::any::Any;
 use std::cmp::Ordering;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -42,6 +43,17 @@ pub struct ListArrayReader<OffsetSize: OffsetSizeTrait> {
     /// If this list is nullable
     nullable: bool,
     _marker: PhantomData<OffsetSize>,
+}
+
+impl <OffsetSize: OffsetSizeTrait> Debug for ListArrayReader<OffsetSize> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListArrayReader<OffsetSize>")
+            .field("item_reader", &"...")
+            .field("data_type", &self.data_type)
+            .field("def_level", &self.def_level)
+            .field("rep_level", &self.rep_level)
+            .finish()
+    }
 }
 
 impl<OffsetSize: OffsetSizeTrait> ListArrayReader<OffsetSize> {

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -23,6 +23,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 /// Implementation of a map array reader.
+#[derive(Debug)]
 pub struct MapArrayReader {
     data_type: ArrowType,
     reader: ListArrayReader<i32>,

--- a/parquet/src/arrow/array_reader/null_array.rs
+++ b/parquet/src/arrow/array_reader/null_array.rs
@@ -26,6 +26,7 @@ use arrow_array::ArrayRef;
 use arrow_buffer::Buffer;
 use arrow_schema::DataType as ArrowType;
 use std::any::Any;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// A NullArrayReader reads Parquet columns stored as null int32s with an Arrow
@@ -40,6 +41,17 @@ where
     def_levels_buffer: Option<Buffer>,
     rep_levels_buffer: Option<Buffer>,
     record_reader: RecordReader<T>,
+}
+
+impl<T> Debug for NullArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NullArrayReader<T>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl<T> NullArrayReader<T>

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -33,6 +33,7 @@ use arrow_buffer::Buffer;
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, TimeUnit};
 use std::any::Any;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// Primitive array readers are leaves of array reader tree. They accept page iterator
@@ -48,6 +49,18 @@ where
     rep_levels_buffer: Option<Buffer>,
     record_reader: RecordReader<T>,
 }
+
+impl<T> Debug for  PrimitiveArrayReader<T>
+where
+    T: DataType,
+    T::T: ScalarValue,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrimitiveArrayReader<T>")
+            .finish_non_exhaustive()
+    }
+}
+
 
 impl<T> PrimitiveArrayReader<T>
 where

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -21,6 +21,7 @@ use arrow_array::{builder::BooleanBufferBuilder, Array, ArrayRef, StructArray};
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::DataType as ArrowType;
 use std::any::Any;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// Implementation of struct array reader.
@@ -30,6 +31,14 @@ pub struct StructArrayReader {
     struct_def_level: i16,
     struct_rep_level: i16,
     nullable: bool,
+}
+
+impl Debug for StructArrayReader
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StructArrayReader")
+            .finish_non_exhaustive()
+    }
 }
 
 impl StructArrayReader {

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+
 use crate::arrow::ProjectionMask;
 use arrow_array::{BooleanArray, RecordBatch};
 use arrow_schema::ArrowError;
@@ -38,6 +40,12 @@ pub trait ArrowPredicate: Send + 'static {
 pub struct ArrowPredicateFn<F> {
     f: F,
     projection: ProjectionMask,
+}
+
+impl<F> Debug for ArrowPredicateFn<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArrowPredicateFn").finish_non_exhaustive()
+    }
 }
 
 impl<F> ArrowPredicateFn<F>
@@ -98,6 +106,17 @@ where
 pub struct RowFilter {
     /// A list of [`ArrowPredicate`]
     pub(crate) predicates: Vec<Box<dyn ArrowPredicate>>,
+}
+
+impl Debug for RowFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RowFilter")
+            .field(
+                "predicates",
+                &format!("{} predicates", self.predicates.len()),
+            )
+            .finish()
+    }
 }
 
 impl RowFilter {

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -18,6 +18,7 @@
 //! Contains reader which reads parquet data into arrow [`RecordBatch`]
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
@@ -52,6 +53,7 @@ pub use selection::{RowSelection, RowSelector};
 /// * For an asynchronous API - [`ParquetRecordBatchStreamBuilder`]
 ///
 /// [`ParquetRecordBatchStreamBuilder`]: crate::arrow::async_reader::ParquetRecordBatchStreamBuilder
+#[derive(Debug)]
 pub struct ArrowReaderBuilder<T> {
     pub(crate) input: T,
 
@@ -238,6 +240,7 @@ impl ArrowReaderOptions {
 
 #[doc(hidden)]
 /// A newtype used within [`ReaderOptionsBuilder`] to distinguish sync readers from async
+#[derive(Debug)]
 pub struct SyncReader<T: ChunkReader>(SerializedFileReader<T>);
 
 /// A synchronous builder used to construct [`ParquetRecordBatchReader`] for a file
@@ -323,6 +326,17 @@ pub struct ParquetRecordBatchReader {
     array_reader: Box<dyn ArrayReader>,
     schema: SchemaRef,
     selection: Option<VecDeque<RowSelector>>,
+}
+
+impl Debug for ParquetRecordBatchReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParquetRecordBatchReader")
+            .field("batch_size", &self.batch_size)
+            .field("array_reader", &"...")
+            .field("schema", &self.schema)
+            .field("selection", &self.selection)
+            .finish()
+    }
 }
 
 impl Iterator for ParquetRecordBatchReader {

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -18,6 +18,7 @@
 //! Contains writer which writes arrow data into parquet data.
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -90,6 +91,31 @@ pub struct ArrowWriter<W: Write> {
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
+}
+
+impl<W: Write> Debug for ArrowWriter<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut buffered_batches = 0;
+        let mut buffered_memory = 0;
+
+        for batch in self.buffer.iter() {
+            buffered_batches += 1;
+            for arr in batch.iter() {
+                buffered_memory += arr.get_array_memory_size()
+            }
+        }
+
+        f.debug_struct("ArrowWriter")
+            .field("writer", &self.writer)
+            .field(
+                "buffer",
+                &format!("{buffered_batches} , {buffered_memory} bytes"),
+            )
+            .field("buffered_rows", &self.buffered_rows)
+            .field("arrow_schema", &self.arrow_schema)
+            .field("max_row_group_size", &self.max_row_group_size)
+            .finish()
+    }
 }
 
 impl<W: Write> ArrowWriter<W> {

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -212,6 +212,7 @@ impl<T: AsyncRead + AsyncSeek + Unpin + Send> AsyncFileReader for T {
 ///
 /// Allows sharing the same builder for both the sync and async versions, whilst also not
 /// breaking the pre-existing ParquetRecordBatchStreamBuilder API
+#[derive(Debug)]
 pub struct AsyncReader<T>(T);
 
 /// A builder used to construct a [`ParquetRecordBatchStream`] for a parquet file
@@ -437,6 +438,7 @@ impl<T> std::fmt::Debug for StreamState<T> {
 
 /// An asynchronous [`Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) of [`RecordBatch`]
 /// for a parquet file that can be constructed using [`ParquetRecordBatchStreamBuilder`].
+#[derive(Debug)]
 pub struct ParquetRecordBatchStream<T> {
     metadata: Arc<ParquetMetaData>,
 

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -68,6 +68,7 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 /// It is implemented based on the sync writer [`ArrowWriter`] with an inner buffer.
 /// The buffered data will be flushed to the writer provided by caller when the
 /// buffer's threshold is exceeded.
+#[derive(Debug)]
 pub struct AsyncArrowWriter<W> {
     /// Underlying sync writer
     sync_writer: ArrowWriter<SharedBuffer>,
@@ -166,7 +167,7 @@ impl<W: AsyncWrite + Unpin + Send> AsyncArrowWriter<W> {
 
 /// A buffer with interior mutability shared by the [`ArrowWriter`] and
 /// [`AsyncArrowWriter`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct SharedBuffer {
     /// The inner buffer for reading and writing
     ///

--- a/parquet/src/arrow/decoder/delta_byte_array.rs
+++ b/parquet/src/arrow/decoder/delta_byte_array.rs
@@ -21,6 +21,7 @@ use crate::errors::{ParquetError, Result};
 use crate::util::memory::ByteBufferPtr;
 
 /// Decoder for `Encoding::DELTA_BYTE_ARRAY`
+#[derive(Debug)]
 pub struct DeltaByteArrayDecoder {
     prefix_lengths: Vec<i32>,
     suffix_lengths: Vec<i32>,

--- a/parquet/src/arrow/decoder/dictionary_index.rs
+++ b/parquet/src/arrow/decoder/dictionary_index.rs
@@ -20,6 +20,7 @@ use crate::errors::Result;
 use crate::util::memory::ByteBufferPtr;
 
 /// Decoder for `Encoding::RLE_DICTIONARY` indices
+#[derive(Debug)]
 pub struct DictIndexDecoder {
     /// Decoder for the dictionary offsets array
     decoder: RleDecoder,

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -33,6 +33,7 @@ use crate::util::memory::ByteBufferPtr;
 
 use super::{buffer::ScalarBuffer, MIN_BATCH_SIZE};
 
+#[derive(Debug)]
 enum BufferInner {
     /// Compute levels and null mask
     Full {
@@ -48,6 +49,7 @@ enum BufferInner {
     Mask { nulls: BooleanBufferBuilder },
 }
 
+#[derive(Debug)]
 pub struct DefinitionLevelBuffer {
     inner: BufferInner,
 
@@ -146,11 +148,13 @@ impl LevelsBufferSlice for DefinitionLevelBuffer {
     }
 }
 
+#[derive(Debug)]
 enum MaybePacked {
     Packed(PackedDecoder),
     Fallback(ColumnLevelDecoderImpl),
 }
 
+#[derive(Debug)]
 pub struct DefinitionLevelBufferDecoder {
     max_level: i16,
     decoder: MaybePacked,
@@ -242,6 +246,7 @@ impl DefinitionLevelDecoder for DefinitionLevelBufferDecoder {
 ///
 /// [RLE]: https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3
 /// [BIT_PACKED]: https://github.com/apache/parquet-format/blob/master/Encodings.md#bit-packed-deprecated-bit_packed--4
+#[derive(Debug)]
 struct PackedDecoder {
     data: ByteBufferPtr,
     data_offset: usize,

--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -35,6 +35,7 @@ fn get_repetition(t: &Type) -> Repetition {
 }
 
 /// Representation of a parquet file, in terms of arrow schema elements
+#[derive(Debug)]
 pub struct ParquetField {
     /// The level which represents an insertion into the current list
     /// i.e. guaranteed to be > 0 for a list type
@@ -82,6 +83,7 @@ impl ParquetField {
     }
 }
 
+#[derive(Debug)]
 pub enum ParquetFieldType {
     Primitive {
         /// The index of the column in parquet

--- a/parquet/src/column/page.rs
+++ b/parquet/src/column/page.rs
@@ -29,7 +29,7 @@ use crate::util::memory::ByteBufferPtr;
 /// List of supported pages.
 /// These are 1-to-1 mapped from the equivalent Thrift definitions, except `buf` which
 /// used to store uncompressed bytes of the page.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Page {
     DataPage {
         buf: ByteBufferPtr,
@@ -110,6 +110,7 @@ impl Page {
 /// data page v2).
 ///
 /// The difference with `Page` is that `Page` buffer is always uncompressed.
+#[derive(Debug)]
 pub struct CompressedPage {
     compressed_page: Page,
     uncompressed_size: usize,
@@ -165,6 +166,7 @@ impl CompressedPage {
 }
 
 /// Contains page write metrics.
+#[derive(Debug)]
 pub struct PageWriteSpec {
     pub page_type: PageType,
     pub uncompressed_size: usize,
@@ -195,7 +197,7 @@ impl PageWriteSpec {
 }
 
 /// Contains metadata for a page
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PageMetadata {
     /// The number of rows in this page
     pub num_rows: usize,

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -18,6 +18,7 @@
 //! Contains column reader API.
 
 use std::cmp::min;
+use std::fmt::Debug;
 
 use super::page::{Page, PageReader};
 use crate::basic::*;
@@ -133,6 +134,20 @@ pub struct GenericColumnReader<R, D, V> {
 
     /// The decoder for the values
     values_decoder: V,
+}
+
+impl<R, D, V> Debug for GenericColumnReader<R, D, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericColumnReader<R, D, V>")
+            .field("descr", &self.descr)
+            .field("page_reader", &"...")
+            .field("num_buffered_values", &self.num_buffered_values)
+            .field("num_decoded_values", &self.num_decoded_values)
+            .field("def_level_decoder", &"...")
+            .field("rep_level_decoder", &"...")
+            .field("values_decoder", &"...")
+            .finish()
+    }
 }
 
 impl<V> GenericColumnReader<ColumnLevelDecoderImpl, ColumnLevelDecoderImpl, V>

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::ops::Range;
 
 use crate::basic::Encoding;
@@ -162,6 +163,16 @@ pub struct ColumnValueDecoderImpl<T: DataType> {
     decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
 }
 
+impl<T: DataType> Debug for ColumnValueDecoderImpl<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColumnValueDecoderImpl<T>")
+            .field("descr", &self.descr)
+            .field("current_encoding", &self.current_encoding)
+            .field("decoders", &"...")
+            .finish()
+    }
+}
+
 impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     type Slice = [T::T];
 
@@ -267,6 +278,7 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
 const SKIP_BUFFER_SIZE: usize = 1024;
 
 /// An implementation of [`ColumnLevelDecoder`] for `[i16]`
+#[derive(Debug)]
 pub struct ColumnLevelDecoderImpl {
     decoder: Option<LevelDecoderInner>,
     /// Temporary buffer populated when skipping values
@@ -311,6 +323,7 @@ impl ColumnLevelDecoderImpl {
     }
 }
 
+#[derive(Debug)]
 enum LevelDecoderInner {
     Packed(BitReader, u8),
     Rle(RleDecoder),

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+
 use crate::basic::Encoding;
 use crate::bloom_filter::Sbbf;
 use crate::column::writer::{
@@ -49,6 +51,7 @@ impl<T: ParquetValueType> ColumnValues for [T] {
 }
 
 /// The encoded data for a dictionary page
+#[derive(Debug)]
 pub struct DictionaryPage {
     pub buf: ByteBufferPtr,
     pub num_values: usize,
@@ -56,6 +59,7 @@ pub struct DictionaryPage {
 }
 
 /// The encoded values for a data page, with optional statistics
+#[derive(Debug)]
 pub struct DataPageValues<T> {
     pub buf: ByteBufferPtr,
     pub num_values: usize,
@@ -132,6 +136,21 @@ pub struct ColumnValueEncoderImpl<T: DataType> {
     min_value: Option<T::T>,
     max_value: Option<T::T>,
     bloom_filter: Option<Sbbf>,
+}
+
+impl<T: DataType> Debug for ColumnValueEncoderImpl<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColumnValueEncoderImpl<T>")
+            .field("encoder", &"...")
+            .field("dict_encoder", &"...")
+            .field("descr", &self.descr)
+            .field("num_values", &self.num_values)
+            .field("statistics_enabled", &self.statistics_enabled)
+            .field("min_value", &self.min_value)
+            .field("max_value", &self.max_value)
+            .field("bloom_filter", &self.bloom_filter)
+            .finish()
+    }
 }
 
 impl<T: DataType> ColumnValueEncoderImpl<T> {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -20,6 +20,7 @@
 use crate::bloom_filter::Sbbf;
 use crate::format::{ColumnIndex, OffsetIndex};
 use std::collections::{BTreeSet, VecDeque};
+use std::fmt::Debug;
 
 use crate::basic::{Compression, ConvertedType, Encoding, LogicalType, PageType, Type};
 use crate::column::page::{CompressedPage, Page, PageWriteSpec, PageWriter};
@@ -44,6 +45,7 @@ use crate::util::memory::ByteBufferPtr;
 pub(crate) mod encoder;
 
 /// Column writer for a Parquet type.
+#[derive(Debug)]
 pub enum ColumnWriter<'a> {
     BoolColumnWriter(ColumnWriterImpl<'a, BoolType>),
     Int32ColumnWriter(ColumnWriterImpl<'a, Int32Type>),
@@ -165,7 +167,7 @@ pub struct ColumnCloseResult {
 }
 
 // Metrics per page
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct PageMetrics {
     num_buffered_values: u32,
     num_buffered_rows: u32,
@@ -173,6 +175,7 @@ struct PageMetrics {
 }
 
 // Metrics per column writer
+#[derive(Debug)]
 struct ColumnMetrics<T> {
     total_bytes_written: u64,
     total_rows_written: u64,
@@ -215,6 +218,13 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     // column index and offset index
     column_index_builder: ColumnIndexBuilder,
     offset_index_builder: OffsetIndexBuilder,
+}
+
+impl<'a, E: ColumnValueEncoder> Debug for GenericColumnWriter<'a, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericColumnWriter<'a, E>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -20,6 +20,8 @@
 //! See [`Compression`](crate::basic::Compression) enum for all available compression
 //! algorithms.
 //!
+use std::fmt::Debug;
+
 #[cfg_attr(
     feature = "experimental",
     doc = r##"
@@ -51,7 +53,7 @@ use crate::basic::Compression as CodecType;
 use crate::errors::{ParquetError, Result};
 
 /// Parquet compression codec interface.
-pub trait Codec: Send {
+pub trait Codec: Send + Debug {
     /// Compresses data stored in slice `input_buf` and appends the compressed result
     /// to `output_buf`.
     ///
@@ -87,6 +89,7 @@ impl Default for CodecOptions {
     }
 }
 
+#[derive(Debug)]
 pub struct CodecOptionsBuilder {
     /// Whether or not to fallback to other LZ4 older implementations on error in LZ4_HADOOP.
     backward_compatible_lz4: bool,
@@ -176,6 +179,7 @@ mod snappy_codec {
     use crate::errors::Result;
 
     /// Codec for Snappy compression format.
+    #[derive(Debug)]
     pub struct SnappyCodec {
         decoder: Decoder,
         encoder: Encoder,
@@ -237,6 +241,7 @@ mod gzip_codec {
     use super::GzipLevel;
 
     /// Codec for GZIP compression algorithm.
+    #[derive(Debug)]
     pub struct GZipCodec {
         level: GzipLevel,
     }
@@ -315,6 +320,7 @@ mod brotli_codec {
     const BROTLI_DEFAULT_LG_WINDOW_SIZE: u32 = 22; // recommended between 20-22
 
     /// Codec for Brotli compression algorithm.
+    #[derive(Debug)]
     pub struct BrotliCodec {
         level: BrotliLevel,
     }
@@ -393,6 +399,7 @@ mod lz4_codec {
     const LZ4_BUFFER_SIZE: usize = 4096;
 
     /// Codec for LZ4 compression algorithm.
+    #[derive(Debug)]
     pub struct LZ4Codec {}
 
     impl LZ4Codec {
@@ -449,6 +456,7 @@ mod zstd_codec {
     use crate::errors::Result;
 
     /// Codec for Zstandard compression algorithm.
+    #[derive(Debug)]
     pub struct ZSTDCodec {
         level: ZstdLevel,
     }
@@ -525,6 +533,7 @@ mod lz4_raw_codec {
     use crate::errors::Result;
 
     /// Codec for LZ4 Raw compression algorithm.
+    #[derive(Debug)]
     pub struct LZ4RawCodec {}
 
     impl LZ4RawCodec {
@@ -605,6 +614,7 @@ mod lz4_hadoop_codec {
     const PREFIX_LEN: usize = SIZE_U32 * 2;
 
     /// Codec for LZ4 Hadoop compression algorithm.
+    #[derive(Debug)]
     pub struct LZ4HadoopCodec {
         /// Whether or not to fallback to other LZ4 implementations on error.
         /// Fallback is done to be backward compatible with older versions of this

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -1150,7 +1150,7 @@ where
 
 macro_rules! make_type {
     ($name:ident, $reader_ident: ident, $writer_ident: ident, $native_ty:ty, $size:expr) => {
-        #[derive(Clone)]
+        #[derive(Debug, Clone)]
         pub struct $name {}
 
         impl DataType for $name {

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -226,7 +226,7 @@ pub fn get_decoder<T: DataType>(
 // ----------------------------------------------------------------------
 // PLAIN Decoding
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PlainDecoderDetails {
     // The remaining number of values in the byte array
     pub(crate) num_values: usize,
@@ -248,6 +248,7 @@ pub struct PlainDecoderDetails {
 /// Values are encoded back to back. For native types, data is encoded as little endian.
 /// Floating point types are encoded in IEEE.
 /// See [`PlainEncoder`](crate::encoding::PlainEncoder) for more information.
+#[derive(Debug)]
 pub struct PlainDecoder<T: DataType> {
     // The binary details needed for decoding
     inner: PlainDecoderDetails,
@@ -308,6 +309,7 @@ impl<T: DataType> Decoder<T> for PlainDecoder<T> {
 /// The dictionary encoding builds a dictionary of values encountered in a given column.
 /// The dictionary is be stored in a dictionary page per column chunk.
 /// See [`DictEncoder`](crate::encoding::DictEncoder) for more information.
+#[derive(Debug)]
 pub struct DictDecoder<T: DataType> {
     // The dictionary, which maps ids to the values
     dictionary: Vec<T::T>,
@@ -394,6 +396,7 @@ impl<T: DataType> Decoder<T> for DictDecoder<T> {
 /// RLE/Bit-Packing hybrid decoding for values.
 /// Currently is used only for data pages v2 and supports boolean types.
 /// See [`RleValueEncoder`](crate::encoding::RleValueEncoder) for more information.
+#[derive(Debug)]
 pub struct RleValueDecoder<T: DataType> {
     values_left: usize,
     decoder: RleDecoder,
@@ -465,6 +468,7 @@ impl<T: DataType> Decoder<T> for RleValueDecoder<T> {
 /// Supports INT32 and INT64 types.
 /// See [`DeltaBitPackEncoder`](crate::encoding::DeltaBitPackEncoder) for more
 /// information.
+#[derive(Debug)]
 pub struct DeltaBitPackDecoder<T: DataType> {
     bit_reader: BitReader,
     initialized: bool,
@@ -802,6 +806,7 @@ where
 /// are encoded using DELTA_BINARY_PACKED encoding.
 /// See [`DeltaLengthByteArrayEncoder`](crate::encoding::DeltaLengthByteArrayEncoder)
 /// for more information.
+#[derive(Debug)]
 pub struct DeltaLengthByteArrayDecoder<T: DataType> {
     // Lengths for each byte array in `data`
     // TODO: add memory tracker to this
@@ -934,6 +939,7 @@ impl<T: DataType> Decoder<T> for DeltaLengthByteArrayDecoder<T> {
 /// using `DELTA_LENGTH_BYTE_ARRAY` encoding.
 /// See [`DeltaByteArrayEncoder`](crate::encoding::DeltaByteArrayEncoder) for more
 /// information.
+#[derive(Debug)]
 pub struct DeltaByteArrayDecoder<T: DataType> {
     // Prefix lengths for each byte array
     // TODO: add memory tracker to this

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -72,6 +72,7 @@ impl<T: DataType> Storage for KeyStorage<T> {
 /// Data page format: the bit width used to encode the entry ids stored as 1 byte
 /// (max bit width = 32), followed by the values encoded using RLE/Bit packed described
 /// above (with the given bit width).
+#[derive(Debug)]
 pub struct DictEncoder<T: DataType> {
     interner: Interner<KeyStorage<T>>,
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -106,6 +106,7 @@ pub fn get_encoder<T: DataType>(encoding: Encoding) -> Result<Box<dyn Encoder<T>
 /// - DOUBLE - 8 bytes per value, stored as IEEE little-endian.
 /// - BYTE_ARRAY - 4 byte length stored as little endian, followed by bytes.
 /// - FIXED_LEN_BYTE_ARRAY - just the bytes are stored.
+#[derive(Debug)]
 pub struct PlainEncoder<T: DataType> {
     buffer: Vec<u8>,
     bit_writer: BitWriter,
@@ -164,6 +165,7 @@ const DEFAULT_RLE_BUFFER_LEN: usize = 1024;
 
 /// RLE/Bit-Packing hybrid encoding for values.
 /// Currently is used only for data pages v2 and supports boolean types.
+#[derive(Debug)]
 pub struct RleValueEncoder<T: DataType> {
     // Buffer with raw values that we collect,
     // when flushing buffer they are encoded using RLE encoder
@@ -272,6 +274,7 @@ const DEFAULT_NUM_MINI_BLOCKS: usize = 4;
 /// writes out all data and resets internal state, including page header.
 ///
 /// Supports only INT32 and INT64.
+#[derive(Debug)]
 pub struct DeltaBitPackEncoder<T: DataType> {
     page_header_writer: BitWriter,
     bit_writer: BitWriter,
@@ -533,6 +536,7 @@ impl<T: DataType> DeltaBitPackEncoderConversion<T> for DeltaBitPackEncoder<T> {
 /// Encoding for byte arrays to separate the length values and the data.
 /// The lengths are encoded using DELTA_BINARY_PACKED encoding, data is
 /// stored as raw bytes.
+#[derive(Debug)]
 pub struct DeltaLengthByteArrayEncoder<T: DataType> {
     // length encoder
     len_encoder: DeltaBitPackEncoder<Int32Type>,
@@ -621,6 +625,7 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 
 /// Encoding for byte arrays, prefix lengths are encoded using DELTA_BINARY_PACKED
 /// encoding, followed by suffixes with DELTA_LENGTH_BYTE_ARRAY encoding.
+#[derive(Debug)]
 pub struct DeltaByteArrayEncoder<T: DataType> {
     prefix_len_encoder: DeltaBitPackEncoder<Int32Type>,
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -48,6 +48,7 @@ const MAX_GROUPS_PER_BIT_PACKED_RUN: usize = 1 << 6;
 
 /// A RLE/Bit-Packing hybrid encoder.
 // TODO: tracking memory usage
+#[derive(Debug)]
 pub struct RleEncoder {
     // Number of bits needed to encode the value. Must be in the range of [0, 64].
     bit_width: u8,
@@ -293,6 +294,7 @@ impl RleEncoder {
 const RLE_DECODER_INDEX_BUFFER_SIZE: usize = 1024;
 
 /// A RLE/Bit-Packing hybrid decoder.
+#[derive(Debug)]
 pub struct RleDecoder {
     // Number of bits used to encode the value. Must be between [0, 64].
     bit_width: u8,

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -373,6 +373,7 @@ impl RowGroupMetaData {
 }
 
 /// Builder for row group metadata.
+#[derive(Debug)]
 pub struct RowGroupMetaDataBuilder(RowGroupMetaData);
 
 impl RowGroupMetaDataBuilder {
@@ -700,6 +701,7 @@ impl ColumnChunkMetaData {
 }
 
 /// Builder for column chunk metadata.
+#[derive(Debug)]
 pub struct ColumnChunkMetaDataBuilder(ColumnChunkMetaData);
 
 impl ColumnChunkMetaDataBuilder {
@@ -836,6 +838,7 @@ impl ColumnChunkMetaDataBuilder {
 }
 
 /// Builder for column index
+#[derive(Debug)]
 pub struct ColumnIndexBuilder {
     null_pages: Vec<bool>,
     min_values: Vec<Vec<u8>>,
@@ -899,6 +902,7 @@ impl ColumnIndexBuilder {
 }
 
 /// Builder for offset index
+#[derive(Debug)]
 pub struct OffsetIndexBuilder {
     offset_array: Vec<i64>,
     compressed_page_size_array: Vec<i32>,

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -276,6 +276,7 @@ impl WriterProperties {
 }
 
 /// Writer properties builder.
+#[derive(Debug)]
 pub struct WriterPropertiesBuilder {
     data_pagesize_limit: usize,
     dictionary_pagesize_limit: usize,
@@ -749,6 +750,7 @@ const DEFAULT_READ_BLOOM_FILTER: bool = false;
 ///
 /// All properties are immutable and `Send` + `Sync`.
 /// Use [`ReaderPropertiesBuilder`] to assemble these properties.
+#[derive(Debug)]
 pub struct ReaderProperties {
     codec_options: CodecOptions,
     read_bloom_filter: bool,
@@ -772,6 +774,7 @@ impl ReaderProperties {
 }
 
 /// Reader properties builder.
+#[derive(Debug)]
 pub struct ReaderPropertiesBuilder {
     codec_options_builder: CodecOptionsBuilder,
     read_bloom_filter: Option<bool>,

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -20,6 +20,7 @@
 //! iterator.
 
 use bytes::{Buf, Bytes};
+use std::fmt::Debug;
 use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::{boxed::Box, io::Read, sync::Arc};
@@ -214,6 +215,16 @@ pub struct FilePageIterator {
     column_index: usize,
     row_group_indices: Box<dyn Iterator<Item = usize> + Send>,
     file_reader: Arc<dyn FileReader>,
+}
+
+impl Debug for FilePageIterator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilePageIterator")
+            .field("column_index", &self.column_index)
+            .field("row_group_indices", &"...")
+            .field("file_reader", &"...")
+            .finish()
+    }
 }
 
 impl FilePageIterator {

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -19,6 +19,7 @@
 //! Also contains implementations of the ChunkReader for files (with buffering) and byte arrays (RAM)
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::io::Cursor;
 use std::iter;
 use std::{convert::TryFrom, fs::File, io::Read, path::Path, sync::Arc};
@@ -91,6 +92,7 @@ impl IntoIterator for SerializedFileReader<File> {
 // Implementations of file & row group readers
 
 /// A serialized implementation for Parquet [`FileReader`].
+#[derive(Debug)]
 pub struct SerializedFileReader<R: ChunkReader> {
     chunk_reader: Arc<R>,
     metadata: Arc<ParquetMetaData>,
@@ -110,6 +112,19 @@ pub struct ReadOptionsBuilder {
     predicates: Vec<ReadGroupPredicate>,
     enable_page_index: bool,
     props: Option<ReaderProperties>,
+}
+
+impl Debug for ReadOptionsBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOptionsBuilder")
+            .field(
+                "predicates",
+                &format!("{} predicates", self.predicates.len()),
+            )
+            .field("enable_page_index", &self.enable_page_index)
+            .field("props", &self.props)
+            .finish()
+    }
 }
 
 impl ReadOptionsBuilder {
@@ -173,6 +188,19 @@ pub struct ReadOptions {
     predicates: Vec<ReadGroupPredicate>,
     enable_page_index: bool,
     props: ReaderProperties,
+}
+
+impl Debug for ReadOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOptions")
+            .field(
+                "predicates",
+                &format!("{} predicates", self.predicates.len()),
+            )
+            .field("enable_page_index", &self.enable_page_index)
+            .field("props", &self.props)
+            .finish()
+    }
 }
 
 impl<R: 'static + ChunkReader> SerializedFileReader<R> {
@@ -289,6 +317,7 @@ impl<R: 'static + ChunkReader> FileReader for SerializedFileReader<R> {
 }
 
 /// A serialized implementation for Parquet [`RowGroupReader`].
+#[derive(Debug)]
 pub struct SerializedRowGroupReader<'a, R: ChunkReader> {
     chunk_reader: Arc<R>,
     metadata: &'a RowGroupMetaData,
@@ -489,6 +518,7 @@ pub(crate) fn decode_page(
     Ok(result)
 }
 
+#[derive(Debug)]
 enum SerializedPageReaderState {
     Values {
         /// The current byte offset in the reader
@@ -511,6 +541,7 @@ enum SerializedPageReaderState {
 }
 
 /// A serialized implementation for Parquet [`PageReader`].
+#[derive(Debug)]
 pub struct SerializedPageReader<R: ChunkReader> {
     /// The chunk reader
     reader: Arc<R>,

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -91,6 +91,7 @@ impl Row {
 }
 
 /// `RowColumnIter` represents an iterator over column names and values in a Row.
+#[derive(Debug)]
 pub struct RowColumnIter<'a> {
     fields: &'a Vec<(String, Field)>,
     curr: usize,
@@ -152,7 +153,7 @@ pub trait RowAccessor {
 /// ```
 ///
 pub trait RowFormatter {
-    fn fmt(&self, i: usize) -> &dyn fmt::Display;
+    fn fmt_for_display(&self, i: usize) -> &dyn fmt::Display;
 }
 
 /// Macro to generate type-safe get_xxx methods for primitive types,
@@ -191,7 +192,7 @@ macro_rules! row_complex_accessor {
 
 impl RowFormatter for Row {
     /// Get Display reference for a given field.
-    fn fmt(&self, i: usize) -> &dyn fmt::Display {
+    fn fmt_for_display(&self, i: usize) -> &dyn fmt::Display {
         &self.fields[i].1
     }
 }
@@ -1342,30 +1343,33 @@ mod tests {
             ("17".to_string(), Field::Decimal(Decimal::from_i32(4, 7, 2))),
         ]);
 
-        assert_eq!("null", format!("{}", row.fmt(0)));
-        assert_eq!("false", format!("{}", row.fmt(1)));
-        assert_eq!("3", format!("{}", row.fmt(2)));
-        assert_eq!("4", format!("{}", row.fmt(3)));
-        assert_eq!("5", format!("{}", row.fmt(4)));
-        assert_eq!("6", format!("{}", row.fmt(5)));
-        assert_eq!("7", format!("{}", row.fmt(6)));
-        assert_eq!("8", format!("{}", row.fmt(7)));
-        assert_eq!("9", format!("{}", row.fmt(8)));
-        assert_eq!("10", format!("{}", row.fmt(9)));
-        assert_eq!("11.1", format!("{}", row.fmt(10)));
-        assert_eq!("12.1", format!("{}", row.fmt(11)));
-        assert_eq!("\"abc\"", format!("{}", row.fmt(12)));
-        assert_eq!("[1, 2, 3, 4, 5]", format!("{}", row.fmt(13)));
-        assert_eq!(convert_date_to_string(14611), format!("{}", row.fmt(14)));
+        assert_eq!("null", format!("{}", row.fmt_for_display(0)));
+        assert_eq!("false", format!("{}", row.fmt_for_display(1)));
+        assert_eq!("3", format!("{}", row.fmt_for_display(2)));
+        assert_eq!("4", format!("{}", row.fmt_for_display(3)));
+        assert_eq!("5", format!("{}", row.fmt_for_display(4)));
+        assert_eq!("6", format!("{}", row.fmt_for_display(5)));
+        assert_eq!("7", format!("{}", row.fmt_for_display(6)));
+        assert_eq!("8", format!("{}", row.fmt_for_display(7)));
+        assert_eq!("9", format!("{}", row.fmt_for_display(8)));
+        assert_eq!("10", format!("{}", row.fmt_for_display(9)));
+        assert_eq!("11.1", format!("{}", row.fmt_for_display(10)));
+        assert_eq!("12.1", format!("{}", row.fmt_for_display(11)));
+        assert_eq!("\"abc\"", format!("{}", row.fmt_for_display(12)));
+        assert_eq!("[1, 2, 3, 4, 5]", format!("{}", row.fmt_for_display(13)));
+        assert_eq!(
+            convert_date_to_string(14611),
+            format!("{}", row.fmt_for_display(14))
+        );
         assert_eq!(
             convert_timestamp_millis_to_string(1262391174000),
-            format!("{}", row.fmt(15))
+            format!("{}", row.fmt_for_display(15))
         );
         assert_eq!(
             convert_timestamp_micros_to_string(1262391174000000),
-            format!("{}", row.fmt(16))
+            format!("{}", row.fmt_for_display(16))
         );
-        assert_eq!("0.04", format!("{}", row.fmt(17)));
+        assert_eq!("0.04", format!("{}", row.fmt_for_display(17)));
     }
 
     #[test]
@@ -1398,9 +1402,12 @@ mod tests {
             ),
         ]);
 
-        assert_eq!("{x: null, Y: 2}", format!("{}", row.fmt(0)));
-        assert_eq!("[2, 1, null, 12]", format!("{}", row.fmt(1)));
-        assert_eq!("{1 -> 1.2, 2 -> 4.5, 3 -> 2.3}", format!("{}", row.fmt(2)));
+        assert_eq!("{x: null, Y: 2}", format!("{}", row.fmt_for_display(0)));
+        assert_eq!("[2, 1, null, 12]", format!("{}", row.fmt_for_display(1)));
+        assert_eq!(
+            "{1 -> 1.2, 2 -> 4.5, 3 -> 2.3}",
+            format!("{}", row.fmt_for_display(2))
+        );
     }
 
     #[test]

--- a/parquet/src/record/triplet.rs
+++ b/parquet/src/record/triplet.rs
@@ -43,6 +43,7 @@ macro_rules! triplet_enum_func {
 /// High level API wrapper on column reader.
 /// Provides per-element access for each primitive column.
 #[allow(clippy::enum_variant_names)]
+#[derive(Debug)]
 pub enum TripletIter {
     BoolTripletIter(TypedTripletIter<BoolType>),
     Int32TripletIter(TypedTripletIter<Int32Type>),
@@ -175,6 +176,7 @@ impl TripletIter {
 
 /// Internal typed triplet iterator as a wrapper for column reader
 /// (primitive leaf column), provides per-element access.
+#[derive(Debug)]
 pub struct TypedTripletIter<T: DataType> {
     reader: ColumnReaderImpl<T>,
     column_descr: ColumnDescPtr,

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -191,6 +191,7 @@ impl Type {
 /// A builder for primitive types. All attributes are optional
 /// except the name and physical type.
 /// Note that if not specified explicitly, `Repetition::OPTIONAL` is used.
+#[derive(Debug)]
 pub struct PrimitiveTypeBuilder<'a> {
     name: &'a str,
     repetition: Repetition,
@@ -531,6 +532,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
 /// A builder for group types. All attributes are optional except the name.
 /// Note that if not specified explicitly, `None` is used as the repetition of the group,
 /// which means it is a root (message) type.
+#[derive(Debug)]
 pub struct GroupTypeBuilder<'a> {
     name: &'a str,
     repetition: Option<Repetition>,

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -164,6 +164,7 @@ pub fn get_bit(data: &[u8], i: usize) -> bool {
 
 /// Utility class for writing bit/byte streams. This class can write data in either
 /// bit packed or byte aligned fashion.
+#[derive(Debug)]
 pub struct BitWriter {
     buffer: Vec<u8>,
     buffered_values: u64,
@@ -339,6 +340,7 @@ impl BitWriter {
 /// MAX_VLQ_BYTE_LEN = 5 for i32, and MAX_VLQ_BYTE_LEN = 10 for i64
 pub const MAX_VLQ_BYTE_LEN: usize = 10;
 
+#[derive(Debug)]
 pub struct BitReader {
     /// The byte buffer to read from, passed in by client
     buffer: ByteBufferPtr,

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -41,6 +41,7 @@ pub trait DataPageBuilder {
 ///   - add_values() for normal data page / add_indices() for dictionary data page
 ///   - consume()
 /// in order to populate and obtain a data page.
+#[derive(Debug)]
 pub struct DataPageBuilderImpl {
     encoding: Option<Encoding>,
     num_values: u32,
@@ -149,6 +150,7 @@ impl DataPageBuilder for DataPageBuilderImpl {
 }
 
 /// A utility page reader which stores pages in memory.
+#[derive(Debug)]
 pub struct InMemoryPageReader<P: Iterator<Item = Page>> {
     page_iter: Peekable<P>,
 }
@@ -202,7 +204,7 @@ impl<P: Iterator<Item = Page> + Send> Iterator for InMemoryPageReader<P> {
 }
 
 /// A utility page iterator which stores page readers in memory, used for tests.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct InMemoryPageIterator<I: Iterator<Item = Vec<Page>>> {
     schema: SchemaDescPtr,
     column_desc: ColumnDescPtr,


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
This caught me when working on https://github.com/influxdata/influxdb_iox/pull/7855

I had to manually derive a `Debug` impl for a structure because the `ArrowWriter` didn't


# What changes are included in this PR?

1. Add `Debug` impls for public structs in Parquet crate

Note that PR quickly got out of hand, but since I was in here I figured I would simply bash it out

# Are there any user-facing changes?
More `Debug`! 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
