### PR TITLE
Expose `RecordBatchWriter` to `arrow` crate

### DIFF
--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -376,7 +376,9 @@ pub use arrow_json as json;
 pub mod pyarrow;
 
 pub mod record_batch {
-    pub use arrow_array::{RecordBatch, RecordBatchOptions, RecordBatchReader};
+    pub use arrow_array::{
+        RecordBatch, RecordBatchOptions, RecordBatchReader, RecordBatchWriter,
+    };
 }
 pub use arrow_array::temporal_conversions;
 pub use arrow_row as row;


### PR DESCRIPTION
# Which issue does this PR close?

This PR doesn't close any particular issue.

# Rationale for this change
 
Following #4228, I realized that `RecordBatchWriter` was not exposed directly to the `arrow` crate.

# Are there any user-facing changes?

No.