### PR TITLE
Add `Debug` impls for `ArrowWriter` and `SerializedFileWriter`

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -18,6 +18,7 @@
 //! Contains writer which writes arrow data into parquet data.
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -90,6 +91,31 @@ pub struct ArrowWriter<W: Write> {
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
+}
+
+impl<W: Write> Debug for ArrowWriter<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut buffered_batches = 0;
+        let mut buffered_memory = 0;
+
+        for batch in self.buffer.iter() {
+            buffered_batches += 1;
+            for arr in batch.iter() {
+                buffered_memory += arr.get_array_memory_size()
+            }
+        }
+
+        f.debug_struct("ArrowWriter")
+            .field("writer", &self.writer)
+            .field(
+                "buffer",
+                &format!("{buffered_batches} , {buffered_memory} bytes"),
+            )
+            .field("buffered_rows", &self.buffered_rows)
+            .field("arrow_schema", &self.arrow_schema)
+            .field("max_row_group_size", &self.max_row_group_size)
+            .finish()
+    }
 }
 
 impl<W: Write> ArrowWriter<W> {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -21,6 +21,7 @@
 use crate::bloom_filter::Sbbf;
 use crate::format as parquet;
 use crate::format::{ColumnIndex, OffsetIndex, RowGroup};
+use std::fmt::Debug;
 use std::io::{BufWriter, IoSlice, Read};
 use std::{io::Write, sync::Arc};
 use thrift::protocol::{TCompactOutputProtocol, TSerializable};
@@ -145,6 +146,18 @@ pub struct SerializedFileWriter<W: Write> {
     row_group_index: usize,
     // kv_metadatas will be appended to `props` when `write_metadata`
     kv_metadatas: Vec<KeyValue>,
+}
+
+impl<W: Write> Debug for SerializedFileWriter<W> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // implement Debug so this can be used with #[derive(Debug)]
+        // in client code rather than actually listing all the fields
+        f.debug_struct("SerializedFileWriter<W>")
+            .field("descr", &self.descr)
+            .field("row_group_index", &self.row_group_index)
+            .field("kv_metadatas", &self.kv_metadatas)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<W: Write> SerializedFileWriter<W> {


### PR DESCRIPTION
This is an alternate, more targeted version of https://github.com/apache/arrow-rs/pull/4276

# Which issue does this PR close?

N/A

# Rationale for this change
 
This caught me when working on https://github.com/influxdata/influxdb_iox/pull/7855

I had to manually derive a `Debug` impl for a structure because the `ArrowWriter` didn't


# What changes are included in this PR?

1. Add `Debug` impls for `ArrowWriter` and `SerializedFileWriter`


# Are there any user-facing changes?
More `Debug`! 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
