### PR TITLE
feat(flight): add helpers to handle `CommandGetCatalogs`, `CommandGetSchemas`, and `CommandGetTables` requests

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -27,6 +27,7 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+arrow-arith = { workspace = true, optional = true }
 arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 # Cast is needed to work around https://github.com/apache/arrow-rs/issues/3389
@@ -56,7 +57,7 @@ all-features = true
 
 [features]
 default = []
-flight-sql-experimental = ["once_cell", "arrow-data", "arrow-row", "arrow-select", "arrow-string"]
+flight-sql-experimental = ["arrow-arith", "arrow-data", "arrow-row", "arrow-select", "arrow-string", "once_cell"]
 tls = ["tonic/tls"]
 
 # Enable CLI tools

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -31,9 +31,12 @@ arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 # Cast is needed to work around https://github.com/apache/arrow-rs/issues/3389
 arrow-cast = { workspace = true }
-arrow-data = { workspace = true }
+arrow-data = { workspace = true, optional = true }
 arrow-ipc = { workspace = true }
+arrow-row = { workspace = true, optional = true }
+arrow-select = { workspace = true, optional = true }
 arrow-schema = { workspace = true }
+arrow-string = { workspace = true, optional = true }
 base64 = { version = "0.21", default-features = false, features = ["std"] }
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -53,7 +56,7 @@ all-features = true
 
 [features]
 default = []
-flight-sql-experimental = ["once_cell"]
+flight-sql-experimental = ["once_cell", "arrow-data", "arrow-row", "arrow-select", "arrow-string"]
 tls = ["tonic/tls"]
 
 # Enable CLI tools

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -299,9 +299,10 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let options = IpcWriteOptions::default();
 
         // encode the schema into the correct form
-        let IpcMessage(schema) = SchemaAsIpc::new(get_db_schemas_schema(), &options)
-            .try_into()
-            .expect("valid schemas schema");
+        let IpcMessage(schema) =
+            SchemaAsIpc::new(get_db_schemas_schema().as_ref(), &options)
+                .try_into()
+                .expect("valid schemas schema");
 
         let endpoint = vec![FlightEndpoint {
             ticket: Some(ticket),
@@ -494,7 +495,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
 
         let batch = builder.build();
         let stream = FlightDataEncoderBuilder::new()
-            .with_schema(Arc::new(get_db_schemas_schema().clone()))
+            .with_schema(get_db_schemas_schema())
             .build(futures::stream::once(async { batch }))
             .map_err(Status::from);
         Ok(Response::new(Box::pin(stream)))

--- a/arrow-flight/src/sql/catalogs/db_schemas.rs
+++ b/arrow-flight/src/sql/catalogs/db_schemas.rs
@@ -28,8 +28,8 @@ use crate::error::*;
 
 /// Return the schema of the RecordBatch that will be returned from
 /// [`get_db_schemas`].
-pub fn get_db_schemas_schema() -> SchemaRef {
-    Arc::clone(&GET_DB_SCHEMAS_SCHEMA)
+pub fn get_db_schemas_schema() -> &'static Schema {
+    &GET_DB_SCHEMAS_SCHEMA
 }
 
 /// The schema for GetDbSchemas

--- a/arrow-flight/src/sql/catalogs/db_schemas.rs
+++ b/arrow-flight/src/sql/catalogs/db_schemas.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! [`GetSchemasBuilder`] for building responses to [`CommandGetDbSchemas`] queries.
+//!
+//! [`CommandGetDbSchemas`]: crate::sql::CommandGetDbSchemas
+
 use std::sync::Arc;
 
 use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch};
@@ -57,6 +61,14 @@ pub struct GetSchemasBuilder {
 
 impl GetSchemasBuilder {
     /// Create a new instance of [`GetSchemasBuilder`]
+    ///
+    /// # Parameters
+    ///
+    /// - `db_schema_filter_pattern`: Specifies a filter pattern for schemas to search for.
+    ///   When no pattern is provided, the pattern will not be used to narrow the search.
+    ///   In the pattern string, two special characters can be used to denote matching rules:
+    ///     - "%" means to match any substring with 0 or more characters.
+    ///     - "_" means to match any one character.
     pub fn new(db_schema_filter_pattern: Option<impl Into<String>>) -> Self {
         let catalog_name = StringBuilder::new();
         let db_schema_name = StringBuilder::new();

--- a/arrow-flight/src/sql/catalogs/db_schemas.rs
+++ b/arrow-flight/src/sql/catalogs/db_schemas.rs
@@ -1,0 +1,211 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch, UInt32Array};
+use arrow_row::{RowConverter, SortField};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_select::{filter::filter_record_batch, take::take};
+use arrow_string::like::like_utf8_scalar;
+use once_cell::sync::Lazy;
+
+use crate::error::*;
+
+/// Return the schema of the RecordBatch that will be returned from
+/// [`get_db_schemas`].
+pub fn get_db_schemas_schema() -> SchemaRef {
+    Arc::clone(&GET_DB_SCHEMAS_SCHEMA)
+}
+
+/// The schema for GetDbSchemas
+static GET_DB_SCHEMAS_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("catalog_name", DataType::Utf8, false),
+        Field::new("db_schema_name", DataType::Utf8, false),
+    ]))
+});
+
+/// Builds rows like this:
+///
+/// * catalog_name: utf8,
+/// * db_schema_name: utf8,
+///
+/// Applies filters for as described on [`get_db_schemas`]
+pub struct GetSchemasBuilder {
+    // Optional filters to apply
+    db_schema_filter_pattern: Option<String>,
+    // array builder for catalog names
+    catalog_name: StringBuilder,
+    // array builder for schema names
+    db_schema_name: StringBuilder,
+}
+
+impl GetSchemasBuilder {
+    /// Create a new instance of [`GetSchemasBuilder`]
+    pub fn new(db_schema_filter_pattern: Option<impl Into<String>>) -> Self {
+        let catalog_name = StringBuilder::new();
+        let db_schema_name = StringBuilder::new();
+        Self {
+            db_schema_filter_pattern: db_schema_filter_pattern.map(|v| v.into()),
+            catalog_name,
+            db_schema_name,
+        }
+    }
+
+    /// Append a row
+    pub fn append(
+        &mut self,
+        catalog_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+    ) -> Result<()> {
+        self.catalog_name.append_value(catalog_name);
+        self.db_schema_name.append_value(schema_name);
+        Ok(())
+    }
+
+    /// builds the correct schema
+    pub fn build(self) -> Result<RecordBatch> {
+        let Self {
+            db_schema_filter_pattern,
+            mut catalog_name,
+            mut db_schema_name,
+        } = self;
+
+        // Make the arrays
+        let catalog_name = catalog_name.finish();
+        let db_schema_name = db_schema_name.finish();
+
+        // the filter, if requested, getting a BooleanArray that represents the rows that passed the filter
+        let filter = db_schema_filter_pattern
+            .map(|db_schema_filter_pattern| {
+                // use like kernel to get wildcard matching
+                like_utf8_scalar(&db_schema_name, &db_schema_filter_pattern)
+            })
+            .transpose()?;
+
+        let batch = RecordBatch::try_new(
+            get_db_schemas_schema(),
+            vec![
+                Arc::new(catalog_name) as ArrayRef,
+                Arc::new(db_schema_name) as ArrayRef,
+            ],
+        )?;
+
+        // Apply the filters if needed
+        let filtered_batch = if let Some(filter) = filter {
+            filter_record_batch(&batch, &filter)?
+        } else {
+            batch
+        };
+
+        // Order filtered results by catalog_name, then db_schema_name
+        let indices = lexsort_to_indices(filtered_batch.columns());
+        let columns = filtered_batch
+            .columns()
+            .iter()
+            .map(|c| take(c, &indices, None))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(RecordBatch::try_new(get_db_schemas_schema(), columns)?)
+    }
+}
+
+fn lexsort_to_indices(arrays: &[ArrayRef]) -> UInt32Array {
+    let fields = arrays
+        .iter()
+        .map(|a| SortField::new(a.data_type().clone()))
+        .collect();
+    let mut converter = RowConverter::new(fields).unwrap();
+    let rows = converter.convert_columns(arrays).unwrap();
+    let mut sort: Vec<_> = rows.iter().enumerate().collect();
+    sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+    UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{StringArray, UInt32Array};
+
+    fn get_ref_batch() -> RecordBatch {
+        RecordBatch::try_new(
+            get_db_schemas_schema(),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "a_catalog",
+                    "a_catalog",
+                    "b_catalog",
+                    "b_catalog",
+                ])) as ArrayRef,
+                Arc::new(StringArray::from(vec![
+                    "a_schema", "b_schema", "a_schema", "b_schema",
+                ])) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_schemas_are_filterd() {
+        let ref_batch = get_ref_batch();
+
+        let mut builder = GetSchemasBuilder::new(None::<String>);
+        builder.append("a_catalog", "a_schema").unwrap();
+        builder.append("a_catalog", "b_schema").unwrap();
+        builder.append("b_catalog", "a_schema").unwrap();
+        builder.append("b_catalog", "b_schema").unwrap();
+        let schema_batch = builder.build().unwrap();
+
+        assert_eq!(schema_batch, ref_batch);
+
+        let mut builder = GetSchemasBuilder::new(Some("a%"));
+        builder.append("a_catalog", "a_schema").unwrap();
+        builder.append("a_catalog", "b_schema").unwrap();
+        builder.append("b_catalog", "a_schema").unwrap();
+        builder.append("b_catalog", "b_schema").unwrap();
+        let schema_batch = builder.build().unwrap();
+
+        let indices = UInt32Array::from(vec![0, 2]);
+        let ref_filtered = RecordBatch::try_new(
+            get_db_schemas_schema(),
+            ref_batch
+                .columns()
+                .iter()
+                .map(|c| take(c, &indices, None))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(schema_batch, ref_filtered);
+    }
+
+    #[test]
+    fn test_schemas_are_sorted() {
+        let ref_batch = get_ref_batch();
+
+        let mut builder = GetSchemasBuilder::new(None::<String>);
+        builder.append("a_catalog", "b_schema").unwrap();
+        builder.append("b_catalog", "a_schema").unwrap();
+        builder.append("a_catalog", "a_schema").unwrap();
+        builder.append("b_catalog", "b_schema").unwrap();
+        let schema_batch = builder.build().unwrap();
+
+        assert_eq!(schema_batch, ref_batch)
+    }
+}

--- a/arrow-flight/src/sql/catalogs/db_schemas.rs
+++ b/arrow-flight/src/sql/catalogs/db_schemas.rs
@@ -48,8 +48,6 @@ static GET_DB_SCHEMAS_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
 ///
 /// * catalog_name: utf8,
 /// * db_schema_name: utf8,
-///
-/// Applies filters for as described on [`get_db_schemas`]
 pub struct GetSchemasBuilder {
     // Optional filters to apply
     db_schema_filter_pattern: Option<String>,
@@ -62,6 +60,10 @@ pub struct GetSchemasBuilder {
 impl GetSchemasBuilder {
     /// Create a new instance of [`GetSchemasBuilder`]
     ///
+    /// The builder handles filtering by schemapatterns, the caller
+    /// is expected to only pass in tables that match the catalog
+    /// from the [`CommandGetDbSchemas`] request.
+    ///
     /// # Parameters
     ///
     /// - `db_schema_filter_pattern`: Specifies a filter pattern for schemas to search for.
@@ -69,6 +71,8 @@ impl GetSchemasBuilder {
     ///   In the pattern string, two special characters can be used to denote matching rules:
     ///     - "%" means to match any substring with 0 or more characters.
     ///     - "_" means to match any one character.
+    ///
+    /// [`CommandGetDbSchemas`]: crate::sql::CommandGetDbSchemas
     pub fn new(db_schema_filter_pattern: Option<impl Into<String>>) -> Self {
         let catalog_name = StringBuilder::new();
         let db_schema_name = StringBuilder::new();

--- a/arrow-flight/src/sql/catalogs/mod.rs
+++ b/arrow-flight/src/sql/catalogs/mod.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use once_cell::sync::Lazy;
+
+use crate::error::Result;
+
+mod db_schemas;
+
+/// Returns the list of catalogs in the DataFusion catalog
+pub fn get_catalogs_batch(mut catalog_names: Vec<String>) -> Result<RecordBatch> {
+    catalog_names.sort_unstable();
+
+    let batch = RecordBatch::try_new(
+        Arc::clone(&GET_CATALOG_SCHEMA),
+        vec![Arc::new(StringArray::from_iter_values(catalog_names)) as _],
+    )?;
+
+    Ok(batch)
+}
+
+/// Returns the schema that will result from [`get_catalogs`]
+pub fn get_catalogs_schema() -> &'static Schema {
+    &GET_CATALOG_SCHEMA
+}
+
+/// The schema for GetCatalogs
+static GET_CATALOG_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
+    Arc::new(Schema::new(vec![Field::new(
+        "catalog_name",
+        DataType::Utf8,
+        false,
+    )]))
+});

--- a/arrow-flight/src/sql/catalogs/mod.rs
+++ b/arrow-flight/src/sql/catalogs/mod.rs
@@ -23,6 +23,8 @@ use once_cell::sync::Lazy;
 
 use crate::error::Result;
 
+pub use db_schemas::{get_db_schemas_schema, GetSchemasBuilder};
+
 mod db_schemas;
 
 /// Returns the list of catalogs in the DataFusion catalog

--- a/arrow-flight/src/sql/catalogs/mod.rs
+++ b/arrow-flight/src/sql/catalogs/mod.rs
@@ -15,6 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Builders and function for building responses to infromation schema requests
+//!
+//! - [`get_catalogs_batch`] and [`get_catalogs_schema`] for building responses to [`CommandGetCatalogs`] queries.
+//! - [`GetSchemasBuilder`] and [`get_db_schemas_schema`] for building responses to [`CommandGetDbSchemas`] queries.
+//! - [`GetTablesBuilder`] and [`get_tables_schema`] for building responses to [`CommandGetTables`] queries.
+//!
+//! [`CommandGetCatalogs`]: crate::sql::CommandGetCatalogs
+//! [`CommandGetDbSchemas`]: crate::sql::CommandGetDbSchemas
+//! [`CommandGetTables`]: crate::sql::CommandGetTables
+
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, RecordBatch, StringArray, UInt32Array};
@@ -30,7 +40,7 @@ pub use tables::{get_tables_schema, GetTablesBuilder};
 mod db_schemas;
 mod tables;
 
-/// Returns the list of catalogs in the DataFusion catalog
+/// Returns the RecordBatch for
 pub fn get_catalogs_batch(mut catalog_names: Vec<String>) -> Result<RecordBatch> {
     catalog_names.sort_unstable();
 

--- a/arrow-flight/src/sql/catalogs/tables.rs
+++ b/arrow-flight/src/sql/catalogs/tables.rs
@@ -53,8 +53,6 @@ pub fn get_tables_schema(include_schema: bool) -> SchemaRef {
 /// * table_type: utf8 not null,
 /// * (optional) table_schema: bytes not null (schema of the table as described
 ///   in Schema.fbs::Schema it is serialized as an IPC message.)
-///
-/// Applies filters for as described on [`get_tables`]
 pub struct GetTablesBuilder {
     // Optional filters to apply to schemas
     db_schema_filter_pattern: Option<String>,
@@ -75,6 +73,10 @@ pub struct GetTablesBuilder {
 impl GetTablesBuilder {
     /// Create a new instance of [`GetTablesBuilder`]
     ///
+    /// The builder handles filtering by schema and table patterns, the caller
+    /// is expected to only pass in tables that match the catalog and table_type
+    /// from the [`CommandGetTables`] request.
+    ///
     /// # Paramneters
     ///
     /// - `db_schema_filter_pattern`: Specifies a filter pattern for schemas to search for.
@@ -88,6 +90,8 @@ impl GetTablesBuilder {
     ///     - "%" means to match any substring with 0 or more characters.
     ///     - "_" means to match any one character.
     /// - `include_schema`: Specifies if the Arrow schema should be returned for found tables.
+    ///
+    /// [`CommandGetTables`]: crate::sql::CommandGetTables
     pub fn new(
         db_schema_filter_pattern: Option<impl Into<String>>,
         table_name_filter_pattern: Option<impl Into<String>>,

--- a/arrow-flight/src/sql/catalogs/tables.rs
+++ b/arrow-flight/src/sql/catalogs/tables.rs
@@ -1,0 +1,232 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_arith::boolean::and;
+use arrow_array::builder::{BinaryBuilder, StringBuilder};
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_select::{filter::filter_record_batch, take::take};
+use arrow_string::like::like_utf8_scalar;
+use once_cell::sync::Lazy;
+
+use super::lexsort_to_indices;
+use crate::error::*;
+use crate::{IpcMessage, IpcWriteOptions, SchemaAsIpc};
+
+/// Return the schema of the RecordBatch that will be returned from
+/// [`get_tables`].
+///
+/// Note the schema differs based on the values of `include_schema`
+pub fn get_tables_schema(include_schema: bool) -> SchemaRef {
+    if include_schema {
+        Arc::clone(&GET_TABLES_SCHEMA_WITH_TABLE_SCHEMA)
+    } else {
+        Arc::clone(&GET_TABLES_SCHEMA_WITHOUT_TABLE_SCHEMA)
+    }
+}
+
+/// Builds rows like this:
+///
+/// * catalog_name: utf8,
+/// * db_schema_name: utf8,
+/// * table_name: utf8 not null,
+/// * table_type: utf8 not null,
+/// * (optional) table_schema: bytes not null (schema of the table as described
+///   in Schema.fbs::Schema it is serialized as an IPC message.)
+///
+/// Applies filters for as described on [`get_tables`]
+pub struct GetTablesBuilder {
+    // Optional filters to apply to schemas
+    db_schema_filter_pattern: Option<String>,
+    // Optional filters to apply to tables
+    table_name_filter_pattern: Option<String>,
+    catalog_name: StringBuilder,
+    db_schema_name: StringBuilder,
+    table_name: StringBuilder,
+    table_type: StringBuilder,
+    table_schema: Option<BinaryBuilder>,
+}
+
+impl GetTablesBuilder {
+    pub fn new(
+        db_schema_filter_pattern: Option<String>,
+        table_name_filter_pattern: Option<String>,
+        include_schema: bool,
+    ) -> Self {
+        let catalog_name = StringBuilder::new();
+        let db_schema_name = StringBuilder::new();
+        let table_name = StringBuilder::new();
+        let table_type = StringBuilder::new();
+
+        let table_schema = if include_schema {
+            Some(BinaryBuilder::new())
+        } else {
+            None
+        };
+
+        Self {
+            db_schema_filter_pattern,
+            table_name_filter_pattern,
+            catalog_name,
+            db_schema_name,
+            table_name,
+            table_type,
+            table_schema,
+        }
+    }
+
+    /// Append a row
+    pub fn append(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        table_type: &str,
+        table_schema: &Schema,
+    ) -> Result<()> {
+        self.catalog_name.append_value(catalog_name);
+        self.db_schema_name.append_value(schema_name);
+        self.table_name.append_value(table_name);
+        self.table_type.append_value(table_type);
+        if let Some(self_table_schema) = self.table_schema.as_mut() {
+            let options = IpcWriteOptions::default();
+            // encode the schema into the correct form
+            let message: std::result::Result<IpcMessage, _> =
+                SchemaAsIpc::new(table_schema, &options).try_into();
+            let IpcMessage(schema) = message?;
+            self_table_schema.append_value(schema);
+        }
+
+        Ok(())
+    }
+
+    /// builds the correct schema
+    pub fn build(self) -> Result<RecordBatch> {
+        let Self {
+            db_schema_filter_pattern,
+            table_name_filter_pattern,
+
+            mut catalog_name,
+            mut db_schema_name,
+            mut table_name,
+            mut table_type,
+            table_schema,
+        } = self;
+
+        // Make the arrays
+        let catalog_name = catalog_name.finish();
+        let db_schema_name = db_schema_name.finish();
+        let table_name = table_name.finish();
+        let table_type = table_type.finish();
+        let table_schema = table_schema.map(|mut table_schema| table_schema.finish());
+
+        // apply any filters, getting a BooleanArray that represents
+        // the rows that passed the filter
+        let mut filters = vec![];
+
+        if let Some(db_schema_filter_pattern) = db_schema_filter_pattern {
+            // use like kernel to get wildcard matching
+            filters.push(like_utf8_scalar(
+                &db_schema_name,
+                &db_schema_filter_pattern,
+            )?)
+        }
+
+        if let Some(table_name_filter_pattern) = table_name_filter_pattern {
+            // use like kernel to get wildcard matching
+            filters.push(like_utf8_scalar(&table_name, &table_name_filter_pattern)?)
+        }
+
+        let include_schema = table_schema.is_some();
+        let batch = if let Some(table_schema) = table_schema {
+            RecordBatch::try_new(
+                get_tables_schema(include_schema),
+                vec![
+                    Arc::new(catalog_name) as ArrayRef,
+                    Arc::new(db_schema_name) as ArrayRef,
+                    Arc::new(table_name) as ArrayRef,
+                    Arc::new(table_type) as ArrayRef,
+                    Arc::new(table_schema) as ArrayRef,
+                ],
+            )
+        } else {
+            RecordBatch::try_new(
+                get_tables_schema(include_schema),
+                vec![
+                    Arc::new(catalog_name) as ArrayRef,
+                    Arc::new(db_schema_name) as ArrayRef,
+                    Arc::new(table_name) as ArrayRef,
+                    Arc::new(table_type) as ArrayRef,
+                ],
+            )
+        }?;
+
+        // `AND` any filters together
+        let mut total_filter = None;
+        while let Some(filter) = filters.pop() {
+            let new_filter = match total_filter {
+                Some(total_filter) => and(&total_filter, &filter)?,
+                None => filter,
+            };
+            total_filter = Some(new_filter);
+        }
+
+        // Apply the filters if needed
+        let filtered_batch = if let Some(total_filter) = total_filter {
+            filter_record_batch(&batch, &total_filter)?
+        } else {
+            batch
+        };
+
+        // Order filtered results by catalog_name, then db_schema_name, then table_name
+        let sort_cols = filtered_batch.project(&[0, 1, 2])?;
+        let indices = lexsort_to_indices(sort_cols.columns());
+        let columns = filtered_batch
+            .columns()
+            .iter()
+            .map(|c| take(c, &indices, None))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        Ok(RecordBatch::try_new(
+            get_tables_schema(include_schema),
+            columns,
+        )?)
+    }
+}
+
+/// The schema for GetTables without `table_schema` column
+static GET_TABLES_SCHEMA_WITHOUT_TABLE_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("catalog_name", DataType::Utf8, false),
+        Field::new("db_schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("table_type", DataType::Utf8, false),
+    ]))
+});
+
+/// The schema for GetTables with `table_schema` column
+static GET_TABLES_SCHEMA_WITH_TABLE_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("catalog_name", DataType::Utf8, false),
+        Field::new("db_schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("table_type", DataType::Utf8, false),
+        Field::new("table_schema", DataType::Binary, false),
+    ]))
+});

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -95,6 +95,7 @@ pub use gen::UpdateDeleteRules;
 
 pub use sql_info::SqlInfoList;
 
+pub mod catalogs;
 pub mod client;
 pub mod server;
 pub mod sql_info;

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -110,7 +110,7 @@
 //!         .map(|a| SortField::new(a.data_type().clone()))
 //!         .collect();
 //!     let mut converter = RowConverter::new(fields).unwrap();
-//!     let rows = converter.convert_columns(&arrays).unwrap();
+//!     let rows = converter.convert_columns(arrays).unwrap();
 //!     let mut sort: Vec<_> = rows.iter().enumerate().collect();
 //!     sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
 //!     UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32))


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4295

# Rationale for this change
 
see #4295

# What changes are included in this PR?

The main builder implementations were lifted from IOx, but altered to also include sorting the created record batches.

cc @alamb @avantgardnerio 

# Are there any user-facing changes?

Users can use the added Builders and methods to create responses to  `CommandGetCatalogs`, `CommandGetSchemas`, and `CommandGetTables` requests.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
