### PR TITLE
Handle trailing padding when skipping repetition levels (#3911)

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -296,11 +296,11 @@ where
     ///
     /// Returns the number of records skipped
     pub fn skip_records(&mut self, num_records: usize) -> Result<usize> {
-        let mut remaining = num_records;
-        while remaining != 0 {
+        let mut remaining_records = num_records;
+        while remaining_records != 0 {
             if self.num_buffered_values == self.num_decoded_values {
                 let metadata = match self.page_reader.peek_next_page()? {
-                    None => return Ok(num_records - remaining),
+                    None => return Ok(num_records - remaining_records),
                     Some(metadata) => metadata,
                 };
 
@@ -312,25 +312,33 @@ where
 
                 // If page has less rows than the remaining records to
                 // be skipped, skip entire page
-                if metadata.num_rows <= remaining {
+                if metadata.num_rows <= remaining_records {
                     self.page_reader.skip_next_page()?;
-                    remaining -= metadata.num_rows;
+                    remaining_records -= metadata.num_rows;
                     continue;
                 };
                 // because self.num_buffered_values == self.num_decoded_values means
                 // we need reads a new page and set up the decoders for levels
                 if !self.read_new_page()? {
-                    return Ok(num_records - remaining);
+                    return Ok(num_records - remaining_records);
                 }
             }
 
             // start skip values in page level
-            let to_read = remaining
-                .min((self.num_buffered_values - self.num_decoded_values) as usize);
+
+            // The number of levels in the current data page
+            let buffered_levels =
+                (self.num_buffered_values - self.num_decoded_values) as usize;
 
             let (records_read, rep_levels_read) = match self.rep_level_decoder.as_mut() {
-                Some(decoder) => decoder.skip_rep_levels(to_read)?,
-                None => (to_read, to_read),
+                Some(decoder) => {
+                    decoder.skip_rep_levels(remaining_records, buffered_levels)?
+                }
+                None => {
+                    // No repetition levels, so each level corresponds to a row
+                    let levels = buffered_levels.min(remaining_records);
+                    (levels, levels)
+                }
             };
 
             let (values_read, def_levels_read) = match self.def_level_decoder.as_mut() {
@@ -357,9 +365,9 @@ where
             }
 
             self.num_decoded_values += rep_levels_read as u32;
-            remaining -= records_read;
+            remaining_records -= records_read;
         }
-        Ok(num_records - remaining)
+        Ok(num_records - remaining_records)
     }
 
     /// Read the next page as a dictionary page. If the next page is not a dictionary page,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3911

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The length of [RLE encoded](https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3) data is ambiguous if the final block is bit packed. As such the decoder might think it has more level data than it actually has when skipping repetition levels, which conceivably could cause the decoder to get out of sync 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No, these APIs are not public
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
