### PR TITLE
Short-circuit on exhausted page in skip_records

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -333,6 +333,14 @@ where
                 None => (to_read, to_read),
             };
 
+            self.num_decoded_values += rep_levels_read as u32;
+            remaining -= records_read;
+
+            if self.num_buffered_values == self.num_decoded_values {
+                // Exhausted buffered page - no need to advance other decoders
+                continue;
+            }
+
             let (values_read, def_levels_read) = match self.def_level_decoder.as_mut() {
                 Some(decoder) => decoder
                     .skip_def_levels(rep_levels_read, self.descr.max_def_level())?,
@@ -355,9 +363,6 @@ where
                     values_read
                 ));
             }
-
-            self.num_decoded_values += rep_levels_read as u32;
-            remaining -= records_read;
         }
         Ok(num_records - remaining)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Noticed whilst working on https://github.com/apache/arrow-rs/pull/4319

If skipping would exhaust the currently buffered page, there is no point advancing the other decoders, as they will simply be discarded when the next page is loaded 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
