### PR TITLE
minor: remove useless `fmt` and TODO

### DIFF
--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -543,13 +543,6 @@ impl Field {
     }
 }
 
-// TODO: improve display with crate https://crates.io/crates/derive_more ?
-impl std::fmt::Display for Field {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 

# What changes are included in this PR?

remove useless `fn fmt(&self, f: &mut std::fmt::Formatter)` and TODO

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
