### PR TITLE
fix: allow cast between different Interval type

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -254,7 +254,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         },
         (Duration(_), Interval(MonthDayNano)) => true,
         (Interval(MonthDayNano), Duration(_)) => true,
-        (Interval(_), Interval(_)) => true,
+        (Interval(_), Interval(MonthDayNano)) => true,
         (_, _) => false,
     }
 }

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -254,6 +254,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         },
         (Duration(_), Interval(MonthDayNano)) => true,
         (Interval(MonthDayNano), Duration(_)) => true,
+        (Interval(_), Interval(_)) => true,
         (_, _) => false,
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

we should allow cast between different Interval type.

like `Interval(Year) + Interval(Day)` , they both will cast to be `MonthDayNano`

# Rationale for this change
https://github.com/apache/arrow-datafusion/issues/5933

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
