### PR TITLE
Move BooleanBufferBuilder and NullBufferBuilder to arrow_buffer

### DIFF
--- a/arrow-array/src/builder/boolean_builder.rs
+++ b/arrow-array/src/builder/boolean_builder.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::{ArrayBuilder, BooleanBufferBuilder};
 use crate::{ArrayRef, BooleanArray};
 use arrow_buffer::Buffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType};
 use std::any::Any;
@@ -150,7 +150,7 @@ impl BooleanBuilder {
         let builder = ArrayData::builder(DataType::Boolean)
             .len(len)
             .add_buffer(self.values_builder.finish().into_inner())
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(null_bit_buffer);
 
         let array_data = unsafe { builder.build_unchecked() };
         BooleanArray::from(array_data)
@@ -159,15 +159,12 @@ impl BooleanBuilder {
     /// Builds the [BooleanArray] without resetting the builder.
     pub fn finish_cloned(&self) -> BooleanArray {
         let len = self.len();
-        let null_bit_buffer = self
-            .null_buffer_builder
-            .as_slice()
-            .map(Buffer::from_slice_ref);
+        let nulls = self.null_buffer_builder.finish_cloned();
         let value_buffer = Buffer::from_slice_ref(self.values_builder.as_slice());
         let builder = ArrayData::builder(DataType::Boolean)
             .len(len)
             .add_buffer(value_buffer)
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(nulls);
 
         let array_data = unsafe { builder.build_unchecked() };
         BooleanArray::from(array_data)

--- a/arrow-array/src/builder/fixed_size_binary_builder.rs
+++ b/arrow-array/src/builder/fixed_size_binary_builder.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::{ArrayBuilder, UInt8BufferBuilder};
 use crate::{ArrayRef, FixedSizeBinaryArray};
 use arrow_buffer::Buffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType};
 use std::any::Any;
@@ -98,7 +98,7 @@ impl FixedSizeBinaryBuilder {
         let array_data_builder =
             ArrayData::builder(DataType::FixedSizeBinary(self.value_length))
                 .add_buffer(self.values_builder.finish())
-                .null_bit_buffer(self.null_buffer_builder.finish())
+                .nulls(self.null_buffer_builder.finish())
                 .len(array_length);
         let array_data = unsafe { array_data_builder.build_unchecked() };
         FixedSizeBinaryArray::from(array_data)
@@ -111,11 +111,7 @@ impl FixedSizeBinaryBuilder {
         let array_data_builder =
             ArrayData::builder(DataType::FixedSizeBinary(self.value_length))
                 .add_buffer(values_buffer)
-                .null_bit_buffer(
-                    self.null_buffer_builder
-                        .as_slice()
-                        .map(Buffer::from_slice_ref),
-                )
+                .nulls(self.null_buffer_builder.finish_cloned())
                 .len(array_length);
         let array_data = unsafe { array_data_builder.build_unchecked() };
         FixedSizeBinaryArray::from(array_data)

--- a/arrow-array/src/builder/fixed_size_list_builder.rs
+++ b/arrow-array/src/builder/fixed_size_list_builder.rs
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::ArrayBuilder;
 use crate::{ArrayRef, FixedSizeListArray};
-use arrow_buffer::Buffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_data::ArrayData;
 use arrow_schema::{DataType, Field};
 use std::any::Any;
@@ -167,14 +166,14 @@ where
             len,
         );
 
-        let null_bit_buffer = self.null_buffer_builder.finish();
+        let nulls = self.null_buffer_builder.finish();
         let array_data = ArrayData::builder(DataType::FixedSizeList(
             Arc::new(Field::new("item", values_data.data_type().clone(), true)),
             self.list_len,
         ))
         .len(len)
         .add_child_data(values_data)
-        .null_bit_buffer(null_bit_buffer);
+        .nulls(nulls);
 
         let array_data = unsafe { array_data.build_unchecked() };
 
@@ -195,17 +194,14 @@ where
             len,
         );
 
-        let null_bit_buffer = self
-            .null_buffer_builder
-            .as_slice()
-            .map(Buffer::from_slice_ref);
+        let nulls = self.null_buffer_builder.finish_cloned();
         let array_data = ArrayData::builder(DataType::FixedSizeList(
             Arc::new(Field::new("item", values_data.data_type().clone(), true)),
             self.list_len,
         ))
         .len(len)
         .add_child_data(values_data)
-        .null_bit_buffer(null_bit_buffer);
+        .nulls(nulls);
 
         let array_data = unsafe { array_data.build_unchecked() };
 

--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::{ArrayBuilder, BufferBuilder, UInt8BufferBuilder};
 use crate::types::{ByteArrayType, GenericBinaryType, GenericStringType};
 use crate::{ArrayRef, GenericByteArray, OffsetSizeTrait};
+use arrow_buffer::NullBufferBuilder;
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::ArrayDataBuilder;
 use std::any::Any;
@@ -123,7 +123,7 @@ impl<T: ByteArrayType> GenericByteBuilder<T> {
             .len(self.len())
             .add_buffer(self.offsets_builder.finish())
             .add_buffer(self.value_builder.finish())
-            .null_bit_buffer(self.null_buffer_builder.finish());
+            .nulls(self.null_buffer_builder.finish());
 
         self.offsets_builder.append(self.next_offset());
         let array_data = unsafe { array_builder.build_unchecked() };
@@ -139,11 +139,7 @@ impl<T: ByteArrayType> GenericByteBuilder<T> {
             .len(self.len())
             .add_buffer(offset_buffer)
             .add_buffer(value_buffer)
-            .null_bit_buffer(
-                self.null_buffer_builder
-                    .as_slice()
-                    .map(Buffer::from_slice_ref),
-            );
+            .nulls(self.null_buffer_builder.finish_cloned());
 
         let array_data = unsafe { array_builder.build_unchecked() };
         GenericByteArray::from(array_data)

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::{ArrayBuilder, BufferBuilder};
 use crate::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::Buffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_data::ArrayData;
 use arrow_schema::Field;
 use std::any::Any;
@@ -243,7 +243,7 @@ where
             .len(len)
             .add_buffer(offset_buffer)
             .add_child_data(values_data)
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(null_bit_buffer);
 
         let array_data = unsafe { array_data_builder.build_unchecked() };
 
@@ -257,10 +257,7 @@ where
         let values_data = values_arr.to_data();
 
         let offset_buffer = Buffer::from_slice_ref(self.offsets_builder.as_slice());
-        let null_bit_buffer = self
-            .null_buffer_builder
-            .as_slice()
-            .map(Buffer::from_slice_ref);
+        let nulls = self.null_buffer_builder.finish_cloned();
         let field = Arc::new(Field::new(
             "item",
             values_data.data_type().clone(),
@@ -271,7 +268,7 @@ where
             .len(len)
             .add_buffer(offset_buffer)
             .add_child_data(values_data)
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(nulls);
 
         let array_data = unsafe { array_data_builder.build_unchecked() };
 

--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -148,8 +148,7 @@
 //! }
 //! ```
 
-mod boolean_buffer_builder;
-pub use boolean_buffer_builder::*;
+pub use arrow_buffer::BooleanBufferBuilder;
 
 mod boolean_builder;
 pub use boolean_builder::*;
@@ -165,7 +164,6 @@ mod generic_list_builder;
 pub use generic_list_builder::*;
 mod map_builder;
 pub use map_builder::*;
-mod null_buffer_builder;
 mod primitive_builder;
 pub use primitive_builder::*;
 mod primitive_dictionary_builder;

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::*;
 use crate::{Array, ArrayRef, StructArray};
-use arrow_buffer::Buffer;
+use arrow_buffer::NullBufferBuilder;
 use arrow_data::ArrayData;
 use arrow_schema::{DataType, Fields, IntervalUnit, TimeUnit};
 use std::any::Any;
@@ -247,12 +246,12 @@ impl StructBuilder {
             child_data.push(arr.to_data());
         }
         let length = self.len();
-        let null_bit_buffer = self.null_buffer_builder.finish();
+        let nulls = self.null_buffer_builder.finish();
 
         let builder = ArrayData::builder(DataType::Struct(self.fields.clone()))
             .len(length)
             .child_data(child_data)
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(nulls);
 
         let array_data = unsafe { builder.build_unchecked() };
         StructArray::from(array_data)
@@ -268,15 +267,12 @@ impl StructBuilder {
             child_data.push(arr.to_data());
         }
         let length = self.len();
-        let null_bit_buffer = self
-            .null_buffer_builder
-            .as_slice()
-            .map(Buffer::from_slice_ref);
+        let nulls = self.null_buffer_builder.finish_cloned();
 
         let builder = ArrayData::builder(DataType::Struct(self.fields.clone()))
             .len(length)
             .child_data(child_data)
-            .null_bit_buffer(null_bit_buffer);
+            .nulls(nulls);
 
         let array_data = unsafe { builder.build_unchecked() };
         StructArray::from(array_data)

--- a/arrow-array/src/builder/union_builder.rs
+++ b/arrow-array/src/builder/union_builder.rs
@@ -16,9 +16,9 @@
 // under the License.
 
 use crate::builder::buffer_builder::{Int32BufferBuilder, Int8BufferBuilder};
-use crate::builder::null_buffer_builder::NullBufferBuilder;
 use crate::builder::BufferBuilder;
 use crate::{make_array, ArrowPrimitiveType, UnionArray};
+use arrow_buffer::NullBufferBuilder;
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, Field};
@@ -292,7 +292,7 @@ impl UnionBuilder {
             let arr_data_builder = ArrayDataBuilder::new(data_type.clone())
                 .add_buffer(buffer)
                 .len(slots)
-                .null_bit_buffer(bitmap_builder.finish());
+                .nulls(bitmap_builder.finish());
 
             let arr_data_ref = unsafe { arr_data_builder.build_unchecked() };
             let array_ref = make_array(arr_data_ref);

--- a/arrow-buffer/src/builder/boolean.rs
+++ b/arrow-buffer/src/builder/boolean.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_buffer::{bit_util, BooleanBuffer, Buffer, MutableBuffer};
-use arrow_data::bit_mask;
+use crate::{bit_mask, bit_util, BooleanBuffer, Buffer, MutableBuffer};
 use std::ops::Range;
 
 /// Builder for [`BooleanBuffer`]
@@ -220,6 +219,11 @@ impl BooleanBufferBuilder {
         let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
         let len = std::mem::replace(&mut self.len, 0);
         BooleanBuffer::new(buf.into(), 0, len)
+    }
+
+    /// Builds the [BooleanBuffer] without resetting the builder.
+    pub fn finish_cloned(&self) -> BooleanBuffer {
+        BooleanBuffer::new(Buffer::from_slice_ref(self.as_slice()), 0, self.len)
     }
 }
 

--- a/arrow-buffer/src/builder/mod.rs
+++ b/arrow-buffer/src/builder/mod.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod bit_chunk_iterator;
-pub mod bit_iterator;
-pub mod bit_mask;
-pub mod bit_util;
+//! Buffer builders
+
+mod boolean;
+pub use boolean::*;
+mod null;
+pub use null::*;

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -180,7 +180,6 @@ impl NullBufferBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Buffer;
 
     #[test]
     fn test_null_buffer_builder() {

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::BooleanBufferBuilder;
-use arrow_buffer::{Buffer, MutableBuffer};
+use crate::{BooleanBufferBuilder, MutableBuffer, NullBuffer};
 
 /// Builder for creating the null bit buffer.
 /// This builder only materializes the buffer when we append `false`.
@@ -24,7 +23,7 @@ use arrow_buffer::{Buffer, MutableBuffer};
 /// `None` when calling [`finish`](#method.finish).
 /// This optimization is **very** important for the performance.
 #[derive(Debug)]
-pub(super) struct NullBufferBuilder {
+pub struct NullBufferBuilder {
     bitmap_builder: Option<BooleanBufferBuilder>,
     /// Store the length of the buffer before materializing.
     len: usize,
@@ -128,10 +127,15 @@ impl NullBufferBuilder {
 
     /// Builds the null buffer and resets the builder.
     /// Returns `None` if the builder only contains `true`s.
-    pub fn finish(&mut self) -> Option<Buffer> {
-        let buf = self.bitmap_builder.take().map(Into::into);
+    pub fn finish(&mut self) -> Option<NullBuffer> {
         self.len = 0;
-        buf
+        Some(NullBuffer::new(self.bitmap_builder.take()?.finish()))
+    }
+
+    /// Builds the [NullBuffer] without resetting the builder.
+    pub fn finish_cloned(&self) -> Option<NullBuffer> {
+        let buffer = self.bitmap_builder.as_ref()?.finish_cloned();
+        Some(NullBuffer::new(buffer))
     }
 
     /// Returns the inner bitmap builder as slice
@@ -176,6 +180,7 @@ impl NullBufferBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Buffer;
 
     #[test]
     fn test_null_buffer_builder() {
@@ -187,7 +192,7 @@ mod tests {
         assert_eq!(6, builder.len());
 
         let buf = builder.finish().unwrap();
-        assert_eq!(Buffer::from(&[0b110010_u8]), buf);
+        assert_eq!(&[0b110010_u8], buf.validity());
     }
 
     #[test]
@@ -199,7 +204,7 @@ mod tests {
         assert_eq!(6, builder.len());
 
         let buf = builder.finish().unwrap();
-        assert_eq!(Buffer::from(&[0b0_u8]), buf);
+        assert_eq!(&[0b0_u8], buf.validity());
     }
 
     #[test]
@@ -228,6 +233,6 @@ mod tests {
         builder.append_slice(&[true, true, false, true]);
 
         let buf = builder.finish().unwrap();
-        assert_eq!(Buffer::from(&[0b1011_u8]), buf);
+        assert_eq!(&[0b1011_u8], buf.validity());
     }
 }

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -21,6 +21,9 @@ pub mod alloc;
 pub mod buffer;
 pub use buffer::*;
 
+pub mod builder;
+pub use builder::*;
+
 mod bigint;
 mod bytes;
 mod native;

--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -17,11 +17,8 @@
 
 //! Utils for working with packed bit masks
 
-use crate::ArrayData;
-use arrow_buffer::bit_chunk_iterator::BitChunks;
-use arrow_buffer::bit_util::{ceil, get_bit, set_bit};
-use arrow_buffer::buffer::buffer_bin_and;
-use arrow_buffer::Buffer;
+use crate::bit_chunk_iterator::BitChunks;
+use crate::bit_util::{ceil, get_bit, set_bit};
 
 /// Sets all bits on `write_data` in the range `[offset_write..offset_write+len]` to be equal to the
 /// bits in `data` in the range `[offset_read..offset_read+len]`
@@ -65,45 +62,9 @@ pub fn set_bits(
     null_count as usize
 }
 
-/// Combines the null bitmaps of multiple arrays using a bitwise `and` operation.
-///
-/// This function is useful when implementing operations on higher level arrays.
-#[deprecated(note = "Use NullBuffer::union")]
-pub fn combine_option_bitmap(
-    arrays: &[&ArrayData],
-    len_in_bits: usize,
-) -> Option<Buffer> {
-    let (buffer, offset) = arrays
-        .iter()
-        .map(|array| match array.nulls() {
-            Some(n) => (Some(n.buffer().clone()), n.offset()),
-            None => (None, 0),
-        })
-        .reduce(|acc, buffer_and_offset| match (acc, buffer_and_offset) {
-            ((None, _), (None, _)) => (None, 0),
-            ((Some(buffer), offset), (None, _)) | ((None, _), (Some(buffer), offset)) => {
-                (Some(buffer), offset)
-            }
-            ((Some(buffer_left), offset_left), (Some(buffer_right), offset_right)) => (
-                Some(buffer_bin_and(
-                    &buffer_left,
-                    offset_left,
-                    &buffer_right,
-                    offset_right,
-                    len_in_bits,
-                )),
-                0,
-            ),
-        })?;
-
-    Some(buffer?.bit_slice(offset, len_in_bits))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_schema::DataType;
-    use std::sync::Arc;
 
     #[test]
     fn test_set_bits_aligned() {
@@ -225,113 +186,5 @@ mod tests {
 
         assert_eq!(destination, expected_data);
         assert_eq!(result, expected_null_count);
-    }
-
-    fn make_data_with_null_bit_buffer(
-        len: usize,
-        offset: usize,
-        null_bit_buffer: Option<Buffer>,
-    ) -> Arc<ArrayData> {
-        let buffer = Buffer::from(&vec![11; len + offset]);
-
-        Arc::new(
-            ArrayData::try_new(
-                DataType::UInt8,
-                len,
-                null_bit_buffer,
-                offset,
-                vec![buffer],
-                vec![],
-            )
-            .unwrap(),
-        )
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_combine_option_bitmap() {
-        let none_bitmap = make_data_with_null_bit_buffer(8, 0, None);
-        let some_bitmap =
-            make_data_with_null_bit_buffer(8, 0, Some(Buffer::from([0b01001010])));
-        let inverse_bitmap =
-            make_data_with_null_bit_buffer(8, 0, Some(Buffer::from([0b10110101])));
-        let some_other_bitmap =
-            make_data_with_null_bit_buffer(8, 0, Some(Buffer::from([0b11010111])));
-        assert_eq!(None, combine_option_bitmap(&[], 8));
-        assert_eq!(
-            Some(Buffer::from([0b01001010])),
-            combine_option_bitmap(&[&some_bitmap], 8)
-        );
-        assert_eq!(
-            None,
-            combine_option_bitmap(&[&none_bitmap, &none_bitmap], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b01001010])),
-            combine_option_bitmap(&[&some_bitmap, &none_bitmap], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b11010111])),
-            combine_option_bitmap(&[&none_bitmap, &some_other_bitmap], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b01001010])),
-            combine_option_bitmap(&[&some_bitmap, &some_bitmap], 8,)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b0])),
-            combine_option_bitmap(&[&some_bitmap, &inverse_bitmap], 8,)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b01000010])),
-            combine_option_bitmap(&[&some_bitmap, &some_other_bitmap, &none_bitmap], 8,)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b00001001])),
-            combine_option_bitmap(
-                &[
-                    &some_bitmap.slice(3, 5),
-                    &inverse_bitmap.slice(2, 5),
-                    &some_other_bitmap.slice(1, 5)
-                ],
-                5,
-            )
-        );
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_combine_option_bitmap_with_offsets() {
-        let none_bitmap = make_data_with_null_bit_buffer(8, 0, None);
-        let bitmap0 =
-            make_data_with_null_bit_buffer(8, 0, Some(Buffer::from([0b10101010])));
-        let bitmap1 =
-            make_data_with_null_bit_buffer(8, 1, Some(Buffer::from([0b01010100, 0b1])));
-        let bitmap2 =
-            make_data_with_null_bit_buffer(8, 2, Some(Buffer::from([0b10101000, 0b10])));
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&bitmap1], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&bitmap2], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&bitmap1, &none_bitmap], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&none_bitmap, &bitmap2], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&bitmap0, &bitmap1], 8)
-        );
-        assert_eq!(
-            Some(Buffer::from([0b10101010])),
-            combine_option_bitmap(&[&bitmap1, &bitmap2], 8)
-        );
     }
 }

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -23,8 +23,7 @@ pub use data::*;
 mod equal;
 pub mod transform;
 
-pub use arrow_buffer::bit_iterator;
-pub mod bit_mask;
+pub use arrow_buffer::{bit_iterator, bit_mask};
 pub mod decimal;
 
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Manually creating a NullBuffer is cumbersome, moving the builders into arrow_buffer will allow defining more ergonomic constructors for these types

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

It removes the deprecated combine_option_bitmap
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
