### PR TITLE
chore: expose Xdbc related enums

### DIFF
--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -75,6 +75,8 @@ pub use gen::CommandStatementQuery;
 pub use gen::CommandStatementSubstraitPlan;
 pub use gen::CommandStatementUpdate;
 pub use gen::DoPutUpdateResult;
+pub use gen::Nullable;
+pub use gen::Searchable;
 pub use gen::SqlInfo;
 pub use gen::SqlNullOrdering;
 pub use gen::SqlOuterJoinsSupportLevel;
@@ -93,6 +95,8 @@ pub use gen::SqlTransactionIsolationLevel;
 pub use gen::SupportedSqlGrammar;
 pub use gen::TicketStatementQuery;
 pub use gen::UpdateDeleteRules;
+pub use gen::XdbcDataType;
+pub use gen::XdbcDatetimeSubcode;
 
 pub use sql_info::SqlInfoList;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4339.

# Rationale for this change

Enums `XdbcDataType`, `XdbcDatetimeSubcode`, `Nullable`, and `Searchable` that are defined and implemented in the following file is missing in module `arrow_flight::sql` as well as missing in [doc](https://docs.rs/arrow-flight/40.0.0/arrow_flight/sql/index.html)

https://github.com/apache/arrow-rs/blob/b5a7481ac592c3bebe92adea1b7d50672f479439/arrow-flight/src/sql/arrow.flight.protocol.sql.rs#L2374-L2693

# What changes are included in this PR?

Exposing thess enums

# Are there any user-facing changes?

Doc is updated. Here is a local version of the doc
<img width="1243" alt="arow_flight sql doc" src="https://github.com/apache/arrow-rs/assets/14298407/3c939ce9-f460-457f-9997-45eef870460e">



