### PR TITLE
Rename list contains kernels to in_list (#4289)

### DIFF
--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -2700,7 +2700,7 @@ where
 }
 
 /// Checks if a [`GenericListArray`] contains a value in the [`PrimitiveArray`]
-pub fn contains<T, OffsetSize>(
+pub fn in_list<T, OffsetSize>(
     left: &PrimitiveArray<T>,
     right: &GenericListArray<OffsetSize>,
 ) -> Result<BooleanArray, ArrowError>
@@ -2742,7 +2742,7 @@ where
 }
 
 /// Checks if a [`GenericListArray`] contains a value in the [`GenericStringArray`]
-pub fn contains_utf8<OffsetSize>(
+pub fn in_list_utf8<OffsetSize>(
     left: &GenericStringArray<OffsetSize>,
     right: &ListArray,
 ) -> Result<BooleanArray, ArrowError>
@@ -3425,7 +3425,7 @@ mod tests {
         let list_array = LargeListArray::from(list_data);
 
         let nulls = Int32Array::from(vec![None, None, None, None]);
-        let nulls_result = contains(&nulls, &list_array).unwrap();
+        let nulls_result = in_list(&nulls, &list_array).unwrap();
         assert_eq!(
             nulls_result
                 .as_any()
@@ -3435,7 +3435,7 @@ mod tests {
         );
 
         let values = Int32Array::from(vec![Some(0), Some(0), Some(0), Some(0)]);
-        let values_result = contains(&values, &list_array).unwrap();
+        let values_result = in_list(&values, &list_array).unwrap();
         assert_eq!(
             values_result
                 .as_any()
@@ -3695,7 +3695,7 @@ mod tests {
 
         let v: Vec<Option<&str>> = vec![None, None, None, None];
         let nulls = StringArray::from(v);
-        let nulls_result = contains_utf8(&nulls, &list_array).unwrap();
+        let nulls_result = in_list_utf8(&nulls, &list_array).unwrap();
         assert_eq!(
             nulls_result
                 .as_any()
@@ -3710,7 +3710,7 @@ mod tests {
             Some("Lorem"),
             Some("Lorem"),
         ]);
-        let values_result = contains_utf8(&values, &list_array).unwrap();
+        let values_result = in_list_utf8(&values, &list_array).unwrap();
         assert_eq!(
             values_result
                 .as_any()

--- a/arrow/examples/builders.rs
+++ b/arrow/examples/builders.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-///! Many builders are available to easily create different types of arrow arrays
-extern crate arrow;
+//! Many builders are available to easily create different types of arrow arrays
 
 use std::sync::Arc;
 

--- a/arrow/examples/collect.rs
+++ b/arrow/examples/collect.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-///! `FromIterator` API is implemented for different array types to easily create them
-/// from values.
+//! `FromIterator` API is implemented for different array types to easily create them
+//! from values.
+
 use arrow::array::Array;
 use arrow_array::types::Int32Type;
 use arrow_array::{Float32Array, Int32Array, Int8Array, ListArray};

--- a/arrow/examples/dynamic_types.rs
+++ b/arrow/examples/dynamic_types.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-///! This example demonstrates dealing with mixed types dynamically at runtime
+//! This example demonstrates dealing with mixed types dynamically at runtime
 use std::sync::Arc;
 
 extern crate arrow;

--- a/arrow/examples/tensor_builder.rs
+++ b/arrow/examples/tensor_builder.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-///! Tensor builder example
-extern crate arrow;
+//! Tensor builder example
 
 use arrow::array::*; //{Int32BufferBuilder, Float32BufferBuilder};
 use arrow::buffer::Buffer;

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -948,8 +948,7 @@ fn test_try_new_sliced_struct() {
 
     let struct_array = builder.finish();
     let struct_array_slice = struct_array.slice(1, 3);
-    let cloned = struct_array_slice.clone();
-    assert_eq!(&struct_array_slice, &cloned);
+    assert_eq!(struct_array_slice, struct_array_slice);
 }
 
 #[test]

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -483,7 +483,7 @@ macro_rules! gen_as_bytes {
                 unsafe {
                     std::slice::from_raw_parts(
                         self_.as_ptr() as *const u8,
-                        std::mem::size_of::<$source_ty>() * self_.len(),
+                        std::mem::size_of_val(self_),
                     )
                 }
             }
@@ -493,7 +493,7 @@ macro_rules! gen_as_bytes {
             unsafe fn slice_as_bytes_mut(self_: &mut [Self]) -> &mut [u8] {
                 std::slice::from_raw_parts_mut(
                     self_.as_mut_ptr() as *mut u8,
-                    std::mem::size_of::<$source_ty>() * self_.len(),
+                    std::mem::size_of_val(self_),
                 )
             }
         }
@@ -735,7 +735,7 @@ pub(crate) mod private {
                     let raw = unsafe {
                         std::slice::from_raw_parts(
                             values.as_ptr() as *const u8,
-                            std::mem::size_of::<$ty>() * values.len(),
+                            std::mem::size_of_val(values),
                         )
                     };
                     writer.write_all(raw)?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4289

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

#3502 added contains string comparison kernels. These overlapped with similarly named kernels for list membership. This would have prevented anyone from using these kernels via the re-exports in the top-level arrow crate, and as of the latest Rust results in a compiler warning on build. 

I opted to rename the older kernel as:

* Given this hasn't been reported it might suggest the downstream impact will be minimal
* I felt in_list was a better name for the kernels that are checking list membership

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes two kernels are renamed
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
