### PR TITLE
Fix MutableArrayData::extend_nulls (#1230)

### DIFF
--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -922,6 +922,29 @@ fn test_fixed_size_binary_append() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn test_extend_nulls() {
+    let int = Int32Array::from(vec![1, 2, 3, 4]).into_data();
+    let mut mutable = MutableArrayData::new(vec![&int], true, 4);
+    mutable.extend(0, 2, 3);
+    mutable.extend_nulls(2);
+
+    let data = mutable.freeze();
+    data.validate_full().unwrap();
+    let out = Int32Array::from(data);
+
+    assert_eq!(out.null_count(), 2);
+    assert_eq!(out.iter().collect::<Vec<_>>(), vec![Some(3), None, None]);
+}
+
+#[test]
+#[should_panic(expected = "MutableArrayData not nullable")]
+fn test_extend_nulls_panic() {
+    let int = Int32Array::from(vec![1, 2, 3, 4]).into_data();
+    let mut mutable = MutableArrayData::new(vec![&int], false, 4);
+    mutable.extend_nulls(2);
+}
+
 /*
 // this is an old test used on a meanwhile removed dead code
 // that is still useful when `MutableArrayData` supports fixed-size lists.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1230
Closes #4324 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

MutableArrayData::extend_nulls doesn't update the null bitmask, and so has never worked correctly. Since #3775 it most likely will result in freeze panicking. It is surprising that nobody has hit this before, although we use `MutableArrayData` in very limited places, and `MutableArrayData::extend_nulls` in even fewer.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
