### PR TITLE
Don't infer 16-byte decimal as decimal256

### DIFF
--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -607,6 +607,9 @@ mod tests {
                     REQUIRED INT64 decimal2 (DECIMAL(12,2));
                     REQUIRED FIXED_LEN_BYTE_ARRAY (16) decimal3 (DECIMAL(30,2));
                     REQUIRED BYTE_ARRAY decimal4 (DECIMAL(33,2));
+                    REQUIRED BYTE_ARRAY decimal5 (DECIMAL(38,2));
+                    REQUIRED FIXED_LEN_BYTE_ARRAY (17) decimal6 (DECIMAL(39,2));
+                    REQUIRED BYTE_ARRAY decimal7 (DECIMAL(39,2));
         }
         ";
 
@@ -619,8 +622,11 @@ mod tests {
         let arrow_fields = Fields::from(vec![
             Field::new("decimal1", DataType::Decimal128(4, 2), false),
             Field::new("decimal2", DataType::Decimal128(12, 2), false),
-            Field::new("decimal3", DataType::Decimal256(30, 2), false),
+            Field::new("decimal3", DataType::Decimal128(30, 2), false),
             Field::new("decimal4", DataType::Decimal128(33, 2), false),
+            Field::new("decimal5", DataType::Decimal128(38, 2), false),
+            Field::new("decimal6", DataType::Decimal256(39, 2), false),
+            Field::new("decimal7", DataType::Decimal256(39, 2), false),
         ]);
         assert_eq!(&arrow_fields, converted_arrow_schema.fields());
     }
@@ -1389,6 +1395,8 @@ mod tests {
             REQUIRED INT32 decimal_int32 (DECIMAL(8,2));
             REQUIRED INT64 decimal_int64 (DECIMAL(16,2));
             REQUIRED FIXED_LEN_BYTE_ARRAY (13) decimal_fix_length (DECIMAL(30,2));
+            REQUIRED FIXED_LEN_BYTE_ARRAY (16) decimal128 (DECIMAL(38,2));
+            REQUIRED FIXED_LEN_BYTE_ARRAY (17) decimal256 (DECIMAL(39,2));
         }
         ";
         let parquet_group_type = parse_message_type(message_type).unwrap();
@@ -1473,7 +1481,9 @@ mod tests {
             ),
             Field::new("decimal_int32", DataType::Decimal128(8, 2), false),
             Field::new("decimal_int64", DataType::Decimal128(16, 2), false),
-            Field::new("decimal_fix_length", DataType::Decimal256(30, 2), false),
+            Field::new("decimal_fix_length", DataType::Decimal128(30, 2), false),
+            Field::new("decimal128", DataType::Decimal128(38, 2), false),
+            Field::new("decimal256", DataType::Decimal256(39, 2), false),
         ];
         let arrow_schema = Schema::new(arrow_fields);
         let converted_arrow_schema = arrow_to_parquet_schema(&arrow_schema).unwrap();

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -285,14 +285,14 @@ fn from_fixed_len_byte_array(
     // TODO: This should check the type length for the decimal and interval types
     match (info.logical_type(), info.converted_type()) {
         (Some(LogicalType::Decimal { scale, precision }), _) => {
-            if type_length < 16 {
+            if type_length <= 16 {
                 decimal_128_type(scale, precision)
             } else {
                 decimal_256_type(scale, precision)
             }
         }
         (None, ConvertedType::DECIMAL) => {
-            if type_length < 16 {
+            if type_length <= 16 {
                 decimal_128_type(scale, precision)
             } else {
                 decimal_256_type(scale, precision)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This is a follow up to #4272, in particular it reverts the unreleased and incorrect changes to the behaviour of the schema inference logic

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
