### PR TITLE
Fix ObjectStore::get_range for GetResult::File (#4350)

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -75,3 +75,7 @@ tempfile = "3.1.0"
 futures-test = "0.3"
 rand = "0.8"
 hyper = { version = "0.14.24", features = ["server"] }
+
+[[test]]
+name = "get_range_file"
+path = "tests/get_range_file.rs"

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -359,10 +359,16 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// in the given byte range
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let options = GetOptions {
-            range: Some(range),
+            range: Some(range.clone()),
             ..Default::default()
         };
-        self.get_opts(location, options).await?.bytes().await
+        match self.get_opts(location, options).await? {
+            GetResult::Stream(s) => collect_bytes(s, None).await,
+            GetResult::File(mut file, path) => {
+                maybe_spawn_blocking(move || local::read_range(&mut file, &path, range))
+                    .await
+            }
+        }
     }
 
     /// Return the bytes that are stored at the specified location

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -863,7 +863,7 @@ impl AsyncWrite for LocalUpload {
     }
 }
 
-fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<Bytes> {
+pub(crate) fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<Bytes> {
     let to_read = range.end - range.start;
     file.seek(SeekFrom::Start(range.start as u64))
         .context(SeekSnafu { path })?;

--- a/object_store/tests/get_range_file.rs
+++ b/object_store/tests/get_range_file.rs
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests the default implementation of get_range handles GetResult::File correctly (#4350)
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
+};
+use std::fmt::Formatter;
+use tempfile::tempdir;
+use tokio::io::AsyncWrite;
+
+#[derive(Debug)]
+struct MyStore(LocalFileSystem);
+
+impl std::fmt::Display for MyStore {
+    fn fmt(&self, _: &mut Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl ObjectStore for MyStore {
+    async fn put(&self, path: &Path, data: Bytes) -> object_store::Result<()> {
+        self.0.put(path, data).await
+    }
+
+    async fn put_multipart(
+        &self,
+        _: &Path,
+    ) -> object_store::Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        todo!()
+    }
+
+    async fn abort_multipart(
+        &self,
+        _: &Path,
+        _: &MultipartId,
+    ) -> object_store::Result<()> {
+        todo!()
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.0.get_opts(location, options).await
+    }
+
+    async fn head(&self, _: &Path) -> object_store::Result<ObjectMeta> {
+        todo!()
+    }
+
+    async fn delete(&self, _: &Path) -> object_store::Result<()> {
+        todo!()
+    }
+
+    async fn list(
+        &self,
+        _: Option<&Path>,
+    ) -> object_store::Result<BoxStream<'_, object_store::Result<ObjectMeta>>> {
+        todo!()
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _: Option<&Path>,
+    ) -> object_store::Result<ListResult> {
+        todo!()
+    }
+
+    async fn copy(&self, _: &Path, _: &Path) -> object_store::Result<()> {
+        todo!()
+    }
+
+    async fn copy_if_not_exists(&self, _: &Path, _: &Path) -> object_store::Result<()> {
+        todo!()
+    }
+}
+
+#[tokio::test]
+async fn test_get_range() {
+    let tmp = tempdir().unwrap();
+    let store = MyStore(LocalFileSystem::new_with_prefix(tmp.path()).unwrap());
+    let path = Path::from("foo");
+
+    let expected = Bytes::from_static(b"hello world");
+    store.put(&path, expected.clone()).await.unwrap();
+    let fetched = store.get(&path).await.unwrap().bytes().await.unwrap();
+    assert_eq!(expected, fetched);
+
+    for range in [0..10, 3..5, 0..expected.len()] {
+        let data = store.get_range(&path, range.clone()).await.unwrap();
+        assert_eq!(&data[..], &expected[range])
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4350

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I'm not a massive fan of this, as `GetResult::bytes()` not taking into account any range feels like a bit of a footgun, however, I couldn't see a way around this without making a breaking change. I may revisit this at a later date, but this at least fixes the bug.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changes the default implementation of get_range to correctly handle a returned file

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
