### PR TITLE
Add support for FixedSizeList in array_to_json_array

### DIFF
--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -594,6 +594,15 @@ pub fn as_list_array(arr: &dyn Array) -> &ListArray {
 }
 
 /// Force downcast of an [`Array`], such as an [`ArrayRef`] to
+/// [`FixedSizeListArray`], panic'ing on failure.
+#[inline]
+pub fn as_fixed_size_list_array(arr: &dyn Array) -> &FixedSizeListArray {
+    arr.as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .expect("Unable to downcast to fixed size list array")
+}
+
+/// Force downcast of an [`Array`], such as an [`ArrayRef`] to
 /// [`LargeListArray`], panic'ing on failure.
 #[inline]
 pub fn as_large_list_array(arr: &dyn Array) -> &LargeListArray {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4248


# What changes are included in this PR?

Makes use of the ability to convert `FixedSizeList` to `ListArray` introduced in this PR https://github.com/apache/arrow-rs/pull/4273 to enable `array_to_json_array` to now support converting FixedSizeList`.

# Are there any user-facing changes?
No

