### PR TITLE
deprecate: as_decimal_array

### DIFF
--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -676,7 +676,6 @@ array_downcast_fn!(as_null_array, NullArray);
 array_downcast_fn!(as_struct_array, StructArray);
 array_downcast_fn!(as_union_array, UnionArray);
 array_downcast_fn!(as_map_array, MapArray);
-array_downcast_fn!(as_decimal_array, Decimal128Array);
 
 /// Downcasts a `dyn Array` to a concrete type
 ///
@@ -875,18 +874,6 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-
-    #[test]
-    fn test_as_decimal_array_ref() {
-        let array: Decimal128Array = vec![Some(123), None, Some(1111)]
-            .into_iter()
-            .collect::<Decimal128Array>()
-            .with_precision_and_scale(10, 2)
-            .unwrap();
-        assert!(!as_decimal_array(&array).is_empty());
-        let result_decimal = as_decimal_array(&array);
-        assert_eq!(result_decimal, &array);
-    }
 
     #[test]
     fn test_as_primitive_array_ref() {

--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -677,6 +677,12 @@ array_downcast_fn!(as_struct_array, StructArray);
 array_downcast_fn!(as_union_array, UnionArray);
 array_downcast_fn!(as_map_array, MapArray);
 
+/// Force downcast of an Array, such as an ArrayRef to Decimal128Array, panic’ing on failure.
+#[deprecated(note = "please use `as_primitive_array::<Decimal128Type>` instead")]
+pub fn as_decimal_array(arr: &dyn Array) -> &PrimitiveArray<Decimal128Type> {
+    as_primitive_array::<Decimal128Type>(arr)
+}
+
 /// Downcasts a `dyn Array` to a concrete type
 ///
 /// ```


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow on to https://github.com/apache/arrow-rs/pull/4362

# Rationale for this change
 As @tustvold said `as_decimal_array` was actual when `Decimal128Type` wasn't a primitive type. Now, `Decimal128Type` and `Decimal256Type` are primitive, and this function is redundant.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Removes `as_decimal_array`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
