### PR TITLE
Have array_to_json_array support MapArray

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::array::{get_offsets, print_long_array};
+use crate::iterator::MapArrayIter;
 use crate::{
     make_array, Array, ArrayAccessor, ArrayRef, ListArray, StringArray, StructArray,
 };
@@ -24,7 +25,6 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, Field};
 use std::any::Any;
 use std::sync::Arc;
-use crate::iterator::MapArrayIter;
 
 /// An array of key-value maps
 ///
@@ -293,14 +293,14 @@ impl Array for MapArray {
 }
 
 impl<'a> ArrayAccessor for &'a MapArray {
-    type Item = ArrayRef;
+    type Item = StructArray;
 
     fn value(&self, index: usize) -> Self::Item {
-        Arc::new(MapArray::value(self, index)) as ArrayRef
+        MapArray::value(self, index)
     }
 
     unsafe fn value_unchecked(&self, index: usize) -> Self::Item {
-        Arc::new(MapArray::value(self, index)) as ArrayRef
+        MapArray::value(self, index)
     }
 }
 

--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -21,7 +21,7 @@ use crate::array::{
     ArrayAccessor, BooleanArray, FixedSizeBinaryArray, GenericBinaryArray,
     GenericListArray, GenericStringArray, PrimitiveArray,
 };
-use crate::FixedSizeListArray;
+use crate::{FixedSizeListArray, MapArray};
 
 /// An iterator that returns Some(T) or None, that can be used on any [`ArrayAccessor`]
 ///
@@ -129,6 +129,8 @@ pub type FixedSizeBinaryIter<'a> = ArrayIter<&'a FixedSizeBinaryArray>;
 pub type FixedSizeListIter<'a> = ArrayIter<&'a FixedSizeListArray>;
 /// an iterator that returns Some(T) or None, that can be used on any ListArray
 pub type GenericListArrayIter<'a, O> = ArrayIter<&'a GenericListArray<O>>;
+/// an iterator that returns Some(T) or None, that can be used on any MapArray
+pub type MapArrayIter<'a> = ArrayIter<&'a MapArray>;
 
 #[cfg(test)]
 mod tests {

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -202,6 +202,13 @@ pub fn array_to_json_array(array: &ArrayRef) -> Result<Vec<Value>, ArrowError> {
             let jsonmaps = struct_array_to_jsonmap_array(array.as_struct())?;
             Ok(jsonmaps.into_iter().map(Value::Object).collect())
         }
+        DataType::Map(_, _) => as_map_array(array)
+            .iter()
+            .map(|maybe_value| match maybe_value {
+                Some(v) => Ok(Value::Array(array_to_json_array(&v)?)),
+                None => Ok(Value::Null),
+            })
+            .collect(),
         t => Err(ArrowError::JsonError(format!(
             "data type {t:?} not supported"
         ))),
@@ -618,6 +625,7 @@ mod tests {
     use std::sync::Arc;
 
     use serde_json::json;
+    use arrow_array::builder::{Int32Builder, MapBuilder, StringBuilder};
 
     use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_data::ArrayData;
@@ -1519,5 +1527,53 @@ mod tests {
         let list_array = Arc::new(list_array) as ArrayRef;
 
         assert_eq!(array_to_json_array(&list_array).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn test_array_to_json_array_for_map_array() {
+        let expected_json = serde_json::from_value::<Vec<Value>>(json!([
+            [
+                {
+                    "keys": "joe",
+                    "values": 1
+                }
+            ],
+            [
+                {
+                    "keys": "blogs",
+                    "values": 2
+                },
+                {
+                    "keys": "foo",
+                    "values": 4
+                }
+            ],
+            [],
+            null
+        ]))
+            .unwrap();
+
+        let string_builder = StringBuilder::new();
+        let int_builder = Int32Builder::with_capacity(4);
+
+        let mut builder = MapBuilder::new(None, string_builder, int_builder);
+
+        builder.keys().append_value("joe");
+        builder.values().append_value(1);
+        builder.append(true).unwrap();
+
+        builder.keys().append_value("blogs");
+        builder.values().append_value(2);
+        builder.keys().append_value("foo");
+        builder.values().append_value(4);
+        builder.append(true).unwrap();
+        builder.append(true).unwrap();
+        builder.append(false).unwrap();
+
+        let array = builder.finish();
+
+        let map_array = Arc::new(array) as ArrayRef;
+
+        assert_eq!(array_to_json_array(&map_array).unwrap(), expected_json);
     }
 }

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -94,6 +94,7 @@
 //! ```
 
 use std::iter;
+use std::sync::Arc;
 use std::{fmt::Debug, io::Write};
 
 use serde_json::map::Map as JsonMap;
@@ -205,7 +206,9 @@ pub fn array_to_json_array(array: &ArrayRef) -> Result<Vec<Value>, ArrowError> {
         DataType::Map(_, _) => as_map_array(array)
             .iter()
             .map(|maybe_value| match maybe_value {
-                Some(v) => Ok(Value::Array(array_to_json_array(&v)?)),
+                Some(v) => Ok(Value::Array(array_to_json_array(
+                    &(Arc::new(v) as ArrayRef),
+                )?)),
                 None => Ok(Value::Null),
             })
             .collect(),
@@ -624,8 +627,8 @@ mod tests {
     use std::io::{BufReader, Seek};
     use std::sync::Arc;
 
-    use serde_json::json;
     use arrow_array::builder::{Int32Builder, MapBuilder, StringBuilder};
+    use serde_json::json;
 
     use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_data::ArrayData;
@@ -1551,7 +1554,7 @@ mod tests {
             [],
             null
         ]))
-            .unwrap();
+        .unwrap();
 
         let string_builder = StringBuilder::new();
         let int_builder = Int32Builder::with_capacity(4);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4297

# Rationale for this change
 
Extended `array_to_json_array` to support `MapArray`