### PR TITLE
Make PrimitiveArray::with_timezone consuming

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1132,24 +1132,21 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
     }
 
     /// Construct a timestamp array with new timezone
-    pub fn with_timezone(&self, timezone: impl Into<Arc<str>>) -> Self {
+    pub fn with_timezone(self, timezone: impl Into<Arc<str>>) -> Self {
         self.with_timezone_opt(Some(timezone.into()))
     }
 
     /// Construct a timestamp array with UTC
-    pub fn with_timezone_utc(&self) -> Self {
+    pub fn with_timezone_utc(self) -> Self {
         self.with_timezone("+00:00")
     }
 
     /// Construct a timestamp array with an optional timezone
-    pub fn with_timezone_opt<S: Into<Arc<str>>>(&self, timezone: Option<S>) -> Self {
-        let array_data = unsafe {
-            self.to_data()
-                .into_builder()
-                .data_type(DataType::Timestamp(T::UNIT, timezone.map(Into::into)))
-                .build_unchecked()
-        };
-        PrimitiveArray::from(array_data)
+    pub fn with_timezone_opt<S: Into<Arc<str>>>(self, timezone: Option<S>) -> Self {
+        Self {
+            data_type: DataType::Timestamp(T::UNIT, timezone.map(Into::into)),
+            ..self
+        }
     }
 }
 

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -502,7 +502,7 @@ mod tests {
                         )
                         .as_str(),
                     )
-                    $(.with_timezone($timezone))?
+                    $(.clone().with_timezone($timezone))?
                     ;
 
                 // create expected array as primitive, and cast to result type
@@ -527,7 +527,7 @@ mod tests {
                         )
                         .as_str(),
                     )
-                    $(.with_timezone($timezone))?
+                    $(.clone().with_timezone($timezone))?
                     ;
                 assert_eq!(expected, array);
             }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Typically `with_` methods in the arrow codebase are consuming, e.g. `with_precision_and_scale`. It was an oddity that these weren't, and so I opted to clean them up. Technically this is a breaking change, in practice I expect the downstream impact to be minimal

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
