### PR TITLE
Add more examples of constructing Boolean, Primitive, String,  and Decimal Arrays, and From impl for i256

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -27,42 +27,50 @@ use std::sync::Arc;
 
 /// An array of [boolean values](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout)
 ///
-/// # Example
+/// # Examples
+///
+/// Construction
 ///
 /// ```
-///     use arrow_array::{Array, BooleanArray};
-///     let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
-///     assert_eq!(4, arr.len());
-///     assert_eq!(1, arr.null_count());
-///     assert!(arr.is_valid(0));
-///     assert!(!arr.is_null(0));
-///     assert_eq!(false, arr.value(0));
-///     assert!(arr.is_valid(1));
-///     assert!(!arr.is_null(1));
-///     assert_eq!(true, arr.value(1));
-///     assert!(!arr.is_valid(2));
-///     assert!(arr.is_null(2));
-///     assert!(arr.is_valid(3));
-///     assert!(!arr.is_null(3));
-///     assert_eq!(true, arr.value(3));
+///#     use arrow_array::{Array, BooleanArray};
+/// // Create from Vec<Option<bool>>
+/// let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
+/// // Create from Vec<bool>
+/// let arr = BooleanArray::from(vec![false, true, true]);
+/// // Create from iter/collect
+/// let arr: BooleanArray = std::iter::repeat(true).take(10).collect();
 /// ```
 ///
-/// Using `from_iter`
+/// Construction and Access
+///
 /// ```
-///     use arrow_array::{Array, BooleanArray};
-///     let v = vec![Some(false), Some(true), Some(false), Some(true)];
-///     let arr = v.into_iter().collect::<BooleanArray>();
-///     assert_eq!(4, arr.len());
-///     assert_eq!(0, arr.offset());
-///     assert_eq!(0, arr.null_count());
-///     assert!(arr.is_valid(0));
-///     assert_eq!(false, arr.value(0));
-///     assert!(arr.is_valid(1));
-///     assert_eq!(true, arr.value(1));
-///     assert!(arr.is_valid(2));
-///     assert_eq!(false, arr.value(2));
-///     assert!(arr.is_valid(3));
-///     assert_eq!(true, arr.value(3));
+/// use arrow_array::{Array, BooleanArray};
+/// let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
+/// assert_eq!(4, arr.len());
+/// assert_eq!(1, arr.null_count());
+/// assert!(arr.is_valid(0));
+/// assert!(!arr.is_null(0));
+/// assert_eq!(false, arr.value(0));
+/// assert!(!arr.is_valid(2));
+/// assert!(arr.is_null(2));
+/// ```
+///
+/// Using `collect`
+/// ```
+/// use arrow_array::{Array, BooleanArray};
+/// let v = vec![Some(false), Some(true), Some(false), Some(true)];
+/// let arr = v.into_iter().collect::<BooleanArray>();
+/// assert_eq!(4, arr.len());
+/// assert_eq!(0, arr.offset());
+/// assert_eq!(0, arr.null_count());
+/// assert!(arr.is_valid(0));
+/// assert_eq!(false, arr.value(0));
+/// assert!(arr.is_valid(1));
+/// assert_eq!(true, arr.value(1));
+/// assert!(arr.is_valid(2));
+/// assert_eq!(false, arr.value(2));
+/// assert!(arr.is_valid(3));
+/// assert_eq!(true, arr.value(3));
 /// ```
 #[derive(Clone)]
 pub struct BooleanArray {

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -36,76 +36,156 @@ use std::sync::Arc;
 
 /// An array of `i8`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::Int8Array;
-/// let arr : Int8Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<i8>>
+/// let arr = Int8Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<i8>
+/// let arr = Int8Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: Int8Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type Int8Array = PrimitiveArray<Int8Type>;
 
 /// An array of `i16`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::Int16Array;
-/// let arr : Int16Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<i16>>
+/// let arr = Int16Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<i16>
+/// let arr = Int16Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: Int16Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type Int16Array = PrimitiveArray<Int16Type>;
 
 /// An array of `i32`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::Int32Array;
-/// let arr : Int32Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<i32>>
+/// let arr = Int32Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<i32>
+/// let arr = Int32Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: Int32Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type Int32Array = PrimitiveArray<Int32Type>;
 
 /// An array of `i64`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::Int64Array;
-/// let arr : Int64Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<i64>>
+/// let arr = Int64Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<i64>
+/// let arr = Int64Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: Int64Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type Int64Array = PrimitiveArray<Int64Type>;
 
 /// An array of `u8`
-/// # Example: Using `collect`
+///
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::UInt8Array;
-/// let arr : UInt8Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<u8>>
+/// let arr = UInt8Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<u8>
+/// let arr = UInt8Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: UInt8Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type UInt8Array = PrimitiveArray<UInt8Type>;
 
 /// An array of `u16`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::UInt16Array;
-/// let arr : UInt16Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<u16>>
+/// let arr = UInt16Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<u16>
+/// let arr = UInt16Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: UInt16Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type UInt16Array = PrimitiveArray<UInt16Type>;
 
 /// An array of `u32`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::UInt32Array;
-/// let arr : UInt32Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<u32>>
+/// let arr = UInt32Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<u32>
+/// let arr = UInt32Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: UInt32Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type UInt32Array = PrimitiveArray<UInt32Type>;
 
 /// An array of `u64`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::UInt64Array;
-/// let arr : UInt64Array = [Some(1), Some(2)].into_iter().collect();
+/// // Create from Vec<Option<u64>>
+/// let arr = UInt64Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<u64>
+/// let arr = UInt64Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: UInt64Array = std::iter::repeat(42).take(10).collect();
 /// ```
 pub type UInt64Array = PrimitiveArray<UInt64Type>;
 
 /// An array of `f16`
+///
+/// # Examples
+///
+/// Construction
+///
+/// ```
+/// # use arrow_array::Float16Array;
+/// use half::f16;
+/// // Create from Vec<Option<f16>>
+/// let arr = Float16Array::from(vec![Some(f16::from_f64(1.0)), Some(f16::from_f64(2.0))]);
+/// // Create from Vec<i8>
+/// let arr = Float16Array::from(vec![f16::from_f64(1.0), f16::from_f64(2.0), f16::from_f64(3.0)]);
+/// // Create iter/collect
+/// let arr: Float16Array = std::iter::repeat(f16::from_f64(1.0)).take(10).collect();
+/// ```
 ///
 /// # Example: Using `collect`
 /// ```
@@ -117,19 +197,35 @@ pub type Float16Array = PrimitiveArray<Float16Type>;
 
 /// An array of `f32`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
 /// # use arrow_array::Float32Array;
-/// let arr : Float32Array = [Some(1.0), Some(2.0)].into_iter().collect();
+/// // Create from Vec<Option<f32>>
+/// let arr = Float32Array::from(vec![Some(1.0), None, Some(2.0)]);
+/// // Create from Vec<f32>
+/// let arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
+/// // Create iter/collect
+/// let arr: Float32Array = std::iter::repeat(42.0).take(10).collect();
 /// ```
 pub type Float32Array = PrimitiveArray<Float32Type>;
 
 /// An array of `f64`
 ///
-/// # Example: Using `collect`
+/// # Examples
+///
+/// Construction
+///
 /// ```
-/// # use arrow_array::Float64Array;
-/// let arr : Float64Array = [Some(1.0), Some(2.0)].into_iter().collect();
+/// # use arrow_array::Float32Array;
+/// // Create from Vec<Option<f32>>
+/// let arr = Float32Array::from(vec![Some(1.0), None, Some(2.0)]);
+/// // Create from Vec<f32>
+/// let arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
+/// // Create iter/collect
+/// let arr: Float32Array = std::iter::repeat(42.0).take(10).collect();
 /// ```
 pub type Float64Array = PrimitiveArray<Float64Type>;
 
@@ -256,9 +352,38 @@ pub type DurationMicrosecondArray = PrimitiveArray<DurationMicrosecondType>;
 pub type DurationNanosecondArray = PrimitiveArray<DurationNanosecondType>;
 
 /// An array of 128-bit fixed point decimals
+///
+/// # Examples
+///
+/// Construction
+///
+/// ```
+/// # use arrow_array::Decimal128Array;
+/// // Create from Vec<Option<i18>>
+/// let arr = Decimal128Array::from(vec![Some(1), None, Some(2)]);
+/// // Create from Vec<i128>
+/// let arr = Decimal128Array::from(vec![1, 2, 3]);
+/// // Create iter/collect
+/// let arr: Decimal128Array = std::iter::repeat(42).take(10).collect();
+/// ```
 pub type Decimal128Array = PrimitiveArray<Decimal128Type>;
 
 /// An array of 256-bit fixed point decimals
+///
+/// # Examples
+///
+/// Construction
+///
+/// ```
+/// # use arrow_array::Decimal256Array;
+/// use arrow_buffer::i256;
+/// // Create from Vec<Option<i256>>
+/// let arr = Decimal256Array::from(vec![Some(i256::from(1)), None, Some(i256::from(2))]);
+/// // Create from Vec<i256>
+/// let arr = Decimal256Array::from(vec![i256::from(1), i256::from(2), i256::from(3)]);
+/// // Create iter/collect
+/// let arr: Decimal256Array = std::iter::repeat(i256::from(42)).take(10).collect();
+/// ```
 pub type Decimal256Array = PrimitiveArray<Decimal256Type>;
 
 pub use crate::types::ArrowPrimitiveType;

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -210,10 +210,24 @@ impl<OffsetSize: OffsetSizeTrait> From<Vec<String>> for GenericStringArray<Offse
 
 /// An array of `str` using `i32` offsets
 ///
-/// Example
+/// # Examples
+///
+/// Construction
 ///
 /// ```
-/// use arrow_array::StringArray;
+/// # use arrow_array::StringArray;
+/// // Create from Vec<Option<&str>>
+/// let arr = StringArray::from(vec![Some("foo"), Some("bar"), None, Some("baz")]);
+/// // Create from Vec<&str>
+/// let arr = StringArray::from(vec!["foo", "bar", "baz"]);
+/// // Create from iter/collect (requires Option<&str>)
+/// let arr: StringArray = std::iter::repeat(Some("foo")).take(10).collect();
+/// ```
+///
+/// Construction and Access
+///
+/// ```
+/// # use arrow_array::StringArray;
 /// let array = StringArray::from(vec![Some("foo"), None, Some("bar")]);
 /// assert_eq!(array.value(0), "foo");
 /// ```
@@ -221,7 +235,21 @@ pub type StringArray = GenericStringArray<i32>;
 
 /// An array of `str` using `i64` offsets
 ///
-/// Example
+/// # Examples
+///
+/// Construction
+///
+/// ```
+/// # use arrow_array::LargeStringArray;
+/// // Create from Vec<Option<&str>>
+/// let arr = LargeStringArray::from(vec![Some("foo"), Some("bar"), None, Some("baz")]);
+/// // Create from Vec<&str>
+/// let arr = LargeStringArray::from(vec!["foo", "bar", "baz"]);
+/// // Create from iter/collect (requires Option<&str>)
+/// let arr: LargeStringArray = std::iter::repeat(Some("foo")).take(10).collect();
+/// ```
+///
+/// Constructon and Access
 ///
 /// ```
 /// use arrow_array::LargeStringArray;

--- a/arrow-buffer/src/bigint.rs
+++ b/arrow-buffer/src/bigint.rs
@@ -97,6 +97,30 @@ impl FromStr for i256 {
     }
 }
 
+impl From<i8> for i256 {
+    fn from(value: i8) -> Self {
+        Self::from_i128(value.into())
+    }
+}
+
+impl From<i16> for i256 {
+    fn from(value: i16) -> Self {
+        Self::from_i128(value.into())
+    }
+}
+
+impl From<i32> for i256 {
+    fn from(value: i32) -> Self {
+        Self::from_i128(value.into())
+    }
+}
+
+impl From<i64> for i256 {
+    fn from(value: i64) -> Self {
+        Self::from_i128(value.into())
+    }
+}
+
 /// Parse `s` with any sign and leading 0s removed
 fn parse_impl(s: &str, negative: bool) -> Result<i256, ParseI256Error> {
     if s.len() <= 38 {


### PR DESCRIPTION


# Which issue does this PR close?

N/A

# Rationale for this change
 
While working on https://github.com/apache/arrow-datafusion/pull/6587 I realized it is still confusing to create arrays (as in it may not be clear how easy it is to do)

# What changes are included in this PR?

1. Add more examples of constructing Boolean, PrimitiveArray, StringArray and Decimal*Array
2. Add `From` impl for `i256` and `i8`, `i16`, `i32` and `i64` to make constructing them easier (used in the doc examples)

# Are there any user-facing changes?
Easier to construct `i256` and better docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
