### PR TITLE
feat(flight): harmonize server metadata APIs

### DIFF
--- a/arrow-flight/src/sql/metadata/mod.rs
+++ b/arrow-flight/src/sql/metadata/mod.rs
@@ -34,7 +34,7 @@ mod xdbc_info;
 
 pub use catalogs::GetCatalogsBuilder;
 pub use db_schemas::GetDbSchemasBuilder;
-pub use sql_info::SqlInfoList;
+pub use sql_info::{SqlInfoData, SqlInfoDataBuilder};
 pub use tables::GetTablesBuilder;
 pub use xdbc_info::{XdbcTypeInfo, XdbcTypeInfoData, XdbcTypeInfoDataBuilder};
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
In a previous PR (#4359) we refined the APIs for supporting implementors to communicate xdbc data type infos for flight sql servers. 

# What changes are included in this PR?

sql info apis / patterns updated to match xdbc type info.

# Are there any user-facing changes?

Yes, the APIs for sql infos changed.
