### PR TITLE
Truncate Min/Max values in the Column Index

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -684,7 +684,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     }
 
     fn truncate_minmax_value(&self, data: &[u8]) -> Vec<u8> {
-        if let Some(max_len) = self.props.truncate_minmax_value_len() {
+        if let Some(max_len) = self.props.minmax_value_truncate_len() {
             data[0..usize::min(data.len(), max_len)].to_vec()
         } else {
             data.to_vec()

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1183,7 +1183,7 @@ fn compare_greater_byte_array_decimals(a: &[u8], b: &[u8]) -> bool {
 
 /// Truncate a UTF8 slice to the longest prefix that is still a valid UTF8 string, while being less than `max_len` bytes.
 fn truncate_utf8(data: &str, max_len: usize) -> Vec<u8> {
-    let mut max_possible_len = usize::min(data.len(), max_len);
+    let mut max_possible_len = data.len().min(max_len);
 
     if data.is_char_boundary(max_possible_len) {
         return data.as_bytes()[0..max_possible_len].to_vec();

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1246,7 +1246,7 @@ fn increment(data: &mut [u8]) {
     }
 }
 
-/// Try and increment the the string's bytes from right to left, returning when the result is a valid UTF8 string.
+/// Try and increment the string's bytes from right to left, returning when the result is a valid UTF8 string.
 fn increment_utf8(data: &mut Vec<u8>) {
     for idx in (0..data.len()).rev() {
         let byte = &mut data[idx];

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -2228,7 +2228,7 @@ mod tests {
         );
     }
 
-    /// Verify min/max value truncation iin the column index works as expected
+    /// Verify min/max value truncation in the column index works as expected
     #[test]
     fn test_column_offset_index_metadata_truncating() {
         // write data

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -868,13 +868,13 @@ impl ColumnIndexBuilder {
     pub fn append(
         &mut self,
         null_page: bool,
-        min_value: &[u8],
-        max_value: &[u8],
+        min_value: Vec<u8>,
+        max_value: Vec<u8>,
         null_count: i64,
     ) {
         self.null_pages.push(null_page);
-        self.min_values.push(min_value.to_vec());
-        self.max_values.push(max_value.to_vec());
+        self.min_values.push(min_value);
+        self.max_values.push(max_value);
         self.null_counts.push(null_count);
     }
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -222,6 +222,9 @@ impl WriterProperties {
         self.sorting_columns.as_ref()
     }
 
+    /// Returns the maximum length of truncated min/max values in the column index.
+    ///
+    /// `None` if truncation is disabled, must be greater than 0 otherwise.
     pub fn column_index_truncate_length(&self) -> Option<usize> {
         self.column_index_truncate_length
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -129,7 +129,7 @@ pub struct WriterProperties {
     default_column_properties: ColumnProperties,
     column_properties: HashMap<ColumnPath, ColumnProperties>,
     sorting_columns: Option<Vec<SortingColumn>>,
-    truncate_minmax_value_len: Option<usize>,
+    minmax_value_truncate_len: Option<usize>,
 }
 
 impl Default for WriterProperties {
@@ -228,8 +228,8 @@ impl WriterProperties {
         self.sorting_columns.as_ref()
     }
 
-    pub fn truncate_minmax_value_len(&self) -> Option<usize> {
-        self.truncate_minmax_value_len
+    pub fn minmax_value_truncate_len(&self) -> Option<usize> {
+        self.minmax_value_truncate_len
     }
 
     /// Returns encoding for a data page, when dictionary encoding is enabled.
@@ -326,7 +326,7 @@ pub struct WriterPropertiesBuilder {
     default_column_properties: ColumnProperties,
     column_properties: HashMap<ColumnPath, ColumnProperties>,
     sorting_columns: Option<Vec<SortingColumn>>,
-    truncate_minmax_value_len: Option<usize>,
+    minmax_value_truncate_len: Option<usize>,
 }
 
 impl WriterPropertiesBuilder {
@@ -344,7 +344,7 @@ impl WriterPropertiesBuilder {
             default_column_properties: Default::default(),
             column_properties: HashMap::new(),
             sorting_columns: None,
-            truncate_minmax_value_len: DEFAULT_COLUMN_INDEX_MINMAX_LEN,
+            minmax_value_truncate_len: DEFAULT_COLUMN_INDEX_MINMAX_LEN,
         }
     }
 
@@ -362,7 +362,7 @@ impl WriterPropertiesBuilder {
             default_column_properties: self.default_column_properties,
             column_properties: self.column_properties,
             sorting_columns: self.sorting_columns,
-            truncate_minmax_value_len: self.truncate_minmax_value_len,
+            minmax_value_truncate_len: self.minmax_value_truncate_len,
         }
     }
 
@@ -638,8 +638,8 @@ impl WriterPropertiesBuilder {
 
     /// Sets the max length of min/max value fields in the column index.
     /// If set to `None` - there's no effective limit.
-    pub fn set_max_size_to_truncate(mut self, max_length: Option<usize>) -> Self {
-        self.truncate_minmax_value_len = max_length;
+    pub fn set_value_truncate_length(mut self, max_length: Option<usize>) -> Self {
+        self.minmax_value_truncate_len = max_length;
         self
     }
 }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -638,7 +638,7 @@ impl WriterPropertiesBuilder {
 
     /// Sets the max length of min/max value fields in the column index.
     /// If set to `None` - there's no effective limit.
-    pub fn set_value_truncate_length(mut self, max_length: Option<usize>) -> Self {
+    pub fn set_column_index_truncate_length(mut self, max_length: Option<usize>) -> Self {
         self.minmax_value_truncate_len = max_length;
         self
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -81,7 +81,7 @@ const DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT: usize = DEFAULT_PAGE_SIZE;
 const DEFAULT_STATISTICS_ENABLED: EnabledStatistics = EnabledStatistics::Page;
 const DEFAULT_MAX_STATISTICS_SIZE: usize = 4096;
 const DEFAULT_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
-const DEFAULT_COLUMN_INDEX_MINMAX_LEN: Option<usize> = Some(128);
+const DEFAULT_COLUMN_INDEX_MINMAX_LEN: Option<usize> = Some(64);
 const DEFAULT_CREATED_BY: &str =
     concat!("parquet-rs version ", env!("CARGO_PKG_VERSION"));
 /// default value for the false positive probability used in a bloom filter.

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1751,7 +1751,10 @@ mod tests {
                 let page_idx = &v.indexes[0];
                 assert_eq!(page_idx.null_count.unwrap(), 1);
                 assert_eq!(page_idx.min.as_ref().unwrap().as_ref(), &[0; 11]);
-                assert_eq!(page_idx.max.as_ref().unwrap().as_ref(), &[5; 11]);
+                assert_eq!(
+                    page_idx.max.as_ref().unwrap().as_ref(),
+                    &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6]
+                );
             }
             _ => unreachable!(),
         }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1751,10 +1751,7 @@ mod tests {
                 let page_idx = &v.indexes[0];
                 assert_eq!(page_idx.null_count.unwrap(), 1);
                 assert_eq!(page_idx.min.as_ref().unwrap().as_ref(), &[0; 11]);
-                assert_eq!(
-                    page_idx.max.as_ref().unwrap().as_ref(),
-                    &[5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6]
-                );
+                assert_eq!(page_idx.max.as_ref().unwrap().as_ref(), &[5; 11]);
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4126 .

# Rationale for this change
For use cases that store large binary or string values in Parquet files, page-level statistics might blow up as the min/max values are stored in them as part of the [Column Index](https://github.com/apache/parquet-format/blob/master/PageIndex.md). This "feature" is part of the spec, and is implemented in other languages.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
This adds a new member to `WriterProperties` and its builder, and truncates min/max values at a specific length, while still allowing shorter ones or disabeling truncation all together (maintaing the current default behavior).

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
There are two user-facing changes in this PR:
1. It adds a new option to `WriterPropertiesBuilder`to specify the max length of min/max values before they are truncated.
2. It will change the default behavior to truncating at the 128 byte line. That might cause some performance changes to users that have long binary arrays with shared prefixes.
3. Max values will now be "Incremented", like in this [example](https://github.com/apache/parquet-format/blob/master/PageIndex.md#technical-approach) from the spec.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
