### PR TITLE
Minor: Derive `Hash` impls for `CastOptions` and `FormatOptions`

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -57,7 +57,7 @@ use num::cast::AsPrimitive;
 use num::{NumCast, ToPrimitive};
 
 /// CastOptions provides a way to override the default cast behaviors
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CastOptions<'a> {
     /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
     pub safe: bool,

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -39,7 +39,7 @@ type TimeFormat<'a> = Option<&'a str>;
 /// By default nulls are formatted as `""` and temporal types formatted
 /// according to RFC3339
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FormatOptions<'a> {
     /// If set to `true` any formatting errors will be written to the output
     /// instead of being converted into a [`std::fmt::Error`]


### PR DESCRIPTION
# Which issue does this PR close?

N/A
# Rationale for this change
 
 We are trying to add `Hash` in DataFusion in https://github.com/apache/arrow-datafusion/pull/6625 and it would be more convenient if `CastOptions` also implemented `Hash`.

# What changes are included in this PR?

Derive `Hash` impls for `CastOptions` and `FormatOptions`
# Are there any user-facing changes?

More hash
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
