### PR TITLE
Improve `take` kernel performance on primitive arrays, fix bad null index handling  (#4404)

### DIFF
--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -128,6 +128,7 @@ impl BooleanBuffer {
     /// # Panics
     ///
     /// Panics if `i >= self.len()`
+    #[inline]
     pub fn value(&self, idx: usize) -> bool {
         assert!(idx < self.len);
         unsafe { self.value_unchecked(idx) }

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -140,6 +140,12 @@ impl<T: ArrowNativeType> From<Vec<T>> for ScalarBuffer<T> {
     }
 }
 
+impl<T: ArrowNativeType> FromIterator<T> for ScalarBuffer<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into()
+    }
+}
+
 impl<'a, T: ArrowNativeType> IntoIterator for &'a ScalarBuffer<T> {
     type Item = &'a T;
     type IntoIter = std::slice::Iter<'a, T>;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4404

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Fixes #4404 and improves performance significantly

Using the benchmarks in #4403 

```
take i32 512            time:   [259.96 ns 260.19 ns 260.43 ns]
                        change: [-33.771% -33.654% -33.538%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

take i32 1024           time:   [411.64 ns 411.83 ns 412.05 ns]
                        change: [-31.098% -31.057% -31.012%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

take i32 null indices 1024
                        time:   [556.36 ns 556.65 ns 556.94 ns]
                        change: [-14.529% -14.467% -14.407%] (p = 0.00 < 0.05)
                        Performance has improved.

take i32 null values 1024
                        time:   [1.3158 µs 1.3167 µs 1.3176 µs]
                        change: [-41.607% -41.530% -41.446%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

take i32 null values null indices 1024
                        time:   [1.6743 µs 1.6761 µs 1.6775 µs]
                        change: [-43.953% -43.710% -43.467%] (p = 0.00 < 0.05)
                        Performance has improved.

take check bounds i32 512
                        time:   [381.76 ns 381.99 ns 382.22 ns]
                        change: [-25.746% -25.670% -25.599%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

take check bounds i32 1024
                        time:   [662.78 ns 663.02 ns 663.26 ns]
                        change: [-22.074% -21.942% -21.848%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool 512           time:   [525.34 ns 525.72 ns 526.11 ns]
                        change: [-6.8248% -6.5847% -6.3665%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low severe
  1 (1.00%) high mild
  1 (1.00%) high severe

take bool 1024          time:   [885.39 ns 886.30 ns 887.29 ns]
                        change: [-12.935% -12.734% -12.536%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

take bool null indices 1024
                        time:   [1.0396 µs 1.0401 µs 1.0406 µs]
                        change: [-51.963% -51.923% -51.885%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

take bool null values 1024
                        time:   [1.7840 µs 1.7853 µs 1.7871 µs]
                        change: [-2.8921% -2.7540% -2.6122%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

take bool null values null indices 1024
                        time:   [2.1861 µs 2.1878 µs 2.1897 µs]
                        change: [-45.707% -45.587% -45.456%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Previously a negative index would return an error even when `TakeOptions::check_bound` was `false`. The code will now consistently panic on out of bounds errors, regardless of if that is the result of a wrapping conversion of a negative numbers. This yields a non-trivial speedup, as the additional branch seemed to cause LLVM some issues.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
