### PR TITLE
Fix bug in compression

### DIFF
--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -69,7 +69,7 @@ impl CompressionCodec {
             output.extend_from_slice(&uncompressed_data_len.to_le_bytes());
             self.compress(input, output)?;
 
-            let compression_len = output.len();
+            let compression_len = output.len() - original_output_len;
             if compression_len > uncompressed_data_len {
                 // length of compressed data was larger than
                 // uncompressed data, use the uncompressed data with


### PR DESCRIPTION
The wrongly calculated compressed length included the full original buffer length, which will decline almost all the compressable data. Suppose original buffer len is *a*, incoming data len is *b*, compressed data len is *c*, the code should compare *b* and *c* instead of *b* and *a+c*

# Which issue does this PR close?
Closes #4410.

# Rationale for this change
 We observe abnormal compress ratio in our production code even with ZSTD.

# What changes are included in this PR?
Fix the compressed length calculation

# Are there any user-facing changes?
No
