### PR TITLE
Add DictionaryArray::occupancy

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -56,5 +56,10 @@ simd = ["packed_simd"]
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+criterion = { version = "0.5", default-features = false }
 
 [build-dependencies]
+
+[[bench]]
+name = "occupancy"
+harness = false

--- a/arrow-array/benches/occupancy.rs
+++ b/arrow-array/benches/occupancy.rs
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::types::Int32Type;
+use arrow_array::{DictionaryArray, Int32Array};
+use arrow_buffer::NullBuffer;
+use criterion::*;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+fn gen_dict(
+    len: usize,
+    values_len: usize,
+    occupancy: f64,
+    null_percent: f64,
+) -> DictionaryArray<Int32Type> {
+    let mut rng = thread_rng();
+    let values = Int32Array::from(vec![0; values_len]);
+    let max_key = (values_len as f64 * occupancy) as i32;
+    let keys = (0..len).map(|_| rng.gen_range(0..max_key)).collect();
+    let nulls = (0..len).map(|_| !rng.gen_bool(null_percent)).collect();
+
+    let keys = Int32Array::new(keys, Some(NullBuffer::new(nulls)));
+    DictionaryArray::new(keys, Arc::new(values))
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    for values in [10, 100, 512] {
+        for occupancy in [1., 0.5, 0.1] {
+            for null_percent in [0.0, 0.1, 0.5, 0.9] {
+                let dict = gen_dict(1024, values, occupancy, null_percent);
+                c.bench_function(&format!("occupancy(values: {values}, occupancy: {occupancy}, null_percent: {null_percent})"), |b| {
+                    b.iter(|| {
+                        black_box(&dict).occupancy()
+                    });
+                });
+            }
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4414 
Relates to https://github.com/apache/arrow-rs/issues/506


# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Split out from #3558 this adds a `DictionaryArray::occupancy` which provides a mask of the "used" values. This is effectively a selection vector for the values (#4095)

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
