### PR TITLE
gcp: Exclude authorization header when bearer empty

### DIFF
--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -394,16 +394,19 @@ impl GetClient for GoogleCloudStorageClient {
             false => Method::GET,
         };
 
-        let response = self
-            .client
-            .request(method, url)
-            .bearer_auth(&credential.bearer)
-            .with_get_options(options)
-            .send_retry(&self.retry_config)
-            .await
-            .context(GetRequestSnafu {
-                path: path.as_ref(),
-            })?;
+        let mut request = self.client.request(method, url).with_get_options(options);
+
+        if !credential.bearer.is_empty() {
+            request = request.bearer_auth(&credential.bearer);
+        }
+
+        let response =
+            request
+                .send_retry(&self.retry_config)
+                .await
+                .context(GetRequestSnafu {
+                    path: path.as_ref(),
+                })?;
 
         Ok(response)
     }


### PR DESCRIPTION
GCP tries to authorize when there's the authorization header. If the bearer is empty, exclude the header since this doesn't let us get a public object.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4417.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
