### PR TITLE
Fix reading gzip file with multiple gzip headers in parquet-fromcsv.

### DIFF
--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -381,7 +381,7 @@ fn convert_csv_to_parquet(args: &Args) -> Result<(), ParquetFromCsvError> {
             Box::new(snap::read::FrameDecoder::new(input_file)) as Box<dyn Read>
         }
         Compression::GZIP(_) => {
-            Box::new(flate2::read::GzDecoder::new(input_file)) as Box<dyn Read>
+            Box::new(flate2::read::MultiGzDecoder::new(input_file)) as Box<dyn Read>
         }
         Compression::BROTLI(_) => {
             Box::new(brotli::Decompressor::new(input_file, 0)) as Box<dyn Read>


### PR DESCRIPTION
Fix reading gzip file with multiple gzip headers in parquet-fromcsv.

Closes: #4173

# Which issue does this PR close?

Closes #4173.

# Rationale for this change

Gzipped CSV/TSV files containing multiple gzip headers, could not be read properly before.
This kind of files are commonly generated in bioinformatic workflows with the `bgzip` compression tool.
