### PR TITLE
fix(json reader): infer unsigned int as u64

### DIFF
--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1479,7 +1479,7 @@ mod tests {
         assert_eq!(schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
-        assert_eq!(&DataType::Int64, a.1.data_type());
+        assert_eq!(&DataType::UInt64, a.1.data_type());
         let b = schema.column_with_name("b").unwrap();
         assert_eq!(&DataType::Float64, b.1.data_type());
         let c = schema.column_with_name("c").unwrap();
@@ -1487,7 +1487,7 @@ mod tests {
         let d = schema.column_with_name("d").unwrap();
         assert_eq!(&DataType::Utf8, d.1.data_type());
 
-        let aa = batch.column(a.0).as_primitive::<Int64Type>();
+        let aa = batch.column(a.0).as_primitive::<UInt64Type>();
         assert!(aa.is_valid(0));
         assert!(!aa.is_valid(1));
         assert!(!aa.is_valid(11));

--- a/arrow-json/src/reader/schema.rs
+++ b/arrow-json/src/reader/schema.rs
@@ -314,7 +314,9 @@ fn infer_scalar_array_type(array: &[Value]) -> Result<InferredType, ArrowError> 
         match v {
             Value::Null => {}
             Value::Number(n) => {
-                if n.is_i64() {
+                if n.is_u64() {
+                    hs.insert(DataType::UInt64);
+                } else if n.is_i64() {
                     hs.insert(DataType::Int64);
                 } else {
                     hs.insert(DataType::Float64);

--- a/arrow-json/src/reader/schema.rs
+++ b/arrow-json/src/reader/schema.rs
@@ -488,7 +488,7 @@ fn collect_field_types_from_object(
 ///
 /// The following type coercion logic is implemented:
 /// * Unsigned integer are converted to `UInt64`
-/// * Signed integer are converted to `Int64`
+/// * Signed integer smaller than 64 bits are converted to `Int64`
 /// * `Int64` and `UInt64` are converted to `Int64`
 /// * Less than `i64::MIN` or greater than `u64::MAX` are converted to `Float64`
 /// * `Int64` and `Float64` are converted to `Float64`

--- a/arrow-json/src/reader/schema.rs
+++ b/arrow-json/src/reader/schema.rs
@@ -597,7 +597,7 @@ mod tests {
         let inferred_schema = infer_json_schema_from_iterator(
             vec![
                 Ok(serde_json::json!({
-                    "c1": -1i64, "c2": (u64::MAX - 1) as u64, "c3": 1.0f64,
+                    "c1": -1i64, "c2": i64::MAX as u64 + 1, "c3": 1.0f64,
                 })),
                 Ok(serde_json::json!({
                     "c1": -1i64, "c2": 1u64, "c3": 1.0f64,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
Referring an `u64` integer which is bigger than `i64::Max` as a `DataType::Float64` isn't quite accurate. For example:

```rust
let span_id: u64 = ThreadRng::default().gen();
```

Where the `span_id` is less than `i64::Max`, it is referred to as a `DataType::Int64`, while it is bigger than `i64::Max`, it is mis-inferred to `DataType::Float64`.

However, `serde_json::Number` loses the necessary concrete type (`u8`, `u16`, `u32`, etc), otherwise, we can refer integer more accurately.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Not sure.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
