### PR TITLE
feat: add strict mode to json reader

### DIFF
--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -35,6 +35,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
     pub fn new(
         data_type: DataType,
         coerce_primitive: bool,
+        strict_mode: bool,
         is_nullable: bool,
     ) -> Result<Self, ArrowError> {
         let field = match &data_type {
@@ -45,6 +46,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
         let decoder = make_decoder(
             field.data_type().clone(),
             coerce_primitive,
+            strict_mode,
             field.is_nullable(),
         )?;
 

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -34,6 +34,7 @@ impl MapArrayDecoder {
     pub fn new(
         data_type: DataType,
         coerce_primitive: bool,
+        strict_mode: bool,
         is_nullable: bool,
     ) -> Result<Self, ArrowError> {
         let fields = match &data_type {
@@ -56,11 +57,13 @@ impl MapArrayDecoder {
         let keys = make_decoder(
             fields[0].data_type().clone(),
             coerce_primitive,
+            strict_mode,
             fields[0].is_nullable(),
         )?;
         let values = make_decoder(
             fields[1].data_type().clone(),
             coerce_primitive,
+            strict_mode,
             fields[1].is_nullable(),
         )?;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Hello,

This PR adds a new _strict mode_ for the json reader. If strict mode is enabled, the parser will return an error if it encounters a column not present in the schema. It's useful for example if you want to ensure that your schema match 100% the JSON file.

The strict mode is added as a new option of `ReaderBuilder`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
