### PR TITLE
Remove Float64 -> Float32 cast in IPC Reader

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 
 use arrow_array::*;
 use arrow_buffer::{Buffer, MutableBuffer};
-use arrow_cast::cast;
 use arrow_data::ArrayData;
 use arrow_schema::*;
 
@@ -248,6 +247,7 @@ fn create_primitive_array(
         | Boolean
         | Int64
         | UInt64
+        | Float32
         | Float64
         | Time64(_)
         | Timestamp(_, _)
@@ -259,25 +259,6 @@ fn create_primitive_array(
                 .add_buffer(buffers[1].clone())
                 .null_bit_buffer(null_buffer)
                 .build()?
-        }
-        Float32 => {
-            if buffers[1].len() / 8 == length && length != 1 {
-                // interpret as a f64, and cast appropriately
-                let data = ArrayData::builder(DataType::Float64)
-                    .len(length)
-                    .add_buffer(buffers[1].clone())
-                    .null_bit_buffer(null_buffer)
-                    .build()?;
-                let values = Arc::new(Float64Array::from(data)) as ArrayRef;
-                let casted = cast(&values, data_type)?;
-                casted.into_data()
-            } else {
-                ArrayData::builder(data_type.clone())
-                    .len(length)
-                    .add_buffer(buffers[1].clone())
-                    .null_bit_buffer(null_buffer)
-                    .build()?
-            }
         }
         Interval(IntervalUnit::MonthDayNano) | Decimal128(_, _) => {
             let buffer = get_aligned_buffer::<i128>(&buffers[1], length);


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
Address unresolved comment from #4412

# What changes are included in this PR?

Removes Float32 -> Float64 reinterpret cast in create_array.

# Are there any user-facing changes?
