### PR TITLE
fix: Allow reading of arrow files with more than one million columns

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -650,7 +650,7 @@ impl<R: Read + Seek> FileReader<R> {
         reader.read_exact(&mut footer_data)?;
 
         // construct verifier options that reflect actual number of columns
-        // in file
+        // in file and avoid an error if the file contains more than 1M rows
         let verifier_options = VerifierOptions {
             max_depth: 128,
             max_tables: footer_len as usize * 8,

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -657,9 +657,10 @@ impl<R: Read + Seek> FileReader<R> {
             ..Default::default()
         };
 
-        let footer = crate::root_as_footer_with_opts(&verifier_options, &footer_data[..]).map_err(|err| {
-            ArrowError::IoError(format!("Unable to get root as footer: {err:?}"))
-        })?;
+        let footer = crate::root_as_footer_with_opts(&verifier_options, &footer_data[..])
+            .map_err(|err| {
+                ArrowError::IoError(format!("Unable to get root as footer: {err:?}"))
+            })?;
 
         let blocks = footer.recordBatches().ok_or_else(|| {
             ArrowError::IoError(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4432.

*This is my first time contributing to this repository. My apologies if I missed anything from the contribution guide.*

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
It seems reasonable that that arrow files with greater than one million columns should be able to be read by `arrow-ipc`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
All of the changes take place in `arrow-ipc::reader::FileReader::try_new`. I added `VerifierOptions` that get passed to `crate::root_as_footer_with_opts` as opposed to the call to `crate::root_as_footer`, which uses, downstream, the default `VerifierOptions` that caused the million column limit. This has the effect of setting the `max_tables` option based on the number of columns in the given file. This change is directly mirrored from [arrow2's dealing with this same problem](https://github.com/jorgecarleitao/arrow2/commit/8e146a78f53899dd7f7166512c1b73a51803b0ab)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No. The interfaces are otherwise untouched.
<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
This should not introduce any breaking changes.