### PR TITLE
doc: deploy crate docs to GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
           rust-version: ${{ matrix.rust }}
       - name: Run cargo doc
         run: cargo doc --document-private-items --no-deps --workspace --all-features
-      - name: Archive artifact
+      - name: Fix file permissions
         shell: sh
         run: |
           chmod -c -R +rX "target/doc" |
@@ -69,6 +69,8 @@ jobs:
           path: target/doc
 
   deploy:
+    # Only deploy if a push to master
+    if: github.ref_name == 'master' && github.event_name == 'push'
     needs: docs
     permissions:
       pages: write # to deploy to Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
-        RUSTDOCFLAGS: "-Dwarnings"
+        RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,3 +56,28 @@ jobs:
           rust-version: ${{ matrix.rust }}
       - name: Run cargo doc
         run: cargo doc --document-private-items --no-deps --workspace --all-features
+      - name: Archive artifact
+        shell: sh
+        run: |
+          chmod -c -R +rX "target/doc" |
+          while read line; do
+              echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/doc
+
+  deploy:
+    needs: docs
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This repo contains the following main components:
 | arrow-flight | Support for Arrow-Flight IPC protocol                                     | [(README)][flight-readme]      |
 | object-store | Support for object store interactions (aws, azure, gcp, local, in-memory) | [(README)][objectstore-readme] |
 
+See the list of all crates in this repo and their rustdocs [here](https://apache.github.io/arrow-rs).
+
 There are two related crates in a different repository
 
 | Crate      | Description                             | Documentation                 |

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -24,7 +24,7 @@
 
 This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation.
 
-The [crate documentation](https://docs.rs/arrow/latest/arrow/) contains examples and full API.
+The [crate documentation](https://apache.github.io/arrow-rs/arrow/index.html) contains examples and full API.
 There are several [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples) to start from as well.
 
 ## Rust Version Compatibility

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -24,7 +24,7 @@
 
 This crate contains the official Native Rust implementation of [Apache Parquet](https://parquet.apache.org/), which is part of the [Apache Arrow](https://arrow.apache.org/) project.
 
-See [crate documentation](https://docs.rs/parquet/latest/parquet/) for examples and the full API.
+See [crate documentation](https://apache.github.io/arrow-rs/parquet/index.html) for examples and the full API.
 
 ## Rust Version Compatibility
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

arrow-rs has so many crates. We often need to browse the doc for more than one crates. But on doc.rs, we can't go to other crates conveniently.

<img width="642" alt="image" src="https://github.com/apache/arrow-rs/assets/37948597/08114ace-dfac-407e-9ce7-885db2ea1638">

Deploying to GitHub pages can improve the situation

<img width="580" alt="image" src="https://github.com/apache/arrow-rs/assets/37948597/92b6c8be-75bf-46a4-9319-f036c74ef17e">


See it on my fork: https://xxchan.github.io/arrow-rs

https://github.com/xxchan/arrow-rs/actions/workflows/docs.yml 

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
