### PR TITLE
perf(parquet): use optimized bloom filter

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -64,8 +64,9 @@ seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.14", default-features = false }
-twox-hash = { version = "1.6", default-features = false }
+xxhash-rust = { version = "0.8", features = ["xxh64"] }
 paste = { version = "1.0" }
+sbbf-rs-safe = "0.1.2"
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["std"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.0", optional = true, default-features = false, features =
 hashbrown = { version = "0.14", default-features = false }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 paste = { version = "1.0" }
-sbbf-rs-safe = "0.1.2"
+sbbf-rs-safe = "0.2"
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["std"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.0", optional = true, default-features = false, features =
 hashbrown = { version = "0.14", default-features = false }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 paste = { version = "1.0" }
-sbbf-rs-safe = "0.3"
+sbbf-rs-safe = { version = "0.3", optional = true }
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["std"] }
@@ -101,6 +101,8 @@ experimental = []
 async = ["futures", "tokio"]
 # Enable object_store integration
 object_store = ["dep:object_store", "async"]
+# Enable faster bloom filter implementation using sbbf_rs
+fast_bloom_filter = ["sbbf-rs-safe"]
 
 [[example]]
 name = "read_parquet"

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.0", optional = true, default-features = false, features =
 hashbrown = { version = "0.14", default-features = false }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 paste = { version = "1.0" }
-sbbf-rs-safe = "0.2.2"
+sbbf-rs-safe = "0.3"
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["std"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "1.0", optional = true, default-features = false, features =
 hashbrown = { version = "0.14", default-features = false }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 paste = { version = "1.0" }
-sbbf-rs-safe = "0.2"
+sbbf-rs-safe = "0.2.2"
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["std"] }

--- a/parquet/src/bloom_filter/default.rs
+++ b/parquet/src/bloom_filter/default.rs
@@ -147,7 +147,7 @@ impl Sbbf {
     }
 
     /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
-    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    /// to the next power of two bounded by [super::BITSET_MIN_LENGTH] and [super::BITSET_MAX_LENGTH].
     pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
         let num_bytes = optimal_num_of_bytes(num_bytes);
         let bitset = vec![0_u8; num_bytes];

--- a/parquet/src/bloom_filter/default.rs
+++ b/parquet/src/bloom_filter/default.rs
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Default bloom filter implementation specific to Parquet, as described
+//! in the [spec](https://github.com/apache/parquet-format/blob/master/BloomFilter.md).
+
+use crate::data_type::AsBytes;
+use crate::errors::ParquetError;
+use crate::file::metadata::ColumnChunkMetaData;
+use crate::file::reader::ChunkReader;
+use crate::format::{
+    BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash, BloomFilterHeader,
+    SplitBlockAlgorithm, Uncompressed, XxHash,
+};
+use std::io::Write;
+use std::sync::Arc;
+use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol, TSerializable};
+
+use super::{
+    chunk_read_bloom_filter_header_and_offset, hash_as_bytes, num_of_bits_from_ndv_fpp,
+    optimal_num_of_bytes,
+};
+
+/// Salt as defined in the [spec](https://github.com/apache/parquet-format/blob/master/BloomFilter.md#technical-approach).
+const SALT: [u32; 8] = [
+    0x47b6137b_u32,
+    0x44974d91_u32,
+    0x8824ad5b_u32,
+    0xa2b7289d_u32,
+    0x705495c7_u32,
+    0x2df1424b_u32,
+    0x9efc4947_u32,
+    0x5c6bfb31_u32,
+];
+
+/// Each block is 256 bits, broken up into eight contiguous "words", each consisting of 32 bits.
+/// Each word is thought of as an array of bits; each bit is either "set" or "not set".
+#[derive(Debug, Copy, Clone)]
+struct Block([u32; 8]);
+impl Block {
+    const ZERO: Block = Block([0; 8]);
+
+    /// takes as its argument a single unsigned 32-bit integer and returns a block in which each
+    /// word has exactly one bit set.
+    fn mask(x: u32) -> Self {
+        let mut result = [0_u32; 8];
+        for i in 0..8 {
+            // wrapping instead of checking for overflow
+            let y = x.wrapping_mul(SALT[i]);
+            let y = y >> 27;
+            result[i] = 1 << y;
+        }
+        Self(result)
+    }
+
+    #[inline]
+    #[cfg(target_endian = "little")]
+    fn to_le_bytes(self) -> [u8; 32] {
+        self.to_ne_bytes()
+    }
+
+    #[inline]
+    #[cfg(not(target_endian = "little"))]
+    fn to_le_bytes(self) -> [u8; 32] {
+        self.swap_bytes().to_ne_bytes()
+    }
+
+    #[inline]
+    fn to_ne_bytes(self) -> [u8; 32] {
+        unsafe { std::mem::transmute(self) }
+    }
+
+    #[inline]
+    #[cfg(not(target_endian = "little"))]
+    fn swap_bytes(mut self) -> Self {
+        self.0.iter_mut().for_each(|x| *x = x.swap_bytes());
+        self
+    }
+
+    /// setting every bit in the block that was also set in the result from mask
+    fn insert(&mut self, hash: u32) {
+        let mask = Self::mask(hash);
+        for i in 0..8 {
+            self[i] |= mask[i];
+        }
+    }
+
+    /// returns true when every bit that is set in the result of mask is also set in the block.
+    fn check(&self, hash: u32) -> bool {
+        let mask = Self::mask(hash);
+        for i in 0..8 {
+            if self[i] & mask[i] == 0 {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl std::ops::Index<usize> for Block {
+    type Output = u32;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.index(index)
+    }
+}
+
+impl std::ops::IndexMut<usize> for Block {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.0.index_mut(index)
+    }
+}
+
+/// A split block Bloom filter. The creation of this structure is based on the
+/// [`crate::file::properties::BloomFilterProperties`] struct set via [`crate::file::properties::WriterProperties`] and
+/// is thus hidden by default.
+#[derive(Debug, Clone)]
+pub struct Sbbf(Vec<Block>);
+
+impl Sbbf {
+    /// Create a new [Sbbf] with given number of distinct values and false positive probability.
+    /// Will panic if `fpp` is greater than 1.0 or less than 0.0.
+    pub(crate) fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Result<Self, ParquetError> {
+        if !(0.0..1.0).contains(&fpp) {
+            return Err(ParquetError::General(format!(
+                "False positive probability must be between 0.0 and 1.0, got {fpp}"
+            )));
+        }
+        let num_bits = num_of_bits_from_ndv_fpp(ndv, fpp);
+        Ok(Self::new_with_num_of_bytes(num_bits / 8))
+    }
+
+    /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
+    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
+        let num_bytes = optimal_num_of_bytes(num_bytes);
+        let bitset = vec![0_u8; num_bytes];
+        Self::new(&bitset)
+    }
+
+    pub(crate) fn new(bitset: &[u8]) -> Self {
+        let data = bitset
+            .chunks_exact(4 * 8)
+            .map(|chunk| {
+                let mut block = Block::ZERO;
+                for (i, word) in chunk.chunks_exact(4).enumerate() {
+                    block[i] = u32::from_le_bytes(word.try_into().unwrap());
+                }
+                block
+            })
+            .collect::<Vec<Block>>();
+        Self(data)
+    }
+
+    /// Write the bloom filter data (header and then bitset) to the output. This doesn't
+    /// flush the writer in order to boost performance of bulk writing all blocks. Caller
+    /// must remember to flush the writer.
+    pub(crate) fn write<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
+        let mut protocol = TCompactOutputProtocol::new(&mut writer);
+        let header = self.header();
+        header.write_to_out_protocol(&mut protocol).map_err(|e| {
+            ParquetError::General(format!("Could not write bloom filter header: {e}"))
+        })?;
+        protocol.flush()?;
+        self.write_bitset(&mut writer)?;
+        Ok(())
+    }
+
+    /// Write the bitset in serialized form to the writer.
+    fn write_bitset<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
+        for block in &self.0 {
+            writer
+                .write_all(block.to_le_bytes().as_slice())
+                .map_err(|e| {
+                    ParquetError::General(format!(
+                        "Could not write bloom filter bit set: {e}"
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Create and populate [`BloomFilterHeader`] from this bitset for writing to serialized form
+    fn header(&self) -> BloomFilterHeader {
+        BloomFilterHeader {
+            // 8 i32 per block, 4 bytes per i32
+            num_bytes: self.0.len() as i32 * 4 * 8,
+            algorithm: BloomFilterAlgorithm::BLOCK(SplitBlockAlgorithm {}),
+            hash: BloomFilterHash::XXHASH(XxHash {}),
+            compression: BloomFilterCompression::UNCOMPRESSED(Uncompressed {}),
+        }
+    }
+
+    /// Read a new bloom filter from the given offset in the given reader.
+    pub(crate) fn read_from_column_chunk<R: ChunkReader>(
+        column_metadata: &ColumnChunkMetaData,
+        reader: Arc<R>,
+    ) -> Result<Option<Self>, ParquetError> {
+        let offset: u64 = if let Some(offset) = column_metadata.bloom_filter_offset() {
+            offset.try_into().map_err(|_| {
+                ParquetError::General("Bloom filter offset is invalid".to_string())
+            })?
+        } else {
+            return Ok(None);
+        };
+
+        let (header, bitset_offset) =
+            chunk_read_bloom_filter_header_and_offset(offset, reader.clone())?;
+
+        match header.algorithm {
+            BloomFilterAlgorithm::BLOCK(_) => {
+                // this match exists to future proof the singleton algorithm enum
+            }
+        }
+        match header.compression {
+            BloomFilterCompression::UNCOMPRESSED(_) => {
+                // this match exists to future proof the singleton compression enum
+            }
+        }
+        match header.hash {
+            BloomFilterHash::XXHASH(_) => {
+                // this match exists to future proof the singleton hash enum
+            }
+        }
+        // length in bytes
+        let length: usize = header.num_bytes.try_into().map_err(|_| {
+            ParquetError::General("Bloom filter length is invalid".to_string())
+        })?;
+        let bitset = reader.get_bytes(bitset_offset, length)?;
+        Ok(Some(Self::new(&bitset)))
+    }
+
+    #[inline]
+    fn hash_to_block_index(&self, hash: u64) -> usize {
+        // unchecked_mul is unstable, but in reality this is safe, we'd just use saturating mul
+        // but it will not saturate
+        (((hash >> 32).saturating_mul(self.0.len() as u64)) >> 32) as usize
+    }
+
+    /// Insert an [AsBytes] value into the filter
+    pub fn insert<T: AsBytes + ?Sized>(&mut self, value: &T) {
+        self.insert_hash(hash_as_bytes(value));
+    }
+
+    /// Insert a hash into the filter
+    fn insert_hash(&mut self, hash: u64) {
+        let block_index = self.hash_to_block_index(hash);
+        self.0[block_index].insert(hash as u32)
+    }
+
+    /// Check if an [AsBytes] value is probably present or definitely absent in the filter
+    pub fn check<T: AsBytes>(&self, value: &T) -> bool {
+        self.check_hash(hash_as_bytes(value))
+    }
+
+    /// Check if a hash is in the filter. May return
+    /// true for values that was never inserted ("false positive")
+    /// but will always return false if a hash has not been inserted.
+    fn check_hash(&self, hash: u64) -> bool {
+        let block_index = self.hash_to_block_index(hash);
+        self.0[block_index].check(hash as u32)
+    }
+}

--- a/parquet/src/bloom_filter/fast.rs
+++ b/parquet/src/bloom_filter/fast.rs
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optional, fast bloom filter implementation using sbbf_rs
+//! in the [spec](https://github.com/apache/parquet-format/blob/master/BloomFilter.md).
+
+use crate::data_type::AsBytes;
+use crate::errors::ParquetError;
+use crate::file::metadata::ColumnChunkMetaData;
+use crate::file::reader::ChunkReader;
+use crate::format::{
+    BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash, BloomFilterHeader,
+    SplitBlockAlgorithm, Uncompressed, XxHash,
+};
+use sbbf_rs_safe::Filter;
+use std::io::Read;
+use std::io::Write;
+use std::sync::Arc;
+use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol, TSerializable};
+
+use super::{
+    chunk_read_bloom_filter_header_and_offset, hash_as_bytes, num_of_bits_from_ndv_fpp,
+    optimal_num_of_bytes,
+};
+
+/// A split block Bloom filter. The creation of this structure is based on the
+/// [`crate::file::properties::BloomFilterProperties`] struct set via [`crate::file::properties::WriterProperties`] and
+/// is thus hidden by default.
+#[derive(Debug, Clone)]
+pub struct Sbbf(Filter);
+
+// see http://algo2.iti.kit.edu/documents/cacheefficientbloomfilters-jea.pdf
+// given fpp = (1 - e^(-k * n / m)) ^ k
+// we have m = - k * n / ln(1 - fpp ^ (1 / k))
+// where k = number of hash functions, m = number of bits, n = number of distinct values
+
+impl Sbbf {
+    /// Create a new [Sbbf] with given number of distinct values and false positive probability.
+    /// Will panic if `fpp` is greater than 1.0 or less than 0.0.
+    pub(crate) fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Result<Self, ParquetError> {
+        if !(0.0..1.0).contains(&fpp) {
+            return Err(ParquetError::General(format!(
+                "False positive probability must be between 0.0 and 1.0, got {fpp}"
+            )));
+        }
+        let num_bits = num_of_bits_from_ndv_fpp(ndv, fpp);
+        Ok(Self::new_with_num_of_bytes(num_bits / 8))
+    }
+
+    /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
+    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
+        let num_bytes = optimal_num_of_bytes(num_bytes);
+        Self(Filter::new(8, num_bytes))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(bitset: &[u8]) -> Self {
+        Self(Filter::from_bytes(bitset).unwrap())
+    }
+
+    /// Write the bloom filter data (header and then bitset) to the output. This doesn't
+    /// flush the writer in order to boost performance of bulk writing all blocks. Caller
+    /// must remember to flush the writer.
+    pub(crate) fn write<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
+        let mut protocol = TCompactOutputProtocol::new(&mut writer);
+        let header = self.header();
+        header.write_to_out_protocol(&mut protocol).map_err(|e| {
+            ParquetError::General(format!("Could not write bloom filter header: {e}"))
+        })?;
+        protocol.flush()?;
+        self.write_bitset(&mut writer)?;
+        Ok(())
+    }
+
+    /// Write the bitset in serialized form to the writer.
+    fn write_bitset<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
+        writer.write_all(self.0.as_bytes()).map_err(|e| {
+            ParquetError::General(format!("Could not write bloom filter bit set: {e}"))
+        })?;
+        Ok(())
+    }
+
+    /// Create and populate [`BloomFilterHeader`] from this bitset for writing to serialized form
+    fn header(&self) -> BloomFilterHeader {
+        BloomFilterHeader {
+            // 8 i32 per block, 4 bytes per i32
+            num_bytes: i32::try_from(self.0.as_bytes().len()).unwrap(),
+            algorithm: BloomFilterAlgorithm::BLOCK(SplitBlockAlgorithm {}),
+            hash: BloomFilterHash::XXHASH(XxHash {}),
+            compression: BloomFilterCompression::UNCOMPRESSED(Uncompressed {}),
+        }
+    }
+
+    /// Read a new bloom filter from the given offset in the given reader.
+    pub(crate) fn read_from_column_chunk<R: ChunkReader>(
+        column_metadata: &ColumnChunkMetaData,
+        reader: Arc<R>,
+    ) -> Result<Option<Self>, ParquetError> {
+        let offset: u64 = if let Some(offset) = column_metadata.bloom_filter_offset() {
+            offset.try_into().map_err(|_| {
+                ParquetError::General("Bloom filter offset is invalid".to_string())
+            })?
+        } else {
+            return Ok(None);
+        };
+
+        let (header, bitset_offset) =
+            chunk_read_bloom_filter_header_and_offset(offset, reader.clone())?;
+
+        match header.algorithm {
+            BloomFilterAlgorithm::BLOCK(_) => {
+                // this match exists to future proof the singleton algorithm enum
+            }
+        }
+        match header.compression {
+            BloomFilterCompression::UNCOMPRESSED(_) => {
+                // this match exists to future proof the singleton compression enum
+            }
+        }
+        match header.hash {
+            BloomFilterHash::XXHASH(_) => {
+                // this match exists to future proof the singleton hash enum
+            }
+        }
+        // length in bytes
+        let length: usize = header.num_bytes.try_into().map_err(|_| {
+            ParquetError::General("Bloom filter length is invalid".to_string())
+        })?;
+
+        let mut filter = Filter::new(8, length);
+
+        reader
+            .get_read(bitset_offset)?
+            .read_exact(filter.as_bytes_mut())?;
+
+        Ok(Some(Self(filter)))
+    }
+
+    /// Insert an [AsBytes] value into the filter
+    #[inline]
+    pub fn insert<T: AsBytes + ?Sized>(&mut self, value: &T) {
+        self.insert_hash(hash_as_bytes(value));
+    }
+
+    /// Insert a hash into the filter.
+    /// Returns true if the filter might have already contained the hash.
+    #[inline]
+    fn insert_hash(&mut self, hash: u64) -> bool {
+        self.0.insert_hash(hash)
+    }
+
+    /// Check if an [AsBytes] value is probably present or definitely absent in the filter
+    #[inline]
+    pub fn check<T: AsBytes>(&self, value: &T) -> bool {
+        self.check_hash(hash_as_bytes(value))
+    }
+
+    /// Check if a hash is in the filter. May return
+    /// true for values that was never inserted ("false positive")
+    /// but will always return false if a hash has not been inserted.
+    #[inline]
+    fn check_hash(&self, hash: u64) -> bool {
+        self.0.contains_hash(hash)
+    }
+}

--- a/parquet/src/bloom_filter/fast.rs
+++ b/parquet/src/bloom_filter/fast.rs
@@ -62,7 +62,7 @@ impl Sbbf {
     }
 
     /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
-    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    /// to the next power of two bounded by [super::BITSET_MIN_LENGTH] and [super::BITSET_MAX_LENGTH].
     pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
         let num_bytes = optimal_num_of_bytes(num_bytes);
         Self(Filter::new(8, num_bytes))

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -110,12 +110,7 @@ impl Sbbf {
     /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
     pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
         let num_bytes = optimal_num_of_bytes(num_bytes);
-        let bitset = vec![0_u8; num_bytes];
-        Self::new(&bitset)
-    }
-
-    fn new(bitset: &[u8]) -> Self {
-        Self(Filter::from_bytes(bitset).unwrap())
+        Self(Filter::new(8, num_bytes))
     }
 
     /// Write the bloom filter data (header and then bitset) to the output. This doesn't
@@ -197,17 +192,20 @@ impl Sbbf {
     }
 
     /// Insert an [AsBytes] value into the filter
+    #[inline]
     pub fn insert<T: AsBytes + ?Sized>(&mut self, value: &T) {
         self.insert_hash(hash_as_bytes(value));
     }
 
     /// Insert a hash into the filter.
     /// Returns true if the filter might have already contained the hash.
+    #[inline]
     fn insert_hash(&mut self, hash: u64) -> bool {
         self.0.insert_hash(hash)
     }
 
     /// Check if an [AsBytes] value is probably present or definitely absent in the filter
+    #[inline]
     pub fn check<T: AsBytes>(&self, value: &T) -> bool {
         self.check_hash(hash_as_bytes(value))
     }
@@ -215,6 +213,7 @@ impl Sbbf {
     /// Check if a hash is in the filter. May return
     /// true for values that was never inserted ("false positive")
     /// but will always return false if a hash has not been inserted.
+    #[inline]
     fn check_hash(&self, hash: u64) -> bool {
         self.0.contains_hash(hash)
     }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -133,13 +133,9 @@ impl Sbbf {
 
     /// Write the bitset in serialized form to the writer.
     fn write_bitset<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
-        writer
-            .write_all(self.0.as_bytes())
-            .map_err(|e| {
-                ParquetError::General(format!(
-                    "Could not write bloom filter bit set: {e}"
-                ))
-            })?;
+        writer.write_all(self.0.as_bytes()).map_err(|e| {
+            ParquetError::General(format!("Could not write bloom filter bit set: {e}"))
+        })?;
         Ok(())
     }
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -247,7 +247,7 @@ mod tests {
             200, 1, 80, 20, 64, 68, 8, 109, 6, 37, 4, 67, 144, 80, 96, 32, 8, 132, 43,
             33, 0, 5, 99, 65, 2, 0, 224, 44, 64, 78, 96, 4,
         ];
-        let sbbf = Sbbf::new(bitset);
+        let sbbf = Sbbf(Filter::from_bytes(bitset).unwrap());
         for a in 0..10i64 {
             let value = format!("a{a}");
             assert!(sbbf.check(&value.as_str()));

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -20,27 +20,22 @@
 
 use crate::data_type::AsBytes;
 use crate::errors::ParquetError;
-use crate::file::metadata::ColumnChunkMetaData;
 use crate::file::reader::ChunkReader;
-use crate::format::{
-    BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash, BloomFilterHeader,
-    SplitBlockAlgorithm, Uncompressed, XxHash,
-};
+use crate::format::BloomFilterHeader;
 use bytes::{Buf, Bytes};
-use sbbf_rs_safe::Filter;
-use std::io::Read;
-use std::io::Write;
 use std::sync::Arc;
-use thrift::protocol::{
-    TCompactInputProtocol, TCompactOutputProtocol, TOutputProtocol, TSerializable,
-};
+use thrift::protocol::{TCompactInputProtocol, TSerializable};
 use xxhash_rust::xxh64::xxh64;
 
-/// A split block Bloom filter. The creation of this structure is based on the
-/// [`crate::file::properties::BloomFilterProperties`] struct set via [`crate::file::properties::WriterProperties`] and
-/// is thus hidden by default.
-#[derive(Debug, Clone)]
-pub struct Sbbf(Filter);
+#[cfg(not(feature = "fast_bloom_filter"))]
+mod default;
+#[cfg(not(feature = "fast_bloom_filter"))]
+pub use default::*;
+
+#[cfg(feature = "fast_bloom_filter")]
+mod fast;
+#[cfg(feature = "fast_bloom_filter")]
+pub use fast::*;
 
 const SBBF_HEADER_SIZE_ESTIMATE: usize = 20;
 
@@ -83,142 +78,6 @@ fn optimal_num_of_bytes(num_bytes: usize) -> usize {
     num_bytes.next_power_of_two()
 }
 
-// see http://algo2.iti.kit.edu/documents/cacheefficientbloomfilters-jea.pdf
-// given fpp = (1 - e^(-k * n / m)) ^ k
-// we have m = - k * n / ln(1 - fpp ^ (1 / k))
-// where k = number of hash functions, m = number of bits, n = number of distinct values
-#[inline]
-fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
-    let num_bits = -8.0 * ndv as f64 / (1.0 - fpp.powf(1.0 / 8.0)).ln();
-    num_bits as usize
-}
-
-impl Sbbf {
-    /// Create a new [Sbbf] with given number of distinct values and false positive probability.
-    /// Will panic if `fpp` is greater than 1.0 or less than 0.0.
-    pub(crate) fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Result<Self, ParquetError> {
-        if !(0.0..1.0).contains(&fpp) {
-            return Err(ParquetError::General(format!(
-                "False positive probability must be between 0.0 and 1.0, got {fpp}"
-            )));
-        }
-        let num_bits = num_of_bits_from_ndv_fpp(ndv, fpp);
-        Ok(Self::new_with_num_of_bytes(num_bits / 8))
-    }
-
-    /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
-    /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
-    pub(crate) fn new_with_num_of_bytes(num_bytes: usize) -> Self {
-        let num_bytes = optimal_num_of_bytes(num_bytes);
-        Self(Filter::new(8, num_bytes))
-    }
-
-    /// Write the bloom filter data (header and then bitset) to the output. This doesn't
-    /// flush the writer in order to boost performance of bulk writing all blocks. Caller
-    /// must remember to flush the writer.
-    pub(crate) fn write<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
-        let mut protocol = TCompactOutputProtocol::new(&mut writer);
-        let header = self.header();
-        header.write_to_out_protocol(&mut protocol).map_err(|e| {
-            ParquetError::General(format!("Could not write bloom filter header: {e}"))
-        })?;
-        protocol.flush()?;
-        self.write_bitset(&mut writer)?;
-        Ok(())
-    }
-
-    /// Write the bitset in serialized form to the writer.
-    fn write_bitset<W: Write>(&self, mut writer: W) -> Result<(), ParquetError> {
-        writer.write_all(self.0.as_bytes()).map_err(|e| {
-            ParquetError::General(format!("Could not write bloom filter bit set: {e}"))
-        })?;
-        Ok(())
-    }
-
-    /// Create and populate [`BloomFilterHeader`] from this bitset for writing to serialized form
-    fn header(&self) -> BloomFilterHeader {
-        BloomFilterHeader {
-            // 8 i32 per block, 4 bytes per i32
-            num_bytes: i32::try_from(self.0.as_bytes().len()).unwrap(),
-            algorithm: BloomFilterAlgorithm::BLOCK(SplitBlockAlgorithm {}),
-            hash: BloomFilterHash::XXHASH(XxHash {}),
-            compression: BloomFilterCompression::UNCOMPRESSED(Uncompressed {}),
-        }
-    }
-
-    /// Read a new bloom filter from the given offset in the given reader.
-    pub(crate) fn read_from_column_chunk<R: ChunkReader>(
-        column_metadata: &ColumnChunkMetaData,
-        reader: Arc<R>,
-    ) -> Result<Option<Self>, ParquetError> {
-        let offset: u64 = if let Some(offset) = column_metadata.bloom_filter_offset() {
-            offset.try_into().map_err(|_| {
-                ParquetError::General("Bloom filter offset is invalid".to_string())
-            })?
-        } else {
-            return Ok(None);
-        };
-
-        let (header, bitset_offset) =
-            chunk_read_bloom_filter_header_and_offset(offset, reader.clone())?;
-
-        match header.algorithm {
-            BloomFilterAlgorithm::BLOCK(_) => {
-                // this match exists to future proof the singleton algorithm enum
-            }
-        }
-        match header.compression {
-            BloomFilterCompression::UNCOMPRESSED(_) => {
-                // this match exists to future proof the singleton compression enum
-            }
-        }
-        match header.hash {
-            BloomFilterHash::XXHASH(_) => {
-                // this match exists to future proof the singleton hash enum
-            }
-        }
-        // length in bytes
-        let length: usize = header.num_bytes.try_into().map_err(|_| {
-            ParquetError::General("Bloom filter length is invalid".to_string())
-        })?;
-
-        let mut filter = Filter::new(8, length);
-
-        reader
-            .get_read(bitset_offset)?
-            .read_exact(filter.as_bytes_mut())?;
-
-        Ok(Some(Self(filter)))
-    }
-
-    /// Insert an [AsBytes] value into the filter
-    #[inline]
-    pub fn insert<T: AsBytes + ?Sized>(&mut self, value: &T) {
-        self.insert_hash(hash_as_bytes(value));
-    }
-
-    /// Insert a hash into the filter.
-    /// Returns true if the filter might have already contained the hash.
-    #[inline]
-    fn insert_hash(&mut self, hash: u64) -> bool {
-        self.0.insert_hash(hash)
-    }
-
-    /// Check if an [AsBytes] value is probably present or definitely absent in the filter
-    #[inline]
-    pub fn check<T: AsBytes>(&self, value: &T) -> bool {
-        self.check_hash(hash_as_bytes(value))
-    }
-
-    /// Check if a hash is in the filter. May return
-    /// true for values that was never inserted ("false positive")
-    /// but will always return false if a hash has not been inserted.
-    #[inline]
-    fn check_hash(&self, hash: u64) -> bool {
-        self.0.contains_hash(hash)
-    }
-}
-
 // per spec we use xxHash with seed=0
 const SEED: u64 = 0;
 
@@ -227,12 +86,18 @@ fn hash_as_bytes<A: AsBytes + ?Sized>(value: &A) -> u64 {
     xxh64(value.as_bytes(), SEED)
 }
 
+#[inline]
+fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
+    let num_bits = -8.0 * ndv as f64 / (1.0 - fpp.powf(1.0 / 8.0)).ln();
+    num_bits as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::format::{
-        BloomFilterAlgorithm, BloomFilterCompression, SplitBlockAlgorithm, Uncompressed,
-        XxHash,
+        BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash,
+        SplitBlockAlgorithm, Uncompressed, XxHash,
     };
 
     #[test]
@@ -247,7 +112,7 @@ mod tests {
             200, 1, 80, 20, 64, 68, 8, 109, 6, 37, 4, 67, 144, 80, 96, 32, 8, 132, 43,
             33, 0, 5, 99, 65, 2, 0, 224, 44, 64, 78, 96, 4,
         ];
-        let sbbf = Sbbf(Filter::from_bytes(bitset).unwrap());
+        let sbbf = Sbbf::new(bitset);
         for a in 0..10i64 {
             let value = format!("a{a}");
             assert!(sbbf.check(&value.as_str()));


### PR DESCRIPTION
Closes #4213 

Uses bloom filter implementation from a different crate. This crate uses CPU-specific optimized implementations so it is faster than the old implementation. [benchmarks are on this repo](https://github.com/ozgrakkurt/sbbf-rs)

I am the author of the library that this PR uses.

There are no user-facing changes.