### PR TITLE
Docs: Add clearer API doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Welcome to the implementation of Arrow, the popular in-memory columnar format, i
 
 This repo contains the following main components:
 
-| Crate        | Description                                                               | Documentation                  |
-| ------------ | ------------------------------------------------------------------------- | ------------------------------ |
-| arrow        | Core functionality (memory layout, arrays, low level computations)        | [(README)][arrow-readme]       |
-| parquet      | Support for Parquet columnar file format                                  | [(README)][parquet-readme]     |
-| arrow-flight | Support for Arrow-Flight IPC protocol                                     | [(README)][flight-readme]      |
-| object-store | Support for object store interactions (aws, azure, gcp, local, in-memory) | [(README)][objectstore-readme] |
+| Crate        | Description                                                               | Latest API Docs                                | README                        |
+| ------------ | ------------------------------------------------------------------------- | ---------------------------------------------- | ----------------------------- |
+| arrow        | Core functionality (memory layout, arrays, low level computations)        | [docs.rs](https://docs.rs/arrow/latest)        | [(README)][arrow-readme]      |
+| parquet      | Support for Parquet columnar file format                                  | [docs.rs](https://docs.rs/parquet/latest)      | [(README)][parquet-readme]    |
+| arrow-flight | Support for Arrow-Flight IPC protocol                                     | [docs.rs](https://docs.rs/arrow-flight/latest) | [(README)][flight-readme]     |
+| object-store | Support for object store interactions (aws, azure, gcp, local, in-memory) | [docs.rs](https://docs.rs/object_store/latest) | [(README)][objectstore-readme]|
 
-See the list of all crates in this repo and their rustdocs [here](https://arrow.apache.org/rust).
+The current development version the API documentation in this repo can be found [here](https://arrow.apache.org/rust).
 
 There are two related crates in a different repository
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Welcome to the implementation of Arrow, the popular in-memory columnar format, i
 
 This repo contains the following main components:
 
-| Crate        | Description                                                               | Latest API Docs                                | README                        |
-| ------------ | ------------------------------------------------------------------------- | ---------------------------------------------- | ----------------------------- |
-| arrow        | Core functionality (memory layout, arrays, low level computations)        | [docs.rs](https://docs.rs/arrow/latest)        | [(README)][arrow-readme]      |
-| parquet      | Support for Parquet columnar file format                                  | [docs.rs](https://docs.rs/parquet/latest)      | [(README)][parquet-readme]    |
-| arrow-flight | Support for Arrow-Flight IPC protocol                                     | [docs.rs](https://docs.rs/arrow-flight/latest) | [(README)][flight-readme]     |
-| object-store | Support for object store interactions (aws, azure, gcp, local, in-memory) | [docs.rs](https://docs.rs/object_store/latest) | [(README)][objectstore-readme]|
+| Crate        | Description                                                               | Latest API Docs                                | README                         |
+| ------------ | ------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------ |
+| arrow        | Core functionality (memory layout, arrays, low level computations)        | [docs.rs](https://docs.rs/arrow/latest)        | [(README)][arrow-readme]       |
+| parquet      | Support for Parquet columnar file format                                  | [docs.rs](https://docs.rs/parquet/latest)      | [(README)][parquet-readme]     |
+| arrow-flight | Support for Arrow-Flight IPC protocol                                     | [docs.rs](https://docs.rs/arrow-flight/latest) | [(README)][flight-readme]      |
+| object-store | Support for object store interactions (aws, azure, gcp, local, in-memory) | [docs.rs](https://docs.rs/object_store/latest) | [(README)][objectstore-readme] |
 
 The current development version the API documentation in this repo can be found [here](https://arrow.apache.org/rust).
 

--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -21,6 +21,11 @@
 
 [![Crates.io](https://img.shields.io/crates/v/arrow-flight.svg)](https://crates.io/crates/arrow-flight)
 
+
+See the [API documentation](https://docs.rs/arrow_flight/latest) for examples and the full API.
+
+The API documentation for most recent, unreleased code is available [here](https://arrow.apache.org/rust/arrow_flight/index.html).
+
 ## Usage
 
 Add this to your Cargo.toml:

--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -21,7 +21,6 @@
 
 [![Crates.io](https://img.shields.io/crates/v/arrow-flight.svg)](https://crates.io/crates/arrow-flight)
 
-
 See the [API documentation](https://docs.rs/arrow_flight/latest) for examples and the full API.
 
 The API documentation for most recent, unreleased code is available [here](https://arrow.apache.org/rust/arrow_flight/index.html).

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -24,8 +24,10 @@
 
 This crate contains the official Native Rust implementation of [Apache Arrow][arrow] in memory format, governed by the Apache Software Foundation.
 
-The [crate documentation](https://arrow.apache.org/rust/arrow/index.html) contains examples and full API.
+The [API documentation](https://docs.rs/arrow/latest) contains examples and full API.
 There are several [examples](https://github.com/apache/arrow-rs/tree/master/arrow/examples) to start from as well.
+
+The API documentation for most recent, unreleased code is available [here](https://arrow.apache.org/rust/arrow/index.html).
 
 ## Rust Version Compatibility
 

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -24,7 +24,9 @@
 
 This crate contains the official Native Rust implementation of [Apache Parquet](https://parquet.apache.org/), which is part of the [Apache Arrow](https://arrow.apache.org/) project.
 
-See [crate documentation](https://arrow.apache.org/rust/parquet/index.html) for examples and the full API.
+See the [API documentation](https://docs.rs/parquet/latest) for examples and the full API.
+
+The API documentation for most recent, unreleased code is available [here](https://arrow.apache.org/rust/parquet/index.html).
 
 ## Rust Version Compatibility
 


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-rs/pull/4436 from @xxchan 

# Rationale for this change
 
I think we should be directing people to the published version of the docs on docs.rs rather than the unreleased API by default. The unreleased API is now available at https://arrow.apache.org/rust/ thanks to @xxchan  ❤️ 

# What changes are included in this PR?

Add some links to try and drive people to the docs.rs (released) version of the docs
 
# Are there any user-facing changes?
README is different. See rendered version here: https://github.com/alamb/arrow-rs/tree/alamb/doc_links

