### PR TITLE
DO NOT MERGE: patched 42.0.0 with fix for #4459

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -690,11 +690,10 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                     }
                 }
             }
-
-            // update the offset index
-            self.offset_index_builder
-                .append_row_count(self.page_metrics.num_buffered_rows as i64);
         }
+        // update the offset index
+        self.offset_index_builder
+            .append_row_count(self.page_metrics.num_buffered_rows as i64);
     }
 
     fn truncate_min_value(&self, data: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
This contains the fix for https://github.com/apache/arrow-rs/issues/4459  by cherry-picking 554aebe3b523737b3aaf6109846f4735110b26f8 to the `42.0.0` tag

I made it via

```shell
git checkout 42.0.0
git cherry-pick 554aebe3b523737b3aaf6109846f4735110b26f8
git cherry-pick 554aebe3b523737b3aaf6109846f4735110b26f8
[alamb/42.0.0_patched 20f6bd7ed] Fix empty offset index for all null columns (#4459) (#4460)
 Author: Raphael Taylor-Davies <1781103+tustvold@users.noreply.github.com>
 Date: Wed Jun 28 19:53:51 2023 +0100
 2 files changed, 30 insertions(+), 4 deletions(-)
```