### PR TITLE
Revert ParquetError: PartialEq

### DIFF
--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -44,23 +44,6 @@ pub enum ParquetError {
     External(Box<dyn Error + Send + Sync>),
 }
 
-impl PartialEq for ParquetError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::General(l0), Self::General(r0)) => l0 == r0,
-            (Self::NYI(l0), Self::NYI(r0)) => l0 == r0,
-            (Self::EOF(l0), Self::EOF(r0)) => l0 == r0,
-            #[cfg(feature = "arrow")]
-            (Self::ArrowError(l0), Self::ArrowError(r0)) => l0 == r0,
-            (Self::IndexOutOfBound(l0, l1), Self::IndexOutOfBound(r0, r1)) => {
-                l0 == r0 && l1 == r1
-            }
-            (Self::External(l0), Self::External(r0)) => l0.to_string() == r0.to_string(),
-            _ => false,
-        }
-    }
-}
-
 impl std::fmt::Display for ParquetError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self {

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -23,6 +23,9 @@ use std::{cell, io, result, str};
 #[cfg(feature = "arrow")]
 use arrow_schema::ArrowError;
 
+/// Parquet error enumeration
+// Note: we don't implement PartialEq as the semantics for the
+// external variant are not well defined (#4469)
 #[derive(Debug)]
 pub enum ParquetError {
     /// General Parquet error.

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -810,7 +810,9 @@ mod tests {
         let file_iter = read_from_file.get_row_iter(None).unwrap();
         let cursor_iter = read_from_cursor.get_row_iter(None).unwrap();
 
-        assert!(file_iter.eq(cursor_iter));
+        for (a, b) in file_iter.zip(cursor_iter) {
+            assert_eq!(a.unwrap(), b.unwrap())
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This was added in https://github.com/apache/arrow-rs/pull/4428, however, this omission was intentional as the semantics are not well defined for the external variant.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Not yet released so no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
