### PR TITLE
Improve in-place primitive sorts by 13-67%

### DIFF
--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -59,13 +59,13 @@ pub fn sort(
     options: Option<SortOptions>,
 ) -> Result<ArrayRef, ArrowError> {
     downcast_primitive_array!(
-        values => return sort_native_type(values, options),
-        DataType::RunEndEncoded(_, _) => return sort_run(values, options, None),
+        values => sort_native_type(values, options),
+        DataType::RunEndEncoded(_, _) => sort_run(values, options, None),
         _ => {
             let indices = sort_to_indices(values, options, None)?;
-            return take(values, &indices, None)
+            take(values, &indices, None)
         }
-    );
+    )
 }
 
 fn sort_native_type<T>(

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -189,6 +189,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "sort_kernel_primitives"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "partition_kernels"
 harness = false
 required-features = ["test_utils"]

--- a/arrow/benches/sort_kernel_primitives.rs
+++ b/arrow/benches/sort_kernel_primitives.rs
@@ -38,7 +38,6 @@ fn bench_sort(array: &ArrayRef) {
 }
 
 fn add_benchmark(c: &mut Criterion) {
-
     let arr_a = create_i64_array(2u64.pow(10) as usize, false);
 
     c.bench_function("sort 2^10", |b| b.iter(|| bench_sort(&arr_a)));

--- a/arrow/benches/sort_kernel_primitives.rs
+++ b/arrow/benches/sort_kernel_primitives.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use arrow_ord::sort::sort;
+use criterion::Criterion;
+
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::util::bench_util::*;
+use arrow::{array::*, datatypes::Int64Type};
+
+fn create_i64_array(size: usize, with_nulls: bool) -> ArrayRef {
+    let null_density = if with_nulls { 0.5 } else { 0.0 };
+    let array = create_primitive_array::<Int64Type>(size, null_density);
+    Arc::new(array)
+}
+
+fn bench_sort(array: &ArrayRef) {
+    criterion::black_box(sort(criterion::black_box(array), None).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
+
+    let arr_a = create_i64_array(2u64.pow(10) as usize, false);
+
+    c.bench_function("sort 2^10", |b| b.iter(|| bench_sort(&arr_a)));
+
+    let arr_a = create_i64_array(2u64.pow(12) as usize, false);
+
+    c.bench_function("sort 2^12", |b| b.iter(|| bench_sort(&arr_a)));
+
+    let arr_a = create_i64_array(2u64.pow(10) as usize, true);
+
+    c.bench_function("sort nulls 2^10", |b| b.iter(|| bench_sort(&arr_a)));
+
+    let arr_a = create_i64_array(2u64.pow(12) as usize, true);
+
+    c.bench_function("sort nulls 2^12", |b| b.iter(|| bench_sort(&arr_a)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
The current sort implementation for primitive types first sorts by indices and then performs a take operation. The kernel can be improved by directly sorting.

The results for i64 on my laptop are as follows

```
sort 2^10               time:   [9.1287 µs 9.1711 µs 9.2279 µs]
                        change: [-27.180% -25.980% -24.697%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  11 (11.00%) high severe

sort 2^12               time:   [70.191 µs 70.437 µs 70.741 µs]
                        change: [-15.190% -13.941% -12.614%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

sort nulls 2^10         time:   [4.9898 µs 5.0080 µs 5.0319 µs]
                        change: [-68.212% -67.754% -67.288%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  10 (10.00%) high severe

sort nulls 2^12         time:   [34.333 µs 34.641 µs 34.983 µs]
                        change: [-58.256% -57.089% -56.063%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe
```

# What changes are included in this PR?

I reworked the sort kernel so that primitive types are sorted directly without using sort_by_indices . I have also included a new primitive benchmark `sort_kernel_primitives.rs` .

# Are there any user-facing changes?

No
