### PR TITLE
add num-complex requirement

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -47,6 +47,7 @@ arrow-data = { workspace = true }
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.8", optional = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
+num-complex = "0.4.2"
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.14", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3849

# Rationale for this change

More correct package dependencies.
 
arrow-array relies on the num-complex crate and uses its ComplexFloat trait, but that was only released in 0.4.2. The num dependency alone only requires num-complex 0.4.0, so this can cause compilation errors:

```bash
error[E0432]: unresolved import `num::complex::ComplexFloat`
  --> /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arrow-array-30.0.1/src/arithmetic.rs:21:5
   |
21 | use num::complex::ComplexFloat;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ComplexFloat` in `complex`

error[E0599]: no method named `powi` found for struct `f16` in the current scope
   --> /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arrow-array-30.0.1/src/arithmetic.rs:351:25
    |
351 |                 Ok(self.powi(exp as i32))
    |                         ^^^^ method not found in `f16`
...
380 | native_type_float_op!(f16, f16::ONE, f16::ZERO);
    | ----------------------------------------------- in this macro invocation
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `native_type_float_op` (in Nightly builds, run with -Z macro-backtrace for more info)
help: the following traits are implemented but not in scope; perhaps add a `use` for one of them:
    |
18  + use num::Float;
    |
18  + use num::traits::float::FloatCore;
    |
18  + use num::traits::real::Real;
    |

error[E0599]: no method named `powi` found for struct `f16` in the current scope
   --> /Users/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/arrow-array-30.0.1/src/arithmetic.rs:356:22
    |
356 |                 self.powi(exp as i32)
    |                      ^^^^ method not found in `f16`
...
380 | native_type_float_op!(f16, f16::ONE, f16::ZERO);
    | ----------------------------------------------- in this macro invocation
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `native_type_float_op` (in Nightly builds, run with -Z macro-backtrace for more info)
help: the following traits are implemented but not in scope; perhaps add a `use` for one of them:
    |
18  + use num::Float;
    |
18  + use num::traits::float::FloatCore;
    |
18  + use num::traits::real::Real;
    |
```

# What changes are included in this PR?

Cargo.toml change to arrow-array

# Are there any user-facing changes?

no