### PR TITLE
ci: verify MSRV on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,3 +100,27 @@ jobs:
         run: rustup component add rustfmt
       - name: Run
         run: cargo fmt --all -- --check
+
+  msrv:
+    name: Verify MSRV
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Check arrow
+        working-directory: arrow
+        run: cargo msrv verify
+      - name: Check parquet
+        working-directory: parquet
+        run: cargo msrv verify
+      - name: Check arrow-flight
+        working-directory: arrow-flight
+        run: cargo msrv verify
+      - name: Check object_store
+        working-directory: object_store
+        run: cargo msrv verify

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -20,7 +20,7 @@ name = "arrow-flight"
 description = "Apache Arrow Flight"
 version = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70.0"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -31,7 +31,7 @@ include = [
     "Cargo.toml",
 ]
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70.0"
 
 [lib]
 name = "arrow"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -24,6 +24,7 @@ readme = "README.md"
 description = "A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files."
 keywords = ["object", "storage", "cloud"]
 repository = "https://github.com/apache/arrow-rs/tree/master/object_store"
+rust-version = "1.62.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -26,7 +26,7 @@ authors = { workspace = true }
 keywords = ["arrow", "parquet", "hadoop"]
 readme = "README.md"
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.70.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4487

# Rationale for this change
 
Check the MSRV of the main crates included in the workspace on CI.

# What changes are included in this PR?

Add a new job on GitHub Actions to check MSRV of `arrow`, `parquet`, `arrow-flight` and `object_store`.

# Are there any user-facing changes?

No.