### PR TITLE
object_store/InMemory: Make `clone()` non-async and implement `Clone` trait

### DIFF
--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -287,16 +287,6 @@ impl InMemory {
         Self::default()
     }
 
-    /// Creates a clone of the store
-    pub fn clone(&self) -> Self {
-        let storage = self.storage.read();
-        let storage = storage.clone();
-
-        Self {
-            storage: Arc::new(RwLock::new(storage)),
-        }
-    }
-
     async fn entry(&self, location: &Path) -> Result<(Bytes, DateTime<Utc>)> {
         let storage = self.storage.read();
         let value = storage
@@ -307,6 +297,18 @@ impl InMemory {
             })?;
 
         Ok(value)
+    }
+}
+
+impl Clone for InMemory {
+    /// Creates a clone of the store
+    fn clone(&self) -> Self {
+        let storage = self.storage.read();
+        let storage = storage.clone();
+
+        Self {
+            storage: Arc::new(RwLock::new(storage)),
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes apache/arrow-rs#123` indicates that this PR will close issue apache/arrow-rs#123.
-->

Closes apache/arrow-rs-object-store#156.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

As described in the issue and the commit messages, this PR is removing the `async` keyword from the `clone()` fn of the `object_store::InMemory` struct and then implements the `Clone` trait for it.

# Are there any user-facing changes?

Yes, since the function signature changes and any users would have to remove the `.await` from any calls to this function.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

> If there are any breaking changes to public APIs, please add the `breaking change` label.

I'm not sure how to do that since I can't select any labels when opening the PR. Since we are changing the signature of the public `clone()` fn I guess this should be considered a breaking change.