### PR TITLE
object_store/InMemory: Add `fork()` fn and deprecate `clone()` fn

### DIFF
--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -287,14 +287,18 @@ impl InMemory {
         Self::default()
     }
 
-    /// Creates a clone of the store
-    pub async fn clone(&self) -> Self {
+    /// Creates a fork of the store, with the current content copied into the
+    /// new store.
+    pub fn fork(&self) -> Self {
         let storage = self.storage.read();
-        let storage = storage.clone();
+        let storage = Arc::new(RwLock::new(storage.clone()));
+        Self { storage }
+    }
 
-        Self {
-            storage: Arc::new(RwLock::new(storage)),
-        }
+    /// Creates a clone of the store
+    #[deprecated(note = "Use fork() instead")]
+    pub async fn clone(&self) -> Self {
+        self.fork()
     }
 
     async fn entry(&self, location: &Path) -> Result<(Bytes, DateTime<Utc>)> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4496.

# Rationale for this change
 
see https://github.com/apache/arrow-rs/pull/4497

# What changes are included in this PR?

This PR adds a non-async `fork()` fn to the `InMemory` store implementation, which does the same as the `clone()` fn, but without the async keyword. The `clone()` fn is changed to call `fork()` internally and is subsequently deprecated.

# Are there any user-facing changes?

Yes, any user using `.clone()` will see a deprecation warning now.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

/cc @tustvold 