### PR TITLE
feat: `into_builder` method for BooleanArray

### DIFF
--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -137,7 +137,7 @@ impl BooleanBuffer {
     /// Returns the boolean value at index `i`.
     ///
     /// # Safety
-    /// This doesn't check bounds, the caller must ensure that index < self.len()
+    /// This doesn't check bounds, the caller must ensure that `index < self.len()`
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> bool {
         unsafe { bit_util::get_bit_raw(self.buffer.as_ptr(), i + self.offset) }
@@ -184,7 +184,7 @@ impl BooleanBuffer {
         &self.buffer
     }
 
-    /// Returns the inner [`Buffer`], consuming self
+    /// Returns the inner [`Buffer`], consuming `self`
     pub fn into_inner(self) -> Buffer {
         self.buffer
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-rs/issues/4506

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
New methods:
`BooleanArray`:
- `into_builder`

`BooleanBuilder`:
- `values_slice`
- `values_slice_mut`
- `validity_slice`
- `validity_slice_mut`
- `new_from_buffer`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
