### PR TITLE
feat: `builder` method for GenericByteArray

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -214,6 +214,11 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         &self.value_data
     }
 
+    /// Returns a new generic byte array builder
+    pub fn builder(item_capacity: usize, data_capacity: usize) -> GenericByteBuilder<T> {
+        GenericByteBuilder::<T>::with_capacity(item_capacity, data_capacity)
+    }
+
     /// Returns the raw value data
     pub fn value_data(&self) -> &[u8] {
         self.value_data.as_slice()
@@ -579,5 +584,18 @@ mod tests {
         );
 
         BinaryArray::new(offsets, non_ascii_data, None);
+    }
+
+    #[test]
+    fn test_builder_with_null_fmt_debug() {
+        let mut builder = StringArray::builder(3, 5);
+        builder.append_slice(&["Let", "How"]);
+        builder.append_null();
+        builder.append_slice(&["Get", "Log"]);
+        let arr = builder.finish();
+        assert_eq!(
+            "StringArray\n[\n  \"Let\",\n  \"How\",\n  null,\n  \"Get\",\n  \"Log\",\n]",
+            format!("{arr:?}")
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-rs/issues/4506

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
New methods:
`GenericByteArray`:
- `builder`

`GenericByteBuilder`:
- `values_slice_mut`
- `append_nulls`
- `append_slice`
- `append_values`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
