### PR TITLE
object_store: Export `ClientConfigKey` and add `HttpBuilder::with_config`

### DIFF
--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -43,8 +43,8 @@ use url::Url;
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
-    ClientOptions, GetOptions, GetResult, ListResult, MultipartId, ObjectMeta,
-    ObjectStore, Result, RetryConfig,
+    ClientConfigKey, ClientOptions, GetOptions, GetResult, ListResult, MultipartId,
+    ObjectMeta, ObjectStore, Result, RetryConfig,
 };
 
 mod client;
@@ -228,6 +228,12 @@ impl HttpBuilder {
     /// Set the retry configuration
     pub fn with_retry(mut self, retry_config: RetryConfig) -> Self {
         self.retry_config = retry_config;
+        self
+    }
+
+    /// Set individual client configuration without overriding the entire config
+    pub fn with_config(mut self, key: ClientConfigKey, value: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_config(key, value);
         self
     }
 

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -274,7 +274,7 @@ use std::sync::Arc;
 use tokio::io::AsyncWrite;
 
 #[cfg(any(feature = "azure", feature = "aws", feature = "gcp", feature = "http"))]
-pub use client::ClientOptions;
+pub use client::{ClientConfigKey, ClientOptions};
 
 /// An alias for a dynamically dispatched object store implementation.
 pub type DynObjectStore = dyn ObjectStore;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4515

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The changes here are to enable more consistent use of the different providers in the object_store crate. It would be useful for polars to have access to this to make implementing http more consistent with the rest. See https://github.com/pola-rs/polars/blob/96b0e07e75a882eaed7be05e619307bc144aa5b4/polars/polars-core/src/cloud.rs

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Exporting `ClientConfigKey`
- Add `HttpBuilder::with_config`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

There are user facing changes, but not breaking. The addition has been documented.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
