### PR TITLE
Add FixedWidthRows for the arrow-row

### DIFF
--- a/arrow-row/src/dictionary.rs
+++ b/arrow-row/src/dictionary.rs
@@ -17,7 +17,7 @@
 
 use crate::fixed::{FixedLengthEncoding, FromSlice};
 use crate::interner::{Interned, OrderPreservingInterner};
-use crate::{null_sentinel, Row, Rows};
+use crate::{null_sentinel, IRows, Row};
 use arrow_array::builder::*;
 use arrow_array::cast::*;
 use arrow_array::types::*;
@@ -61,7 +61,7 @@ pub fn encode_dictionary_values<K: ArrowDictionaryKeyType>(
     data: &mut [u8],
     offsets: &mut [usize],
     column: &DictionaryArray<K>,
-    values: &Rows,
+    values: &dyn IRows,
     null: &Row<'_>,
 ) {
     for (offset, k) in offsets.iter_mut().skip(1).zip(column.keys()) {

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -975,6 +975,8 @@ pub trait IRows: Debug + Send {
     /// Get a [`Row`]
     fn row(&self, row: usize) -> Row<'_>;
 
+    fn row_data(&self, row: usize) -> &[u8];
+
     fn num_rows(&self) -> usize;
 
     fn iter(&self) -> RowsIter<'_>;
@@ -1017,12 +1019,16 @@ impl IRows for Rows {
     }
 
     fn row(&self, row: usize) -> Row<'_> {
-        let end = self.offsets[row + 1];
-        let start = self.offsets[row];
         Row {
-            data: &self.buffer[start..end],
+            data: self.row_data(row),
             config: &self.config,
         }
+    }
+
+    fn row_data(&self, row: usize) -> &[u8] {
+        let end = self.offsets[row + 1];
+        let start = self.offsets[row];
+        &self.buffer[start..end]
     }
 
     fn num_rows(&self) -> usize {
@@ -1075,13 +1081,16 @@ impl IRows for FixedWidthRows {
     }
 
     fn row(&self, row: usize) -> Row<'_> {
-        let start = self.width * row;
-        let end = start + self.width;
-
         Row {
-            data: &self.buffer[start..end],
+            data: self.row_data(row),
             config: &self.config,
         }
+    }
+
+    fn row_data(&self, row: usize) -> &[u8] {
+        let start = self.width * row;
+        let end = start + self.width;
+        &self.buffer[start..end]
     }
 
     fn num_rows(&self) -> usize {

--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{RowConverter, Rows, SortField};
+use crate::{IRows, RowConverter, SortField};
 use arrow_array::builder::BufferBuilder;
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_data::ArrayDataBuilder;
@@ -24,7 +24,7 @@ use std::ops::Range;
 
 pub fn compute_lengths<O: OffsetSizeTrait>(
     lengths: &mut [usize],
-    rows: &Rows,
+    rows: &dyn IRows,
     array: &GenericListArray<O>,
 ) {
     let offsets = array.value_offsets().windows(2);
@@ -40,7 +40,7 @@ pub fn compute_lengths<O: OffsetSizeTrait>(
         });
 }
 
-fn encoded_len(rows: &Rows, range: Option<Range<usize>>) -> usize {
+fn encoded_len(rows: &dyn IRows, range: Option<Range<usize>>) -> usize {
     match range {
         None => 1,
         Some(range) if range.start == range.end => 1,
@@ -59,7 +59,7 @@ fn encoded_len(rows: &Rows, range: Option<Range<usize>>) -> usize {
 pub fn encode<O: OffsetSizeTrait>(
     data: &mut [u8],
     offsets: &mut [usize],
-    rows: &Rows,
+    rows: &dyn IRows,
     opts: SortOptions,
     array: &GenericListArray<O>,
 ) {
@@ -82,7 +82,7 @@ pub fn encode<O: OffsetSizeTrait>(
 fn encode_one(
     out: &mut [u8],
     temporary: &mut Vec<u8>,
-    rows: &Rows,
+    rows: &dyn IRows,
     range: Option<Range<usize>>,
     opts: SortOptions,
 ) -> usize {

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -59,7 +59,7 @@ fn do_bench(
     });
 
     c.bench_function(&format!("convert_rows {name}"), |b| {
-        b.iter(|| black_box(converter.convert_rows(&rows).unwrap()));
+        b.iter(|| black_box(converter.convert_rows(rows.as_ref()).unwrap()));
     });
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4523.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There are mainly two reasons to introduce the `FixedWidthRows`:
- For group value of fixed length, we don't need to store the `offsets` vector to get the row value, which makes the operation of getting the row value much more efficient. It's also proved by the benchmark results, especially for tpch q17.
- By introducing the `row_width` to the `RowConverter`, it will be much easier for the Datafusion side to decide whether to make the group value embedded or not. The benchmark results also prove that when the group values are of small enough fixed length, to embed the value to the RawTable will bring great benefits.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
