### PR TITLE
use new num version instead of explicit num-complex dependency

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -46,8 +46,7 @@ arrow-schema = { workspace = true }
 arrow-data = { workspace = true }
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.8", optional = true }
-num = { version = "0.4", default-features = false, features = ["std"] }
-num-complex = "0.4.2"
+num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.14", default-features = false }
 packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }


### PR DESCRIPTION
# Which issue does this PR close?

Minor cleanup for issue https://github.com/apache/arrow-rs/issues/3849 which was partly resolved in https://github.com/apache/arrow-rs/pull/4482/. Now `num` [has version 0.4.1 which requires the downstream versions we need directly](https://github.com/rust-num/num/issues/426), making this change possible.

# Rationale for this change
 
The whole point of num is to be a wrapper crate around num-*, so having an explicit dependency on num-complex seems undesirable.

# What changes are included in this PR?

* Remove direct num-complex dependency
* Require num >= 0.4.1

# Are there any user-facing changes?

no
