### PR TITLE
feat(parquet): optionally support serde of ParquetMetaData.

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -100,6 +100,8 @@ experimental = []
 async = ["futures", "tokio"]
 # Enable object_store integration
 object_store = ["dep:object_store", "async"]
+# Enable serde of ParquetMetaData
+serde = ["dep:serde", "bytes/serde", "serde/rc", "serde/std"]
 
 [[example]]
 name = "read_parquet"

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -43,6 +43,7 @@ pub use crate::format::{
 /// For example INT16 is not included as a type since a good encoding of INT32
 /// would handle this.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum Type {
     BOOLEAN,
@@ -65,6 +66,7 @@ pub enum Type {
 /// This struct was renamed from `LogicalType` in version 4.0.0.
 /// If targeting Parquet format 2.4.0 or above, please use [LogicalType] instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum ConvertedType {
     NONE,
@@ -167,6 +169,7 @@ pub enum ConvertedType {
 /// 4.0.0. The struct previously named `LogicalType` was renamed to
 /// [`ConvertedType`]. Please see the README.md for more details.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LogicalType {
     String,
     Map,
@@ -200,6 +203,7 @@ pub enum LogicalType {
 
 /// Representation of field types in schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum Repetition {
     /// Field is required (can not be null) and each record has exactly 1 value.
@@ -217,6 +221,7 @@ pub enum Repetition {
 /// Not all encodings are valid for all types. These enums are also used to specify the
 /// encoding of definition and repetition levels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum Encoding {
     /// Default byte encoding.
@@ -283,6 +288,7 @@ pub enum Encoding {
 
 /// Supported compression algorithms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum Compression {
     UNCOMPRESSED,
@@ -301,6 +307,7 @@ pub enum Compression {
 /// Available data pages for Parquet file format.
 /// Note that some of the page types may not be supported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum PageType {
     DATA_PAGE,
@@ -321,6 +328,7 @@ pub enum PageType {
 /// See reference in
 /// <https://github.com/apache/parquet-cpp/blob/master/src/parquet/types.h>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum SortOrder {
     /// Signed (either value or legacy byte-wise) comparison.
@@ -344,6 +352,7 @@ impl SortOrder {
 /// If column order is undefined, then it is the legacy behaviour and all values should
 /// be compared as signed values/bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum ColumnOrder {
     /// Column uses the order defined by its logical or physical type

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -272,6 +272,7 @@ pub use gzip_codec::*;
 
 /// Represents a valid gzip compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GzipLevel(u32);
 
 impl Default for GzipLevel {
@@ -356,6 +357,7 @@ pub use brotli_codec::*;
 
 /// Represents a valid brotli compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BrotliLevel(u32);
 
 impl Default for BrotliLevel {
@@ -489,6 +491,7 @@ pub use zstd_codec::*;
 
 /// Represents a valid zstd compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ZstdLevel(i32);
 
 impl CompressionLevel<i32> for ZstdLevel {

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -33,6 +33,7 @@ use crate::util::{bit_util::FromBytes, memory::ByteBufferPtr};
 /// Rust representation for logical type INT96, value is backed by an array of `u32`.
 /// The type only takes 12 bytes, without extra padding.
 #[derive(Clone, Copy, Debug, PartialOrd, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Int96 {
     value: [u32; 3],
 }
@@ -102,6 +103,7 @@ impl fmt::Display for Int96 {
 /// Rust representation for BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY Parquet physical types.
 /// Value is backed by a byte buffer.
 #[derive(Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ByteArray {
     data: Option<ByteBufferPtr>,
 }
@@ -263,6 +265,7 @@ impl fmt::Display for ByteArray {
 /// level logical types, removing the data-hazard from all decoding and encoding paths.
 #[repr(transparent)]
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FixedLenByteArray(ByteArray);
 
 impl PartialEq for FixedLenByteArray {

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -74,6 +74,7 @@ pub type ParquetOffsetIndex = Vec<Vec<Vec<PageLocation>>>;
 
 /// Global Parquet metadata.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParquetMetaData {
     file_metadata: FileMetaData,
     row_groups: Vec<RowGroupMetaData>,
@@ -174,6 +175,7 @@ pub type FileMetaDataPtr = Arc<FileMetaData>;
 
 /// Metadata for a Parquet file.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FileMetaData {
     version: i32,
     num_rows: i64,
@@ -271,6 +273,7 @@ pub type RowGroupMetaDataPtr = Arc<RowGroupMetaData>;
 
 /// Metadata for a row group.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RowGroupMetaData {
     columns: Vec<ColumnChunkMetaData>,
     num_rows: i64,
@@ -427,6 +430,7 @@ impl RowGroupMetaDataBuilder {
 
 /// Metadata for a column chunk.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColumnChunkMetaData {
     column_descr: ColumnDescPtr,
     encodings: Vec<Encoding>,

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -25,6 +25,7 @@ use crate::format::{
 
 /// PageEncodingStats for a column chunk and data page.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PageEncodingStats {
     /// the page type (data/dic/...)
     pub page_type: PageType,

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -34,6 +34,7 @@ use std::fmt::Debug;
 ///
 /// [Column Index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PageIndex<T> {
     /// The minimum value, It is None when all values are null
     pub min: Option<T>,
@@ -56,6 +57,7 @@ impl<T> PageIndex<T> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 /// Typed statistics for a data page in a column chunk. This structure
 /// is obtained from decoding the [ColumnIndex] in the parquet file
@@ -105,6 +107,7 @@ impl Index {
 
 /// Stores the [`PageIndex`] for each page of a column
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NativeIndex<T: ParquetValueType> {
     /// The indexes, one item per page
     pub indexes: Vec<PageIndex<T>>,

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -267,6 +267,7 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
 
 /// Statistics for a column chunk and data page.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Statistics {
     Boolean(ValueStatistics<bool>),
     Int32(ValueStatistics<i32>),
@@ -415,6 +416,7 @@ pub type TypedStatistics<T> = ValueStatistics<<T as DataType>::T>;
 
 /// Statistics for a particular `ParquetValueType`
 #[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueStatistics<T> {
     min: Option<T>,
     max: Option<T>,

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -519,6 +519,7 @@ impl From<&CompressionCodec> for i32 {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PageType(pub i32);
 
 impl PageType {
@@ -578,6 +579,7 @@ impl From<&PageType> for i32 {
 /// Enum to annotate whether lists of min/max elements inside ColumnIndex
 /// are ordered and if so, in which direction.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoundaryOrder(pub i32);
 
 impl BoundaryOrder {
@@ -1207,6 +1209,7 @@ impl TSerializable for DecimalType {
 
 /// Time units for logical types
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MilliSeconds {
 }
 
@@ -1255,6 +1258,7 @@ impl Default for MilliSeconds {
 //
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MicroSeconds {
 }
 
@@ -1303,6 +1307,7 @@ impl Default for MicroSeconds {
 //
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NanoSeconds {
 }
 
@@ -1351,6 +1356,7 @@ impl Default for NanoSeconds {
 //
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TimeUnit {
   MILLIS(MilliSeconds),
   MICROS(MicroSeconds),
@@ -3244,6 +3250,7 @@ impl TSerializable for PageHeader {
 
 /// Wrapper struct to store key values
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyValue {
   pub key: String,
   pub value: Option<String>,
@@ -3314,6 +3321,7 @@ impl TSerializable for KeyValue {
 
 /// Wrapper struct to specify sort order
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SortingColumn {
   /// The column index (in this row group) *
   pub column_idx: i32,
@@ -4434,6 +4442,7 @@ impl TSerializable for ColumnOrder {
 //
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PageLocation {
   /// Offset of the page in the file *
   pub offset: i64,

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -42,6 +42,7 @@ pub type ColumnDescPtr = Arc<ColumnDescriptor>;
 /// Note that the top-level schema type is represented using `GroupType` whose
 /// repetition is `None`.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Type {
     PrimitiveType {
         basic_info: BasicTypeInfo,
@@ -607,6 +608,7 @@ impl<'a> GroupTypeBuilder<'a> {
 /// Basic type info. This contains information such as the name of the type,
 /// the repetition level, the logical type and the kind of the type (group, primitive).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BasicTypeInfo {
     name: String,
     repetition: Option<Repetition>,
@@ -662,6 +664,7 @@ impl BasicTypeInfo {
 
 /// Represents a path in a nested schema
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColumnPath {
     parts: Vec<String>,
 }
@@ -739,6 +742,7 @@ impl AsRef<[String]> for ColumnPath {
 /// This encapsulates information such as definition and repetition levels and is used to
 /// re-assemble nested data.
 #[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColumnDescriptor {
     // The "leaf" primitive type of this column
     primitive_type: TypePtr,
@@ -861,6 +865,7 @@ impl ColumnDescriptor {
 /// A schema descriptor. This encapsulates the top-level schemas for all the columns,
 /// as well as all descriptors for all the primitive columns.
 #[derive(PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SchemaDescriptor {
     // The top-level schema (the "message" type).
     // This must be a `GroupType` where each field is a root column type in the schema.

--- a/parquet/src/util/memory.rs
+++ b/parquet/src/util/memory.rs
@@ -32,6 +32,7 @@ use std::{
 ///
 /// TODO: Remove and replace with [`bytes::Bytes`]
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ByteBufferPtr {
     data: Bytes,
 }


### PR DESCRIPTION
# Rationale for this change

I want to use arrow-rs to read parquet files in a distributed way: 
read metadata in `master/coordinator`,  distributed them to diff `slave/worker`s to read data.

# What changes are included in this PR?


no additional dependency is added if  feature `serde` = false (by default)
when it is true, ParquetMetaData `derive(serde::Serialize, serde::Deserialize)`

# Are there any user-facing changes?

no
