### PR TITLE
docs: fix wrong parameter name

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -212,7 +212,7 @@ where
         Ok((values, levels))
     }
 
-    /// Read up to `num_records` returning the number of complete records, non-null
+    /// Read up to `max_records` returning the number of complete records, non-null
     /// values and levels decoded
     ///
     /// If the max definition level is 0, `def_levels` will be ignored, otherwise it will be


### PR DESCRIPTION
Skip the PR template as there are no code changes.

1. Correct a wrong parameter name in the parquet column reader doc