### PR TITLE
Restructure `sum` for better auto-vectorization

### DIFF
--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -29,6 +29,10 @@ fn bench_sum(arr_a: &Float32Array) {
     criterion::black_box(sum(arr_a).unwrap());
 }
 
+fn bench_sum_test(arr_a: &Float32Array) {
+    criterion::black_box(sum_test(arr_a).unwrap());
+}
+
 fn bench_min(arr_a: &Float32Array) {
     criterion::black_box(min(arr_a).unwrap());
 }
@@ -45,12 +49,14 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array::<Float32Type>(512, 0.0);
 
     c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
+    c.bench_function("sum test 512", |b| b.iter(|| bench_sum_test(&arr_a)));
     c.bench_function("min 512", |b| b.iter(|| bench_min(&arr_a)));
     c.bench_function("max 512", |b| b.iter(|| bench_max(&arr_a)));
 
     let arr_a = create_primitive_array::<Float32Type>(512, 0.5);
 
     c.bench_function("sum nulls 512", |b| b.iter(|| bench_sum(&arr_a)));
+    c.bench_function("sum nulls test 512", |b| b.iter(|| bench_sum_test(&arr_a)));
     c.bench_function("min nulls 512", |b| b.iter(|| bench_min(&arr_a)));
     c.bench_function("max nulls 512", |b| b.iter(|| bench_max(&arr_a)));
 

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -29,10 +29,6 @@ fn bench_sum(arr_a: &Float32Array) {
     criterion::black_box(sum(arr_a).unwrap());
 }
 
-fn bench_sum_test(arr_a: &Float32Array) {
-    criterion::black_box(sum_test(arr_a).unwrap());
-}
-
 fn bench_min(arr_a: &Float32Array) {
     criterion::black_box(min(arr_a).unwrap());
 }
@@ -49,14 +45,12 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array::<Float32Type>(512, 0.0);
 
     c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
-    c.bench_function("sum test 512", |b| b.iter(|| bench_sum_test(&arr_a)));
     c.bench_function("min 512", |b| b.iter(|| bench_min(&arr_a)));
     c.bench_function("max 512", |b| b.iter(|| bench_max(&arr_a)));
 
     let arr_a = create_primitive_array::<Float32Type>(512, 0.5);
 
     c.bench_function("sum nulls 512", |b| b.iter(|| bench_sum(&arr_a)));
-    c.bench_function("sum nulls test 512", |b| b.iter(|| bench_sum_test(&arr_a)));
     c.bench_function("min nulls 512", |b| b.iter(|| bench_min(&arr_a)));
     c.bench_function("max nulls 512", |b| b.iter(|| bench_max(&arr_a)));
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Restructure the code for `sum` to allow for better auto-vectorization.
The code in the `simd` module is very similar, but it depends on `packed_simd`.
The auto-vectorized non-null case now has the same performance the `simd` feature impl. See benchmarks.

I didn't manage to make the null case quite as fast as the `simd` feature impl, but it's pretty close.
If I/someone else manages to also make the null case identical, I think we can remove the `simd` version altogether to remove duplicated code.

## Benchmarks:
```
[svs@nixos:~/code/arrow-rs]$ RUSTFLAGS='-C target-cpu=native' cargo +nightly bench --features="simd" --bench aggregate_kernels "sum"
    Finished bench [optimized] target(s) in 0.11s
     Running benches/aggregate_kernels.rs (target/release/deps/aggregate_kernels-20ec62142ba71a42)
sum 512                 time:   [30.901 ns 31.125 ns 31.385 ns]

Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

sum nulls 512           time:   [72.911 ns 74.171 ns 75.687 ns]

Found 19 outliers among 100 measurements (19.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  12 (12.00%) high severe
```

```
[svs@nixos:~/code/arrow-rs]$ RUSTFLAGS='-C target-cpu=native' cargo +nightly bench --bench aggregate_kernels "sum"
    Finished bench [optimized] target(s) in 0.10s
     Running benches/aggregate_kernels.rs (target/release/deps/aggregate_kernels-da08a889b5821ed5)
sum 512                 time:   [27.895 ns 27.952 ns 28.018 ns]

Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  9 (9.00%) high severe

sum nulls 512           time:   [79.906 ns 80.048 ns 80.211 ns]

Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe
```


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Faster implementation of `sum`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
