### PR TITLE
support NullArray un arith/boolean kernel

### DIFF
--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -313,13 +313,10 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray, ArrowError> {
 pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
     let values = match input.nulls() {
         // NullArray has no nulls buffer yet all values are null
-        None => {
-            if input.data_type().equals_datatype(&DataType::Null) {
-                BooleanBuffer::new_set(input.len())
-            } else {
-                BooleanBuffer::new_unset(input.len())
-            }
+        None if input.data_type() == &DataType::Null => {
+            BooleanBuffer::new_set(input.len())
         }
+        None => BooleanBuffer::new_unset(input.len()),
         Some(nulls) => !nulls.inner(),
     };
 
@@ -339,14 +336,11 @@ pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
 /// ```
 pub fn is_not_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
     let values = match input.nulls() {
-        None => {
-            // NullArray has no nulls buffer yet all values are null
-            if input.data_type().equals_datatype(&DataType::Null) {
-                BooleanBuffer::new_unset(input.len())
-            } else {
-                BooleanBuffer::new_set(input.len())
-            }
+        // NullArray has no nulls buffer yet all values are null
+        None if input.data_type() == &DataType::Null => {
+            BooleanBuffer::new_unset(input.len())
         }
+        None => BooleanBuffer::new_set(input.len()),
         Some(n) => n.inner().clone(),
     };
     Ok(BooleanArray::new(values, None))

--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -25,7 +25,7 @@
 use arrow_array::*;
 use arrow_buffer::buffer::{bitwise_bin_op_helper, bitwise_quaternary_op_helper};
 use arrow_buffer::{BooleanBuffer, NullBuffer};
-use arrow_schema::ArrowError;
+use arrow_schema::{ArrowError, DataType};
 
 /// Logical 'and' boolean values with Kleene logic
 ///
@@ -312,7 +312,14 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray, ArrowError> {
 /// ```
 pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
     let values = match input.nulls() {
-        None => BooleanBuffer::new_unset(input.len()),
+        // NullArray has no nulls buffer yet all values are null
+        None => {
+            if input.data_type().equals_datatype(&DataType::Null) {
+                BooleanBuffer::new_set(input.len())
+            } else {
+                BooleanBuffer::new_unset(input.len())
+            }
+        }
         Some(nulls) => !nulls.inner(),
     };
 
@@ -332,7 +339,14 @@ pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
 /// ```
 pub fn is_not_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
     let values = match input.nulls() {
-        None => BooleanBuffer::new_set(input.len()),
+        None => {
+            // NullArray has no nulls buffer yet all values are null
+            if input.data_type().equals_datatype(&DataType::Null) {
+                BooleanBuffer::new_unset(input.len())
+            } else {
+                BooleanBuffer::new_set(input.len())
+            }
+        }
         Some(n) => n.inner().clone(),
     };
     Ok(BooleanArray::new(values, None))
@@ -867,6 +881,30 @@ mod tests {
         let res = is_not_null(&a).unwrap();
 
         let expected = BooleanArray::from(vec![true, false, true, false]);
+
+        assert_eq!(expected, res);
+        assert!(res.nulls().is_none());
+    }
+
+    #[test]
+    fn test_null_array_is_null() {
+        let a = NullArray::new(3);
+
+        let res = is_null(&a).unwrap();
+
+        let expected = BooleanArray::from(vec![true, true, true]);
+
+        assert_eq!(expected, res);
+        assert!(res.nulls().is_none());
+    }
+
+    #[test]
+    fn test_null_array_is_not_null() {
+        let a = NullArray::new(3);
+
+        let res = is_not_null(&a).unwrap();
+
+        let expected = BooleanArray::from(vec![false, false, false]);
 
         assert_eq!(expected, res);
         assert!(res.nulls().is_none());


### PR DESCRIPTION
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4565.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Since NullArray has no nulls buffer, we need to handle that case for `is_null` and `is_not_null` to work correctly

# Are there any user-facing changes?
Nope

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Don't think so
<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
Nope