### PR TITLE
Write Page Offset Index For All-Nan Pages

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -500,12 +500,23 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         let metadata = self.write_column_metadata()?;
         self.page_writer.close()?;
 
-        let column_index = if self.column_index_builder.valid() {
-            Some(self.column_index_builder.build_to_thrift())
+        // previous
+        let (column_index, offset_index) = if self.column_index_builder.valid() {
+            // build the column and offset index
+            let column_index = self.column_index_builder.build_to_thrift();
+            let offset_index = self.offset_index_builder.build_to_thrift();
+            (Some(column_index), Some(offset_index))
         } else {
-            None
+            (None, None)
         };
-        let offset_index = Some(self.offset_index_builder.build_to_thrift());
+
+        // modified
+        // let column_index = if self.column_index_builder.valid() {
+        //     Some(self.column_index_builder.build_to_thrift())
+        // } else {
+        //     None
+        // };
+        // let offset_index = Some(self.offset_index_builder.build_to_thrift());
 
         Ok(ColumnCloseResult {
             bytes_written: self.column_metrics.total_bytes_written,

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -500,23 +500,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         let metadata = self.write_column_metadata()?;
         self.page_writer.close()?;
 
-        // previous
-        let (column_index, offset_index) = if self.column_index_builder.valid() {
-            // build the column and offset index
-            let column_index = self.column_index_builder.build_to_thrift();
-            let offset_index = self.offset_index_builder.build_to_thrift();
-            (Some(column_index), Some(offset_index))
-        } else {
-            (None, None)
-        };
-
-        // modified
-        // let column_index = if self.column_index_builder.valid() {
-        //     Some(self.column_index_builder.build_to_thrift())
-        // } else {
-        //     None
-        // };
-        // let offset_index = Some(self.offset_index_builder.build_to_thrift());
+        let column_index = self
+            .column_index_builder
+            .valid()
+            .then(|| self.column_index_builder.build_to_thrift());
+        let offset_index = Some(self.offset_index_builder.build_to_thrift());
 
         Ok(ColumnCloseResult {
             bytes_written: self.column_metrics.total_bytes_written,

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -500,14 +500,12 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         let metadata = self.write_column_metadata()?;
         self.page_writer.close()?;
 
-        let (column_index, offset_index) = if self.column_index_builder.valid() {
-            // build the column and offset index
-            let column_index = self.column_index_builder.build_to_thrift();
-            let offset_index = self.offset_index_builder.build_to_thrift();
-            (Some(column_index), Some(offset_index))
+        let column_index = if self.column_index_builder.valid() {
+            Some(self.column_index_builder.build_to_thrift())
         } else {
-            (None, None)
+            None
         };
+        let offset_index = Some(self.offset_index_builder.build_to_thrift());
 
         Ok(ColumnCloseResult {
             bytes_written: self.column_metrics.total_bytes_written,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
Currently page offset index is set to `none` when page column index is `none`, which cause error when init meta data with pre load page index. The error info is bellow:
```
decode page indexes for meta data, file_path:0/14/489.sst, err:Parquet error: failed to build page indexes in metadata, err:Parquet error: missing offset index.
```
The relevant code is: https://github.com/apache/arrow-rs/blob/master/parquet/src/arrow/async_reader/metadata.rs#L198

# What changes are included in this PR?

* Build page offset index even if page column index is none

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
