### PR TITLE
Make object_store::multipart public

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -250,8 +250,8 @@ pub use client::{backoff::BackoffConfig, retry::RetryConfig, CredentialProvider}
 #[cfg(any(feature = "gcp", feature = "aws", feature = "azure", feature = "http"))]
 mod config;
 
-#[cfg(any(feature = "azure", feature = "aws", feature = "gcp"))]
-mod multipart;
+#[cfg(feature = "cloud")]
+pub mod multipart;
 mod parse;
 mod util;
 

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -15,6 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Cloud Multi-Part Upload
+//!
+//! This crate provides an asynchronous interface for multipart file uploads to cloud storage services.
+//! It's designed to offer efficient, non-blocking operations,
+//! especially useful when dealing with large files or high-throughput systems.
+
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use std::{io, pin::Pin, sync::Arc, task::Poll};
@@ -42,11 +48,13 @@ pub trait CloudMultiPartUploadImpl: 'static {
     async fn complete(&self, completed_parts: Vec<UploadPart>) -> Result<(), io::Error>;
 }
 
+/// Represents a part of a file that has been successfully uploaded in a multipart upload process.
 #[derive(Debug, Clone)]
 pub struct UploadPart {
     pub content_id: String,
 }
 
+/// Struct that manages and controls multipart uploads to a cloud storage service.
 pub struct CloudMultiPartUpload<T>
 where
     T: CloudMultiPartUploadImpl,

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -56,6 +56,7 @@ pub struct UploadPart {
 }
 
 /// Struct that manages and controls multipart uploads to a cloud storage service.
+#[derive(Debug)]
 pub struct CloudMultiPartUpload<T>
 where
     T: CloudMultiPartUploadImpl,

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -28,7 +28,7 @@ type BoxedTryFuture<T> = Pin<Box<dyn Future<Output = Result<T, io::Error>> + Sen
 /// and used in combination with [`CloudMultiPartUpload`] to provide
 /// multipart upload support
 #[async_trait]
-pub(crate) trait CloudMultiPartUploadImpl: 'static {
+pub trait CloudMultiPartUploadImpl: 'static {
     /// Upload a single part
     async fn put_multipart_part(
         &self,
@@ -43,7 +43,7 @@ pub(crate) trait CloudMultiPartUploadImpl: 'static {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct UploadPart {
+pub struct UploadPart {
     pub content_id: String,
 }
 

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -56,7 +56,6 @@ pub struct UploadPart {
 }
 
 /// Struct that manages and controls multipart uploads to a cloud storage service.
-#[derive(Debug)]
 pub struct CloudMultiPartUpload<T>
 where
     T: CloudMultiPartUploadImpl,
@@ -267,5 +266,18 @@ where
         });
 
         Pin::new(completion_task).poll(cx)
+    }
+}
+
+impl<T: CloudMultiPartUploadImpl> std::fmt::Debug for CloudMultiPartUpload<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudMultiPartUpload")
+            .field("completed_parts", &self.completed_parts)
+            .field("tasks", &self.tasks)
+            .field("max_concurrency", &self.max_concurrency)
+            .field("current_buffer", &self.current_buffer)
+            .field("part_size", &self.part_size)
+            .field("current_part_idx", &self.current_part_idx)
+            .finish()
     }
 }

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Cloud Multi-Part Upload
+//! Cloud Multipart Upload
 //!
 //! This crate provides an asynchronous interface for multipart file uploads to cloud storage services.
 //! It's designed to offer efficient, non-blocking operations,

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -47,7 +47,7 @@ pub struct UploadPart {
     pub content_id: String,
 }
 
-pub(crate) struct CloudMultiPartUpload<T>
+pub struct CloudMultiPartUpload<T>
 where
     T: CloudMultiPartUploadImpl,
 {

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -51,6 +51,7 @@ pub trait CloudMultiPartUploadImpl: 'static {
 /// Represents a part of a file that has been successfully uploaded in a multipart upload process.
 #[derive(Debug, Clone)]
 pub struct UploadPart {
+    /// Id of this part
     pub content_id: String,
 }
 
@@ -83,6 +84,7 @@ impl<T> CloudMultiPartUpload<T>
 where
     T: CloudMultiPartUploadImpl,
 {
+    /// Create a new multipart upload with the implementation and the given maximum concurrency
     pub fn new(inner: T, max_concurrency: usize) -> Self {
         Self {
             inner: Arc::new(inner),
@@ -111,6 +113,7 @@ where
         to_copy
     }
 
+    /// Poll current tasks
     pub fn poll_tasks(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4569.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Make some of the APIs in `object_store::multipart` public so we can also have HDFS implementation support `put_multipart`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
New API 


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
