### PR TITLE
Fix take_bytes Null and Overflow Handling (#4576)

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -375,6 +375,8 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
         let null_slice = null_buf.as_slice_mut();
         offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
+            // check index is valid before using index. The value in
+            // NULL index slots may not be within bounds of array
             let index = index.as_usize();
             if indices.is_valid(i) && array.is_valid(index) {
                 let s: &[u8] = array.value(index).as_ref();
@@ -1911,6 +1913,7 @@ mod tests {
 
     #[test]
     fn test_take_null_indices() {
+        // Build indices with values that are out of bounds, but masked by null mask
         let indices = Int32Array::new(
             vec![1, 2, 400, 400].into(),
             Some(NullBuffer::from(vec![true, true, false, false])),

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -337,10 +337,9 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
     let mut values = MutableBuffer::new(0);
 
     let nulls;
-    let take = indices.values().iter().map(|x| x.as_usize());
     if array.null_count() == 0 && indices.null_count() == 0 {
-        offsets.extend(take.map(|index| {
-            let s: &[u8] = array.value(index).as_ref();
+        offsets.extend(indices.values().iter().map(|index| {
+            let s: &[u8] = array.value(index.as_usize()).as_ref();
             values.extend_from_slice(s);
             T::Offset::usize_as(values.len())
         }));
@@ -350,7 +349,8 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
 
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
         let null_slice = null_buf.as_slice_mut();
-        offsets.extend(take.enumerate().map(|(i, index)| {
+        offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
+            let index = index.as_usize();
             if array.is_valid(index) {
                 let s: &[u8] = array.value(index).as_ref();
                 values.extend_from_slice(s.as_ref());
@@ -361,9 +361,9 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         }));
         nulls = Some(null_buf.into());
     } else if array.null_count() == 0 {
-        offsets.extend(take.enumerate().map(|(i, index)| {
+        offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
             if indices.is_valid(i) {
-                let s: &[u8] = array.value(index).as_ref();
+                let s: &[u8] = array.value(index.as_usize()).as_ref();
                 values.extend_from_slice(s);
             }
             T::Offset::usize_as(values.len())
@@ -374,7 +374,8 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
 
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
         let null_slice = null_buf.as_slice_mut();
-        offsets.extend(take.enumerate().map(|(i, index)| {
+        offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
+            let index = index.as_usize();
             if indices.is_valid(i) && array.is_valid(index) {
                 let s: &[u8] = array.value(index).as_ref();
                 values.extend_from_slice(s);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4576

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This fixes the overflow and null checking behaviour of take_bytes. This does regress the performance slightly, but I think this is acceptable given the prior logic was incorrect.

```
take str 512            time:   [3.8135 µs 3.8144 µs 3.8155 µs]
                        change: [+8.1351% +8.5262% +8.8652%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe

take str 1024           time:   [6.6656 µs 6.6665 µs 6.6675 µs]
                        change: [+10.429% +10.776% +10.972%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

take str null indices 512
                        time:   [3.2013 µs 3.2048 µs 3.2081 µs]
                        change: [+6.4883% +6.7476% +7.0323%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

take str null indices 1024
                        time:   [6.3864 µs 6.4001 µs 6.4149 µs]
                        change: [+8.6045% +9.0105% +9.4405%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

take str null values 1024
                        time:   [6.9174 µs 6.9204 µs 6.9236 µs]
                        change: [-3.4004% -3.0300% -2.7115%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

take str null values null indices 1024
                        time:   [5.5812 µs 5.5842 µs 5.5873 µs]
                        change: [+2.1866% +2.5807% +2.9030%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
