### PR TITLE
fix(data): create child arrays of correct length when building a sparse union null array

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -841,6 +841,8 @@ mod tests {
                 assert_eq!(a.null_count(), 1);
                 assert!(a.is_null(0))
             }
+
+            array.to_data().validate_full().unwrap();
         }
     }
 

--- a/arrow-data/src/data/mod.rs
+++ b/arrow-data/src/data/mod.rs
@@ -634,9 +634,12 @@ impl ArrayData {
                     let children = f
                         .iter()
                         .enumerate()
-                        .map(|(idx, (_, f))| match idx {
-                            0 => Self::new_null(f.data_type(), len),
-                            _ => Self::new_empty(f.data_type()),
+                        .map(|(idx, (_, f))| {
+                            if idx == 0 || *mode == UnionMode::Sparse {
+                                Self::new_null(f.data_type(), len)
+                            } else {
+                                Self::new_empty(f.data_type())
+                            }
                         })
                         .collect();
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4600.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
