### PR TITLE
impl `Default` for `arrow_buffer::buffer::MutableBuffer`

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -777,6 +777,19 @@ mod tests {
     }
 
     #[test]
+    fn test_mutable_default() {
+        let buf = MutableBuffer::default();
+        assert_eq!(0, buf.capacity());
+        assert_eq!(0, buf.len());
+        assert!(buf.is_empty());
+
+        let mut buf = MutableBuffer::default();
+        buf.extend_from_slice(b"hello");
+        assert_eq!(5, buf.len());
+        assert_eq!(b"hello", buf.as_slice());
+    }
+
+    #[test]
     fn test_mutable_extend_from_slice() {
         let mut buf = MutableBuffer::new(100);
         buf.extend_from_slice(b"hello");

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -643,6 +643,12 @@ impl MutableBuffer {
     }
 }
 
+impl Default for MutableBuffer {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
 impl std::ops::Deref for MutableBuffer {
     type Target = [u8];
 


### PR DESCRIPTION
# Which issue does this PR close?

None. I can create one if needed.

# Rationale for this change
 
Enables constructing a mutable buffer via the `Default` trait.

# What changes are included in this PR?

A `std::default::Default` implementation for `arrow_buffer::buffer::MutableBuffer`.

# Are there any user-facing changes?

Yes.