### PR TITLE
fix: compute_dictionary_mapping use wrong offsetSize

### DIFF
--- a/arrow-row/src/dictionary.rs
+++ b/arrow-row/src/dictionary.rs
@@ -37,7 +37,7 @@ pub fn compute_dictionary_mapping(
         values => interner
             .intern(values.iter().map(|x| x.map(|x| x.encode()))),
         DataType::Binary => {
-            let iter = as_generic_binary_array::<i64>(values).iter();
+            let iter = as_generic_binary_array::<i32>(values).iter();
             interner.intern(iter)
         }
         DataType::LargeBinary => {

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -2442,4 +2442,32 @@ mod tests {
             assert_eq!(&back[0], &array);
         }
     }
+
+    #[test]
+    fn test_append_codec_dictionary_binary() {
+        use DataType::*;
+        // Dictionary RowConverter
+        let mut converter = RowConverter::new(vec![SortField::new(Dictionary(
+            Box::new(Int32),
+            Box::new(Binary),
+        ))])
+        .unwrap();
+        let mut rows = converter.empty_rows(4, 128);
+
+        let keys = Int32Array::from_iter_values([0, 1, 2, 3]);
+        let values = BinaryArray::from(vec![
+            Some("a".as_bytes()),
+            Some(b"b"),
+            Some(b"c"),
+            Some(b"d"),
+        ]);
+        let dict_array = DictionaryArray::new(keys, Arc::new(values));
+
+        rows.clear();
+        let array = Arc::new(dict_array) as ArrayRef;
+        converter.append(&mut rows, &[array.clone()]).unwrap();
+        let back = converter.convert_rows(&rows).unwrap();
+
+        assert_eq!(&back[0], &array);
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
compute_dictionary_mapping use wrong offsetSize.

Binary should use i32 instead of i64

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
