### PR TITLE
Minor: tweak wording of `lexicographical_partition_ranges` docs

### DIFF
--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -30,7 +30,7 @@ use std::ops::Range;
 /// have the same number of rows.
 ///
 /// Returns an iterator with `k` items where `k` is cardinality of the
-/// sort values: Consecutive values will be connected: `(a, b)` and `(b,
+/// sort values: Consecutive ranges will be contiguous: `(a, b)` and `(b,
 /// c)`, where `start = 0` and `end = n` for the first and last range.
 ///
 /// # Example:


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 Implement suggestion from @tustvold in https://github.com/apache/arrow-rs/pull/4615#discussion_r1281787103 that missed the merge

# What changes are included in this PR?
Update docstring wording
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
slightly better docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
