### PR TITLE
fix: from_thrift avoid panic when stats in invalid.

### DIFF
--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -616,7 +616,7 @@ impl ColumnChunkMetaData {
         let data_page_offset = col_metadata.data_page_offset;
         let index_page_offset = col_metadata.index_page_offset;
         let dictionary_page_offset = col_metadata.dictionary_page_offset;
-        let statistics = statistics::from_thrift(column_type, col_metadata.statistics);
+        let statistics = statistics::from_thrift(column_type, col_metadata.statistics)?;
         let encoding_stats = col_metadata
             .encoding_stats
             .as_ref()

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -461,7 +461,7 @@ pub(crate) fn decode_page(
                 encoding: Encoding::try_from(header.encoding)?,
                 def_level_encoding: Encoding::try_from(header.definition_level_encoding)?,
                 rep_level_encoding: Encoding::try_from(header.repetition_level_encoding)?,
-                statistics: statistics::from_thrift(physical_type, header.statistics),
+                statistics: statistics::from_thrift(physical_type, header.statistics)?,
             }
         }
         PageType::DATA_PAGE_V2 => {
@@ -477,7 +477,7 @@ pub(crate) fn decode_page(
                 def_levels_byte_len: header.definition_levels_byte_length as u32,
                 rep_levels_byte_len: header.repetition_levels_byte_length as u32,
                 is_compressed,
-                statistics: statistics::from_thrift(physical_type, header.statistics),
+                statistics: statistics::from_thrift(physical_type, header.statistics)?,
             }
         }
         _ => {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1135,7 +1135,8 @@ mod tests {
                         statistics: from_thrift(
                             physical_type,
                             to_thrift(statistics.as_ref()),
-                        ),
+                        )
+                        .unwrap(),
                     }
                 }
                 Page::DataPageV2 {
@@ -1168,7 +1169,8 @@ mod tests {
                         statistics: from_thrift(
                             physical_type,
                             to_thrift(statistics.as_ref()),
-                        ),
+                        )
+                        .unwrap(),
                     }
                 }
                 Page::DictionaryPage {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3577.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
