### PR TITLE
impl `From<Vec<T>>` for `BufferBuilder` and `MutableBuffer`

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -502,6 +502,12 @@ impl<A: ArrowNativeType> Extend<A> for MutableBuffer {
     }
 }
 
+impl<T: ArrowNativeType> From<Vec<T>> for MutableBuffer {
+    fn from(value: Vec<T>) -> Self {
+        Self::from_vec(value)
+    }
+}
+
 impl MutableBuffer {
     #[inline]
     pub(super) fn extend_from_iter<T: ArrowNativeType, I: Iterator<Item = T>>(

--- a/arrow-buffer/src/builder/mod.rs
+++ b/arrow-buffer/src/builder/mod.rs
@@ -372,6 +372,12 @@ impl<T: ArrowNativeType> Extend<T> for BufferBuilder<T> {
     }
 }
 
+impl<T: ArrowNativeType> From<Vec<T>> for BufferBuilder<T> {
+    fn from(value: Vec<T>) -> Self {
+        Self::new_from_buffer(MutableBuffer::from_vec(value))
+    }
+}
+
 impl<T: ArrowNativeType> FromIterator<T> for BufferBuilder<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut builder = Self::default();


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
Both `BufferBuilder` and `MutableBuffer` provide methods to convert from a `Vec`. These implementations provide these conversions through the `From` trait.

# What changes are included in this PR?

Implementations for `From<Vec<T>>` for `BufferBuilder` and `MutableBuffer`.

# Are there any user-facing changes?

Users can now use the `std::convert` traits to convert.