### PR TITLE
Update packed_simd and run miri tests on simd code

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -142,8 +142,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          # Pinned nightly (#4651)
-          rust-version: nightly-2023-08-03
+          rust-version: nightly
       - name: Test arrow-array with SIMD
         run: cargo test -p arrow-array --features simd
       - name: Test arrow-ord with SIMD
@@ -169,8 +168,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          # Pinned nightly (#4651)
-          rust-version: nightly-2023-08-03
+          rust-version: nightly
           target: wasm32-unknown-unknown,wasm32-wasi
       - name: Build wasm32-unknown-unknown
         run: cargo build -p arrow --no-default-features --features=json,csv,ipc,simd,ffi --target wasm32-unknown-unknown

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,7 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
-        # Pinned nightly (#4651)
-        rust: [ nightly-2023-08-03 ]
+        rust: [ nightly ]
     container:
       image: ${{ matrix.arch }}/rust
       env:

--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -5,11 +5,7 @@
 # Must be run with nightly rust for example
 # rustup default nightly
 
-
-# stacked borrows checking uses too much memory to run successfully in github actions
-# re-enable if the CI is migrated to something more powerful (https://github.com/apache/arrow-rs/issues/1833)
-# see also https://github.com/rust-lang/miri/issues/1367
-export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
+export MIRIFLAGS="-Zmiri-disable-isolation"
 cargo miri setup
 cargo clean
 
@@ -18,3 +14,5 @@ cargo miri test -p arrow-buffer
 cargo miri test -p arrow-data --features ffi
 cargo miri test -p arrow-schema --features ffi
 cargo miri test -p arrow-array
+cargo miri test -p arrow-arith --features simd
+cargo miri test -p arrow-ord --features simd

--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -49,7 +49,7 @@ chrono-tz = { version = "0.8", optional = true }
 num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.14", default-features = false }
-packed_simd = { version = "0.3", default-features = false, optional = true, package = "packed_simd_2" }
+packed_simd = { version = "0.3.9", default-features = false, optional = true }
 
 [features]
 simd = ["packed_simd"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4651.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

This PR also runs miri tests on the aggregate and ord kernels with the simd featues enabled. The previous issues with miri in those tests were fixed in https://github.com/rust-lang/packed_simd/pull/351

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Dependency changes from packed_simd_2 back to packed_simd.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
