### PR TITLE
enhancement: batches_to_flight_data use a schema ref as param.

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -196,9 +196,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
         self.check_token(&request)?;
         let batch =
             Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
-        let schema = (*batch.schema()).clone();
+        let schema = batch.schema();
         let batches = vec![batch];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let flight_data = batches_to_flight_data(schema.as_ref(), batches)
             .map_err(|e| status!("Could not convert batches", e))?
             .into_iter()
             .map(Ok);

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -147,11 +147,11 @@ pub fn ipc_message_from_arrow_schema(
 
 /// Convert `RecordBatch`es to wire protocol `FlightData`s
 pub fn batches_to_flight_data(
-    schema: Schema,
+    schema: &Schema,
     batches: Vec<RecordBatch>,
 ) -> Result<Vec<FlightData>, ArrowError> {
     let options = IpcWriteOptions::default();
-    let schema_flight_data: FlightData = SchemaAsIpc::new(&schema, &options).into();
+    let schema_flight_data: FlightData = SchemaAsIpc::new(schema, &options).into();
     let mut dictionaries = vec![];
     let mut flight_data = vec![];
 

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -144,9 +144,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
             "part_2" => batch.slice(2, 1),
             ticket => panic!("Invalid ticket: {ticket:?}"),
         };
-        let schema = (*batch.schema()).clone();
+        let schema = batch.schema();
         let batches = vec![batch];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let flight_data = batches_to_flight_data(schema.as_ref(), batches)
             .unwrap()
             .into_iter()
             .map(Ok);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4656.

# Rationale for this change
 
batches_to_flight_data use a schema ref as param.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

batches_to_flight_data accept a ref schema as param