### PR TITLE
More intuitive bool-to-string casting

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -1220,7 +1220,7 @@ pub fn cast_with_options(
                 Ok(Arc::new(
                     array
                         .iter()
-                        .map(|value| value.map(|value| if value { "1" } else { "0" }))
+                        .map(|value| value.map(|value| if value { "true" } else { "false" }))
                         .collect::<StringArray>(),
                 ))
             }
@@ -1229,7 +1229,7 @@ pub fn cast_with_options(
                 Ok(Arc::new(
                     array
                         .iter()
-                        .map(|value| value.map(|value| if value { "1" } else { "0" }))
+                        .map(|value| value.map(|value| if value { "true" } else { "false" }))
                         .collect::<LargeStringArray>(),
                 ))
             }

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -4764,6 +4764,26 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_bool_to_utf8() {
+        let array = BooleanArray::from(vec![Some(true), Some(false), None]);
+        let b = cast(&array, &DataType::Utf8).unwrap();
+        let c = b.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!("true", c.value(0));
+        assert_eq!("false", c.value(1));
+        assert!(!c.is_valid(2));
+    }
+
+    #[test]
+    fn test_cast_bool_to_large_utf8() {
+        let array = BooleanArray::from(vec![Some(true), Some(false), None]);
+        let b = cast(&array, &DataType::LargeUtf8).unwrap();
+        let c = b.as_any().downcast_ref::<LargeStringArray>().unwrap();
+        assert_eq!("true", c.value(0));
+        assert_eq!("false", c.value(1));
+        assert!(!c.is_valid(2));
+    }
+
+    #[test]
     fn test_cast_bool_to_f64() {
         let array = BooleanArray::from(vec![Some(true), Some(false), None]);
         let b = cast(&array, &DataType::Float64).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

More intuitive values for default bool-to-string conversion

# Rationale for this change
 
It's non very obvious that bool will be converted to `1` or `0`, I imagine that the main case for such casting would be comparison with string, which I guess should be done using a direct string representation of bool like `true` & `false`

# What changes are included in this PR?

The default behavior for bool casting to string

# Are there any user-facing changes?

Yes
