### PR TITLE
Minor: Improve API docs for FlightSQL metadata builders

### DIFF
--- a/arrow-flight/src/sql/metadata/mod.rs
+++ b/arrow-flight/src/sql/metadata/mod.rs
@@ -21,10 +21,14 @@
 //! - [`GetCatalogsBuilder`] for building responses to [`CommandGetCatalogs`] queries.
 //! - [`GetDbSchemasBuilder`] for building responses to [`CommandGetDbSchemas`] queries.
 //! - [`GetTablesBuilder`]for building responses to [`CommandGetTables`] queries.
+//! - [`SqlInfoDataBuilder`]for building responses to [`CommandGetSqlInfo`] queries.
+//! - [`XdbcTypeInfoDataBuilder`]for building responses to [`CommandGetXdbcTypeInfo`] queries.
 //!
 //! [`CommandGetCatalogs`]: crate::sql::CommandGetCatalogs
 //! [`CommandGetDbSchemas`]: crate::sql::CommandGetDbSchemas
 //! [`CommandGetTables`]: crate::sql::CommandGetTables
+//! [`CommandGetSqlInfo`]: crate::sql::CommandGetSqlInfo
+//! [`CommandGetXdbcTypeInfo`]: crate::sql::CommandGetXdbcTypeInfo
 
 mod catalogs;
 mod db_schemas;

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -334,8 +334,8 @@ impl SqlInfoUnionBuilder {
 /// [`CommandGetSqlInfo`] are metadata requests used by a Flight SQL
 /// server to communicate supported capabilities to Flight SQL clients.
 ///
-/// Servers constuct - usually static - [`SqlInfoData`] via the [SqlInfoDataBuilder`],
-/// and build responses by passing the [`GetSqlInfoBuilder`].
+/// Servers constuct - usually static - [`SqlInfoData`] via the [`SqlInfoDataBuilder`],
+/// and build responses using [`CommandGetSqlInfo::into_builder`]
 #[derive(Debug, Clone, PartialEq)]
 pub struct SqlInfoDataBuilder {
     /// Use BTreeMap to ensure the values are sorted by value as

--- a/arrow-flight/src/sql/metadata/xdbc_info.rs
+++ b/arrow-flight/src/sql/metadata/xdbc_info.rs
@@ -70,8 +70,8 @@ pub struct XdbcTypeInfo {
 /// [`CommandGetXdbcTypeInfo`] are metadata requests used by a Flight SQL
 /// server to communicate supported capabilities to Flight SQL clients.
 ///
-/// Servers constuct - usually static - [`XdbcTypeInfoData`] via the [XdbcTypeInfoDataBuilder`],
-/// and build responses by passing the [`GetXdbcTypeInfoBuilder`].
+/// Servers constuct - usually static - [`XdbcTypeInfoData`] via the [`XdbcTypeInfoDataBuilder`],
+/// and build responses using [`CommandGetXdbcTypeInfo::into_builder`].
 pub struct XdbcTypeInfoData {
     batch: RecordBatch,
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/a

# Rationale for this change
 
When updating IOx to use some of these APIs in https://github.com/influxdata/influxdb_iox/pull/8455 and https://github.com/influxdata/influxdb_iox/pull/8453 I notices some documentation inconsistencies. 

# What changes are included in this PR?

Update doc APIs

# Are there any user-facing changes?

better docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
