### PR TITLE
Fix equality of nested nullable FixedSizeBinary (#4637)

### DIFF
--- a/arrow-data/src/equal/fixed_binary.rs
+++ b/arrow-data/src/equal/fixed_binary.rs
@@ -80,7 +80,7 @@ pub(super) fn fixed_binary_equal(
                 lhs_start + lhs_nulls.offset(),
                 len,
             );
-            let rhs_nulls = lhs.nulls().unwrap();
+            let rhs_nulls = rhs.nulls().unwrap();
             let rhs_slices_iter = BitSliceIterator::new(
                 rhs_nulls.validity(),
                 rhs_start + rhs_nulls.offset(),

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -1295,3 +1295,25 @@ fn test_struct_equal_slice() {
 
     test_equal(&a, &b, true);
 }
+
+#[test]
+fn test_list_excess_children_equal() {
+    let mut a = ListBuilder::new(FixedSizeBinaryBuilder::new(5));
+    a.values().append_value(b"11111").unwrap(); // Masked value
+    a.append_null();
+    a.values().append_value(b"22222").unwrap();
+    a.values().append_null();
+    a.append(true);
+    let a = a.finish();
+
+    let mut b = ListBuilder::new(FixedSizeBinaryBuilder::new(5));
+    b.append_null();
+    b.values().append_value(b"22222").unwrap();
+    b.values().append_null();
+    b.append(true);
+    let b = b.finish();
+
+    assert_eq!(a.value_offsets(), &[0, 1, 3]);
+    assert_eq!(b.value_offsets(), &[0, 0, 2]);
+    assert_eq!(a, b);
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4637

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
