### PR TITLE
Add range and ObjectMeta to GetResult (#4352) (#4495)

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -374,8 +374,6 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     }
 
     /// Perform a get request with options
-    ///
-    /// Note: options.range will be ignored if [`GetResult::File`]
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult>;
 
     /// Return the bytes that are stored at the specified location
@@ -806,8 +804,8 @@ impl GetResult {
 
     /// Converts this into a byte stream
     ///
-    /// If the result is [`Self::File`] will perform chunked reads of the file, otherwise
-    /// will return the [`Self::Stream`].
+    /// If the `self.kind` is [`GetResultPayload::File`] will perform chunked reads of the file,
+    /// otherwise will return the [`GetResultPayload::Stream`].
     ///
     /// # Tokio Compatibility
     ///

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -800,7 +800,8 @@ impl GetResult {
         match self.payload {
             #[cfg(not(target_arch = "wasm32"))]
             GetResultPayload::File(file, path) => {
-                local::chunked_stream(file, path, self.range, 8 * 1024)
+                const CHUNK_SIZE: usize = 8 * 1024;
+                local::chunked_stream(file, path, self.range, CHUNK_SIZE)
             }
             GetResultPayload::Stream(s) => s,
             #[cfg(target_arch = "wasm32")]

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -363,17 +363,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
             range: Some(range.clone()),
             ..Default::default()
         };
-        // Temporary until GetResult::File supports range (#4352)
-        match self.get_opts(location, options).await? {
-            GetResult::Stream(s) => collect_bytes(s, None).await,
-            #[cfg(not(target_arch = "wasm32"))]
-            GetResult::File(mut file, path) => {
-                maybe_spawn_blocking(move || local::read_range(&mut file, &path, range))
-                    .await
-            }
-            #[cfg(target_arch = "wasm32")]
-            _ => unimplemented!("File IO not implemented on wasm32."),
-        }
+        self.get_opts(location, options).await?.bytes().await
     }
 
     /// Return the bytes that are stored at the specified location
@@ -729,21 +719,32 @@ impl GetOptions {
 }
 
 /// Result for a get request
+#[derive(Debug)]
+pub struct GetResult {
+    /// The [`GetResultPayload`]
+    pub payload: GetResultPayload,
+    /// The [`ObjectMeta`] for this object
+    pub meta: ObjectMeta,
+    /// The range of bytes returned by this request
+    pub range: Range<usize>,
+}
+
+/// The kind of a [`GetResult`]
 ///
 /// This special cases the case of a local file, as some systems may
 /// be able to optimise the case of a file already present on local disk
-pub enum GetResult {
-    /// A file and its path on the local filesystem
+pub enum GetResultPayload {
+    /// The file, path
     File(std::fs::File, std::path::PathBuf),
-    /// An asynchronous stream
+    /// An opaque stream of bytes
     Stream(BoxStream<'static, Result<Bytes>>),
 }
 
-impl Debug for GetResult {
+impl Debug for GetResultPayload {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::File(_, _) => write!(f, "GetResult(File)"),
-            Self::Stream(_) => write!(f, "GetResult(Stream)"),
+            Self::File(_, _) => write!(f, "GetResultPayload(File)"),
+            Self::Stream(_) => write!(f, "GetResultPayload(Stream)"),
         }
     }
 }
@@ -751,32 +752,31 @@ impl Debug for GetResult {
 impl GetResult {
     /// Collects the data into a [`Bytes`]
     pub async fn bytes(self) -> Result<Bytes> {
-        match self {
+        let len = self.range.end - self.range.start;
+        match self.payload {
             #[cfg(not(target_arch = "wasm32"))]
-            Self::File(mut file, path) => {
+            GetResultPayload::File(mut file, path) => {
                 maybe_spawn_blocking(move || {
-                    let len = file.seek(SeekFrom::End(0)).map_err(|source| {
-                        local::Error::Seek {
+                    file.seek(SeekFrom::Start(self.range.start as _)).map_err(
+                        |source| local::Error::Seek {
                             source,
                             path: path.clone(),
-                        }
-                    })?;
+                        },
+                    )?;
 
-                    file.rewind().map_err(|source| local::Error::Seek {
-                        source,
-                        path: path.clone(),
-                    })?;
-
-                    let mut buffer = Vec::with_capacity(len as usize);
-                    file.read_to_end(&mut buffer).map_err(|source| {
-                        local::Error::UnableToReadBytes { source, path }
-                    })?;
+                    let mut buffer = Vec::with_capacity(len);
+                    file.take(len as _)
+                        .read_to_end(&mut buffer)
+                        .map_err(|source| local::Error::UnableToReadBytes {
+                            source,
+                            path,
+                        })?;
 
                     Ok(buffer.into())
                 })
                 .await
             }
-            Self::Stream(s) => collect_bytes(s, None).await,
+            GetResultPayload::Stream(s) => collect_bytes(s, Some(len)).await,
             #[cfg(target_arch = "wasm32")]
             _ => unimplemented!("File IO not implemented on wasm32."),
         }
@@ -797,36 +797,12 @@ impl GetResult {
     /// If not called from a tokio context, this will perform IO on the current thread with
     /// no additional complexity or overheads
     pub fn into_stream(self) -> BoxStream<'static, Result<Bytes>> {
-        match self {
+        match self.payload {
             #[cfg(not(target_arch = "wasm32"))]
-            Self::File(file, path) => {
-                const CHUNK_SIZE: usize = 8 * 1024;
-
-                futures::stream::try_unfold(
-                    (file, path, false),
-                    |(mut file, path, finished)| {
-                        maybe_spawn_blocking(move || {
-                            if finished {
-                                return Ok(None);
-                            }
-
-                            let mut buffer = Vec::with_capacity(CHUNK_SIZE);
-                            let read = file
-                                .by_ref()
-                                .take(CHUNK_SIZE as u64)
-                                .read_to_end(&mut buffer)
-                                .map_err(|e| local::Error::UnableToReadBytes {
-                                    source: e,
-                                    path: path.clone(),
-                                })?;
-
-                            Ok(Some((buffer.into(), (file, path, read != CHUNK_SIZE))))
-                        })
-                    },
-                )
-                .boxed()
+            GetResultPayload::File(file, path) => {
+                local::chunked_stream(file, path, self.range, 8 * 1024)
             }
-            Self::Stream(s) => s,
+            GetResultPayload::Stream(s) => s,
             #[cfg(target_arch = "wasm32")]
             _ => unimplemented!("File IO not implemented on wasm32."),
         }

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -19,16 +19,17 @@
 use crate::{
     maybe_spawn_blocking,
     path::{absolute_path_to_url, Path},
-    GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result,
+    GetOptions, GetResult, GetResultPayload, ListResult, MultipartId, ObjectMeta,
+    ObjectStore, Result,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
-use futures::FutureExt;
 use futures::{stream::BoxStream, StreamExt};
+use futures::{FutureExt, TryStreamExt};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use std::fs::{metadata, symlink_metadata, File, OpenOptions};
+use std::fs::{metadata, symlink_metadata, File, Metadata, OpenOptions};
 use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::pin::Pin;
@@ -370,18 +371,20 @@ impl ObjectStore for LocalFileSystem {
         let location = location.clone();
         let path = self.config.path_to_filesystem(&location)?;
         maybe_spawn_blocking(move || {
-            let file = open_file(&path)?;
+            let (file, metadata) = open_file(&path)?;
             if options.if_unmodified_since.is_some()
                 || options.if_modified_since.is_some()
             {
-                let metadata = file.metadata().map_err(|e| Error::Metadata {
-                    source: e.into(),
-                    path: location.to_string(),
-                })?;
                 options.check_modified(&location, last_modified(&metadata))?;
             }
 
-            Ok(GetResult::File(file, path))
+            let meta = convert_metadata(metadata, location)?;
+
+            Ok(GetResult {
+                payload: GetResultPayload::File(file, path),
+                range: options.range.unwrap_or(0..meta.size),
+                meta,
+            })
         })
         .await
     }
@@ -389,7 +392,7 @@ impl ObjectStore for LocalFileSystem {
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let path = self.config.path_to_filesystem(location)?;
         maybe_spawn_blocking(move || {
-            let mut file = open_file(&path)?;
+            let (mut file, _) = open_file(&path)?;
             read_range(&mut file, &path, range)
         })
         .await
@@ -404,7 +407,7 @@ impl ObjectStore for LocalFileSystem {
         let ranges = ranges.to_vec();
         maybe_spawn_blocking(move || {
             // Vectored IO might be faster
-            let mut file = open_file(&path)?;
+            let (mut file, _) = open_file(&path)?;
             ranges
                 .into_iter()
                 .map(|r| read_range(&mut file, &path, r))
@@ -863,7 +866,56 @@ impl AsyncWrite for LocalUpload {
     }
 }
 
-pub(crate) fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<Bytes> {
+pub(crate) fn chunked_stream(
+    mut file: File,
+    path: PathBuf,
+    range: Range<usize>,
+    chunk_size: usize,
+) -> BoxStream<'static, Result<Bytes, super::Error>> {
+    futures::stream::once(async move {
+        let (file, path) = maybe_spawn_blocking(move || {
+            file.seek(SeekFrom::Start(range.start as _))
+                .map_err(|source| Error::Seek {
+                    source,
+                    path: path.clone(),
+                })?;
+            Ok((file, path))
+        })
+        .await?;
+
+        let stream = futures::stream::try_unfold(
+            (file, path, range.end - range.start),
+            move |(mut file, path, remaining)| {
+                maybe_spawn_blocking(move || {
+                    if remaining == 0 {
+                        return Ok(None);
+                    }
+
+                    let to_read = remaining.min(chunk_size);
+                    let mut buffer = Vec::with_capacity(to_read);
+                    let read = (&mut file)
+                        .take(to_read as u64)
+                        .read_to_end(&mut buffer)
+                        .map_err(|e| Error::UnableToReadBytes {
+                            source: e,
+                            path: path.clone(),
+                        })?;
+
+                    Ok(Some((buffer.into(), (file, path, remaining - read))))
+                })
+            },
+        );
+        Ok::<_, super::Error>(stream)
+    })
+    .try_flatten()
+    .boxed()
+}
+
+pub(crate) fn read_range(
+    file: &mut File,
+    path: &PathBuf,
+    range: Range<usize>,
+) -> Result<Bytes> {
     let to_read = range.end - range.start;
     file.seek(SeekFrom::Start(range.start as u64))
         .context(SeekSnafu { path })?;
@@ -885,8 +937,8 @@ pub(crate) fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -
     Ok(buf.into())
 }
 
-fn open_file(path: &PathBuf) -> Result<File> {
-    let file = match File::open(path).and_then(|f| Ok((f.metadata()?, f))) {
+fn open_file(path: &PathBuf) -> Result<(File, Metadata)> {
+    let ret = match File::open(path).and_then(|f| Ok((f.metadata()?, f))) {
         Err(e) => Err(match e.kind() {
             ErrorKind::NotFound => Error::NotFound {
                 path: path.clone(),
@@ -898,14 +950,14 @@ fn open_file(path: &PathBuf) -> Result<File> {
             },
         }),
         Ok((metadata, file)) => match !metadata.is_dir() {
-            true => Ok(file),
+            true => Ok((file, metadata)),
             false => Err(Error::NotFound {
                 path: path.clone(),
                 source: io::Error::new(ErrorKind::NotFound, "is directory"),
             }),
         },
     }?;
-    Ok(file)
+    Ok(ret)
 }
 
 fn convert_entry(entry: DirEntry, location: Path) -> Result<ObjectMeta> {
@@ -923,7 +975,7 @@ fn last_modified(metadata: &std::fs::Metadata) -> DateTime<Utc> {
         .into()
 }
 
-fn convert_metadata(metadata: std::fs::Metadata, location: Path) -> Result<ObjectMeta> {
+fn convert_metadata(metadata: Metadata, location: Path) -> Result<ObjectMeta> {
     let last_modified = last_modified(&metadata);
     let size = usize::try_from(metadata.len()).context(FileSizeOverflowedUsizeSnafu {
         path: location.as_ref(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4352 
Relates to #4495

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Not including the byte range results in unexpected behaviour of `GetResult::bytes`.

Additionally it is beneficial to return the `ObjectMeta` alongside the returned data, as this is effectively free, and can be useful for additional data validation

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
