### PR TITLE
Validate ArrayData Buffer Alignment and Automatically Align IPC buffers (#4255)

### DIFF
--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -1037,13 +1037,17 @@ mod tests {
     #[should_panic(
         expected = "Memory pointer is not aligned with the specified scalar type"
     )]
+    // Different error messages, so skip for now
+    // https://github.com/apache/arrow-rs/issues/1545
+    #[cfg(not(feature = "force_validate"))]
     fn test_primitive_array_alignment() {
         let buf = Buffer::from_slice_ref([0_u64]);
         let buf2 = buf.slice(1);
-        let array_data = ArrayData::builder(DataType::Int32)
-            .add_buffer(buf2)
-            .build()
-            .unwrap();
+        let array_data = unsafe {
+            ArrayData::builder(DataType::Int32)
+                .add_buffer(buf2)
+                .build_unchecked()
+        };
         drop(Int32Array::from(array_data));
     }
 

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -1494,7 +1494,6 @@ pub type LargeBinaryType = GenericBinaryType<i64>;
 mod tests {
     use super::*;
     use arrow_data::{layout, BufferSpec};
-    use std::mem::size_of;
 
     #[test]
     fn month_day_nano_should_roundtrip() {
@@ -1541,7 +1540,8 @@ mod tests {
         assert_eq!(
             spec,
             &BufferSpec::FixedWidth {
-                byte_width: size_of::<T::Native>()
+                byte_width: std::mem::size_of::<T::Native>(),
+                alignment: std::mem::align_of::<T::Native>(),
             }
         );
     }

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -766,10 +766,11 @@ impl ArrayData {
                         )));
                     }
 
-                    if buffer.as_ptr().align_offset(*alignment) != 0 {
+                    let align_offset = buffer.as_ptr().align_offset(*alignment);
+                    if align_offset != 0 {
                         return Err(ArrowError::InvalidArgumentError(format!(
-                            "Misaligned buffers[{i}] in array of type {:?}, expected {alignment}",
-                            self.data_type,
+                            "Misaligned buffers[{i}] in array of type {:?}, offset from expected alignment of {alignment} by {}",
+                            self.data_type, align_offset.min(alignment - align_offset)
                         )));
                     }
                 }
@@ -2116,7 +2117,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Invalid argument error: Misaligned buffers[0] in array of type Int32, expected 4"
+            "Invalid argument error: Misaligned buffers[0] in array of type Int32, offset from expected alignment of 4 by 1"
         );
 
         data.align_buffers();

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1146,7 +1146,7 @@ fn buffer_need_truncate(
 #[inline]
 fn get_buffer_element_width(spec: &BufferSpec) -> usize {
     match spec {
-        BufferSpec::FixedWidth { byte_width } => *byte_width,
+        BufferSpec::FixedWidth { byte_width, .. } => *byte_width,
         _ => 0,
     }
 }

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -56,7 +56,9 @@ fn test_bad_number_of_buffers() {
 }
 
 #[test]
-#[should_panic(expected = "Need at least 18446744073709551615 bytes in buffers[0] in array of type Int64, but got 8")]
+#[should_panic(
+    expected = "Need at least 18446744073709551615 bytes in buffers[0] in array of type Int64, but got 8"
+)]
 fn test_fixed_width_overflow() {
     let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(DataType::Int64, usize::MAX, None, 0, vec![buffer], vec![])

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -56,7 +56,7 @@ fn test_bad_number_of_buffers() {
 }
 
 #[test]
-#[should_panic(expected = "integer overflow computing min buffer size")]
+#[should_panic(expected = "Need at least 18446744073709551615 bytes in buffers[0] in array of type Int64, but got 8")]
 fn test_fixed_width_overflow() {
     let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(DataType::Int64, usize::MAX, None, 0, vec![buffer], vec![])


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4255

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This will allow zero-copy IPC (#4254), whilst also acting as an escape valve for issues like https://github.com/apache/arrow/issues/32276 where arrow-cpp produces unaligned buffers

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
