### PR TITLE
Minor: improve object_store docs.rs library landing page

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -28,10 +28,32 @@
 
 //! # object_store
 //!
-//! This crate provides a uniform API for interacting with object storage services and
-//! local files via the the [`ObjectStore`] trait.
+//! This crate provides a uniform API for interacting with object
+//! storage services and local files via the [`ObjectStore`]
+//! trait.
 //!
-//! # Create an [`ObjectStore`] implementation:
+//! Using this crate, the same binary and code can run in multiple
+//! clouds and local test environments, via a simple runtime
+//! configuration change.
+//!
+//! # Features:
+//!
+//! 1. A focused, easy to use, idiomatic, well documented, high
+//! performance, `async` API.
+//!
+//! 2. Production quality, leading this crate to be used in large
+//! scale production systems, such as [crates.io] and [InfluxDB IOx].
+//!
+//! 3. Stable and predictable governance via the [Apache Arrow] project.
+//!
+//! Originally developed for [InfluxDB IOx] and subsequently donated
+//! to [Apache Arrow].
+//!
+//! [Apache Arrow]: https://arrow.apache.org/
+//! [InfluxDB IOx]: https://github.com/influxdata/influxdb_iox/
+//! [crates.io]: https://github.com/rust-lang/crates.io
+//!
+//! # Example: Create an [`ObjectStore`] implementation:
 //!
 #![cfg_attr(
     feature = "gcp",


### PR DESCRIPTION
# Which issue does this PR close?

N/A
# Rationale for this change

While reviewing the docs.rs page for this crate, I realized its description was sparse and prospective users might not be able to figure out quickly if they should invest the time looking at the crate more carefully. 

# What changes are included in this PR?

Changes https://docs.rs/object_store/0.6.1/object_store/ to add content from https://github.com/apache/arrow-rs/blob/master/object_store/README.md

Old look
<img width="1417" alt="Screenshot 2023-08-11 at 7 04 06 AM" src="https://github.com/apache/arrow-rs/assets/490673/87c440bc-be46-45e6-850d-578dec47d911">

New look:

<img width="1254" alt="Screenshot 2023-08-11 at 7 06 41 AM" src="https://github.com/apache/arrow-rs/assets/490673/a3bc720f-91c7-4970-970c-b06f1d0e5af3">


# Are there any user-facing changes?

Different landing page from docs.rs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
