### PR TITLE
Fix object_store docs and Add CI job 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
-        RUSTDOCFLAGS: "-Dwarnings"
+        RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
-        RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
+        RUSTDOCFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -66,6 +66,10 @@ jobs:
         run: cargo clippy --all-features --all-targets -- -D warnings
 
   # test doc links still work
+  #
+  # Note that since object_store is not part of the main workspace,
+  # this needs a separate docs job as it is not covered by
+  # `cargo doc --workspace`
   docs:
     name: Rustdocs
     runs-on: ubuntu-latest

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -65,6 +65,20 @@ jobs:
       - name: Run clippy with all features and all targets
         run: cargo clippy --all-features --all-targets -- -D warnings
 
+  # test doc links still work
+  docs:
+    name: Rustdocs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: object_store
+      env:
+        RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run cargo doc
+        run: cargo doc --document-private-items --no-deps --workspace --all-features
+
   # test the crate
   # This runs outside a container to workaround lack of support for passing arguments
   # to service containers - https://github.com/orgs/community/discussions/26688

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -73,7 +73,7 @@ jobs:
       run:
         working-directory: object_store
     env:
-      RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
+      RUSTDOCFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v3
       - name: Run cargo doc

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -72,8 +72,8 @@ jobs:
     defaults:
       run:
         working-directory: object_store
-      env:
-        RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
+    env:
+      RUSTDOCFLAGS: "-Dwarnings --enable-index-page -Zunstable-options"
     steps:
       - uses: actions/checkout@v3
       - name: Run cargo doc

--- a/object_store/src/aws/copy.rs
+++ b/object_store/src/aws/copy.rs
@@ -17,7 +17,10 @@
 
 use crate::config::Parse;
 
-/// Configure how to provide [`ObjectStore::copy_if_not_exists`] for [`AmazonS3`]
+/// Configure how to provide [`ObjectStore::copy_if_not_exists`] for
+/// `AmazonS3`.
+///
+/// [`ObjectStore::copy_if_not_exists`]: crate::ObjectStore::copy_if_not_exists
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum S3CopyIfNotExists {
@@ -32,6 +35,8 @@ pub enum S3CopyIfNotExists {
     ///
     /// For example `header: cf-copy-destination-if-none-match: *`, would set
     /// the header `cf-copy-destination-if-none-match` to `*`
+    ///
+    /// [`ObjectStore::copy_if_not_exists`]: crate::ObjectStore::copy_if_not_exists
     Header(String, String),
 }
 

--- a/object_store/src/aws/copy.rs
+++ b/object_store/src/aws/copy.rs
@@ -18,9 +18,10 @@
 use crate::config::Parse;
 
 /// Configure how to provide [`ObjectStore::copy_if_not_exists`] for
-/// `AmazonS3`.
+/// [`AmazonS3`].
 ///
 /// [`ObjectStore::copy_if_not_exists`]: crate::ObjectStore::copy_if_not_exists
+/// [`AmazonS3`]: super::AmazonS3
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum S3CopyIfNotExists {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/4683

# Rationale for this change
 
Docs are important and we don't want to find out they are broken after releasing a crate to crates.io

# What changes are included in this PR?
1. Add CI job
2. Fix documentation errors preventing a clean CI run

# Are there any user-facing changes?
No

Example CI failure: https://github.com/apache/arrow-rs/actions/runs/5832061836/job/15816723694?pr=4684
Example CI pass: https://github.com/apache/arrow-rs/actions/runs/5832147821/job/15816978755?pr=4684

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
