### PR TITLE
Improve `Array` Logical Nullability

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -198,7 +198,7 @@ where
         return Ok(PrimitiveArray::from(ArrayData::new_empty(&O::DATA_TYPE)));
     }
 
-    let nulls = NullBuffer::union(a.nulls(), b.nulls());
+    let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
     let values = a.values().iter().zip(b.values()).map(|(l, r)| op(*l, *r));
     // JUSTIFICATION
@@ -248,7 +248,7 @@ where
         ))));
     }
 
-    let nulls = NullBuffer::union(a.nulls(), b.nulls());
+    let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
     let mut builder = a.into_builder()?;
 
@@ -296,7 +296,9 @@ where
     if a.null_count() == 0 && b.null_count() == 0 {
         try_binary_no_nulls(len, a, b, op)
     } else {
-        let nulls = NullBuffer::union(a.nulls(), b.nulls()).unwrap();
+        let nulls =
+            NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref())
+                .unwrap();
 
         let mut buffer = BufferBuilder::<O::Native>::new(len);
         buffer.append_n_zeroed(len);
@@ -355,7 +357,10 @@ where
     if a.null_count() == 0 && b.null_count() == 0 {
         try_binary_no_nulls_mut(len, a, b, op)
     } else {
-        let nulls = NullBuffer::union(a.nulls(), b.nulls()).unwrap();
+        let nulls =
+            NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref())
+                .unwrap();
+
         let mut builder = a.into_builder()?;
 
         let slice = builder.values_slice_mut();

--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -25,7 +25,7 @@
 use arrow_array::*;
 use arrow_buffer::buffer::{bitwise_bin_op_helper, bitwise_quaternary_op_helper};
 use arrow_buffer::{BooleanBuffer, NullBuffer};
-use arrow_schema::{ArrowError, DataType};
+use arrow_schema::ArrowError;
 
 /// Logical 'and' boolean values with Kleene logic
 ///
@@ -311,11 +311,7 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray, ArrowError> {
 /// assert_eq!(a_is_null, BooleanArray::from(vec![false, false, true]));
 /// ```
 pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
-    let values = match input.nulls() {
-        // NullArray has no nulls buffer yet all values are null
-        None if input.data_type() == &DataType::Null => {
-            BooleanBuffer::new_set(input.len())
-        }
+    let values = match input.logical_nulls() {
         None => BooleanBuffer::new_unset(input.len()),
         Some(nulls) => !nulls.inner(),
     };
@@ -335,11 +331,7 @@ pub fn is_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
 /// assert_eq!(a_is_not_null, BooleanArray::from(vec![true, true, false]));
 /// ```
 pub fn is_not_null(input: &dyn Array) -> Result<BooleanArray, ArrowError> {
-    let values = match input.nulls() {
-        // NullArray has no nulls buffer yet all values are null
-        None if input.data_type() == &DataType::Null => {
-            BooleanBuffer::new_unset(input.len())
-        }
+    let values = match input.logical_nulls() {
         None => BooleanBuffer::new_set(input.len()),
         Some(n) => n.inner().clone(),
     };

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -205,7 +205,7 @@ impl BooleanArray {
     where
         F: FnMut(T::Item) -> bool,
     {
-        let nulls = left.nulls().cloned();
+        let nulls = left.logical_nulls();
         let values = BooleanBuffer::collect_bool(left.len(), |i| unsafe {
             // SAFETY: i in range 0..len
             op(left.value_unchecked(i))
@@ -239,7 +239,10 @@ impl BooleanArray {
     {
         assert_eq!(left.len(), right.len());
 
-        let nulls = NullBuffer::union(left.nulls(), right.nulls());
+        let nulls = NullBuffer::union(
+            left.logical_nulls().as_ref(),
+            right.logical_nulls().as_ref(),
+        );
         let values = BooleanBuffer::collect_bool(left.len(), |i| unsafe {
             // SAFETY: i in range 0..len
             op(left.value_unchecked(i), right.value_unchecked(i))

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -147,7 +147,7 @@ impl FixedSizeListArray {
     /// * `size < 0`
     /// * `values.len() / size != nulls.len()`
     /// * `values.data_type() != field.data_type()`
-    /// * `!field.is_nullable() && !nulls.expand(size).contains(values.nulls())`
+    /// * `!field.is_nullable() && !nulls.expand(size).contains(values.logical_nulls())`
     pub fn try_new(
         field: FieldRef,
         size: i32,
@@ -181,11 +181,11 @@ impl FixedSizeListArray {
             )));
         }
 
-        if let Some(a) = values.nulls() {
+        if let Some(a) = values.logical_nulls() {
             let nulls_valid = field.is_nullable()
                 || nulls
                     .as_ref()
-                    .map(|n| n.expand(size as _).contains(a))
+                    .map(|n| n.expand(size as _).contains(&a))
                     .unwrap_or_default();
 
             if !nulls_valid {

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -161,7 +161,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     ///
     /// * `offsets.len() - 1 != nulls.len()`
     /// * `offsets.last() > values.len()`
-    /// * `!field.is_nullable() && values.null_count() != 0`
+    /// * `!field.is_nullable() && values.is_nullable()`
     /// * `field.data_type() != values.data_type()`
     pub fn try_new(
         field: FieldRef,
@@ -189,7 +189,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
                 )));
             }
         }
-        if !field.is_nullable() && values.null_count() != 0 {
+        if !field.is_nullable() && values.is_nullable() {
             return Err(ArrowError::InvalidArgumentError(format!(
                 "Non-nullable field of {}ListArray {:?} cannot contain nulls",
                 OffsetSize::PREFIX,

--- a/arrow-array/src/builder/null_builder.rs
+++ b/arrow-array/src/builder/null_builder.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// let arr = b.finish();
 ///
 /// assert_eq!(8, arr.len());
-/// assert_eq!(8, arr.null_count());
+/// assert_eq!(0, arr.null_count());
 /// ```
 #[derive(Debug)]
 pub struct NullBuilder {
@@ -160,7 +160,8 @@ mod tests {
         let arr = builder.finish();
         assert_eq!(20, arr.len());
         assert_eq!(0, arr.offset());
-        assert_eq!(20, arr.null_count());
+        assert_eq!(0, arr.null_count());
+        assert!(arr.is_nullable());
     }
 
     #[test]
@@ -170,10 +171,10 @@ mod tests {
         builder.append_empty_value();
         builder.append_empty_values(3);
         let mut array = builder.finish_cloned();
-        assert_eq!(21, array.null_count());
+        assert_eq!(21, array.len());
 
         builder.append_empty_values(5);
         array = builder.finish();
-        assert_eq!(26, array.null_count());
+        assert_eq!(26, array.len());
     }
 }

--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -22,6 +22,7 @@ use crate::array::{
     GenericListArray, GenericStringArray, PrimitiveArray,
 };
 use crate::{FixedSizeListArray, MapArray};
+use arrow_buffer::NullBuffer;
 
 /// An iterator that returns Some(T) or None, that can be used on any [`ArrayAccessor`]
 ///
@@ -46,6 +47,7 @@ use crate::{FixedSizeListArray, MapArray};
 #[derive(Debug)]
 pub struct ArrayIter<T: ArrayAccessor> {
     array: T,
+    logical_nulls: Option<NullBuffer>,
     current: usize,
     current_end: usize,
 }
@@ -54,11 +56,21 @@ impl<T: ArrayAccessor> ArrayIter<T> {
     /// create a new iterator
     pub fn new(array: T) -> Self {
         let len = array.len();
+        let logical_nulls = array.logical_nulls();
         ArrayIter {
             array,
+            logical_nulls,
             current: 0,
             current_end: len,
         }
+    }
+
+    #[inline]
+    fn is_null(&self, idx: usize) -> bool {
+        self.logical_nulls
+            .as_ref()
+            .map(|x| x.is_null(idx))
+            .unwrap_or_default()
     }
 }
 
@@ -69,7 +81,7 @@ impl<T: ArrayAccessor> Iterator for ArrayIter<T> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current == self.current_end {
             None
-        } else if self.array.is_null(self.current) {
+        } else if self.is_null(self.current) {
             self.current += 1;
             Some(None)
         } else {
@@ -98,7 +110,7 @@ impl<T: ArrayAccessor> DoubleEndedIterator for ArrayIter<T> {
             None
         } else {
             self.current_end -= 1;
-            Some(if self.array.is_null(self.current_end) {
+            Some(if self.is_null(self.current_end) {
                 None
             } else {
                 // Safety:

--- a/arrow-buffer/src/builder/boolean.rs
+++ b/arrow-buffer/src/builder/boolean.rs
@@ -203,6 +203,12 @@ impl BooleanBufferBuilder {
         );
     }
 
+    /// Append [`BooleanBuffer`] to this [`BooleanBufferBuilder`]
+    pub fn append_buffer(&mut self, buffer: &BooleanBuffer) {
+        let range = buffer.offset()..buffer.offset() + buffer.len();
+        self.append_packed_range(range, buffer.values())
+    }
+
     /// Returns the packed bits
     pub fn as_slice(&self) -> &[u8] {
         self.buffer.as_slice()

--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -7233,9 +7233,8 @@ mod tests {
         assert_eq!(array.data_type(), &data_type);
         let cast_array = cast(&array, &DataType::Null).expect("cast failed");
         assert_eq!(cast_array.data_type(), &DataType::Null);
-        for i in 0..4 {
-            assert!(cast_array.is_null(i));
-        }
+        assert_eq!(cast_array.len(), 4);
+        assert_eq!(cast_array.logical_nulls().unwrap().null_count(), 4);
     }
 
     #[test]

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -6352,4 +6352,18 @@ mod tests {
             .to_string()
             .contains("Could not convert ToType with to_i128"));
     }
+
+    #[test]
+    #[cfg(feature = "dyn_cmp_dict")]
+    fn test_dictionary_nested_nulls() {
+        let keys = Int32Array::from(vec![0, 1, 2]);
+        let v1 = Arc::new(Int32Array::from(vec![Some(0), None, Some(2)]));
+        let a = DictionaryArray::new(keys.clone(), v1);
+        let v2 = Arc::new(Int32Array::from(vec![None, Some(0), Some(2)]));
+        let b = DictionaryArray::new(keys, v2);
+
+        let r = eq_dyn(&a, &b).unwrap();
+        assert_eq!(r.null_count(), 2);
+        assert!(r.is_valid(2));
+    }
 }

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -581,7 +581,10 @@ where
         ));
     }
 
-    let nulls = NullBuffer::union(left.nulls(), right.nulls());
+    let nulls = NullBuffer::union(
+        left.logical_nulls().as_ref(),
+        right.logical_nulls().as_ref(),
+    );
 
     let mut result = BooleanBufferBuilder::new(left.len());
     for i in 0..left.len() {

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1965,7 +1965,7 @@ mod tests {
 
         assert_eq!(a.value(0).len(), 0);
         assert_eq!(a.value(2).len(), 2);
-        assert_eq!(a.value(2).null_count(), 2);
+        assert_eq!(a.value(2).logical_nulls().unwrap().null_count(), 2);
 
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
         roundtrip(batch, None);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4690
Closes #4689
Closes #4688
Closes #2687
Closes #4616 
Relates to #4565

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Various types have nullability that is not accurately reflected in their reported NullBuffer, this causes incorrect behaviour for various kernels that have special handling of the null buffers.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds two methods to Array:

* Array::logical_nulls - which computes the logical null mask
* Array::is_nullable - which only returns false if an array cannot contain nulls

This logical null mask can then be used in the places where the logic relies on logical nullability

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
