### PR TITLE
Add `with_proxy_ca_certificate` and `with_proxy_excludes`

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -946,6 +946,23 @@ impl AmazonS3Builder {
         self
     }
 
+    /// Set a trusted proxy CA certificate
+    pub fn with_proxy_ca_certificate(
+        mut self,
+        proxy_ca_certificate: impl Into<String>,
+    ) -> Self {
+        self.client_options = self
+            .client_options
+            .with_proxy_ca_certificate(proxy_ca_certificate);
+        self
+    }
+
+    /// Set a list of hosts to exclude from proxy connections
+    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
+        self
+    }
+
     /// Sets the client options, overriding any already set
     pub fn with_client_options(mut self, options: ClientOptions) -> Self {
         self.client_options = options;

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -958,8 +958,8 @@ impl AmazonS3Builder {
     }
 
     /// Set a list of hosts to exclude from proxy connections
-    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
-        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
+    pub fn with_proxy_excludes(mut self, proxy_excludes: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_excludes(proxy_excludes);
         self
     }
 

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -921,8 +921,8 @@ impl MicrosoftAzureBuilder {
     }
 
     /// Set a list of hosts to exclude from proxy connections
-    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
-        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
+    pub fn with_proxy_excludes(mut self, proxy_excludes: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_excludes(proxy_excludes);
         self
     }
 

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -436,7 +436,7 @@ pub enum AzureConfigKey {
 
     /// Use object store with url scheme account.dfs.fabric.microsoft.com
     ///
-    /// Supported keys:        
+    /// Supported keys:
     /// - `azure_use_fabric_endpoint`
     /// - `use_fabric_endpoint`
     UseFabricEndpoint,
@@ -906,6 +906,23 @@ impl MicrosoftAzureBuilder {
     /// Set the proxy_url to be used by the underlying client
     pub fn with_proxy_url(mut self, proxy_url: impl Into<String>) -> Self {
         self.client_options = self.client_options.with_proxy_url(proxy_url);
+        self
+    }
+
+    /// Set a trusted proxy CA certificate
+    pub fn with_proxy_ca_certificate(
+        mut self,
+        proxy_ca_certificate: impl Into<String>,
+    ) -> Self {
+        self.client_options = self
+            .client_options
+            .with_proxy_ca_certificate(proxy_ca_certificate);
+        self
+    }
+
+    /// Set a list of hosts to exclude from proxy connections
+    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
         self
     }
 

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -343,9 +343,24 @@ impl ClientOptions {
         self
     }
 
-    /// Set an HTTP proxy to use for requests
+    /// Set a proxy URL to use for requests
     pub fn with_proxy_url(mut self, proxy_url: impl Into<String>) -> Self {
         self.proxy_url = Some(proxy_url.into());
+        self
+    }
+
+    /// Set a trusted proxy CA certificate
+    pub fn with_proxy_ca_certificate(
+        mut self,
+        proxy_ca_certificate: impl Into<String>,
+    ) -> Self {
+        self.proxy_ca_certificate = Some(proxy_ca_certificate.into());
+        self
+    }
+
+    /// Set a list of hosts to exclude from proxy connections
+    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
+        self.proxy_exclude = Some(proxy_exclude.into());
         self
     }
 

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -106,7 +106,7 @@ pub enum ClientConfigKey {
     /// PEM-formatted CA certificate for proxy connections
     ProxyCaCertificate,
     /// List of hosts that bypass proxy
-    ProxyExclude,
+    ProxyExcludes,
     /// Request timeout
     ///
     /// The timeout is applied from when the request starts connecting until the
@@ -132,7 +132,7 @@ impl AsRef<str> for ClientConfigKey {
             Self::PoolMaxIdlePerHost => "pool_max_idle_per_host",
             Self::ProxyUrl => "proxy_url",
             Self::ProxyCaCertificate => "proxy_ca_certificate",
-            Self::ProxyExclude => "proxy_exclude",
+            Self::ProxyExcludes => "proxy_excludes",
             Self::Timeout => "timeout",
             Self::UserAgent => "user_agent",
         }
@@ -175,7 +175,7 @@ pub struct ClientOptions {
     default_headers: Option<HeaderMap>,
     proxy_url: Option<String>,
     proxy_ca_certificate: Option<String>,
-    proxy_exclude: Option<String>,
+    proxy_excludes: Option<String>,
     allow_http: ConfigValue<bool>,
     allow_insecure: ConfigValue<bool>,
     timeout: Option<ConfigValue<Duration>>,
@@ -227,7 +227,7 @@ impl ClientOptions {
             ClientConfigKey::ProxyCaCertificate => {
                 self.proxy_ca_certificate = Some(value.into())
             }
-            ClientConfigKey::ProxyExclude => self.proxy_exclude = Some(value.into()),
+            ClientConfigKey::ProxyExcludes => self.proxy_excludes = Some(value.into()),
             ClientConfigKey::Timeout => {
                 self.timeout = Some(ConfigValue::Deferred(value.into()))
             }
@@ -268,7 +268,7 @@ impl ClientOptions {
             }
             ClientConfigKey::ProxyUrl => self.proxy_url.clone(),
             ClientConfigKey::ProxyCaCertificate => self.proxy_ca_certificate.clone(),
-            ClientConfigKey::ProxyExclude => self.proxy_exclude.clone(),
+            ClientConfigKey::ProxyExcludes => self.proxy_excludes.clone(),
             ClientConfigKey::Timeout => self.timeout.as_ref().map(fmt_duration),
             ClientConfigKey::UserAgent => self
                 .user_agent
@@ -359,8 +359,8 @@ impl ClientOptions {
     }
 
     /// Set a list of hosts to exclude from proxy connections
-    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
-        self.proxy_exclude = Some(proxy_exclude.into());
+    pub fn with_proxy_excludes(mut self, proxy_excludes: impl Into<String>) -> Self {
+        self.proxy_excludes = Some(proxy_excludes.into());
         self
     }
 
@@ -468,8 +468,8 @@ impl ClientOptions {
                 builder = builder.add_root_certificate(certificate);
             }
 
-            if let Some(proxy_exclude) = &self.proxy_exclude {
-                let no_proxy = NoProxy::from_string(&proxy_exclude);
+            if let Some(proxy_excludes) = &self.proxy_excludes {
+                let no_proxy = NoProxy::from_string(&proxy_excludes);
 
                 proxy = proxy.no_proxy(no_proxy);
             }

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -469,7 +469,7 @@ impl ClientOptions {
             }
 
             if let Some(proxy_excludes) = &self.proxy_excludes {
-                let no_proxy = NoProxy::from_string(&proxy_excludes);
+                let no_proxy = NoProxy::from_string(proxy_excludes);
 
                 proxy = proxy.no_proxy(no_proxy);
             }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -1004,8 +1004,8 @@ impl GoogleCloudStorageBuilder {
     }
 
     /// Set a list of hosts to exclude from proxy connections
-    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
-        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
+    pub fn with_proxy_excludes(mut self, proxy_excludes: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_excludes(proxy_excludes);
         self
     }
 

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -992,6 +992,23 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
+    /// Set a trusted proxy CA certificate
+    pub fn with_proxy_ca_certificate(
+        mut self,
+        proxy_ca_certificate: impl Into<String>,
+    ) -> Self {
+        self.client_options = self
+            .client_options
+            .with_proxy_ca_certificate(proxy_ca_certificate);
+        self
+    }
+
+    /// Set a list of hosts to exclude from proxy connections
+    pub fn with_proxy_exclude(mut self, proxy_exclude: impl Into<String>) -> Self {
+        self.client_options = self.client_options.with_proxy_exclude(proxy_exclude);
+        self
+    }
+
     /// Sets the client options, overriding any already set
     pub fn with_client_options(mut self, options: ClientOptions) -> Self {
         self.client_options = options;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4713

# Rationale for this change
 
Currently, object_store has a `with_proxy_url` function that only accepts a URL. The underlying reqwest library supports more proxy options, such as proxy authentication and a 'no proxy' list, but these cannot be set in object_store.

# What changes are included in this PR?

Adds public API functions `with_proxy_ca_certificate` and `with_proxy_excludes` to allow a proxy CA certificate and proxy exclude list to be set.

# Are there any user-facing changes?

New API functions `with_proxy_ca_certificate` and `with_proxy_excludes`. The currently available `with_proxy_url` remains unchanged.
