### PR TITLE
Add a `CardinalityAwareRowConverter` 

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1470,9 +1470,8 @@ impl CardinalityAwareRowConverter {
         if !self.done {
             for (i, col) in columns.iter().enumerate() {
                 if let DataType::Dictionary(_, _) = col.data_type() {
-                    let cardinality = col.as_any().downcast_ref::<DictionaryArray<Int32Type>>().unwrap().keys().len();
-                    println!("cardinality: {}", cardinality);
-                    if cardinality >= 1 {
+                    let cardinality = col.as_any().downcast_ref::<DictionaryArray<Int32Type>>().unwrap().values().len();
+                    if cardinality >= 10 {
                         let mut sort_field = self.inner.fields[i].clone();
                         sort_field.preserve_dictionaries = false; 
                         self.inner.codecs[i] = Codec::new(&sort_field).unwrap();
@@ -1504,7 +1503,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cardinality() {
+    fn test_card_aware_row_converter() {
         let values = StringArray::from_iter_values(["a", "b", "c"]);
         let keys = Int32Array::from(vec![0, 0, 1, 2, 2, 1, 1, 0, 2]);
         let a: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).unwrap());
@@ -1528,8 +1527,6 @@ mod tests {
         let rows = converter.convert_columns(&cols).unwrap();
         let back = converter.convert_rows(&rows).unwrap();
         println!("{:?}", back);
-
-
     }
 
     fn test_fixed_width() {

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1455,6 +1455,8 @@ macro_rules! downcast_dict {
     }};
 }
 
+const LOW_CARDINALITY_THRESHOLD: usize = 10;
+
 #[derive(Debug)]
 pub struct CardinalityAwareRowConverter {
     inner: RowConverter,
@@ -1495,7 +1497,7 @@ impl CardinalityAwareRowConverter {
                         _ => unreachable!(),
                     };
 
-                    if cardinality >= 10 {
+                    if cardinality >= LOW_CARDINALITY_THRESHOLD {
                         let mut sort_field = self.inner.fields[i].clone();
                         sort_field.preserve_dictionaries = false; 
                         self.inner.codecs[i] = Codec::new(&sort_field).unwrap();

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -131,7 +131,7 @@ use std::sync::Arc;
 
 use arrow_array::cast::*;
 use arrow_array::*;
-use arrow_array::types::{ArrowDictionaryKeyType, ArrowPrimitiveType, Int32Type};
+use arrow_array::types::Int32Type;
 use arrow_buffer::ArrowNativeType;
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::*;

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1460,6 +1460,10 @@ impl CardinalityAwareRowConverter {
         })
     }
 
+    pub fn size(&self) -> usize {
+        self.inner.size()
+    }
+
     pub fn convert_rows(&self, rows: &Rows) -> Result<Vec<ArrayRef>, ArrowError> {
         self.inner.convert_rows(rows)
     }


### PR DESCRIPTION
# Which issue does this PR close?

This PR adds a `CardinalityAwareRowConverter` (a wrapper around `RowConverter`) to `arrow-row`. Basically, when the cardinality of dict-encoded sort fields is `>= 10`, we don't preserve dictionary encoding any more and fall back to using string encoding. 

Closes https://github.com/apache/arrow-datafusion/issues/7200.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
