### PR TITLE
Clear row buffer before reuse

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -981,9 +981,7 @@ impl Rows {
     /// Sets the length of this [`Rows`] to 0
     pub fn clear(&mut self) {
         self.offsets.truncate(1);
-        unsafe {
-            std::ptr::write_bytes(self.buffer.as_mut_ptr(), 0, self.buffer.len());
-        }
+        self.buffer.clear();
     }
 
     /// Returns the number of [`Row`] in this [`Rows`]

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -981,6 +981,9 @@ impl Rows {
     /// Sets the length of this [`Rows`] to 0
     pub fn clear(&mut self) {
         self.offsets.truncate(1);
+        unsafe {
+            std::ptr::write_bytes(self.buffer.as_mut_ptr(), 0, self.buffer.len());
+        }
     }
 
     /// Returns the number of [`Row`] in this [`Rows`]
@@ -2429,17 +2432,26 @@ mod tests {
             RowConverter::new(vec![SortField::new(DataType::Int32)]).unwrap();
         let mut rows = converter.empty_rows(3, 128);
 
-        let arrays = [
-            Int32Array::from(vec![None, Some(2), Some(4)]),
-            Int32Array::from(vec![Some(2), None, Some(4)]),
-        ];
+        let first = Int32Array::from(vec![None, Some(2), Some(4)]);
+        let second = Int32Array::from(vec![Some(2), None, Some(4)]);
+        let arrays = vec![Arc::new(first) as ArrayRef, Arc::new(second) as ArrayRef];
 
-        for array in arrays {
+        for array in arrays.iter() {
             rows.clear();
-            let array = Arc::new(array) as ArrayRef;
             converter.append(&mut rows, &[array.clone()]).unwrap();
             let back = converter.convert_rows(&rows).unwrap();
-            assert_eq!(&back[0], &array);
+            assert_eq!(&back[0], array);
+        }
+
+        let mut rows_expected = converter.empty_rows(3, 128);
+        converter.append(&mut rows_expected, &arrays[1..]).unwrap();
+
+        for (i, (actual, expected)) in rows.iter().zip(rows_expected.iter()).enumerate() {
+            assert_eq!(
+                actual, expected,
+                "For row {}: expected {:?}, actual: {:?}",
+                i, expected, actual
+            );
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4741.

# Rationale for this change
When reusing rows buffer, previous rows' fixed-length field content isn't cleared, causing the `Row` to become incomparable if a null value is written for the new row.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fill the `Rows` buffer with zero to keep the row comparable after buffer reuse.

# Are there any user-facing changes?
No.


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
