### PR TITLE
Implement PyArrowType for `Box<dyn RecordBatchReader + Send>`

### DIFF
--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -155,7 +155,7 @@ fn reader_return_errors(obj: PyArrowType<ArrowArrayStreamReader>) -> PyResult<()
 
 #[pyfunction]
 fn boxed_reader_roundtrip(
-    obj: PyArrowType<Box<dyn RecordBatchReader + Send>>,
+    obj: PyArrowType<ArrowArrayStreamReader>,
 ) -> PyArrowType<Box<dyn RecordBatchReader + Send>> {
     let schema = obj.0.schema();
     let batches = obj

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -409,6 +409,13 @@ def test_record_batch_reader():
     got_batches = list(b)
     assert got_batches == batches
 
+    # Also try the boxed reader variant
+    a = pa.RecordBatchReader.from_batches(schema, batches)
+    b = rust.boxed_reader_roundtrip(a)
+    assert b.schema == schema
+    got_batches = list(b)
+    assert got_batches == batches
+
 def test_record_batch_reader_error():
     schema = pa.schema([('ints', pa.list_(pa.int32()))])
 

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -375,7 +375,8 @@ pub mod pyarrow;
 
 pub mod record_batch {
     pub use arrow_array::{
-        RecordBatch, RecordBatchOptions, RecordBatchReader, RecordBatchWriter,
+        RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader,
+        RecordBatchWriter,
     };
 }
 pub use arrow_array::temporal_conversions;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4730.

I couldn't get it to work for a generic RBR, but it needs to be boxed anyways.


# Rationale for this change
 
Saves the user the step of creating an `ArrowArrayStreamReader` when exporting a record batch reader.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
