### PR TITLE
Return error when converting schema 

### DIFF
--- a/arrow/src/ffi_stream.rs
+++ b/arrow/src/ffi_stream.rs
@@ -281,7 +281,7 @@ fn get_stream_schema(stream_ptr: *mut FFI_ArrowArrayStream) -> Result<SchemaRef>
     let ret_code = unsafe { (*stream_ptr).get_schema.unwrap()(stream_ptr, &mut schema) };
 
     if ret_code == 0 {
-        let schema = Schema::try_from(&schema).unwrap();
+        let schema = Schema::try_from(&schema)?;
         Ok(Arc::new(schema))
     } else {
         Err(ArrowError::CDataInterface(format!(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4750.

# Rationale for this change
 
Some implementations allow invalid utf-8 sequences in metadata, so we should return an error when importing.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
