### PR TITLE
fix: avoid panic if offset index not exists.

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -480,7 +480,10 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
         let rg = self.metadata.row_group(rg_idx);
         let meta = rg.column(self.column_idx);
         let offset_index = self.metadata.offset_index();
-        let page_locations = offset_index.map(|i| i[rg_idx][self.column_idx].clone());
+        // `offset_index` may not exist and the inner `Vec` will be empty.
+        let page_locations = offset_index
+            .filter(|i| !i[rg_idx].is_empty())
+            .map(|i| i[rg_idx][self.column_idx].clone());
         let total_rows = rg.num_rows() as usize;
         let reader = self.reader.clone();
 

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -480,7 +480,8 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
         let rg = self.metadata.row_group(rg_idx);
         let meta = rg.column(self.column_idx);
         let offset_index = self.metadata.offset_index();
-        // `offset_index` may not exist and the inner `Vec` will be empty.
+        // `offset_index` may not exist and `i[rg_idx]` will be empty.
+        // To avoid `i[rg_idx][self.oolumn_idx`] panic, we need to filter out empty `i[rg_idx]`.
         let page_locations = offset_index
             .filter(|i| !i[rg_idx].is_empty())
             .map(|i| i[rg_idx][self.column_idx].clone());
@@ -2482,6 +2483,43 @@ mod tests {
             .unwrap();
         assert_ne!(1024, num_rows);
         assert_eq!(reader.batch_size, num_rows as usize);
+    }
+
+    #[test]
+    fn test_read_with_page_index_enabled() {
+        let testdata = arrow::util::test_util::parquet_test_data();
+
+        {
+            // `alltypes_tiny_pages.parquet` has page index
+            let path = format!("{testdata}/alltypes_tiny_pages.parquet");
+            let test_file = File::open(path).unwrap();
+            let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(
+                test_file,
+                ArrowReaderOptions::new().with_page_index(true),
+            )
+            .unwrap();
+            assert!(!builder.metadata().offset_index().unwrap()[0].is_empty());
+            let reader = builder.build().unwrap();
+            let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+            assert_eq!(batches.len(), 8);
+        }
+
+        {
+            // `alltypes_plain.parquet` doesn't have page index
+            let path = format!("{testdata}/alltypes_plain.parquet");
+            let test_file = File::open(path).unwrap();
+            let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(
+                test_file,
+                ArrowReaderOptions::new().with_page_index(true),
+            )
+            .unwrap();
+            // Although `Vec<Vec<PageLoacation>>` of each row group is empty,
+            // we should read the file successfully.
+            assert!(builder.metadata().offset_index().unwrap()[0].is_empty());
+            let reader = builder.build().unwrap();
+            let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+            assert_eq!(batches.len(), 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

`index_reader::read_pages_locations` will return an empty `Vec<PageLocation>` if there isn't an offset index:

```rust
pub fn read_pages_locations<R: ChunkReader>(
    reader: &R,
    chunks: &[ColumnChunkMetaData],
) -> Result<Vec<Vec<PageLocation>>, ParquetError> {
    let fetch = chunks
        .iter()
        .fold(None, |range, c| acc_range(range, c.offset_index_range()));

    let fetch = match fetch {
        Some(r) => r,
        None => return Ok(vec![]),
    };

    let bytes = reader.get_bytes(fetch.start as _, fetch.end - fetch.start)?;
    let get = |r: Range<usize>| &bytes[(r.start - fetch.start)..(r.end - fetch.start)];

    chunks
        .iter()
        .map(|c| match c.offset_index_range() {
            Some(r) => decode_offset_index(get(r)),
            None => Err(general_err!("missing offset index")),
        })
        .collect()
}
```

However, it will be set as a `Some(ParquetOffsetIndex)` to `ParquetMetaData`'s `offset_index`.

When we read data by a `ChunkReader`, we will get page locations of a column by `i[rg_idx][self.column_idx]`. But `i[rg_idx]` maybe empty and it will lead to panic!
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Check if `offset_index` is empty before getting `PageLocations` from it.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
