### PR TITLE
Remove unused dyn_cmp_dict feature

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Test arrow with default features
         run: cargo test -p arrow
       - name: Test arrow with all features apart from simd
-        run: cargo test -p arrow --features=force_validate,prettyprint,ipc_compression,ffi,dyn_cmp_dict,chrono-tz
+        run: cargo test -p arrow --features=force_validate,prettyprint,ipc_compression,ffi,chrono-tz
       - name: Run examples
         run: |
           # Test arrow examples
@@ -211,7 +211,7 @@ jobs:
       - name: Clippy arrow-row with all features
         run: cargo clippy -p arrow-row --all-targets --all-features -- -D warnings
       - name: Clippy arrow with all features except SIMD
-        run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,dyn_cmp_dict,chrono-tz --all-targets -- -D warnings
+        run: cargo clippy -p arrow --features=prettyprint,csv,ipc,test_utils,ffi,ipc_compression,chrono-tz --all-targets -- -D warnings
       - name: Clippy arrow-integration-test with all features
         run: cargo clippy -p arrow-integration-test --all-targets --all-features -- -D warnings
       - name: Clippy arrow-integration-testing with all features

--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -42,9 +42,3 @@ arrow-select = { workspace = true }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 regex-syntax = { version = "0.7.1", default-features = false, features = ["unicode"] }
 num = { version = "0.4", default-features = false, features = ["std"] }
-
-[package.metadata.docs.rs]
-all-features = true
-
-[features]
-dyn_cmp_dict = []

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -405,7 +405,6 @@ mod tests {
     macro_rules! test_dict_utf8 {
         ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
             #[test]
-            #[cfg(feature = "dyn_cmp_dict")]
             fn $test_name() {
                 let expected = BooleanArray::from($expected);
                 let left: DictionaryArray<Int8Type> = $left.into_iter().collect();

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -63,7 +63,7 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 pyo3 = { version = "0.19", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
-features = ["prettyprint", "ipc_compression", "dyn_cmp_dict", "ffi", "pyarrow"]
+features = ["prettyprint", "ipc_compression", "ffi", "pyarrow"]
 
 [features]
 default = ["csv", "ipc", "json"]
@@ -85,9 +85,6 @@ pyarrow = ["pyo3", "ffi"]
 force_validate = ["arrow-data/force_validate"]
 # Enable ffi support
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]
-# Enable dyn-comparison of dictionary arrays with other arrays
-# Note: this does not impact comparison against scalars
-dyn_cmp_dict = ["arrow-string/dyn_cmp_dict"]
 chrono-tz = ["arrow-array/chrono-tz"]
 
 [dev-dependencies]

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -54,7 +54,6 @@ The `arrow` crate provides the following features which may be enabled in your `
 - `chrono-tz` - support of parsing timezone using [chrono-tz](https://docs.rs/chrono-tz/0.6.0/chrono_tz/)
 - `ffi` - bindings for the Arrow C [C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html)
 - `pyarrow` - bindings for pyo3 to call arrow-rs from python
-- `dyn_cmp_dict` - enables comparison of dictionary arrays within dyn comparison kernels
 
 ## Arrow Feature Status
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

With the new Datum kernels (#4595) (#4595) which make use of `AnyDictionaryArray` (#4707), this feature is no longer necessary as the codegen explosion has been mitigated

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
