### PR TITLE
Allow custom tree builder for parquet::record::RowIter

### DIFF
--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -747,6 +747,12 @@ impl<'a> RowIter<'a> {
         }
     }
 
+    /// Sets tree builder for this row iter.
+    pub fn with_tree_builder(mut self, tree_builder: TreeBuilder) -> Self {
+        self.tree_builder = tree_builder;
+        self
+    }
+
     /// Returns common tree builder, so the same settings are applied to both iterators
     /// from file reader and row group.
     #[inline]

--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -747,9 +747,9 @@ impl<'a> RowIter<'a> {
         }
     }
 
-    /// Sets tree builder for this row iter.
-    pub fn with_tree_builder(mut self, tree_builder: TreeBuilder) -> Self {
-        self.tree_builder = tree_builder;
+    /// Sets batch size for this row iter.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.tree_builder = self.tree_builder.with_batch_size(batch_size);
         self
     }
 


### PR DESCRIPTION
It will allow to read parquet with custom batch_size. 
Currently the only possible batch_size for parquet::record::RowIter is 1024

Closes #4782
