### PR TITLE
Make coalesce_ranges and collect_bytes available for crate users

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -282,7 +282,7 @@ pub use parse::{parse_url, parse_url_opts};
 use crate::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::util::maybe_spawn_blocking;
-use crate::util::{coalesce_ranges, collect_bytes, OBJECT_STORE_COALESCE_DEFAULT};
+pub use crate::util::{coalesce_ranges, collect_bytes, OBJECT_STORE_COALESCE_DEFAULT};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};


### PR DESCRIPTION
# Which issue does this PR close?

I didn't create an issue

# Rationale for this change
 
Both `coalesce_ranges` and `collect_bytes` are useful for `AsyncFileReader` implementations that don't quite fit `object_store` interface, but address the same fundamental problem — fetching data from a remote location.

# What changes are included in this PR?

`coalesce_ranges`, `collect_bytes` and `OBJECT_STORE_COALESCE_DEFAULT` are made `pub use`
# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
