### PR TITLE
Fix flight sql do put handling, add bind parameter support to FlightSQL cli client

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use arrow_flight::sql::server::PeekableFlightDataStream;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use futures::stream::Peekable;
 use futures::{stream, Stream, TryStreamExt};
 use once_cell::sync::Lazy;
 use prost::Message;
@@ -603,7 +603,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_statement_update(
         &self,
         _ticket: CommandStatementUpdate,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Ok(FAKE_UPDATE_RESULT)
     }
@@ -611,7 +611,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_substrait_plan(
         &self,
         _ticket: CommandStatementSubstraitPlan,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_substrait_plan not implemented",
@@ -621,7 +621,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_prepared_statement_query(
         &self,
         _query: CommandPreparedStatementQuery,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_query not implemented",
@@ -631,7 +631,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_prepared_statement_update(
         &self,
         _query: CommandPreparedStatementUpdate,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_update not implemented",

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -17,6 +17,7 @@
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use futures::stream::Peekable;
 use futures::{stream, Stream, TryStreamExt};
 use once_cell::sync::Lazy;
 use prost::Message;
@@ -602,7 +603,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_statement_update(
         &self,
         _ticket: CommandStatementUpdate,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Ok(FAKE_UPDATE_RESULT)
     }
@@ -610,7 +611,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_substrait_plan(
         &self,
         _ticket: CommandStatementSubstraitPlan,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_substrait_plan not implemented",
@@ -620,7 +621,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_prepared_statement_query(
         &self,
         _query: CommandPreparedStatementQuery,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_query not implemented",
@@ -630,7 +631,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_prepared_statement_update(
         &self,
         _query: CommandPreparedStatementUpdate,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_update not implemented",

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -555,7 +555,7 @@ fn status_to_arrow_error(status: tonic::Status) -> ArrowError {
 fn flight_error_to_arrow_error(err: FlightError) -> ArrowError {
     match err {
         FlightError::Arrow(e) => e,
-        e => ArrowError::ExternalError(Box::new(e))
+        e => ArrowError::ExternalError(Box::new(e)),
     }
 }
 

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -555,11 +555,7 @@ fn status_to_arrow_error(status: tonic::Status) -> ArrowError {
 fn flight_error_to_arrow_error(err: FlightError) -> ArrowError {
     match err {
         FlightError::Arrow(e) => e,
-        FlightError::NotYetImplemented(s) => ArrowError::NotYetImplemented(s),
-        FlightError::Tonic(status) => status_to_arrow_error(status),
-        FlightError::ProtocolError(e) => ArrowError::IpcError(e),
-        FlightError::DecodeError(s) => ArrowError::IpcError(s),
-        FlightError::ExternalError(e) => ArrowError::ExternalError(e),
+        e => ArrowError::ExternalError(Box::new(e))
     }
 }
 

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -24,6 +24,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use tonic::metadata::AsciiMetadataKey;
 
+use crate::encode::FlightDataEncoderBuilder;
+use crate::error::FlightError;
 use crate::flight_service_client::FlightServiceClient;
 use crate::sql::server::{CLOSE_PREPARED_STATEMENT, CREATE_PREPARED_STATEMENT};
 use crate::sql::{
@@ -32,8 +34,8 @@ use crate::sql::{
     CommandGetCrossReference, CommandGetDbSchemas, CommandGetExportedKeys,
     CommandGetImportedKeys, CommandGetPrimaryKeys, CommandGetSqlInfo,
     CommandGetTableTypes, CommandGetTables, CommandGetXdbcTypeInfo,
-    CommandPreparedStatementQuery, CommandStatementQuery, CommandStatementUpdate,
-    DoPutUpdateResult, ProstMessageExt, SqlInfo,
+    CommandPreparedStatementQuery, CommandPreparedStatementUpdate, CommandStatementQuery,
+    CommandStatementUpdate, DoPutUpdateResult, ProstMessageExt, SqlInfo,
 };
 use crate::{
     Action, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest,
@@ -439,9 +441,12 @@ impl PreparedStatement<Channel> {
 
     /// Executes the prepared statement query on the server.
     pub async fn execute(&mut self) -> Result<FlightInfo, ArrowError> {
+        self.write_bind_params().await?;
+
         let cmd = CommandPreparedStatementQuery {
             prepared_statement_handle: self.handle.clone(),
         };
+
         let result = self
             .flight_sql_client
             .get_flight_info_for_command(cmd)
@@ -451,7 +456,9 @@ impl PreparedStatement<Channel> {
 
     /// Executes the prepared statement update query on the server.
     pub async fn execute_update(&mut self) -> Result<i64, ArrowError> {
-        let cmd = CommandPreparedStatementQuery {
+        self.write_bind_params().await?;
+
+        let cmd = CommandPreparedStatementUpdate {
             prepared_statement_handle: self.handle.clone(),
         };
         let descriptor = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
@@ -492,6 +499,36 @@ impl PreparedStatement<Channel> {
         Ok(())
     }
 
+    /// Submit parameters to the server, if any have been set on this prepared statement instance
+    async fn write_bind_params(&mut self) -> Result<(), ArrowError> {
+        if let Some(ref params_batch) = self.parameter_binding {
+            let cmd = CommandPreparedStatementQuery {
+                prepared_statement_handle: self.handle.clone(),
+            };
+
+            let descriptor = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
+            let flight_stream_builder = FlightDataEncoderBuilder::new()
+                .with_flight_descriptor(Some(descriptor))
+                .with_schema(params_batch.schema());
+            let flight_data = flight_stream_builder
+                .build(futures::stream::iter(
+                    self.parameter_binding.clone().map(Ok),
+                ))
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(flight_error_to_arrow_error)?;
+
+            self.flight_sql_client
+                .do_put(stream::iter(flight_data))
+                .await?
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(status_to_arrow_error)?;
+        }
+
+        Ok(())
+    }
+
     /// Close the prepared statement, so that this PreparedStatement can not used
     /// anymore and server can free up any resources.
     pub async fn close(mut self) -> Result<(), ArrowError> {
@@ -513,6 +550,17 @@ fn decode_error_to_arrow_error(err: prost::DecodeError) -> ArrowError {
 
 fn status_to_arrow_error(status: tonic::Status) -> ArrowError {
     ArrowError::IpcError(format!("{status:?}"))
+}
+
+fn flight_error_to_arrow_error(err: FlightError) -> ArrowError {
+    match err {
+        FlightError::Arrow(e) => e,
+        FlightError::NotYetImplemented(s) => ArrowError::NotYetImplemented(s),
+        FlightError::Tonic(status) => status_to_arrow_error(status),
+        FlightError::ProtocolError(e) => ArrowError::IpcError(e),
+        FlightError::DecodeError(s) => ArrowError::IpcError(s),
+        FlightError::ExternalError(e) => ArrowError::ExternalError(e),
+    }
 }
 
 // A polymorphic structure to natively represent different types of data contained in `FlightData`

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -19,7 +19,7 @@
 
 use std::pin::Pin;
 
-use futures::{stream::Peekable, Stream};
+use futures::{stream::Peekable, Stream, StreamExt};
 use prost::Message;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -366,7 +366,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     /// Implementors may override to handle additional calls to do_put()
     async fn do_put_fallback(
         &self,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
         message: Any,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
         Err(Status::unimplemented(format!(
@@ -379,7 +379,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     async fn do_put_statement_update(
         &self,
         _ticket: CommandStatementUpdate,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_statement_update has no default implementation",
@@ -390,7 +390,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     async fn do_put_prepared_statement_query(
         &self,
         _query: CommandPreparedStatementQuery,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_query has no default implementation",
@@ -401,7 +401,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     async fn do_put_prepared_statement_update(
         &self,
         _query: CommandPreparedStatementUpdate,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_update has no default implementation",
@@ -412,7 +412,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     async fn do_put_substrait_plan(
         &self,
         _query: CommandStatementSubstraitPlan,
-        _request: Request<Peekable<Streaming<FlightData>>>,
+        _request: Request<PeekableFlightDataStream>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_substrait_plan has no default implementation",
@@ -696,7 +696,7 @@ where
         // To allow the first message to be reused by the `do_put` handler,
         // we wrap this stream in a `Peekable` one, which allows us to peek at
         // the first message without discarding it.
-        let mut request = request.map(futures::StreamExt::peekable);
+        let mut request = request.map(PeekableFlightDataStream::new);
         let cmd = Pin::new(request.get_mut()).peek().await.unwrap().clone()?;
 
         let message = Any::decode(&*cmd.flight_descriptor.unwrap().cmd)
@@ -964,4 +964,90 @@ fn decode_error_to_status(err: prost::DecodeError) -> Status {
 
 fn arrow_error_to_status(err: arrow_schema::ArrowError) -> Status {
     Status::internal(format!("{err:?}"))
+}
+
+/// A wrapper around [`Streaming<FlightData>`] that allows "peeking" at the
+/// message at the front of the stream without consuming it.
+/// This is needed because sometimes the first message in the stream will contain
+/// a [`FlightDescriptor`] in addition to potentially any data, and the dispatch logic
+/// must inspect this information.
+///
+/// # Example
+///
+/// [`PeekableFlightDataStream::peek`] can be used to peek at the first message without
+/// discarding it; otherwise, `PeekableFlightDataStream` can be used as a regular stream.
+/// See the following example:
+///
+/// ```no_run
+/// use arrow_array::RecordBatch;
+/// use arrow_flight::decode::FlightRecordBatchStream;
+/// use arrow_flight::FlightDescriptor;
+/// use arrow_flight::error::FlightError;
+/// use arrow_flight::sql::server::PeekableFlightDataStream;
+/// use tonic::{Request, Status};
+/// use futures::TryStreamExt;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Status> {
+///     let request: Request<PeekableFlightDataStream> = todo!();
+///     let stream: PeekableFlightDataStream = request.into_inner();
+///
+///     // The first message contains the flight descriptor and the schema.
+///     // Read the flight descriptor without discarding the schema:
+///     let flight_descriptor: FlightDescriptor = stream
+///         .peek()
+///         .await
+///         .cloned()
+///         .transpose()?
+///         .and_then(|data| data.flight_descriptor)
+///         .expect("first message should contain flight descriptor");
+///
+///     // Pass the stream through a decoder
+///     let batches: Vec<RecordBatch> = FlightRecordBatchStream::new_from_flight_data(
+///         request.into_inner().map_err(|e| e.into()),
+///     )
+///     .try_collect()
+///     .await?;
+/// }
+/// ```
+pub struct PeekableFlightDataStream {
+    inner: Peekable<Streaming<FlightData>>,
+}
+
+impl PeekableFlightDataStream {
+    fn new(stream: Streaming<FlightData>) -> Self {
+        Self {
+            inner: stream.peekable(),
+        }
+    }
+
+    /// Convert this stream into a `Streaming<FlightData>`.
+    /// Any messages observed through [`Self::peek`] will be lost
+    /// after the conversion.
+    pub fn into_inner(self) -> Streaming<FlightData> {
+        self.inner.into_inner()
+    }
+
+    /// Convert this stream into a `Peekable<Streaming<FlightData>>`.
+    /// Preserves the state of the stream, so that calls to [`Self::peek`]
+    /// and [`Self::poll_next`] are the same.
+    pub fn into_peekable(self) -> Peekable<Streaming<FlightData>> {
+        self.inner
+    }
+
+    /// Peek at the head of this stream without advancing it.
+    pub async fn peek(&mut self) -> Option<&Result<FlightData, Status>> {
+        Pin::new(&mut self.inner).peek().await
+    }
+}
+
+impl Stream for PeekableFlightDataStream {
+    type Item = Result<FlightData, Status>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
 }

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -19,6 +19,7 @@ use std::{net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
 
 use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray};
 use arrow_flight::{
+    decode::FlightRecordBatchStream,
     flight_service_server::{FlightService, FlightServiceServer},
     sql::{
         server::FlightSqlService, ActionBeginSavepointRequest,
@@ -36,11 +37,13 @@ use arrow_flight::{
     },
     utils::batches_to_flight_data,
     Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
-    HandshakeResponse, Ticket,
+    HandshakeResponse, IpcMessage, PutResult, SchemaAsIpc, Ticket,
 };
+use arrow_ipc::writer::IpcWriteOptions;
 use arrow_schema::{ArrowError, DataType, Field, Schema};
 use assert_cmd::Command;
-use futures::Stream;
+use bytes::Bytes;
+use futures::{stream::Peekable, Stream, StreamExt, TryStreamExt};
 use prost::Message;
 use tokio::{net::TcpListener, task::JoinHandle};
 use tonic::{Request, Response, Status, Streaming};
@@ -63,7 +66,54 @@ async fn test_simple() {
             .arg(addr.ip().to_string())
             .arg("--port")
             .arg(addr.port().to_string())
+            .arg("statement-query")
             .arg(QUERY)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    })
+    .await
+    .unwrap();
+
+    fixture.shutdown_and_wait().await;
+
+    assert_eq!(
+        std::str::from_utf8(&stdout).unwrap().trim(),
+        "+--------------+-----------+\
+        \n| field_string | field_int |\
+        \n+--------------+-----------+\
+        \n| Hello        | 42        |\
+        \n| lovely       |           |\
+        \n| FlightSQL!   | 1337      |\
+        \n+--------------+-----------+",
+    );
+}
+
+const PREPARED_QUERY: &str = "SELECT * FROM table WHERE field = $1";
+const PREPARED_STATEMENT_HANDLE: &str = "prepared_statement_handle";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_do_put_prepared_statement() {
+    let test_server = FlightSqlServiceImpl {};
+    let fixture = TestFixture::new(&test_server).await;
+    let addr = fixture.addr;
+
+    let stdout = tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("flight_sql_client")
+            .unwrap()
+            .env_clear()
+            .env("RUST_BACKTRACE", "1")
+            .env("RUST_LOG", "warn")
+            .arg("--host")
+            .arg(addr.ip().to_string())
+            .arg("--port")
+            .arg(addr.port().to_string())
+            .arg("prepared-statement-query")
+            .arg(PREPARED_QUERY)
+            .args(["-p", "$1=string"])
+            .args(["-p", "$2=64"])
             .assert()
             .success()
             .get_output()
@@ -90,7 +140,7 @@ async fn test_simple() {
 /// All tests must complete within this many seconds or else the test server is shutdown
 const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct FlightSqlServiceImpl {}
 
 impl FlightSqlServiceImpl {
@@ -116,6 +166,59 @@ impl FlightSqlServiceImpl {
         ];
         RecordBatch::try_new(Arc::new(schema), cols)
     }
+
+    fn create_fake_prepared_stmt(
+    ) -> Result<ActionCreatePreparedStatementResult, ArrowError> {
+        let handle = PREPARED_STATEMENT_HANDLE.to_string();
+        let schema = Schema::new(vec![
+            Field::new("field_string", DataType::Utf8, false),
+            Field::new("field_int", DataType::Int64, true),
+        ]);
+
+        let parameter_schema = Schema::new(vec![
+            Field::new("$1", DataType::Utf8, false),
+            Field::new("$2", DataType::Int64, true),
+        ]);
+
+        Ok(ActionCreatePreparedStatementResult {
+            prepared_statement_handle: handle.into(),
+            dataset_schema: serialize_schema(&schema)?,
+            parameter_schema: serialize_schema(&parameter_schema)?,
+        })
+    }
+
+    fn fake_flight_info(&self) -> Result<FlightInfo, ArrowError> {
+        let batch = Self::fake_result()?;
+
+        Ok(FlightInfo::new()
+            .try_with_schema(&batch.schema())
+            .expect("encoding schema")
+            .with_endpoint(
+                FlightEndpoint::new().with_ticket(Ticket::new(
+                    FetchResults {
+                        handle: String::from("part_1"),
+                    }
+                    .as_any()
+                    .encode_to_vec(),
+                )),
+            )
+            .with_endpoint(
+                FlightEndpoint::new().with_ticket(Ticket::new(
+                    FetchResults {
+                        handle: String::from("part_2"),
+                    }
+                    .as_any()
+                    .encode_to_vec(),
+                )),
+            )
+            .with_total_records(batch.num_rows() as i64)
+            .with_total_bytes(batch.get_array_memory_size() as i64)
+            .with_ordered(false))
+    }
+}
+
+fn serialize_schema(schema: &Schema) -> Result<Bytes, ArrowError> {
+    Ok(IpcMessage::try_from(SchemaAsIpc::new(schema, &IpcWriteOptions::default()))?.0)
 }
 
 #[tonic::async_trait]
@@ -164,45 +267,21 @@ impl FlightSqlService for FlightSqlServiceImpl {
     ) -> Result<Response<FlightInfo>, Status> {
         assert_eq!(query.query, QUERY);
 
-        let batch = Self::fake_result().unwrap();
-
-        let info = FlightInfo::new()
-            .try_with_schema(&batch.schema())
-            .expect("encoding schema")
-            .with_endpoint(
-                FlightEndpoint::new().with_ticket(Ticket::new(
-                    FetchResults {
-                        handle: String::from("part_1"),
-                    }
-                    .as_any()
-                    .encode_to_vec(),
-                )),
-            )
-            .with_endpoint(
-                FlightEndpoint::new().with_ticket(Ticket::new(
-                    FetchResults {
-                        handle: String::from("part_2"),
-                    }
-                    .as_any()
-                    .encode_to_vec(),
-                )),
-            )
-            .with_total_records(batch.num_rows() as i64)
-            .with_total_bytes(batch.get_array_memory_size() as i64)
-            .with_ordered(false);
-
-        let resp = Response::new(info);
+        let resp = Response::new(self.fake_flight_info().unwrap());
         Ok(resp)
     }
 
     async fn get_flight_info_prepared_statement(
         &self,
-        _cmd: CommandPreparedStatementQuery,
+        cmd: CommandPreparedStatementQuery,
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        Err(Status::unimplemented(
-            "get_flight_info_prepared_statement not implemented",
-        ))
+        assert_eq!(
+            cmd.prepared_statement_handle,
+            PREPARED_STATEMENT_HANDLE.as_bytes()
+        );
+        let resp = Response::new(self.fake_flight_info().unwrap());
+        Ok(resp)
     }
 
     async fn get_flight_info_substrait_plan(
@@ -426,7 +505,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_statement_update(
         &self,
         _ticket: CommandStatementUpdate,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_statement_update not implemented",
@@ -436,7 +515,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_substrait_plan(
         &self,
         _ticket: CommandStatementSubstraitPlan,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_substrait_plan not implemented",
@@ -446,17 +525,36 @@ impl FlightSqlService for FlightSqlServiceImpl {
     async fn do_put_prepared_statement_query(
         &self,
         _query: CommandPreparedStatementQuery,
-        _request: Request<Streaming<FlightData>>,
+        request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
-        Err(Status::unimplemented(
-            "do_put_prepared_statement_query not implemented",
+        // just make sure decoding the parameters works
+        let parameters = FlightRecordBatchStream::new_from_flight_data(
+            request.into_inner().map_err(|e| e.into()),
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+
+        for (left, right) in parameters[0].schema().all_fields().iter().zip(vec![
+            Field::new("$1", DataType::Utf8, false),
+            Field::new("$2", DataType::Int64, true),
+        ]) {
+            if left.name() != right.name() || left.data_type() != right.data_type() {
+                return Err(Status::invalid_argument(format!(
+                    "Parameters did not match parameter schema\ngot {}",
+                    parameters[0].schema(),
+                )));
+            }
+        }
+
+        Ok(Response::new(
+            futures::stream::once(async { Ok(PutResult::default()) }).boxed(),
         ))
     }
 
     async fn do_put_prepared_statement_update(
         &self,
         _query: CommandPreparedStatementUpdate,
-        _request: Request<Streaming<FlightData>>,
+        _request: Request<Peekable<Streaming<FlightData>>>,
     ) -> Result<i64, Status> {
         Err(Status::unimplemented(
             "do_put_prepared_statement_update not implemented",
@@ -468,9 +566,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         _query: ActionCreatePreparedStatementRequest,
         _request: Request<Action>,
     ) -> Result<ActionCreatePreparedStatementResult, Status> {
-        Err(Status::unimplemented(
-            "do_action_create_prepared_statement not implemented",
-        ))
+        Self::create_fake_prepared_stmt()
+            .map_err(|e| Status::internal(format!("Unable to serialize schema: {e}")))
     }
 
     async fn do_action_close_prepared_statement(

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -50,7 +50,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 const QUERY: &str = "SELECT * FROM table;";
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn test_simple() {
     let test_server = FlightSqlServiceImpl {};
     let fixture = TestFixture::new(&test_server).await;
@@ -94,7 +94,7 @@ async fn test_simple() {
 const PREPARED_QUERY: &str = "SELECT * FROM table WHERE field = $1";
 const PREPARED_STATEMENT_HANDLE: &str = "prepared_statement_handle";
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn test_do_put_prepared_statement() {
     let test_server = FlightSqlServiceImpl {};
     let fixture = TestFixture::new(&test_server).await;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4658 and closes #3598

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`DoPut` requests with nonempty flight streams cannot be handled properly by the Rust FlightSQL server implementation in its current state. 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

We change all `DoPut` methods on the `FlightSqlService` trait to accept a `Peekable<Streaming<FlightData>>` instead of a regular `Streaming<FlightData>`. We also finished the parameter binding functionality in the client, in order to test prepared statements properly. 

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

Yes, there is unfortunately an API change for the `FlightSqlService` trait. I am open to alternatives, as it is probably possible to do evil things with `Peekable`, but I do not think it is possible to fix this without a breaking change. 