### PR TITLE
Improve CSV Reader Benchmark Coverage of Small Primitives

### DIFF
--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -18,15 +18,18 @@
 extern crate arrow;
 extern crate criterion;
 
+use std::io::Cursor;
+use std::sync::Arc;
+
 use criterion::*;
+use rand::Rng;
 
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 use arrow::util::bench_util::{create_primitive_array, create_string_array_with_len};
-use std::io::Cursor;
-use std::sync::Arc;
+use arrow::util::test_util::seedable_rng;
 
 fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
     let batch = RecordBatch::try_from_iter(cols.into_iter().map(|a| ("col", a))).unwrap();
@@ -55,18 +58,49 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let cols = vec![Arc::new(create_primitive_array::<UInt64Type>(4096, 0.)) as ArrayRef];
+    let mut rng = seedable_rng();
+
+    let values = Int32Array::from_iter_values((0..4096).map(|_| rng.gen_range(0..1024)));
+    let cols = vec![Arc::new(values) as ArrayRef];
+    do_bench(c, "4096 i32_small(0)", cols);
+
+    let values = Int32Array::from_iter_values((0..4096).map(|_| rng.gen()));
+    let cols = vec![Arc::new(values) as ArrayRef];
+    do_bench(c, "4096 i32(0)", cols);
+
+    let values = UInt64Array::from_iter_values((0..4096).map(|_| rng.gen_range(0..1024)));
+    let cols = vec![Arc::new(values) as ArrayRef];
+    do_bench(c, "4096 u64_small(0)", cols);
+
+    let values = UInt64Array::from_iter_values((0..4096).map(|_| rng.gen()));
+    let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 u64(0)", cols);
 
-    let cols = vec![Arc::new(create_primitive_array::<Int64Type>(4096, 0.)) as ArrayRef];
+    let values =
+        Int64Array::from_iter_values((0..4096).map(|_| rng.gen_range(0..1024) - 512));
+    let cols = vec![Arc::new(values) as ArrayRef];
+    do_bench(c, "4096 i64_small(0)", cols);
+
+    let values = Int64Array::from_iter_values((0..4096).map(|_| rng.gen()));
+    let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 i64(0)", cols);
 
-    let cols =
-        vec![Arc::new(create_primitive_array::<Float32Type>(4096, 0.)) as ArrayRef];
+    let cols = vec![Arc::new(Float32Array::from_iter_values(
+        (0..4096).map(|_| rng.gen_range(0..1024000) as f32 / 1000.),
+    )) as _];
+    do_bench(c, "4096 f32_small(0)", cols);
+
+    let values = Float32Array::from_iter_values((0..4096).map(|_| rng.gen()));
+    let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 f32(0)", cols);
 
-    let cols =
-        vec![Arc::new(create_primitive_array::<Float64Type>(4096, 0.)) as ArrayRef];
+    let cols = vec![Arc::new(Float64Array::from_iter_values(
+        (0..4096).map(|_| rng.gen_range(0..1024000) as f64 / 1000.),
+    )) as _];
+    do_bench(c, "4096 f64_small(0)", cols);
+
+    let values = Float64Array::from_iter_values((0..4096).map(|_| rng.gen()));
+    let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 f64(0)", cols);
 
     let cols =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

As we look to make changes to both the CSV reader itself (#4795) and the way that values are parsed (#4785) having good benchmark coverage is really important. Whilst reviewing #4795 I noticed an oversight in the benchmarks I added in #3357. In particular the parsers are tested with values sampled from the entire range of primitives. It is fairly common for CSVs to contain primitives on the order of thousands, not trillions, and so we should have benchmark coverage for this case.

On my local machine we can see the difference this makes

```
4096 i32_small(0) - 4096
                        time:   [78.292 µs 78.340 µs 78.390 µs]
4096 i32(0) - 4096      time:   [137.50 µs 137.95 µs 138.39 µs]

4096 u64_small(0) - 4096
                        time:   [81.071 µs 81.153 µs 81.244 µs]
4096 u64(0) - 4096      time:   [146.21 µs 146.36 µs 146.51 µs]

4096 i64_small(0) - 4096
                        time:   [101.31 µs 101.44 µs 101.59 µs]
4096 i64(0) - 4096      time:   [162.49 µs 163.03 µs 163.63 µs]

4096 f32_small(0) - 4096
                        time:   [128.87 µs 129.04 µs 129.18 µs]

4096 f32(0) - 4096      time:   [157.81 µs 157.88 µs 157.95 µs]
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
