### PR TITLE
fix: entries field is non-nullable

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -330,7 +330,7 @@ impl MapArray {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );
@@ -477,7 +477,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );
@@ -523,7 +523,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );
@@ -645,7 +645,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );

--- a/arrow-integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/arrow-integration-testing/src/bin/arrow-json-integration-test.rs
@@ -124,7 +124,7 @@ fn canonicalize_schema(schema: &Schema) -> Schema {
                     let key_field = Arc::new(Field::new(
                         "key",
                         first_field.data_type().clone(),
-                        first_field.is_nullable(),
+                        false,
                     ));
                     let second_field = fields.get(1).unwrap();
                     let value_field = Arc::new(Field::new(
@@ -135,8 +135,7 @@ fn canonicalize_schema(schema: &Schema) -> Schema {
 
                     let fields = Fields::from([key_field, value_field]);
                     let struct_type = DataType::Struct(fields);
-                    let child_field =
-                        Field::new("entries", struct_type, child_field.is_nullable());
+                    let child_field = Field::new("entries", struct_type, false);
 
                     Arc::new(Field::new(
                         field.name().as_str(),

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1487,7 +1487,7 @@ mod tests {
         let keys_field = Arc::new(Field::new_dict(
             "keys",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
-            true,
+            true, // It is technically not legal for this field to be null.
             1,
             false,
         ));
@@ -1506,7 +1506,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1385,7 +1385,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 entry_struct.data_type().clone(),
-                true,
+                false,
             )),
             false,
         );

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -833,7 +833,7 @@ mod tests {
 
         // Construct a map array from the above two
         let map_data_type =
-            DataType::Map(Arc::new(Field::new("entries", entry_struct, true)), true);
+            DataType::Map(Arc::new(Field::new("entries", entry_struct, false)), true);
 
         let arrow_schema = FFI_ArrowSchema::try_from(map_data_type).unwrap();
         assert!(arrow_schema.map_keys_sorted());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4807.

# Rationale for this change
 
The "entries" field shouldn't be nullable:

https://github.com/apache/arrow/blob/c4b01c60fba85bbfc3a1b1510e179153c0f79515/format/Schema.fbs#L124

Elsewhere, we have this as false already:

https://github.com/apache/arrow-rs/blob/master/arrow-schema/src/field.rs#L230

The inconsistency on this causes schema mismatch issues, such as those documented in:

https://github.com/delta-io/delta-rs/issues/1619

# What changes are included in this PR?

Changes all functions that construct the `"entries"` field to be non-nullable.

# Are there any user-facing changes?

Yes, this will change the type output by the `MapType::new_from_strings()` and `canonicalize_schema()` functions.
