### PR TITLE
feat(datafusion-7181): enable slicing of rows

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1011,7 +1011,7 @@ impl Rows {
     /// Panics if `offset` with `length` is greater than row length.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
-            offset + length <= self.num_rows(),
+            offset.saturating_add(length) <= self.num_rows(),
             "offset + length is greater than row length"
         );
 
@@ -1023,11 +1023,11 @@ impl Rows {
 
         let start = current_offsets[offset];
         let end = current_offsets[offset + length];
-        let mut buffer: Vec<u8> = vec![0_u8; end - start];
-        buffer.copy_from_slice(&current_buffer[start..end]);
+        let mut buffer: Vec<u8> = Vec::with_capacity(end - start);
+        buffer.extend_from_slice(&current_buffer[start..end]);
 
-        let mut offsets: Vec<usize> = vec![0_usize; length + 1];
-        offsets.copy_from_slice(&current_offsets[offset..offset + length + 1]);
+        let mut offsets: Vec<usize> = Vec::with_capacity(length + 1);
+        offsets.extend_from_slice(&current_offsets[offset..offset + length + 1]);
         // mutate offsets to match new buffer length
         offsets = offsets.iter_mut().map(|x| *x - start).collect();
 


### PR DESCRIPTION
# Which issue does this PR close?

This is a change required in order to slice the row cursor in the [cascaded sort order](https://github.com/apache/arrow-datafusion/pull/7379).

precursor for https://github.com/apache/arrow-datafusion/issues/7181

# Rationale for this change
 
During the cascaded merge, we may yield partial record batch (a.k.a. partial cursors) from a given merge node (in the cascade tree). As such, the cursor would need to be sliced as [described here](https://github.com/apache/arrow-datafusion/blob/d52049675ee5c335285635aea984d51b7cca9f74/datafusion/core/src/physical_plan/sorts/builder.rs#L170).

# What changes are included in this PR?

Slicing the cursor.

# Are there any user-facing changes?

No breaking changes.
Only a new API `.slice()` method, including documentation.
