### PR TITLE
feat: FixedSizeBinaryArray::value_data return reference

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -179,9 +179,18 @@ impl FixedSizeBinaryArray {
         self.value_length
     }
 
-    /// Returns the value buffer.
-    pub fn value_data(&self) -> &Buffer {
+    /// Returns the values of this array.
+    ///
+    /// Unlike [`Self::value_data`] this returns the [`Buffer`]
+    /// allowing for zero-copy cloning.
+    #[inline]
+    pub fn values(&self) -> &Buffer {
         &self.value_data
+    }
+
+    /// Returns the raw value data.
+    pub fn value_data(&self) -> &[u8] {
+        self.value_data.as_slice()
     }
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -179,9 +179,9 @@ impl FixedSizeBinaryArray {
         self.value_length
     }
 
-    /// Returns a clone of the value data buffer
-    pub fn value_data(&self) -> Buffer {
-        self.value_data.clone()
+    /// Returns the value buffer.
+    pub fn value_data(&self) -> &Buffer {
+        &self.value_data
     }
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.

--- a/arrow-string/src/substring.rs
+++ b/arrow-string/src/substring.rs
@@ -347,8 +347,7 @@ fn fixed_size_binary_substring(
 
     // build value buffer
     let num_of_elements = array.len();
-    let values = array.value_data();
-    let data = values.as_slice();
+    let data = array.value_data();
     let mut new_values = MutableBuffer::new(num_of_elements * (new_len as usize));
     (0..num_of_elements)
         .map(|idx| {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4820.

# Rationale for this change
 
Make it possible to get reference to underlying values.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

This is a change to the API. Existing users calling `.value_data()` will need to rewrite as `.values().clone()`.