### PR TITLE
fix: add missing precision overflow checking for `cast_string_to_decimal`

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -8107,32 +8107,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_string_to_decimal128_precision_overflow() {
-        let array = StringArray::from(vec!["1000".to_string()]);
-        let array = Arc::new(array) as ArrayRef;
-        let casted_array = cast_with_options(
-            &array,
-            &DataType::Decimal128(10, 8),
-            &CastOptions {
-                safe: true,
-                format_options: FormatOptions::default(),
-            },
-        );
-        assert!(casted_array.is_ok());
-        assert!(casted_array.unwrap().is_null(0));
-
-        let err = cast_with_options(
-            &array,
-            &DataType::Decimal128(10, 8),
-            &CastOptions {
-                safe: false,
-                format_options: FormatOptions::default(),
-            },
-        );
-        assert_eq!("Invalid argument error: 100000000000 is too large to store in a Decimal128 of precision 10. Max is 9999999999", err.unwrap_err().to_string());
-    }
-
-    #[test]
     fn test_cast_invalid_utf8_to_decimal() {
         let str_array = StringArray::from(vec!["4.4.5", ". 0.123"]);
         let array = Arc::new(str_array) as ArrayRef;
@@ -8185,6 +8159,32 @@ mod tests {
             "100000000000000000000000000000000000.00",
             decimal_arr.value_as_string(4)
         );
+    }
+
+    #[test]
+    fn test_cast_string_to_decimal128_precision_overflow() {
+        let array = StringArray::from(vec!["1000".to_string()]);
+        let array = Arc::new(array) as ArrayRef;
+        let casted_array = cast_with_options(
+            &array,
+            &DataType::Decimal128(10, 8),
+            &CastOptions {
+                safe: true,
+                format_options: FormatOptions::default(),
+            },
+        );
+        assert!(casted_array.is_ok());
+        assert!(casted_array.unwrap().is_null(0));
+
+        let err = cast_with_options(
+            &array,
+            &DataType::Decimal128(10, 8),
+            &CastOptions {
+                safe: false,
+                format_options: FormatOptions::default(),
+            },
+        );
+        assert_eq!("Invalid argument error: 100000000000 is too large to store in a Decimal128 of precision 10. Max is 9999999999", err.unwrap_err().to_string());
     }
 
     #[test]
@@ -8242,6 +8242,32 @@ mod tests {
         );
         assert!(decimal_arr.is_null(5));
         assert!(decimal_arr.is_null(6));
+    }
+
+    #[test]
+    fn test_cast_string_to_decimal256_precision_overflow() {
+        let array = StringArray::from(vec!["1000".to_string()]);
+        let array = Arc::new(array) as ArrayRef;
+        let casted_array = cast_with_options(
+            &array,
+            &DataType::Decimal256(10, 8),
+            &CastOptions {
+                safe: true,
+                format_options: FormatOptions::default(),
+            },
+        );
+        assert!(casted_array.is_ok());
+        assert!(casted_array.unwrap().is_null(0));
+
+        let err = cast_with_options(
+            &array,
+            &DataType::Decimal256(10, 8),
+            &CastOptions {
+                safe: false,
+                format_options: FormatOptions::default(),
+            },
+        );
+        assert_eq!("Invalid argument error: 100000000000 is too large to store in a Decimal256 of precision 10. Max is 9999999999", err.unwrap_err().to_string());
     }
 
     #[test]


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4829.

# Rationale for this change
 
Perform a precision overflow check when casting from a string to a decimal.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No
