### PR TITLE
fix: object store http header last modified

### DIFF
--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -49,8 +49,8 @@ impl<T: GetClient> GetClientExt for T {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
         let response = self.get_request(location, options, false).await?;
-        let meta =
-            header_meta(location, response.headers()).map_err(|e| Error::Generic {
+        let meta = header_meta(location, response.headers(), Default::default())
+            .map_err(|e| Error::Generic {
                 store: T::STORE,
                 source: Box::new(e),
             })?;
@@ -73,9 +73,11 @@ impl<T: GetClient> GetClientExt for T {
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let options = GetOptions::default();
         let response = self.get_request(location, options, true).await?;
-        header_meta(location, response.headers()).map_err(|e| Error::Generic {
-            store: T::STORE,
-            source: Box::new(e),
+        header_meta(location, response.headers(), Default::default()).map_err(|e| {
+            Error::Generic {
+                store: T::STORE,
+                source: Box::new(e),
+            }
         })
     }
 }

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -100,13 +100,8 @@ pub fn header_meta(
             let e_tag = e_tag.to_str().context(BadHeaderSnafu)?;
             Some(e_tag.to_string())
         }
-        None => {
-            if cfg.etag_required {
-                return Err(Error::MissingEtag);
-            } else {
-                None
-            }
-        }
+        None if cfg.etag_required => return Err(Error::MissingEtag),
+        None => None,
     };
 
     let content_length = headers

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -86,13 +86,8 @@ pub fn header_meta(
                 .context(InvalidLastModifiedSnafu { last_modified })?
                 .with_timezone(&Utc)
         }
-        None => {
-            if cfg.last_modified_required {
-                return Err(Error::MissingLastModified);
-            } else {
-                chrono::Utc.timestamp_nanos(0)
-            }
-        }
+        None if cfg.last_modified_required => return Err(Error::MissingLastModified),
+        None => Utc.timestamp_nanos(0),
     };
 
     let e_tag = match headers.get(ETAG) {

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -82,10 +82,9 @@ pub fn header_meta(
     let last_modified = match headers.get(LAST_MODIFIED) {
         Some(last_modified) => {
             let last_modified = last_modified.to_str().context(BadHeaderSnafu)?;
-            let last_modified = DateTime::parse_from_rfc2822(last_modified)
+            DateTime::parse_from_rfc2822(last_modified)
                 .context(InvalidLastModifiedSnafu { last_modified })?
-                .with_timezone(&Utc);
-            last_modified
+                .with_timezone(&Utc)
         }
         None => {
             if cfg.last_modified_required {

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -40,7 +40,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 use url::Url;
 
-use crate::client::header::header_meta;
+use crate::client::header::{header_meta, HeaderConfig};
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
@@ -117,7 +117,12 @@ impl ObjectStore for HttpStore {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
         let response = self.client.get(location, options).await?;
-        let meta = header_meta(location, response.headers()).context(MetadataSnafu)?;
+        let cfg = HeaderConfig {
+            last_modified_required: false,
+            etag_required: false,
+        };
+        let meta =
+            header_meta(location, response.headers(), cfg).context(MetadataSnafu)?;
 
         let stream = response
             .bytes_stream()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4831

# Rationale for this change

object store 0.7.0 caused breaking changes in fetching from endpoints without `last_modified`
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

If the `last-modified` header is not present, it will default to the epoch. 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
