### PR TITLE
Perform HEAD request for HttpStore::head

### DIFF
--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::header::header_meta;
+use crate::client::header::{header_meta, HeaderConfig};
 use crate::path::Path;
 use crate::{Error, GetOptions, GetResult, ObjectMeta};
 use crate::{GetResultPayload, Result};
@@ -27,6 +27,12 @@ use reqwest::Response;
 #[async_trait]
 pub trait GetClient: Send + Sync + 'static {
     const STORE: &'static str;
+
+    /// Configure the [`HeaderConfig`] for this client
+    const HEADER_CONFIG: HeaderConfig = HeaderConfig {
+        etag_required: true,
+        last_modified_required: true,
+    };
 
     async fn get_request(
         &self,
@@ -49,10 +55,12 @@ impl<T: GetClient> GetClientExt for T {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
         let response = self.get_request(location, options, false).await?;
-        let meta = header_meta(location, response.headers(), Default::default())
-            .map_err(|e| Error::Generic {
-                store: T::STORE,
-                source: Box::new(e),
+        let meta =
+            header_meta(location, response.headers(), T::HEADER_CONFIG).map_err(|e| {
+                Error::Generic {
+                    store: T::STORE,
+                    source: Box::new(e),
+                }
             })?;
 
         let stream = response
@@ -73,7 +81,7 @@ impl<T: GetClient> GetClientExt for T {
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let options = GetOptions::default();
         let response = self.get_request(location, options, true).await?;
-        header_meta(location, response.headers(), Default::default()).map_err(|e| {
+        header_meta(location, response.headers(), T::HEADER_CONFIG).map_err(|e| {
             Error::Generic {
                 store: T::STORE,
                 source: Box::new(e),

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -24,7 +24,7 @@ use hyper::header::{CONTENT_LENGTH, ETAG, LAST_MODIFIED};
 use hyper::HeaderMap;
 use snafu::{OptionExt, ResultExt, Snafu};
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 /// Configuration for header extraction
 pub struct HeaderConfig {
     /// Whether to require an ETag header when extracting [`ObjectMeta`] from headers.

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -37,15 +37,6 @@ pub struct HeaderConfig {
     pub last_modified_required: bool,
 }
 
-impl Default for HeaderConfig {
-    fn default() -> Self {
-        Self {
-            etag_required: true,
-            last_modified_required: true,
-        }
-    }
-}
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("ETag Header missing from response"))]

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -27,7 +27,6 @@ pub mod retry;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub mod pagination;
 
-#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub mod get;
 
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -281,6 +281,8 @@ impl Client {
 impl GetClient for Client {
     const STORE: &'static str = "HTTP";
 
+    /// Override the [`HeaderConfig`] to be less strict to support a
+    /// broader range of HTTP servers (#4831)
     const HEADER_CONFIG: HeaderConfig = HeaderConfig {
         etag_required: false,
         last_modified_required: false,

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::client::get::GetClient;
+use crate::client::header::HeaderConfig;
 use crate::client::retry::{self, RetryConfig, RetryExt};
 use crate::client::GetOptionsExt;
 use crate::path::{Path, DELIMITER};
@@ -276,6 +277,11 @@ impl Client {
 #[async_trait]
 impl GetClient for Client {
     const STORE: &'static str = "HTTP";
+
+    const HEADER_CONFIG: HeaderConfig = HeaderConfig {
+        etag_required: false,
+        last_modified_required: false,
+    };
 
     async fn get_request(
         &self,

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -34,18 +34,18 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use itertools::Itertools;
 use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 use url::Url;
 
-use crate::client::header::header_meta;
+use crate::client::get::GetClientExt;
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
-    ClientConfigKey, ClientOptions, GetOptions, GetResult, GetResultPayload, ListResult,
-    MultipartId, ObjectMeta, ObjectStore, Result, RetryConfig,
+    ClientConfigKey, ClientOptions, GetOptions, GetResult, ListResult, MultipartId,
+    ObjectMeta, ObjectStore, Result, RetryConfig,
 };
 
 mod client;
@@ -115,41 +115,11 @@ impl ObjectStore for HttpStore {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        let range = options.range.clone();
-        let response = self.client.get(location, options).await?;
-        let meta = header_meta(location, response.headers()).context(MetadataSnafu)?;
-
-        let stream = response
-            .bytes_stream()
-            .map_err(|source| Error::Reqwest { source }.into())
-            .boxed();
-
-        Ok(GetResult {
-            payload: GetResultPayload::Stream(stream),
-            range: range.unwrap_or(0..meta.size),
-            meta,
-        })
+        self.client.get_opts(location, options).await
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let status = self.client.list(Some(location), "0").await?;
-        match status.response.len() {
-            1 => {
-                let response = status.response.into_iter().next().unwrap();
-                response.check_ok()?;
-                match response.is_dir() {
-                    true => Err(crate::Error::NotFound {
-                        path: location.to_string(),
-                        source: "Is directory".to_string().into(),
-                    }),
-                    false => response.object_meta(self.client.base_url()),
-                }
-            }
-            x => Err(crate::Error::NotFound {
-                path: location.to_string(),
-                source: format!("Expected 1 result, got {x}").into(),
-            }),
-        }
+        self.client.head(location).await
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Issuing a head request instead of a GET request allows HttpStore::head to be used against regular HTTP servers that don't speak WebDav.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Technically perhaps, but we already enforced that GET requests return the necessary headers for metadata, and so this is just an evolution of that to HEAD requests.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
