### PR TITLE
Refine documentation to `Array::is_null`

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -186,7 +186,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     ///
     /// In most cases this will be the same as [`Array::nulls`], except for:
     ///
-    /// * ['DictionaryArray`] where [`DictionaryArray::values`] contains nulls
+    /// * [`DictionaryArray`] where [`DictionaryArray::values`] contains nulls
     /// * [`RunArray`] where [`RunArray::values`] contains nulls
     /// * [`NullArray`] where all indices are nulls
     ///
@@ -200,7 +200,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     ///
     /// Note: For performance reasons, this method returns nullability solely as determined by the
     /// null buffer. This difference can lead to surprising results, for example, [`NullArray::is_null`] always
-    /// returns `false` as the array lacks a null buffer. Similarly [`DictionaryArray]` and [`RunArray`] may
+    /// returns `false` as the array lacks a null buffer. Similarly [`DictionaryArray`] and [`RunArray`] may
     /// encode nullability in their children. See [`Self::logical_nulls`] for more information.
     ///
     /// # Example:
@@ -212,7 +212,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// assert_eq!(array.is_null(0), false);
     /// assert_eq!(array.is_null(1), true);
     ///
-    /// // NullArrays do not have a validity mask, and therefore always
+    /// // NullArrays do not have a null buffer, and therefore always
     /// // return false for is_null.
     /// let array = NullArray::new(1);
     /// assert_eq!(array.is_null(0), false);

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -203,7 +203,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// nullability for some types. This difference can lead to surprising results,
     /// such as [`NullArray::is_null`] always
     /// returns `false`. Other arrays which may have surprising results are [`DictionaryArray]` and
-    /// [`RunArray`]. See [`Self::is_logical_null`] for logical nullability.
+    /// [`RunArray`]. See [`Self::logical_nulls`] for logical nullability.
     ///
     /// Note: When using this function on a slice, the index is relative to the slice.
     ///

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -175,7 +175,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
 
     /// Returns the null buffer of this array if any.
     ///
-    /// The null buffer encodes the "physical" nulls of an array and is pre-computed and very efficient.
+    /// The null buffer encodes the "physical" nulls of an array.
     /// However, some arrays can also encode nullability in their children, for example,
     /// [`DictionaryArray::values`] values or [`RunArray::values`], or without a null buffer,
     /// such as [`NullArray`]. To determine if each element of such an array is logically null,
@@ -196,16 +196,12 @@ pub trait Array: std::fmt::Debug + Send + Sync {
         self.nulls().cloned()
     }
 
-    /// Returns whether the element at `index` is "physically" null, as explained
-    /// on [`Array::nulls`].
+    /// Returns whether the element at `index` is null according to [`Array::nulls`]
     ///
-    /// Note: For performance reasons, logical nullability can and does differ from the physical
-    /// nullability for some types. This difference can lead to surprising results,
-    /// such as [`NullArray::is_null`] always
-    /// returns `false`. Other arrays which may have surprising results are [`DictionaryArray]` and
-    /// [`RunArray`]. See [`Self::logical_nulls`] for logical nullability.
-    ///
-    /// Note: When using this function on a slice, the index is relative to the slice.
+    /// Note: For performance reasons, this method returns nullability solely as determined by the
+    /// null buffer. This difference can lead to surprising results, for example, [`NullArray::is_null`] always
+    /// returns `false` as the array lacks a null buffer. Similarly [`DictionaryArray]` and [`RunArray`] may
+    /// encode nullability in their children. See [`Self::logical_nulls`] for more information.
     ///
     /// # Example:
     ///

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -113,10 +113,6 @@ impl Array for NullArray {
         (self.len != 0).then(|| NullBuffer::new_null(self.len))
     }
 
-    fn is_logical_null(&self, _index: usize) -> bool {
-        true
-    }
-
     fn is_nullable(&self) -> bool {
         !self.is_empty()
     }

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -113,6 +113,10 @@ impl Array for NullArray {
         (self.len != 0).then(|| NullBuffer::new_null(self.len))
     }
 
+    fn is_logical_null(&self, _index: usize) -> bool {
+        true
+    }
+
     fn is_nullable(&self) -> bool {
         !self.is_empty()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/4835

# Rationale for this change

The fact that `NullArray::is_null()` returns false is both consistent with the technical definition of physical/logical nulls, but also deeply confusing to a casual user, as explained on https://github.com/apache/arrow-rs/issues/4835

I don't think the implications of logical vs physical nullability are well understood by the arrow user community (and to be honest I am not sure they should in most cases).

Thus helping them find the right API for what they want to do would be incel 

# What changes are included in this PR?
1. Update doc comments to explicitly mention the `NullArray` case (the one where I think it is the most deeply confusing, even though this does potentially apply to `DictionaryArray` and `RunArray`
2. Add an `Array::is_logical_null` that returns the the logical nullability  (mostly as a way to document the behavior and save downstream crates from having to handle `NullArray` specially)

# Are there any user-facing changes?
New function and improved documentation

# Questions
1. What are your opinions on `Array::is_logical_null` 
2. Should I add an equivalent of `Array::is_logical_valid` to mirror `Array::is_valid` ?