### PR TITLE
Error if Remote Ignores HTTP Range Header

### DIFF
--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -37,6 +37,9 @@ enum Error {
     #[snafu(display("Request error: {}", source))]
     Reqwest { source: reqwest::Error },
 
+    #[snafu(display("Range request not supported by {}", href))]
+    RangeNotSupported { href: String },
+
     #[snafu(display("Error decoding PROPFIND response: {}", source))]
     InvalidPropFind { source: quick_xml::de::DeError },
 
@@ -238,8 +241,9 @@ impl Client {
     pub async fn get(&self, location: &Path, options: GetOptions) -> Result<Response> {
         let url = self.path_url(location);
         let builder = self.client.get(url);
+        let has_range = options.range.is_some();
 
-        builder
+        let res = builder
             .with_get_options(options)
             .send_retry(&self.retry_config)
             .await
@@ -252,7 +256,18 @@ impl Client {
                     }
                 }
                 _ => Error::Request { source }.into(),
-            })
+            })?;
+
+        if has_range && res.status() != StatusCode::PARTIAL_CONTENT {
+            return Err(crate::Error::Generic {
+                store: "HTTP",
+                source: Box::new(Error::RangeNotSupported {
+                    href: location.to_string(),
+                }),
+            });
+        }
+
+        Ok(res)
     }
 
     pub async fn copy(&self, from: &Path, to: &Path, overwrite: bool) -> Result<()> {

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -261,8 +261,7 @@ impl Client {
         // We expect a 206 Partial Content response if a range was requested
         // a 200 OK response would indicate the server did not fulfill the request
         if has_range && res.status() == StatusCode::OK {
-            return Err(crate::Error::Generic {
-                store: "HTTP",
+            return Err(crate::Error::NotSupported {
                 source: Box::new(Error::RangeNotSupported {
                     href: location.to_string(),
                 }),

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -258,7 +258,9 @@ impl Client {
                 _ => Error::Request { source }.into(),
             })?;
 
-        if has_range && res.status() != StatusCode::PARTIAL_CONTENT {
+        // We expect a 206 Partial Content response if a range was requested
+        // a 200 OK response would indicate the server did not fulfill the request
+        if has_range && res.status() == StatusCode::OK {
             return Err(crate::Error::Generic {
                 store: "HTTP",
                 source: Box::new(Error::RangeNotSupported {

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -260,7 +260,7 @@ impl Client {
 
         // We expect a 206 Partial Content response if a range was requested
         // a 200 OK response would indicate the server did not fulfill the request
-        if has_range && res.status() == StatusCode::OK {
+        if has_range && res.status() != StatusCode::PARTIAL_CONTENT {
             return Err(crate::Error::NotSupported {
                 source: Box::new(Error::RangeNotSupported {
                     href: location.to_string(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4839

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

If a range was requested and the server returned a 200 instead of a 206, we error out as it means that the server didn't fulfill the request. 

# Are there any user-facing changes?

this could cause some backwards incompatibility with previously working queries no longer working as we are now a bit stricter about what we are expecting. 

Some examples that would no longer work
- a server _could_ satisfy the range request, but due to misconfiguration is still returning a `200`. 
- the server never satisfied the range request & we fetched the entire data multiple times. 

The latter example is the one this is aiming to prevent. If it can't fulfill the range request, we shouldn't continue on as nothing happened, we should error instead of overfetching data. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
