### PR TITLE
Make ArrowRowGroupWriter Public and SerializedRowGroupWriter Send

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -248,7 +248,7 @@ impl<W: Write + Send> RecordBatchWriter for ArrowWriter<W> {
 
 /// A list of [`Bytes`] comprising a single column chunk
 #[derive(Default)]
-struct ArrowColumnChunk {
+pub struct ArrowColumnChunk {
     length: usize,
     data: Vec<Bytes>,
 }
@@ -273,7 +273,7 @@ impl ChunkReader for ArrowColumnChunk {
 }
 
 /// A [`Read`] for an iterator of [`Bytes`]
-struct ChainReader(Peekable<IntoIter<Bytes>>);
+pub struct ChainReader(Peekable<IntoIter<Bytes>>);
 
 impl Read for ChainReader {
     fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
@@ -362,14 +362,14 @@ impl ArrowColumnWriter {
 }
 
 /// Encodes [`RecordBatch`] to a parquet row group
-struct ArrowRowGroupWriter {
+pub struct ArrowRowGroupWriter {
     writers: Vec<(SharedColumnChunk, ArrowColumnWriter)>,
     schema: SchemaRef,
     buffered_rows: usize,
 }
 
 impl ArrowRowGroupWriter {
-    fn new(
+    pub fn new(
         parquet: &SchemaDescriptor,
         props: &WriterPropertiesPtr,
         arrow: &SchemaRef,
@@ -386,7 +386,7 @@ impl ArrowRowGroupWriter {
         })
     }
 
-    fn write(&mut self, batch: &RecordBatch) -> Result<()> {
+    pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         self.buffered_rows += batch.num_rows();
         let mut writers = self.writers.iter_mut().map(|(_, x)| x);
         for (array, field) in batch.columns().iter().zip(&self.schema.fields) {
@@ -396,7 +396,7 @@ impl ArrowRowGroupWriter {
         Ok(())
     }
 
-    fn close(self) -> Result<Vec<(ArrowColumnChunk, ColumnCloseResult)>> {
+    pub fn close(self) -> Result<Vec<(ArrowColumnChunk, ColumnCloseResult)>> {
         self.writers
             .into_iter()
             .map(|(chunk, writer)| {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -115,7 +115,8 @@ pub type OnCloseRowGroup<'a> = Box<
             Vec<Option<ColumnIndex>>,
             Vec<Option<OffsetIndex>>,
         ) -> Result<()>
-        + 'a,
+        + 'a
+        + Send,
 >;
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
# Which issue does this PR close?

Enables https://github.com/apache/arrow-datafusion/pull/7632
Related to #1718 

# Rationale for this change
 
While working on improving DataFusions async parallel parquet writer (draft pr: https://github.com/apache/arrow-datafusion/pull/7632), some changes were needed at the arrow level. The DataFusion parallel writer writes separate partitions to different RowGroups in parallel and later concatenates them into one file. Using ArrowRowGroupWriter directly is more efficient for this use case than ArrowWriter and allows retaining column indexes/bloom filters. 

# What changes are included in this PR?

- `ArrowRowGroupWriter` and related structs/methods are marked public
- `OnCloseRowGroup` closure is now required to be `Send`

# Are there any user-facing changes?

ArrowRowGroupWriter can now be used directly by downstream arrow users.
