### PR TITLE
Enable External ArrowColumnWriter Access

### DIFF
--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -49,10 +49,7 @@ use std::ops::Range;
 
 /// Performs a depth-first scan of the children of `array`, constructing [`LevelInfo`]
 /// for each leaf column encountered
-pub fn calculate_array_levels(
-    array: &ArrayRef,
-    field: &Field,
-) -> Result<Vec<LevelInfo>> {
+pub fn calculate_array_levels(array: &ArrayRef, field: &Field) -> Result<Vec<LevelInfo>> {
     let mut builder = LevelInfoBuilder::try_new(field, Default::default())?;
     builder.write(array, 0..array.len());
     Ok(builder.finish())

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -49,7 +49,7 @@ use std::ops::Range;
 
 /// Performs a depth-first scan of the children of `array`, constructing [`LevelInfo`]
 /// for each leaf column encountered
-pub(crate) fn calculate_array_levels(
+pub fn calculate_array_levels(
     array: &ArrayRef,
     field: &Field,
 ) -> Result<Vec<LevelInfo>> {
@@ -538,7 +538,7 @@ impl LevelInfoBuilder {
 /// The data necessary to write a primitive Arrow array to parquet, taking into account
 /// any non-primitive parents it may have in the arrow representation
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) struct LevelInfo {
+pub struct LevelInfo {
     /// Array's definition levels
     ///
     /// Present if `max_def_level != 0`

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -49,7 +49,10 @@ use std::ops::Range;
 
 /// Performs a depth-first scan of the children of `array`, constructing [`LevelInfo`]
 /// for each leaf column encountered
-pub fn calculate_array_levels(array: &ArrayRef, field: &Field) -> Result<Vec<LevelInfo>> {
+pub(crate) fn calculate_array_levels(
+    array: &ArrayRef,
+    field: &Field,
+) -> Result<Vec<LevelInfo>> {
     let mut builder = LevelInfoBuilder::try_new(field, Default::default())?;
     builder.write(array, 0..array.len());
     Ok(builder.finish())
@@ -535,7 +538,7 @@ impl LevelInfoBuilder {
 /// The data necessary to write a primitive Arrow array to parquet, taking into account
 /// any non-primitive parents it may have in the arrow representation
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct LevelInfo {
+pub(crate) struct LevelInfo {
     /// Array's definition levels
     ///
     /// Present if `max_def_level != 0`

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -437,8 +437,7 @@ impl ArrowRowGroupWriter {
     pub fn close(self) -> Result<Vec<(ArrowColumnChunk, ColumnCloseResult)>> {
         self.shared_buffers
             .into_iter()
-            .into_iter()
-            .zip(self.writers.into_iter())
+            .zip(self.writers)
             .map(|(chunk, writer)| {
                 let close_result = match writer {
                     ArrowColumnWriter::ByteArray(c) => c.close()?,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -29,7 +29,7 @@ use thrift::protocol::{TCompactOutputProtocol, TSerializable};
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::{Array, FixedSizeListArray, RecordBatch, RecordBatchWriter};
-use arrow_schema::{ArrowError, DataType as ArrowDataType, IntervalUnit, SchemaRef};
+use arrow_schema::{ArrowError, DataType as ArrowDataType, IntervalUnit, SchemaRef, Schema};
 
 use super::schema::{
     add_encoded_arrow_schema_to_metadata, arrow_to_parquet_schema,
@@ -52,7 +52,7 @@ use crate::schema::types::{ColumnDescPtr, SchemaDescriptor};
 use levels::{calculate_array_levels, LevelInfo};
 
 mod byte_array;
-mod levels;
+pub mod levels;
 
 /// Arrow writer
 ///
@@ -348,7 +348,7 @@ impl PageWriter for ArrowPageWriter {
 }
 
 /// Encodes a leaf column to [`ArrowPageWriter`]
-enum ArrowColumnWriter {
+pub enum ArrowColumnWriter {
     ByteArray(GenericColumnWriter<'static, ByteArrayEncoder>),
     Column(ColumnWriter<'static>),
 }
@@ -398,6 +398,17 @@ impl ArrowRowGroupWriter {
         Ok(())
     }
 
+    pub fn schema(&self)-> &Arc<Schema> {
+        &self.schema
+    }
+
+    /// Converts this [ArrowRowGroupWriter] into a collection of individual [ArrowColumnWriter]s
+    /// and associated [SharedColumnChunk]s. This permits the caller greater control over how
+    /// data is serialized, such as via parallel threads or async tasks. 
+    pub fn into_col_writers(self) -> Vec<(SharedColumnChunk, ArrowColumnWriter)> {
+        self.writers
+    }
+
     pub fn close(self) -> Result<Vec<(ArrowColumnChunk, ColumnCloseResult)>> {
         self.writers
             .into_iter()
@@ -411,6 +422,23 @@ impl ArrowRowGroupWriter {
                 Ok((chunk, close_result))
             })
             .collect()
+    }
+}
+
+/// Represents components of a [ArrowRowGroupWriter] which have been broken apart by passing ownership
+/// back out to the caller.
+type DeconstructedRowGroupWriterComponents = (Arc<Schema>, Vec<(SharedColumnChunk, ArrowColumnWriter)>);
+
+impl From<DeconstructedRowGroupWriterComponents> for ArrowRowGroupWriter{
+    fn from(value: DeconstructedRowGroupWriterComponents) -> Self{
+        let schema = value.0;
+        let writers = value.1;
+        Self { writers, 
+            schema, 
+            /// The caller is responsible for tracking buffered_rows when dissasembling and
+            /// reasembling ArrowRowGroupWriter
+            buffered_rows: 0
+        }
     }
 }
 
@@ -479,7 +507,7 @@ fn get_arrow_column_writer(
 }
 
 /// Write the leaves of `array` in depth-first order to `writers` with `levels`
-fn write_leaves<'a, W>(
+pub fn write_leaves<'a, W>(
     writers: &mut W,
     levels: &mut IntoIter<LevelInfo>,
     array: &(dyn Array + 'static),
@@ -519,7 +547,7 @@ where
     Ok(())
 }
 
-fn write_leaf(
+pub fn write_leaf(
     writer: &mut ColumnWriter<'_>,
     column: &dyn Array,
     levels: LevelInfo,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -301,7 +301,7 @@ impl Read for ArrowColumnChunkReader {
 
 /// A shared [`ArrowColumnChunk`]
 ///
-/// This allows it to be owned by [`ArrowPageWriter`] whilst allowing access via
+/// This allows it to be owned by lower level page writers whilst allowing access via
 /// [`ArrowRowGroupWriter`] on flush, without requiring self-referential borrows
 pub type SharedColumnChunk = Arc<Mutex<ArrowColumnChunk>>;
 


### PR DESCRIPTION
# Which issue does this PR close?

Related to: #1718 
Enables: https://github.com/apache/arrow-datafusion/pull/7655

# Rationale for this change
 
#4850 enabled external access to `ArrowRowGroupWriter` so downstream users could orchestrate serialization of row groups in parallel on threads/tokio tasks as desired. This PR goes one level deeper to make `ArrowColumnWriter` and associated structs/functions public, so that downstream users can serialize columns in parallel. 

This PR also adds some utility methods to break apart and reconstruct `ArrowRowGroupWriter`. The idea is to do the following:

1. Initialize `ArrowRowGroupWriter`
2. Break into component `ArrowColumnWriter`s and distribute to threads/tasks
3. Serialize columns in parallel
4. Join column writers back to main thread, reconstruct `ArrowRowGroupWriter` and finalize the row group

The above strategy is implemented in https://github.com/apache/arrow-datafusion/pull/7655.

# What changes are included in this PR?
`ArrowColumnWriter` and associated sturcts/functions are marked `pub`. Additional utility methods implemented for `ArrowRowGroupWriter`.


# Are there any user-facing changes?

Additional structs and functions are public.
