### PR TITLE
Faster Serde Integration (~80% faster)

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -54,3 +54,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1.27", default-features = false, features = ["io-util"] }
 bytes = "1.4"
+criterion = { version = "0.5", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+
+[[bench]]
+name = "serde"
+harness = false
+

--- a/arrow-json/benches/serde.rs
+++ b/arrow-json/benches/serde.rs
@@ -29,7 +29,7 @@ fn do_bench<R: Serialize>(c: &mut Criterion, name: &str, rows: &[R], schema: &Sc
         b.iter(|| {
             let builder = ReaderBuilder::new(schema.clone()).with_batch_size(64);
             let mut decoder = builder.build_decoder().unwrap();
-            decoder.serialize(&rows)
+            decoder.serialize(rows)
         })
     });
 }

--- a/arrow-json/benches/serde.rs
+++ b/arrow-json/benches/serde.rs
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_json::ReaderBuilder;
+use arrow_schema::{DataType, Field, Schema};
+use criterion::*;
+use rand::{thread_rng, Rng};
+use serde::Serialize;
+use std::sync::Arc;
+
+#[allow(deprecated)]
+fn do_bench<R: Serialize>(c: &mut Criterion, name: &str, rows: &[R], schema: &Schema) {
+    let schema = Arc::new(schema.clone());
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let builder = ReaderBuilder::new(schema.clone()).with_batch_size(64);
+            let mut decoder = builder.build_decoder().unwrap();
+            decoder.serialize(&rows)
+        })
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = thread_rng();
+    let schema = Schema::new(vec![Field::new("i32", DataType::Int32, false)]);
+    let v: Vec<i32> = (0..2048).map(|_| rng.gen_range(0..10000)).collect();
+
+    do_bench(c, "small_i32", &v, &schema);
+    let v: Vec<i32> = (0..2048).map(|_| rng.gen()).collect();
+    do_bench(c, "large_i32", &v, &schema);
+
+    let schema = Schema::new(vec![Field::new("i64", DataType::Int64, false)]);
+    let v: Vec<i64> = (0..2048).map(|_| rng.gen_range(0..10000)).collect();
+    do_bench(c, "small_i64", &v, &schema);
+    let v: Vec<i64> = (0..2048).map(|_| rng.gen_range(0..i32::MAX as _)).collect();
+    do_bench(c, "medium_i64", &v, &schema);
+    let v: Vec<i64> = (0..2048).map(|_| rng.gen()).collect();
+    do_bench(c, "large_i64", &v, &schema);
+
+    let schema = Schema::new(vec![Field::new("f32", DataType::Float32, false)]);
+    let v: Vec<f32> = (0..2048).map(|_| rng.gen_range(0.0..10000.)).collect();
+    do_bench(c, "small_f32", &v, &schema);
+    let v: Vec<f32> = (0..2048).map(|_| rng.gen_range(0.0..f32::MAX)).collect();
+    do_bench(c, "large_f32", &v, &schema);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow-json/src/reader/timestamp_array.rs
+++ b/arrow-json/src/reader/timestamp_array.rs
@@ -96,6 +96,13 @@ where
 
                     builder.append_value(value)
                 }
+                TapeElement::I32(v) => builder.append_value(v as i64),
+                TapeElement::I64(high) => match tape.get(p + 1) {
+                    TapeElement::I32(low) => {
+                        builder.append_value((high as i64) << 32 | low as i64)
+                    }
+                    _ => unreachable!(),
+                },
                 _ => return Err(tape.error(*p, "primitive")),
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Encoding numerics directly in the tape drastically improves the performance of the serde integration.

```
small_i32               time:   [5.3992 µs 5.4006 µs 5.4020 µs]
                        change: [-70.553% -70.532% -70.511%] (p = 0.00 < 0.05)
                        Performance has improved.

large_i32               time:   [5.2606 µs 5.2618 µs 5.2631 µs]
                        change: [-76.768% -76.747% -76.727%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

small_i64               time:   [5.2937 µs 5.2960 µs 5.2986 µs]
                        change: [-73.032% -73.002% -72.974%] (p = 0.00 < 0.05)
                        Performance has improved.

medium_i64              time:   [5.3314 µs 5.3372 µs 5.3417 µs]
                        change: [-77.574% -77.553% -77.533%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild

large_i64               time:   [5.6473 µs 5.6503 µs 5.6532 µs]
                        change: [-81.152% -81.103% -81.056%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  22 (22.00%) low severe

small_f32               time:   [3.6082 µs 3.6101 µs 3.6121 µs]
                        change: [-93.595% -93.591% -93.588%] (p = 0.00 < 0.05)
                        Performance has improved.

large_f32               time:   [3.5233 µs 3.5245 µs 3.5256 µs]
                        change: [-94.058% -94.055% -94.053%] (p = 0.00 < 0.05)
                        Performance has improved.
```

It additionally opens the door to eager parsing in the future, which may yield performance improvements for regular JSON decoding.

I have confirmed this does not regress the performance of the JSON decoder

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
