### PR TITLE
feat: improve flight CLI error handling

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.0", default-features = false, features = ["macros", "rt",
 tonic = { version = "0.10.0", default-features = false, features = ["transport", "codegen", "prost"] }
 
 # CLI-related dependencies
+anyhow = { version = "1.0", optional = true }
 clap = { version = "4.1", default-features = false, features = ["std", "derive", "env", "help", "error-context", "usage"], optional = true }
 tracing-log = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["ansi", "fmt"], optional = true }
@@ -62,7 +63,7 @@ flight-sql-experimental = ["arrow-arith", "arrow-data", "arrow-ord", "arrow-row"
 tls = ["tonic/tls"]
 
 # Enable CLI tools
-cli = ["arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
+cli = ["anyhow", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Make error message actually readable:

**Before:**

```text
thread 'main' panicked at 'collect data stream: Status { code: Internal, message: "h2 protocol error: error reading a body from connection: stream error received: unexpected internal error encountered", source: Some(hyper::Error(Body, Error { kind: Reset(S
treamId(3), INTERNAL_ERROR, Remote) })) }', arrow-flight/src/bin/flight_sql_client.rs:130:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**After:**

```text
Error: read flight data

Caused by:
    0: collect data stream
    1: status: Internal, message: "h2 protocol error: error reading a body from connection: stream error received: unexpected internal error encountered", details: [], metadata: MetadataMap { headers: {} }
    2: error reading a body from connection: stream error received: unexpected internal error encountered
    3: stream error received: unexpected internal error encountered
```

# What changes are included in this PR?
Use `anyhow`s context instead of `expect` all over the place.

Note that this ONLY applies to the CLI, not to any library error handling.

# Are there any user-facing changes?
Better errors.