### PR TITLE
feat: `SSLKEYLOGFILE` support for flight CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,6 @@ arrow-string = { version = "47.0.0", path = "./arrow-string" }
 parquet = { version = "47.0.0", path = "./parquet", default-features = false }
 
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+
+[patch.crates-io]
+tonic = { git = "https://github.com/crepererum/tonic.git", branch = "crepererum/keylog" }

--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -85,6 +85,14 @@ struct ClientArgs {
     #[clap(long)]
     tls: bool,
 
+    /// Dump TLS key log.
+    ///
+    /// The target file is specified by the `SSLKEYLOGFILE` environment variable.
+    ///
+    /// Required `--tls`.
+    #[clap(long, requires = "tls")]
+    key_log: bool,
+
     /// Server host.
     #[clap(long)]
     host: String,
@@ -235,7 +243,12 @@ async fn setup_client(args: ClientArgs) -> Result<FlightSqlServiceClient<Channel
         .keep_alive_while_idle(true);
 
     if args.tls {
-        let tls_config = ClientTlsConfig::new();
+        let mut tls_config = ClientTlsConfig::new();
+
+        if args.key_log {
+            tls_config = tls_config.use_key_log();
+        }
+
         endpoint = endpoint
             .tls_config(tls_config)
             .context("create TLS endpoint")?;


### PR DESCRIPTION
**:warning: Requires https://github.com/hyperium/tonic/pull/1539 !**

# Which issue does this PR close?
\-

# Rationale for this change
Allows analysis of TLS traffic with an external tool like Wireshark.

See https://wiki.wireshark.org/TLS#using-the-pre-master-secret

# What changes are included in this PR?
New flag that opts into into the standard `SSLKEYLOGFILE` handling that other libraries and browsers support.

# Are there any user-facing changes?
Mostly none for normal users, but might be helpful for developers.