### PR TITLE
Add AWS presigned URL support

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -45,7 +45,6 @@ walkdir = "2"
 
 # Cloud storage support
 base64 = { version = "0.21", default-features = false, features = ["std"], optional = true }
-http = { version = "0.2", default_features = false, optional = true }
 hyper = { version = "0.14", default-features = false, optional = true }
 quick-xml = { version = "0.30.0", features = ["serialize", "overlapped-lists"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -65,7 +64,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 nix = { version = "0.27.1", features = ["fs"] }
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml", "dep:http", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
+cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -45,6 +45,7 @@ walkdir = "2"
 
 # Cloud storage support
 base64 = { version = "0.21", default-features = false, features = ["std"], optional = true }
+http = { version = "0.2", default_features = false, optional = true }
 hyper = { version = "0.14", default-features = false, optional = true }
 quick-xml = { version = "0.30.0", features = ["serialize", "overlapped-lists"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -64,7 +65,7 @@ tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-ut
 nix = { version = "0.27.1", features = ["fs"] }
 
 [features]
-cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
+cloud = ["serde", "serde_json", "quick-xml", "dep:http", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -212,7 +212,7 @@ pub struct S3Config {
 }
 
 impl S3Config {
-    pub fn path_url(&self, path: &Path) -> String {
+    pub(crate) fn path_url(&self, path: &Path) -> String {
         format!("{}/{}", self.bucket_endpoint, encode_path(path))
     }
 }

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -212,7 +212,7 @@ pub struct S3Config {
 }
 
 impl S3Config {
-    fn path_url(&self, path: &Path) -> String {
+    pub fn path_url(&self, path: &Path) -> String {
         format!("{}/{}", self.bucket_endpoint, encode_path(path))
     }
 }

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -184,41 +184,7 @@ impl<'a> AwsAuthorizer<'a> {
         request.headers_mut().insert(AUTH_HEADER, authorization_val);
     }
 
-    /// Authorize a request via `method` to `url` valid for the duration specified in `expires_in`
-    /// by attaching the relevant [AWS SigV4] query parameters.
-    ///
-    /// [AWS SigV4]: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
-    ///
-    /// # Example
-    ///
-    /// This example modifies `url` to add the signing parameters needed to enable a user to upload
-    /// a file to "some-folder/some-file.txt" in the next hour.
-    ///
-    /// ```
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use object_store::{aws::{AmazonS3Builder, AwsAuthorizer}, path::Path};
-    /// use reqwest::Method;
-    /// use std::time::Duration;
-    /// use url::Url;
-    ///
-    /// let region = "us-east-1";
-    /// let s3 = AmazonS3Builder::new()
-    ///     .with_region(region)
-    ///     .with_bucket_name("my-bucket")
-    ///     .with_access_key_id("my-access-key-id")
-    ///     .with_secret_access_key("my-secret-access-key")
-    ///     .build()?;
-    /// let credential = s3
-    ///     .credentials()
-    ///     .get_credential()
-    ///     .await?;
-    /// let authorizer = AwsAuthorizer::new(&credential, "s3", region);
-    /// let mut url = Url::parse(&s3.path_url(&Path::from("some-folder/some-file.txt")))?;
-    /// authorizer.sign(Method::PUT, &mut url, Duration::from_secs(60 * 60));
-    /// #     Ok(())
-    /// # }
-    /// ```
-    pub fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
+    pub(crate) fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
         let date = self.date.unwrap_or_else(Utc::now);
         let scope = self.scope(date);
 

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -30,7 +30,7 @@ use reqwest::{Client, Method, Request, RequestBuilder, StatusCode};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::warn;
 use url::Url;
 
@@ -182,6 +182,56 @@ impl<'a> AwsAuthorizer<'a> {
 
         let authorization_val = HeaderValue::from_str(&authorisation).unwrap();
         request.headers_mut().insert(AUTH_HEADER, authorization_val);
+    }
+
+    /// Authorize a request via `method` to `url` valid for the duration specified in `expires_in`
+    /// by attaching the relevant [AWS SigV4] query parameters.
+    ///
+    /// [AWS SigV4]: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+    pub fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
+        let date = self.date.unwrap_or_else(Utc::now);
+        let scope = self.scope(date);
+
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+        url.query_pairs_mut()
+            .append_pair("X-Amz-Algorithm", ALGORITHM)
+            .append_pair(
+                "X-Amz-Credential",
+                &format!("{}/{}", self.credential.key_id, scope),
+            )
+            .append_pair("X-Amz-Date", &date.format("%Y%m%dT%H%M%SZ").to_string())
+            .append_pair("X-Amz-Expires", &expires_in.as_secs().to_string())
+            .append_pair("X-Amz-SignedHeaders", "host");
+
+        // TODO: For S3, you must include the X-Amz-Security-Token query parameter in the URL if
+        // using credentials sourced from the STS service.
+
+        // We don't have a payload; the user is going to send the payload directly themselves.
+        let digest = UNSIGNED_PAYLOAD;
+
+        let host = &url[url::Position::BeforeHost..url::Position::AfterPort].to_string();
+        let mut headers = HeaderMap::new();
+        let host_val = HeaderValue::from_str(host).unwrap();
+        headers.insert("host", host_val);
+
+        let (signed_headers, canonical_headers) = canonicalize_headers(&headers);
+
+        let string_to_sign = self.string_to_sign(
+            date,
+            &scope,
+            &method,
+            url,
+            &canonical_headers,
+            &signed_headers,
+            digest,
+        );
+
+        let signature =
+            self.credential
+                .sign(&string_to_sign, date, self.region, self.service);
+
+        url.query_pairs_mut()
+            .append_pair("X-Amz-Signature", &signature);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -697,7 +747,46 @@ mod tests {
         };
 
         authorizer.authorize(&mut request, None);
-        assert_eq!(request.headers().get(AUTH_HEADER).unwrap(), "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20220806/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=653c3d8ea261fd826207df58bc2bb69fbb5003e9eb3c0ef06e4a51f2a81d8699")
+        assert_eq!(request.headers().get(AUTH_HEADER).unwrap(), "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20220806/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=653c3d8ea261fd826207df58bc2bb69fbb5003e9eb3c0ef06e4a51f2a81d8699");
+    }
+
+    #[test]
+    fn signed_get_url() {
+        // Values from https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+        let credential = AwsCredential {
+            key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            token: None,
+        };
+
+        let date = DateTime::parse_from_rfc3339("2013-05-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let authorizer = AwsAuthorizer {
+            date: Some(date),
+            credential: &credential,
+            service: "s3",
+            region: "us-east-1",
+            sign_payload: false,
+        };
+
+        let mut url =
+            Url::parse("https://examplebucket.s3.amazonaws.com/test.txt").unwrap();
+        authorizer.sign(Method::GET, &mut url, Duration::from_secs(86400));
+
+        assert_eq!(
+            url,
+            Url::parse(
+                "https://examplebucket.s3.amazonaws.com/test.txt?\
+                X-Amz-Algorithm=AWS4-HMAC-SHA256&\
+                X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&\
+                X-Amz-Date=20130524T000000Z&\
+                X-Amz-Expires=86400&\
+                X-Amz-SignedHeaders=host&\
+                X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404"
+            ).unwrap()
+        );
     }
 
     #[test]

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -185,13 +185,7 @@ impl<'a> AwsAuthorizer<'a> {
             self.service
         );
 
-        let string_to_sign = format!(
-            "{}\n{}\n{}\n{}",
-            ALGORITHM,
-            date.format("%Y%m%dT%H%M%SZ"),
-            scope,
-            hashed_canonical_request
-        );
+        let string_to_sign = self.string_to_sign(date, &scope, &hashed_canonical_request);
 
         // sign the string
         let signature =
@@ -206,6 +200,21 @@ impl<'a> AwsAuthorizer<'a> {
 
         let authorization_val = HeaderValue::from_str(&authorisation).unwrap();
         request.headers_mut().insert(AUTH_HEADER, authorization_val);
+    }
+
+    fn string_to_sign(
+        &self,
+        date: DateTime<Utc>,
+        scope: &str,
+        hashed_canonical_request: &str,
+    ) -> String {
+        format!(
+            "{}\n{}\n{}\n{}",
+            ALGORITHM,
+            date.format("%Y%m%dT%H%M%SZ"),
+            scope,
+            hashed_canonical_request
+        )
     }
 }
 

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -178,12 +178,7 @@ impl<'a> AwsAuthorizer<'a> {
         );
 
         let hashed_canonical_request = hex_digest(canonical_request.as_bytes());
-        let scope = format!(
-            "{}/{}/{}/aws4_request",
-            date.format("%Y%m%d"),
-            self.region,
-            self.service
-        );
+        let scope = self.scope(date);
 
         let string_to_sign = self.string_to_sign(date, &scope, &hashed_canonical_request);
 
@@ -214,6 +209,15 @@ impl<'a> AwsAuthorizer<'a> {
             date.format("%Y%m%dT%H%M%SZ"),
             scope,
             hashed_canonical_request
+        )
+    }
+
+    fn scope(&self, date: DateTime<Utc>) -> String {
+        format!(
+            "{}/{}/{}/aws4_request",
+            date.format("%Y%m%d"),
+            self.region,
+            self.service
         )
     }
 }

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -89,6 +89,7 @@ const DATE_HEADER: &str = "x-amz-date";
 const HASH_HEADER: &str = "x-amz-content-sha256";
 const TOKEN_HEADER: &str = "x-amz-security-token";
 const AUTH_HEADER: &str = "authorization";
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
 
 impl<'a> AwsAuthorizer<'a> {
     /// Create a new [`AwsAuthorizer`]
@@ -185,7 +186,8 @@ impl<'a> AwsAuthorizer<'a> {
         );
 
         let string_to_sign = format!(
-            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+            "{}\n{}\n{}\n{}",
+            ALGORITHM,
             date.format("%Y%m%dT%H%M%SZ"),
             scope,
             hashed_canonical_request
@@ -198,8 +200,8 @@ impl<'a> AwsAuthorizer<'a> {
 
         // build the actual auth header
         let authorisation = format!(
-            "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-            self.credential.key_id, scope, signed_headers, signature
+            "{} Credential={}/{}, SignedHeaders={}, Signature={}",
+            ALGORITHM, self.credential.key_id, scope, signed_headers, signature
         );
 
         let authorization_val = HeaderValue::from_str(&authorisation).unwrap();

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -156,7 +156,6 @@ impl<'a> AwsAuthorizer<'a> {
         request.headers_mut().insert(HASH_HEADER, header_digest);
 
         let (signed_headers, canonical_headers) = canonicalize_headers(request.headers());
-        let canonical_query = canonicalize_query(request.url());
 
         let scope = self.scope(date);
 
@@ -165,7 +164,6 @@ impl<'a> AwsAuthorizer<'a> {
             &scope,
             request.method(),
             request.url(),
-            &canonical_query,
             &canonical_headers,
             &signed_headers,
             &digest,
@@ -193,7 +191,6 @@ impl<'a> AwsAuthorizer<'a> {
         scope: &str,
         request_method: &Method,
         url: &Url,
-        canonical_query: &str,
         canonical_headers: &str,
         signed_headers: &str,
         digest: &str,
@@ -205,6 +202,8 @@ impl<'a> AwsAuthorizer<'a> {
             "s3" => url.path().to_string(),
             _ => utf8_percent_encode(url.path(), &STRICT_PATH_ENCODE_SET).to_string(),
         };
+
+        let canonical_query = canonicalize_query(url);
 
         // https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
         let canonical_request = format!(

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -177,10 +177,9 @@ impl<'a> AwsAuthorizer<'a> {
             digest
         );
 
-        let hashed_canonical_request = hex_digest(canonical_request.as_bytes());
         let scope = self.scope(date);
 
-        let string_to_sign = self.string_to_sign(date, &scope, &hashed_canonical_request);
+        let string_to_sign = self.string_to_sign(date, &scope, &canonical_request);
 
         // sign the string
         let signature =
@@ -201,8 +200,10 @@ impl<'a> AwsAuthorizer<'a> {
         &self,
         date: DateTime<Utc>,
         scope: &str,
-        hashed_canonical_request: &str,
+        canonical_request: &str,
     ) -> String {
+        let hashed_canonical_request = hex_digest(canonical_request.as_bytes());
+
         format!(
             "{}\n{}\n{}\n{}",
             ALGORITHM,

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -188,6 +188,36 @@ impl<'a> AwsAuthorizer<'a> {
     /// by attaching the relevant [AWS SigV4] query parameters.
     ///
     /// [AWS SigV4]: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+    ///
+    /// # Example
+    ///
+    /// This example modifies `url` to add the signing parameters needed to enable a user to upload
+    /// a file to "some-folder/some-file.txt" in the next hour.
+    ///
+    /// ```
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use object_store::{aws::{AmazonS3Builder, AwsAuthorizer}, path::Path};
+    /// use reqwest::Method;
+    /// use std::time::Duration;
+    /// use url::Url;
+    ///
+    /// let region = "us-east-1";
+    /// let s3 = AmazonS3Builder::new()
+    ///     .with_region(region)
+    ///     .with_bucket_name("my-bucket")
+    ///     .with_access_key_id("my-access-key-id")
+    ///     .with_secret_access_key("my-secret-access-key")
+    ///     .build()?;
+    /// let credential = s3
+    ///     .credentials()
+    ///     .get_credential()
+    ///     .await?;
+    /// let authorizer = AwsAuthorizer::new(&credential, "s3", region);
+    /// let mut url = Url::parse(&s3.path_url(&Path::from("some-folder/some-file.txt")))?;
+    /// authorizer.sign(Method::PUT, &mut url, Duration::from_secs(60 * 60));
+    /// #     Ok(())
+    /// # }
+    /// ```
     pub fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
         let date = self.date.unwrap_or_else(Utc::now);
         let scope = self.scope(date);

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -233,8 +233,12 @@ impl<'a> AwsAuthorizer<'a> {
             .append_pair("X-Amz-Expires", &expires_in.as_secs().to_string())
             .append_pair("X-Amz-SignedHeaders", "host");
 
-        // TODO: For S3, you must include the X-Amz-Security-Token query parameter in the URL if
+        // For S3, you must include the X-Amz-Security-Token query parameter in the URL if
         // using credentials sourced from the STS service.
+        if let Some(ref token) = self.credential.token {
+            url.query_pairs_mut()
+                .append_pair("X-Amz-Security-Token", token);
+        }
 
         // We don't have a payload; the user is going to send the payload directly themselves.
         let digest = UNSIGNED_PAYLOAD;

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -231,10 +231,10 @@ impl Signer for AmazonS3 {
     ///
     /// ```
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use object_store::{aws::AmazonS3Builder, path::Path, signer::Signer};
-    /// use http::Method;
-    /// use std::time::Duration;
-    ///
+    /// # use object_store::{aws::AmazonS3Builder, path::Path, signer::Signer};
+    /// # use http::Method;
+    /// # use std::time::Duration;
+    /// #
     /// let region = "us-east-1";
     /// let s3 = AmazonS3Builder::new()
     ///     .with_region(region)

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -232,7 +232,7 @@ impl Signer for AmazonS3 {
     /// ```
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # use object_store::{aws::AmazonS3Builder, path::Path, signer::Signer};
-    /// # use http::Method;
+    /// # use reqwest::Method;
     /// # use std::time::Duration;
     /// #
     /// let region = "us-east-1";

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -209,6 +209,11 @@ impl AmazonS3 {
     pub fn credentials(&self) -> &AwsCredentialProvider {
         &self.client.config().credentials
     }
+
+    /// Create a full URL to the resource specified by `path` with this instance's configuration.
+    pub fn path_url(&self, path: &Path) -> String {
+        self.client.config().path_url(path)
+    }
 }
 
 #[async_trait]

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -262,7 +262,7 @@ impl AmazonS3 {
     }
 
     /// Create a full URL to the resource specified by `path` with this instance's configuration.
-    pub fn path_url(&self, path: &Path) -> String {
+    fn path_url(&self, path: &Path) -> String {
         self.client.config().path_url(path)
     }
 }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -36,10 +36,10 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
-use std::str::FromStr;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc, time::Duration};
 use tokio::io::AsyncWrite;
 use tracing::info;
 use url::Url;
@@ -208,6 +208,57 @@ impl AmazonS3 {
     /// Returns the [`AwsCredentialProvider`] used by [`AmazonS3`]
     pub fn credentials(&self) -> &AwsCredentialProvider {
         &self.client.config().credentials
+    }
+
+    /// Create a URL containing the relevant [AWS SigV4] query parameters that authorize a request
+    /// via `method` to the resource at `path` valid for the duration specified in `expires_in`.
+    ///
+    /// [AWS SigV4]: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+    ///
+    /// # Example
+    ///
+    /// This example returns a URL that will enable a user to upload a file to
+    /// "some-folder/some-file.txt" in the next hour.
+    ///
+    /// ```
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use object_store::{aws::AmazonS3Builder, path::Path};
+    /// use reqwest::Method;
+    /// use std::time::Duration;
+    ///
+    /// let region = "us-east-1";
+    /// let s3 = AmazonS3Builder::new()
+    ///     .with_region(region)
+    ///     .with_bucket_name("my-bucket")
+    ///     .with_access_key_id("my-access-key-id")
+    ///     .with_secret_access_key("my-secret-access-key")
+    ///     .build()?;
+    ///
+    /// let url = s3.signed_url(
+    ///     Method::PUT,
+    ///     &Path::from("some-folder/some-file.txt"),
+    ///     Duration::from_secs(60 * 60)
+    /// ).await?;
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub async fn signed_url(
+        &self,
+        method: Method,
+        path: &Path,
+        expires_in: Duration,
+    ) -> Result<Url> {
+        let credential = self.credentials().get_credential().await?;
+        let authorizer =
+            AwsAuthorizer::new(&credential, "s3", &self.client.config().region);
+
+        let path_url = self.path_url(path);
+        let mut url =
+            Url::parse(&path_url).context(UnableToParseUrlSnafu { url: path_url })?;
+
+        authorizer.sign(method, &mut url, expires_in);
+
+        Ok(url)
     }
 
     /// Create a full URL to the resource specified by `path` with this instance's configuration.

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -267,6 +267,8 @@ pub mod local;
 pub mod memory;
 pub mod path;
 pub mod prefix;
+#[cfg(feature = "cloud")]
+pub mod signer;
 pub mod throttle;
 
 #[cfg(feature = "cloud")]

--- a/object_store/src/signer.rs
+++ b/object_store/src/signer.rs
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Abstraction of signed URL generation for those object store implementations that support it
+
+use crate::{path::Path, Result};
+use async_trait::async_trait;
+use http::Method;
+use std::{fmt, time::Duration};
+use url::Url;
+
+/// Universal API to presigned URLs generated from multiple object store services. Not supported by
+/// all object store services.
+#[async_trait]
+pub trait Signer: Send + Sync + fmt::Debug + 'static {
+    /// Given the intended [`Method`] and [`Path`] to use and the desired length of time for which
+    /// the URL should be valid, return a signed [`Url`] created with the object store
+    /// implementation's credentials such that the URL can be handed to something that doesn't have
+    /// access to the object store's credentials, to allow limited access to the object store.
+    async fn signed_url(
+        &self,
+        method: Method,
+        path: &Path,
+        expires_in: Duration,
+    ) -> Result<Url>;
+}

--- a/object_store/src/signer.rs
+++ b/object_store/src/signer.rs
@@ -19,7 +19,7 @@
 
 use crate::{path::Path, Result};
 use async_trait::async_trait;
-use http::Method;
+use reqwest::Method;
 use std::{fmt, time::Duration};
 use url::Url;
 


### PR DESCRIPTION
Ok, I'm feeling pretty good about this-- I did test it against a real live S3 bucket and I was able to upload a file with cURL using signed URLs generated by these new functions!

There's always more refactoring that could be done... the private method where I told clippy to let me have many arguments points to the worst of it.

If you take a look commit-by-commit, the last commit adds a public `signed_url` method directly to `AmazonS3`, which I think makes it super convenient, but might be more than you'd like to expose. I'm happy to back that commit out!

# Which issue does this PR close?

Closes #4763.
Connects to #3027, which is requesting signed GET URLs for all object store implementations that support it-- this PR implements support for both GET and PUT signed URLs, but only for AWS.

# Rationale for this change

Enable reusing the authorization and signing code to generate signed URLs that can be used to give permission to upload or view particular objects. 

# What changes are included in this PR?

A new public method on `AwsAuthorizer`, currently called `sign` (as opposed to the existing `authorize` method) that adds AWS signature query parameters to a specified `Url` so that it can be given to another user to authorize uploading or viewing a particular resource.

This shares a lot of the signing code with the existing `authorize` method, so I've pulled out a few private methods, but I don't think the current structure is ideal yet. Thoughts on how far to take this are very welcome, such as if there's another struct or three starting to cry to be let out of `AwsAuthorizer`, if these should be free functions, etc.

# Are there any user-facing changes?

Yes, one (or possibly two) new method(s) in the public API. See the included examples!