### PR TITLE
Mark OnCloseRowGroup Send

### DIFF
--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -115,7 +115,8 @@ pub type OnCloseRowGroup<'a> = Box<
             Vec<Option<ColumnIndex>>,
             Vec<Option<OffsetIndex>>,
         ) -> Result<()>
-        + 'a,
+        + 'a
+        + Send,
 >;
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
# Which issue does this PR close?

Enables https://github.com/apache/arrow-datafusion/pull/7655

# Rationale for this change
 
#4871 rolled back this change, but without it https://github.com/apache/arrow-datafusion/pull/7655 encounters a compile time error since `OnCloseRowGroup` is used across an `await`.

Apart from this change, https://github.com/apache/arrow-datafusion/pull/7655 is working great against the current master branch of `arrow-rs`.

The compile error can be viewed here: https://github.com/apache/arrow-datafusion/actions/runs/6412903672/job/17410973730?pr=7655

# What changes are included in this PR?

OnCloseRowGroup is marked Send.

# Are there any user-facing changes?

