### PR TITLE
feat: log headers/trailers in flight CLI (+ minor fixes)

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -52,7 +52,7 @@ tonic = { version = "0.10.0", default-features = false, features = ["transport",
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4.1", default-features = false, features = ["std", "derive", "env", "help", "error-context", "usage"], optional = true }
 tracing-log = { version = "0.1", optional = true }
-tracing-subscriber = { version = "0.3.1", default-features = false, features = ["ansi", "fmt"], optional = true }
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["ansi", "env-filter", "fmt"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -789,7 +789,6 @@ mod tests {
 
     use arrow_cast::pretty::pretty_format_batches;
     use arrow_flight::sql::client::FlightSqlServiceClient;
-    use arrow_flight::utils::flight_data_to_batches;
     use tonic::transport::server::TcpIncoming;
     use tonic::transport::{Certificate, Endpoint};
     use tower::service_fn;
@@ -955,8 +954,7 @@ mod tests {
 
             let ticket = flight_info.endpoint[0].ticket.as_ref().unwrap().clone();
             let flight_data = client.do_get(ticket).await.unwrap();
-            let flight_data: Vec<FlightData> = flight_data.try_collect().await.unwrap();
-            let batches = flight_data_to_batches(&flight_data).unwrap();
+            let batches: Vec<_> = flight_data.try_collect().await.unwrap();
 
             let res = pretty_format_batches(batches.as_slice()).unwrap();
             let expected = r#"

--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -17,7 +17,7 @@
 
 use std::{error::Error, sync::Arc, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use arrow_array::{ArrayRef, Datum, RecordBatch, StringArray};
 use arrow_cast::{cast_with_options, pretty::pretty_format_batches, CastOptions};
 use arrow_flight::{sql::client::FlightSqlServiceClient, FlightInfo};
@@ -65,6 +65,10 @@ where
 #[derive(Debug, Parser)]
 pub struct LoggingArgs {
     /// Log verbosity.
+    ///
+    /// Use `-v for warn, `-vv for info, -vvv for debug, -vvvv for trace.
+    ///
+    /// Note you can also set logging level using `RUST_LOG` environment variable: `RUST_LOG=debug`
     #[clap(
         short = 'v',
         long = "verbose",
@@ -193,7 +197,7 @@ async fn execute_flight(
 
     for endpoint in info.endpoint {
         let Some(ticket) = &endpoint.ticket else {
-            panic!("did not get ticket");
+            bail!("did not get ticket");
         };
 
         let mut flight_data = client.do_get(ticket.clone()).await.context("do get")?;
@@ -299,10 +303,10 @@ async fn setup_client(args: ClientArgs) -> Result<FlightSqlServiceClient<Channel
             info!("performed handshake");
         }
         (Some(_), None) => {
-            panic!("when username is set, you also need to set a password")
+            bail!("when username is set, you also need to set a password")
         }
         (None, Some(_)) => {
-            panic!("when password is set, you also need to set a username")
+            bail!("when password is set, you also need to set a username")
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Give users a way to easily show headers/trailers in flight CLI. Mostly useful for debugging servers.

# What changes are included in this PR?
1. improve CLI logging setup (implements the usual `-v` flag)
2. change flight SQL client API to return a better high-level wrapper instead of `FlightData`, similar to what the non-SQL flight client does **breaking change**
3. log headers/trailers in CLI
4. drive-by clean up: replace explicit panic in CLI w/ proper errors

# Are there any user-facing changes?
`-v` now shows logs including headers and trailers
