### PR TITLE
Cleanup CSV WriterBuilder, Default to AutoSI Second Precision (#4735)

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -676,7 +676,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555,23:46:03,foo
 
         let mut file = tempfile::tempfile().unwrap();
 
-        let builder = WriterBuilder::new().with_rfc3339();
+        let builder = WriterBuilder::new();
         let mut writer = builder.build(&mut file);
         let batches = vec![&batch];
         for batch in batches {

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -77,21 +77,21 @@ const DEFAULT_NULL_VALUE: &str = "";
 pub struct Writer<W: Write> {
     /// The object to write to
     writer: csv::Writer<W>,
-    /// Whether file should be written with headers. Defaults to `true`
+    /// Whether file should be written with headers, defaults to `true`
     has_headers: bool,
-    /// The date format for date arrays
+    /// The date format for date arrays, defaults to RFC3339
     date_format: Option<String>,
-    /// The datetime format for datetime arrays
+    /// The datetime format for datetime arrays, defaults to RFC3339
     datetime_format: Option<String>,
-    /// The timestamp format for timestamp arrays
+    /// The timestamp format for timestamp arrays, defaults to RFC3339
     timestamp_format: Option<String>,
-    /// The timestamp format for timestamp (with timezone) arrays
+    /// The timestamp format for timestamp (with timezone) arrays, defaults to RFC3339
     timestamp_tz_format: Option<String>,
-    /// The time format for time arrays
+    /// The time format for time arrays, defaults to RFC3339
     time_format: Option<String>,
     /// Is the beginning-of-writer
     beginning: bool,
-    /// The value to represent null entries
+    /// The value to represent null entries, defaults to [`DEFAULT_NULL_VALUE`]
     null_value: Option<String>,
 }
 
@@ -333,6 +333,7 @@ impl WriterBuilder {
     }
 
     /// Use RFC3339 format for date/time/timestamps (default)
+    #[deprecated(note = "Use WriterBuilder::default()")]
     pub fn with_rfc3339(mut self) -> Self {
         self.date_format = None;
         self.datetime_format = None;

--- a/arrow/tests/csv.rs
+++ b/arrow/tests/csv.rs
@@ -54,48 +54,6 @@ fn test_export_csv_timestamps() {
     drop(writer);
 
     let left = "c1,c2
-2019-04-18T20:54:47.378000000+10:00,2019-04-18T10:54:47.378000000
-2021-10-30T17:59:07.000000000+11:00,2021-10-30T06:59:07.000000000\n";
-    let right = String::from_utf8(sw).unwrap();
-    assert_eq!(left, right);
-}
-
-#[test]
-fn test_export_csv_timestamps_using_rfc3339() {
-    let schema = Schema::new(vec![
-        Field::new(
-            "c1",
-            DataType::Timestamp(TimeUnit::Millisecond, Some("Australia/Sydney".into())),
-            true,
-        ),
-        Field::new("c2", DataType::Timestamp(TimeUnit::Millisecond, None), true),
-    ]);
-
-    let c1 = TimestampMillisecondArray::from(
-        // 1555584887 converts to 2019-04-18, 20:54:47 in time zone Australia/Sydney (AEST).
-        // The offset (difference to UTC) is +10:00.
-        // 1635577147 converts to 2021-10-30 17:59:07 in time zone Australia/Sydney (AEDT)
-        // The offset (difference to UTC) is +11:00. Note that daylight savings is in effect on 2021-10-30.
-        //
-        vec![Some(1555584887378), Some(1635577147000)],
-    )
-    .with_timezone("Australia/Sydney");
-    let c2 =
-        TimestampMillisecondArray::from(vec![Some(1555584887378), Some(1635577147000)]);
-    let batch =
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)]).unwrap();
-
-    let mut sw = Vec::new();
-    let mut writer = arrow_csv::WriterBuilder::new()
-        .with_rfc3339()
-        .build(&mut sw);
-    let batches = vec![&batch];
-    for batch in batches {
-        writer.write(batch).unwrap();
-    }
-    drop(writer);
-
-    let left = "c1,c2
 2019-04-18T20:54:47.378+10:00,2019-04-18T10:54:47.378
 2021-10-30T17:59:07+11:00,2021-10-30T06:59:07\n";
     let right = String::from_utf8(sw).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4735
Closes https://github.com/apache/arrow-rs/pull/4906

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Cleans up `WriterBuilder` to not default the format strings, this not only saves allocations, but also allows using the fast formatting path for RFC3339 formatting.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

This changes timestamps to default to [AutoSI](https://docs.rs/chrono/latest/chrono/enum.SecondsFormat.html#variant.AutoSi). I'm not sure this really counts as a breaking change, any well-behaved parser should handle this 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
