### PR TITLE
fix(csv)!: infer null for empty column.

### DIFF
--- a/arrow-csv/test/data/init_null_test.csv
+++ b/arrow-csv/test/data/init_null_test.csv
@@ -1,0 +1,6 @@
+c_int,c_float,c_string,c_bool,c_null
+,,,,
+2,2.2,"a",TRUE,
+3,,"b",true,
+4,4.4,,False,
+5,6.6,"",FALSE,


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4903.

# Rationale for this change
 Correctly reflect the fact the data had no values

# What changes are included in this PR?
* inference starts with state implying `Null` data type, then moves to more specific types
* csv reader can read columns with `Null` data type, expects it to be empty 

# Are there any user-facing changes?
Previously inference assumed `Utf8` data type for empty column, which later on could accept non-empty values. Now `Null` type is inferred and thus the column won't accept any non-empty values unless user modifies schema to handle null case differently.
