### PR TITLE
feat: add method for async read bloom filter

### DIFF
--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -132,7 +132,7 @@ impl std::ops::IndexMut<usize> for Block {
 #[derive(Debug, Clone)]
 pub struct Sbbf(Vec<Block>);
 
-const SBBF_HEADER_SIZE_ESTIMATE: usize = 20;
+pub(crate) const SBBF_HEADER_SIZE_ESTIMATE: usize = 20;
 
 /// given an initial offset, and a byte buffer, try to read out a bloom filter header and return
 /// both the header and the offset after it (for bitset).
@@ -147,7 +147,7 @@ fn chunk_read_bloom_filter_header_and_offset(
 /// given a [Bytes] buffer, try to read out a bloom filter header and return both the header and
 /// length of the header.
 #[inline]
-fn read_bloom_filter_header_and_length(
+pub(crate) fn read_bloom_filter_header_and_length(
     buffer: Bytes,
 ) -> Result<(BloomFilterHeader, u64), ParquetError> {
     let total_length = buffer.len();
@@ -199,7 +199,7 @@ impl Sbbf {
         Self::new(&bitset)
     }
 
-    fn new(bitset: &[u8]) -> Self {
+    pub(crate) fn new(bitset: &[u8]) -> Self {
         let data = bitset
             .chunks_exact(4 * 8)
             .map(|chunk| {


### PR DESCRIPTION
# Which issue does this PR close?

Impl #3851

We want to filter `row_groups` in Datafusion but there is no async API for reading `bloom filter`.

# What changes are included in this PR?

Implemented a function `get_row_group_column_bloom_filter` for `ParquetRecordBatchStreamBuilder` to support reading `bloom filter` outside arrow.

# Are there any user-facing changes?

Add an function `get_row_group_column_bloom_filter` in `ParquetRecordBatchStreamBuilder`
