### PR TITLE
Generate `ETag`s for `InMemory` and `LocalFileSystem` (#4879)

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -720,7 +720,7 @@ impl GetOptions {
     /// Returns an error if the modification conditions on this request are not satisfied
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc7232#section-6>
-    fn test(&self, meta: &ObjectMeta) -> Result<()> {
+    fn check_preconditions(&self, meta: &ObjectMeta) -> Result<()> {
         // The use of the invalid etag "*" means no ETag is equivalent to never matching
         let etag = meta.e_tag.as_deref().unwrap_or("*");
         let last_modified = meta.last_modified;
@@ -1712,76 +1712,76 @@ mod tests {
         };
 
         let mut options = GetOptions::default();
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_modified_since = Some(Utc.timestamp_nanos(50));
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_modified_since = Some(Utc.timestamp_nanos(100));
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options.if_modified_since = Some(Utc.timestamp_nanos(101));
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options = GetOptions::default();
 
         options.if_unmodified_since = Some(Utc.timestamp_nanos(50));
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options.if_unmodified_since = Some(Utc.timestamp_nanos(100));
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_unmodified_since = Some(Utc.timestamp_nanos(101));
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options = GetOptions::default();
 
         options.if_match = Some("123".to_string());
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_match = Some("123,354".to_string());
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_match = Some("354, 123,".to_string());
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_match = Some("354".to_string());
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options.if_match = Some("*".to_string());
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         // If-Match takes precedence
         options.if_unmodified_since = Some(Utc.timestamp_nanos(200));
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options = GetOptions::default();
 
         options.if_none_match = Some("123".to_string());
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options.if_none_match = Some("*".to_string());
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options.if_none_match = Some("1232".to_string());
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
 
         options.if_none_match = Some("23, 123".to_string());
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         // If-None-Match takes precedence
         options.if_modified_since = Some(Utc.timestamp_nanos(10));
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         // Check missing ETag
         meta.e_tag = None;
         options = GetOptions::default();
 
         options.if_none_match = Some("*".to_string()); // Fails if any file exists
-        options.test(&meta).unwrap_err();
+        options.check_preconditions(&meta).unwrap_err();
 
         options = GetOptions::default();
         options.if_match = Some("*".to_string()); // Passes if file exists
-        options.test(&meta).unwrap();
+        options.check_preconditions(&meta).unwrap();
     }
 }

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -370,7 +370,7 @@ impl ObjectStore for LocalFileSystem {
         maybe_spawn_blocking(move || {
             let (file, metadata) = open_file(&path)?;
             let meta = convert_metadata(metadata, location)?;
-            options.test(&meta)?;
+            options.check_preconditions(&meta)?;
 
             Ok(GetResult {
                 payload: GetResultPayload::File(file, path),

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1012,11 +1012,14 @@ fn convert_metadata(metadata: Metadata, location: Path) -> Result<ObjectMeta> {
 }
 
 #[cfg(unix)]
+/// We include the inode when available to yield an ETag more resistant to collisions
+/// and as used by popular web servers such as [Apache](https://httpd.apache.org/docs/2.2/mod/core.html#fileetag)
 fn get_inode(metadata: &Metadata) -> u64 {
     std::os::unix::fs::MetadataExt::ino(metadata)
 }
 
 #[cfg(not(unix))]
+/// On platforms where an inode isn't available, fallback to just relying on size and mtime
 fn get_inode(metadata: &Metadata) -> u64 {
     0
 }

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -155,7 +155,7 @@ impl ObjectStore for InMemory {
             size: data.len(),
             e_tag: Some(etag),
         };
-        options.test(&meta)?;
+        options.check_preconditions(&meta)?;
 
         let (range, data) = match options.range {
             Some(range) => {

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -35,9 +35,6 @@ use std::sync::Arc;
 use std::task::Poll;
 use tokio::io::AsyncWrite;
 
-type Entry = (Bytes, DateTime<Utc>);
-type StorageType = Arc<RwLock<BTreeMap<Path, Entry>>>;
-
 /// A specialized `Error` for in-memory object store-related errors
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
@@ -80,7 +77,25 @@ impl From<Error> for super::Error {
 /// storage provider.
 #[derive(Debug, Default)]
 pub struct InMemory {
-    storage: StorageType,
+    storage: SharedStorage,
+}
+
+type Entry = (Bytes, DateTime<Utc>, usize);
+
+#[derive(Debug, Default, Clone)]
+struct Storage {
+    next_etag: usize,
+    map: BTreeMap<Path, Entry>,
+}
+
+type SharedStorage = Arc<RwLock<Storage>>;
+
+impl Storage {
+    fn insert(&mut self, location: &Path, bytes: Bytes) {
+        let etag = self.next_etag;
+        self.next_etag += 1;
+        self.map.insert(location.clone(), (bytes, Utc::now(), etag));
+    }
 }
 
 impl std::fmt::Display for InMemory {
@@ -92,9 +107,7 @@ impl std::fmt::Display for InMemory {
 #[async_trait]
 impl ObjectStore for InMemory {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        self.storage
-            .write()
-            .insert(location.clone(), (bytes, Utc::now()));
+        self.storage.write().insert(location, bytes);
         Ok(())
     }
 
@@ -128,24 +141,21 @@ impl ObjectStore for InMemory {
         Ok(Box::new(InMemoryAppend {
             location: location.clone(),
             data: Vec::<u8>::new(),
-            storage: StorageType::clone(&self.storage),
+            storage: SharedStorage::clone(&self.storage),
         }))
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        if options.if_match.is_some() || options.if_none_match.is_some() {
-            return Err(super::Error::NotSupported {
-                source: "ETags not supported by InMemory".to_string().into(),
-            });
-        }
-        let (data, last_modified) = self.entry(location).await?;
-        options.check_modified(location, last_modified)?;
+        let (data, last_modified, etag) = self.entry(location).await?;
+        let etag = etag.to_string();
+
         let meta = ObjectMeta {
             location: location.clone(),
             last_modified,
             size: data.len(),
-            e_tag: None,
+            e_tag: Some(etag),
         };
+        options.test(&meta)?;
 
         let (range, data) = match options.range {
             Some(range) => {
@@ -190,12 +200,12 @@ impl ObjectStore for InMemory {
             location: location.clone(),
             last_modified: entry.1,
             size: entry.0.len(),
-            e_tag: None,
+            e_tag: Some(entry.2.to_string()),
         })
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        self.storage.write().remove(location);
+        self.storage.write().map.remove(location);
         Ok(())
     }
 
@@ -208,6 +218,7 @@ impl ObjectStore for InMemory {
 
         let storage = self.storage.read();
         let values: Vec<_> = storage
+            .map
             .range((prefix)..)
             .take_while(|(key, _)| key.as_ref().starts_with(prefix.as_ref()))
             .filter(|(key, _)| {
@@ -221,7 +232,7 @@ impl ObjectStore for InMemory {
                     location: key.clone(),
                     last_modified: value.1,
                     size: value.0.len(),
-                    e_tag: None,
+                    e_tag: Some(value.2.to_string()),
                 })
             })
             .collect();
@@ -241,7 +252,7 @@ impl ObjectStore for InMemory {
         // Only objects in this base level should be returned in the
         // response. Otherwise, we just collect the common prefixes.
         let mut objects = vec![];
-        for (k, v) in self.storage.read().range((prefix)..) {
+        for (k, v) in self.storage.read().map.range((prefix)..) {
             if !k.as_ref().starts_with(prefix.as_ref()) {
                 break;
             }
@@ -265,7 +276,7 @@ impl ObjectStore for InMemory {
                     location: k.clone(),
                     last_modified: v.1,
                     size: v.0.len(),
-                    e_tag: None,
+                    e_tag: Some(v.2.to_string()),
                 };
                 objects.push(object);
             }
@@ -279,22 +290,20 @@ impl ObjectStore for InMemory {
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
         let data = self.entry(from).await?;
-        self.storage
-            .write()
-            .insert(to.clone(), (data.0, Utc::now()));
+        self.storage.write().insert(to, data.0);
         Ok(())
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
         let data = self.entry(from).await?;
         let mut storage = self.storage.write();
-        if storage.contains_key(to) {
+        if storage.map.contains_key(to) {
             return Err(Error::AlreadyExists {
                 path: to.to_string(),
             }
             .into());
         }
-        storage.insert(to.clone(), (data.0, Utc::now()));
+        storage.insert(to, data.0);
         Ok(())
     }
 }
@@ -319,9 +328,10 @@ impl InMemory {
         self.fork()
     }
 
-    async fn entry(&self, location: &Path) -> Result<(Bytes, DateTime<Utc>)> {
+    async fn entry(&self, location: &Path) -> Result<Entry> {
         let storage = self.storage.read();
         let value = storage
+            .map
             .get(location)
             .cloned()
             .context(NoDataInMemorySnafu {
@@ -335,7 +345,7 @@ impl InMemory {
 struct InMemoryUpload {
     location: Path,
     data: Vec<u8>,
-    storage: StorageType,
+    storage: Arc<RwLock<Storage>>,
 }
 
 impl AsyncWrite for InMemoryUpload {
@@ -343,7 +353,7 @@ impl AsyncWrite for InMemoryUpload {
         mut self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<Result<usize, io::Error>> {
+    ) -> Poll<Result<usize, io::Error>> {
         self.data.extend_from_slice(buf);
         Poll::Ready(Ok(buf.len()))
     }
@@ -351,18 +361,16 @@ impl AsyncWrite for InMemoryUpload {
     fn poll_flush(
         self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
+    ) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
+    ) -> Poll<Result<(), io::Error>> {
         let data = Bytes::from(std::mem::take(&mut self.data));
-        self.storage
-            .write()
-            .insert(self.location.clone(), (data, Utc::now()));
+        self.storage.write().insert(&self.location, data);
         Poll::Ready(Ok(()))
     }
 }
@@ -370,7 +378,7 @@ impl AsyncWrite for InMemoryUpload {
 struct InMemoryAppend {
     location: Path,
     data: Vec<u8>,
-    storage: StorageType,
+    storage: Arc<RwLock<Storage>>,
 }
 
 impl AsyncWrite for InMemoryAppend {
@@ -378,7 +386,7 @@ impl AsyncWrite for InMemoryAppend {
         mut self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<Result<usize, io::Error>> {
+    ) -> Poll<Result<usize, io::Error>> {
         self.data.extend_from_slice(buf);
         Poll::Ready(Ok(buf.len()))
     }
@@ -386,20 +394,18 @@ impl AsyncWrite for InMemoryAppend {
     fn poll_flush(
         mut self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
-        let storage = StorageType::clone(&self.storage);
+    ) -> Poll<Result<(), io::Error>> {
+        let storage = Arc::clone(&self.storage);
 
         let mut writer = storage.write();
 
-        if let Some((bytes, _)) = writer.remove(&self.location) {
+        if let Some((bytes, _, _)) = writer.map.remove(&self.location) {
             let buf = std::mem::take(&mut self.data);
             let concat = Bytes::from_iter(bytes.into_iter().chain(buf));
-            writer.insert(self.location.clone(), (concat, Utc::now()));
+            writer.insert(&self.location, concat);
         } else {
-            writer.insert(
-                self.location.clone(),
-                (Bytes::from(std::mem::take(&mut self.data)), Utc::now()),
-            );
+            let data = Bytes::from(std::mem::take(&mut self.data));
+            writer.insert(&self.location, data);
         };
         Poll::Ready(Ok(()))
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4879

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Implements ETag for InMemory using a simple monotonic counter.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
