### PR TITLE
Support service_account in ApplicationDefaultCredentials and Use SelfSignedJwt

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -126,7 +126,7 @@ jobs:
           # Give the container a moment to start up prior to configuring it
           sleep 1
           curl -v -X POST --data-binary '{"name":"test-bucket"}' -H "Content-Type: application/json" "http://localhost:4443/storage/v1/b"
-          echo '{"gcs_base_url": "http://localhost:4443", "disable_oauth": true, "client_email": "", "private_key": ""}' > "$GOOGLE_SERVICE_ACCOUNT"
+          echo '{"gcs_base_url": "http://localhost:4443", "disable_oauth": true, "client_email": "", "private_key": "", "private_key_id": ""}' > "$GOOGLE_SERVICE_ACCOUNT"
 
       - name: Setup WebDav
         run: docker run -d -p 8080:80 rclone/rclone serve webdav /data --addr :80

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -144,7 +144,10 @@ struct TokenResponse {
     expires_in: u64,
 }
 
-/// <https://google.aip.dev/auth/4111>
+/// Self-signed JWT (JSON Web Token).
+///
+/// # References
+/// - <https://google.aip.dev/auth/4111>
 #[derive(Debug)]
 pub struct SelfSignedJwt {
     issuer: String,
@@ -273,8 +276,9 @@ impl ServiceAccountCredentials {
     /// We use a scope of [`DEFAULT_SCOPE`] as opposed to an audience
     /// as GCS appears to not support audience
     ///
-    /// <https://stackoverflow.com/questions/63222450/service-account-authorization-without-oauth-can-we-get-file-from-google-cloud/71834557#71834557>
-    /// <https://www.codejam.info/2022/05/google-cloud-service-account-authorization-without-oauth.html>
+    /// # References
+    /// - <https://stackoverflow.com/questions/63222450/service-account-authorization-without-oauth-can-we-get-file-from-google-cloud/71834557#71834557>
+    /// - <https://www.codejam.info/2022/05/google-cloud-service-account-authorization-without-oauth.html>
     pub fn token_provider(self) -> crate::Result<SelfSignedJwt> {
         Ok(SelfSignedJwt::new(
             self.private_key_id,
@@ -371,15 +375,22 @@ impl TokenProvider for InstanceCredentialProvider {
 
 /// A deserialized `application_default_credentials.json`-file.
 ///
-/// <https://cloud.google.com/docs/authentication/application-default-credentials#personal>
-/// <https://google.aip.dev/auth/4110>
+/// # References
+/// - <https://cloud.google.com/docs/authentication/application-default-credentials#personal>
+/// - <https://google.aip.dev/auth/4110>
 #[derive(serde::Deserialize)]
 #[serde(tag = "type")]
 pub enum ApplicationDefaultCredentials {
-    /// <https://google.aip.dev/auth/4112>
+    /// Service Account.
+    ///
+    /// # References
+    /// - <https://google.aip.dev/auth/4112>
     #[serde(rename = "service_account")]
     ServiceAccount(ServiceAccountCredentials),
-    /// <https://google.aip.dev/auth/4113>
+    /// Authorized user via "gcloud CLI Integration".
+    ///
+    /// # References
+    /// - <https://google.aip.dev/auth/4113>
     #[serde(rename = "authorized_user")]
     AuthorizedUser(AuthorizedUserCredentials),
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

https://google.aip.dev/auth/4111 defines a process for using self-signed JWTs directly with Google Cloud services, without first exchanging them with the Google OAuth server. Additionally it states that they should be used by default for service accounts

> Considering its better efficiency and reliability comparing with OAuth flow (bypassing the exchanging step), [ADC](https://google.aip.dev/auth/4110) should use self-signed JWT as the default authentication flow when service account key is provided as the source credential.

This PR therefore adds support for service_account in ApplicationDefaultCredentials, and uses the self-signed JWT flow for service accounts

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
