### PR TITLE
Add GetOptions::head

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -554,15 +554,10 @@ impl GetClient for S3Client {
     const STORE: &'static str = STORE;
 
     /// Make an S3 GET request <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>
-    async fn get_request(
-        &self,
-        path: &Path,
-        options: GetOptions,
-        head: bool,
-    ) -> Result<Response> {
+    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response> {
         let credential = self.get_credential().await?;
         let url = self.config.path_url(path);
-        let method = match head {
+        let method = match options.head {
             true => Method::HEAD,
             false => Method::GET,
         };

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -307,10 +307,6 @@ impl ObjectStore for AmazonS3 {
         self.client.get_opts(location, options).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.client.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         self.client.delete_request(location, &()).await
     }

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -264,15 +264,10 @@ impl GetClient for AzureClient {
     /// Make an Azure GET request
     /// <https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob>
     /// <https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-properties>
-    async fn get_request(
-        &self,
-        path: &Path,
-        options: GetOptions,
-        head: bool,
-    ) -> Result<Response> {
+    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response> {
         let credential = self.get_credential().await?;
         let url = self.config.path_url(path);
-        let method = match head {
+        let method = match options.head {
             true => Method::HEAD,
             false => Method::GET,
         };

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -202,10 +202,6 @@ impl ObjectStore for MicrosoftAzure {
         self.client.get_opts(location, options).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.client.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         self.client.delete_request(location, &()).await
     }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -17,7 +17,7 @@
 
 use crate::client::header::{header_meta, HeaderConfig};
 use crate::path::Path;
-use crate::{Error, GetOptions, GetResult, ObjectMeta};
+use crate::{Error, GetOptions, GetResult};
 use crate::{GetResultPayload, Result};
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
@@ -34,27 +34,20 @@ pub trait GetClient: Send + Sync + 'static {
         last_modified_required: true,
     };
 
-    async fn get_request(
-        &self,
-        path: &Path,
-        options: GetOptions,
-        head: bool,
-    ) -> Result<Response>;
+    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response>;
 }
 
 /// Extension trait for [`GetClient`] that adds common retrieval functionality
 #[async_trait]
 pub trait GetClientExt {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult>;
-
-    async fn head(&self, location: &Path) -> Result<ObjectMeta>;
 }
 
 #[async_trait]
 impl<T: GetClient> GetClientExt for T {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
-        let response = self.get_request(location, options, false).await?;
+        let response = self.get_request(location, options).await?;
         let meta =
             header_meta(location, response.headers(), T::HEADER_CONFIG).map_err(|e| {
                 Error::Generic {
@@ -75,17 +68,6 @@ impl<T: GetClient> GetClientExt for T {
             range: range.unwrap_or(0..meta.size),
             payload: GetResultPayload::Stream(stream),
             meta,
-        })
-    }
-
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let options = GetOptions::default();
-        let response = self.get_request(location, options, true).await?;
-        header_meta(location, response.headers(), T::HEADER_CONFIG).map_err(|e| {
-            Error::Generic {
-                store: T::STORE,
-                source: Box::new(e),
-            }
         })
     }
 }

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -389,16 +389,11 @@ impl GetClient for GoogleCloudStorageClient {
     const STORE: &'static str = STORE;
 
     /// Perform a get request <https://cloud.google.com/storage/docs/xml-api/get-object-download>
-    async fn get_request(
-        &self,
-        path: &Path,
-        options: GetOptions,
-        head: bool,
-    ) -> Result<Response> {
+    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response> {
         let credential = self.get_credential().await?;
         let url = self.object_url(path);
 
-        let method = match head {
+        let method = match options.head {
             true => Method::HEAD,
             false => Method::GET,
         };
@@ -602,10 +597,6 @@ impl ObjectStore for GoogleCloudStorage {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         self.client.get_opts(location, options).await
-    }
-
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.client.head(location).await
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -288,14 +288,9 @@ impl GetClient for Client {
         last_modified_required: false,
     };
 
-    async fn get_request(
-        &self,
-        location: &Path,
-        options: GetOptions,
-        head: bool,
-    ) -> Result<Response> {
-        let url = self.path_url(location);
-        let method = match head {
+    async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response> {
+        let url = self.path_url(path);
+        let method = match options.head {
             true => Method::HEAD,
             false => Method::GET,
         };
@@ -311,7 +306,7 @@ impl GetClient for Client {
                 Some(StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED) => {
                     crate::Error::NotFound {
                         source: Box::new(source),
-                        path: location.to_string(),
+                        path: path.to_string(),
                     }
                 }
                 _ => Error::Request { source }.into(),
@@ -322,7 +317,7 @@ impl GetClient for Client {
         if has_range && res.status() != StatusCode::PARTIAL_CONTENT {
             return Err(crate::Error::NotSupported {
                 source: Box::new(Error::RangeNotSupported {
-                    href: location.to_string(),
+                    href: path.to_string(),
                 }),
             });
         }

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -118,10 +118,6 @@ impl ObjectStore for HttpStore {
         self.client.get_opts(location, options).await
     }
 
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        self.client.head(location).await
-    }
-
     async fn delete(&self, location: &Path) -> Result<()> {
         self.client.delete(location).await
     }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -410,7 +410,13 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     }
 
     /// Return the metadata for the specified location
-    async fn head(&self, location: &Path) -> Result<ObjectMeta>;
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        let options = GetOptions {
+            head: true,
+            ..Default::default()
+        };
+        Ok(self.get_opts(location, options).await?.meta)
+    }
 
     /// Delete the object at the specified location.
     async fn delete(&self, location: &Path) -> Result<()>;
@@ -716,6 +722,10 @@ pub struct GetOptions {
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc9110#name-range>
     pub range: Option<Range<usize>>,
+    /// Request transfer of no content
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc9110#name-head>
+    pub head: bool,
 }
 
 impl GetOptions {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #4925
Relates to #4525 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Adds `GetOptions::head`. This achieves a couple of goals:

* Allows conditional HEAD requests (#4925)
* Allows a default impl of `ObjectStore::head`
* Provides a mechanism to get a local file if available, without the risk of performing a network fetch of the entire object

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
