### PR TITLE
Export `SubstraitPlan` structure in arrow_flight::sql (#4932)

### DIFF
--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -93,6 +93,7 @@ pub use gen::SqlSupportedTransactions;
 pub use gen::SqlSupportedUnions;
 pub use gen::SqlSupportsConvert;
 pub use gen::SqlTransactionIsolationLevel;
+pub use gen::SubstraitPlan;
 pub use gen::SupportedSqlGrammar;
 pub use gen::TicketStatementQuery;
 pub use gen::UpdateDeleteRules;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4932.

# Rationale for this change
 
# What changes are included in this PR?

Exposes missing structure.

# Are there any user-facing changes?
