### PR TITLE
Add `FileWriter` schema getter

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -832,6 +832,11 @@ impl<W: Write> FileWriter<W> {
         Ok(())
     }
 
+    /// Gets underlying schema.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
     /// Gets a reference to the underlying writer.
     pub fn get_ref(&self) -> &W {
         self.writer.get_ref()

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -23,6 +23,7 @@
 use std::cmp::min;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
+use std::sync::Arc;
 
 use flatbuffers::FlatBufferBuilder;
 
@@ -696,7 +697,7 @@ pub struct FileWriter<W: Write> {
     /// IPC write options
     write_options: IpcWriteOptions,
     /// A reference to the schema, used in validating record batches
-    schema: Schema,
+    schema: SchemaRef,
     /// The number of bytes between each block of bytes, as an offset for random access
     block_offsets: usize,
     /// Dictionary blocks that will be written as part of the IPC footer
@@ -739,7 +740,7 @@ impl<W: Write> FileWriter<W> {
         Ok(Self {
             writer,
             write_options,
-            schema: schema.clone(),
+            schema: Arc::new(schema.clone()),
             block_offsets: meta + data + header_size,
             dictionary_blocks: vec![],
             record_blocks: vec![],
@@ -832,8 +833,8 @@ impl<W: Write> FileWriter<W> {
         Ok(())
     }
 
-    /// Gets underlying schema.
-    pub fn schema(&self) -> &Schema {
+    /// Returns the arrow [`SchemaRef`] for this arrow file.
+    pub fn schema(&self) -> &SchemaRef {
         &self.schema
     }
 


### PR DESCRIPTION
# Rationale for this change
 
This PR adds a `schema` getter. This makes it easier to create `RecordBatch` that needs the same `schema` when been created.

# Are there any user-facing changes?

There is a new getter function within the `arrow-ipc` `FileWriter` struct. I have added a docstring, and happy to do more documentation if needed.

