### PR TITLE
Not reexport RecordBatch twice

### DIFF
--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -30,11 +30,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::*;
+use arrow::array::{RecordBatch, RecordBatchReader};
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::compute;
 use arrow::datatypes::*;
 use arrow::error::{ArrowError, Result};
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use arrow::util::bit_util;
 use arrow_buffer::i256;
 

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -30,7 +30,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::*;
-use arrow::array::{RecordBatch, RecordBatchReader};
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::compute;
 use arrow::datatypes::*;

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -20,10 +20,10 @@ use std::collections::HashMap;
 
 use arrow::{
     array::ArrayRef,
+    array::RecordBatch,
     buffer::Buffer,
     datatypes::SchemaRef,
     ipc::{self, reader, writer},
-    record_batch::RecordBatch,
 };
 use arrow_flight::{
     flight_descriptor::DescriptorType, flight_service_client::FlightServiceClient,

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -22,11 +22,11 @@ use std::sync::Arc;
 
 use arrow::{
     array::ArrayRef,
+    array::RecordBatch,
     buffer::Buffer,
     datatypes::Schema,
     datatypes::SchemaRef,
     ipc::{self, reader, writer},
-    record_batch::RecordBatch,
 };
 use arrow_flight::{
     flight_descriptor::DescriptorType, flight_service_server::FlightService,

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -19,9 +19,9 @@
 
 use serde_json::Value;
 
+use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
 use arrow::error::Result;
-use arrow::record_batch::RecordBatch;
 use arrow::util::test_util::arrow_test_data;
 use arrow_integration_test::*;
 use std::collections::HashMap;

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -21,7 +21,7 @@
 use std::sync::Arc;
 
 use arrow::array::new_empty_array;
-use arrow::record_batch::{RecordBatchIterator, RecordBatchReader};
+use arrow::array::{RecordBatchIterator, RecordBatchReader};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
@@ -32,7 +32,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
 use arrow::ffi_stream::ArrowArrayStreamReader;
 use arrow::pyarrow::{FromPyArrow, PyArrowException, PyArrowType, ToPyArrow};
-use arrow::record_batch::RecordBatch;
+use arrow::array::RecordBatch;
 
 fn to_py_err(err: ArrowError) -> PyErr {
     PyArrowException::new_err(err.to_string())

--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -24,10 +24,10 @@ use std::sync::Arc;
 use criterion::*;
 use rand::Rng;
 
+use arrow::array::RecordBatch;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
 use arrow::util::bench_util::{create_primitive_array, create_string_array_with_len};
 use arrow::util::test_util::seedable_rng;
 

--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use criterion::*;
 use rand::Rng;
 
-use arrow::array::RecordBatch;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;

--- a/arrow/benches/csv_writer.rs
+++ b/arrow/benches/csv_writer.rs
@@ -20,10 +20,10 @@ extern crate criterion;
 
 use criterion::*;
 
+use arrow::array::RecordBatch;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
 use std::env;
 use std::fs::File;
 use std::sync::Arc;

--- a/arrow/benches/csv_writer.rs
+++ b/arrow/benches/csv_writer.rs
@@ -20,7 +20,6 @@ extern crate criterion;
 
 use criterion::*;
 
-use arrow::array::RecordBatch;
 use arrow::array::*;
 use arrow::csv;
 use arrow::datatypes::*;

--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -18,8 +18,8 @@ extern crate arrow;
 
 use std::sync::Arc;
 
+use arrow::array::RecordBatch;
 use arrow::compute::{filter_record_batch, FilterBuilder, FilterPredicate};
-use arrow::record_batch::RecordBatch;
 use arrow::util::bench_util::*;
 
 use arrow::array::*;

--- a/arrow/src/ffi_stream.rs
+++ b/arrow/src/ffi_stream.rs
@@ -30,7 +30,7 @@
 //! # use arrow::error::Result;
 //! # use arrow::ffi_stream::{export_reader_into_raw, ArrowArrayStreamReader, FFI_ArrowArrayStream};
 //! # use arrow::ipc::reader::FileReader;
-//! # use arrow::record_batch::RecordBatchReader;
+//! # use arrow::array::RecordBatchReader;
 //! # fn main() -> Result<()> {
 //! // create an record batch reader natively
 //! let file = File::open("arrow_file").unwrap();

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -221,7 +221,7 @@
 //! ```
 //! # use std::sync::Arc;
 //! # use arrow::array::{Float32Array, Int32Array};
-//! # use arrow::record_batch::RecordBatch;
+//! # use arrow::array::RecordBatch;
 //! #
 //! let col_1 = Arc::new(Int32Array::from_iter([1, 2, 3])) as _;
 //! let col_2 = Arc::new(Float32Array::from_iter([1., 6.3, 4.])) as _;
@@ -373,11 +373,6 @@ pub use arrow_json as json;
 #[cfg(feature = "pyarrow")]
 pub mod pyarrow;
 
-pub mod record_batch {
-    pub use arrow_array::{
-        RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader, RecordBatchWriter,
-    };
-}
 pub use arrow_array::temporal_conversions;
 pub use arrow_row as row;
 pub mod tensor;

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -21,8 +21,8 @@ use std::{convert::TryFrom, sync::Arc};
 
 use rand::{distributions::uniform::SampleUniform, Rng};
 
+use crate::array::{RecordBatch, RecordBatchOptions};
 use crate::error::{ArrowError, Result};
-use crate::record_batch::{RecordBatch, RecordBatchOptions};
 use crate::{array::*, datatypes::SchemaRef};
 use crate::{
     buffer::{Buffer, MutableBuffer},

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -21,7 +21,6 @@ use std::{convert::TryFrom, sync::Arc};
 
 use rand::{distributions::uniform::SampleUniform, Rng};
 
-use crate::array::{RecordBatch, RecordBatchOptions};
 use crate::error::{ArrowError, Result};
 use crate::{array::*, datatypes::SchemaRef};
 use crate::{

--- a/arrow/src/util/string_writer.rs
+++ b/arrow/src/util/string_writer.rs
@@ -28,7 +28,7 @@
 //! use arrow::array::*;
 //! use arrow::csv;
 //! use arrow::datatypes::*;
-//! use arrow::record_batch::RecordBatch;
+//! use arrow::array::RecordBatch;
 //! use arrow::util::string_writer::StringWriter;
 //! use std::sync::Arc;
 //!

--- a/arrow/tests/pyarrow.rs
+++ b/arrow/tests/pyarrow.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use arrow::array::RecordBatch;
 use arrow::array::{ArrayRef, Int32Array, StringArray};
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
-use arrow::record_batch::RecordBatch;
 use pyo3::Python;
 use std::sync::Arc;
 

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -17,8 +17,8 @@
 
 //! Tests that the ArrowWriter correctly lays out values into multiple pages
 
+use arrow::array::RecordBatch;
 use arrow::array::{Int32Array, StringArray};
-use arrow::record_batch::RecordBatch;
 use arrow_array::builder::{Int32Builder, ListBuilder};
 use bytes::Bytes;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};


### PR DESCRIPTION
# Which issue does this PR close?

There are two duplicated reexports with different path. But actually they point to the same source.
![image](https://github.com/apache/arrow-rs/assets/17514693/0f068f40-f19a-4fd5-99aa-4df61358adb8)

After this pr,
![image](https://github.com/apache/arrow-rs/assets/17514693/b3b83580-a55f-47d7-a800-ee1c4cbf490b)


# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
