### PR TITLE
Increase default timeout to 30 seconds

### DIFF
--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -193,6 +193,9 @@ impl Default for ClientOptions {
         // <https://docs.aws.amazon.com/sdkref/latest/guide/feature-smart-config-defaults.html>
         // <https://docs.aws.amazon.com/whitepapers/latest/s3-optimizing-performance-best-practices/timeouts-and-retries-for-latency-sensitive-applications.html>
         // Which recommend a connection timeout of 3.1s and a request timeout of 2s
+        //
+        // As object store requests may involve the transfer of non-trivial volumes of data
+        // we opt for a slightly higher default timeout of 30 seconds
         Self {
             user_agent: None,
             content_type_map: Default::default(),
@@ -203,7 +206,7 @@ impl Default for ClientOptions {
             proxy_excludes: None,
             allow_http: Default::default(),
             allow_insecure: Default::default(),
-            timeout: Some(Duration::from_secs(5).into()),
+            timeout: Some(Duration::from_secs(30).into()),
             connect_timeout: Some(Duration::from_secs(5).into()),
             pool_idle_timeout: None,
             pool_max_idle_per_host: None,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

https://github.com/apache/arrow-rs/pull/4928 configured default connection and request timeouts of 5 seconds. These are sensible defaults when operating in cloud providers, but when running integration tests over my extremely asymmetric home internet connection I would occasionally see timeouts for the multipart upload tests which necessarily have to write multiples of 10Mib.

In the interests of providing a good out-of-the-box experience I think it is necessary to accommodate such scenarios in the defaults, even if most of the world probably benefits from a slightly less terrible upload bandwidth :sweat_smile:  

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
