### PR TITLE
feat(flight-sql): Allow custom commands in get-flight-info

### DIFF
--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -225,6 +225,18 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
         ))
     }
 
+    /// Implementors may override to handle additional calls to get_flight_info()
+    async fn get_flight_info_fallback(
+        &self,
+        cmd: Command,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
+        Err(Status::unimplemented(format!(
+            "get_flight_info: The defined request is invalid: {}",
+            cmd.type_url()
+        )))
+    }
+
     // do_get
 
     /// Get a FlightDataStream containing the query results.
@@ -616,10 +628,7 @@ where
             Command::CommandGetXdbcTypeInfo(token) => {
                 self.get_flight_info_xdbc_type_info(token, request).await
             }
-            cmd => Err(Status::unimplemented(format!(
-                "get_flight_info: The defined request is invalid: {}",
-                cmd.type_url()
-            ))),
+            cmd => self.get_flight_info_fallback(cmd, request).await,
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4996.

# Rationale for this change

Allows implementations of `FlightSqlService` to support custom commands in `GetFlightInfo`. Capability already exists for `DoGet`.

# What changes are included in this PR?

Added the methods `get_flight_info_fallback` to the trait `FlightSqlService`, and corresponding use in `impl<T: FlightSqlService + Send + 'static> FlightService for T` following the same pattern that already existed for `do_get`. 

# Are there any user-facing changes?

Yes, extended the API surface of the trait `FlightSqlService`.
