### PR TITLE
Support onelake fabric paths in parse_url (#5000)

### DIFF
--- a/object_store/src/parse.rs
+++ b/object_store/src/parse.rs
@@ -81,7 +81,10 @@ impl ObjectStoreScheme {
             }
             ("http", Some(_)) => (Self::Http, url.path()),
             ("https", Some(host)) => {
-                if host.ends_with("dfs.core.windows.net") || host.ends_with("blob.core.windows.net")
+                if host.ends_with("dfs.core.windows.net")
+                    || host.ends_with("blob.core.windows.net")
+                    || host.ends_with("dfs.fabric.microsoft.com")
+                    || host.ends_with("blob.fabric.microsoft.com")
                 {
                     (Self::MicrosoftAzure, url.path())
                 } else if host.ends_with("amazonaws.com") {
@@ -240,6 +243,30 @@ mod tests {
             ),
             ("http://mydomain/path", (ObjectStoreScheme::Http, "path")),
             ("https://mydomain/path", (ObjectStoreScheme::Http, "path")),
+            (
+                "abfss://file_system@account.dfs.fabric.microsoft.com/",
+                (ObjectStoreScheme::MicrosoftAzure, ""),
+            ),
+            (
+                "abfss://file_system@account.dfs.fabric.microsoft.com/",
+                (ObjectStoreScheme::MicrosoftAzure, ""),
+            ),
+            (
+                "https://account.dfs.fabric.microsoft.com/",
+                (ObjectStoreScheme::MicrosoftAzure, ""),
+            ),
+            (
+                "https://account.dfs.fabric.microsoft.com/container",
+                (ObjectStoreScheme::MicrosoftAzure, "container"),
+            ),
+            (
+                "https://account.blob.fabric.microsoft.com/",
+                (ObjectStoreScheme::MicrosoftAzure, ""),
+            ),
+            (
+                "https://account.blob.fabric.microsoft.com/container",
+                (ObjectStoreScheme::MicrosoftAzure, "container"),
+            ),
         ];
 
         for (s, (expected_scheme, expected_path)) in cases {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5000

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

#4573 added support for parsing these URLs within `MicrosoftAzureBuilder`, this PR extends the `ObjectStoreScheme` detection logic to also understand these paths, so that `parse_url` handles them correctly

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
