### PR TITLE
Remove ObjectStore::append

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -53,11 +53,6 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"], optional = true }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util", "fs"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]

--- a/object_store/src/limit.rs
+++ b/object_store/src/limit.rs
@@ -94,13 +94,6 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.abort_multipart(location, multipart_id).await
     }
-
-    async fn append(&self, location: &Path) -> Result<Box<dyn AsyncWrite + Unpin + Send>> {
-        let permit = Arc::clone(&self.semaphore).acquire_owned().await.unwrap();
-        let write = self.inner.append(location).await?;
-        Ok(Box::new(PermitWrapper::new(write, permit)))
-    }
-
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let permit = Arc::clone(&self.semaphore).acquire_owned().await.unwrap();
         let r = self.inner.get(location).await?;

--- a/object_store/src/prefix.rs
+++ b/object_store/src/prefix.rs
@@ -103,12 +103,6 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         let full_path = self.full_path(location);
         self.inner.abort_multipart(&full_path, multipart_id).await
     }
-
-    async fn append(&self, location: &Path) -> Result<Box<dyn AsyncWrite + Unpin + Send>> {
-        let full_path = self.full_path(location);
-        self.inner.append(&full_path).await
-    }
-
     async fn get(&self, location: &Path) -> Result<GetResult> {
         let full_path = self.full_path(location);
         self.inner.get(&full_path).await

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -169,10 +169,6 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         Err(super::Error::NotImplemented)
     }
 
-    async fn append(&self, _location: &Path) -> Result<Box<dyn AsyncWrite + Unpin + Send>> {
-        Err(super::Error::NotImplemented)
-    }
-
     async fn get(&self, location: &Path) -> Result<GetResult> {
         sleep(self.config().wait_get_per_call).await;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

ObjectStore::append has always been somewhat at odds with the design goals of the crate, as it is not an object store API, and has rather unfortunate characteristics with regards to atomicity. It was largely added to accommodate streaming workloads in DataFusion that are overloading the file IO abstractions.

https://github.com/apache/arrow-datafusion/issues/7994 tracks addressing this upstream, and is an effort I intend to drive to completion. Whilst removing it is slightly jumping the gun, I want this to make the next release #5010 which will still give plenty of time to prepare DataFusion for this change

This functionality was only implemented by InMemory and LocalFileSystem and so applications can easily reproduce this functionality should they so desire.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
