### PR TITLE
chore: Update docs to refer to non deprecated function (`partition`)

### DIFF
--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -78,7 +78,7 @@ impl Partitions {
 /// # Example:
 ///
 /// For example, given columns `x`, `y` and `z`, calling
-/// `lexicographical_partition_ranges(values, (x, y))` will divide the
+/// [`partition`]`(values, (x, y))` will divide the
 /// rows into ranges where the values of `(x, y)` are equal:
 ///
 /// ```text

--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -160,8 +160,9 @@ fn find_boundaries(v: &dyn Array) -> Result<BooleanBuffer, ArrowError> {
     Ok(distinct(&v1, &v2)?.values().clone())
 }
 
-/// Given a list of already sorted columns, find partition ranges that would partition
-/// lexicographically equal values across columns.
+/// Use [`partition`] instead. Given a list of already sorted columns, find
+/// partition ranges that would partition lexicographically equal values across
+/// columns.
 ///
 /// The returned vec would be of size k where k is cardinality of the sorted values; Consecutive
 /// values will be connected: (a, b) and (b, c), where start = 0 and end = n for the first and last


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 I noticed the documentation referred to `lexicographical_partition_ranges` which has been deprecated in favor of `partition`

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Change docs to use `partition`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
