### PR TITLE
refactor: feature-switch for `object_store` CA certs

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -55,13 +55,13 @@ jobs:
       - name: Run clippy with default features
         run: cargo clippy -- -D warnings
       - name: Run clippy with aws feature
-        run: cargo clippy --features aws -- -D warnings
+        run: cargo clippy --features aws,tls-webpki-roots -- -D warnings
       - name: Run clippy with gcp feature
-        run: cargo clippy --features gcp -- -D warnings
+        run: cargo clippy --features gcp,tls-webpki-roots -- -D warnings
       - name: Run clippy with azure feature
-        run: cargo clippy --features azure -- -D warnings
+        run: cargo clippy --features azure,tls-webpki-roots -- -D warnings
       - name: Run clippy with http feature
-        run: cargo clippy --features http -- -D warnings
+        run: cargo clippy --features http,tls-webpki-roots -- -D warnings
       - name: Run clippy with all features
         run: cargo clippy --all-features -- -D warnings
       - name: Run clippy with all features and all targets
@@ -150,7 +150,7 @@ jobs:
           rustup default stable
 
       - name: Run object_store tests
-        run: cargo test --features=aws,azure,gcp,http
+        run: cargo test --features=aws,azure,gcp,http,tls-webpki-roots
 
   # test the object_store crate builds against wasm32 in stable rust
   wasm32-build:

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -50,7 +50,7 @@ quick-xml = { version = "0.31.0", features = ["serialize", "overlapped-lists"], 
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"], optional = true }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-manual-roots"], optional = true }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "1.0", default-features = false, optional = true }
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
@@ -64,6 +64,8 @@ azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud"]
 http = ["cloud"]
+tls-native-roots = ["reqwest?/rustls-tls-native-roots"]
+tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 
 [dev-dependencies] # In alphabetical order
 tempfile = "3.1.0"

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -86,6 +86,13 @@
     doc = "* [`http`]: [HTTP/WebDAV Storage](https://datatracker.ietf.org/doc/html/rfc2518). See [`HttpBuilder`](http::HttpBuilder)"
 )]
 //!
+//! Stores that use HTTPS/TLS (this is true for most cloud stores) can use the source of their [CA]
+//! certificates. This is controlled by a feature switch:
+//!
+//! - `tls-native-roots`: use certificates bundled with the operating system, see [`rustls-native-certs`]
+//! - `tls-webpki-roots`: use Mozilla's root certificates bundled with the library/application, see
+//!   [`webpki-roots`]
+//!
 //! # Why not a Filesystem Interface?
 //!
 //! Whilst this crate does provide a [`BufReader`], the [`ObjectStore`] interface mirrors the APIs
@@ -434,7 +441,10 @@
 //!
 //! [Optimistic Concurrency Control]: https://en.wikipedia.org/wiki/Optimistic_concurrency_control
 //! [Apache Iceberg]: https://iceberg.apache.org/
+//! [CA]: https://en.wikipedia.org/wiki/Certificate_authority
 //! [Delta Lake]: https://delta.io/
+//! [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs/
+//! [`webpki-roots`]: https://crates.io/crates/webpki-roots
 //!
 
 #[cfg(all(
@@ -442,6 +452,13 @@
     any(feature = "gcp", feature = "aws", feature = "azure", feature = "http")
 ))]
 compile_error!("Features 'gcp', 'aws', 'azure', 'http' are not supported on wasm.");
+
+#[cfg(all(
+    feature = "cloud",
+    not(feature = "tls-native-roots"),
+    not(feature = "tls-webpki-roots"),
+))]
+compile_error!("Feature 'cloud' needs at a CA root feature, use either 'tls-native-roots' or 'tls-webpki-roots'.");
 
 #[cfg(feature = "aws")]
 pub mod aws;


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4870.

# Rationale for this change
See issue.

# What changes are included in this PR?
Feature switches, do NOT make any choice by default.

# Are there any user-facing changes?
**Breaking:** Users now must choose their CA source.
