### PR TITLE
Parquet: Fix string display for f32/f64 zero values

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -737,7 +737,7 @@ impl fmt::Display for Field {
             Field::UInt(value) => write!(f, "{value}"),
             Field::ULong(value) => write!(f, "{value}"),
             Field::Float(value) => {
-                if !(1e-15..=1e19).contains(&value) && value.abs() != 0.0 {
+                if !(1e-15..=1e19).contains(&value) && value != 0.0 {
                     write!(f, "{value:E}")
                 } else if value.trunc() == value {
                     write!(f, "{value}.0")
@@ -746,7 +746,7 @@ impl fmt::Display for Field {
                 }
             }
             Field::Double(value) => {
-                if !(1e-15..=1e19).contains(&value) && value.abs() != 0.0 {
+                if !(1e-15..=1e19).contains(&value) && value != 0.0 {
                     write!(f, "{value:E}")
                 } else if value.trunc() == value {
                     write!(f, "{value}.0")

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -1159,7 +1159,7 @@ mod tests {
         assert_eq!(format!("{}", Field::Float(f32::INFINITY)), "inf");
         assert_eq!(format!("{}", Field::Float(f32::NEG_INFINITY)), "-inf");
         assert_eq!(format!("{}", Field::Float(0.0)), "0.0");
-        assert_eq!(format!("{}", Field::Float(f32::neg_zero())), "-0.0");
+        assert_eq!(format!("{}", Field::Float(-0.0)), "-0.0");
     }
 
     #[test]
@@ -1182,7 +1182,7 @@ mod tests {
         assert_eq!(format!("{}", Field::Double(f64::INFINITY)), "inf");
         assert_eq!(format!("{}", Field::Double(f64::NEG_INFINITY)), "-inf");
         assert_eq!(format!("{}", Field::Double(0.0)), "0.0");
-        assert_eq!(format!("{}", Field::Double(f64::neg_zero())), "-0.0");
+        assert_eq!(format!("{}", Field::Double(-0.0)), "-0.0");
     }
 
     #[test]

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -737,7 +737,7 @@ impl fmt::Display for Field {
             Field::UInt(value) => write!(f, "{value}"),
             Field::ULong(value) => write!(f, "{value}"),
             Field::Float(value) => {
-                if !(1e-15..=1e19).contains(&value) {
+                if !(1e-15..=1e19).contains(&value) && value.abs() != 0.0 {
                     write!(f, "{value:E}")
                 } else if value.trunc() == value {
                     write!(f, "{value}.0")
@@ -746,7 +746,7 @@ impl fmt::Display for Field {
                 }
             }
             Field::Double(value) => {
-                if !(1e-15..=1e19).contains(&value) {
+                if !(1e-15..=1e19).contains(&value) && value.abs() != 0.0 {
                     write!(f, "{value:E}")
                 } else if value.trunc() == value {
                     write!(f, "{value}.0")
@@ -1155,6 +1155,11 @@ mod tests {
         assert_eq!(format!("{}", Field::Float(1e20)), "1E20");
         assert_eq!(format!("{}", Field::Float(1.7976931E30)), "1.7976931E30");
         assert_eq!(format!("{}", Field::Float(-1.7976931E30)), "-1.7976931E30");
+        assert_eq!(format!("{}", Field::Float(f32::NAN)), "NaN");
+        assert_eq!(format!("{}", Field::Float(f32::INFINITY)), "inf");
+        assert_eq!(format!("{}", Field::Float(f32::NEG_INFINITY)), "-inf");
+        assert_eq!(format!("{}", Field::Float(0.0)), "0.0");
+        assert_eq!(format!("{}", Field::Float(f32::neg_zero())), "-0.0");
     }
 
     #[test]
@@ -1173,6 +1178,11 @@ mod tests {
             format!("{}", Field::Double(-1.79769313486E308)),
             "-1.79769313486E308"
         );
+        assert_eq!(format!("{}", Field::Double(f64::NAN)), "NaN");
+        assert_eq!(format!("{}", Field::Double(f64::INFINITY)), "inf");
+        assert_eq!(format!("{}", Field::Double(f64::NEG_INFINITY)), "-inf");
+        assert_eq!(format!("{}", Field::Double(0.0)), "0.0");
+        assert_eq!(format!("{}", Field::Double(f64::neg_zero())), "-0.0");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5045

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
