### PR TITLE
Backport CI fixes to `48.0.0_maintenance`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,8 +57,14 @@ jobs:
     env:
       ARROW_USE_CCACHE: OFF
       ARROW_CPP_EXE_PATH: /build/cpp/debug
-      ARROW_GO_INTEGRATION: 1
       BUILD_DOCS_CPP: OFF
+      ARROW_INTEGRATION_CPP: ON
+      ARROW_INTEGRATION_CSHARP: ON
+      ARROW_INTEGRATION_GO: ON
+      ARROW_INTEGRATION_JAVA: ON
+      ARROW_INTEGRATION_JS: ON
+      # https://github.com/apache/arrow/pull/38403/files#r1371281630
+      ARCHERY_INTEGRATION_WITH_RUST: ON
       # These are necessary because the github runner overrides $HOME
       # https://github.com/actions/runner/issues/863
       RUSTUP_HOME: /root/.rustup
@@ -88,43 +94,10 @@ jobs:
         with:
           path: rust
           fetch-depth: 0
-      - name: Install pythonnet
-        run: conda run --no-capture-output pip install pythonnet
-      - name: Install archery
-        run: conda run --no-capture-output pip install -e dev/archery[integration]
-      - name: Make build directory
-        run: mkdir /build
-      - name: Build Rust
-        run: conda run --no-capture-output ci/scripts/rust_build.sh $PWD /build
-      - name: Build C++
-        run: conda run --no-capture-output ci/scripts/cpp_build.sh $PWD /build
-      - name: Build C#
-        run: conda run --no-capture-output ci/scripts/csharp_build.sh $PWD /build
-      - name: Build Go
-        run: conda run --no-capture-output ci/scripts/go_build.sh $PWD
-# Temporarily disabled - https://github.com/apache/arrow-rs/issues/4963
-#      - name: Build Java
-#        run: conda run --no-capture-output ci/scripts/java_build.sh $PWD /build
-      - name: Build JS
-        run: conda run --no-capture-output ci/scripts/js_build.sh $PWD /build
-      - name: Run integration tests
-        run: |
-          conda run --no-capture-output archery integration \
-            --run-flight \
-            --run-c-data \
-            --run-ipc \
-            --with-cpp=1 \
-            --with-csharp=1 \
-            --with-java=0 \
-            --with-js=1 \
-            --with-go=1 \
-            --with-rust=1 \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/0.14.1 \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/0.17.1 \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/1.0.0-bigendian \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/1.0.0-littleendian \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/2.0.0-compression \
-            --gold-dirs=testing/data/arrow-ipc-stream/integration/4.0.0-shareddict
+      - name: Build
+        run: conda run --no-capture-output ci/scripts/integration_arrow_build.sh $PWD /build
+      - name: Run
+        run: conda run --no-capture-output ci/scripts/integration_arrow.sh $PWD /build
 
   # test FFI against the C-Data interface exposed by pyarrow
   pyarrow-integration-test:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,8 +102,9 @@ jobs:
         run: conda run --no-capture-output ci/scripts/csharp_build.sh $PWD /build
       - name: Build Go
         run: conda run --no-capture-output ci/scripts/go_build.sh $PWD
-      - name: Build Java
-        run: conda run --no-capture-output ci/scripts/java_build.sh $PWD /build
+# Temporarily disabled - https://github.com/apache/arrow-rs/issues/4963
+#      - name: Build Java
+#        run: conda run --no-capture-output ci/scripts/java_build.sh $PWD /build
       - name: Build JS
         run: conda run --no-capture-output ci/scripts/js_build.sh $PWD /build
       - name: Run integration tests
@@ -114,7 +115,7 @@ jobs:
             --run-ipc \
             --with-cpp=1 \
             --with-csharp=1 \
-            --with-java=1 \
+            --with-java=0 \
             --with-js=1 \
             --with-go=1 \
             --with-rust=1 \


### PR DESCRIPTION



# Which issue does this PR close?
Related to https://github.com/apache/arrow-rs/issues/5050


# Rationale for this change
CI is failing when I tried to run it on the 48.0.0 maintenance branch:  https://github.com/apache/arrow-rs/pull/5059#issuecomment-1802733777 which @tustvold fixed a few weeks ago on master. 

# What changes are included in this PR?
Backports
https://github.com/apache/arrow-rs/pull/4957
https://github.com/apache/arrow-rs/pull/4988

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
