### PR TITLE
Add a PR under "Breaking changes" in the object_store 0.8.0 changelog

### DIFF
--- a/object_store/CHANGELOG.md
+++ b/object_store/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add ObjectMeta::version and GetOptions::version \(\#4925\) [\#4935](https://github.com/apache/arrow-rs/pull/4935) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
 - Add GetOptions::head [\#4931](https://github.com/apache/arrow-rs/pull/4931) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
 - Remove Nested async and Fallibility from ObjectStore::list [\#4930](https://github.com/apache/arrow-rs/pull/4930) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
+- Add ObjectStore::put_opts / Conditional Put [\#4879](https://github.com/apache/arrow-rs/pull/4984) [[object-store](https://github.com/apache/arrow-rs/labels/object-store)] ([tustvold](https://github.com/tustvold))
 
 **Implemented enhancements:**
 


### PR DESCRIPTION
This PR adds a method, `put_opts`, to the `ObjectStore` trait, so any implementer of this trait will need to update their code when they upgrade to 0.8.0.

# Which issue does this PR close?

I will file an issue if you realllyyyy want me to, but do you need a changelog entry for a fix to the changelog? 🤔 

# Rationale for this change
 
I tried updating the IOx codebase from object_store 0.7.1 to 0.8.0 and got errors about an implementation of `ObjectStore` missing `put_opts`. I went to the changelog to learn more about the change, and I couldn't find the information I needed because the PR that added this method wasn't under the breaking changes section and searching the changelog for "put_opts" didn't return results either  :)

# What changes are included in this PR?

Adding a PR to the Breaking Changes section of the object_store 0.8.0 changelog.

# Are there any user-facing changes?

This is some documentation for the user-facing change made previously :)