### PR TITLE
Allow writing null valued keys in JSON

### DIFF
--- a/arrow-array/src/numeric.rs
+++ b/arrow-array/src/numeric.rs
@@ -618,7 +618,6 @@ mod tests {
         let mask = 0b01010101_01010101_10101010_10101010;
         let actual = UInt16Type::mask_from_u64(mask);
         let expected = expected_mask!(i16, mask);
-        dbg!(&expected);
         let expected = m16x32::from_cast(i16x32::from_slice_unaligned(expected.as_slice()));
 
         assert_eq!(expected, actual);

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -82,7 +82,7 @@ pub type RawReader<R> = Reader<R>;
 pub type RawReaderBuilder = ReaderBuilder;
 
 pub use self::reader::{Reader, ReaderBuilder};
-pub use self::writer::{ArrayWriter, LineDelimitedWriter, Writer};
+pub use self::writer::{ArrayWriter, LineDelimitedWriter, Writer, WriterBuilder};
 use half::f16;
 use serde_json::{Number, Value};
 

--- a/arrow-json/test/data/nested_with_nulls.json
+++ b/arrow-json/test/data/nested_with_nulls.json
@@ -1,0 +1,4 @@
+{"a": null, "b": null, "c":  null, "d": {"d1":         null, "d2": [null, 1, 2, null]}}
+{"a": null, "b": -3.5, "c":  true, "d": {"d1":         null, "d2": null}}
+{"a": null, "b": null, "c": false, "d": {"d1": "1970-01-01", "d2": null}}
+{"a":    1, "b":  2.0, "c": false, "d": {"d1":         null, "d2": null}}

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -617,8 +617,6 @@ mod tests {
             .downcast_ref::<GenericListArray<Offset>>()
             .unwrap();
 
-        dbg!(&array);
-
         // verify
         let expected = GenericListArray::<Offset>::from(list_data);
         assert_eq!(&array.value(0), &expected.value(0));

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -47,7 +47,6 @@ fn test_cast_timestamp_to_string() {
     let a = TimestampMillisecondArray::from(vec![Some(864000000005), Some(1545696000001), None])
         .with_timezone("UTC".to_string());
     let array = Arc::new(a) as ArrayRef;
-    dbg!(&array);
     let b = cast(&array, &DataType::Utf8).unwrap();
     let c = b.as_any().downcast_ref::<StringArray>().unwrap();
     assert_eq!(&DataType::Utf8, c.data_type());

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -605,7 +605,7 @@ mod tests {
             .with_bucket_name("foo")
             .with_proxy_url("https://example.com")
             .build();
-        assert!(dbg!(gcs).is_ok());
+        assert!(gcs.is_ok());
 
         let err = GoogleCloudStorageBuilder::new()
             .with_service_account_path(service_account_path.to_str().unwrap())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3774

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Allow users to write JSON with null values for keys, where previous (and default) is to skip the keys.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In arrow-json writer mod, new builder for `Writer` which allows configuring how null valued keys (and null arrays) should be handled. Will default to skipping keys with null values for backward compatibility.

# Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
