### PR TITLE
Improve C Data Interface and Add Integration Testing Entrypoints

### DIFF
--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -168,6 +168,12 @@ impl FFI_ArrowArray {
             .collect::<Box<_>>();
         let n_children = children.len() as i64;
 
+        // As in the IPC format, emit null_count = length for Null type
+        let null_count = match data.data_type() {
+            DataType::Null => data.len(),
+            _ => data.null_count(),
+        };
+
         // create the private data owning everything.
         // any other data must be added here, e.g. via a struct, to track lifetime.
         let mut private_data = Box::new(ArrayPrivateData {
@@ -179,7 +185,7 @@ impl FFI_ArrowArray {
 
         Self {
             length: data.len() as i64,
-            null_count: data.null_count() as i64,
+            null_count: null_count as i64,
             offset: data.offset() as i64,
             n_buffers,
             n_children,

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -27,11 +27,14 @@ edition = { workspace = true }
 publish = false
 rust-version = { workspace = true }
 
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [features]
 logging = ["tracing-subscriber"]
 
 [dependencies]
-arrow = { path = "../arrow", default-features = false, features = ["test_utils", "ipc", "ipc_compression", "json"] }
+arrow = { path = "../arrow", default-features = false, features = ["test_utils", "ipc", "ipc_compression", "json", "ffi"] }
 arrow-flight = { path = "../arrow-flight", default-features = false }
 arrow-buffer = { path = "../arrow-buffer", default-features = false }
 arrow-integration-test = { path = "../arrow-integration-test", default-features = false }

--- a/arrow-integration-testing/README.md
+++ b/arrow-integration-testing/README.md
@@ -48,7 +48,7 @@ ln -s <path_to_arrow_rs> arrow/rust
 
 ```shell
 cd arrow
-pip install -e dev/archery[docker]
+pip install -e dev/archery[integration]
 ```
 
 ### Build the C++ binaries:

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -244,9 +244,9 @@ fn cdata_integration_import_batch_and_compare_to_json(
         read_single_batch_from_json_file(json_name.to_str()?, batch_num.try_into().unwrap())?;
     let schema = json_batch.schema();
 
+    let data_type_for_import = DataType::Struct(schema.fields.clone());
     let imported_array = unsafe { FFI_ArrowArray::from_raw(c_array) };
-    let imported_array =
-        from_ffi_and_data_type(imported_array, DataType::Struct(schema.fields.clone()))?;
+    let imported_array = unsafe { from_ffi_and_data_type(imported_array, data_type_for_import) }?;
     imported_array.validate_full()?;
     let imported_batch = RecordBatch::from(StructArray::from(imported_array));
 

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -87,13 +87,13 @@ pub fn canonicalize_schema(schema: &Schema) -> Schema {
     Schema::new(fields).with_metadata(schema.metadata().clone())
 }
 
-struct PartialArrowFile {
+struct LazyArrowFile {
     schema: Schema,
     dictionaries: HashMap<i64, ArrowJsonDictionaryBatch>,
     arrow_json: Value,
 }
 
-fn read_json_file_metadata(json_name: &str) -> Result<PartialArrowFile> {
+fn read_json_file_metadata(json_name: &str) -> Result<LazyArrowFile> {
     let json_file = File::open(json_name)?;
     let reader = BufReader::new(json_file);
     let arrow_json: Value = serde_json::from_reader(reader).unwrap();
@@ -111,7 +111,7 @@ fn read_json_file_metadata(json_name: &str) -> Result<PartialArrowFile> {
             dictionaries.insert(json_dict.id, json_dict);
         }
     }
-    Ok(PartialArrowFile {
+    Ok(LazyArrowFile {
         schema,
         dictionaries,
         arrow_json,

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -113,8 +113,8 @@ fn read_json_file_metadata(json_name: &str) -> Result<PartialArrowFile> {
     }
     Ok(PartialArrowFile {
         schema,
-        dictionaries: dictionaries,
-        arrow_json: arrow_json,
+        dictionaries,
+        arrow_json,
     })
 }
 
@@ -260,9 +260,13 @@ fn result_to_c_error<T, E: std::fmt::Display>(result: &std::result::Result<T, E>
     }
 }
 
-// Release a const char* exported by result_to_c_error()
+/// Release a const char* exported by result_to_c_error()
+///
+/// # Safety
+///
+/// The pointer is assumed to have been obtained using CString::into_raw.
 #[no_mangle]
-pub extern "C" fn arrow_rs_free_error(c_error: *mut i8) {
+pub unsafe extern "C" fn arrow_rs_free_error(c_error: *mut i8) {
     if !c_error.is_null() {
         drop(unsafe { CString::from_raw(c_error) });
     }

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -19,14 +19,19 @@
 
 use serde_json::Value;
 
-use arrow::datatypes::Schema;
-use arrow::error::Result;
+use arrow::array::{Array, StructArray};
+use arrow::datatypes::{DataType, Field, Fields, Schema};
+use arrow::error::{ArrowError, Result};
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow::record_batch::RecordBatch;
 use arrow::util::test_util::arrow_test_data;
 use arrow_integration_test::*;
 use std::collections::HashMap;
+use std::ffi::{c_int, CStr, CString};
 use std::fs::File;
 use std::io::BufReader;
+use std::ptr;
+use std::sync::Arc;
 
 /// The expected username for the basic auth integration test.
 pub const AUTH_USERNAME: &str = "arrow";
@@ -44,7 +49,50 @@ pub struct ArrowFile {
     pub batches: Vec<RecordBatch>,
 }
 
-pub fn read_json_file(json_name: &str) -> Result<ArrowFile> {
+// Canonicalize the names of map fields in a schema
+pub fn canonicalize_schema(schema: &Schema) -> Schema {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| match field.data_type() {
+            DataType::Map(child_field, sorted) => match child_field.data_type() {
+                DataType::Struct(fields) if fields.len() == 2 => {
+                    let first_field = fields.get(0).unwrap();
+                    let key_field =
+                        Arc::new(Field::new("key", first_field.data_type().clone(), false));
+                    let second_field = fields.get(1).unwrap();
+                    let value_field = Arc::new(Field::new(
+                        "value",
+                        second_field.data_type().clone(),
+                        second_field.is_nullable(),
+                    ));
+
+                    let fields = Fields::from([key_field, value_field]);
+                    let struct_type = DataType::Struct(fields);
+                    let child_field = Field::new("entries", struct_type, false);
+
+                    Arc::new(Field::new(
+                        field.name().as_str(),
+                        DataType::Map(Arc::new(child_field), *sorted),
+                        field.is_nullable(),
+                    ))
+                }
+                _ => panic!("The child field of Map type should be Struct type with 2 fields."),
+            },
+            _ => field.clone(),
+        })
+        .collect::<Fields>();
+
+    Schema::new(fields).with_metadata(schema.metadata().clone())
+}
+
+struct PartialArrowFile {
+    schema: Schema,
+    dictionaries: HashMap<i64, ArrowJsonDictionaryBatch>,
+    arrow_json: Value,
+}
+
+fn read_json_file_metadata(json_name: &str) -> Result<PartialArrowFile> {
     let json_file = File::open(json_name)?;
     let reader = BufReader::new(json_file);
     let arrow_json: Value = serde_json::from_reader(reader).unwrap();
@@ -62,18 +110,35 @@ pub fn read_json_file(json_name: &str) -> Result<ArrowFile> {
             dictionaries.insert(json_dict.id, json_dict);
         }
     }
+    Ok(PartialArrowFile {
+        schema,
+        dictionaries: dictionaries,
+        arrow_json: arrow_json,
+    })
+}
+
+pub fn read_json_file(json_name: &str) -> Result<ArrowFile> {
+    let f = read_json_file_metadata(json_name)?;
 
     let mut batches = vec![];
-    for b in arrow_json["batches"].as_array().unwrap() {
+    for b in f.arrow_json["batches"].as_array().unwrap() {
         let json_batch: ArrowJsonBatch = serde_json::from_value(b.clone()).unwrap();
-        let batch = record_batch_from_json(&schema, json_batch, Some(&dictionaries))?;
+        let batch = record_batch_from_json(&f.schema, json_batch, Some(&f.dictionaries))?;
         batches.push(batch);
     }
     Ok(ArrowFile {
-        schema,
-        _dictionaries: dictionaries,
+        schema: f.schema,
+        _dictionaries: f.dictionaries,
         batches,
     })
+}
+
+pub fn read_single_batch_from_json_file(json_name: &str, batch_num: usize) -> Result<RecordBatch> {
+    let f = read_json_file_metadata(json_name)?;
+    let b = f.arrow_json["batches"].get(batch_num).unwrap();
+    let json_batch: ArrowJsonBatch = serde_json::from_value(b.clone()).unwrap();
+    let batch = record_batch_from_json(&f.schema, json_batch, Some(&f.dictionaries))?;
+    Ok(batch)
 }
 
 /// Read gzipped JSON test file
@@ -99,4 +164,99 @@ pub fn read_gzip_json(version: &str, path: &str) -> ArrowJson {
     // convert to Arrow JSON
     let arrow_json: ArrowJson = serde_json::from_str(&s).unwrap();
     arrow_json
+}
+
+//
+// C Data Integration entrypoints
+//
+
+fn cdata_integration_export_schema_from_json(
+    c_json_name: *const i8,
+    out: *mut FFI_ArrowSchema,
+) -> Result<()> {
+    let json_name = unsafe { CStr::from_ptr(c_json_name) };
+    let f = read_json_file_metadata(json_name.to_str()?)?;
+    let c_schema = FFI_ArrowSchema::try_from(&f.schema)?;
+    // Move exported schema into output struct
+    unsafe { ptr::replace(out, c_schema) };
+    Ok(())
+}
+
+fn cdata_integration_export_batch_from_json(
+    c_json_name: *const i8,
+    batch_num: c_int,
+    out: *mut FFI_ArrowArray,
+) -> Result<()> {
+    let json_name = unsafe { CStr::from_ptr(c_json_name) };
+    let b = read_single_batch_from_json_file(json_name.to_str()?, batch_num.try_into().unwrap())?;
+    let a = StructArray::from(b).into_data();
+    let c_array = FFI_ArrowArray::new(&a);
+    // Move exported array into output struct
+    unsafe { ptr::replace(out, c_array) };
+    Ok(())
+}
+
+fn cdata_integration_import_schema_and_compare_to_json(
+    c_json_name: *const i8,
+    c_schema: *mut FFI_ArrowSchema,
+) -> Result<()> {
+    let json_name = unsafe { CStr::from_ptr(c_json_name) };
+    let json_schema = read_json_file_metadata(json_name.to_str()?)?.schema;
+
+    // The source ArrowSchema will be released when this is dropped
+    let imported_schema = unsafe { std::ptr::replace(c_schema, FFI_ArrowSchema::empty()) };
+    let imported_schema = Schema::try_from(&imported_schema)?;
+
+    // compare schemas
+    if canonicalize_schema(&json_schema) != canonicalize_schema(&imported_schema) {
+        return Err(ArrowError::ComputeError(format!(
+            "Schemas do not match.\n- JSON: {:?}\n- Imported: {:?}",
+            json_schema, imported_schema
+        )));
+    }
+    Ok(())
+}
+
+// If Result is an error, then export a const char* to its string display, otherwise NULL
+fn result_to_c_error<T, E: std::fmt::Display>(result: &std::result::Result<T, E>) -> *mut i8 {
+    match result {
+        Ok(_) => ptr::null_mut(),
+        Err(e) => CString::new(format!("{}", e)).unwrap().into_raw(),
+    }
+}
+
+// Release a const char* exported by result_to_c_error()
+#[no_mangle]
+pub extern "C" fn arrow_rs_free_error(c_error: *mut i8) {
+    if !c_error.is_null() {
+        drop(unsafe { CString::from_raw(c_error) });
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn arrow_rs_cdata_integration_export_schema_from_json(
+    c_json_name: *const i8,
+    out: *mut FFI_ArrowSchema,
+) -> *mut i8 {
+    let r = cdata_integration_export_schema_from_json(c_json_name, out);
+    result_to_c_error(&r)
+}
+
+#[no_mangle]
+pub extern "C" fn arrow_rs_cdata_integration_import_schema_and_compare_to_json(
+    c_json_name: *const i8,
+    out: *mut FFI_ArrowSchema,
+) -> *mut i8 {
+    let r = cdata_integration_import_schema_and_compare_to_json(c_json_name, out);
+    result_to_c_error(&r)
+}
+
+#[no_mangle]
+pub extern "C" fn arrow_rs_cdata_integration_export_batch_from_json(
+    c_json_name: *const i8,
+    batch_num: c_int,
+    out: *mut FFI_ArrowArray,
+) -> *mut i8 {
+    let r = cdata_integration_export_batch_from_json(c_json_name, batch_num, out);
+    result_to_c_error(&r)
 }

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -179,7 +179,7 @@ fn cdata_integration_export_schema_from_json(
     let f = read_json_file_metadata(json_name.to_str()?)?;
     let c_schema = FFI_ArrowSchema::try_from(&f.schema)?;
     // Move exported schema into output struct
-    unsafe { ptr::replace(out, c_schema) };
+    unsafe { ptr::write(out, c_schema) };
     Ok(())
 }
 
@@ -193,7 +193,7 @@ fn cdata_integration_export_batch_from_json(
     let a = StructArray::from(b).into_data();
     let c_array = FFI_ArrowArray::new(&a);
     // Move exported array into output struct
-    unsafe { ptr::replace(out, c_array) };
+    unsafe { ptr::write(out, c_array) };
     Ok(())
 }
 

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -205,7 +205,7 @@ fn cdata_integration_import_schema_and_compare_to_json(
     let json_schema = read_json_file_metadata(json_name.to_str()?)?.schema;
 
     // The source ArrowSchema will be released when this is dropped
-    let imported_schema = unsafe { std::ptr::replace(c_schema, FFI_ArrowSchema::empty()) };
+    let imported_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema) };
     let imported_schema = Schema::try_from(&imported_schema)?;
 
     // compare schemas
@@ -244,7 +244,7 @@ fn cdata_integration_import_batch_and_compare_to_json(
         read_single_batch_from_json_file(json_name.to_str()?, batch_num.try_into().unwrap())?;
     let schema = json_batch.schema();
 
-    let imported_array = unsafe { std::ptr::replace(c_array, FFI_ArrowArray::empty()) };
+    let imported_array = unsafe { FFI_ArrowArray::from_raw(c_array) };
     let imported_array =
         from_ffi_and_data_type(imported_array, DataType::Struct(schema.fields.clone()))?;
     imported_array.validate_full()?;

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -247,6 +247,7 @@ fn cdata_integration_import_batch_and_compare_to_json(
     let imported_array = unsafe { std::ptr::replace(c_array, FFI_ArrowArray::empty()) };
     let imported_array =
         from_ffi_and_data_type(imported_array, DataType::Struct(schema.fields.clone()))?;
+    imported_array.validate_full()?;
     let imported_batch = RecordBatch::from(StructArray::from(imported_array));
 
     compare_batches(&json_batch, &imported_batch)

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -58,6 +58,12 @@ impl From<std::io::Error> for ArrowError {
     }
 }
 
+impl From<std::str::Utf8Error> for ArrowError {
+    fn from(error: std::str::Utf8Error) -> Self {
+        ArrowError::ParseError(error.to_string())
+    }
+}
+
 impl From<std::string::FromUtf8Error> for ArrowError {
     fn from(error: std::string::FromUtf8Error) -> Self {
         ArrowError::ParseError(error.to_string())

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -34,7 +34,9 @@
 //! assert_eq!(schema, back);
 //! ```
 
-use crate::{ArrowError, DataType, Field, FieldRef, Schema, TimeUnit, UnionFields, UnionMode};
+use crate::{
+    ArrowError, DataType, Field, FieldRef, IntervalUnit, Schema, TimeUnit, UnionFields, UnionMode,
+};
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -402,6 +404,9 @@ impl TryFrom<&FFI_ArrowSchema> for DataType {
             "tDm" => DataType::Duration(TimeUnit::Millisecond),
             "tDu" => DataType::Duration(TimeUnit::Microsecond),
             "tDn" => DataType::Duration(TimeUnit::Nanosecond),
+            "tiM" => DataType::Interval(IntervalUnit::YearMonth),
+            "tiD" => DataType::Interval(IntervalUnit::DayTime),
+            "tin" => DataType::Interval(IntervalUnit::MonthDayNano),
             "+l" => {
                 let c_child = c_schema.child(0);
                 DataType::List(Arc::new(Field::try_from(c_child)?))
@@ -669,6 +674,9 @@ fn get_format_string(dtype: &DataType) -> Result<String, ArrowError> {
         DataType::Duration(TimeUnit::Millisecond) => Ok("tDm".to_string()),
         DataType::Duration(TimeUnit::Microsecond) => Ok("tDu".to_string()),
         DataType::Duration(TimeUnit::Nanosecond) => Ok("tDn".to_string()),
+        DataType::Interval(IntervalUnit::YearMonth) => Ok("tiM".to_string()),
+        DataType::Interval(IntervalUnit::DayTime) => Ok("tiD".to_string()),
+        DataType::Interval(IntervalUnit::MonthDayNano) => Ok("tin".to_string()),
         DataType::List(_) => Ok("+l".to_string()),
         DataType::LargeList(_) => Ok("+L".to_string()),
         DataType::Struct(_) => Ok("+s".to_string()),

--- a/arrow/src/array/ffi.rs
+++ b/arrow/src/array/ffi.rs
@@ -70,7 +70,7 @@ mod tests {
         let schema = FFI_ArrowSchema::try_from(expected.data_type())?;
 
         // simulate an external consumer by being the consumer
-        let result = &from_ffi(array, &schema)?;
+        let result = &unsafe { from_ffi(array, &schema) }?;
 
         assert_eq!(result, expected);
         Ok(())

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -108,6 +108,7 @@ use std::{mem::size_of, ptr::NonNull, sync::Arc};
 
 pub use arrow_data::ffi::FFI_ArrowArray;
 pub use arrow_schema::ffi::{FFI_ArrowSchema, Flags};
+
 use arrow_schema::UnionMode;
 
 use crate::array::{layout, ArrayData};
@@ -234,31 +235,46 @@ pub fn to_ffi(data: &ArrayData) -> Result<(FFI_ArrowArray, FFI_ArrowSchema)> {
 ///
 /// This struct assumes that the incoming data agrees with the C data interface.
 pub fn from_ffi(array: FFI_ArrowArray, schema: &FFI_ArrowSchema) -> Result<ArrayData> {
+    let dt = DataType::try_from(schema)?;
     let array = Arc::new(array);
-    let tmp = ArrowArray {
+    let tmp = ImportedArrowArray {
         array: &array,
-        schema,
+        data_type: dt,
+        owner: &array,
+    };
+    tmp.consume()
+}
+
+/// Import [ArrayData] from the C Data Interface
+///
+/// # Safety
+///
+/// This struct assumes that the incoming data agrees with the C data interface.
+pub fn from_ffi_and_data_type(array: FFI_ArrowArray, data_type: DataType) -> Result<ArrayData> {
+    let array = Arc::new(array);
+    let tmp = ImportedArrowArray {
+        array: &array,
+        data_type,
         owner: &array,
     };
     tmp.consume()
 }
 
 #[derive(Debug)]
-struct ArrowArray<'a> {
+struct ImportedArrowArray<'a> {
     array: &'a FFI_ArrowArray,
-    schema: &'a FFI_ArrowSchema,
+    data_type: DataType,
     owner: &'a Arc<FFI_ArrowArray>,
 }
 
-impl<'a> ArrowArray<'a> {
+impl<'a> ImportedArrowArray<'a> {
     fn consume(self) -> Result<ArrayData> {
-        let dt = DataType::try_from(self.schema)?;
         let len = self.array.len();
         let offset = self.array.offset();
         let null_count = self.array.null_count();
 
-        let data_layout = layout(&dt);
-        let buffers = self.buffers(data_layout.can_contain_null_mask, &dt)?;
+        let data_layout = layout(&self.data_type);
+        let buffers = self.buffers(data_layout.can_contain_null_mask)?;
 
         let null_bit_buffer = if data_layout.can_contain_null_mask {
             self.null_bit_buffer()
@@ -266,14 +282,9 @@ impl<'a> ArrowArray<'a> {
             None
         };
 
-        let mut child_data = (0..self.array.num_children())
-            .map(|i| {
-                let child = self.child(i);
-                child.consume()
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let mut child_data = self.consume_children()?;
 
-        if let Some(d) = self.dictionary() {
+        if let Some(d) = self.dictionary()? {
             // For dictionary type there should only be a single child, so we don't need to worry if
             // there are other children added above.
             assert!(child_data.is_empty());
@@ -283,7 +294,7 @@ impl<'a> ArrowArray<'a> {
         // Should FFI be checking validity?
         Ok(unsafe {
             ArrayData::new_unchecked(
-                dt,
+                self.data_type,
                 len,
                 Some(null_count),
                 null_bit_buffer,
@@ -294,14 +305,49 @@ impl<'a> ArrowArray<'a> {
         })
     }
 
+    fn consume_children(&self) -> Result<Vec<ArrayData>> {
+        match &self.data_type {
+            DataType::List(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::LargeList(field)
+            | DataType::Map(field, _) => Ok([self.consume_child(0, field.data_type())?].to_vec()),
+            DataType::Struct(fields) => {
+                assert!(fields.len() == self.array.num_children());
+                fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, field)| self.consume_child(i, field.data_type()))
+                    .collect::<Result<Vec<_>>>()
+            }
+            DataType::Union(union_fields, _) => {
+                assert!(union_fields.len() == self.array.num_children());
+                union_fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (_, field))| self.consume_child(i, field.data_type()))
+                    .collect::<Result<Vec<_>>>()
+            }
+            _ => Ok(Vec::new()),
+        }
+    }
+
+    fn consume_child(&self, index: usize, child_type: &DataType) -> Result<ArrayData> {
+        ImportedArrowArray {
+            array: self.array.child(index),
+            data_type: child_type.clone(),
+            owner: self.owner,
+        }
+        .consume()
+    }
+
     /// returns all buffers, as organized by Rust (i.e. null buffer is skipped if it's present
     /// in the spec of the type)
-    fn buffers(&self, can_contain_null_mask: bool, dt: &DataType) -> Result<Vec<Buffer>> {
+    fn buffers(&self, can_contain_null_mask: bool) -> Result<Vec<Buffer>> {
         // + 1: skip null buffer
         let buffer_begin = can_contain_null_mask as usize;
         (buffer_begin..self.array.num_buffers())
             .map(|index| {
-                let len = self.buffer_len(index, dt)?;
+                let len = self.buffer_len(index, &self.data_type)?;
 
                 match unsafe { create_buffer(self.owner.clone(), self.array, index, len) } {
                     Some(buf) => Ok(buf),
@@ -388,25 +434,20 @@ impl<'a> ArrowArray<'a> {
         unsafe { create_buffer(self.owner.clone(), self.array, 0, buffer_len) }
     }
 
-    fn child(&self, index: usize) -> ArrowArray {
-        ArrowArray {
-            array: self.array.child(index),
-            schema: self.schema.child(index),
-            owner: self.owner,
-        }
-    }
-
-    fn dictionary(&self) -> Option<ArrowArray> {
-        match (self.array.dictionary(), self.schema.dictionary()) {
-            (Some(array), Some(schema)) => Some(ArrowArray {
+    fn dictionary(&self) -> Result<Option<ImportedArrowArray>> {
+        match (self.array.dictionary(), &self.data_type) {
+            (Some(array), DataType::Dictionary(_, value_type)) => Ok(Some(ImportedArrowArray {
                 array,
-                schema,
+                data_type: *value_type.clone(),
                 owner: self.owner,
-            }),
-            (None, None) => None,
-            _ => panic!(
-                "Dictionary should both be set or not set in FFI_ArrowArray and FFI_ArrowSchema"
-            ),
+            })),
+            (Some(_), _) => Err(ArrowError::CDataInterface(format!(
+                "Got dictionary in FFI_ArrowArray for non-dictionary data type"
+            ))),
+            (None, DataType::Dictionary(_, _)) => Err(ArrowError::CDataInterface(format!(
+                "Missing dictionary in FFI_ArrowArray for dictionary data type"
+            ))),
+            (_, _) => Ok(None),
         }
     }
 }

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -43,7 +43,7 @@
 //! let (out_array, out_schema) = to_ffi(&data)?;
 //!
 //! // import it
-//! let data = from_ffi(out_array, &out_schema)?;
+//! let data = unsafe { from_ffi(out_array, &out_schema) }?;
 //! let array = Int32Array::from(data);
 //!
 //! // perform some operation
@@ -80,7 +80,7 @@
 //!     let mut schema = FFI_ArrowSchema::empty();
 //!     let mut array = FFI_ArrowArray::empty();
 //!     foreign.export_to_c(addr_of_mut!(array), addr_of_mut!(schema));
-//!     Ok(make_array(from_ffi(array, &schema)?))
+//!     Ok(make_array(unsafe { from_ffi(array, &schema) }?))
 //! }
 //! ```
 
@@ -234,7 +234,7 @@ pub fn to_ffi(data: &ArrayData) -> Result<(FFI_ArrowArray, FFI_ArrowSchema)> {
 /// # Safety
 ///
 /// This struct assumes that the incoming data agrees with the C data interface.
-pub fn from_ffi(array: FFI_ArrowArray, schema: &FFI_ArrowSchema) -> Result<ArrayData> {
+pub unsafe fn from_ffi(array: FFI_ArrowArray, schema: &FFI_ArrowSchema) -> Result<ArrayData> {
     let dt = DataType::try_from(schema)?;
     let array = Arc::new(array);
     let tmp = ImportedArrowArray {
@@ -250,7 +250,10 @@ pub fn from_ffi(array: FFI_ArrowArray, schema: &FFI_ArrowSchema) -> Result<Array
 /// # Safety
 ///
 /// This struct assumes that the incoming data agrees with the C data interface.
-pub fn from_ffi_and_data_type(array: FFI_ArrowArray, data_type: DataType) -> Result<ArrayData> {
+pub unsafe fn from_ffi_and_data_type(
+    array: FFI_ArrowArray,
+    data_type: DataType,
+) -> Result<ArrayData> {
     let array = Arc::new(array);
     let tmp = ImportedArrowArray {
         array: &array,
@@ -487,7 +490,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.into_data()).unwrap();
 
         // (simulate consumer) import it
-        let array = Int32Array::from(from_ffi(array, &schema).unwrap());
+        let array = Int32Array::from(unsafe { from_ffi(array, &schema) }.unwrap());
         let array = kernels::numeric::add(&array, &array).unwrap();
 
         // verify
@@ -531,7 +534,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -561,7 +564,7 @@ mod tests {
         let (array, schema) = to_ffi(&original_array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -583,7 +586,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -652,7 +655,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // downcast
@@ -692,7 +695,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -737,7 +740,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -763,7 +766,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -792,7 +795,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -828,7 +831,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -889,7 +892,7 @@ mod tests {
         let (array, schema) = to_ffi(&list_data)?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -934,7 +937,7 @@ mod tests {
         let (array, schema) = to_ffi(&dict_array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -972,7 +975,7 @@ mod tests {
         }
 
         // (simulate consumer) import it
-        let data = from_ffi(out_array, &out_schema)?;
+        let data = unsafe { from_ffi(out_array, &out_schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -993,7 +996,7 @@ mod tests {
         let (array, schema) = to_ffi(&array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -1030,7 +1033,7 @@ mod tests {
         let (array, schema) = to_ffi(&map_array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -1053,7 +1056,7 @@ mod tests {
         let (array, schema) = to_ffi(&struct_array.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         // perform some operation
@@ -1077,7 +1080,7 @@ mod tests {
         let (array, schema) = to_ffi(&union.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = make_array(data);
 
         let array = array.as_any().downcast_ref::<UnionArray>().unwrap();
@@ -1138,7 +1141,7 @@ mod tests {
         let (array, schema) = to_ffi(&union.to_data())?;
 
         // (simulate consumer) import it
-        let data = from_ffi(array, &schema)?;
+        let data = unsafe { from_ffi(array, &schema) }?;
         let array = UnionArray::from(data);
 
         let expected_type_ids = vec![0_i8, 0, 1, 0];

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -441,12 +441,12 @@ impl<'a> ImportedArrowArray<'a> {
                 data_type: *value_type.clone(),
                 owner: self.owner,
             })),
-            (Some(_), _) => Err(ArrowError::CDataInterface(format!(
-                "Got dictionary in FFI_ArrowArray for non-dictionary data type"
-            ))),
-            (None, DataType::Dictionary(_, _)) => Err(ArrowError::CDataInterface(format!(
-                "Missing dictionary in FFI_ArrowArray for dictionary data type"
-            ))),
+            (Some(_), _) => Err(ArrowError::CDataInterface(
+                "Got dictionary in FFI_ArrowArray for non-dictionary data type".to_string(),
+            )),
+            (None, DataType::Dictionary(_, _)) => Err(ArrowError::CDataInterface(
+                "Missing dictionary in FFI_ArrowArray for dictionary data type".to_string(),
+            )),
             (_, _) => Ok(None),
         }
     }

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -271,7 +271,10 @@ impl<'a> ImportedArrowArray<'a> {
     fn consume(self) -> Result<ArrayData> {
         let len = self.array.len();
         let offset = self.array.offset();
-        let null_count = self.array.null_count();
+        let null_count = match &self.data_type {
+            DataType::Null => 0,
+            _ => self.array.null_count(),
+        };
 
         let data_layout = layout(&self.data_type);
         let buffers = self.buffers(data_layout.can_contain_null_mask)?;

--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -441,7 +441,7 @@ impl<'a> ImportedArrowArray<'a> {
         match (self.array.dictionary(), &self.data_type) {
             (Some(array), DataType::Dictionary(_, value_type)) => Ok(Some(ImportedArrowArray {
                 array,
-                data_type: *value_type.clone(),
+                data_type: value_type.as_ref().clone(),
                 owner: self.owner,
             })),
             (Some(_), _) => Err(ArrowError::CDataInterface(

--- a/arrow/src/ffi_stream.rs
+++ b/arrow/src/ffi_stream.rs
@@ -357,9 +357,11 @@ impl Iterator for ArrowArrayStreamReader {
             }
 
             let schema_ref = self.schema();
+            // NOTE: this parses the FFI_ArrowSchema again on each iterator call;
+            // should probably use from_ffi_and_data_type() instead.
             let schema = FFI_ArrowSchema::try_from(schema_ref.as_ref()).ok()?;
 
-            let data = from_ffi(array, &schema).ok()?;
+            let data = unsafe { from_ffi(array, &schema) }.ok()?;
 
             let record_batch = RecordBatch::from(StructArray::from(data));
 
@@ -464,7 +466,7 @@ mod tests {
                 break;
             }
 
-            let array = from_ffi(ffi_array, &ffi_schema).unwrap();
+            let array = unsafe { from_ffi(ffi_array, &ffi_schema) }.unwrap();
 
             let record_batch = RecordBatch::from(StructArray::from(array));
             produced_batches.push(record_batch);

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -267,7 +267,7 @@ impl FromPyArrow for ArrayData {
 
             let schema_ptr = unsafe { schema_capsule.reference::<FFI_ArrowSchema>() };
             let array = unsafe { FFI_ArrowArray::from_raw(array_capsule.pointer() as _) };
-            return ffi::from_ffi(array, schema_ptr).map_err(to_py_err);
+            return unsafe { ffi::from_ffi(array, schema_ptr) }.map_err(to_py_err);
         }
 
         validate_class("Array", value)?;
@@ -287,7 +287,7 @@ impl FromPyArrow for ArrayData {
             ),
         )?;
 
-        ffi::from_ffi(array, &schema).map_err(to_py_err)
+        unsafe { ffi::from_ffi(array, &schema) }.map_err(to_py_err)
     }
 }
 
@@ -348,7 +348,7 @@ impl FromPyArrow for RecordBatch {
 
             let schema_ptr = unsafe { schema_capsule.reference::<FFI_ArrowSchema>() };
             let ffi_array = unsafe { FFI_ArrowArray::from_raw(array_capsule.pointer() as _) };
-            let array_data = ffi::from_ffi(ffi_array, schema_ptr).map_err(to_py_err)?;
+            let array_data = unsafe { ffi::from_ffi(ffi_array, schema_ptr) }.map_err(to_py_err)?;
             if !matches!(array_data.data_type(), DataType::Struct(_)) {
                 return Err(PyTypeError::new_err(
                     "Expected Struct type from __arrow_c_array.",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4867.

# Rationale for this change

Allow Rust to participate in integration testing for the C Data Interface, as explained here:
https://arrow.apache.org/docs/dev/format/Integration.html#example-c-data-interface

# What changes are included in this PR?

Add C-compatible entrypoints for the C Data Interface integration testing machinery.

Add support for exporting and importing Intervals over the C Data Interface.

Allow importing from a FFI_ArrowArray and an existing DataType.

Fix handling of `null_count` field in the C ArrowArray struct.

# Are there any user-facing changes?

No.
