### PR TITLE
Parquet: derive boundary order when writing

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1116,7 +1116,7 @@ fn update_stat<T: ParquetValueType, F>(
 }
 
 /// Evaluate `a > b` according to underlying logical type.
-pub fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) -> bool {
+fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) -> bool {
     if let Some(LogicalType::Integer { is_signed, .. }) = descr.logical_type() {
         if !is_signed {
             // need to compare unsigned

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -228,12 +228,13 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     // column index and offset index
     column_index_builder: ColumnIndexBuilder,
     offset_index_builder: OffsetIndexBuilder,
-    // Below fields used to incrementally check boundary order across data pages
-    // We assume they are ascending/descending until proven wrong
+
+    // Below fields used to incrementally check boundary order across data pages.
+    // We assume they are ascending/descending until proven wrong.
     data_page_boundary_ascending: bool,
     data_page_boundary_descending: bool,
     /// (min, max)
-    latest_non_null_data_page_min_max: Option<(E::T, E::T)>,
+    last_non_null_data_page_min_max: Option<(E::T, E::T)>,
 }
 
 impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
@@ -287,7 +288,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             encodings,
             data_page_boundary_ascending: true,
             data_page_boundary_descending: true,
-            latest_non_null_data_page_min_max: None,
+            last_non_null_data_page_min_max: None,
         }
     }
 
@@ -482,8 +483,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         ) {
             // If the lists are composed of equal elements then will be marked as ascending
             // (Also the case if all pages are null pages)
-            (true, true) => BoundaryOrder::ASCENDING,
-            (true, false) => BoundaryOrder::ASCENDING,
+            (true, _) => BoundaryOrder::ASCENDING,
             (false, true) => BoundaryOrder::DESCENDING,
             (false, false) => BoundaryOrder::UNORDERED,
         };
@@ -632,7 +632,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     }
 
     /// Update the column index and offset index when adding the data page
-    fn update_column_offset_index(&mut self, page_statistics: Option<&Statistics>) {
+    fn update_column_offset_index(&mut self, page_statistics: Option<&ValueStatistics<E::T>>) {
         // update the column index
         let null_page =
             (self.page_metrics.num_buffered_rows as u64) == self.page_metrics.num_page_nulls;
@@ -653,6 +653,30 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                     self.column_index_builder.to_invalid();
                 }
                 Some(stat) => {
+                    // Check if min/max are still ascending/descending across pages
+                    let new_min = stat.min();
+                    let new_max = stat.max();
+                    if let Some((last_min, last_max)) = &self.last_non_null_data_page_min_max {
+                        if self.data_page_boundary_ascending {
+                            // If last min/max are greater than new min/max then not ascending anymore
+                            let not_ascending = compare_greater(&self.descr, last_min, new_min)
+                                || compare_greater(&self.descr, last_max, new_max);
+                            if not_ascending {
+                                self.data_page_boundary_ascending = false;
+                            }
+                        }
+
+                        if self.data_page_boundary_descending {
+                            // If new min/max are greater than last min/max then not descending anymore
+                            let not_descending = compare_greater(&self.descr, new_min, last_min)
+                                || compare_greater(&self.descr, new_max, last_max);
+                            if not_descending {
+                                self.data_page_boundary_descending = false;
+                            }
+                        }
+                    }
+                    self.last_non_null_data_page_min_max = Some((new_min.clone(), new_max.clone()));
+
                     // We only truncate if the data is represented as binary
                     match self.descr.physical_type() {
                         Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY => {
@@ -725,36 +749,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             (Some(min), Some(max)) => {
                 update_min(&self.descr, &min, &mut self.column_metrics.min_column_value);
                 update_max(&self.descr, &max, &mut self.column_metrics.max_column_value);
-
-                // Check if min/max are still ascending/descending across pages
-                // Null pages aren't considered in this sort order
-                let null_page = (self.page_metrics.num_buffered_rows as u64)
-                    == self.page_metrics.num_page_nulls;
-                if !null_page {
-                    if let Some((latest_min, latest_max)) = &self.latest_non_null_data_page_min_max
-                    {
-                        if self.data_page_boundary_ascending {
-                            // If latest min/max are greater than new min/max then not ascending anymore
-                            let not_ascending = compare_greater(&self.descr, latest_min, &min)
-                                || compare_greater(&self.descr, latest_max, &max);
-                            if not_ascending {
-                                self.data_page_boundary_ascending = false;
-                            }
-                        }
-
-                        if self.data_page_boundary_descending {
-                            // If new min/max are greater than latest min/max then not descending anymore
-                            let not_descending = compare_greater(&self.descr, &min, latest_min)
-                                || compare_greater(&self.descr, &max, latest_max);
-                            if not_descending {
-                                self.data_page_boundary_descending = false;
-                            }
-                        }
-                    }
-                    self.latest_non_null_data_page_min_max = Some((min.clone(), max.clone()));
-                }
-
-                Some(Statistics::new(
+                Some(ValueStatistics::new(
                     Some(min),
                     Some(max),
                     None,
@@ -767,6 +762,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
         // update column and offset index
         self.update_column_offset_index(page_statistics.as_ref());
+        let page_statistics = page_statistics.map(Statistics::from);
 
         let compressed_page = match self.props.writer_version() {
             WriterVersion::PARQUET_1_0 => {
@@ -2942,6 +2938,158 @@ mod tests {
         assert!(incremented.is_none())
     }
 
+    #[test]
+    fn test_boundary_order() -> Result<()> {
+        let descr = Arc::new(get_test_column_descr::<Int32Type>(1, 0));
+        // min max both ascending
+        let column_close_result = write_multiple_pages::<Int32Type>(
+            &descr,
+            &[
+                &[Some(-10), Some(10)],
+                &[Some(-5), Some(11)],
+                &[None],
+                &[Some(-5), Some(11)],
+            ],
+        )?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+
+        // min max both descending
+        let column_close_result = write_multiple_pages::<Int32Type>(
+            &descr,
+            &[
+                &[Some(10), Some(11)],
+                &[Some(5), Some(11)],
+                &[None],
+                &[Some(-5), Some(0)],
+            ],
+        )?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::DESCENDING);
+
+        // min max both equal
+        let column_close_result = write_multiple_pages::<Int32Type>(
+            &descr,
+            &[&[Some(10), Some(11)], &[None], &[Some(10), Some(11)]],
+        )?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+
+        // only nulls
+        let column_close_result =
+            write_multiple_pages::<Int32Type>(&descr, &[&[None], &[None], &[None]])?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+
+        // one page
+        let column_close_result =
+            write_multiple_pages::<Int32Type>(&descr, &[&[Some(-10), Some(10)]])?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+
+        // one non-null page
+        let column_close_result =
+            write_multiple_pages::<Int32Type>(&descr, &[&[Some(-10), Some(10)], &[None]])?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+
+        // min max both unordered
+        let column_close_result = write_multiple_pages::<Int32Type>(
+            &descr,
+            &[
+                &[Some(10), Some(11)],
+                &[Some(11), Some(16)],
+                &[None],
+                &[Some(-5), Some(0)],
+            ],
+        )?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+
+        // min max both ordered in different orders
+        let column_close_result = write_multiple_pages::<Int32Type>(
+            &descr,
+            &[
+                &[Some(1), Some(9)],
+                &[Some(2), Some(8)],
+                &[None],
+                &[Some(3), Some(7)],
+            ],
+        )?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_boundary_order_logical_type() -> Result<()> {
+        // ensure that logical types account for different sort order than underlying
+        // physical type representation
+        let f16_descr = Arc::new(get_test_float16_column_descr(1, 0));
+        let fba_descr = {
+            let tpe = SchemaType::primitive_type_builder(
+                "col",
+                FixedLenByteArrayType::get_physical_type(),
+            )
+            .with_length(2)
+            .build()?;
+            Arc::new(ColumnDescriptor::new(
+                Arc::new(tpe),
+                1,
+                0,
+                ColumnPath::from("col"),
+            ))
+        };
+
+        let values: &[&[Option<FixedLenByteArray>]] = &[
+            &[Some(FixedLenByteArray::from(ByteArray::from(f16::ONE)))],
+            &[Some(FixedLenByteArray::from(ByteArray::from(f16::ZERO)))],
+            &[Some(FixedLenByteArray::from(ByteArray::from(
+                f16::NEG_ZERO,
+            )))],
+            &[Some(FixedLenByteArray::from(ByteArray::from(f16::NEG_ONE)))],
+        ];
+
+        // f16 descending
+        let column_close_result =
+            write_multiple_pages::<FixedLenByteArrayType>(&f16_descr, values)?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::DESCENDING);
+
+        // same bytes, but fba unordered
+        let column_close_result =
+            write_multiple_pages::<FixedLenByteArrayType>(&fba_descr, values)?;
+        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
+        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+
+        Ok(())
+    }
+
+    fn write_multiple_pages<T: DataType>(
+        column_descr: &Arc<ColumnDescriptor>,
+        pages: &[&[Option<T::T>]],
+    ) -> Result<ColumnCloseResult> {
+        let column_writer = get_column_writer(
+            column_descr.clone(),
+            Default::default(),
+            get_test_page_writer(),
+        );
+        let mut writer = get_typed_column_writer::<T>(column_writer);
+
+        for &page in pages {
+            let values = page.iter().filter_map(Clone::clone).collect::<Vec<_>>();
+            let def_levels = page
+                .iter()
+                .map(|maybe_value| if maybe_value.is_some() { 1 } else { 0 })
+                .collect::<Vec<_>>();
+            writer.write_batch(&values, Some(&def_levels), None)?;
+            writer.flush_data_pages()?;
+        }
+
+        writer.close()
+    }
+
     /// Performs write-read roundtrip with randomly generated values and levels.
     /// `max_size` is maximum number of values or levels (if `max_def_level` > 0) to write
     /// for a column.
@@ -3248,8 +3396,7 @@ mod tests {
     ) -> ValueStatistics<FixedLenByteArray> {
         let page_writer = get_test_page_writer();
         let props = Default::default();
-        let mut writer =
-            get_test_float16_column_writer::<FixedLenByteArrayType>(page_writer, 0, 0, props);
+        let mut writer = get_test_float16_column_writer(page_writer, 0, 0, props);
         writer.write_batch(values, None, None).unwrap();
 
         let metadata = writer.close().unwrap().metadata;
@@ -3260,30 +3407,25 @@ mod tests {
         }
     }
 
-    fn get_test_float16_column_writer<T: DataType>(
+    fn get_test_float16_column_writer(
         page_writer: Box<dyn PageWriter>,
         max_def_level: i16,
         max_rep_level: i16,
         props: WriterPropertiesPtr,
-    ) -> ColumnWriterImpl<'static, T> {
-        let descr = Arc::new(get_test_float16_column_descr::<T>(
-            max_def_level,
-            max_rep_level,
-        ));
+    ) -> ColumnWriterImpl<'static, FixedLenByteArrayType> {
+        let descr = Arc::new(get_test_float16_column_descr(max_def_level, max_rep_level));
         let column_writer = get_column_writer(descr, props, page_writer);
-        get_typed_column_writer::<T>(column_writer)
+        get_typed_column_writer::<FixedLenByteArrayType>(column_writer)
     }
 
-    fn get_test_float16_column_descr<T: DataType>(
-        max_def_level: i16,
-        max_rep_level: i16,
-    ) -> ColumnDescriptor {
+    fn get_test_float16_column_descr(max_def_level: i16, max_rep_level: i16) -> ColumnDescriptor {
         let path = ColumnPath::from("col");
-        let tpe = SchemaType::primitive_type_builder("col", T::get_physical_type())
-            .with_length(2)
-            .with_logical_type(Some(LogicalType::Float16))
-            .build()
-            .unwrap();
+        let tpe =
+            SchemaType::primitive_type_builder("col", FixedLenByteArrayType::get_physical_type())
+                .with_length(2)
+                .with_logical_type(Some(LogicalType::Float16))
+                .build()
+                .unwrap();
         ColumnDescriptor::new(Arc::new(tpe), max_def_level, max_rep_level, path)
     }
 

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -931,6 +931,9 @@ impl ColumnIndexBuilder {
         self.min_values.push(min_value);
         self.max_values.push(max_value);
         self.null_counts.push(null_count);
+        // backwards compatibility: default to UNORDERED
+        self.boundary_ascending = false;
+        self.boundary_descending = false;
     }
 
     pub fn append_with_boundary_check<T: ParquetValueType>(

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -36,8 +36,6 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use crate::column::writer::compare_greater;
-use crate::data_type::private::ParquetValueType;
 use crate::format::{
     BoundaryOrder, ColumnChunk, ColumnIndex, ColumnMetaData, OffsetIndex, PageLocation, RowGroup,
     SortingColumn,
@@ -888,15 +886,9 @@ pub struct ColumnIndexBuilder {
     min_values: Vec<Vec<u8>>,
     max_values: Vec<Vec<u8>>,
     null_counts: Vec<i64>,
+    boundary_order: BoundaryOrder,
     // If one page can't get build index, need to ignore all index in this column
     valid: bool,
-    // Below fields used to incrementally check boundary order
-    // We assume they are ascending/descending until proven wrong
-    boundary_ascending: bool,
-    boundary_descending: bool,
-    // This indexes into min_values/max_values (None when empty)
-    // Easier way of keeping track of latest non-null min/max
-    latest_values_index: Option<usize>,
 }
 
 impl Default for ColumnIndexBuilder {
@@ -912,14 +904,11 @@ impl ColumnIndexBuilder {
             min_values: Vec::new(),
             max_values: Vec::new(),
             null_counts: Vec::new(),
+            boundary_order: BoundaryOrder::UNORDERED,
             valid: true,
-            boundary_ascending: true,
-            boundary_descending: true,
-            latest_values_index: None,
         }
     }
 
-    #[deprecated(note = "Use append_with_boundary_check")]
     pub fn append(
         &mut self,
         null_page: bool,
@@ -931,55 +920,10 @@ impl ColumnIndexBuilder {
         self.min_values.push(min_value);
         self.max_values.push(max_value);
         self.null_counts.push(null_count);
-        // backwards compatibility: default to UNORDERED
-        self.boundary_ascending = false;
-        self.boundary_descending = false;
     }
 
-    pub fn append_with_boundary_check<T: ParquetValueType>(
-        &mut self,
-        descr: &ColumnDescriptor,
-        null_page: bool,
-        min_value: Vec<u8>,
-        max_value: Vec<u8>,
-        null_count: i64,
-    ) -> Result<()> {
-        // Check if min/max are still ascending/descending
-        // Null pages aren't considered in this sort order
-        if !null_page {
-            if let Some(index) = self.latest_values_index {
-                // Convert into types for accurate comparison according to their sort orders
-                let latest_min = T::try_from_le_slice(&self.min_values[index])?;
-                let latest_max = T::try_from_le_slice(&self.max_values[index])?;
-                let min_value = T::try_from_le_slice(&min_value)?;
-                let max_value = T::try_from_le_slice(&max_value)?;
-
-                if self.boundary_ascending {
-                    // If latest min/max are greater than new min/max then not ascending anymore
-                    let not_ascending = compare_greater(descr, &latest_min, &min_value)
-                        || compare_greater(descr, &latest_max, &max_value);
-                    if not_ascending {
-                        self.boundary_ascending = false;
-                    }
-                }
-
-                if self.boundary_descending {
-                    // If new min/max are greater than latest min/max then not descending anymore
-                    let not_descending = compare_greater(descr, &min_value, &latest_min)
-                        || compare_greater(descr, &max_value, &latest_max);
-                    if not_descending {
-                        self.boundary_descending = false;
-                    }
-                }
-            }
-            // No need to -1 for last index as haven't yet pushed to min/max_values here
-            self.latest_values_index = Some(self.min_values.len());
-        }
-        self.null_pages.push(null_page);
-        self.min_values.push(min_value);
-        self.max_values.push(max_value);
-        self.null_counts.push(null_count);
-        Ok(())
+    pub fn set_boundary_order(&mut self, boundary_order: BoundaryOrder) {
+        self.boundary_order = boundary_order;
     }
 
     pub fn to_invalid(&mut self) {
@@ -992,19 +936,11 @@ impl ColumnIndexBuilder {
 
     /// Build and get the thrift metadata of column index
     pub fn build_to_thrift(self) -> ColumnIndex {
-        let boundary_order = match (self.boundary_ascending, self.boundary_descending) {
-            // If the lists are composed of equal elements then will be marked as ascending
-            // (Also the case if all pages are null pages)
-            (true, true) => BoundaryOrder::ASCENDING,
-            (true, false) => BoundaryOrder::ASCENDING,
-            (false, true) => BoundaryOrder::DESCENDING,
-            (false, false) => BoundaryOrder::UNORDERED,
-        };
         ColumnIndex::new(
             self.null_pages,
             self.min_values,
             self.max_values,
-            boundary_order,
+            self.boundary_order,
             self.null_counts,
         )
     }
@@ -1060,13 +996,8 @@ impl OffsetIndexBuilder {
 
 #[cfg(test)]
 mod tests {
-    use half::f16;
-
     use super::*;
-    use crate::{
-        basic::{Encoding, LogicalType, PageType},
-        data_type::{ByteArray, DataType, FixedLenByteArray, FixedLenByteArrayType, Int32Type},
-    };
+    use crate::basic::{Encoding, PageType};
 
     #[test]
     fn test_row_group_metadata_thrift_conversion() {
@@ -1209,146 +1140,5 @@ mod tests {
             .unwrap();
 
         Arc::new(SchemaDescriptor::new(Arc::new(schema)))
-    }
-
-    // each entry in min/max values represents the min/max for a data page
-    // append N data pages (N = len of min/max slice) to builder and return built index
-    // (None represents null page)
-    fn create_column_index_with_values<T: ParquetValueType>(
-        descr: &ColumnDescriptor,
-        min_values: &[Option<T>],
-        max_values: &[Option<T>],
-    ) -> ColumnIndex {
-        assert_eq!(
-            min_values.len(),
-            max_values.len(),
-            "min and max values must be equal length"
-        );
-        let mut cib = ColumnIndexBuilder::new();
-        for (min, max) in min_values.iter().zip(max_values.iter()) {
-            match (min, max) {
-                (Some(min), Some(max)) => {
-                    cib.append_with_boundary_check::<T>(
-                        descr,
-                        false,
-                        min.as_bytes().to_vec(),
-                        max.as_bytes().to_vec(),
-                        0,
-                    )
-                    .unwrap();
-                }
-                _ => {
-                    cib.append_with_boundary_check::<T>(descr, true, vec![0], vec![0], 0)
-                        .unwrap();
-                }
-            }
-        }
-        cib.build_to_thrift()
-    }
-
-    #[test]
-    fn test_column_index_builder_boundary_order() -> Result<()> {
-        let descr = {
-            let tpe = SchemaType::primitive_type_builder("col", Int32Type::get_physical_type())
-                .build()?;
-            ColumnDescriptor::new(Arc::new(tpe), 1, 1, ColumnPath::from("col"))
-        };
-
-        // both ascending
-        let ci = create_column_index_with_values(
-            &descr,
-            &[Some(-10), Some(-5), None, Some(-5)],
-            &[Some(10), Some(11), None, Some(11)],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::ASCENDING);
-
-        // both descending
-        let ci = create_column_index_with_values(
-            &descr,
-            &[Some(10), Some(5), None, Some(-5)],
-            &[Some(11), Some(11), None, Some(0)],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::DESCENDING);
-
-        // both equal
-        let ci = create_column_index_with_values(
-            &descr,
-            &[Some(10), None, Some(10)],
-            &[Some(11), None, Some(11)],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::ASCENDING);
-
-        // only nulls
-        let ci = create_column_index_with_values::<i32>(
-            &descr,
-            &[None, None, None],
-            &[None, None, None],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::ASCENDING);
-
-        // one page
-        let ci = create_column_index_with_values(&descr, &[Some(-10)], &[Some(10)]);
-        assert_eq!(ci.boundary_order, BoundaryOrder::ASCENDING);
-
-        // one non-null page
-        let ci = create_column_index_with_values(&descr, &[Some(-10), None], &[Some(10), None]);
-        assert_eq!(ci.boundary_order, BoundaryOrder::ASCENDING);
-
-        // both unordered
-        let ci = create_column_index_with_values(
-            &descr,
-            &[Some(10), Some(11), None, Some(-5)],
-            &[Some(11), Some(16), None, Some(0)],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::UNORDERED);
-
-        // ordered in different orders
-        let ci = create_column_index_with_values(
-            &descr,
-            &[Some(1), Some(2), None, Some(3)],
-            &[Some(9), Some(8), None, Some(7)],
-        );
-        assert_eq!(ci.boundary_order, BoundaryOrder::UNORDERED);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_column_index_builder_boundary_order_logical_type() -> Result<()> {
-        // ensure that logical types account for different sort order than underlying
-        // physical type representation
-        let f16_descr = {
-            let tpe = SchemaType::primitive_type_builder(
-                "col",
-                FixedLenByteArrayType::get_physical_type(),
-            )
-            .with_length(2)
-            .with_logical_type(Some(LogicalType::Float16))
-            .build()?;
-            ColumnDescriptor::new(Arc::new(tpe), 1, 1, ColumnPath::from("col"))
-        };
-        let fba_descr = {
-            let tpe = SchemaType::primitive_type_builder(
-                "col",
-                FixedLenByteArrayType::get_physical_type(),
-            )
-            .with_length(2)
-            .build()?;
-            ColumnDescriptor::new(Arc::new(tpe), 1, 1, ColumnPath::from("col"))
-        };
-
-        // f16 descending
-        let values = [f16::ONE, f16::ZERO, f16::NEG_ZERO, f16::NEG_ONE]
-            .into_iter()
-            .map(|s| Some(ByteArray::from(s).into()))
-            .collect::<Vec<Option<FixedLenByteArray>>>();
-        let ci = create_column_index_with_values(&f16_descr, &values, &values);
-        assert_eq!(ci.boundary_order, BoundaryOrder::DESCENDING);
-
-        // same bytes, but fba unordered
-        let ci = create_column_index_with_values(&fba_descr, &values, &values);
-        assert_eq!(ci.boundary_order, BoundaryOrder::UNORDERED);
-
-        Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5074

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change ColumnIndexBuilder to add new append method which incrementally keeps track of sort state of min/max values of data pages to eventually derive the boundary_order thrift field

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
