### PR TITLE
JSON: write struct array nulls as null

### DIFF
--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1542,7 +1542,7 @@ mod tests {
             Some(vec![]),
             Some(vec![Some(3), None]), // masked for a
             Some(vec![Some(4), Some(5)]),
-            None, // masked for b
+            None, // masked for a
             None,
         ]);
 

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -136,11 +136,7 @@ fn struct_array_to_jsonmap_array(
         // Ensure we write nulls for struct arrays as nulls in JSON
         // Instead of writing a struct with nulls
         .map(|index| {
-            if array.is_null(index) {
-                None
-            } else {
-                Some(JsonMap::new())
-            }
+            array.is_valid(index).then(JsonMap::new)
         })
         .collect::<Vec<Option<JsonMap<String, Value>>>>();
 

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -133,7 +133,7 @@ fn struct_array_to_jsonmap_array(
     let inner_col_names = array.column_names();
 
     let mut inner_objs = (0..array.len())
-        // Ensure we write nulls for structarrays as nulls in JSON
+        // Ensure we write nulls for struct arrays as nulls in JSON
         // Instead of writing a struct with nulls
         .map(|index| {
             if array.is_null(index) {
@@ -1535,7 +1535,7 @@ mod tests {
     }
 
     #[test]
-    fn json_struct_array_logical_nulls() {
+    fn json_struct_array_nulls() {
         let inner = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
             Some(vec![Some(1), Some(2)]),
             Some(vec![None]),

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -135,9 +135,7 @@ fn struct_array_to_jsonmap_array(
     let mut inner_objs = (0..array.len())
         // Ensure we write nulls for struct arrays as nulls in JSON
         // Instead of writing a struct with nulls
-        .map(|index| {
-            array.is_valid(index).then(JsonMap::new)
-        })
+        .map(|index| array.is_valid(index).then(JsonMap::new))
         .collect::<Vec<Option<JsonMap<String, Value>>>>();
 
     for (j, struct_col) in array.columns().iter().enumerate() {
@@ -233,13 +231,7 @@ fn array_to_json_array_internal(
             let jsonmaps = struct_array_to_jsonmap_array(array.as_struct(), explicit_nulls)?;
             let json_values = jsonmaps
                 .into_iter()
-                .map(|maybe_map| {
-                    if let Some(map) = maybe_map {
-                        Value::Object(map)
-                    } else {
-                        Value::Null
-                    }
-                })
+                .map(|maybe_map| maybe_map.map(Value::Object).unwrap_or(Value::Null))
                 .collect();
             Ok(json_values)
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5066

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Nulls in struct arrays are written as `null` in JSON, where previously was written as `{}` (or filled with nulls for the keys if explicit nulls are written)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
