### PR TITLE
Deprecate Fields::remove and Schema::remove

### DIFF
--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -117,6 +117,8 @@ impl Fields {
     /// assert_eq!(fields.remove(1), Field::new("b", DataType::Int8, false).into());
     /// assert_eq!(fields.len(), 2);
     /// ```
+    #[deprecated(note = "Use SchemaBuilder::remove")]
+    #[doc(hidden)]
     pub fn remove(&mut self, index: usize) -> FieldRef {
         let mut builder = SchemaBuilder::from(Fields::from(&*self.0));
         let field = builder.remove(index);

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -402,6 +402,9 @@ impl Schema {
     /// assert_eq!(schema.remove(1), Field::new("b", DataType::Int8, false).into());
     /// assert_eq!(schema.fields.len(), 2);
     /// ```
+    #[deprecated(note = "Use SchemaBuilder::remove")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn remove(&mut self, index: usize) -> FieldRef {
         self.fields.remove(index)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

These were added in #4959 but in hindsight we should just direct users to SchemaBuilder. This keeps the API of Schema and Fields consistently immutable.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
