### PR TITLE
Removing ahash

### DIFF
--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -38,12 +38,6 @@ name = "arrow"
 path = "src/lib.rs"
 bench = false
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
-
 [dependencies]
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
Ahash is not being used anywhere in crate arrow. Hence I am removing it.

# What changes are included in this PR?

Remove ahash as a dependency from arrow crate

# Are there any user-facing changes?

No
