### PR TITLE
Easy way to zero-copy IPC buffers. 

### DIFF
--- a/arrow-ipc/Cargo.toml
+++ b/arrow-ipc/Cargo.toml
@@ -42,12 +42,10 @@ arrow-schema = { workspace = true }
 flatbuffers = { version = "23.1.21", default-features = false }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13.0", default-features = false, optional = true }
-memmap2 = { version = "0.9.0", optional = true }
 
 [features]
-default = ["memmap"]
+default = []
 lz4 = ["lz4_flex"]
-memmap = ["dep:memmap2"]
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/arrow-ipc/Cargo.toml
+++ b/arrow-ipc/Cargo.toml
@@ -45,9 +45,9 @@ zstd = { version = "0.13.0", default-features = false, optional = true }
 memmap2 = { version = "0.9.0", optional = true }
 
 [features]
-default = []
+default = ["memmap"]
 lz4 = ["lz4_flex"]
-memmap = ["memmap2"]
+memmap = ["dep:memmap2"]
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/arrow-ipc/Cargo.toml
+++ b/arrow-ipc/Cargo.toml
@@ -42,10 +42,12 @@ arrow-schema = { workspace = true }
 flatbuffers = { version = "23.1.21", default-features = false }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13.0", default-features = false, optional = true }
+memmap2 = { version = "0.9.0", optional = true }
 
 [features]
 default = []
 lz4 = ["lz4_flex"]
+memmap = ["memmap2"]
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1030,7 +1030,6 @@ impl<R: Read> RecordBatchReader for StreamReader<R> {
 }
 
 /// Arrow Memmap reader. It does not copy the underlying buffers.
-#[cfg(feature = "memmap")]
 pub struct BufferReader<A> {
     /// The memmap we're reading from
     buffer: Arc<A>,
@@ -1064,7 +1063,6 @@ pub struct BufferReader<A> {
     projection: Option<(Vec<usize>, Schema)>,
 }
 
-#[cfg(feature = "memmap")]
 impl<A> fmt::Debug for BufferReader<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         f.debug_struct("FileReader<R>")
@@ -1080,7 +1078,6 @@ impl<A> fmt::Debug for BufferReader<A> {
     }
 }
 
-#[cfg(feature = "memmap")]
 impl<A: Deref<Target = [u8]> + Allocation + 'static> BufferReader<A> {
     /// Try to create a new file reader
     ///
@@ -1171,7 +1168,7 @@ impl<A: Deref<Target = [u8]> + Allocation + 'static> BufferReader<A> {
                         // Safety: The memmap is allocated and held. We've just checked that it's of the correct lenght.
                         let buf = unsafe {
                             Buffer::from_custom_allocation(
-                                buf_slice.get(0).expect("Length is non-zero").into(),
+                                buf_slice.first().expect("Length is non-zero").into(),
                                 len,
                                 buffer.clone(),
                             )
@@ -1292,7 +1289,7 @@ impl<A: Deref<Target = [u8]> + Allocation + 'static> BufferReader<A> {
                 // Safety: The memmap is allocated and held. We've just checked that it's of the correct lenght.
                 let buf = unsafe {
                     Buffer::from_custom_allocation(
-                        buf_slice.get(0).expect("Length is non-zero").into(),
+                        buf_slice.first().expect("Length is non-zero").into(),
                         len,
                         self.buffer.clone(),
                     )
@@ -1333,7 +1330,6 @@ impl<A: Deref<Target = [u8]> + Allocation + 'static> BufferReader<A> {
     }
 }
 
-#[cfg(feature = "memmap")]
 impl<A: Deref<Target = [u8]> + Allocation + 'static> Iterator for BufferReader<A> {
     type Item = Result<RecordBatch, ArrowError>;
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1540,6 +1540,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "memmap")]
     fn test_projection_array_values_memmap() {
         // define schema
         let schema = create_test_projection_schema();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5153

# Rationale for this change
 
There are ways to memmap buffers, if you know the header information, but no easy way to use the existing IPC file format in a zero-copy way. 

# What changes are included in this PR?

Reused the IPC reader code to read the header and footer information from an IPC file, but swapped out the read/copy of the buffer for the Buffer creation with `Buffer::from_custom_allocation`. Minor savings can be had by not allocating the arbitrary-sized footer and message read, but the easy way to do this requires a nightly API in the Cursor object. 

This duplicated some code, but it's messy to deduplicate because most of it is boilerplate around reading the flatbuffer messages. The better way to deduplicate is to change the `FileReader` to optionally accept a buffer and conditionally use that in the 2 locations where buffers are actually read. Perfectly happy to do it this way as well.

# Are there any user-facing changes?

There's a new struct that mirrors the current IPC reader struct that passes back zero-copy buffers. 


