### PR TITLE
fix: ensure take_fixed_size_list can handle null indices

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -704,7 +704,7 @@ where
                 values.append_trusted_len_iter(start..start + length);
             }
         } else {
-            values.append_nulls(length);
+            values.append_nulls(length as usize);
         }
     }
 

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::builder::BufferBuilder;
+use arrow_array::builder::{BufferBuilder, UInt32Builder};
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
@@ -689,7 +689,7 @@ fn take_value_indices_from_fixed_size_list<IndexType>(
 where
     IndexType: ArrowPrimitiveType,
 {
-    let mut values = Vec::with_capacity(length as usize * indices.len());
+    let mut values = UInt32Builder::with_capacity(length as usize * indices.len());
 
     for i in 0..indices.len() {
         if indices.is_valid(i) {
@@ -705,7 +705,7 @@ where
         }
     }
 
-    Ok(PrimitiveArray::<UInt32Type>::from(values))
+    Ok(values.finish())
 }
 
 /// To avoid generating take implementations for every index type, instead we

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1989,7 +1989,7 @@ mod tests {
 
     #[test]
     fn test_take_fixed_size_list_null_indices() {
-        let indices = Int32Array::new(vec![0, 1].into(), Some(NullBuffer::from(vec![true, false])));
+        let indices = Int32Array::from_iter([Some(1), None]);
         let values = Arc::new(Int32Array::from(vec![0, 1, 2, 3]));
         let arr_field = Arc::new(Field::new("item", values.data_type().clone(), true));
         let values = FixedSizeListArray::try_new(arr_field, 2, values, None).unwrap();
@@ -1999,9 +1999,8 @@ mod tests {
             .as_fixed_size_list()
             .values()
             .as_primitive::<Int32Type>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        assert_eq!(&values, &[Some(0), Some(1), None, None])
+            .values();
+        assert_eq!(values, &[Some(0), Some(1), None, None])
     }
 
     #[test]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -699,9 +699,12 @@ where
                 .ok_or_else(|| ArrowError::ComputeError("Cast to usize failed".to_string()))?;
             let start = list.value_offset(index) as <UInt32Type as ArrowPrimitiveType>::Native;
 
-            values.extend((start..start + length).map(Some));
+            // Safety: Range always has known length.
+            unsafe {
+                values.append_trusted_len_iter(start..start + length);
+            }
         } else {
-            values.extend((0..length).map(|_| None));
+            values.append_nulls(length);
         }
     }
 

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -689,7 +689,7 @@ fn take_value_indices_from_fixed_size_list<IndexType>(
 where
     IndexType: ArrowPrimitiveType,
 {
-    let mut values = vec![];
+    let mut values = Vec::with_capacity(length as usize * indices.len());
 
     for i in 0..indices.len() {
         if indices.is_valid(i) {
@@ -1989,7 +1989,7 @@ mod tests {
 
     #[test]
     fn test_take_fixed_size_list_null_indices() {
-        let indices = Int32Array::from_iter([Some(1), None]);
+        let indices = Int32Array::from_iter([Some(0), None]);
         let values = Arc::new(Int32Array::from(vec![0, 1, 2, 3]));
         let arr_field = Arc::new(Field::new("item", values.data_type().clone(), true));
         let values = FixedSizeListArray::try_new(arr_field, 2, values, None).unwrap();
@@ -1999,7 +1999,8 @@ mod tests {
             .as_fixed_size_list()
             .values()
             .as_primitive::<Int32Type>()
-            .values();
+            .into_iter()
+            .collect::<Vec<_>>();
         assert_eq!(values, &[Some(0), Some(1), None, None])
     }
 

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -699,7 +699,7 @@ where
                 .ok_or_else(|| ArrowError::ComputeError("Cast to usize failed".to_string()))?;
             let start = list.value_offset(index) as <UInt32Type as ArrowPrimitiveType>::Native;
 
-            values.extend((start..start + length).map(|idx| Some(idx)));
+            values.extend((start..start + length).map(Some));
         } else {
             values.extend((0..length).map(|_| None));
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5169 

# Rationale for this change
 
See issue

# What changes are included in this PR?

The take implementation for fixed size list currently works by expanding the indices from "list indices" into "child indices".  In other words, if the list is a fixed size list of 3 and the indices are `[0, 5]` then it converts this into `[0, 1, 2, 15, 16, 17]`.  This process was ignoring null indices and the result was that the child array would be too short.  For example, `[0, null]` would turn into `[0, 1, 2]` which is too short.  This PR propagates the null into the child index list.  So now `[0, null]` turns into `[0, 1, 2, null, null, null]`.

# Are there any user-facing changes?

None