### PR TITLE
fix: Changed labeler.yml to latest format

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -16,33 +16,21 @@
 # under the License.
 
 arrow:
-  - arrow-arith/**/*
-  - arrow-array/**/*
-  - arrow-buffer/**/*
-  - arrow-cast/**/*
-  - arrow-csv/**/*
-  - arrow-data/**/*
-  - arrow-flight/**/*
-  - arrow-integration-test/**/*
-  - arrow-integration-testing/**/*
-  - arrow-ipc/**/*
-  - arrow-json/**/*
-  - arrow-avro/**/*
-  - arrow-ord/**/*
-  - arrow-row/**/*
-  - arrow-schema/**/*
-  - arrow-select/**/*
-  - arrow-string/**/*
-  - arrow/**/*
+- changed-files:
+  - any-glob-to-any-file: ['arrow-arith/**/*', 'arrow-array/**/*', 'arrow-buffer/**/*', 'arrow-cast/**/*', 'arrow-csv/**/*', 'arrow-data/**/*', 'arrow-flight/**/*', 'arrow-integration-test/**/*', 'arrow-integration-testing/**/*', 'arrow-ipc/**/*', 'arrow-json/**/*', 'arrow-avro/**/*', 'arrow-ord/**/*', 'arrow-row/**/*', 'arrow-schema/**/*', 'arrow-select/**/*', 'arrow-string/**/*', 'arrow/**/*']
 
 arrow-flight:
-  - arrow-flight/**/*
+- changed-files:
+  - any-glob-to-any-file: ['arrow-flight/**/*']
 
 parquet:
-  - parquet/**/*
+- changed-files:
+  - any-glob-to-any-file: ['parquet/**/*']
 
 parquet-derive:
-  - parquet_derive/**/*
+- changed-files:
+  - any-glob-to-any-file: ['parquet_derive/**/*']
 
 object-store:
-  - object_store/**/*
+- changed-files:
+  - any-glob-to-any-file: ['object_store/**/*']


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->


Labeler is broken now, e.g., https://github.com/apache/arrow-rs/actions/runs/7107268511/job/19348449969?pr=5171.

```
Run actions/labeler@v5.0.0
The configuration file (path: .github/workflows/dev_pr/labeler.yml) was found locally, reading from the file
Error: Error: found unexpected type for label 'arrow' (should be array of config options)
Error: found unexpected type for label 'arrow' (should be array of config options)
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Tries to restore labeler CI by following latest format.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
