### PR TITLE
Parquet: Ensure page statistics are written only when conifgured from the Arrow Writer

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2745,7 +2745,6 @@ mod tests {
         let file_schema = Schema::new(vec![
             Field::new("a", DataType::Utf8, true),
             Field::new("b", DataType::Utf8, true),
-            Field::new("c", DataType::UInt32, true),
         ]);
         let file_schema = Arc::new(file_schema);
 
@@ -2754,7 +2753,6 @@ mod tests {
             vec![
                 Arc::new(StringArray::from(vec!["a", "b", "c", "d"])) as _,
                 Arc::new(StringArray::from(vec!["w", "x", "y", "z"])) as _,
-                Arc::new(UInt32Array::from(vec![1, 2, 3, 4])) as _,
             ],
         )
         .unwrap();
@@ -2771,34 +2769,47 @@ mod tests {
         let metadata = writer.close().unwrap();
         assert_eq!(metadata.row_groups.len(), 1);
         let row_group = &metadata.row_groups[0];
-        assert_eq!(row_group.columns.len(), 3);
+        assert_eq!(row_group.columns.len(), 2);
         // Column "a" has both offset and column index, as requested
         assert!(row_group.columns[0].offset_index_offset.is_some());
         assert!(row_group.columns[0].column_index_offset.is_some());
         // Column "b" should only have offset index
         assert!(row_group.columns[1].offset_index_offset.is_some());
         assert!(row_group.columns[1].column_index_offset.is_none());
-        // Column "c" should only have offset index
-        assert!(row_group.columns[1].offset_index_offset.is_some());
-        assert!(row_group.columns[1].column_index_offset.is_none());
 
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(Bytes::from(buf), options).unwrap();
 
+        let row_group = reader.get_row_group(0).unwrap();
+        let a_col = row_group.metadata().column(0);
+        let b_col = row_group.metadata().column(1);
+
+        // Column chunk of column "a" should have chunk level statistics
+        if let Statistics::ByteArray(byte_array_stats) = a_col.statistics().unwrap() {
+            let min = byte_array_stats.min();
+            let max = byte_array_stats.max();
+
+            assert_eq!(min.as_bytes(), &[b'a']);
+            assert_eq!(max.as_bytes(), &[b'd']);
+        } else {
+            panic!("expecting Statistics::ByteArray");
+        }
+
+        // The column chunk for column "b" shouldn't have statistics
+        assert!(b_col.statistics().is_none());
+
         let offset_index = reader.metadata().offset_index().unwrap();
         assert_eq!(offset_index.len(), 1); // 1 row group
-        assert_eq!(offset_index[0].len(), 3); // 2 columns
+        assert_eq!(offset_index[0].len(), 2); // 2 columns
 
         let column_index = reader.metadata().column_index().unwrap();
         assert_eq!(column_index.len(), 1); // 1 row group
-        assert_eq!(column_index[0].len(), 3); // 23column
+        assert_eq!(column_index[0].len(), 2); // 2 columns
 
         let a_idx = &column_index[0][0];
         assert!(matches!(a_idx, Index::BYTE_ARRAY(_)), "{a_idx:?}");
         let b_idx = &column_index[0][1];
         assert!(matches!(b_idx, Index::NONE), "{b_idx:?}");
-        let c_idx = &column_index[0][2];
-        assert!(matches!(c_idx, Index::NONE), "{c_idx:?}");
     }
 
     #[test]
@@ -2806,7 +2817,6 @@ mod tests {
         let file_schema = Schema::new(vec![
             Field::new("a", DataType::Utf8, true),
             Field::new("b", DataType::Utf8, true),
-            Field::new("c", DataType::UInt32, true),
         ]);
         let file_schema = Arc::new(file_schema);
 
@@ -2815,7 +2825,6 @@ mod tests {
             vec![
                 Arc::new(StringArray::from(vec!["a", "b", "c", "d"])) as _,
                 Arc::new(StringArray::from(vec!["w", "x", "y", "z"])) as _,
-                Arc::new(UInt32Array::from(vec![1, 2, 3, 4])) as _,
             ],
         )
         .unwrap();
@@ -2832,30 +2841,22 @@ mod tests {
         let metadata = writer.close().unwrap();
         assert_eq!(metadata.row_groups.len(), 1);
         let row_group = &metadata.row_groups[0];
-        assert_eq!(row_group.columns.len(), 3);
+        assert_eq!(row_group.columns.len(), 2);
         // Column "a" should only have offset index
         assert!(row_group.columns[0].offset_index_offset.is_some());
         assert!(row_group.columns[0].column_index_offset.is_none());
         // Column "b" should only have offset index
         assert!(row_group.columns[1].offset_index_offset.is_some());
         assert!(row_group.columns[1].column_index_offset.is_none());
-        // Column "c" should only have offset index
-        assert!(row_group.columns[1].offset_index_offset.is_some());
-        assert!(row_group.columns[1].column_index_offset.is_none());
 
-        let options = ReadOptionsBuilder::new().build();
+        let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(Bytes::from(buf), options).unwrap();
 
         let row_group = reader.get_row_group(0).unwrap();
-
         let a_col = row_group.metadata().column(0);
         let b_col = row_group.metadata().column(1);
-        let c_col = row_group.metadata().column(2);
 
-        assert!(a_col.statistics().is_some());
-        assert!(b_col.statistics().is_none());
-        assert!(c_col.statistics().is_none());
-
+        // Column chunk of column "a" should have chunk level statistics
         if let Statistics::ByteArray(byte_array_stats) = a_col.statistics().unwrap() {
             let min = byte_array_stats.min();
             let max = byte_array_stats.max();
@@ -2865,5 +2866,17 @@ mod tests {
         } else {
             panic!("expecting Statistics::ByteArray");
         }
+
+        // The column chunk for column "b"  shouldn't have statistics
+        assert!(b_col.statistics().is_none());
+
+        let column_index = reader.metadata().column_index().unwrap();
+        assert_eq!(column_index.len(), 1); // 1 row group
+        assert_eq!(column_index[0].len(), 2); // 2 columns
+
+        let a_idx = &column_index[0][0];
+        assert!(matches!(a_idx, Index::NONE), "{a_idx:?}");
+        let b_idx = &column_index[0][1];
+        assert!(matches!(b_idx, Index::NONE), "{b_idx:?}");
     }
 }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -916,8 +916,9 @@ mod tests {
     use crate::basic::Encoding;
     use crate::data_type::AsBytes;
     use crate::file::metadata::ParquetMetaData;
+    use crate::file::page_index::index::Index;
     use crate::file::page_index::index_reader::read_pages_locations;
-    use crate::file::properties::{ReaderProperties, WriterVersion};
+    use crate::file::properties::{EnabledStatistics, ReaderProperties, WriterVersion};
     use crate::file::serialized_reader::ReadOptionsBuilder;
     use crate::file::{
         reader::{FileReader, SerializedFileReader},
@@ -2737,5 +2738,132 @@ mod tests {
         assert_eq!(index[0].len(), 2); // 2 columns
         assert_eq!(index[0][0].len(), 1); // 1 page
         assert_eq!(index[0][1].len(), 1); // 1 page
+    }
+
+    #[test]
+    fn test_disabled_statistics_with_page() {
+        let file_schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::UInt32, true),
+        ]);
+        let file_schema = Arc::new(file_schema);
+
+        let batch = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "d"])) as _,
+                Arc::new(StringArray::from(vec!["w", "x", "y", "z"])) as _,
+                Arc::new(UInt32Array::from(vec![1, 2, 3, 4])) as _,
+            ],
+        )
+        .unwrap();
+
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled("a".into(), EnabledStatistics::Page)
+            .build();
+
+        let mut buf = Vec::with_capacity(1024);
+        let mut writer = ArrowWriter::try_new(&mut buf, file_schema.clone(), Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+
+        let metadata = writer.close().unwrap();
+        assert_eq!(metadata.row_groups.len(), 1);
+        let row_group = &metadata.row_groups[0];
+        assert_eq!(row_group.columns.len(), 3);
+        // Column "a" has both offset and column index, as requested
+        assert!(row_group.columns[0].offset_index_offset.is_some());
+        assert!(row_group.columns[0].column_index_offset.is_some());
+        // Column "b" should only have offset index
+        assert!(row_group.columns[1].offset_index_offset.is_some());
+        assert!(row_group.columns[1].column_index_offset.is_none());
+        // Column "c" should only have offset index
+        assert!(row_group.columns[1].offset_index_offset.is_some());
+        assert!(row_group.columns[1].column_index_offset.is_none());
+
+        let options = ReadOptionsBuilder::new().with_page_index().build();
+        let reader = SerializedFileReader::new_with_options(Bytes::from(buf), options).unwrap();
+
+        let offset_index = reader.metadata().offset_index().unwrap();
+        assert_eq!(offset_index.len(), 1); // 1 row group
+        assert_eq!(offset_index[0].len(), 3); // 2 columns
+
+        let column_index = reader.metadata().column_index().unwrap();
+        assert_eq!(column_index.len(), 1); // 1 row group
+        assert_eq!(column_index[0].len(), 3); // 23column
+
+        let a_idx = &column_index[0][0];
+        assert!(matches!(a_idx, Index::BYTE_ARRAY(_)), "{a_idx:?}");
+        let b_idx = &column_index[0][1];
+        assert!(matches!(b_idx, Index::NONE), "{b_idx:?}");
+        let c_idx = &column_index[0][2];
+        assert!(matches!(c_idx, Index::NONE), "{c_idx:?}");
+    }
+
+    #[test]
+    fn test_disabled_statistics_with_chunk() {
+        let file_schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new("c", DataType::UInt32, true),
+        ]);
+        let file_schema = Arc::new(file_schema);
+
+        let batch = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "d"])) as _,
+                Arc::new(StringArray::from(vec!["w", "x", "y", "z"])) as _,
+                Arc::new(UInt32Array::from(vec![1, 2, 3, 4])) as _,
+            ],
+        )
+        .unwrap();
+
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled("a".into(), EnabledStatistics::Chunk)
+            .build();
+
+        let mut buf = Vec::with_capacity(1024);
+        let mut writer = ArrowWriter::try_new(&mut buf, file_schema.clone(), Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+
+        let metadata = writer.close().unwrap();
+        assert_eq!(metadata.row_groups.len(), 1);
+        let row_group = &metadata.row_groups[0];
+        assert_eq!(row_group.columns.len(), 3);
+        // Column "a" should only have offset index
+        assert!(row_group.columns[0].offset_index_offset.is_some());
+        assert!(row_group.columns[0].column_index_offset.is_none());
+        // Column "b" should only have offset index
+        assert!(row_group.columns[1].offset_index_offset.is_some());
+        assert!(row_group.columns[1].column_index_offset.is_none());
+        // Column "c" should only have offset index
+        assert!(row_group.columns[1].offset_index_offset.is_some());
+        assert!(row_group.columns[1].column_index_offset.is_none());
+
+        let options = ReadOptionsBuilder::new().build();
+        let reader = SerializedFileReader::new_with_options(Bytes::from(buf), options).unwrap();
+
+        let row_group = reader.get_row_group(0).unwrap();
+
+        let a_col = row_group.metadata().column(0);
+        let b_col = row_group.metadata().column(1);
+        let c_col = row_group.metadata().column(2);
+
+        assert!(a_col.statistics().is_some());
+        assert!(b_col.statistics().is_none());
+        assert!(c_col.statistics().is_none());
+
+        if let Statistics::ByteArray(byte_array_stats) = a_col.statistics().unwrap() {
+            let min = byte_array_stats.min();
+            let max = byte_array_stats.max();
+
+            assert_eq!(min.as_bytes(), &[b'a']);
+            assert_eq!(max.as_bytes(), &[b'd']);
+        } else {
+            panic!("expecting Statistics::ByteArray");
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5162.

# Rationale for this change
Currently, he ArrowWriter writes page-level statistics for byte-array-encoded types whether its configured to do so or not.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
