### PR TITLE
Fix: Ensure Timestamp Parsing Rejects Characters After 'Z

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -210,7 +210,7 @@ pub fn string_to_datetime<T: TimeZone>(timezone: &T, s: &str) -> Result<DateTime
             .ok_or_else(|| err("error computing timezone offset"));
     }
 
-    if bytes[tz_offset] == b'z' || bytes[tz_offset] == b'Z' {
+    if (bytes[tz_offset] == b'z' || bytes[tz_offset] == b'Z') && tz_offset == bytes.len() - 1 {
         return Ok(timezone.from_utc_datetime(&datetime));
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5182

# What changes are included in this PR?

I have changed the `string_to_datetime` to make sure that the 'Z is always the last charachter.

# Are there any user-facing changes?

No