### PR TITLE
Fix deprecated note for `Buffer::from_raw_parts`

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -99,7 +99,7 @@ impl Buffer {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// bytes. If the `ptr` and `capacity` come from a `Buffer`, then this is guaranteed.
-    #[deprecated(note = "Use From<Vec<T>>")]
+    #[deprecated(note = "Use Buffer::from_vec")]
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, len: usize, capacity: usize) -> Self {
         assert!(len <= capacity);
         let layout = Layout::from_size_align(capacity, ALIGNMENT).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
`Buffer` does not implement `From<Vec<T>>`. 

# What changes are included in this PR?

Update the note to point to the existing alternative: `Buffer::from_vec`.

# Are there any user-facing changes?

Users of this deprecated method can directly find the alternative.