### PR TITLE
arrow_json: support decimal 128 and 256 types in json writer

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -34,11 +34,17 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-arrow-array = { workspace = true }
-arrow-buffer = { workspace = true }
-arrow-cast = { workspace = true }
-arrow-data = { workspace = true }
-arrow-schema = { workspace = true }
+arrow-array = { version = "49" }
+# arrow-buffer = { workspace = true }
+# arrow-cast = { workspace = true }
+# arrow-data = { workspace = true }
+# arrow-schema = { workspace = true }
+
+arrow-buffer = { version = "49" }
+arrow-cast = { version = "49" }
+arrow-data = { version = "49" }
+arrow-schema = { version = "49" }
+
 half = { version = "2.1", default-features = false }
 indexmap = { version = "2.0", default-features = false, features = ["std"] }
 num = { version = "0.4", default-features = false, features = ["std"] }
@@ -49,15 +55,19 @@ lexical-core = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.3"
-flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1", default-features = false, features = [
+    "rust_backend",
+] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1.27", default-features = false, features = ["io-util"] }
 bytes = "1.4"
 criterion = { version = "0.5", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.8", default-features = false, features = [
+    "std",
+    "std_rng",
+] }
 
 [[bench]]
 name = "serde"
 harness = false
-

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -470,7 +470,7 @@ fn set_column_for_json_rows(
             }
         }
         DataType::Decimal128(_precision, _scale) | DataType::Decimal256(_precision, _scale) => {
-            to_json_number_via_f64(rows, array, col_name, explicit_nulls)?;
+            to_json_float(rows, array, col_name, explicit_nulls)?;
         }
         _ => {
             return Err(ArrowError::JsonError(format!(
@@ -482,7 +482,7 @@ fn set_column_for_json_rows(
     Ok(())
 }
 
-fn to_json_number_via_f64(
+fn to_json_float(
     rows: &mut [Option<JsonMap<String, Value>>],
     array: &ArrayRef,
     col_name: &str,

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -524,7 +524,6 @@ fn to_json_float(
                         .map(Value::Number)
                 })
             })
-            // pivot the Option<Result> to Result<Option>
             .map_or_else(|| Ok(None), |result| result.map(Some));
 
         if let Some(j) = maybe_value? {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5198

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This PR will enable support for Decimal type columns to json as floats

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR uses similar logic that's used to write arrow date types to write the decimal types to json. 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
