### PR TITLE
impl `From<BufferBuilder<T>>` for `ScalarBuffer<T>`

### DIFF
--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -18,7 +18,7 @@
 use crate::alloc::Deallocation;
 use crate::buffer::Buffer;
 use crate::native::ArrowNativeType;
-use crate::MutableBuffer;
+use crate::{BufferBuilder, MutableBuffer};
 use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -154,6 +154,13 @@ impl<T: ArrowNativeType> From<Vec<T>> for ScalarBuffer<T> {
     }
 }
 
+impl<T: ArrowNativeType> From<BufferBuilder<T>> for ScalarBuffer<T> {
+    fn from(mut value: BufferBuilder<T>) -> Self {
+        let len = value.len();
+        Self::new(value.finish(), 0, len)
+    }
+}
+
 impl<T: ArrowNativeType> FromIterator<T> for ScalarBuffer<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         iter.into_iter().collect::<Vec<_>>().into()
@@ -262,5 +269,13 @@ mod tests {
     fn test_end_overflow() {
         let buffer = Buffer::from_iter([0_i32, 1, 2]);
         ScalarBuffer::<i32>::new(buffer, 0, usize::MAX / 4 + 1);
+    }
+
+    #[test]
+    fn convert_from_buffer_builder() {
+        let input = vec![1, 2, 3, 4];
+        let buffer_builder = BufferBuilder::from(input.clone());
+        let scalar_buffer = ScalarBuffer::from(buffer_builder);
+        assert_eq!(scalar_buffer.as_ref(), input);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
This allows directly converting a strongly typed `BufferBuilder<T>` to a strongly typed `ScalarBuffer<T>`.

# What changes are included in this PR?

The `From<BufferBuilder<T>>` implementation for `ScalarBuffer<T>`.

# Are there any user-facing changes?

The conversion via the `From` trait.