### PR TITLE
impl `From<BufferBuilder<T>>` for `Buffer`

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use crate::alloc::{Allocation, Deallocation, ALIGNMENT};
 use crate::util::bit_chunk_iterator::{BitChunks, UnalignedBitChunk};
+use crate::BufferBuilder;
 use crate::{bytes::Bytes, native::ArrowNativeType};
 
 use super::ops::bitwise_unary_op_helper;
@@ -368,6 +369,12 @@ impl From<MutableBuffer> for Buffer {
     #[inline]
     fn from(buffer: MutableBuffer) -> Self {
         buffer.into_buffer()
+    }
+}
+
+impl<T: ArrowNativeType> From<BufferBuilder<T>> for Buffer {
+    fn from(mut value: BufferBuilder<T>) -> Self {
+        value.finish()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
This allows directly converting a strongly typed `BufferBuilder<T>` to a `Buffer`.

# What changes are included in this PR?

The `From<BufferBuilder<T>>` implementation for `Buffer`.

# Are there any user-facing changes?

The conversion via the `From` trait.