### PR TITLE
impl `From<OffsetBuffer<T>>` for `ScalarBuffer<T>`

### DIFF
--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -18,7 +18,7 @@
 use crate::alloc::Deallocation;
 use crate::buffer::Buffer;
 use crate::native::ArrowNativeType;
-use crate::MutableBuffer;
+use crate::{MutableBuffer, OffsetBuffer};
 use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -142,6 +142,12 @@ impl<T: ArrowNativeType> From<Buffer> for ScalarBuffer<T> {
             buffer,
             phantom: Default::default(),
         }
+    }
+}
+
+impl<T: ArrowNativeType> From<OffsetBuffer<T>> for ScalarBuffer<T> {
+    fn from(value: OffsetBuffer<T>) -> Self {
+        value.into_inner()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
This allows directly converting a strongly typed `OffsetBuffer<T>` to a strongly typed `ScalarBuffer<T>`.

# What changes are included in this PR?

The `From<OffsetBuffer<T>>` implementation for `ScalarBuffer<T>`.

# Are there any user-facing changes?

The conversion via the `From` trait.