### PR TITLE
Implement a lazy multipart writer that does direct PUT for small files

### DIFF
--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1433,6 +1433,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_multipart_lazy() {
+        let root = TempDir::new().unwrap();
+        let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
+        let store = Arc::new(integration);
+        crate::tests::multipart_lazy(store).await;
+    }
+
+    #[tokio::test]
     async fn filesystem_filename_with_percent() {
         let temp_dir = TempDir::new().unwrap();
         let integration = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

I can create an issue for this.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

For small files, multipart upload is unnecessary, but it can be convenient to use the same interface, ie. same AsyncWrite that can internally either do a direct PUT for small files or use multipart upload.

# What changes are included in this PR?

Adds new code to create an async writer that lazily creates the multipart upload after there is enough data.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
yes


#### notes

* i couldn't really find way to avoid duplicating the code from the existing WriteMultipart, lmk if there's a better way.
* I wasn't sure on naming, feel free to suggest alternative
