### PR TITLE
object_store: suffix requests

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -693,7 +693,7 @@ impl GetSuffixClient for S3Client {
                 path: location.as_ref(),
             })?;
 
-        response_to_get_result::<S3Client>(response, location, Some(HttpRange::new_suffix(nbytes)))?
+        response_to_get_result::<Self>(response, location, Some(HttpRange::new_suffix(nbytes)))?
             .bytes()
             .await
     }

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -42,7 +42,7 @@ use tokio::io::AsyncWrite;
 use url::Url;
 
 use crate::aws::client::S3Client;
-use crate::client::get::GetClientExt;
+use crate::client::get::{GetClientExt, GetSuffixClient};
 use crate::client::list::ListClientExt;
 use crate::client::CredentialProvider;
 use crate::multipart::{MultiPartStore, PartId, PutPart, WriteMultiPart};
@@ -214,6 +214,10 @@ impl ObjectStore for AmazonS3 {
         self.client
             .delete_request(location, &[("uploadId", multipart_id)])
             .await
+    }
+
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        self.client.get_suffix(location, nbytes).await
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {

--- a/object_store/src/chunked.rs
+++ b/object_store/src/chunked.rs
@@ -136,6 +136,10 @@ impl ObjectStore for ChunkedStore {
         self.inner.get_range(location, range).await
     }
 
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        self.inner.get_suffix(location, nbytes).await
+    }
+
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         self.inner.head(location).await
     }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -72,7 +72,7 @@ pub(crate) fn response_to_get_result<T: GetClient>(
 #[async_trait]
 impl<T: GetClient> GetClientExt for T {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        let range = options.range.clone().map(|r| HttpRange::from(r));
+        let range = options.range.clone().map(HttpRange::from);
         let response = self.get_request(location, options).await?;
         response_to_get_result::<T>(response, location, range)
     }

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -571,6 +571,11 @@ impl ClientOptions {
     }
 }
 
+pub(crate) fn with_suffix_header(builder: RequestBuilder, nbytes: usize) -> RequestBuilder {
+    let range = format!("bytes=-{nbytes}");
+    builder.header(hyper::header::RANGE, range)
+}
+
 pub trait GetOptionsExt {
     fn with_get_options(self, options: GetOptions) -> Self;
 }

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::get::GetClient;
+use crate::client::get::{response_to_get_result, GetClient, GetSuffixClient};
 use crate::client::header::{get_put_result, get_version, HeaderConfig};
 use crate::client::list::ListClient;
 use crate::client::retry::RetryExt;
@@ -23,10 +23,11 @@ use crate::client::s3::{
     CompleteMultipartUpload, CompleteMultipartUploadResult, InitiateMultipartUploadResult,
     ListResponse,
 };
-use crate::client::GetOptionsExt;
+use crate::client::{with_suffix_header, GetOptionsExt};
 use crate::gcp::{GcpCredential, GcpCredentialProvider, STORE};
 use crate::multipart::PartId;
 use crate::path::{Path, DELIMITER};
+use crate::util::HttpRange;
 use crate::{
     ClientOptions, GetOptions, ListResult, MultipartId, PutMode, PutOptions, PutResult, Result,
     RetryConfig,
@@ -459,6 +460,41 @@ impl GetClient for GoogleCloudStorageClient {
             })?;
 
         Ok(response)
+    }
+}
+
+#[async_trait]
+impl GetSuffixClient for GoogleCloudStorageClient {
+    async fn get_suffix(&self, path: &Path, nbytes: usize) -> Result<Bytes> {
+        let credential = self.get_credential().await?;
+        let url = self.object_url(path);
+
+        let method = Method::GET;
+
+        let mut request = self.client.request(method, url);
+
+        // if let Some(version) = &options.version {
+        //     request = request.query(&[("generation", version)]);
+        // }
+
+        if !credential.bearer.is_empty() {
+            request = request.bearer_auth(&credential.bearer);
+        }
+
+        let response = with_suffix_header(request, nbytes)
+            .send_retry(&self.config.retry_config)
+            .await
+            .context(GetRequestSnafu {
+                path: path.as_ref(),
+            })?;
+
+        response_to_get_result::<GoogleCloudStorageClient>(
+            response,
+            path,
+            Some(HttpRange::new_suffix(nbytes)),
+        )?
+        .bytes()
+        .await
     }
 }
 

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -488,7 +488,7 @@ impl GetSuffixClient for GoogleCloudStorageClient {
                 path: path.as_ref(),
             })?;
 
-        response_to_get_result::<GoogleCloudStorageClient>(
+        response_to_get_result::<Self>(
             response,
             path,
             Some(HttpRange::new_suffix(nbytes)),

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -44,7 +44,7 @@ use client::GoogleCloudStorageClient;
 use futures::stream::BoxStream;
 use tokio::io::AsyncWrite;
 
-use crate::client::get::GetClientExt;
+use crate::client::get::{GetClientExt, GetSuffixClient};
 use crate::client::list::ListClientExt;
 use crate::multipart::MultiPartStore;
 pub use builder::{GoogleCloudStorageBuilder, GoogleConfigKey};
@@ -137,6 +137,10 @@ impl ObjectStore for GoogleCloudStorage {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         self.client.get_opts(location, options).await
+    }
+
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        self.client.get_suffix(location, nbytes).await
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -353,7 +353,7 @@ impl GetSuffixClient for Client {
             });
         }
 
-        response_to_get_result::<Client>(res, location, Some(HttpRange::new_suffix(nbytes)))?
+        response_to_get_result::<Self>(res, location, Some(HttpRange::new_suffix(nbytes)))?
             .bytes()
             .await
     }

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -40,7 +40,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 use url::Url;
 
-use crate::client::get::GetClientExt;
+use crate::client::get::{GetClientExt, GetSuffixClient};
 use crate::client::header::get_etag;
 use crate::http::client::Client;
 use crate::path::Path;
@@ -128,6 +128,10 @@ impl ObjectStore for HttpStore {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         self.client.get_opts(location, options).await
+    }
+
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        self.client.get_suffix(location, nbytes).await
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -797,6 +797,10 @@ macro_rules! as_ref_impl {
                 self.as_ref().get_range(location, range).await
             }
 
+            async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+                self.as_ref().get_suffix(location, nbytes).await
+            }
+
             async fn get_ranges(
                 &self,
                 location: &Path,

--- a/object_store/src/limit.rs
+++ b/object_store/src/limit.rs
@@ -111,6 +111,11 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
         self.inner.get_range(location, range).await
     }
 
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        let _permit = self.semaphore.acquire().await.unwrap();
+        self.inner.get_suffix(location, nbytes).await
+    }
+
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
         let _permit = self.semaphore.acquire().await.unwrap();
         self.inner.get_ranges(location, ranges).await

--- a/object_store/src/prefix.rs
+++ b/object_store/src/prefix.rs
@@ -113,6 +113,11 @@ impl<T: ObjectStore> ObjectStore for PrefixStore<T> {
         self.inner.get_range(&full_path, range).await
     }
 
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        let full_path = self.full_path(location);
+        self.inner.get_suffix(&full_path, nbytes).await
+    }
+
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let full_path = self.full_path(location);
         self.inner.get_opts(&full_path, options).await

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -200,6 +200,16 @@ impl<T: ObjectStore> ObjectStore for ThrottledStore<T> {
         self.inner.get_range(location, range).await
     }
 
+    async fn get_suffix(&self, location: &Path, nbytes: usize) -> Result<Bytes> {
+        let config = self.config();
+
+        let sleep_duration = config.wait_get_per_call + config.wait_get_per_byte * nbytes as u32;
+
+        sleep(sleep_duration).await;
+
+        self.inner.get_suffix(location, nbytes).await
+    }
+
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
         let config = self.config();
 

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -179,7 +179,6 @@ fn merge_ranges(ranges: &[std::ops::Range<usize>], coalesce: usize) -> Vec<std::
 /// These can be created from [usize] ranges, like
 ///
 /// ```rust
-/// # use byteranges::request::HttpRange;
 /// let range1: HttpRange = (50..150).into();
 /// let range2: HttpRange = (50..=150).into();
 /// let range3: HttpRange = (50..).into();

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -124,7 +124,7 @@ where
 
             let start = range.start - fetch_range.start;
             let end = range.end - fetch_range.start;
-            fetch_bytes.slice(start..end)
+            fetch_bytes.slice(start..end.min(fetch_bytes.len()))
         })
         .collect())
 }


### PR DESCRIPTION
# Which issue does this PR close?

Relates to #4611, but should not close it.

# Rationale for this change
 
Certain use cases require suffix requests (see linked issue). Most stores support such requests directly; a workaround for Azure is trivial although not fast.

# What changes are included in this PR?

`pub trait GetSuffixClient`, with an implementation for all clients except Azure. Additionally, `ObjectStore::get_suffix`, with a default implementation with the workaround (HEAD then GET), which is then overridden in all stores except Azure.

Also includes some of the infrastructure around full support for HTTP ranges, which is the direction this functionality should go in when we next make a breaking API change. That infra is probably overcomplicated for its use here, but gives a good foundation for full support later, e.g.  https://github.com/apache/arrow-rs/commit/80cdf66d5fa5057384b39255a33bdbbf9d9e6b71

# Are there any user-facing changes?

Downstream implementors of `ObjectStore` should override the default `get_suffix` method, if their clients support a direct form, preferably by implementing `GetSuffixClient` on their client.

# Remaining questions

- `GetSuffixClient` probably doesn't need to be a trait as it doesn't depend on any behaviour and isn't used in generics; `get_suffix` could just be implemented directly on the client structs. However, it will make it much easier to delete suffix-specific behaviour when a breaking API  change is allowed.
- This is a lot of code in a lot of places (much of it copy-pasted), but I don't think there's a way around that with the current API.
- This probably needs checking for errors where the requested `nbytes` are longer than the resource. However, AFAICT that isn't currently done with current range requests outside of the local and memory stores.

# Better solution

Per the linked issue, GetOptions should contain a full representation of an HTTP range (implementing `From<Range<usize>>`) and this functionality should be built into `get_opts`.