### PR TITLE
Change `Array::logical_nulls` to only copy when necessary

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -194,7 +194,10 @@ where
         return Ok(PrimitiveArray::from(ArrayData::new_empty(&O::DATA_TYPE)));
     }
 
-    let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
+    let nulls = NullBuffer::union(
+        a.logical_nulls().as_ref().map(|n| n.as_ref()),
+        b.logical_nulls().as_ref().map(|n| n.as_ref()),
+    );
 
     let values = a.values().iter().zip(b.values()).map(|(l, r)| op(*l, *r));
     // JUSTIFICATION
@@ -244,7 +247,10 @@ where
         ))));
     }
 
-    let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
+    let nulls = NullBuffer::union(
+        a.logical_nulls().as_ref().map(|n| n.as_ref()),
+        b.logical_nulls().as_ref().map(|n| n.as_ref()),
+    );
 
     let mut builder = a.into_builder()?;
 
@@ -292,8 +298,11 @@ where
     if a.null_count() == 0 && b.null_count() == 0 {
         try_binary_no_nulls(len, a, b, op)
     } else {
-        let nulls =
-            NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref()).unwrap();
+        let nulls = NullBuffer::union(
+            a.logical_nulls().as_ref().map(|n| n.as_ref()),
+            b.logical_nulls().as_ref().map(|n| n.as_ref()),
+        )
+        .unwrap();
 
         let mut buffer = BufferBuilder::<O::Native>::new(len);
         buffer.append_n_zeroed(len);
@@ -351,8 +360,11 @@ where
     if a.null_count() == 0 && b.null_count() == 0 {
         try_binary_no_nulls_mut(len, a, b, op)
     } else {
-        let nulls =
-            NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref()).unwrap();
+        let nulls = NullBuffer::union(
+            a.logical_nulls().as_ref().map(|n| n.as_ref()),
+            b.logical_nulls().as_ref().map(|n| n.as_ref()),
+        )
+        .unwrap();
 
         let mut builder = a.into_builder()?;
 

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -214,7 +214,7 @@ impl BooleanArray {
     where
         F: FnMut(T::Item) -> bool,
     {
-        let nulls = left.logical_nulls();
+        let nulls = left.logical_nulls().map(|n| n.into_owned());
         let values = BooleanBuffer::collect_bool(left.len(), |i| unsafe {
             // SAFETY: i in range 0..len
             op(left.value_unchecked(i))
@@ -245,8 +245,8 @@ impl BooleanArray {
         assert_eq!(left.len(), right.len());
 
         let nulls = NullBuffer::union(
-            left.logical_nulls().as_ref(),
-            right.logical_nulls().as_ref(),
+            left.logical_nulls().as_ref().map(|n| n.as_ref()),
+            right.logical_nulls().as_ref().map(|n| n.as_ref()),
         );
         let values = BooleanBuffer::collect_bool(left.len(), |i| unsafe {
             // SAFETY: i in range 0..len

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -172,7 +172,8 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// you can use the slower [`Array::logical_nulls`] to obtain a computed mask .
     fn nulls(&self) -> Option<&NullBuffer>;
 
-    /// Returns a potentially computed [`NullBuffer`] that represent the logical null values of this array, if any.
+    /// Returns a potentially computed [`NullBuffer`] that represent the logical
+    /// null values of this array, if any.
     ///
     /// In most cases this will be the same as [`Array::nulls`], except for:
     ///
@@ -182,6 +183,9 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     ///
     /// In these cases a logical [`NullBuffer`] will be computed, encoding the logical nullability
     /// of these arrays, beyond what is encoded in [`Array::nulls`]
+    ///
+    /// Returns a [`Cow<'_, NullBuffer>`] to avoid a copy of the null buffer
+    /// when it is already present.
     ///
     /// # Example:
     /// ```

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -23,6 +23,7 @@ use arrow_buffer::buffer::NullBuffer;
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::DataType;
 use std::any::Any;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 /// An array of [null values](https://arrow.apache.org/docs/format/Columnar.html#null-layout)
@@ -109,8 +110,8 @@ impl Array for NullArray {
         None
     }
 
-    fn logical_nulls(&self) -> Option<NullBuffer> {
-        (self.len != 0).then(|| NullBuffer::new_null(self.len))
+    fn logical_nulls(&self) -> Option<Cow<'_, NullBuffer>> {
+        (self.len != 0).then(|| Cow::Owned(NullBuffer::new_null(self.len)))
     }
 
     fn is_nullable(&self) -> bool {

--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -17,12 +17,13 @@
 
 //! Idiomatic iterators for [`Array`](crate::Array)
 
+use arrow_buffer::NullBuffer;
+
 use crate::array::{
     ArrayAccessor, BooleanArray, FixedSizeBinaryArray, GenericBinaryArray, GenericListArray,
     GenericStringArray, PrimitiveArray,
 };
 use crate::{FixedSizeListArray, MapArray};
-use arrow_buffer::NullBuffer;
 
 /// An iterator that returns Some(T) or None, that can be used on any [`ArrayAccessor`]
 ///
@@ -56,7 +57,7 @@ impl<T: ArrayAccessor> ArrayIter<T> {
     /// create a new iterator
     pub fn new(array: T) -> Self {
         let len = array.len();
-        let logical_nulls = array.logical_nulls();
+        let logical_nulls = array.logical_nulls().map(|n| n.into_owned());
         ArrayIter {
             array,
             logical_nulls,

--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -252,8 +252,8 @@ fn compare_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, 
         (Some(_), true, Some(a), false) | (Some(a), false, Some(_), true) => {
             // Scalar is null, other side is non-scalar and nullable
             match op {
-                Op::Distinct => a.into_inner().into(),
-                Op::NotDistinct => a.into_inner().not().into(),
+                Op::Distinct => a.into_owned().into_inner().into(),
+                Op::NotDistinct => a.into_owned().into_inner().not().into(),
                 _ => BooleanArray::new_null(len),
             }
         }
@@ -276,7 +276,7 @@ fn compare_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, 
                         BooleanBuffer::new(buffer, 0, len).into()
                     }
                     Op::NotDistinct => (nulls.inner() & &values()).into(),
-                    _ => BooleanArray::new(values(), Some(nulls)),
+                    _ => BooleanArray::new(values(), Some(nulls.into_owned())),
                 },
             }
         }

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -770,7 +770,7 @@ impl LexicographicalComparator {
                 // flatten and convert build comparators
                 let values = column.values.as_ref();
                 Ok((
-                    values.logical_nulls(),
+                    values.logical_nulls().map(|n| n.into_owned()),
                     build_compare(values, values)?,
                     column.options.unwrap_or_default(),
                 ))

--- a/arrow-select/src/dictionary.rs
+++ b/arrow-select/src/dictionary.rs
@@ -152,7 +152,7 @@ pub fn merge_dictionary_values<K: ArrowDictionaryKeyType>(
     for (idx, dictionary) in dictionaries.iter().enumerate() {
         let mask = masks.and_then(|m| m.get(idx));
         let key_mask = match (dictionary.logical_nulls(), mask) {
-            (Some(n), None) => Some(n.into_inner()),
+            (Some(n), None) => Some(n.into_owned().into_inner()),
             (None, Some(n)) => Some(n.clone()),
             (Some(n), Some(m)) => Some(n.inner() & m),
             (None, None) => None,


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/5208

# Rationale for this change
 
I would like to avoid copies when unecessary

# What changes are included in this PR?

1. Return `Cow<NullBuffer>` rather than `NullBuffer` 
2. Update existing code
3. Add comments and examples to make what is happening clearer (as I think using `Cow`s requires finagling that is sometimes obtuse)

# Are there any user-facing changes?
Yes, this is an API change

I tried to make it as easy as possible with documentation

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
