### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download crate docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: crate-docs
           path: website/build


### PR DESCRIPTION
Reverts apache/arrow-rs#5212

This appears to be incompatible https://github.com/apache/arrow-rs/actions/runs/7223753149/job/19683593554

Possibly related, although there isn't a new version of upload-pages-artifact - https://github.com/actions/download-artifact/issues/250