### PR TITLE
feat(ord): Support equality of StructArray

### DIFF
--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -341,9 +341,8 @@ fn compare_op_struct_values(
     // compare each field of struct
     let child_res = l
         .columns()
-        .to_vec()
         .iter()
-        .zip(r.columns().to_vec().iter())
+        .zip(r.columns().iter())
         .map(|(col_l, col_r)| compare_op_values(Op::Equal, col_l, l_s, col_r, r_s, len))
         .collect::<Result<Vec<BooleanBuffer>, ArrowError>>()?;
     // combine the result of each field


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5199 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- refactor closure ```values()``` to function ```compare_op_struct_values()```
- compare struct arrays by recursively checking each field

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
