### PR TITLE
Add `keys_and_values` to `MapBuilder` to return both key and value array builders

### DIFF
--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -119,6 +119,11 @@ impl<K: ArrayBuilder, V: ArrayBuilder> MapBuilder<K, V> {
         &mut self.value_builder
     }
 
+    /// Returns both the key and value array builders of the map
+    pub fn keys_and_values(&mut self) -> (&mut K, &mut V) {
+        (&mut self.key_builder, &mut self.value_builder)
+    }
+
     /// Finish the current map array slot
     ///
     /// Returns an error if the key and values builders are in an inconsistent state.

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -831,6 +831,57 @@ fn test_map_nulls_append() {
 }
 
 #[test]
+fn test_map_keys_values_append() {
+    let mut builder = MapBuilder::<Int64Builder, Int64Builder>::new(
+        None,
+        Int64Builder::with_capacity(32),
+        Int64Builder::with_capacity(32),
+    );
+    let (keys, values) = builder.keys_and_values();
+    keys.append_slice(&[1, 2, 3]);
+    values.append_slice(&[1, 3, 4]);
+    builder.append(true).unwrap();
+
+    let (keys, values) = builder.keys_and_values();
+    keys.append_slice(&[4, 5]);
+    values.append_slice(&[4, 6]);
+    builder.append(true).unwrap();
+
+    builder.append(false).unwrap();
+
+    let map = builder.finish();
+    assert!(map.is_null(2));
+
+    let first = map.value(0);
+    let keys = first
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    let values = first
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(keys, &Int64Array::from(vec![Some(1), Some(2), Some(3)]));
+    assert_eq!(values, &Int64Array::from(vec![Some(1), Some(3), Some(4)]));
+
+    let second = map.value(1);
+    let keys = second
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    let values = second
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(keys, &Int64Array::from(vec![Some(4), Some(5)]));
+    assert_eq!(values, &Int64Array::from(vec![Some(4), Some(6)]));
+}
+
+#[test]
 fn test_list_of_strings_append() {
     // [["alpha", "beta", None]]
     let mut builder = ListBuilder::new(StringBuilder::new());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`MapBuilder` provides `keys` and `values` functions to get key and value array builders of map separately. As it is mutable borrow of the map builder, when we want to set keys and values in a loop like:

```rust
let key_builder = builder.keys();
let value_builder = builder.values();

let keys = ...;
let values = ...;

for idx in 0..keys.get_num_elements() {
    let key = keys.get(idx);
    let value = values.get(idx);

    key_builder.append_value(key);
    value_builder.append_value(value);
}
```

The compiler will complain `error[E0499]: cannot borrow `*builder` as mutable more than once at a time`.

Although there is workaround that is to get key and value builders inside the loop, no sure if it is efficient. More, especially we can have `Box<dyn ArrayBuilder>` as key and value builders now, it means that we need to `downcast` both key and value builders for each iteration in the loop.

This patch adds `keys_and_values` API to `MapBuilder` that can get both key and value builders in one mutable borrow.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
