### PR TITLE
Use `try_new` when casting between structs to propagate error

### DIFF
--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -86,7 +86,7 @@ impl NullBuffer {
         }
         let lhs = self.inner().bit_chunks().iter_padded();
         let rhs = other.inner().bit_chunks().iter_padded();
-        lhs.zip(rhs).all(|(l, r)| (l & !r) == 0) // l:0 -> r:0 or 1, l:1 -> r:1
+        lhs.zip(rhs).all(|(l, r)| (l & !r) == 0)
     }
 
     /// Returns a new [`NullBuffer`] where each bit in the current null buffer

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -86,7 +86,7 @@ impl NullBuffer {
         }
         let lhs = self.inner().bit_chunks().iter_padded();
         let rhs = other.inner().bit_chunks().iter_padded();
-        lhs.zip(rhs).all(|(l, r)| (l & !r) == 0)
+        lhs.zip(rhs).all(|(l, r)| (l & !r) == 0) // l:0 -> r:0 or 1, l:1 -> r:1
     }
 
     /// Returns a new [`NullBuffer`] where each bit in the current null buffer


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Different to casting from primitive types, casting between structs needs to consider nullability as the fields of structs have nullability properties. We use `StructArray::new` when casting structs for now which simply fails. We should use `StructArray::try_new` to propagate the error.



# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
