### PR TITLE
Improve regexp kernels performance by avoiding cloning Regex

### DIFF
--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -88,8 +88,7 @@ pub fn regexp_is_match_utf8<OffsetSize: OffsetSizeTrait>(
                                     "Regular expression did not compile: {e:?}"
                                 ))
                             })?;
-                            patterns.insert(pattern.clone(), re);
-                            patterns.get(&pattern).unwrap()
+                            patterns.entry(pattern).or_insert(re)
                         }
                     };
                     result.append(re.is_match(value));
@@ -223,8 +222,7 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
                                     "Regular expression did not compile: {e:?}"
                                 ))
                             })?;
-                            patterns.insert(pattern.clone(), re);
-                            patterns.get(&pattern).unwrap()
+                            patterns.entry(pattern).or_insert(re)
                         }
                     };
                     match re.captures(value) {

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -81,15 +81,15 @@ pub fn regexp_is_match_utf8<OffsetSize: OffsetSizeTrait>(
                 (Some(value), Some(pattern)) => {
                     let existing_pattern = patterns.get(&pattern);
                     let re = match existing_pattern {
-                        Some(re) => re.clone(),
+                        Some(re) => re,
                         None => {
                             let re = Regex::new(pattern.as_str()).map_err(|e| {
                                 ArrowError::ComputeError(format!(
                                     "Regular expression did not compile: {e:?}"
                                 ))
                             })?;
-                            patterns.insert(pattern, re.clone());
-                            re
+                            patterns.insert(pattern.clone(), re);
+                            patterns.get(&pattern).unwrap()
                         }
                     };
                     result.append(re.is_match(value));
@@ -216,15 +216,15 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
                 (Some(value), Some(pattern)) => {
                     let existing_pattern = patterns.get(&pattern);
                     let re = match existing_pattern {
-                        Some(re) => re.clone(),
+                        Some(re) => re,
                         None => {
                             let re = Regex::new(pattern.as_str()).map_err(|e| {
                                 ArrowError::ComputeError(format!(
                                     "Regular expression did not compile: {e:?}"
                                 ))
                             })?;
-                            patterns.insert(pattern, re.clone());
-                            re
+                            patterns.insert(pattern.clone(), re);
+                            patterns.get(&pattern).unwrap()
                         }
                     };
                     match re.captures(value) {

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -248,6 +248,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "regexp_kernels"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "array_data_validate"
 harness = false
 

--- a/arrow/benches/regexp_kernels.rs
+++ b/arrow/benches/regexp_kernels.rs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::compute::kernels::regexp::*;
+use arrow::util::bench_util::*;
+
+fn bench_regexp(arr: &GenericStringArray<i32>, regex_array: &GenericStringArray<i32>) {
+    regexp_match(criterion::black_box(arr), regex_array, None).unwrap();
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let size = 65536;
+    let val_len = 1000;
+
+    let arr_string = create_string_array_with_len::<i32>(size, 0.0, val_len);
+    let pattern_values = vec![r".*-(\d*)-.*"; size];
+    let pattern = GenericStringArray::<i32>::from(pattern_values);
+
+    c.bench_function("regexp", |b| b.iter(|| bench_regexp(&arr_string, &pattern)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The `regexp_match` scalar expression in DataFusion is quite slow. As looking for the cause, it is found that the bad performance is due to cloning `Regex` per row. `Regex` has a `CachePool`. Cloning `Regex` will create a fresh `CachePool` and it is somehow expensive to re-creating cache space per row instead of reusing the cache.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This patch removes cloning on `Regex` in regexp kernels.

```
regexp                  time:   [6.4153 ms 6.4331 ms 6.4519 ms]
                        change: [-97.721% -97.713% -97.705%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
```

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
