### PR TITLE
Make regexp_match take scalar pattern and flag

### DIFF
--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -378,11 +378,9 @@ pub fn regexp_match(
         match array.data_type() {
             DataType::Utf8 => regexp_scalar_match(array.as_string::<i32>(), &re),
             DataType::LargeUtf8 => regexp_scalar_match(array.as_string::<i64>(), &re),
-            _ => {
-                return Err(ArrowError::ComputeError(
-                    "regexp_match() requires array to be either Utf8 or LargeUtf8".to_string(),
-                ));
-            }
+            _ => Err(ArrowError::ComputeError(
+                "regexp_match() requires array to be either Utf8 or LargeUtf8".to_string(),
+            )),
         }
     } else {
         match array.data_type() {
@@ -396,11 +394,9 @@ pub fn regexp_match(
                 let flags_array = flags.map(|flags| flags.as_string());
                 regexp_array_match(array.as_string::<i64>(), regex_array, flags_array)
             }
-            _ => {
-                return Err(ArrowError::ComputeError(
-                    "regexp_match() requires array to be either Utf8 or LargeUtf8".to_string(),
-                ));
-            }
+            _ => Err(ArrowError::ComputeError(
+                "regexp_match() requires array to be either Utf8 or LargeUtf8".to_string(),
+            )),
         }
     }
 }

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -153,7 +153,7 @@ pub fn regexp_is_match_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     Ok(BooleanArray::from(data))
 }
 
-pub fn regexp_array_match<OffsetSize: OffsetSizeTrait>(
+fn regexp_array_match<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     regex_array: &GenericStringArray<OffsetSize>,
     flags_array: Option<&GenericStringArray<OffsetSize>>,

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -328,9 +328,10 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
     let (rhs, is_rhs_scalar) = regex_array.get();
 
     if array.data_type() != rhs.data_type() {
-        return Err(ArrowError::ComputeError(format!(
+        return Err(ArrowError::ComputeError(
             "regexp_match() requires both array and pattern to be either Utf8 or LargeUtf8"
-        )));
+                .to_string(),
+        ));
     }
 
     let (flags, is_flags_scalar) = match flags_array {
@@ -342,15 +343,17 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
     };
 
     if is_flags_scalar.is_some() && is_rhs_scalar != is_flags_scalar.unwrap() {
-        return Err(ArrowError::ComputeError(format!(
+        return Err(ArrowError::ComputeError(
             "regexp_match() requires both pattern and flags to be either scalar or array"
-        )));
+                .to_string(),
+        ));
     }
 
     if flags_array.is_some() && rhs.data_type() != flags.unwrap().data_type() {
-        return Err(ArrowError::ComputeError(format!(
+        return Err(ArrowError::ComputeError(
             "regexp_match() requires both pattern and flags to be either string or largestring"
-        )));
+                .to_string(),
+        ));
     }
 
     if is_rhs_scalar {
@@ -359,9 +362,9 @@ pub fn regexp_match<OffsetSize: OffsetSizeTrait>(
             DataType::Utf8 => get_scalar_pattern_flag::<i32>(rhs, flags),
             DataType::LargeUtf8 => get_scalar_pattern_flag::<i64>(rhs, flags),
             _ => {
-                return Err(ArrowError::ComputeError(format!(
-                    "regexp_match() requires pattern to be either Utf8 or LargeUtf8"
-                )));
+                return Err(ArrowError::ComputeError(
+                    "regexp_match() requires pattern to be either Utf8 or LargeUtf8".to_string(),
+                ));
             }
         };
 

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -152,7 +152,7 @@ pub fn regexp_is_match_utf8_scalar<OffsetSize: OffsetSizeTrait>(
     Ok(BooleanArray::from(data))
 }
 
-fn regexp_array_match<OffsetSize: OffsetSizeTrait>(
+pub fn regexp_array_match<OffsetSize: OffsetSizeTrait>(
     array: &GenericStringArray<OffsetSize>,
     regex_array: &GenericStringArray<OffsetSize>,
     flags_array: Option<&GenericStringArray<OffsetSize>>,

--- a/arrow/benches/regexp_kernels.rs
+++ b/arrow/benches/regexp_kernels.rs
@@ -25,7 +25,7 @@ use arrow::array::*;
 use arrow::compute::kernels::regexp::*;
 use arrow::util::bench_util::*;
 
-fn bench_regexp(arr: &GenericStringArray<i32>, regex_array: &GenericStringArray<i32>) {
+fn bench_regexp(arr: &GenericStringArray<i32>, regex_array: &dyn Datum) {
     regexp_match(criterion::black_box(arr), regex_array, None).unwrap();
 }
 
@@ -38,6 +38,13 @@ fn add_benchmark(c: &mut Criterion) {
     let pattern = GenericStringArray::<i32>::from(pattern_values);
 
     c.bench_function("regexp", |b| b.iter(|| bench_regexp(&arr_string, &pattern)));
+
+    let pattern_values = vec![r".*-(\d*)-.*"];
+    let pattern = Scalar::new(GenericStringArray::<i32>::from(pattern_values));
+
+    c.bench_function("regexp scalar", |b| {
+        b.iter(|| bench_regexp(&arr_string, &pattern))
+    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5246.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`regexp_match` kernel currently assumes patterns and flags are all arrays with same length as string array. For the kernel, one usual case is to use scalar pattern and flag, we don't need to build pattern hash map.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This patch changes `regexp_match` to take `Datum` as parameters. It allows scalar pattern and flag.

For two benchmarks running against same array but one using pattern array and other using pattern scalar, scalar run takes ~50% less time.

```
regexp                  time:   [6.5667 ms 6.5763 ms 6.5857 ms]
                        change: [-2.3573% -1.6335% -0.9522%] (p = 0.00 < 0.05)
                        Change within noise threshold.

regexp scalar           time:   [3.4878 ms 3.4925 ms 3.4973 ms]
                        change: [-3.4210% -3.1127% -2.7738%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
