### PR TITLE
Bring some methods over from ArrowWriter to the async version

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -163,6 +163,11 @@ impl<W: Write + Send> ArrowWriter<W> {
             .unwrap_or_default()
     }
 
+    /// Returns the number of bytes written by this instance
+    pub fn bytes_written(&self) -> usize {
+        self.writer.bytes_written()
+    }
+
     /// Encodes the provided [`RecordBatch`]
     ///
     /// If this would cause the current row group to exceed [`WriterProperties::max_row_group_size`]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2699,6 +2699,7 @@ mod tests {
         // starts empty
         assert_eq!(writer.in_progress_size(), 0);
         assert_eq!(writer.in_progress_rows(), 0);
+        assert_eq!(writer.bytes_written(), 4); // Initial header
         writer.write(&batch).unwrap();
 
         // updated on write
@@ -2711,10 +2712,12 @@ mod tests {
         assert!(writer.in_progress_size() > initial_size);
         assert_eq!(writer.in_progress_rows(), 10);
 
-        // cleared on flush
+        // in progress tracking is cleared, but the overall data written is updated
+        let pre_flush_bytes_written = writer.bytes_written();
         writer.flush().unwrap();
         assert_eq!(writer.in_progress_size(), 0);
         assert_eq!(writer.in_progress_rows(), 0);
+        assert!(writer.bytes_written() > pre_flush_bytes_written);
 
         writer.close().unwrap();
     }

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -124,6 +124,11 @@ impl<W: AsyncWrite + Unpin + Send> AsyncArrowWriter<W> {
         self.sync_writer.in_progress_rows()
     }
 
+    /// Returns the number of bytes written by this instance
+    pub fn data_written(&self) -> usize {
+        self.sync_writer.bytes_written()
+    }
+
     /// Enqueues the provided `RecordBatch` to be written
     ///
     /// After every sync write by the inner [ArrowWriter], the inner buffer will be

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -445,6 +445,7 @@ mod tests {
             // starts empty
             assert_eq!(writer.in_progress_size(), 0);
             assert_eq!(writer.in_progress_rows(), 0);
+            assert_eq!(writer.bytes_written(), 4); // Initial Parquet header
             writer.write(&batch).await.unwrap();
 
             // updated on write
@@ -457,10 +458,12 @@ mod tests {
             assert!(writer.in_progress_size() > initial_size);
             assert_eq!(writer.in_progress_rows(), batch.num_rows() * 2);
 
-            // cleared on flush
+            // in progress tracking is cleared, but the overall data written is updated
+            let pre_flush_bytes_written = writer.bytes_written();
             writer.flush().await.unwrap();
             assert_eq!(writer.in_progress_size(), 0);
             assert_eq!(writer.in_progress_rows(), 0);
+            assert!(writer.bytes_written() > pre_flush_bytes_written);
 
             writer.close().await.unwrap();
         }

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -125,7 +125,7 @@ impl<W: AsyncWrite + Unpin + Send> AsyncArrowWriter<W> {
     }
 
     /// Returns the number of bytes written by this instance
-    pub fn data_written(&self) -> usize {
+    pub fn bytes_written(&self) -> usize {
         self.sync_writer.bytes_written()
     }
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -394,6 +394,11 @@ impl<W: Write + Send> SerializedFileWriter<W> {
 
         self.buf.into_inner()
     }
+
+    /// Returns the number of bytes written to this instance
+    pub fn bytes_written(&self) -> usize {
+        self.buf.bytes_written()
+    }
 }
 
 /// Parquet row group writer API.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5099.

# Are there any user-facing changes?
Adds five new methods to `AsyncArrowWriter` and one to `ArrowWriter`:
- `flushed_row_groups`
- `in_progress_size`
- `in_progress_rows`
- `flush`
- `bytes_written` (to both)

It doesn't change or touch any existing functionality.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
