### PR TITLE
feat(object_store): Azure url signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ parquet/data.parquet
 justfile
 .prettierignore
 .env
+.editorconfig
 # local azurite file
 __azurite*
 __blobstorage__

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -177,7 +177,7 @@ impl<'a> AwsAuthorizer<'a> {
         request.headers_mut().insert(AUTH_HEADER, authorization_val);
     }
 
-    pub(crate) fn sign(&self, method: &Method, url: &mut Url, expires_in: Duration) {
+    pub(crate) fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
         let date = self.date.unwrap_or_else(Utc::now);
         let scope = self.scope(date);
 
@@ -212,7 +212,7 @@ impl<'a> AwsAuthorizer<'a> {
         let string_to_sign = self.string_to_sign(
             date,
             &scope,
-            method,
+            &method,
             url,
             &canonical_headers,
             &signed_headers,
@@ -766,7 +766,7 @@ mod tests {
         };
 
         let mut url = Url::parse("https://examplebucket.s3.amazonaws.com/test.txt").unwrap();
-        authorizer.sign(&Method::GET, &mut url, Duration::from_secs(86400));
+        authorizer.sign(Method::GET, &mut url, Duration::from_secs(86400));
 
         assert_eq!(
             url,

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -177,7 +177,7 @@ impl<'a> AwsAuthorizer<'a> {
         request.headers_mut().insert(AUTH_HEADER, authorization_val);
     }
 
-    pub(crate) fn sign(&self, method: Method, url: &mut Url, expires_in: Duration) {
+    pub(crate) fn sign(&self, method: &Method, url: &mut Url, expires_in: Duration) {
         let date = self.date.unwrap_or_else(Utc::now);
         let scope = self.scope(date);
 
@@ -212,7 +212,7 @@ impl<'a> AwsAuthorizer<'a> {
         let string_to_sign = self.string_to_sign(
             date,
             &scope,
-            &method,
+            method,
             url,
             &canonical_headers,
             &signed_headers,
@@ -766,7 +766,7 @@ mod tests {
         };
 
         let mut url = Url::parse("https://examplebucket.s3.amazonaws.com/test.txt").unwrap();
-        authorizer.sign(Method::GET, &mut url, Duration::from_secs(86400));
+        authorizer.sign(&Method::GET, &mut url, Duration::from_secs(86400));
 
         assert_eq!(
             url,

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -136,14 +136,14 @@ impl Signer for AmazonS3 {
     ///     .build()?;
     ///
     /// let url = s3.signed_url(
-    ///     Method::PUT,
+    ///     &Method::PUT,
     ///     &Path::from("some-folder/some-file.txt"),
     ///     Duration::from_secs(60 * 60)
     /// ).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    async fn signed_url(&self, method: Method, path: &Path, expires_in: Duration) -> Result<Url> {
+    async fn signed_url(&self, method: &Method, path: &Path, expires_in: Duration) -> Result<Url> {
         let credential = self.credentials().get_credential().await?;
         let authorizer = AwsAuthorizer::new(&credential, "s3", &self.client.config().region);
 

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -346,6 +346,7 @@ mod tests {
         rename_and_copy(&integration).await;
         stream_get(&integration).await;
         multipart(&integration, &integration).await;
+        signing(&integration).await;
 
         tagging(&integration, !config.disable_tagging, |p| {
             let client = Arc::clone(&integration.client);

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -136,14 +136,14 @@ impl Signer for AmazonS3 {
     ///     .build()?;
     ///
     /// let url = s3.signed_url(
-    ///     &Method::PUT,
+    ///     Method::PUT,
     ///     &Path::from("some-folder/some-file.txt"),
     ///     Duration::from_secs(60 * 60)
     /// ).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    async fn signed_url(&self, method: &Method, path: &Path, expires_in: Duration) -> Result<Url> {
+    async fn signed_url(&self, method: Method, path: &Path, expires_in: Duration) -> Result<Url> {
         let credential = self.credentials().get_credential().await?;
         let authorizer = AwsAuthorizer::new(&credential, "s3", &self.client.config().region);
 

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -376,6 +376,10 @@ impl AzureClient {
         Ok(response)
     }
 
+    /// Creat an AzureSigner for generating SAS tokens (pre-signed urls).
+    ///
+    /// Depending on the type of credential, this will either use the account key or a user delegation key.
+    /// Since delegation keys are acquired ad-hoc, the signer aloows for signing multiple urls with the same key.
     pub async fn signer(&self, expires_in: Duration) -> Result<AzureSigner> {
         let credential = self.get_credential().await?;
         let signed_start = chrono::Utc::now();

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -294,16 +294,8 @@ fn string_to_sign_sas(
     start: &DateTime<Utc>,
     end: &DateTime<Utc>,
 ) -> (String, String, String, String, String) {
-    let signed_resource = if u
-        .query()
-        .map(|q| q.contains("comp=list"))
-        .unwrap_or_default()
-    {
-        "c"
-    } else {
-        "b"
-    }
-    .to_string();
+    // NOTE: for now only blob signing is supported.
+    let signed_resource = "b".to_string();
 
     // https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#permissions-for-a-directory-container-or-blob
     let signed_permissions = match *method {
@@ -1052,7 +1044,7 @@ mod tests {
         integration.put(&path, data.clone()).await.unwrap();
 
         let signed = integration
-            .signed_url(&Method::GET, &path, Duration::from_secs(60))
+            .signed_url(Method::GET, &path, Duration::from_secs(60))
             .await
             .unwrap();
 

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -170,7 +170,7 @@ impl AzureSigner {
         let (str_to_sign, query_pairs) = match &self.delegation_key {
             Some(delegation_key) => string_to_sign_user_delegation_sas(
                 url,
-                &method,
+                method,
                 &self.account,
                 &self.start,
                 &self.end,

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -909,7 +909,6 @@ impl CredentialProvider for AzureCliCredential {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
     use futures::executor::block_on;
     use hyper::body::to_bytes;
     use hyper::{Body, Response};
@@ -917,11 +916,7 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::*;
-    use crate::azure::MicrosoftAzureBuilder;
     use crate::client::mock_server::MockServer;
-    use crate::path::Path;
-    use crate::signer::Signer;
-    use crate::ObjectStore;
 
     #[tokio::test]
     async fn test_managed_identity() {
@@ -1029,28 +1024,5 @@ mod tests {
             token.token.as_ref(),
             &AzureCredential::BearerToken("TOKEN".into())
         );
-    }
-
-    #[tokio::test]
-    async fn test_service_sas() {
-        crate::test_util::maybe_skip_integration!();
-        let integration = MicrosoftAzureBuilder::from_env()
-            .with_container_name("test-bucket")
-            .build()
-            .unwrap();
-
-        let data = Bytes::from("hello world");
-        let path = Path::from("file.txt");
-        integration.put(&path, data.clone()).await.unwrap();
-
-        let signed = integration
-            .signed_url(Method::GET, &path, Duration::from_secs(60))
-            .await
-            .unwrap();
-
-        let resp = reqwest::get(signed).await.unwrap();
-        let loaded = resp.bytes().await.unwrap();
-
-        assert_eq!(data, loaded);
     }
 }

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -161,23 +161,23 @@ impl Signer for MicrosoftAzure {
     ///     .build()?;
     ///
     /// let url = azure.signed_url(
-    ///     &Method::PUT,
+    ///     Method::PUT,
     ///     &Path::from("some-folder/some-file.txt"),
     ///     Duration::from_secs(60 * 60)
     /// ).await?;
     /// #     Ok(())
     /// # }
     /// ```
-    async fn signed_url(&self, method: &Method, path: &Path, expires_in: Duration) -> Result<Url> {
+    async fn signed_url(&self, method: Method, path: &Path, expires_in: Duration) -> Result<Url> {
         let mut url = self.path_url(path);
         let signer = self.client.signer(expires_in).await?;
-        signer.sign(method, &mut url)?;
+        signer.sign(&method, &mut url)?;
         Ok(url)
     }
 
     async fn signed_urls(
         &self,
-        method: &Method,
+        method: Method,
         paths: &[Path],
         expires_in: Duration,
     ) -> Result<Vec<Url>> {
@@ -185,7 +185,7 @@ impl Signer for MicrosoftAzure {
         let signer = self.client.signer(expires_in).await?;
         for path in paths {
             let mut url = self.path_url(path);
-            signer.sign(method, &mut url)?;
+            signer.sign(&method, &mut url)?;
             urls.push(url);
         }
         Ok(urls)
@@ -297,7 +297,7 @@ mod tests {
         integration.put(&path, data.clone()).await.unwrap();
 
         let signed = integration
-            .signed_url(&Method::GET, &path, Duration::from_secs(60))
+            .signed_url(Method::GET, &path, Duration::from_secs(60))
             .await
             .unwrap();
 

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -266,6 +266,7 @@ mod tests {
         stream_get(&integration).await;
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
+        signing(&integration).await;
 
         let validate = !integration.client.config().disable_tagging;
         tagging(&integration, validate, |p| {

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -302,7 +302,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(key.value.len() > 0);
+        assert!(!key.value.is_empty());
         assert_eq!(key.signed_tid, tenant_id);
 
         let data = Bytes::from("hello world");

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -185,7 +185,7 @@ impl Signer for MicrosoftAzure {
         let signer = self.client.signer(expires_in).await?;
         for path in paths {
             let mut url = self.path_url(path);
-            signer.sign(&method, &mut url)?;
+            signer.sign(method, &mut url)?;
             urls.push(url);
         }
         Ok(urls)

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1886,7 +1886,7 @@ mod tests {
 
         // We can abort an in-progress write
         let (upload_id, mut writer) = storage.put_multipart(&location).await.unwrap();
-        if let Some(chunk) = data.get(0) {
+        if let Some(chunk) = data.first() {
             writer.write_all(chunk).await.unwrap();
             let _ = writer.write(chunk).await.unwrap();
         }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -2115,6 +2115,29 @@ mod tests {
         assert_eq!(meta.size, chunk_size * 2);
     }
 
+    #[cfg(any(feature = "azure", feature = "aws"))]
+    pub(crate) async fn signing<T>(integration: &T)
+    where
+        T: ObjectStore + crate::signer::Signer,
+    {
+        use reqwest::Method;
+        use std::time::Duration;
+
+        let data = Bytes::from("hello world");
+        let path = Path::from("file.txt");
+        integration.put(&path, data.clone()).await.unwrap();
+
+        let signed = integration
+            .signed_url(Method::GET, &path, Duration::from_secs(60))
+            .await
+            .unwrap();
+
+        let resp = reqwest::get(signed).await.unwrap();
+        let loaded = resp.bytes().await.unwrap();
+
+        assert_eq!(data, loaded);
+    }
+
     #[cfg(any(feature = "aws", feature = "azure"))]
     pub(crate) async fn tagging<F, Fut>(storage: &dyn ObjectStore, validate: bool, get_tags: F)
     where

--- a/object_store/src/signer.rs
+++ b/object_store/src/signer.rs
@@ -30,5 +30,21 @@ pub trait Signer: Send + Sync + fmt::Debug + 'static {
     /// the URL should be valid, return a signed [`Url`] created with the object store
     /// implementation's credentials such that the URL can be handed to something that doesn't have
     /// access to the object store's credentials, to allow limited access to the object store.
-    async fn signed_url(&self, method: Method, path: &Path, expires_in: Duration) -> Result<Url>;
+    async fn signed_url(&self, method: &Method, path: &Path, expires_in: Duration) -> Result<Url>;
+
+    /// Generate signed urls for multiple paths.
+    ///
+    /// See [`Signer::signed_url`] for more details.
+    async fn signed_urls(
+        &self,
+        method: &Method,
+        paths: &[Path],
+        expires_in: Duration,
+    ) -> Result<Vec<Url>> {
+        let mut urls = Vec::with_capacity(paths.len());
+        for path in paths {
+            urls.push(self.signed_url(method, path, expires_in).await?);
+        }
+        Ok(urls)
+    }
 }

--- a/object_store/src/signer.rs
+++ b/object_store/src/signer.rs
@@ -30,20 +30,20 @@ pub trait Signer: Send + Sync + fmt::Debug + 'static {
     /// the URL should be valid, return a signed [`Url`] created with the object store
     /// implementation's credentials such that the URL can be handed to something that doesn't have
     /// access to the object store's credentials, to allow limited access to the object store.
-    async fn signed_url(&self, method: &Method, path: &Path, expires_in: Duration) -> Result<Url>;
+    async fn signed_url(&self, method: Method, path: &Path, expires_in: Duration) -> Result<Url>;
 
     /// Generate signed urls for multiple paths.
     ///
     /// See [`Signer::signed_url`] for more details.
     async fn signed_urls(
         &self,
-        method: &Method,
+        method: Method,
         paths: &[Path],
         expires_in: Duration,
     ) -> Result<Vec<Url>> {
         let mut urls = Vec::with_capacity(paths.len());
         for path in paths {
-            urls.push(self.signed_url(method, path, expires_in).await?);
+            urls.push(self.signed_url(method.clone(), path, expires_in).await?);
         }
         Ok(urls)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5232

# Rationale for this change

see issue.

# What changes are included in this PR?

Moves request authorization to a new `AzureAuthorizer`, analogous to the AWS implementation. Some structs are made public, such that they can be used independently. Specifically, when going via the `Signer` trait, in each request a new user delegation key is requested. If users want to sign multiple URLs, this is quite inefficient. Thus the `AzureSigner` as well as the new `get_user_delegation_key` method are  `pub`, so users can also cover more elaborate signing scenarios efficiently.

# Are there any user-facing changes?

Users can now sign urls also for azure. Supported methods are via access key, or via identity auth with a user delegation key.

