### PR TITLE
docs(object_store): Mention `with_allow_http` in docs of `with_endpoint`

### DIFF
--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -595,6 +595,9 @@ impl AmazonS3Builder {
     /// i.e. if `virtual_hosted_style_request` is set to true then `endpoint`
     /// should have the bucket name included.
     ///
+    /// By default, only HTTPS schemes are enabled. To connect to an HTTP endpoint, enable
+    /// [`Self::with_allow_http`].
+    ///
     /// [region endpoint]: https://docs.aws.amazon.com/general/latest/gr/s3.html
     pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -687,6 +687,9 @@ impl MicrosoftAzureBuilder {
     /// Override the endpoint used to communicate with blob storage
     ///
     /// Defaults to `https://{account}.blob.core.windows.net`
+    ///
+    /// By default, only HTTPS schemes are enabled. To connect to an HTTP endpoint, enable
+    /// [`Self::with_allow_http`].
     pub fn with_endpoint(mut self, endpoint: String) -> Self {
         self.endpoint = Some(endpoint);
         self


### PR DESCRIPTION
# Which issue does this PR close?


Part of https://github.com/apache/arrow-rs/issues/5273

# Rationale for this change

Enhance the usability of `with_endpoint`.

# What changes are included in this PR?

Add docs for `with_endpoint`

# Are there any user-facing changes?

No, docs only.
