### PR TITLE
Extend string parsing support for Date32

### DIFF
--- a/arrow-cast/src/cast.rs
+++ b/arrow-cast/src/cast.rs
@@ -7482,9 +7482,9 @@ mod tests {
 
         let a = StringArray::from(vec![
             "2000-01-01",          // valid date with leading 0s
+            "2000-01-01T12:00:00", // valid datetime, will throw away the time part
             "2000-2-2",            // valid date without leading 0s
             "2000-00-00",          // invalid month and day
-            "2000-01-01T12:00:00", // date + time is invalid
             "2000",                // just a year is invalid
         ]);
         let array = Arc::new(a) as ArrayRef;
@@ -7500,17 +7500,19 @@ mod tests {
         assert!(c.is_valid(0)); // "2000-01-01"
         assert_eq!(date_value, c.value(0));
 
+        assert!(c.is_valid(1)); // "2000-01-01T12:00:00"
+        assert_eq!(date_value, c.value(1));
+
         let date_value = since(
             NaiveDate::from_ymd_opt(2000, 2, 2).unwrap(),
             from_ymd(1970, 1, 1).unwrap(),
         )
         .num_days() as i32;
-        assert!(c.is_valid(1)); // "2000-2-2"
-        assert_eq!(date_value, c.value(1));
+        assert!(c.is_valid(2)); // "2000-2-2"
+        assert_eq!(date_value, c.value(2));
 
         // test invalid inputs
-        assert!(!c.is_valid(2)); // "2000-00-00"
-        assert!(!c.is_valid(3)); // "2000-01-01T12:00:00"
+        assert!(!c.is_valid(3)); // "2000-00-00"
         assert!(!c.is_valid(4)); // "2000"
     }
 


### PR DESCRIPTION
This now includes the timestamp format besides the plain date format.

# Which issue does this PR close?

Closes #5280.

# Rationale for this change
 
PG supports casting a valid timestamp string into a date (by throwing away the time part).

# What changes are included in this PR?

Fallback to parsing a datetime if the string length is too long for just a date.

# Are there any user-facing changes?

None, except additional format support when casting to Date32.
