### PR TITLE
Result into error in case of endianness mismatches

### DIFF
--- a/arrow-ipc/src/gen/Schema.rs
+++ b/arrow-ipc/src/gen/Schema.rs
@@ -1039,6 +1039,15 @@ impl Endianness {
             _ => None,
         }
     }
+
+    /// Returns true if the endianness of the source system matches the endianness of the target system.
+    pub fn equals_to_target_endianness(self) -> bool {
+        match self {
+            Self::Little => cfg!(target_endian = "little"),
+            Self::Big => cfg!(target_endian = "big"),
+            _ => false,
+        }
+    }
 }
 impl core::fmt::Debug for Endianness {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -790,6 +790,12 @@ impl FileReaderBuilder {
         let total_blocks = blocks.len();
 
         let ipc_schema = footer.schema().unwrap();
+        if !ipc_schema.endianness().equals_to_target_endianness() {
+            return Err(ArrowError::IpcError(
+                "the endianness of the source system does not match the endianness of the target system.".to_owned()
+            ));
+        }
+
         let schema = crate::convert::fb_to_schema(ipc_schema);
 
         let mut custom_metadata = HashMap::new();


### PR DESCRIPTION
This commit implements the Byte Order (Endianness) recommendations we can read from the Apache Arrow official specification (quoted here):

> _At first we will return an error when trying to read a Schema
> with an endianness that does not match the underlying system._

Closes:  #3459
Closes: #859
