### PR TITLE
Update IOx links

### DIFF
--- a/object_store/README.md
+++ b/object_store/README.md
@@ -20,7 +20,7 @@
 # Rust Object Store
 
 A focused, easy to use, idiomatic, high performance, `async` object
-store library interacting with object stores.
+store library for interacting with object stores.
 
 Using this crate, the same binary and code can easily run in multiple
 clouds and local test environments, via a simple runtime configuration
@@ -33,7 +33,7 @@ change. Supported object stores include:
 * Memory
 * Custom implementations
 
-Originally developed for [InfluxDB IOx](https://github.com/influxdata/influxdb_iox/) and later split out and donated to [Apache Arrow](https://arrow.apache.org/).
+Originally developed by [InfluxData](https://www.influxdata.com/) and later donated to [Apache Arrow](https://arrow.apache.org/).
 
 See [docs.rs](https://docs.rs/object_store) for usage instructions
 

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -51,11 +51,11 @@
 //!
 //! 5. Small dependency footprint, depending on only a small number of common crates
 //!
-//! Originally developed for [InfluxDB IOx] and subsequently donated
+//! Originally developed by [InfluxData] and subsequently donated
 //! to [Apache Arrow].
 //!
 //! [Apache Arrow]: https://arrow.apache.org/
-//! [InfluxDB IOx]: https://github.com/influxdata/influxdb_iox/
+//! [InfluxData]: https://www.influxdata.com/
 //! [crates.io]: https://github.com/rust-lang/crates.io
 //! [ACID]: https://en.wikipedia.org/wiki/ACID
 //! [S3]: https://aws.amazon.com/s3/


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5309.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The IOx repository is no longer public and so we can't link to it. I therefore updated the credits to link back to InfluxData as a whole. Whilst there is some IOx code in https://github.com/influxdata/influxdb it isn't being actively worked on in that repo, and so I don't think makes for the best advertisement.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
