### PR TITLE
Minor/Doc Expand FlightSqlServiceClient::handshake doc

### DIFF
--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -131,8 +131,10 @@ impl FlightSqlServiceClient<Channel> {
         self.get_flight_info_for_command(cmd).await
     }
 
-    /// Perform a `handshake` with the server, passing credentials and establishing a session
-    /// Returns arbitrary auth/handshake info binary blob
+    /// Perform a `handshake` with the server, passing credentials and establishing a session.
+    /// If the server returns an "authorization" header, it is automatically parsed and set as
+    /// a token for future requests. Any other data returned by the server in the handshake
+    /// response is returned as a binary blob.
     pub async fn handshake(&mut self, username: &str, password: &str) -> Result<Bytes, ArrowError> {
         let cmd = HandshakeRequest {
             protocol_version: 0,

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -132,6 +132,7 @@ impl FlightSqlServiceClient<Channel> {
     }
 
     /// Perform a `handshake` with the server, passing credentials and establishing a session.
+    ///
     /// If the server returns an "authorization" header, it is automatically parsed and set as
     /// a token for future requests. Any other data returned by the server in the handshake
     /// response is returned as a binary blob.


### PR DESCRIPTION
# Which issue does this PR close?

na

# Rationale for this change
 
I had previously assumed that `FlightSqlServiceClient::handshake` returned the bearer token and it needed to be parsed and passed to FlightSqlServiceClient::set_token subsequently. After looking more closely at the source code, I realized this was incorrect.

# What changes are included in this PR?

Clarifies the documentation for `FlightSqlServiceClient::handshake` so it is clear that the token is automatically set.

# Are there any user-facing changes?

no