### PR TITLE
Add ListBuilder::with_field to support non nullable list fields (#5330)

### DIFF
--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -765,8 +765,8 @@ mod tests {
     }
 
     #[test]
-    fn test_non_nullable_list() {
-        let field = Arc::new(Field::new("item", DataType::Int32, false));
+    fn test_with_field() {
+        let field = Arc::new(Field::new("bar", DataType::Int32, false));
         let mut builder = ListBuilder::new(Int32Builder::new()).with_field(field.clone());
         builder.append_value([Some(1), Some(2), Some(3)]);
         builder.append_null(); // This is fine as nullability refers to nullability of values

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -124,7 +124,8 @@ impl<OffsetSize: OffsetSizeTrait, T: ArrayBuilder> GenericListBuilder<OffsetSize
     ///
     /// By default a nullable field is created with the name `item`
     ///
-    /// Note: [`Self::finish`] and [`Self::finish_cloned`] will panic if the provided data type does not match `T`
+    /// Note: [`Self::finish`] and [`Self::finish_cloned`] will panic if the
+    /// field's data type does not match that of `T`
     pub fn with_field(self, field: impl Into<FieldRef>) -> Self {
         Self {
             field: Some(field.into()),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5330

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This lets users override the `Field` used by `ListBuilder`, allowing overriding the nullability, name, and other metadata. It also switches over to using the safer `ListArray` constructors.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
