### PR TITLE
fix: Return an error on type mismatch rather than panic (#4995)

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -183,7 +183,9 @@ impl<W: Write + Send> ArrowWriter<W> {
     ///
     /// If this would cause the current row group to exceed [`WriterProperties::max_row_group_size`]
     /// rows, the contents of `batch` will be written to one or more row groups such that all but
-    /// the final row group in the file contain [`WriterProperties::max_row_group_size`] rows
+    /// the final row group in the file contain [`WriterProperties::max_row_group_size`] rows.
+    ///
+    /// This will fail if the `batch`'s schema does not match the writer's schema.
     pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         if batch.num_rows() == 0 {
             return Ok(());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4995.

# Rationale for this change
 
An error with a nice message is better for users than a panic in this case.

# What changes are included in this PR?

I replaced an assertion with returning an error that includes the field name.

# Are there any user-facing changes?

Previously, this code would panic if given unsupported inputs-- now it returns an error. 

I added a bit of documentation on `ArrowWrite::write` that's where I would look for it, that explains what a user might do at that level that would return this error from the inner function.
