### PR TITLE
Track the size of custom allocations for use via Array::get_buffer_memory_size

### DIFF
--- a/arrow-buffer/src/alloc/mod.rs
+++ b/arrow-buffer/src/alloc/mod.rs
@@ -38,7 +38,9 @@ pub(crate) enum Deallocation {
     Standard(Layout),
     /// An allocation from an external source like the FFI interface
     /// Deallocation will happen on `Allocation::drop`
-    Custom(Arc<dyn Allocation>),
+    /// The size of the allocation is tracked here separately only
+    /// for memory usage reporting via `Array::get_buffer_memory_size`
+    Custom(Arc<dyn Allocation>, usize),
 }
 
 impl Debug for Deallocation {
@@ -47,9 +49,22 @@ impl Debug for Deallocation {
             Deallocation::Standard(layout) => {
                 write!(f, "Deallocation::Standard {layout:?}")
             }
-            Deallocation::Custom(_) => {
-                write!(f, "Deallocation::Custom {{ capacity: unknown }}")
+            Deallocation::Custom(_, size) => {
+                write!(f, "Deallocation::Custom {{ capacity: {size} }}")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::alloc::Deallocation;
+
+    #[test]
+    fn test_size_of_deallocation() {
+        assert_eq!(
+            std::mem::size_of::<Deallocation>(),
+            3 * std::mem::size_of::<usize>()
+        );
     }
 }

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -124,7 +124,7 @@ impl Buffer {
         len: usize,
         owner: Arc<dyn Allocation>,
     ) -> Self {
-        Buffer::build_with_arguments(ptr, len, Deallocation::Custom(owner))
+        Buffer::build_with_arguments(ptr, len, Deallocation::Custom(owner, len))
     }
 
     /// Auxiliary method to create a new Buffer

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -134,7 +134,7 @@ impl<T: ArrowNativeType> From<Buffer> for ScalarBuffer<T> {
                 is_aligned,
                 "Memory pointer is not aligned with the specified scalar type"
             ),
-            Deallocation::Custom(_) =>
+            Deallocation::Custom(_, _) =>
                 assert!(is_aligned, "Memory pointer from external source (e.g, FFI) is not aligned with the specified scalar type. Before importing buffer through FFI, please make sure the allocation is aligned."),
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5346.

# Rationale for this change


 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The size of custom allocations previously was always reported as 0. Users might have relied on that, or if they kept track of custom allocations themselves, would now get reports of twice the memory size.

This also affected the reported size for arrays created via FFI.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
