### PR TITLE
Exclude questions from changelog

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -24,5 +24,5 @@ add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["
 #pull-requests=false
 # so that the component is shown associated with the issue
 issue-line-labels=arrow,parquet,arrow-flight
-exclude-labels=development-process,invalid,object-store
+exclude-labels=development-process,invalid,object-store,question
 breaking_labels=api-change

--- a/object_store/.github_changelog_generator
+++ b/object_store/.github_changelog_generator
@@ -23,5 +23,5 @@ add-sections={"documentation":{"prefix":"**Documentation updates:**","labels":["
 # so that the component is shown associated with the issue
 issue-line-labels=object-store
 # skip non object_store issues
-exclude-labels=development-process,invalid,arrow,parquet,arrow-flight,parquet-derive
+exclude-labels=development-process,invalid,arrow,parquet,arrow-flight,parquet-derive,question
 breaking_labels=api-change


### PR DESCRIPTION
People increasingly file questions as issues, which is great, but we should exclude these from the changelogs. I have historically been doing this manually, but automating this is simple enough