### PR TITLE
Make ArrayBuilder also Sync

### DIFF
--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -232,7 +232,7 @@ use std::any::Any;
 ///     "🍎"
 /// );
 /// ```
-pub trait ArrayBuilder: Any + Send {
+pub trait ArrayBuilder: Any + Send + Sync {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize;
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes #5344.

# Rationale for this change
ArrayBuilder has methods that take `&self`, e.g., [`is_empty`](https://docs.rs/arrow/latest/arrow/array/trait.ArrayBuilder.html#method.is_empty).

# Are there any user-facing changes?
There should be no breaking changes.
