### PR TITLE
Add example of converting RecordBatches to JSON objects

### DIFF
--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -86,12 +86,13 @@
 //! # use std::sync::Arc;
 //! # use arrow_array::{Int32Array, RecordBatch};
 //! # use arrow_schema::{DataType, Field, Schema};
+//! # use serde_json::{Map, Value};
 //!
 //! let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 //! let a = Int32Array::from(vec![1, 2, 3]);
 //! let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
 //!
-//! todo!("How do we do this?");
+//! let json_rows: Vec<Map<String, Value>> = todo!("How do we do this?");
 //! // let json_rows = arrow_json::writer::record_batches_to_json_rows(&[&batch]).unwrap();
 //! assert_eq!(
 //!     serde_json::Value::Object(json_rows[1].clone()),

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -78,9 +78,8 @@
 //! ## Writing to [serde_json] JSON Objects
 //!
 //! To serialize [`RecordBatch`]es into an array of
-//! [JSON](https://docs.serde.rs/serde_json/) objects, use the [RawValue] api
-//!
-//! [RawValue]: https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html
+//! [JSON](https://docs.serde.rs/serde_json/) objects you can reparse the resulting JSON string.
+//! Note that this is less efficient than using the `Writer` API.
 //!
 //! ```
 //! # use std::sync::Arc;
@@ -92,17 +91,22 @@
 //! let a = Int32Array::from(vec![1, 2, 3]);
 //! let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
 //!
-//! let json_rows: Vec<Map<String, Value>> = todo!("How do we do this?");
-//! // let json_rows = arrow_json::writer::record_batches_to_json_rows(&[&batch]).unwrap();
+//! // Write the record batch out as a JSON array
+//! let json_string = {
+//!   let buf = Vec::new();
+//!   let mut writer = arrow_json::ArrayWriter::new(buf);
+//!   writer.write_batches(&vec![&batch]).unwrap();
+//!   writer.finish().unwrap();
+//!   String::from_utf8(writer.into_inner()).unwrap()
+//! };
+//!
+//! // Parse the string using serde_json
+//! let json_rows: Vec<Map<String, Value>> = serde_json::from_str(&json_string).unwrap();
 //! assert_eq!(
 //!     serde_json::Value::Object(json_rows[1].clone()),
 //!     serde_json::json!({"a": 2}),
 //! );
 //! ```
-//!
-//!
-//!
-//!
 mod encoder;
 
 use std::iter;

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -74,7 +74,34 @@
 //! [`LineDelimitedWriter`] and [`ArrayWriter`] will omit writing keys with null values.
 //! In order to explicitly write null values for keys, configure a custom [`Writer`] by
 //! using a [`WriterBuilder`] to construct a [`Writer`].
-
+//!
+//! ## Writing to [serde_json] JSON Objects
+//!
+//! To serialize [`RecordBatch`]es into an array of
+//! [JSON](https://docs.serde.rs/serde_json/) objects, use the [RawValue] api
+//!
+//! [RawValue]: https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html
+//!
+//! ```
+//! # use std::sync::Arc;
+//! # use arrow_array::{Int32Array, RecordBatch};
+//! # use arrow_schema::{DataType, Field, Schema};
+//!
+//! let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+//! let a = Int32Array::from(vec![1, 2, 3]);
+//! let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
+//!
+//! todo!("How do we do this?");
+//! // let json_rows = arrow_json::writer::record_batches_to_json_rows(&[&batch]).unwrap();
+//! assert_eq!(
+//!     serde_json::Value::Object(json_rows[1].clone()),
+//!     serde_json::json!({"a": 2}),
+//! );
+//! ```
+//!
+//!
+//!
+//!
 mod encoder;
 
 use std::iter;

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -85,23 +85,20 @@
 //! # use std::sync::Arc;
 //! # use arrow_array::{Int32Array, RecordBatch};
 //! # use arrow_schema::{DataType, Field, Schema};
-//! # use serde_json::{Map, Value};
-//!
 //! let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 //! let a = Int32Array::from(vec![1, 2, 3]);
 //! let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
 //!
-//! // Write the record batch out as a JSON array
-//! let json_string = {
-//!   let buf = Vec::new();
-//!   let mut writer = arrow_json::ArrayWriter::new(buf);
-//!   writer.write_batches(&vec![&batch]).unwrap();
-//!   writer.finish().unwrap();
-//!   String::from_utf8(writer.into_inner()).unwrap()
-//! };
+//! // Write the record batch out as json bytes (string)
+//! let buf = Vec::new();
+//! let mut writer = arrow_json::ArrayWriter::new(buf);
+//! writer.write_batches(&vec![&batch]).unwrap();
+//! writer.finish().unwrap();
+//! let json_data = writer.into_inner();
 //!
 //! // Parse the string using serde_json
-//! let json_rows: Vec<Map<String, Value>> = serde_json::from_str(&json_string).unwrap();
+//! use serde_json::{Map, Value};
+//! let json_rows: Vec<Map<String, Value>> = serde_json::from_reader(json_data.as_slice()).unwrap();
 //! assert_eq!(
 //!     serde_json::Value::Object(json_rows[1].clone()),
 //!     serde_json::json!({"a": 2}),


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/pull/5318

# Rationale for this change
 
@tustvold deprecated `record_batches_to_json_rows` in https://github.com/apache/arrow-rs/pull/5318 but there are at least two of us (https://github.com/apache/arrow-rs/pull/5318/files#r1460432887) who are not quite sure how to use the existing APIs or suggested APIs to achieve the same results. 

While converting from arrow --> JSON objects may not be ideal for certain usecases, I think it is a common request so we shouldn't cause users trouble if they were using it

Thus I think adding an example to show that https://github.com/apache/arrow-rs/pull/5318 doesn't regress functionality is warranted 

# What changes are included in this PR?
Add a doc example about how to convert `RecordBatch`es to `serde_json` objects


# Are there any user-facing changes?
Better examples

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
