### PR TITLE
docs(object-store): add warning to flush

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -551,6 +551,15 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// writer fails or panics, you must call [ObjectStore::abort_multipart]
     /// to clean up partially written data.
     ///
+    /// <div class="warning">
+    /// If there is point where a significant gap in time (> ~30s) can occur between
+    /// successive write calls, it is recommended to await `flush()` first.
+    /// These gaps can include times where the function returns control to the
+    /// caller while keeping the writer open. If `flush` is not called, futures
+    /// for in-flight requests may be left unpolled long enough for the requests
+    /// to time out, causing the write to fail.
+    /// </div>
+    ///
     /// For applications requiring fine-grained control of multipart uploads
     /// see [`MultiPartStore`], although note that this interface cannot be
     /// supported by all [`ObjectStore`] backends.

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -552,8 +552,8 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// to clean up partially written data.
     ///
     /// <div class="warning">
-    /// If there is point where a significant gap in time (> ~30s) can occur between
-    /// successive write calls, it is recommended to await `flush()` first.
+    /// It is recommended applications wait for any in-flight requests to complete by calling `flush`, if 
+    /// there may be a significant gap in time (> ~30s) before the next write.
     /// These gaps can include times where the function returns control to the
     /// caller while keeping the writer open. If `flush` is not called, futures
     /// for in-flight requests may be left unpolled long enough for the requests

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -552,7 +552,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// to clean up partially written data.
     ///
     /// <div class="warning">
-    /// It is recommended applications wait for any in-flight requests to complete by calling `flush`, if 
+    /// It is recommended applications wait for any in-flight requests to complete by calling `flush`, if
     /// there may be a significant gap in time (> ~30s) before the next write.
     /// These gaps can include times where the function returns control to the
     /// caller while keeping the writer open. If `flush` is not called, futures


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5366.

# Rationale for this change
 
As explained in the issue, there is a serious footgun in multi-part write that's worth documenting.

# What changes are included in this PR?

Add a warning to the docs for `put_multipart`

# Are there any user-facing changes?


This is just a documentation change.