### PR TITLE
Return error instead of panic when reading invalid Parquet metadata

### DIFF
--- a/parquet/regen.sh
+++ b/parquet/regen.sh
@@ -21,15 +21,19 @@ REVISION=46cc3a0647d301bb9579ca8dd2cc356caf2a72d2
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
-docker run -v $SOURCE_DIR:/thrift/src -it archlinux pacman -Sy --noconfirm thrift  && \
+docker run -v $SOURCE_DIR:/thrift -it archlinux /bin/bash -c "\
+  pacman -Sy --noconfirm wget thrift && \
   wget https://raw.githubusercontent.com/apache/parquet-format/$REVISION/src/main/thrift/parquet.thrift -O /tmp/parquet.thrift && \
   thrift --gen rs /tmp/parquet.thrift && \
-  echo "Removing TProcessor" && \
+  echo 'Removing TProcessor' && \
   sed -i '/use thrift::server::TProcessor;/d' parquet.rs && \
-  echo "Replacing TSerializable" && \
+  echo 'Replacing TSerializable' && \
   sed -i 's/impl TSerializable for/impl crate::thrift::TSerializable for/g' parquet.rs && \
-  echo "Rewriting write_to_out_protocol" && \
+  echo 'Rewriting write_to_out_protocol' && \
   sed -i 's/fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol)/fn write_to_out_protocol<T: TOutputProtocol>(\&self, o_prot: \&mut T)/g' parquet.rs && \
-  echo "Rewriting read_from_in_protocol" && \
+  echo 'Rewriting read_from_in_protocol' && \
   sed -i 's/fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol)/fn read_from_in_protocol<T: TInputProtocol>(i_prot: \&mut T)/g' parquet.rs && \
-  mv parquet.rs src/format.rs
+  echo 'Rewriting return value expectations' && \
+  sed -i 's/Ok(ret.expect(\"return value should have been constructed\"))/ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, \"return value should have been constructed\")))/g' parquet.rs && \
+  mv parquet.rs /thrift/src/format.rs
+  "

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1250,6 +1250,13 @@ mod tests {
     }
 
     #[test]
+    fn test_file_reader_invalid_metadata() {
+        let data = [255, 172, 1, 0, 50, 82, 65, 73, 1, 0, 0, 0, 169, 168, 168, 162, 87, 255, 16, 0, 0, 0, 80, 65, 82, 49];
+        let ret = SerializedFileReader::new(Bytes::copy_from_slice(&data));
+        assert_eq!(ret.err().unwrap().to_string(), "Parquet error: Could not parse metadata: bad data");
+    }
+
+    #[test]
     // Use java parquet-tools get below pageIndex info
     // !```
     // parquet-tools column-index ./data_index_bloom_encoding_stats.parquet

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1251,9 +1251,15 @@ mod tests {
 
     #[test]
     fn test_file_reader_invalid_metadata() {
-        let data = [255, 172, 1, 0, 50, 82, 65, 73, 1, 0, 0, 0, 169, 168, 168, 162, 87, 255, 16, 0, 0, 0, 80, 65, 82, 49];
+        let data = [
+            255, 172, 1, 0, 50, 82, 65, 73, 1, 0, 0, 0, 169, 168, 168, 162, 87, 255, 16, 0, 0, 0,
+            80, 65, 82, 49,
+        ];
         let ret = SerializedFileReader::new(Bytes::copy_from_slice(&data));
-        assert_eq!(ret.err().unwrap().to_string(), "Parquet error: Could not parse metadata: bad data");
+        assert_eq!(
+            ret.err().unwrap().to_string(),
+            "Parquet error: Could not parse metadata: bad data"
+        );
     }
 
     #[test]

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -4410,7 +4410,7 @@ impl crate::thrift::TSerializable for PageLocation {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OffsetIndex {
   /// PageLocations, ordered by increasing PageLocation.offset. It is required
-  /// that page_locations[i].first_row_index < page_locations[i+1].first_row_index.
+  /// that page_locations\[i\].first_row_index < page_locations\[i+1\].first_row_index.
   pub page_locations: Vec<PageLocation>,
 }
 
@@ -4476,20 +4476,20 @@ impl crate::thrift::TSerializable for OffsetIndex {
 //
 
 /// Description for ColumnIndex.
-/// Each <array-field>[i] refers to the page at OffsetIndex.page_locations[i]
+/// Each `<array-field>`\[i\] refers to the page at OffsetIndex.page_locations\[i\]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ColumnIndex {
   /// A list of Boolean values to determine the validity of the corresponding
   /// min and max values. If true, a page contains only null values, and writers
   /// have to set the corresponding entries in min_values and max_values to
-  /// byte[0], so that all lists have the same length. If false, the
+  /// byte\[0\], so that all lists have the same length. If false, the
   /// corresponding entries in min_values and max_values must be valid.
   pub null_pages: Vec<bool>,
   /// Two lists containing lower and upper bounds for the values of each page
   /// determined by the ColumnOrder of the column. These may be the actual
   /// minimum and maximum values found on a page, but can also be (more compact)
   /// values that do not exist on a page. For example, instead of storing ""Blart
-  /// Versenwald III", a writer may set min_values[i]="B", max_values[i]="C".
+  /// Versenwald III", a writer may set min_values\[i\]="B", max_values\[i\]="C".
   /// Such more compact values must still be valid values within the column's
   /// logical type. Readers must make sure that list entries are populated before
   /// using them by inspecting null_pages.
@@ -4497,7 +4497,7 @@ pub struct ColumnIndex {
   pub max_values: Vec<Vec<u8>>,
   /// Stores whether both min_values and max_values are ordered and if so, in
   /// which direction. This allows readers to perform binary searches in both
-  /// lists. Readers cannot assume that max_values[i] <= min_values[i+1], even
+  /// lists. Readers cannot assume that max_values\[i\] <= min_values\[i+1\], even
   /// if the lists are ordered.
   pub boundary_order: BoundaryOrder,
   /// A list containing the number of null values for each page *
@@ -4919,7 +4919,7 @@ pub struct FileMetaData {
   /// Optional key/value metadata *
   pub key_value_metadata: Option<Vec<KeyValue>>,
   /// String for application that wrote this file.  This should be in the format
-  /// <Application> version <App Version> (build <App Build Hash>).
+  /// `<Application>` version `<App Version>` (build `<App Build Hash>`).
   /// e.g. impala version 1.0 (build 6cf94d29b2b7115df4de2c06e2ab4326d721eb55)
   /// 
   pub created_by: Option<String>,

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -1369,7 +1369,7 @@ impl crate::thrift::TSerializable for TimeUnit {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -1851,7 +1851,7 @@ impl crate::thrift::TSerializable for LogicalType {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -2625,7 +2625,7 @@ impl crate::thrift::TSerializable for BloomFilterAlgorithm {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -2738,7 +2738,7 @@ impl crate::thrift::TSerializable for BloomFilterHash {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -2850,7 +2850,7 @@ impl crate::thrift::TSerializable for BloomFilterCompression {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -3846,7 +3846,7 @@ impl crate::thrift::TSerializable for ColumnCryptoMetaData {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -4300,7 +4300,7 @@ impl crate::thrift::TSerializable for ColumnOrder {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -4410,7 +4410,7 @@ impl crate::thrift::TSerializable for PageLocation {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OffsetIndex {
   /// PageLocations, ordered by increasing PageLocation.offset. It is required
-  /// that page_locations\[i\].first_row_index < page_locations\[i+1\].first_row_index.
+  /// that page_locations[i].first_row_index < page_locations[i+1].first_row_index.
   pub page_locations: Vec<PageLocation>,
 }
 
@@ -4476,20 +4476,20 @@ impl crate::thrift::TSerializable for OffsetIndex {
 //
 
 /// Description for ColumnIndex.
-/// Each `<array-field>`\[i\] refers to the page at OffsetIndex.page_locations\[i\]
+/// Each <array-field>[i] refers to the page at OffsetIndex.page_locations[i]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ColumnIndex {
   /// A list of Boolean values to determine the validity of the corresponding
   /// min and max values. If true, a page contains only null values, and writers
   /// have to set the corresponding entries in min_values and max_values to
-  /// byte\[0\], so that all lists have the same length. If false, the
+  /// byte[0], so that all lists have the same length. If false, the
   /// corresponding entries in min_values and max_values must be valid.
   pub null_pages: Vec<bool>,
   /// Two lists containing lower and upper bounds for the values of each page
   /// determined by the ColumnOrder of the column. These may be the actual
   /// minimum and maximum values found on a page, but can also be (more compact)
   /// values that do not exist on a page. For example, instead of storing ""Blart
-  /// Versenwald III", a writer may set min_values\[i\]="B", max_values\[i\]="C".
+  /// Versenwald III", a writer may set min_values[i]="B", max_values[i]="C".
   /// Such more compact values must still be valid values within the column's
   /// logical type. Readers must make sure that list entries are populated before
   /// using them by inspecting null_pages.
@@ -4497,7 +4497,7 @@ pub struct ColumnIndex {
   pub max_values: Vec<Vec<u8>>,
   /// Stores whether both min_values and max_values are ordered and if so, in
   /// which direction. This allows readers to perform binary searches in both
-  /// lists. Readers cannot assume that max_values\[i\] <= min_values\[i+1\], even
+  /// lists. Readers cannot assume that max_values[i] <= min_values[i+1], even
   /// if the lists are ordered.
   pub boundary_order: BoundaryOrder,
   /// A list containing the number of null values for each page *
@@ -4873,7 +4873,7 @@ impl crate::thrift::TSerializable for EncryptionAlgorithm {
         )
       )
     } else {
-      Ok(ret.expect("return value should have been constructed"))
+      ret.ok_or_else(|| thrift::Error::Protocol(ProtocolError::new(ProtocolErrorKind::InvalidData, "return value should have been constructed")))
     }
   }
   fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
@@ -4919,7 +4919,7 @@ pub struct FileMetaData {
   /// Optional key/value metadata *
   pub key_value_metadata: Option<Vec<KeyValue>>,
   /// String for application that wrote this file.  This should be in the format
-  /// `<Application>` version `<App Version>` (build `<App Build Hash>`).
+  /// <Application> version <App Version> (build <App Build Hash>).
   /// e.g. impala version 1.0 (build 6cf94d29b2b7115df4de2c06e2ab4326d721eb55)
   /// 
   pub created_by: Option<String>,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3279.

# Rationale for this change
 
The Parquet crate typically returns errors instead of panics when reading invalid files. There was a panic left in the code generated by the Thrift compiler, which this PR addresses.

# What changes are included in this PR?

I hit issues running regen.sh on WSL2: it looks like only the pacman command was run inside the archlinux container and the following commands were run outside of it. Not 100% sure, but wrapping all the command instead a bash command string fixed the issue for me.

# Are there any user-facing changes?

`SerializedFileReader::new()` returns errors when it used to panic.