### PR TITLE
Enable running arrow-array and arrow-arith with miri and avoid strict provenance warning

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -16,6 +16,5 @@ cargo miri test -p arrow-buffer
 cargo miri test -p arrow-data --features ffi
 cargo miri test -p arrow-schema --features ffi
 cargo miri test -p arrow-ord
-# inline assembly not supported by Miri
-# cargo miri test -p arrow-array
-# cargo miri test -p arrow-arith
+cargo miri test -p arrow-array
+cargo miri test -p arrow-arith

--- a/arrow-buffer/src/bigint/div.rs
+++ b/arrow-buffer/src/bigint/div.rs
@@ -189,7 +189,7 @@ fn div_rem_word(hi: u64, lo: u64, divisor: u64) -> (u64, u64) {
 
     // LLVM fails to use the div instruction as it is not able to prove
     // that hi < divisor, and therefore the result will fit into 64-bits
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", not(miri)))]
     unsafe {
         let mut quot = lo;
         let mut rem = hi;
@@ -202,7 +202,7 @@ fn div_rem_word(hi: u64, lo: u64, divisor: u64) -> (u64, u64) {
         );
         (quot, rem)
     }
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(any(not(target_arch = "x86_64"), miri))]
     {
         let x = (u128::from(hi) << 64) + u128::from(lo);
         let y = u128::from(divisor);

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -480,7 +480,15 @@ fn dangling_ptr() -> NonNull<u8> {
     // SAFETY: ALIGNMENT is a non-zero usize which is then casted
     // to a *mut T. Therefore, `ptr` is not null and the conditions for
     // calling new_unchecked() are respected.
-    unsafe { NonNull::new_unchecked(ALIGNMENT as *mut u8) }
+    #[cfg(miri)]
+    {
+        // Since miri implies a nightly rust version we can use the unstable strict_provenance feature
+        unsafe { NonNull::new_unchecked(std::ptr::invalid_mut(ALIGNMENT)) }
+    }
+    #[cfg(not(miri))]
+    {
+        unsafe { NonNull::new_unchecked(ALIGNMENT as *mut u8) }
+    }
 }
 
 impl<A: ArrowNativeType> Extend<A> for MutableBuffer {

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -17,6 +17,9 @@
 
 //! Low-level buffer abstractions for [Apache Arrow Rust](https://docs.rs/arrow)
 
+// used by [`buffer::mutable::dangling_ptr`]
+#![cfg_attr(miri, feature(strict_provenance))]
+
 pub mod alloc;
 pub mod buffer;
 pub use buffer::*;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Noticed this while looking into #614, fixes for parquet crate will be done in a separate PR.

# Rationale for this change

 

# What changes are included in this PR?

 - big integer division can simply use the fallback logic when running with miri
 - since miri implies a nightly rust version, we can use the unstable `strict-provenance` feature and avoid a warning when creating buffers with zero capacity

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
