### PR TITLE
Improve like kernel by ~2%

### DIFF
--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -42,3 +42,4 @@ arrow-select = { workspace = true }
 regex = { version = "1.7.0", default-features = false, features = ["std", "unicode", "perf"] }
 regex-syntax = { version = "0.8.0", default-features = false, features = ["unicode"] }
 num = { version = "0.4", default-features = false, features = ["std"] }
+memchr = "2.7.1"

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -17,6 +17,7 @@
 
 use arrow_array::{BooleanArray, GenericStringArray, OffsetSizeTrait};
 use arrow_schema::ArrowError;
+use memchr::memchr2;
 use regex::{Regex, RegexBuilder};
 
 /// A string based predicate
@@ -39,19 +40,19 @@ pub enum Predicate<'a> {
 impl<'a> Predicate<'a> {
     /// Create a predicate for the given like pattern
     pub fn like(pattern: &'a str) -> Result<Self, ArrowError> {
-        if !pattern.contains(is_like_pattern) {
+        if !contains_like_pattern_memchr(pattern) {
             Ok(Self::Eq(pattern))
         } else if pattern.ends_with('%')
             && !pattern.ends_with("\\%")
-            && !pattern[..pattern.len() - 1].contains(is_like_pattern)
+            && !contains_like_pattern_memchr(&pattern[..pattern.len() - 1])
         {
             Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
-        } else if pattern.starts_with('%') && !pattern[1..].contains(is_like_pattern) {
+        } else if pattern.starts_with('%') && !contains_like_pattern_memchr(&pattern[1..]) {
             Ok(Self::EndsWith(&pattern[1..]))
         } else if pattern.starts_with('%')
             && pattern.ends_with('%')
             && !pattern.ends_with("\\%")
-            && !pattern[1..pattern.len() - 1].contains(is_like_pattern)
+            && !contains_like_pattern_memchr(&pattern[1..pattern.len() - 1])
         {
             Ok(Self::Contains(&pattern[1..pattern.len() - 1]))
         } else {
@@ -62,14 +63,14 @@ impl<'a> Predicate<'a> {
     /// Create a predicate for the given ilike pattern
     pub fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
         if is_ascii && pattern.is_ascii() {
-            if !pattern.contains(is_like_pattern) {
+            if !contains_like_pattern_memchr(pattern) {
                 return Ok(Self::IEqAscii(pattern));
             } else if pattern.ends_with('%')
                 && !pattern.ends_with("\\%")
-                && !pattern[..pattern.len() - 1].contains(is_like_pattern)
+                && !contains_like_pattern_memchr(&pattern[..pattern.len() - 1])
             {
                 return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
-            } else if pattern.starts_with('%') && !pattern[1..].contains(is_like_pattern) {
+            } else if pattern.starts_with('%') && !contains_like_pattern_memchr(&pattern[1..]) {
                 return Ok(Self::IEndsWithAscii(&pattern[1..]));
             }
         }
@@ -186,6 +187,12 @@ fn regex_like(pattern: &str, case_insensitive: bool) -> Result<Regex, ArrowError
 
 fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
+}
+
+fn contains_like_pattern_memchr(pattern: &str) -> bool {
+    memchr2('%' as u8, '_' as u8, pattern.as_bytes())
+        .map(|_| true)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -190,9 +190,7 @@ fn is_like_pattern(c: char) -> bool {
 }
 
 fn contains_like_pattern(pattern: &str) -> bool {
-    memchr2(b'%', b'_', pattern.as_bytes())
-        .map(|_| true)
-        .unwrap_or(false)
+    memchr2(b'%', b'_', pattern.as_bytes()).is_some()
 }
 
 #[cfg(test)]

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -40,19 +40,19 @@ pub enum Predicate<'a> {
 impl<'a> Predicate<'a> {
     /// Create a predicate for the given like pattern
     pub fn like(pattern: &'a str) -> Result<Self, ArrowError> {
-        if !contains_like_pattern_memchr(pattern) {
+        if !contains_like_pattern(pattern) {
             Ok(Self::Eq(pattern))
         } else if pattern.ends_with('%')
             && !pattern.ends_with("\\%")
-            && !contains_like_pattern_memchr(&pattern[..pattern.len() - 1])
+            && !contains_like_pattern(&pattern[..pattern.len() - 1])
         {
             Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
-        } else if pattern.starts_with('%') && !contains_like_pattern_memchr(&pattern[1..]) {
+        } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
             Ok(Self::EndsWith(&pattern[1..]))
         } else if pattern.starts_with('%')
             && pattern.ends_with('%')
             && !pattern.ends_with("\\%")
-            && !contains_like_pattern_memchr(&pattern[1..pattern.len() - 1])
+            && !contains_like_pattern(&pattern[1..pattern.len() - 1])
         {
             Ok(Self::Contains(&pattern[1..pattern.len() - 1]))
         } else {
@@ -63,14 +63,14 @@ impl<'a> Predicate<'a> {
     /// Create a predicate for the given ilike pattern
     pub fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
         if is_ascii && pattern.is_ascii() {
-            if !contains_like_pattern_memchr(pattern) {
+            if !contains_like_pattern(pattern) {
                 return Ok(Self::IEqAscii(pattern));
             } else if pattern.ends_with('%')
                 && !pattern.ends_with("\\%")
-                && !contains_like_pattern_memchr(&pattern[..pattern.len() - 1])
+                && !contains_like_pattern(&pattern[..pattern.len() - 1])
             {
                 return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
-            } else if pattern.starts_with('%') && !contains_like_pattern_memchr(&pattern[1..]) {
+            } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
                 return Ok(Self::IEndsWithAscii(&pattern[1..]));
             }
         }
@@ -189,7 +189,7 @@ fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
 }
 
-fn contains_like_pattern_memchr(pattern: &str) -> bool {
+fn contains_like_pattern(pattern: &str) -> bool {
     memchr2(b'%', b'_', pattern.as_bytes())
         .map(|_| true)
         .unwrap_or(false)

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -190,7 +190,7 @@ fn is_like_pattern(c: char) -> bool {
 }
 
 fn contains_like_pattern_memchr(pattern: &str) -> bool {
-    memchr2('%' as u8, '_' as u8, pattern.as_bytes())
+    memchr2(b'%', b'_', pattern.as_bytes())
         .map(|_| true)
         .unwrap_or(false)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
While experimenting with improving like kernel, I found that we can check for like pattern characters much more efficiently using memchr2.


# What changes are included in this PR?
Reworks like kernel logic. Perf numbers in my system is as below

```
regexp                  time:   [14.796 ms 14.914 ms 15.039 ms]
                        change: [-3.3875% -2.2208% -1.0196%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  15 (15.00%) high mild
  3 (3.00%) high severe

regexp scalar           time:   [9.8261 ms 9.9221 ms 10.018 ms]
                        change: [-1.6210% -0.3701% +0.8929%] (p = 0.57 > 0.05)
                        No change in performance detected.
```


# Are there any user-facing changes?
No
