### PR TITLE
Make ffi module consume variable layout arrays with empty offsets

### DIFF
--- a/arrow/src/ffi.rs
+++ b/arrow/src/ffi.rs
@@ -394,6 +394,11 @@ impl<'a> ImportedArrowArray<'a> {
             | (DataType::List(_), 1)
             | (DataType::LargeList(_), 1)
             | (DataType::Map(_, _), 1) => {
+                // An empty array can have 0 offsets
+                if length == 0 {
+                    return Ok(0);
+                }
+
                 // the len of the offset buffer (buffer 1) equals length + 1
                 let bits = bit_width(data_type, i)?;
                 debug_assert_eq!(bits % 8, 0);
@@ -402,6 +407,12 @@ impl<'a> ImportedArrowArray<'a> {
             (DataType::Utf8, 2) | (DataType::Binary, 2) => {
                 // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
                 let len = self.buffer_len(1, dt)?;
+
+                // An empty array can have 0 offsets
+                if len == 0 {
+                    return Ok(0);
+                }
+
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i32`, as Utf8 uses `i32` offsets.
                 #[allow(clippy::cast_ptr_alignment)]
@@ -412,6 +423,12 @@ impl<'a> ImportedArrowArray<'a> {
             (DataType::LargeUtf8, 2) | (DataType::LargeBinary, 2) => {
                 // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
                 let len = self.buffer_len(1, dt)?;
+
+                // An empty array can have 0 offsets
+                if len == 0 {
+                    return Ok(0);
+                }
+
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i64`, as Large uses `i64` offsets.
                 #[allow(clippy::cast_ptr_alignment)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5391.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
