### PR TITLE
Propagate error instead of panic for `take_bytes`

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -420,8 +420,11 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         nulls = Some(null_buf.into())
     }
 
-    T::Offset::from_usize(values.len())
-        .ok_or(ArrowError::ComputeError("Offset overflow".to_string()))?;
+    T::Offset::from_usize(values.len()).ok_or(ArrowError::ComputeError(format!(
+        "Offset overflow for {}BinaryArray: {}",
+        T::Offset::PREFIX,
+        values.len()
+    )))?;
 
     let array_data = ArrayData::builder(T::DATA_TYPE)
         .len(data_len)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -420,7 +420,8 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         nulls = Some(null_buf.into())
     }
 
-    T::Offset::from_usize(values.len()).expect("offset overflow");
+    T::Offset::from_usize(values.len())
+        .ok_or(ArrowError::ComputeError("Offset overflow".to_string()))?;
 
     let array_data = ArrayData::builder(T::DATA_TYPE)
         .len(data_len)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`take_bytes` can propagate error instead of panic.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changing `take_bytes` to propagate error.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
