### PR TITLE
improve float to string cast by ~20%-40%

### DIFF
--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -52,6 +52,7 @@ lexical-core = { version = "^0.8", default-features = false, features = ["write-
 atoi = "2.0.0"
 comfy-table = { version = "7.0", optional = true, default-features = false }
 base64 = "0.21"
+ryu = "1.0.16"
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -427,9 +427,23 @@ macro_rules! primitive_display {
     };
 }
 
+macro_rules! primitive_display_float {
+    ($($t:ty),+) => {
+        $(impl<'a> DisplayIndex for &'a PrimitiveArray<$t>
+        {
+            fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
+                let value = self.value(idx);
+                let mut buffer = ryu::Buffer::new();
+                f.write_str(buffer.format(value))?;
+                Ok(())
+            }
+        })+
+    };
+}
+
 primitive_display!(Int8Type, Int16Type, Int32Type, Int64Type);
 primitive_display!(UInt8Type, UInt16Type, UInt32Type, UInt64Type);
-primitive_display!(Float32Type, Float64Type);
+primitive_display_float!(Float32Type, Float64Type);
 
 impl<'a> DisplayIndex for &'a PrimitiveArray<Float16Type> {
     fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -207,7 +207,9 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast f32 to string 512", |b| {
         b.iter(|| cast_array(&f32_array, DataType::Utf8))
     });
-
+    c.bench_function("cast f64 to string 512", |b| {
+        b.iter(|| cast_array(&f64_array, DataType::Utf8))
+    });
     c.bench_function("cast timestamp_ms to i64 512", |b| {
         b.iter(|| cast_array(&time_ms_array, DataType::Int64))
     });


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
We can use [ryu](https://github.com/dtolnay/ryu) crate to cast floats to string for better performance. Ryu is used in crates like csv and serde-json for fast float to string conversion.


# What changes are included in this PR?
I am using ryu to cast floats to string. The perf numbers are as below
```
cast f32 to string 512  time:   [18.055 µs 18.458 µs 18.932 µs]
                        change: [-26.059% -24.296% -22.401%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) high mild
  6 (6.00%) high severe

cast f64 to string 512  time:   [20.884 µs 21.154 µs 21.470 µs]
                        change: [-42.782% -41.722% -40.605%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# Are there any user-facing changes?
No
