### PR TITLE
Update Flight proto: PollFlightInfo & expiration time

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -44,7 +44,9 @@ bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 once_cell = { version = "1", optional = true }
 paste = { version = "1.0" }
-prost = { version = "0.12.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.3", default-features = false, features = ["prost-derive"] }
+# For Timestamp type
+prost-types = { version = "0.12.3", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
 tonic = { version = "0.11.0", default-features = false, features = ["transport", "codegen", "prost"] }
 

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -249,6 +249,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let endpoint = FlightEndpoint {
             ticket: Some(ticket),
             location: vec![loc],
+            expiration_time: None,
+            app_metadata: vec![].into(),
         };
         let info = FlightInfo::new()
             .try_with_schema(&schema)

--- a/arrow-flight/examples/server.rs
+++ b/arrow-flight/examples/server.rs
@@ -22,7 +22,7 @@ use tonic::{Request, Response, Status, Streaming};
 use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
     ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest,
-    HandshakeResponse, PutResult, SchemaResult, Ticket,
+    HandshakeResponse, PollInfo, PutResult, SchemaResult, Ticket,
 };
 
 #[derive(Clone)]
@@ -57,6 +57,13 @@ impl FlightService for FlightServiceImpl {
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         Err(Status::unimplemented("Implement get_flight_info"))
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("Implement poll_flight_info"))
     }
 
     async fn get_schema(

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -45,6 +45,7 @@ use arrow_ipc::convert::try_schema_from_ipc_buffer;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Bytes;
+use prost_types::Timestamp;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -97,6 +98,9 @@ pub mod error;
 pub use gen::Action;
 pub use gen::ActionType;
 pub use gen::BasicAuth;
+pub use gen::CancelFlightInfoRequest;
+pub use gen::CancelFlightInfoResult;
+pub use gen::CancelStatus;
 pub use gen::Criteria;
 pub use gen::Empty;
 pub use gen::FlightData;
@@ -106,7 +110,9 @@ pub use gen::FlightInfo;
 pub use gen::HandshakeRequest;
 pub use gen::HandshakeResponse;
 pub use gen::Location;
+pub use gen::PollInfo;
 pub use gen::PutResult;
+pub use gen::RenewFlightEndpointRequest;
 pub use gen::Result;
 pub use gen::SchemaResult;
 pub use gen::Ticket;
@@ -225,7 +231,7 @@ impl fmt::Display for FlightEndpoint {
         write!(f, " ticket: ")?;
         match &self.ticket {
             Some(value) => write!(f, "{value}"),
-            None => write!(f, " none"),
+            None => write!(f, " None"),
         }?;
         write!(f, ", location: [")?;
         let mut sep = "";
@@ -234,6 +240,13 @@ impl fmt::Display for FlightEndpoint {
             sep = ", ";
         }
         write!(f, "]")?;
+        write!(f, ", expiration_time:")?;
+        match &self.expiration_time {
+            Some(value) => write!(f, " {value}"),
+            None => write!(f, " None"),
+        }?;
+        write!(f, ", app_metadata: ")?;
+        limited_fmt(f, &self.app_metadata, 8)?;
         write!(f, " }}")
     }
 }
@@ -257,6 +270,68 @@ impl fmt::Display for FlightInfo {
         }
         write!(f, "], total_records: {}", self.total_records)?;
         write!(f, ", total_bytes: {}", self.total_bytes)?;
+        write!(f, ", ordered: {}", self.ordered)?;
+        write!(f, ", app_metadata: ")?;
+        limited_fmt(f, &self.app_metadata, 8)?;
+        write!(f, " }}")
+    }
+}
+
+impl fmt::Display for PollInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PollInfo {{")?;
+        write!(f, " info:")?;
+        match &self.info {
+            Some(value) => write!(f, " {value}"),
+            None => write!(f, " None"),
+        }?;
+        write!(f, ", descriptor:")?;
+        match &self.flight_descriptor {
+            Some(d) => write!(f, " {d}"),
+            None => write!(f, " None"),
+        }?;
+        write!(f, ", progress:")?;
+        match &self.progress {
+            Some(value) => write!(f, " {value}"),
+            None => write!(f, " None"),
+        }?;
+        write!(f, ", expiration_time:")?;
+        match &self.expiration_time {
+            Some(value) => write!(f, " {value}"),
+            None => write!(f, " None"),
+        }?;
+        write!(f, " }}")
+    }
+}
+
+impl fmt::Display for CancelFlightInfoRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CancelFlightInfoRequest {{")?;
+        write!(f, " info: ")?;
+        match &self.info {
+            Some(value) => write!(f, "{value}")?,
+            None => write!(f, "None")?,
+        };
+        write!(f, " }}")
+    }
+}
+
+impl fmt::Display for CancelFlightInfoResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CancelFlightInfoResult {{")?;
+        write!(f, " status: {}", self.status().as_str_name())?;
+        write!(f, " }}")
+    }
+}
+
+impl fmt::Display for RenewFlightEndpointRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RenewFlightEndpointRequest {{")?;
+        write!(f, " endpoint: ")?;
+        match &self.endpoint {
+            Some(value) => write!(f, "{value}")?,
+            None => write!(f, "None")?,
+        };
         write!(f, " }}")
     }
 }
@@ -472,9 +547,6 @@ impl FlightInfo {
     ///   // Encode the Arrow schema
     ///   .try_with_schema(&get_schema())
     ///   .expect("encoding failed")
-    ///   .with_descriptor(
-    ///      FlightDescriptor::new_cmd("a command")
-    ///   )
     ///   .with_endpoint(
     ///      FlightEndpoint::new()
     ///        .with_ticket(Ticket::new("ticket contents")
@@ -493,6 +565,7 @@ impl FlightInfo {
             // https://github.com/apache/arrow-rs/blob/17ca4d51d0490f9c65f5adde144f677dbc8300e7/format/Flight.proto#L287-L289
             total_records: -1,
             total_bytes: -1,
+            app_metadata: Bytes::new(),
         }
     }
 
@@ -546,12 +619,103 @@ impl FlightInfo {
         self.ordered = ordered;
         self
     }
+
+    /// Add optional application specific metadata to the message
+    pub fn with_app_metadata(mut self, app_metadata: impl Into<Bytes>) -> Self {
+        self.app_metadata = app_metadata.into();
+        self
+    }
+}
+
+impl PollInfo {
+    /// Create a new, empty [`PollInfo`], providing information for a long-running query
+    ///
+    /// # Example:
+    /// ```
+    /// # use arrow_flight::{FlightInfo, PollInfo, FlightDescriptor};
+    /// # use prost_types::Timestamp;
+    /// // Create a new PollInfo
+    /// let poll_info = PollInfo::new()
+    ///   .with_info(FlightInfo::new())
+    ///   .with_descriptor(FlightDescriptor::new_cmd("RUN QUERY"))
+    ///   .try_with_progress(0.5)
+    ///   .expect("progress should've been valid")
+    ///   .with_expiration_time(
+    ///     "1970-01-01".parse().expect("invalid timestamp")
+    ///   );
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            info: None,
+            flight_descriptor: None,
+            progress: None,
+            expiration_time: None,
+        }
+    }
+
+    /// Add the current available results for the poll call as a [`FlightInfo`]
+    pub fn with_info(mut self, info: FlightInfo) -> Self {
+        self.info = Some(info);
+        self
+    }
+
+    /// Add a [`FlightDescriptor`] that the client should use for the next poll call,
+    /// if the query is not yet complete
+    pub fn with_descriptor(mut self, flight_descriptor: FlightDescriptor) -> Self {
+        self.flight_descriptor = Some(flight_descriptor);
+        self
+    }
+
+    /// Set the query progress if known. Must be in the range [0.0, 1.0] else this will
+    /// return an error
+    pub fn try_with_progress(mut self, progress: f64) -> ArrowResult<Self> {
+        if !(0.0..=1.0).contains(&progress) {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "PollInfo progress must be in the range [0.0, 1.0], got {progress}"
+            )));
+        }
+        self.progress = Some(progress);
+        Ok(self)
+    }
+
+    /// Specify expiration time for this request
+    pub fn with_expiration_time(mut self, expiration_time: Timestamp) -> Self {
+        self.expiration_time = Some(expiration_time);
+        self
+    }
 }
 
 impl<'a> SchemaAsIpc<'a> {
     pub fn new(schema: &'a Schema, options: &'a IpcWriteOptions) -> Self {
         SchemaAsIpc {
             pair: (schema, options),
+        }
+    }
+}
+
+impl CancelFlightInfoRequest {
+    /// Create a new [`CancelFlightInfoRequest`], providing the [`FlightInfo`]
+    /// of the query to cancel.
+    pub fn new(info: FlightInfo) -> Self {
+        Self { info: Some(info) }
+    }
+}
+
+impl CancelFlightInfoResult {
+    /// Create a new [`CancelFlightInfoResult`] from the provided [`CancelStatus`].
+    pub fn new(status: CancelStatus) -> Self {
+        Self {
+            status: status as i32,
+        }
+    }
+}
+
+impl RenewFlightEndpointRequest {
+    /// Create a new [`RenewFlightEndpointRequest`], providing the [`FlightEndpoint`]
+    /// for which is being requested an extension of its expiration.
+    pub fn new(endpoint: FlightEndpoint) -> Self {
+        Self {
+            endpoint: Some(endpoint),
         }
     }
 }
@@ -631,6 +795,18 @@ impl FlightEndpoint {
     /// [Flight Spec]: https://github.com/apache/arrow-rs/blob/17ca4d51d0490f9c65f5adde144f677dbc8300e7/format/Flight.proto#L307C2-L312
     pub fn with_location(mut self, uri: impl Into<String>) -> Self {
         self.location.push(Location { uri: uri.into() });
+        self
+    }
+
+    /// Specify expiration time for this stream
+    pub fn with_expiration_time(mut self, expiration_time: Timestamp) -> Self {
+        self.expiration_time = Some(expiration_time);
+        self
+    }
+
+    /// Add optional application specific metadata to the message
+    pub fn with_app_metadata(mut self, app_metadata: impl Into<Bytes>) -> Self {
+        self.app_metadata = app_metadata.into();
         self
     }
 }

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -391,6 +391,7 @@ impl FlightSqlServiceClient<Channel> {
 
     /// Explicitly shut down and clean up the client.
     pub async fn close(&mut self) -> Result<(), ArrowError> {
+        // TODO: consume self instead of &mut self to explicitly prevent reuse?
         Ok(())
     }
 

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -36,9 +36,9 @@ use super::{
     DoPutUpdateResult, ProstMessageExt, SqlInfo, TicketStatementQuery,
 };
 use crate::{
-    flight_service_server::FlightService, Action, ActionType, Criteria, Empty, FlightData,
-    FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult, SchemaResult,
-    Ticket,
+    flight_service_server::FlightService, gen::PollInfo, Action, ActionType, Criteria, Empty,
+    FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult,
+    SchemaResult, Ticket,
 };
 
 pub(crate) static CREATE_PREPARED_STATEMENT: &str = "CreatePreparedStatement";
@@ -630,6 +630,13 @@ where
             }
             cmd => self.get_flight_info_fallback(cmd, request).await,
         }
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("Not yet implemented"))
     }
 
     async fn get_schema(

--- a/arrow-flight/tests/client.rs
+++ b/arrow-flight/tests/client.rs
@@ -24,13 +24,15 @@ mod common {
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_flight::{
     decode::FlightRecordBatchStream, encode::FlightDataEncoderBuilder, error::FlightError, Action,
-    ActionType, Criteria, Empty, FlightClient, FlightData, FlightDescriptor, FlightInfo,
-    HandshakeRequest, HandshakeResponse, PutResult, Ticket,
+    ActionType, CancelFlightInfoRequest, CancelFlightInfoResult, CancelStatus, Criteria, Empty,
+    FlightClient, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
+    HandshakeResponse, PollInfo, PutResult, RenewFlightEndpointRequest, Ticket,
 };
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use common::{server::TestFlightServer, trailers_layer::TrailersLayer};
 use futures::{Future, StreamExt, TryStreamExt};
+use prost::Message;
 use tokio::{net::TcpListener, task::JoinHandle};
 use tonic::{
     transport::{Channel, Uri},
@@ -106,6 +108,7 @@ fn test_flight_info(request: &FlightDescriptor) -> FlightInfo {
         total_bytes: 123,
         total_records: 456,
         ordered: false,
+        app_metadata: Bytes::new(),
     }
 }
 
@@ -136,6 +139,47 @@ async fn test_get_flight_info_error() {
         test_server.set_get_flight_info_response(Err(e.clone()));
 
         let response = client.get_flight_info(request.clone()).await.unwrap_err();
+        expect_status(response, e);
+    })
+    .await;
+}
+
+fn test_poll_info(request: &FlightDescriptor) -> PollInfo {
+    PollInfo {
+        info: Some(test_flight_info(request)),
+        flight_descriptor: None,
+        progress: Some(1.0),
+        expiration_time: None,
+    }
+}
+
+#[tokio::test]
+async fn test_poll_flight_info() {
+    do_test(|test_server, mut client| async move {
+        client.add_header("foo-header", "bar-header-value").unwrap();
+        let request = FlightDescriptor::new_cmd(b"My Command".to_vec());
+
+        let expected_response = test_poll_info(&request);
+        test_server.set_poll_flight_info_response(Ok(expected_response.clone()));
+
+        let response = client.poll_flight_info(request.clone()).await.unwrap();
+
+        assert_eq!(response, expected_response);
+        assert_eq!(test_server.take_poll_flight_info_request(), Some(request));
+        ensure_metadata(&client, &test_server);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_poll_flight_info_error() {
+    do_test(|test_server, mut client| async move {
+        let request = FlightDescriptor::new_cmd(b"My Command".to_vec());
+
+        let e = Status::unauthenticated("DENIED");
+        test_server.set_poll_flight_info_response(Err(e.clone()));
+
+        let response = client.poll_flight_info(request.clone()).await.unwrap_err();
         expect_status(response, e);
     })
     .await;
@@ -847,6 +891,105 @@ async fn test_do_action_error_in_stream() {
         expect_status(response, e);
         // server still got the request
         assert_eq!(test_server.take_do_action_request(), Some(request));
+        ensure_metadata(&client, &test_server);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_cancel_flight_info() {
+    do_test(|test_server, mut client| async move {
+        client.add_header("foo-header", "bar-header-value").unwrap();
+
+        let expected_response = CancelFlightInfoResult::new(CancelStatus::Cancelled);
+        let response = expected_response.encode_to_vec();
+        let response = Ok(arrow_flight::Result::new(response));
+        test_server.set_do_action_response(vec![response]);
+
+        let request = CancelFlightInfoRequest::new(FlightInfo::new());
+        let actual_response = client
+            .cancel_flight_info(request.clone())
+            .await
+            .expect("error making request");
+
+        let expected_request = Action::new("CancelFlightInfo", request.encode_to_vec());
+        assert_eq!(actual_response, expected_response);
+        assert_eq!(test_server.take_do_action_request(), Some(expected_request));
+        ensure_metadata(&client, &test_server);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_cancel_flight_info_error_no_response() {
+    do_test(|test_server, mut client| async move {
+        client.add_header("foo-header", "bar-header-value").unwrap();
+
+        test_server.set_do_action_response(vec![]);
+
+        let request = CancelFlightInfoRequest::new(FlightInfo::new());
+        let err = client
+            .cancel_flight_info(request.clone())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "ProtocolError(\"Received no response for cancel_flight_info call\")"
+        );
+        // server still got the request
+        let expected_request = Action::new("CancelFlightInfo", request.encode_to_vec());
+        assert_eq!(test_server.take_do_action_request(), Some(expected_request));
+        ensure_metadata(&client, &test_server);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_renew_flight_endpoint() {
+    do_test(|test_server, mut client| async move {
+        client.add_header("foo-header", "bar-header-value").unwrap();
+
+        let expected_response = FlightEndpoint::new().with_app_metadata(vec![1]);
+        let response = expected_response.encode_to_vec();
+        let response = Ok(arrow_flight::Result::new(response));
+        test_server.set_do_action_response(vec![response]);
+
+        let request =
+            RenewFlightEndpointRequest::new(FlightEndpoint::new().with_app_metadata(vec![0]));
+        let actual_response = client
+            .renew_flight_endpoint(request.clone())
+            .await
+            .expect("error making request");
+
+        let expected_request = Action::new("RenewFlightEndpoint", request.encode_to_vec());
+        assert_eq!(actual_response, expected_response);
+        assert_eq!(test_server.take_do_action_request(), Some(expected_request));
+        ensure_metadata(&client, &test_server);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_renew_flight_endpoint_error_no_response() {
+    do_test(|test_server, mut client| async move {
+        client.add_header("foo-header", "bar-header-value").unwrap();
+
+        test_server.set_do_action_response(vec![]);
+
+        let request = RenewFlightEndpointRequest::new(FlightEndpoint::new());
+        let err = client
+            .renew_flight_endpoint(request.clone())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "ProtocolError(\"Received no response for renew_flight_endpoint call\")"
+        );
+        // server still got the request
+        let expected_request = Action::new("RenewFlightEndpoint", request.encode_to_vec());
+        assert_eq!(test_server.take_do_action_request(), Some(expected_request));
         ensure_metadata(&client, &test_server);
     })
     .await;

--- a/arrow-integration-testing/src/flight_server_scenarios.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios.rs
@@ -44,5 +44,7 @@ pub fn endpoint(ticket: &str, location_uri: impl Into<String>) -> FlightEndpoint
         location: vec![Location {
             uri: location_uri.into(),
         }],
+        expiration_time: None,
+        app_metadata: vec![].into(),
     }
 }

--- a/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
     ActionType, BasicAuth, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
-    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
+    HandshakeRequest, HandshakeResponse, PollInfo, PutResult, SchemaResult, Ticket,
 };
 use futures::{channel::mpsc, sink::SinkExt, Stream, StreamExt};
 use tokio::sync::Mutex;
@@ -174,6 +174,14 @@ impl FlightService for AuthBasicProtoScenarioImpl {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        self.check_auth(request.metadata()).await?;
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    async fn poll_flight_info(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
         self.check_auth(request.metadata()).await?;
         Err(Status::unimplemented("Not yet implemented"))
     }

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -32,7 +32,7 @@ use arrow_flight::{
     flight_descriptor::DescriptorType, flight_service_server::FlightService,
     flight_service_server::FlightServiceServer, Action, ActionType, Criteria, Empty, FlightData,
     FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse, IpcMessage,
-    PutResult, SchemaAsIpc, SchemaResult, Ticket,
+    PollInfo, PutResult, SchemaAsIpc, SchemaResult, Ticket,
 };
 use futures::{channel::mpsc, sink::SinkExt, Stream, StreamExt};
 use std::convert::TryInto;
@@ -196,12 +196,20 @@ impl FlightService for FlightServiceImpl {
                     total_records: total_records as i64,
                     total_bytes: -1,
                     ordered: false,
+                    app_metadata: vec![].into(),
                 };
 
                 Ok(Response::new(info))
             }
             other => Err(Status::unimplemented(format!("Request type: {other}"))),
         }
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("Not yet implemented"))
     }
 
     async fn do_put(

--- a/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
@@ -20,8 +20,8 @@ use std::pin::Pin;
 use arrow_flight::{
     flight_descriptor::DescriptorType, flight_service_server::FlightService,
     flight_service_server::FlightServiceServer, Action, ActionType, Criteria, Empty, FlightData,
-    FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult, SchemaResult,
-    Ticket,
+    FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PollInfo, PutResult,
+    SchemaResult, Ticket,
 };
 use futures::Stream;
 use tonic::{transport::Server, Request, Response, Status, Streaming};
@@ -118,6 +118,13 @@ impl FlightService for MiddlewareScenarioImpl {
         }
 
         Err(status)
+    }
+
+    async fn poll_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        Err(Status::unimplemented("Not yet implemented"))
     }
 
     async fn do_put(

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -17,9 +17,10 @@
  */
 
  syntax = "proto3";
+ import "google/protobuf/timestamp.proto";
 
  option java_package = "org.apache.arrow.flight.impl";
- option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
+ option go_package = "github.com/apache/arrow/go/arrow/flight/gen/flight";
  option csharp_namespace = "Apache.Arrow.Flight.Protocol";
  
  package arrow.flight.protocol;
@@ -63,6 +64,32 @@
     * service.
     */
    rpc GetFlightInfo(FlightDescriptor) returns (FlightInfo) {}
+ 
+   /*
+    * For a given FlightDescriptor, start a query and get information
+    * to poll its execution status. This is a useful interface if the
+    * query may be a long-running query. The first PollFlightInfo call
+    * should return as quickly as possible. (GetFlightInfo doesn't
+    * return until the query is complete.)
+    *
+    * A client can consume any available results before
+    * the query is completed. See PollInfo.info for details.
+    *
+    * A client can poll the updated query status by calling
+    * PollFlightInfo() with PollInfo.flight_descriptor. A server
+    * should not respond until the result would be different from last
+    * time. That way, the client can "long poll" for updates
+    * without constantly making requests. Clients can set a short timeout
+    * to avoid blocking calls if desired.
+    *
+    * A client can't use PollInfo.flight_descriptor after
+    * PollInfo.expiration_time passes. A server might not accept the
+    * retry descriptor anymore and the query may be cancelled.
+    *
+    * A client may use the CancelFlightInfo action with
+    * PollInfo.info to cancel the running query.
+    */
+   rpc PollFlightInfo(FlightDescriptor) returns (PollInfo) {}
  
    /*
     * For a given FlightDescriptor, get the Schema as described in Schema.fbs::Schema
@@ -183,10 +210,58 @@
  }
  
  /*
+  * The request of the CancelFlightInfo action.
+  *
+  * The request should be stored in Action.body.
+  */
+ message CancelFlightInfoRequest {
+   FlightInfo info = 1;
+ }
+ 
+ /*
+  * The request of the RenewFlightEndpoint action.
+  *
+  * The request should be stored in Action.body.
+  */
+ message RenewFlightEndpointRequest {
+   FlightEndpoint endpoint = 1;
+ }
+ 
+ /*
   * An opaque result returned after executing an action.
   */
  message Result {
    bytes body = 1;
+ }
+ 
+ /*
+  * The result of a cancel operation.
+  *
+  * This is used by CancelFlightInfoResult.status.
+  */
+ enum CancelStatus {
+   // The cancellation status is unknown. Servers should avoid using
+   // this value (send a NOT_FOUND error if the requested query is
+   // not known). Clients can retry the request.
+   CANCEL_STATUS_UNSPECIFIED = 0;
+   // The cancellation request is complete. Subsequent requests with
+   // the same payload may return CANCELLED or a NOT_FOUND error.
+   CANCEL_STATUS_CANCELLED = 1;
+   // The cancellation request is in progress. The client may retry
+   // the cancellation request.
+   CANCEL_STATUS_CANCELLING = 2;
+   // The query is not cancellable. The client should not retry the
+   // cancellation request.
+   CANCEL_STATUS_NOT_CANCELLABLE = 3;
+ }
+ 
+ /*
+  * The result of the CancelFlightInfo action.
+  *
+  * The result should be stored in Result.body.
+  */
+ message CancelFlightInfoResult {
+   CancelStatus status = 1;
  }
  
  /*
@@ -292,6 +367,61 @@
     * FlightEndpoints are in the same order as the data.
     */
    bool ordered = 6;
+ 
+   /*
+    * Application-defined metadata.
+    * 
+    * There is no inherent or required relationship between this
+    * and the app_metadata fields in the FlightEndpoints or resulting
+    * FlightData messages. Since this metadata is application-defined,
+    * a given application could define there to be a relationship,
+    * but there is none required by the spec.
+    */
+   bytes app_metadata = 7;
+ }
+ 
+ /*
+  * The information to process a long-running query.
+  */
+ message PollInfo {
+   /*
+    * The currently available results.
+    *
+    * If "flight_descriptor" is not specified, the query is complete
+    * and "info" specifies all results. Otherwise, "info" contains
+    * partial query results.
+    *
+    * Note that each PollInfo response contains a complete
+    * FlightInfo (not just the delta between the previous and current
+    * FlightInfo).
+    *
+    * Subsequent PollInfo responses may only append new endpoints to
+    * info.
+    *
+    * Clients can begin fetching results via DoGet(Ticket) with the
+    * ticket in the info before the query is
+    * completed. FlightInfo.ordered is also valid.
+    */
+   FlightInfo info = 1;
+
+   /*
+    * The descriptor the client should use on the next try.
+    * If unset, the query is complete.
+    */
+   FlightDescriptor flight_descriptor = 2;
+
+   /*
+    * Query progress. If known, must be in [0.0, 1.0] but need not be
+    * monotonic or nondecreasing. If unknown, do not set.
+    */
+   optional double progress = 3;
+
+   /*
+    * Expiration time for this request. After this passes, the server
+    * might not accept the retry descriptor anymore (and the query may
+    * be cancelled). This may be updated on a call to PollFlightInfo.
+    */
+   google.protobuf.Timestamp expiration_time = 4;
  }
  
  /*
@@ -321,6 +451,24 @@
     * represent redundant and/or load balanced services.
     */
    repeated Location location = 2;
+ 
+   /*
+    * Expiration time of this stream. If present, clients may assume
+    * they can retry DoGet requests. Otherwise, it is
+    * application-defined whether DoGet requests may be retried.
+    */
+   google.protobuf.Timestamp expiration_time = 3;
+
+   /*
+    * Application-defined metadata.
+    * 
+    * There is no inherent or required relationship between this
+    * and the app_metadata fields in the FlightInfo or resulting
+    * FlightData messages. Since this metadata is application-defined,
+    * a given application could define there to be a relationship,
+    * but there is none required by the spec.
+    */
+   bytes app_metadata = 4;
  }
  
  /*

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -20,7 +20,7 @@
  import "google/protobuf/descriptor.proto";
  
  option java_package = "org.apache.arrow.flight.sql.impl";
- option go_package = "github.com/apache/arrow/go/arrow/flight/internal/flight";
+ option go_package = "github.com/apache/arrow/go/arrow/flight/gen/flight";
  package arrow.flight.protocol.sql;
  
  /*
@@ -551,7 +551,7 @@
    // Retrieves a int64 value representing the maximum number of characters allowed for a column name.
    SQL_MAX_COLUMN_NAME_LENGTH = 543;
  
-   // Retrieves a int64 value representing the the maximum number of columns allowed in a GROUP BY clause.
+   // Retrieves a int64 value representing the maximum number of columns allowed in a GROUP BY clause.
    SQL_MAX_COLUMNS_IN_GROUP_BY = 544;
  
    // Retrieves a int64 value representing the maximum number of columns allowed in an index.
@@ -943,7 +943,7 @@
  
  /**
   * The JDBC/ODBC-defined type of any object.
-  * All the values here are the sames as in the JDBC and ODBC specs.
+  * All the values here are the same as in the JDBC and ODBC specs.
   */
  enum XdbcDataType {
    XDBC_UNKNOWN_TYPE = 0;
@@ -1023,14 +1023,14 @@
    NULLABILITY_NULLABLE = 1;
  
    /**
-    * Indicates that nullability of the fields can not be determined.
+    * Indicates that nullability of the fields cannot be determined.
     */
    NULLABILITY_UNKNOWN = 2;
  }
  
  enum Searchable {
    /**
-    * Indicates that column can not be used in a WHERE clause.
+    * Indicates that column cannot be used in a WHERE clause.
     */
    SEARCHABLE_NONE = 0;
  
@@ -1196,7 +1196,7 @@
   *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
   *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
   *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
-  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
   *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
   *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
   * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
@@ -1537,11 +1537,14 @@
    bytes prepared_statement_handle = 1;
  
    // If a result set generating query was provided, dataset_schema contains the
-   // schema of the dataset as described in Schema.fbs::Schema, it is serialized as an IPC message.
+   // schema of the result set.  It should be an IPC-encapsulated Schema, as described in Schema.fbs.
+   // For some queries, the schema of the results may depend on the schema of the parameters.  The server
+   // should provide its best guess as to the schema at this point.  Clients must not assume that this
+   // schema, if provided, will be accurate.
    bytes dataset_schema = 2;
  
    // If the query provided contained parameters, parameter_schema contains the
-   // schema of the expected parameters as described in Schema.fbs::Schema, it is serialized as an IPC message.
+   // schema of the expected parameters.  It should be an IPC-encapsulated Schema, as described in Schema.fbs.
    bytes parameter_schema = 3;
  }
  
@@ -1676,7 +1679,7 @@
   *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
   *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
   *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
-  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
   *  - GetFlightInfo: execute the query.
@@ -1702,7 +1705,7 @@
   *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
   *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
   *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
-  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
   *  - GetFlightInfo: execute the query.
@@ -1740,9 +1743,12 @@
   *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
   *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
   *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
-  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
   *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+  *
+  *    If the schema is retrieved after parameter values have been bound with DoPut, then the server should account
+  *    for the parameters when determining the schema.
   *  - DoPut: bind parameter values. All of the bound parameter sets will be executed as a single atomic execution.
   *  - GetFlightInfo: execute the prepared statement instance.
   */
@@ -1755,7 +1761,7 @@
  
  /*
   * Represents a SQL update query. Used in the command member of FlightDescriptor
-  * for the the RPC call DoPut to cause the server to execute the included SQL update.
+  * for the RPC call DoPut to cause the server to execute the included SQL update.
   */
  message CommandStatementUpdate {
    option (experimental) = true;
@@ -1768,7 +1774,7 @@
  
  /*
   * Represents a SQL update query. Used in the command member of FlightDescriptor
-  * for the the RPC call DoPut to cause the server to execute the included
+  * for the RPC call DoPut to cause the server to execute the included
   * prepared statement handle as an update.
   */
  message CommandPreparedStatementUpdate {
@@ -1804,8 +1810,12 @@
   * data.
   *
   * This command is idempotent.
+  *
+  * This command is deprecated since 13.0.0. Use the "CancelFlightInfo"
+  * action with DoAction instead.
   */
  message ActionCancelQueryRequest {
+   option deprecated = true;
    option (experimental) = true;
  
    // The result of the GetFlightInfo RPC that initiated the query.
@@ -1819,8 +1829,12 @@
   * The result of cancelling a query.
   *
   * The result should be wrapped in a google.protobuf.Any message.
+  *
+  * This command is deprecated since 13.0.0. Use the "CancelFlightInfo"
+  * action with DoAction instead.
   */
  message ActionCancelQueryResult {
+   option deprecated = true;
    option (experimental) = true;
  
    enum CancelResult {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5367

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Update `Flight.proto` to as of: https://github.com/apache/arrow/blob/0993b369c4b91d81a17166d1427e7c26cd9beee4/format/Flight.proto

Update `FlightSql.proto` to as of: https://github.com/apache/arrow/blob/0993b369c4b91d81a17166d1427e7c26cd9beee4/format/FlightSql.proto

Taking inspiration from these arrow commits:

- Result set expiration: https://github.com/apache/arrow/commit/0b7bd74daef8fe120fed997975431e7a88f67e5a
- Long running queries: https://github.com/apache/arrow/commit/107b215faa17e9f7c1c08da4024de59323bb7a36

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- New dependency on `prost-types` to get the `Timestamp` struct (also bump `prost` version to latest)
- New fields for following structs (with relevant builder and display impl amended):
  - `FlightEndpoint`: `expiration_time` and `app_metadata`
  - `FlightInfo`: `app_metadata`
- New structs:
  - `PollInfo`
  - `CancelFlightInfoRequest`
  - `CancelFlightInfoResult`
  - `RenewFlightEndpointRequest`
- New `poll_flight_info` method for Flight server
- New methods on Flight client
  - `poll_flight_info`
  - `cancel_flight_info`
  - `renew_flight_endpoint`

# Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
