### PR TITLE
fix(object_store): Include Content-MD5 header for S3 DeleteObjects

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -54,6 +54,7 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
+md5 = { version = "0.7.0", default-features = false, features = ["std"], optional = true }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.27.1", features = ["fs"] }
@@ -62,7 +63,7 @@ nix = { version = "0.27.1", features = ["fs"] }
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
-aws = ["cloud"]
+aws = ["cloud", "md5"]
 http = ["cloud"]
 tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -54,7 +54,7 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
-md5 = { version = "0.7.0", default-features = false, features = ["std"], optional = true }
+md-5 = { version = "0.10.6", default-features = false, optional = true }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.27.1", features = ["fs"] }
@@ -63,7 +63,7 @@ nix = { version = "0.27.1", features = ["fs"] }
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
-aws = ["cloud", "md5"]
+aws = ["cloud", "md-5"]
 http = ["cloud"]
 tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 


### PR DESCRIPTION
S3 API [specification](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) requires the presence of this header for all `DeleteObjects` requests to general purpose buckets:

> The Content-MD5 request header is required for all Multi-Object Delete requests

Some platforms, such as MinIO, enforce this requirement, rejecting requests that don't include the header.

I have successfully tested the change locally against MinIO.


## What changes are included in this PR?
- Add an optional dependency on [md5 crate](https://crates.io/crates/md5)
- Make that dependency part of the aws feature
- Include the `Content-MD5` header unconditionally for all `DeleteObjects` requests
- No changes to any other checksums in the operation

No breaking changes, platforms not interested in the header will ignore it.

Closes #5414 