### PR TITLE
Ensure addition/multiplications in when allocating buffers don't overflow

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -822,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "failed to round 18446744073709551615 up to nearest multiple of 64")]
+    #[should_panic(expected = "failed to round to next highest power of 2")]
     fn test_from_iter_overflow() {
         let iter_len = usize::MAX / std::mem::size_of::<u64>() + 1;
         let _ = Buffer::from_iter(std::iter::repeat(0_u64).take(iter_len));

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -822,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "failed to create layout for MutableBuffer: LayoutError")]
+    #[should_panic(expected = "failed to round 18446744073709551615 up to nearest multiple of 64")]
     fn test_from_iter_overflow() {
         let iter_len = usize::MAX / std::mem::size_of::<u64>() + 1;
         let _ = Buffer::from_iter(std::iter::repeat(0_u64).take(iter_len));

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -61,12 +61,19 @@ pub struct MutableBuffer {
 
 impl MutableBuffer {
     /// Allocate a new [MutableBuffer] with initial capacity to be at least `capacity`.
+    ///
+    /// See [`MutableBuffer::with_capacity`].
     #[inline]
     pub fn new(capacity: usize) -> Self {
         Self::with_capacity(capacity)
     }
 
     /// Allocate a new [MutableBuffer] with initial capacity to be at least `capacity`.
+    ///
+    /// # Panics
+    ///
+    /// If `capacity`, when rounded up to the nearest multiple of [`ALIGNMENT`], is greater
+    /// then `isize::MAX`, then this function will panic.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         let capacity = bit_util::round_upto_multiple_of_64(capacity);

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -67,11 +67,6 @@ impl MutableBuffer {
     }
 
     /// Allocate a new [MutableBuffer] with initial capacity to be at least `capacity`.
-    ///
-    /// # Panics
-    ///
-    /// If `capacity`, when rounded up to a multiple of 64, is larger than `isize::MAX`
-    /// then this function will panic. Avoid allocating capacities above this limit.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         let capacity = bit_util::round_upto_multiple_of_64(capacity);
@@ -1019,7 +1014,8 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "failed to create layout for MutableBuffer: LayoutError")]
-    fn test_with_capacity_overflow() {
-        let _ = MutableBuffer::with_capacity(usize::MAX);
+    fn test_with_capacity_panics_above_max_capacity() {
+        let max_capacity = isize::MAX as usize - (isize::MAX as usize % ALIGNMENT);
+        let _ = MutableBuffer::with_capacity(max_capacity + 1);
     }
 }

--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -39,12 +39,9 @@ pub fn round_upto_multiple_of_64(num: usize) -> usize {
 /// be a power of 2.
 pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
     debug_assert!(factor > 0 && (factor & (factor - 1)) == 0);
-    let rounded = (num.saturating_add(factor - 1)) & !(factor - 1);
-    assert!(
-        rounded >= num,
-        "failed to round {num} up to nearest multiple of {factor}",
-    );
-    rounded
+    num.checked_add(factor - 1)
+        .expect("failed to round to next highest power of 2")
+        & !(factor - 1)
 }
 
 /// Returns whether bit at position `i` in `data` is set or not
@@ -125,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "failed to round 18446744073709551615 up to nearest multiple of 2")]
+    #[should_panic(expected = "failed to round to next highest power of 2")]
     fn test_round_upto_panic() {
         let _ = round_upto_power_of_2(usize::MAX, 2);
     }

--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -39,7 +39,7 @@ pub fn round_upto_multiple_of_64(num: usize) -> usize {
 /// be a power of 2.
 pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
     debug_assert!(factor > 0 && (factor & (factor - 1)) == 0);
-    (num + (factor - 1)) & !(factor - 1)
+    (num.saturating_add(factor - 1)) & !(factor - 1)
 }
 
 /// Returns whether bit at position `i` in `data` is set or not
@@ -117,6 +117,8 @@ mod tests {
         assert_eq!(64, round_upto_multiple_of_64(64));
         assert_eq!(128, round_upto_multiple_of_64(65));
         assert_eq!(192, round_upto_multiple_of_64(129));
+        // TODO: investigate why this is failing
+        // assert_eq!(usize::MAX, round_upto_multiple_of_64(usize::MAX));
     }
 
     #[test]

--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -39,7 +39,12 @@ pub fn round_upto_multiple_of_64(num: usize) -> usize {
 /// be a power of 2.
 pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
     debug_assert!(factor > 0 && (factor & (factor - 1)) == 0);
-    (num.saturating_add(factor - 1)) & !(factor - 1)
+    let rounded = (num.saturating_add(factor - 1)) & !(factor - 1);
+    assert!(
+        rounded >= num,
+        "failed to round {num} up to nearest multiple of {factor}",
+    );
+    rounded
 }
 
 /// Returns whether bit at position `i` in `data` is set or not
@@ -117,8 +122,12 @@ mod tests {
         assert_eq!(64, round_upto_multiple_of_64(64));
         assert_eq!(128, round_upto_multiple_of_64(65));
         assert_eq!(192, round_upto_multiple_of_64(129));
-        // TODO: investigate why this is failing
-        // assert_eq!(usize::MAX, round_upto_multiple_of_64(usize::MAX));
+    }
+
+    #[test]
+    #[should_panic(expected = "failed to round 18446744073709551615 up to nearest multiple of 2")]
+    fn test_round_upto_panic() {
+        let _ = round_upto_power_of_2(usize::MAX, 2);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5412

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Ensure addition and multiplication saturate instead of overflowing (especially for release builds). This will ensure we panic instead of segfaulting.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Update doc on panic behaviour

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
