### PR TITLE
Improve debug output of Time32/Time64 arrays

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1101,11 +1101,10 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                 match as_date::<T>(v) {
                     Some(date) => write!(f, "{date:?}"),
                     None => {
-                        let err = ArrowError::CastError(format!(
-                            "Failed to convert {} to temporal for {:?}",
+                        write!(
+                            "Cast error: Failed to convert {} to temporal for {:?}",
                             v, data_type
-                        ));
-                        write!(f, "{}", err)
+                        );
                     }
                 }
             }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1102,9 +1102,9 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                     Some(date) => write!(f, "{date:?}"),
                     None => {
                         write!(
-                            "Cast error: Failed to convert {} to temporal for {:?}",
-                            v, data_type
-                        );
+                            f,
+                            "Cast error: Failed to convert {v} to temporal for {data_type:?}"
+                        )
                     }
                 }
             }
@@ -1114,9 +1114,9 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                     Some(time) => write!(f, "{time:?}"),
                     None => {
                         write!(
-                            "Cast error: Failed to convert {} to temporal for {:?}",
-                            v, data_type
-                        );
+                            f,
+                            "Cast error: Failed to convert {v} to temporal for {data_type:?}"
+                        )
                     }
                 }
             }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1113,11 +1113,10 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                 match as_time::<T>(v) {
                     Some(time) => write!(f, "{time:?}"),
                     None => {
-                        let err = ArrowError::CastError(format!(
-                            "Failed to convert {} to temporal for {:?}",
+                        write!(
+                            "Cast error: Failed to convert {} to temporal for {:?}",
                             v, data_type
-                        ));
-                        write!(f, "{}", err)
+                        );
                     }
                 }
             }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5336 .

# Rationale for this change
 This change makes the debug output of Time32/Time64 arrays more descriptive.

# What changes are included in this PR?
This PR changes the way Time32 and Time64 arrays are printed to debug. Previously, values that could not be cast to Time32 or Time64 had debug output values of `null`. With this change, unsuccessful casts are included as errors in the debug output.

# Are there any user-facing changes?
Yes, the debug output for Time32 and Time64 arrays will change.
