### PR TITLE
Improve docs for logical and physical nulls even more

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -184,17 +184,17 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// null buffer, such as [`NullArray`].
     ///
     /// To determine if each element of such an array is "logically" null,
-    /// use the slower [`Array::logical_nulls`] to obtain a computed mask .
+    /// use the slower [`Array::logical_nulls`] to obtain a computed mask.
     fn nulls(&self) -> Option<&NullBuffer>;
 
-    /// Returns a potentially computed [`NullBuffer`] that represent the logical
+    /// Returns a potentially computed [`NullBuffer`] that represents the logical
     /// null values of this array, if any.
     ///
     /// Logical nulls represent the values that are null in the array,
     /// regardless of the underlying physical arrow representation.
     ///
     /// For most array types, this is equivalent to the "physical" nulls
-    /// returned by [`Array::nulls`]. However, for the following cases, which
+    /// returned by [`Array::nulls`]. It is different for the following cases, because which
     /// elements are null is not encoded in a single null buffer:
     ///
     /// * [`DictionaryArray`] where [`DictionaryArray::values`] contains nulls

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -175,23 +175,35 @@ pub trait Array: std::fmt::Debug + Send + Sync {
 
     /// Returns the null buffer of this array if any.
     ///
-    /// The null buffer encodes the "physical" nulls of an array.
-    /// However, some arrays can also encode nullability in their children, for example,
-    /// [`DictionaryArray::values`] values or [`RunArray::values`], or without a null buffer,
-    /// such as [`NullArray`]. To determine if each element of such an array is logically null,
-    /// you can use the slower [`Array::logical_nulls`] to obtain a computed mask .
+    /// The null buffer contains the "physical" nulls of an array, that is how
+    /// the nulls are represented in the underlying arrow format.
+    ///
+    /// The physical representation is efficient, but is sometimes non intuitive
+    /// for certain array types such as those with nullable child arrays like
+    /// [`DictionaryArray::values`] or [`RunArray::values`], or without a
+    /// null buffer, such as [`NullArray`].
+    ///
+    /// To determine if each element of such an array is "logically" null,
+    /// use the slower [`Array::logical_nulls`] to obtain a computed mask .
     fn nulls(&self) -> Option<&NullBuffer>;
 
-    /// Returns a potentially computed [`NullBuffer`] that represent the logical null values of this array, if any.
+    /// Returns a potentially computed [`NullBuffer`] that represent the logical
+    /// null values of this array, if any.
     ///
-    /// In most cases this will be the same as [`Array::nulls`], except for:
+    /// Logical nulls represent the values that are null in the array,
+    /// regardless of the underlying physical arrow representation.
+    ///
+    /// For most array types, this is equivalent to the "physical" nulls
+    /// returned by [`Array::nulls`]. However, for the following cases, which
+    /// elements are null is not encoded in a single null buffer:
     ///
     /// * [`DictionaryArray`] where [`DictionaryArray::values`] contains nulls
     /// * [`RunArray`] where [`RunArray::values`] contains nulls
     /// * [`NullArray`] where all indices are nulls
     ///
-    /// In these cases a logical [`NullBuffer`] will be computed, encoding the logical nullability
-    /// of these arrays, beyond what is encoded in [`Array::nulls`]
+    /// In these cases a logical [`NullBuffer`] will be computed, encoding the
+    /// logical nullability of these arrays, beyond what is encoded in
+    /// [`Array::nulls`]
     fn logical_nulls(&self) -> Option<NullBuffer> {
         self.nulls().cloned()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-rs/issues/4840

# Rationale for this change
 
As noted on https://github.com/apache/arrow-rs/issues/4840 the physical / logical concepts is nuanced and confusing so better docs will help people. This came up again with a discussion with @waynexia on https://github.com/apache/arrow-rs/issues/4840#issuecomment-1950989583

# What changes are included in this PR?
Improve documentation / rationale for `Array::nulls` and `Array::logical_nulls`

# Are there any user-facing changes?
Docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
