### PR TITLE
Refine `Display` and `Source` implementation for error types

### DIFF
--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -50,9 +50,9 @@ impl FlightError {
 impl std::fmt::Display for FlightError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FlightError::Arrow(inner) => inner.fmt(f),
+            FlightError::Arrow(source) => write!(f, "Arrow error: {}", source),
             FlightError::NotYetImplemented(desc) => write!(f, "Not yet implemented: {}", desc),
-            FlightError::Tonic(inner) => inner.fmt(f),
+            FlightError::Tonic(source) => write!(f, "Tonic error: {}", source),
             FlightError::ProtocolError(desc) => write!(f, "Protocol error: {}", desc),
             FlightError::DecodeError(desc) => write!(f, "Decode error: {}", desc),
             FlightError::ExternalError(source) => write!(f, "External error: {}", source),
@@ -63,8 +63,8 @@ impl std::fmt::Display for FlightError {
 impl Error for FlightError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            FlightError::Arrow(inner) => inner.source(),
-            FlightError::Tonic(inner) => inner.source(),
+            FlightError::Arrow(source) => Some(source),
+            FlightError::Tonic(source) => Some(source),
             FlightError::ExternalError(source) => Some(source.as_ref()),
             _ => None,
         }

--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -65,7 +65,7 @@ impl Error for FlightError {
         match self {
             FlightError::Arrow(inner) => inner.source(),
             FlightError::Tonic(inner) => inner.source(),
-            FlightError::ExternalError(source) => Some(&**source),
+            FlightError::ExternalError(source) => Some(source.as_ref()),
             _ => None,
         }
     }

--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -49,17 +49,24 @@ impl FlightError {
 
 impl std::fmt::Display for FlightError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO better format / error
-        write!(f, "{self:?}")
+        match self {
+            FlightError::Arrow(inner) => inner.fmt(f),
+            FlightError::NotYetImplemented(desc) => write!(f, "Not yet implemented: {}", desc),
+            FlightError::Tonic(inner) => inner.fmt(f),
+            FlightError::ProtocolError(desc) => write!(f, "Protocol error: {}", desc),
+            FlightError::DecodeError(desc) => write!(f, "Decode error: {}", desc),
+            FlightError::ExternalError(source) => write!(f, "External error: {}", source),
+        }
     }
 }
 
 impl Error for FlightError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        if let Self::ExternalError(e) = self {
-            Some(e.as_ref())
-        } else {
-            None
+        match self {
+            FlightError::Arrow(inner) => inner.source(),
+            FlightError::Tonic(inner) => inner.source(),
+            FlightError::ExternalError(source) => Some(&**source),
+            _ => None,
         }
     }
 }

--- a/arrow-flight/tests/client.rs
+++ b/arrow-flight/tests/client.rs
@@ -935,7 +935,7 @@ async fn test_cancel_flight_info_error_no_response() {
 
         assert_eq!(
             err.to_string(),
-            "ProtocolError(\"Received no response for cancel_flight_info call\")"
+            "Protocol error: Received no response for cancel_flight_info call"
         );
         // server still got the request
         let expected_request = Action::new("CancelFlightInfo", request.encode_to_vec());
@@ -985,7 +985,7 @@ async fn test_renew_flight_endpoint_error_no_response() {
 
         assert_eq!(
             err.to_string(),
-            "ProtocolError(\"Received no response for renew_flight_endpoint call\")"
+            "Protocol error: Received no response for renew_flight_endpoint call"
         );
         // server still got the request
         let expected_request = Action::new("RenewFlightEndpoint", request.encode_to_vec());

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -287,7 +287,7 @@ async fn test_mismatched_record_batch_schema() {
     let err = result.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Invalid argument error: number of columns(1) must match number of fields(2) in schema"
+        "Arrow error: Invalid argument error: number of columns(1) must match number of fields(2) in schema"
     );
 }
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -57,7 +57,7 @@ async fn test_error() {
     let result: Result<Vec<_>, _> = decode_stream.try_collect().await;
 
     let result = result.unwrap_err();
-    assert_eq!(result.to_string(), r#"NotYetImplemented("foo")"#);
+    assert_eq!(result.to_string(), "Not yet implemented: foo");
 }
 
 #[tokio::test]
@@ -287,7 +287,7 @@ async fn test_mismatched_record_batch_schema() {
     let err = result.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Arrow(InvalidArgumentError(\"number of columns(1) must match number of fields(2) in schema\"))"
+        "Invalid argument error: number of columns(1) must match number of fields(2) in schema"
     );
 }
 
@@ -312,7 +312,7 @@ async fn test_chained_streams_batch_decoder() {
     let err = result.unwrap_err();
     assert_eq!(
         err.to_string(),
-        "ProtocolError(\"Unexpectedly saw multiple Schema messages in FlightData stream\")"
+        "Protocol error: Unexpectedly saw multiple Schema messages in FlightData stream"
     );
 }
 

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -115,7 +115,7 @@ impl Display for ArrowError {
 impl Error for ArrowError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            ArrowError::ExternalError(source) => Some(&**source),
+            ArrowError::ExternalError(source) => Some(source.as_ref()),
             ArrowError::IoError(_, source) => Some(source),
             _ => None,
         }

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -114,10 +114,10 @@ impl Display for ArrowError {
 
 impl Error for ArrowError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        if let Self::ExternalError(e) = self {
-            Some(e.as_ref())
-        } else {
-            None
+        match self {
+            ArrowError::ExternalError(source) => Some(&**source),
+            ArrowError::IoError(_, source) => Some(source),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5438.

# Rationale for this change
 
Check the issue for the motivation. Also update the `source` implementation to make it consistent with the changes on `Display`.

~~- If there's a prompt ahead of formatting the inner error, provide it as a source error. This is similar to `#[source]` or `#[from]` in `thiserror`.~~
~~- If there's no prompt but we directly forward the method to the inner error, also forward the `source` method. This is similar to `#[transparent]` in `thiserror`.~~

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The description and source of `ArrowError` and `FlightError` get updated.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
