### PR TITLE
Change RecordBatch::schema return type from SchemaRef to &SchemaRef

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -562,9 +562,10 @@ impl Index<&str> for RecordBatch {
 ///
 /// let batches: Vec<RecordBatch> = vec![record_batch.clone(), record_batch.clone()];
 ///
-/// let mut reader = RecordBatchIterator::new(batches.into_iter().map(Ok), record_batch.schema());
+/// let mut reader = RecordBatchIterator::new(batches.into_iter().map(Ok),
+/// record_batch.schema().clone());
 ///
-/// assert_eq!(reader.schema(), record_batch.schema());
+/// assert_eq!(&reader.schema(), record_batch.schema());
 /// assert_eq!(reader.next().unwrap().unwrap(), record_batch);
 /// # assert_eq!(reader.next().unwrap().unwrap(), record_batch);
 /// # assert!(reader.next().is_none());

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -231,9 +231,9 @@ impl RecordBatch {
         })
     }
 
-    /// Returns the [`Schema`] of the record batch.
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+    /// Returns a reference to the [`Schema`] of the record batch.
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
     }
 
     /// Projects the schema onto the specified columns

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1344,7 +1344,7 @@ mod tests {
         let batch = csv.next().unwrap().unwrap();
         let batch_schema = batch.schema();
 
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
         assert_eq!(37, batch.num_rows());
         assert_eq!(3, batch.num_columns());
 
@@ -1416,7 +1416,7 @@ mod tests {
         ]));
         assert_eq!(projected_schema, csv.schema());
         let batch = csv.next().unwrap().unwrap();
-        assert_eq!(projected_schema, batch.schema());
+        assert_eq!(&projected_schema, batch.schema());
         assert_eq!(37, batch.num_rows());
         assert_eq!(2, batch.num_columns());
     }
@@ -1442,7 +1442,7 @@ mod tests {
         ]));
         assert_eq!(projected_schema, csv.schema());
         let batch = csv.next().unwrap().unwrap();
-        assert_eq!(projected_schema, batch.schema());
+        assert_eq!(&projected_schema, batch.schema());
         assert_eq!(37, batch.num_rows());
         assert_eq!(2, batch.num_columns());
 

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -193,7 +193,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
         self.check_token(&request)?;
         let batch = Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
-        let schema = batch.schema();
+        let schema = batch.schema().clone();
         let batches = vec![batch];
         let flight_data = batches_to_flight_data(schema.as_ref(), batches)
             .map_err(|e| status!("Could not convert batches", e))?
@@ -643,7 +643,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         self.check_token(&request)?;
         let schema = Self::fake_result()
             .map_err(|e| status!("Error getting result schema", e))?
-            .schema();
+            .schema()
+            .clone();
         let message = SchemaAsIpc::new(&schema, &IpcWriteOptions::default())
             .try_into()
             .map_err(|e| status!("Unable to serialize schema", e))?;

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -641,11 +641,10 @@ impl FlightSqlService for FlightSqlServiceImpl {
         request: Request<Action>,
     ) -> Result<ActionCreatePreparedStatementResult, Status> {
         self.check_token(&request)?;
-        let schema = Self::fake_result()
-            .map_err(|e| status!("Error getting result schema", e))?
-            .schema()
-            .clone();
-        let message = SchemaAsIpc::new(&schema, &IpcWriteOptions::default())
+        let record_batch =
+            Self::fake_result().map_err(|e| status!("Error getting result schema", e))?;
+        let schema = record_batch.schema();
+        let message = SchemaAsIpc::new(schema, &IpcWriteOptions::default())
             .try_into()
             .map_err(|e| status!("Unable to serialize schema", e))?;
         let IpcMessage(schema_bytes) = message;

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -570,7 +570,7 @@ mod tests {
         let (_, baseline_flight_batch) = make_flight_data(&batch, &options);
 
         let big_batch = batch.slice(0, batch.num_rows() - 1);
-        let optimized_big_batch = prepare_batch_for_flight(&big_batch, Arc::clone(&schema), false)
+        let optimized_big_batch = prepare_batch_for_flight(&big_batch, Arc::clone(schema), false)
             .expect("failed to optimize");
         let (_, optimized_big_flight_batch) = make_flight_data(&optimized_big_batch, &options);
 
@@ -581,7 +581,7 @@ mod tests {
 
         let small_batch = batch.slice(0, 1);
         let optimized_small_batch =
-            prepare_batch_for_flight(&small_batch, Arc::clone(&schema), false)
+            prepare_batch_for_flight(&small_batch, Arc::clone(schema), false)
                 .expect("failed to optimize");
         let (_, optimized_small_flight_batch) = make_flight_data(&optimized_small_batch, &options);
 

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -320,7 +320,7 @@ impl FlightDataEncoder {
         let schema = match &self.schema {
             Some(schema) => schema.clone(),
             // encode the schema if this is the first time we have seen it
-            None => self.encode_schema(&batch.schema()),
+            None => self.encode_schema(batch.schema()),
         };
 
         // encode the batch

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -611,7 +611,7 @@ mod tests {
                 DecodedPayload::None => {}
                 DecodedPayload::Schema(s) => assert_eq!(s, expected_schema),
                 DecodedPayload::RecordBatch(b) => {
-                    assert_eq!(b.schema(), expected_schema);
+                    assert_eq!(b.schema(), &expected_schema);
                     let expected_array = StringArray::from(vec!["a", "a", "b"]);
                     let actual_array = b.column_by_name("dict").unwrap();
                     let actual_array = downcast_array::<StringArray>(actual_array);
@@ -650,7 +650,7 @@ mod tests {
                 DecodedPayload::None => {}
                 DecodedPayload::Schema(s) => assert_eq!(s, schema),
                 DecodedPayload::RecordBatch(b) => {
-                    assert_eq!(b.schema(), schema);
+                    assert_eq!(b.schema(), &schema);
 
                     let actual_array = Arc::new(downcast_array::<DictionaryArray<UInt16Type>>(
                         b.column_by_name("dict").unwrap(),
@@ -683,7 +683,8 @@ mod tests {
         )
         .expect("cannot create record batch");
 
-        prepare_batch_for_flight(&batch, batch.schema(), false).expect("failed to optimize");
+        prepare_batch_for_flight(&batch, batch.schema().clone(), false)
+            .expect("failed to optimize");
     }
 
     pub fn make_flight_data(

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -510,7 +510,7 @@ impl PreparedStatement<Channel> {
             let descriptor = FlightDescriptor::new_cmd(cmd.as_any().encode_to_vec());
             let flight_stream_builder = FlightDataEncoderBuilder::new()
                 .with_flight_descriptor(Some(descriptor))
-                .with_schema(params_batch.schema());
+                .with_schema(params_batch.schema().clone());
             let flight_data = flight_stream_builder
                 .build(futures::stream::iter(
                     self.parameter_binding.clone().map(Ok),

--- a/arrow-flight/src/sql/metadata/db_schemas.rs
+++ b/arrow-flight/src/sql/metadata/db_schemas.rs
@@ -160,7 +160,10 @@ impl GetDbSchemasBuilder {
             .map(|c| take(c, &indices, None))
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        Ok(RecordBatch::try_new(filtered_batch.schema(), columns)?)
+        Ok(RecordBatch::try_new(
+            filtered_batch.schema().clone(),
+            columns,
+        )?)
     }
 
     /// Return the schema of the RecordBatch that will be returned

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -438,7 +438,7 @@ impl SqlInfoData {
     /// Return the schema of the RecordBatch that will be returned
     /// from [`CommandGetSqlInfo`]
     pub fn schema(&self) -> SchemaRef {
-        self.batch.schema()
+        self.batch.schema().clone()
     }
 }
 

--- a/arrow-flight/src/sql/metadata/tables.rs
+++ b/arrow-flight/src/sql/metadata/tables.rs
@@ -262,7 +262,10 @@ impl GetTablesBuilder {
             .map(|c| take(c, &indices, None))
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        Ok(RecordBatch::try_new(filtered_batch.schema(), columns)?)
+        Ok(RecordBatch::try_new(
+            filtered_batch.schema().clone(),
+            columns,
+        )?)
     }
 
     /// Return the schema of the RecordBatch that will be returned from [`CommandGetTables`]

--- a/arrow-flight/src/sql/metadata/xdbc_info.rs
+++ b/arrow-flight/src/sql/metadata/xdbc_info.rs
@@ -89,7 +89,7 @@ impl XdbcTypeInfoData {
     /// Return the schema of the RecordBatch that will be returned
     /// from [`CommandGetXdbcTypeInfo`]
     pub fn schema(&self) -> SchemaRef {
-        self.batch.schema()
+        self.batch.schema().clone()
     }
 }
 
@@ -262,7 +262,7 @@ impl XdbcTypeInfoDataBuilder {
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         Ok(XdbcTypeInfoData {
-            batch: RecordBatch::try_new(batch.schema(), columns)?,
+            batch: RecordBatch::try_new(batch.schema().clone(), columns)?,
         })
     }
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -41,7 +41,7 @@ async fn test_empty() {
 #[tokio::test]
 async fn test_empty_batch() {
     let batch = make_primitive_batch(5);
-    let empty = RecordBatch::new_empty(batch.schema());
+    let empty = RecordBatch::new_empty(batch.schema().clone());
     roundtrip(vec![empty]).await;
 }
 
@@ -90,7 +90,7 @@ async fn test_primitive_many() {
 #[tokio::test]
 async fn test_primitive_empty() {
     let batch = make_primitive_batch(5);
-    let empty = RecordBatch::new_empty(batch.schema());
+    let empty = RecordBatch::new_empty(batch.schema().clone());
 
     roundtrip(vec![batch, empty]).await;
 }

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -465,7 +465,7 @@ async fn roundtrip(input: Vec<RecordBatch>) {
 /// When <https://github.com/apache/arrow-rs/issues/3389> is resolved,
 /// it should be possible to use `roundtrip`
 async fn roundtrip_dictionary(input: Vec<RecordBatch>) {
-    let schema = Arc::new(prepare_schema_for_flight(&input[0].schema()));
+    let schema = Arc::new(prepare_schema_for_flight(input[0].schema()));
     let expected_output: Vec<_> = input
         .iter()
         .map(|batch| prepare_batch_for_flight(batch, schema.clone()).unwrap())

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -245,9 +245,9 @@ impl FlightSqlService for FlightSqlServiceImpl {
             "part_2" => batch.slice(2, 1),
             ticket => panic!("Invalid ticket: {ticket:?}"),
         };
-        let schema = batch.schema().clone();
-        let batches = vec![batch];
-        let flight_data = batches_to_flight_data(schema.as_ref(), batches)
+        let schema = batch.schema();
+        let batches = vec![batch.clone()];
+        let flight_data = batches_to_flight_data(schema, batches)
             .unwrap()
             .into_iter()
             .map(Ok);

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -189,7 +189,7 @@ impl FlightSqlServiceImpl {
         let batch = Self::fake_result()?;
 
         Ok(FlightInfo::new()
-            .try_with_schema(&batch.schema())
+            .try_with_schema(batch.schema())
             .expect("encoding schema")
             .with_endpoint(
                 FlightEndpoint::new().with_ticket(Ticket::new(
@@ -245,7 +245,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
             "part_2" => batch.slice(2, 1),
             ticket => panic!("Invalid ticket: {ticket:?}"),
         };
-        let schema = batch.schema();
+        let schema = batch.schema().clone();
         let batches = vec![batch];
         let flight_data = batches_to_flight_data(schema.as_ref(), batches)
             .unwrap()

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -213,7 +213,7 @@ async fn consume_flight_location(
             flight_data_to_arrow_batch(&data, actual_schema.clone(), &dictionaries_by_id)
                 .expect("Unable to convert flight data to Arrow batch");
 
-        assert_eq!(actual_schema, actual_batch.schema());
+        assert_eq!(&actual_schema, actual_batch.schema());
         assert_eq!(expected_batch.num_columns(), actual_batch.num_columns());
         assert_eq!(expected_batch.num_rows(), actual_batch.num_rows());
         let schema = expected_batch.schema();

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1794,7 +1794,7 @@ mod tests {
         let roundtrip = read_record_batch(
             &b,
             ipc_batch,
-            batch.schema(),
+            batch.schema().clone(),
             &Default::default(),
             None,
             &message.version(),

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1429,7 +1429,7 @@ mod tests {
 
     fn roundtrip_ipc(rb: &RecordBatch) -> RecordBatch {
         let mut buf = Vec::new();
-        let mut writer = crate::writer::FileWriter::try_new(&mut buf, &rb.schema()).unwrap();
+        let mut writer = crate::writer::FileWriter::try_new(&mut buf, rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
         drop(writer);
@@ -1440,7 +1440,7 @@ mod tests {
 
     fn roundtrip_ipc_stream(rb: &RecordBatch) -> RecordBatch {
         let mut buf = Vec::new();
-        let mut writer = crate::writer::StreamWriter::try_new(&mut buf, &rb.schema()).unwrap();
+        let mut writer = crate::writer::StreamWriter::try_new(&mut buf, rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
         drop(writer);
@@ -1815,7 +1815,7 @@ mod tests {
         let batch = RecordBatch::new_empty(schema);
 
         let mut buf = Vec::new();
-        let mut writer = crate::writer::FileWriter::try_new(&mut buf, &batch.schema()).unwrap();
+        let mut writer = crate::writer::FileWriter::try_new(&mut buf, batch.schema()).unwrap();
         writer.write(&batch).unwrap();
         writer.finish().unwrap();
         drop(writer);
@@ -1842,7 +1842,7 @@ mod tests {
         let batch = RecordBatch::new_empty(schema);
 
         let mut buf = Vec::new();
-        let mut writer = crate::writer::FileWriter::try_new(&mut buf, &batch.schema()).unwrap();
+        let mut writer = crate::writer::FileWriter::try_new(&mut buf, batch.schema()).unwrap();
         writer.write(&batch).unwrap();
         writer.finish().unwrap();
         drop(writer);

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -579,7 +579,7 @@ pub fn read_footer_length(buf: [u8; 10]) -> Result<usize, ArrowError> {
 /// let back = fb_to_schema(footer.schema().unwrap());
 /// assert_eq!(&back, schema.as_ref());
 ///
-/// let mut decoder = FileDecoder::new(schema, footer.version());
+/// let mut decoder = FileDecoder::new(schema.clone(), footer.version());
 ///
 /// // Read dictionaries
 /// for block in footer.dictionaries().iter().flatten() {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1436,7 +1436,7 @@ mod tests {
     use super::*;
 
     fn serialize_file(rb: &RecordBatch) -> Vec<u8> {
-        let mut writer = FileWriter::try_new(vec![], &rb.schema()).unwrap();
+        let mut writer = FileWriter::try_new(vec![], rb.schema()).unwrap();
         writer.write(rb).unwrap();
         writer.finish().unwrap();
         writer.into_inner().unwrap()
@@ -1448,7 +1448,7 @@ mod tests {
     }
 
     fn serialize_stream(record: &RecordBatch) -> Vec<u8> {
-        let mut stream_writer = StreamWriter::try_new(vec![], &record.schema()).unwrap();
+        let mut stream_writer = StreamWriter::try_new(vec![], record.schema()).unwrap();
         stream_writer.write(record).unwrap();
         stream_writer.finish().unwrap();
         stream_writer.into_inner().unwrap()
@@ -1982,7 +1982,7 @@ mod tests {
         )
         .expect("new batch");
 
-        let mut writer = StreamWriter::try_new(vec![], &batch.schema()).expect("new writer");
+        let mut writer = StreamWriter::try_new(vec![], batch.schema()).expect("new writer");
         writer.write(&batch).expect("write");
         let outbuf = writer.into_inner().expect("inner");
 

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! // Read the JSON data
 //! let cursor = Cursor::new(buf);
-//! let mut reader = ReaderBuilder::new(batch.schema()).build(cursor).unwrap();
+//! let mut reader = ReaderBuilder::new(batch.schema().clone()).build(cursor).unwrap();
 //! let batch = reader.next().unwrap().unwrap();
 //!
 //! // Reverse the base64 encoding

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1582,7 +1582,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(0, a.0);
@@ -1630,7 +1630,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(&DataType::Int64, a.1.data_type());
@@ -1971,7 +1971,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(
@@ -2004,7 +2004,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(
@@ -2033,7 +2033,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(&DataType::Date64, a.1.data_type());
@@ -2063,7 +2063,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(schema, batch_schema);
+        assert_eq!(&schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(&DataType::Time64(TimeUnit::Nanosecond), a.1.data_type());
@@ -2098,7 +2098,7 @@ mod tests {
             sum_num_rows += batch.num_rows();
             num_batches += 1;
             let batch_schema = batch.schema();
-            assert_eq!(schema, batch_schema);
+            assert_eq!(&schema, batch_schema);
             let a_array = batch.column(col_a_index).as_primitive::<Int64Type>();
             sum_a += (0..a_array.len()).map(|i| a_array.value(i)).sum::<i64>();
         }

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! // Apply indices to batch columns
 //! let columns = batch.columns().iter().map(|c| take(&*c, &indices, None).unwrap()).collect();
-//! let sorted = RecordBatch::try_new(batch.schema(), columns).unwrap();
+//! let sorted = RecordBatch::try_new(batch.schema().clone(), columns).unwrap();
 //!
 //! let col1 = sorted.column(0).as_primitive::<Int32Type>();
 //! assert_eq!(col1.values(), &[2, 1, 4, 3]);

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -185,7 +185,7 @@ pub fn filter_record_batch(
         .map(|a| filter_array(a, &filter))
         .collect::<Result<Vec<_>, _>>()?;
     let options = RecordBatchOptions::default().with_row_count(Some(filter.count()));
-    RecordBatch::try_new_with_options(record_batch.schema(), filtered_arrays, &options)
+    RecordBatch::try_new_with_options(record_batch.schema().clone(), filtered_arrays, &options)
 }
 
 /// A builder to construct [`FilterPredicate`]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -821,7 +821,7 @@ pub fn take_record_batch(
         .iter()
         .map(|c| take(c, indices, None))
         .collect::<Result<Vec<_>, _>>()?;
-    RecordBatch::try_new(record_batch.schema(), columns)
+    RecordBatch::try_new(record_batch.schema().clone(), columns)
 }
 
 #[cfg(test)]

--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -43,7 +43,7 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
         c.bench_function(&format!("{name} - {batch_size}"), |b| {
             b.iter(|| {
                 let cursor = Cursor::new(buf.as_slice());
-                let reader = csv::ReaderBuilder::new(batch.schema())
+                let reader = csv::ReaderBuilder::new(batch.schema().clone())
                     .with_batch_size(batch_size)
                     .with_header(true)
                     .build_buffered(cursor)

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -386,7 +386,7 @@ impl FromPyArrow for RecordBatch {
 impl ToPyArrow for RecordBatch {
     fn to_pyarrow(&self, py: Python) -> PyResult<PyObject> {
         // Workaround apache/arrow#37669 by returning RecordBatchIterator
-        let reader = RecordBatchIterator::new(vec![Ok(self.clone())], self.schema());
+        let reader = RecordBatchIterator::new(vec![Ok(self.clone())], self.schema().clone());
         let reader: Box<dyn RecordBatchReader + Send> = Box::new(reader);
         let py_reader = reader.into_pyarrow(py)?;
         py_reader.call_method0(py, "read_next_batch")

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -254,7 +254,7 @@ mod tests {
         let schema_ref = Arc::new(schema);
         let batch = create_random_batch(schema_ref.clone(), size, 0.35, 0.7).unwrap();
 
-        assert_eq!(batch.schema(), schema_ref);
+        assert_eq!(batch.schema(), &schema_ref);
         assert_eq!(batch.num_columns(), schema_ref.fields().len());
         for array in batch.columns() {
             assert_eq!(array.len(), size);
@@ -277,7 +277,7 @@ mod tests {
         let schema_ref = Arc::new(schema);
         let batch = create_random_batch(schema_ref.clone(), size, 0.35, 0.7).unwrap();
 
-        assert_eq!(batch.schema(), schema_ref);
+        assert_eq!(batch.schema(), &schema_ref);
         assert_eq!(batch.num_columns(), schema_ref.fields().len());
         for array in batch.columns() {
             assert_eq!(array.null_count(), 0);

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -314,7 +314,7 @@ fn write_batch_enable_bloom_filter(batch: &RecordBatch) -> Result<()> {
 fn write_batch_with_option(batch: &RecordBatch, props: Option<WriterProperties>) -> Result<()> {
     let path = env::temp_dir().join("arrow_writer.temp");
     let file = File::create(path).unwrap();
-    let mut writer = ArrowWriter::try_new(file, batch.schema(), props)?;
+    let mut writer = ArrowWriter::try_new(file, batch.schema().clone(), props)?;
 
     writer.write(batch)?;
     writer.close()?;

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -451,7 +451,7 @@ mod tests {
                 .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema().clone(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
 

--- a/parquet/src/arrow/array_reader/fixed_size_list_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_size_list_array.rs
@@ -608,7 +608,7 @@ mod tests {
             .expect("unable to read record batch");
 
         // Verify values of both read columns match
-        assert_eq!(schema, actual.schema());
+        assert_eq!(&schema, actual.schema());
         let actual_list = actual
             .column(0)
             .as_any()

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -184,21 +184,19 @@ mod tests {
         map_builder.append(true).expect("adding map entry");
 
         // Create record batch
-        let batch =
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_builder.finish())])
-                .expect("create record batch");
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_builder.finish())])
+            .expect("create record batch");
 
         // Write record batch to file
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema(), None)
+        let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema().clone(), None)
             .expect("creat file writer");
         writer.write(&batch).expect("writing file");
         writer.close().expect("close writer");
 
         // Read file
         let reader = Bytes::from(buffer);
-        let record_batch_reader =
-            ParquetRecordBatchReader::try_new(reader, 1024).unwrap();
+        let record_batch_reader = ParquetRecordBatchReader::try_new(reader, 1024).unwrap();
         for maybe_record_batch in record_batch_reader {
             let record_batch = maybe_record_batch.expect("Getting current batch");
             let col = record_batch.column(0);

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1225,7 +1225,7 @@ mod tests {
                 .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema().clone(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
 
@@ -1258,7 +1258,7 @@ mod tests {
                 .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema().clone(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
 
@@ -1295,7 +1295,7 @@ mod tests {
                 .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema().clone(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
 
@@ -2321,9 +2321,12 @@ mod tests {
                 .build();
 
             let file = tempfile().unwrap();
-            let mut writer =
-                ArrowWriter::try_new(file.try_clone().unwrap(), batch.schema(), Some(props))
-                    .unwrap();
+            let mut writer = ArrowWriter::try_new(
+                file.try_clone().unwrap(),
+                batch.schema().clone(),
+                Some(props),
+            )
+            .unwrap();
             writer.write(&batch).unwrap();
             writer.close().unwrap();
             file
@@ -2844,7 +2847,7 @@ mod tests {
         .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, written.schema().clone(), None).unwrap();
         writer.write(&written).unwrap();
         writer.close().unwrap();
 
@@ -2872,7 +2875,8 @@ mod tests {
             .build();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema(), Some(props)).unwrap();
+        let mut writer =
+            ArrowWriter::try_new(&mut buffer, batch.schema().clone(), Some(props)).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
@@ -2913,7 +2917,7 @@ mod tests {
         .unwrap();
 
         let mut buffer = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema().clone(), None).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
@@ -2928,7 +2932,7 @@ mod tests {
         assert_eq!(t4, PhysicalType::FIXED_LEN_BYTE_ARRAY);
 
         let mut reader = builder.build().unwrap();
-        assert_eq!(batch.schema(), reader.schema());
+        assert_eq!(batch.schema(), &reader.schema());
 
         let out = reader.next().unwrap().unwrap();
         assert_eq!(batch, out);

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -3086,7 +3086,7 @@ mod tests {
                     .unwrap();
 
                 let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
-                let actual = concat_batches(&batch.schema(), &batches).unwrap();
+                let actual = concat_batches(batch.schema(), &batches).unwrap();
                 assert_eq!(actual.num_rows(), selection.row_count());
 
                 let mut batch_offset = 0;

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -71,7 +71,7 @@ mod levels;
 /// let to_write = RecordBatch::try_from_iter([("col", col)]).unwrap();
 ///
 /// let mut buffer = Vec::new();
-/// let mut writer = ArrowWriter::try_new(&mut buffer, to_write.schema(), None).unwrap();
+/// let mut writer = ArrowWriter::try_new(&mut buffer, to_write.schema().clone(), None).unwrap();
 /// writer.write(&to_write).unwrap();
 /// writer.close().unwrap();
 ///

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1491,9 +1491,12 @@ mod tests {
             .set_write_batch_size(1)
             .build();
 
-        let mut writer =
-            ArrowWriter::try_new(file.try_clone().unwrap(), batch.schema(), Some(props))
-                .expect("Unable to write file");
+        let mut writer = ArrowWriter::try_new(
+            file.try_clone().unwrap(),
+            batch.schema().clone(),
+            Some(props),
+        )
+        .expect("Unable to write file");
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 
@@ -1553,7 +1556,7 @@ mod tests {
 
         let mut writer = ArrowWriter::try_new(
             file.try_clone().unwrap(),
-            expected_batch.schema(),
+            expected_batch.schema().clone(),
             Some(props),
         )
         .expect("Unable to write file");
@@ -1795,9 +1798,12 @@ mod tests {
         let expected_batch = RecordBatch::try_new(Arc::new(schema), vec![values]).unwrap();
         let file = tempfile::tempfile().unwrap();
 
-        let mut writer =
-            ArrowWriter::try_new(file.try_clone().unwrap(), expected_batch.schema(), None)
-                .expect("Unable to write file");
+        let mut writer = ArrowWriter::try_new(
+            file.try_clone().unwrap(),
+            expected_batch.schema().clone(),
+            None,
+        )
+        .expect("Unable to write file");
         writer.write(&expected_batch).unwrap();
         writer.close().unwrap();
     }
@@ -1809,8 +1815,8 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![values]).unwrap();
 
         let mut out = Vec::with_capacity(1024);
-        let mut writer =
-            ArrowWriter::try_new(&mut out, batch.schema(), None).expect("Unable to write file");
+        let mut writer = ArrowWriter::try_new(&mut out, batch.schema().clone(), None)
+            .expect("Unable to write file");
         writer.write(&batch).unwrap();
         let file_meta_data = writer.close().unwrap();
         for row_group in file_meta_data.row_groups {
@@ -2732,7 +2738,7 @@ mod tests {
 
         let mut read = ParquetRecordBatchReader::try_new(Bytes::from(buf), 1024).unwrap();
         let back = read.next().unwrap().unwrap();
-        assert_eq!(back.schema(), file_schema);
+        assert_eq!(back.schema(), &file_schema);
         assert_ne!(back.schema(), batch.schema());
         assert_eq!(back.column(0).as_ref(), batch.column(0).as_ref());
     }
@@ -2748,7 +2754,7 @@ mod tests {
         // build a record batch
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
 
-        let mut writer = ArrowWriter::try_new(vec![], batch.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(vec![], batch.schema().clone(), None).unwrap();
 
         // starts empty
         assert_eq!(writer.in_progress_size(), 0);
@@ -2787,7 +2793,7 @@ mod tests {
         .unwrap();
 
         let mut buf = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buf, batch.schema().clone(), None).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
 

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1264,7 +1264,7 @@ mod tests {
         .unwrap();
 
         let mut buf = Vec::with_capacity(1024);
-        let mut writer = ArrowWriter::try_new(&mut buf, data.schema(), None).unwrap();
+        let mut writer = ArrowWriter::try_new(&mut buf, data.schema().clone(), None).unwrap();
         writer.write(&data).unwrap();
         writer.close().unwrap();
 
@@ -1338,7 +1338,8 @@ mod tests {
         let props = WriterProperties::builder()
             .set_max_row_group_size(3)
             .build();
-        let mut writer = ArrowWriter::try_new(&mut buf, data.schema(), Some(props)).unwrap();
+        let mut writer =
+            ArrowWriter::try_new(&mut buf, data.schema().clone(), Some(props)).unwrap();
         writer.write(&data).unwrap();
         writer.close().unwrap();
 
@@ -1690,7 +1691,7 @@ mod tests {
             let mut reader = builder.with_projection(mask).build().unwrap();
             let sync_reader_schema = reader.schema();
             let batch = reader.next().unwrap().unwrap();
-            let sync_batch_schema = batch.schema();
+            let sync_batch_schema = batch.schema().clone();
             assert_schemas(sync_builder_schema, sync_reader_schema, sync_batch_schema);
 
             // asynchronous should be same
@@ -1701,7 +1702,7 @@ mod tests {
             let mut reader = builder.with_projection(mask).build().unwrap();
             let async_reader_schema = reader.schema().clone();
             let batch = reader.next().await.unwrap().unwrap();
-            let async_batch_schema = batch.schema();
+            let async_batch_schema = batch.schema().clone();
             assert_schemas(
                 async_builder_schema,
                 async_reader_schema,

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -282,7 +282,7 @@ mod tests {
 
         let mut buffer = Vec::new();
         let mut writer =
-            AsyncArrowWriter::try_new(&mut buffer, to_write.schema(), 0, None).unwrap();
+            AsyncArrowWriter::try_new(&mut buffer, to_write.schema().clone(), 0, None).unwrap();
         writer.write(&to_write).await.unwrap();
         writer.close().await.unwrap();
 
@@ -433,7 +433,8 @@ mod tests {
         let temp = tempfile::tempfile().unwrap();
 
         let file = tokio::fs::File::from_std(temp.try_clone().unwrap());
-        let mut writer = AsyncArrowWriter::try_new(file, to_write.schema(), 0, None).unwrap();
+        let mut writer =
+            AsyncArrowWriter::try_new(file, to_write.schema().clone(), 0, None).unwrap();
         writer.write(&to_write).await.unwrap();
         writer.close().await.unwrap();
 
@@ -461,7 +462,7 @@ mod tests {
             let temp = tempfile::tempfile().unwrap();
             let file = tokio::fs::File::from_std(temp.try_clone().unwrap());
             let mut writer =
-                AsyncArrowWriter::try_new(file, batch.schema(), buffer_size, None).unwrap();
+                AsyncArrowWriter::try_new(file, batch.schema().clone(), buffer_size, None).unwrap();
 
             // starts empty
             assert_eq!(writer.in_progress_size(), 0);

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -36,7 +36,7 @@
 //!
 //! let mut buffer = Vec::new();
 //! let mut writer =
-//!     AsyncArrowWriter::try_new(&mut buffer, to_write.schema(), 0, None).unwrap();
+//!     AsyncArrowWriter::try_new(&mut buffer, to_write.schema().clone(), 0, None).unwrap();
 //! writer.write(&to_write).await.unwrap();
 //! writer.close().await.unwrap();
 //!

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -46,7 +46,7 @@
 //!     .set_compression(Compression::SNAPPY)
 //!     .build();
 //!
-//! let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
+//! let mut writer = ArrowWriter::try_new(file, batch.schema().clone(), Some(props)).unwrap();
 //!
 //! writer.write(&batch).expect("Writing batch");
 //!

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -60,7 +60,7 @@ fn do_test(test: LayoutTest) {
     let mut buf = Vec::with_capacity(1024);
 
     let mut writer =
-        ArrowWriter::try_new(&mut buf, test.batches[0].schema(), Some(test.props)).unwrap();
+        ArrowWriter::try_new(&mut buf, test.batches[0].schema().clone(), Some(test.props)).unwrap();
     for batch in test.batches {
         writer.write(&batch).unwrap();
     }


### PR DESCRIPTION
# Which issue does this PR close?
This addresses the first part of #5342.

# Rationale for this change
Prior to this change, `RecordBatch::schema` returned a `SchemaRef`, which in most cases can only be used as an owned value.  By instead returning `&SchemaRef`, users will have more flexibility in the way they use `RecordBatch::schema`; it's return value can be used as a borrowed value or cloned into an owned value.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
`RecordBatch::schema` returns `&SchemaRef` instead of `SchemaRef`. I made minor changes to  parts of the code where `RecordBatch::schema` is called.

# Are there any user-facing changes?
Yes, this will affect the way that users use `RecordBatch::schema`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
