### PR TITLE
add support for gcp application default auth on windows in object store

### DIFF
--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -397,7 +397,7 @@ impl ApplicationDefaultCredentials {
         "gcloud/application_default_credentials.json"
     } else {
         ".config/gcloud/application_default_credentials.json"
-    }
+    };
 
     // Create a new application default credential in the following situations:
     //  1. a file is passed in and the type matches.

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -407,7 +407,7 @@ impl ApplicationDefaultCredentials {
             return read_credentials_file::<Self>(path).map(Some);
         }
 
-        let home_var = if cfg!(windows) {"APPDATA"} else {"HOME"};
+        let home_var = if cfg!(windows) { "APPDATA" } else { "HOME" };
         if let Some(home) = env::var_os(home_var) {
             let path = Path::new(&home).join(Self::CREDENTIALS_PATH);
 

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -393,7 +393,11 @@ pub enum ApplicationDefaultCredentials {
 }
 
 impl ApplicationDefaultCredentials {
-    const CREDENTIALS_PATH: &'static str = ".config/gcloud/application_default_credentials.json";
+    const CREDENTIALS_PATH: &'static str = if cfg!(windows) {
+        "gcloud/application_default_credentials.json"
+    } else {
+        ".config/gcloud/application_default_credentials.json"
+    }
 
     // Create a new application default credential in the following situations:
     //  1. a file is passed in and the type matches.
@@ -402,7 +406,9 @@ impl ApplicationDefaultCredentials {
         if let Some(path) = path {
             return read_credentials_file::<Self>(path).map(Some);
         }
-        if let Some(home) = env::var_os("HOME") {
+
+        let home_var = if cfg!(windows) {"APPDATA"} else {"HOME"};
+        if let Some(home) = env::var_os(home_var) {
             let path = Path::new(&home).join(Self::CREDENTIALS_PATH);
 
             // It's expected for this file to not exist unless it has been explicitly configured by the user.


### PR DESCRIPTION
# Which issue does this PR close?

Use correct default path for gcp application default auth on windows

Closes #5466.

