### PR TITLE
Remove internal buffering from AsyncArrowWriter (#5484)

### DIFF
--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -65,11 +65,15 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 ///
 /// ## Memory Usage
 ///
-/// The columnar nature of parquet forces buffering data for an entire row group, as such
-/// [`AsyncArrowWriter`] uses [`ArrowWriter`] to encode each row group in memory, before
-/// flushing it to the provided [`AsyncWrite`]. Memory usage can be limited by prematurely
-/// flushing the row group, although this will have implications for file size and query
-/// performance. See [ArrowWriter] for more information.
+/// This writer eagerly writes data as soon as possible to the underlying [`AsyncWrite`],
+/// permitting fine-grained control over buffering and I/O scheduling. However, the columnar
+/// nature of parquet forces data for an entire row group to be buffered in memory, before
+/// it can be flushed. Depending on the data and the configured row group size, this buffering
+/// may be substantial.
+///
+/// Memory usage can be limited by calling [`Self::flush`] to flush the in progress row group,
+/// although this will likely increase overall file size and reduce query performance.
+/// See [ArrowWriter] for more information.
 ///
 /// ```no_run
 /// # use tokio::fs::File;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5484

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Having a separate buffer size argument is confusing, especially when it doesn't actually limit memory consumption in practice, which is instead bounded by the row group size.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
