### PR TITLE
Fix NullBufferBuilder::new_from_buffer wrong size assertion

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -2564,4 +2564,21 @@ mod tests {
         let debug_str = format!("{:?}", array);
         assert_eq!("PrimitiveArray<Time64(Microsecond)>\n[\n  Cast error: Failed to convert -1 to temporal for Time64(Microsecond),\n  00:00:00,\n  23:59:59,\n  Cast error: Failed to convert 86400000000 to temporal for Time64(Microsecond),\n  Cast error: Failed to convert 86401000000 to temporal for Time64(Microsecond),\n  null,\n]", debug_str);
     }
+
+    #[test]
+    fn test_primitive_with_nulls_into_builder() {
+        let array: Int32Array = vec![
+            Some(1),
+            None,
+            Some(3),
+            Some(4),
+            None,
+            Some(7),
+            None,
+            Some(8),
+        ]
+        .into_iter()
+        .collect();
+        let _ = array.into_builder();
+    }
 }

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -54,7 +54,7 @@ impl NullBufferBuilder {
     pub fn new_from_buffer(buffer: MutableBuffer, len: usize) -> Self {
         let capacity = buffer.len() * 8;
 
-        assert!(len < capacity);
+        assert!(len <= capacity);
 
         let bitmap_builder = Some(BooleanBufferBuilder::new_from_buffer(buffer, len));
         Self {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5445.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Avoid panic with the following code
```
        let mut builder = Int32Builder::new();
        for i in 0..64 {
            if i % 2 == 0 {
                builder.append_null();
            } else {
                builder.append_value(i as i32); 
            }
        }
        let array = builder.finish();
        let _ = array.into_builder().expect("into_builder");
```
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
