### PR TITLE
Minor: Add doc comments to `GenericByteViewArray`

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -34,6 +34,9 @@ use std::sync::Arc;
 /// Different than [`crate::GenericByteArray`] as it stores both an offset and length
 /// meaning that take / filter operations can be implemented without copying the underlying data.
 ///
+/// See [`StringViewArray`] for storing utf8 encoded string data and
+/// [`BinaryViewArray`] for storing bytes.
+///
 /// [Variable-size Binary View Layout]: https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-view-layout
 ///
 /// A `GenericByteViewArray` stores variable length byte strings. An array of
@@ -388,10 +391,19 @@ where
 }
 
 /// A [`GenericByteViewArray`] of `[u8]`
+///
+/// # Example
+/// ```
+/// use arrow_array::BinaryViewArray;
+/// let array = BinaryViewArray::from_iter_values(vec![b"hello" as &[u8], b"world", b"lulu", b"large payload over 12 bytes"]);
+/// assert_eq!(array.value(0), b"hello");
+/// assert_eq!(array.value(3), b"large payload over 12 bytes");
+/// ```
 pub type BinaryViewArray = GenericByteViewArray<BinaryViewType>;
 
-/// A [`GenericByteViewArray`] of `str`
+/// A [`GenericByteViewArray`] that stores uf8 data
 ///
+/// # Example
 /// ```
 /// use arrow_array::StringViewArray;
 /// let array = StringViewArray::from_iter_values(vec!["hello", "world", "lulu", "large payload over 12 bytes"]);


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/arrow-rs/issues/5374

# Rationale for this change
 https://github.com/apache/arrow-rs/pull/5481 added this new array type 🙏  @ariesdevil  thank you.

It would be good to start making it easier to use with more documentation. Also I was in the middle of filing other tickets and I wanted a diagram to explain "garbage collection" in this context, so I figured I would also make a diagram for the main array types

# What changes are included in this PR?

Add doc comments / ascii art to the `GenericByteViewArray`

![Screenshot 2024-03-14 at 2 25 04 PM](https://github.com/apache/arrow-rs/assets/490673/b037f069-1051-4362-a870-375fa107de50)


# Are there any user-facing changes?

Only docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
