### PR TITLE
parquet: Use specific error variant when codec is disabled

### DIFF
--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -150,34 +150,34 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
         CodecType::BROTLI(level) => {
             #[cfg(any(feature = "brotli", test))]
             return Ok(Some(Box::new(BrotliCodec::new(level))));
-            Err(ParquetError::Disabled("brotli"))
+            Err(ParquetError::General("Disabled feature at compile time: brotli".into()))
         },
         CodecType::GZIP(level) => {
             #[cfg(any(feature = "flate2", test))]
             return Ok(Some(Box::new(GZipCodec::new(level))));
-            Err(ParquetError::Disabled("flate2"))
+            Err(ParquetError::General("Disabled feature at compile time: flate2".into()))
         },
         CodecType::SNAPPY => {
             #[cfg(any(feature = "snap", test))]
             return Ok(Some(Box::new(SnappyCodec::new())));
-            Err(ParquetError::Disabled("snap"))
+            Err(ParquetError::General("Disabled feature at compile time: snap".into()))
         },
         CodecType::LZ4 => {
             #[cfg(any(feature = "lz4", test))]
             return Ok(Some(Box::new(LZ4HadoopCodec::new(
                 _options.backward_compatible_lz4,
             ))));
-            Err(ParquetError::Disabled("lz4"))
+            Err(ParquetError::General("Disabled feature at compile time: lz4".into()))
         },
         CodecType::ZSTD(level) => {
             #[cfg(any(feature = "zstd", test))]
             return Ok(Some(Box::new(ZSTDCodec::new(level))));
-            Err(ParquetError::Disabled("zstd"))
+            Err(ParquetError::General("Disabled feature at compile time: zstd".into()))
         },
         CodecType::LZ4_RAW => {
             #[cfg(any(feature = "lz4", test))]
             return Ok(Some(Box::new(LZ4RawCodec::new())));
-            Err(ParquetError::Disabled("lz4"))
+            Err(ParquetError::General("Disabled feature at compile time: lz4".into()))
         },
         CodecType::UNCOMPRESSED => Ok(None),
         _ => Err(nyi_err!("The codec type {} is not supported yet", codec)),

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -145,21 +145,40 @@ pub(crate) trait CompressionLevel<T: std::fmt::Display + std::cmp::PartialOrd> {
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
 pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<Box<dyn Codec>>> {
+    #[allow(unreachable_code, unused_variables)]
     match codec {
-        #[cfg(any(feature = "brotli", test))]
-        CodecType::BROTLI(level) => Ok(Some(Box::new(BrotliCodec::new(level)))),
-        #[cfg(any(feature = "flate2", test))]
-        CodecType::GZIP(level) => Ok(Some(Box::new(GZipCodec::new(level)))),
-        #[cfg(any(feature = "snap", test))]
-        CodecType::SNAPPY => Ok(Some(Box::new(SnappyCodec::new()))),
-        #[cfg(any(feature = "lz4", test))]
-        CodecType::LZ4 => Ok(Some(Box::new(LZ4HadoopCodec::new(
-            _options.backward_compatible_lz4,
-        )))),
-        #[cfg(any(feature = "zstd", test))]
-        CodecType::ZSTD(level) => Ok(Some(Box::new(ZSTDCodec::new(level)))),
-        #[cfg(any(feature = "lz4", test))]
-        CodecType::LZ4_RAW => Ok(Some(Box::new(LZ4RawCodec::new()))),
+        CodecType::BROTLI(level) => {
+            #[cfg(any(feature = "brotli", test))]
+            return Ok(Some(Box::new(BrotliCodec::new(level))));
+            Err(ParquetError::Disabled("brotli"))
+        },
+        CodecType::GZIP(level) => {
+            #[cfg(any(feature = "flate2", test))]
+            return Ok(Some(Box::new(GZipCodec::new(level))));
+            Err(ParquetError::Disabled("flate2"))
+        },
+        CodecType::SNAPPY => {
+            #[cfg(any(feature = "snap", test))]
+            return Ok(Some(Box::new(SnappyCodec::new())));
+            Err(ParquetError::Disabled("snap"))
+        },
+        CodecType::LZ4 => {
+            #[cfg(any(feature = "lz4", test))]
+            return Ok(Some(Box::new(LZ4HadoopCodec::new(
+                _options.backward_compatible_lz4,
+            ))));
+            Err(ParquetError::Disabled("lz4"))
+        },
+        CodecType::ZSTD(level) => {
+            #[cfg(any(feature = "zstd", test))]
+            return Ok(Some(Box::new(ZSTDCodec::new(level))));
+            Err(ParquetError::Disabled("zstd"))
+        },
+        CodecType::LZ4_RAW => {
+            #[cfg(any(feature = "lz4", test))]
+            return Ok(Some(Box::new(LZ4RawCodec::new())));
+            Err(ParquetError::Disabled("lz4"))
+        },
         CodecType::UNCOMPRESSED => Ok(None),
         _ => Err(nyi_err!("The codec type {} is not supported yet", codec)),
     }

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -34,10 +34,6 @@ pub enum ParquetError {
     /// "Not yet implemented" Parquet error.
     /// Returned when functionality is not yet available.
     NYI(String),
-    /// "Disabled feature" Parquet error.
-    /// Returned when functionality is not available because it is an optional
-    /// feature that was not enabled at compile-time.
-    Disabled(&'static str),
     /// "End of file" Parquet error.
     /// Returned when IO related failures occur, e.g. when there are not enough bytes to
     /// decode.
@@ -58,9 +54,6 @@ impl std::fmt::Display for ParquetError {
                 write!(fmt, "Parquet error: {message}")
             }
             ParquetError::NYI(message) => write!(fmt, "NYI: {message}"),
-            ParquetError::Disabled(message) => {
-                write!(fmt, "Disabled feature at compile time: {message}")
-            }
             ParquetError::EOF(message) => write!(fmt, "EOF: {message}"),
             #[cfg(feature = "arrow")]
             ParquetError::ArrowError(message) => write!(fmt, "Arrow: {message}"),

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -34,6 +34,10 @@ pub enum ParquetError {
     /// "Not yet implemented" Parquet error.
     /// Returned when functionality is not yet available.
     NYI(String),
+    /// "Disabled feature" Parquet error.
+    /// Returned when functionality is not available because it is an optional
+    /// feature that was not enabled at compile-time.
+    Disabled(&'static str),
     /// "End of file" Parquet error.
     /// Returned when IO related failures occur, e.g. when there are not enough bytes to
     /// decode.
@@ -54,6 +58,9 @@ impl std::fmt::Display for ParquetError {
                 write!(fmt, "Parquet error: {message}")
             }
             ParquetError::NYI(message) => write!(fmt, "NYI: {message}"),
+            ParquetError::Disabled(message) => {
+                write!(fmt, "Disabled feature at compile time: {message}")
+            }
             ParquetError::EOF(message) => write!(fmt, "EOF: {message}"),
             #[cfg(feature = "arrow")]
             ParquetError::ArrowError(message) => write!(fmt, "Arrow: {message}"),


### PR DESCRIPTION
Instead of reporting it as 'not yet implemented'

# Which issue does this PR close?

Closes #5520

# Rationale for this change

It makes it clearer at runtime how to fix the error

# Are there any user-facing changes?

It changes the error message, and adds a variant to the `ParquetError` enum.
