### PR TITLE
Support non-contiguous put payloads / vectored writes (#5514)

### DIFF
--- a/object_store/src/aws/checksum.rs
+++ b/object_store/src/aws/checksum.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::config::Parse;
-use ring::digest::{self, digest as ring_digest};
 use std::str::FromStr;
 
 #[allow(non_camel_case_types)]
@@ -25,20 +24,6 @@ use std::str::FromStr;
 pub enum Checksum {
     /// SHA-256 algorithm.
     SHA256,
-}
-
-impl Checksum {
-    pub(super) fn digest(&self, bytes: &[u8]) -> Vec<u8> {
-        match self {
-            Self::SHA256 => ring_digest(&digest::SHA256, bytes).as_ref().to_owned(),
-        }
-    }
-
-    pub(super) fn header_name(&self) -> &'static str {
-        match self {
-            Self::SHA256 => "x-amz-checksum-sha256",
-        }
-    }
 }
 
 impl std::fmt::Display for Checksum {

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -517,7 +517,9 @@ async fn instance_creds(
     let token_result = client
         .request(Method::PUT, token_url)
         .header("X-aws-ec2-metadata-token-ttl-seconds", "600") // 10 minute TTL
-        .send_retry_with_idempotency(retry_config, true)
+        .retryable(retry_config)
+        .idempotent(true)
+        .send()
         .await;
 
     let token = match token_result {
@@ -607,7 +609,9 @@ async fn web_identity(
             ("Version", "2011-06-15"),
             ("WebIdentityToken", &token),
         ])
-        .send_retry_with_idempotency(retry_config, true)
+        .retryable(retry_config)
+        .idempotent(true)
+        .send()
         .await?
         .bytes()
         .await?;

--- a/object_store/src/aws/dynamo.rs
+++ b/object_store/src/aws/dynamo.rs
@@ -186,11 +186,7 @@ impl DynamoCommit {
         to: &Path,
     ) -> Result<()> {
         self.conditional_op(client, to, None, || async {
-            client
-                .copy_request(from, to)
-                .set_idempotent(false)
-                .send()
-                .await?;
+            client.copy_request(from, to).send().await?;
             Ok(())
         })
         .await

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -27,8 +27,8 @@ use crate::multipart::PartId;
 use crate::path::DELIMITER;
 use crate::util::{deserialize_rfc1123, GetRange};
 use crate::{
-    ClientOptions, GetOptions, ListResult, ObjectMeta, Path, PutMode, PutOptions, PutResult,
-    Result, RetryConfig,
+    ClientOptions, GetOptions, ListResult, ObjectMeta, Path, PutMode, PutOptions, PutPayload,
+    PutResult, Result, RetryConfig,
 };
 use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
@@ -171,6 +171,7 @@ impl AzureConfig {
 struct PutRequest<'a> {
     path: &'a Path,
     config: &'a AzureConfig,
+    payload: PutPayload,
     builder: RequestBuilder,
     idempotent: bool,
 }
@@ -195,8 +196,12 @@ impl<'a> PutRequest<'a> {
         let credential = self.config.get_credential().await?;
         let response = self
             .builder
+            .header(CONTENT_LENGTH, self.payload.content_length())
             .with_azure_authorization(&credential, &self.config.account)
-            .send_retry_with_idempotency(&self.config.retry_config, self.idempotent)
+            .retryable(&self.config.retry_config)
+            .idempotent(true)
+            .payload(Some(self.payload))
+            .send()
             .await
             .context(PutRequestSnafu {
                 path: self.path.as_ref(),
@@ -228,7 +233,7 @@ impl AzureClient {
         self.config.get_credential().await
     }
 
-    fn put_request<'a>(&'a self, path: &'a Path, bytes: Bytes) -> PutRequest<'a> {
+    fn put_request<'a>(&'a self, path: &'a Path, payload: PutPayload) -> PutRequest<'a> {
         let url = self.config.path_url(path);
 
         let mut builder = self.client.request(Method::PUT, url);
@@ -237,21 +242,23 @@ impl AzureClient {
             builder = builder.header(CONTENT_TYPE, value);
         }
 
-        builder = builder
-            .header(CONTENT_LENGTH, HeaderValue::from(bytes.len()))
-            .body(bytes);
-
         PutRequest {
             path,
             builder,
+            payload,
             config: &self.config,
             idempotent: false,
         }
     }
 
     /// Make an Azure PUT request <https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob>
-    pub async fn put_blob(&self, path: &Path, bytes: Bytes, opts: PutOptions) -> Result<PutResult> {
-        let builder = self.put_request(path, bytes);
+    pub async fn put_blob(
+        &self,
+        path: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        let builder = self.put_request(path, payload);
 
         let builder = match &opts.mode {
             PutMode::Overwrite => builder.set_idempotent(true),
@@ -272,11 +279,16 @@ impl AzureClient {
     }
 
     /// PUT a block <https://learn.microsoft.com/en-us/rest/api/storageservices/put-block>
-    pub async fn put_block(&self, path: &Path, part_idx: usize, data: Bytes) -> Result<PartId> {
+    pub async fn put_block(
+        &self,
+        path: &Path,
+        part_idx: usize,
+        payload: PutPayload,
+    ) -> Result<PartId> {
         let content_id = format!("{part_idx:20}");
         let block_id = BASE64_STANDARD.encode(&content_id);
 
-        self.put_request(path, data)
+        self.put_request(path, payload)
             .query(&[("comp", "block"), ("blockid", &block_id)])
             .set_idempotent(true)
             .send()
@@ -349,7 +361,9 @@ impl AzureClient {
 
         builder
             .with_azure_authorization(&credential, &self.config.account)
-            .send_retry_with_idempotency(&self.config.retry_config, true)
+            .retryable(&self.config.retry_config)
+            .idempotent(overwrite)
+            .send()
             .await
             .map_err(|err| err.error(STORE, from.to_string()))?;
 
@@ -382,7 +396,9 @@ impl AzureClient {
             .body(body)
             .query(&[("restype", "service"), ("comp", "userdelegationkey")])
             .with_azure_authorization(&credential, &self.config.account)
-            .send_retry_with_idempotency(&self.config.retry_config, true)
+            .retryable(&self.config.retry_config)
+            .idempotent(true)
+            .send()
             .await
             .context(DelegationKeyRequestSnafu)?
             .bytes()

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -615,7 +615,9 @@ impl TokenProvider for ClientSecretOAuthProvider {
                 ("scope", AZURE_STORAGE_SCOPE),
                 ("grant_type", "client_credentials"),
             ])
-            .send_retry_with_idempotency(retry, true)
+            .retryable(retry)
+            .idempotent(true)
+            .send()
             .await
             .context(TokenRequestSnafu)?
             .json()
@@ -797,7 +799,9 @@ impl TokenProvider for WorkloadIdentityOAuthProvider {
                 ("scope", AZURE_STORAGE_SCOPE),
                 ("grant_type", "client_credentials"),
             ])
-            .send_retry_with_idempotency(retry, true)
+            .retryable(retry)
+            .idempotent(true)
+            .send()
             .await
             .context(TokenRequestSnafu)?
             .json()

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -18,10 +18,10 @@
 //! A shared HTTP client implementation incorporating retries
 
 use crate::client::backoff::{Backoff, BackoffConfig};
+use crate::PutPayload;
 use futures::future::BoxFuture;
-use futures::FutureExt;
 use reqwest::header::LOCATION;
-use reqwest::{Response, StatusCode};
+use reqwest::{Client, Request, Response, StatusCode};
 use snafu::Error as SnafuError;
 use snafu::Snafu;
 use std::time::{Duration, Instant};
@@ -166,26 +166,54 @@ impl Default for RetryConfig {
     }
 }
 
-fn send_retry_impl(
-    builder: reqwest::RequestBuilder,
-    config: &RetryConfig,
-    is_idempotent: Option<bool>,
-) -> BoxFuture<'static, Result<Response>> {
-    let mut backoff = Backoff::new(&config.backoff);
-    let max_retries = config.max_retries;
-    let retry_timeout = config.retry_timeout;
+pub struct RetryableRequest {
+    client: Client,
+    request: Request,
 
-    let (client, req) = builder.build_split();
-    let req = req.expect("request must be valid");
-    let is_idempotent = is_idempotent.unwrap_or(req.method().is_safe());
+    max_retries: usize,
+    retry_timeout: Duration,
+    backoff: Backoff,
 
-    async move {
+    idempotent: Option<bool>,
+    payload: Option<PutPayload>,
+}
+
+impl RetryableRequest {
+    /// Set whether this request is idempotent
+    pub fn idempotent(self, idempotent: bool) -> Self {
+        Self {
+            idempotent: Some(idempotent),
+            ..self
+        }
+    }
+
+    /// Provide a [`PutPayload`]
+    pub fn payload(self, payload: Option<PutPayload>) -> Self {
+        Self { payload, ..self }
+    }
+
+    pub async fn send(self) -> Result<Response> {
+        let max_retries = self.max_retries;
+        let retry_timeout = self.retry_timeout;
         let mut retries = 0;
         let now = Instant::now();
 
+        let mut backoff = self.backoff;
+        let is_idempotent = self
+            .idempotent
+            .unwrap_or_else(|| self.request.method().is_safe());
+
         loop {
-            let s = req.try_clone().expect("request body must be cloneable");
-            match client.execute(s).await {
+            let mut s = self
+                .request
+                .try_clone()
+                .expect("request body must be cloneable");
+
+            if let Some(x) = &self.payload {
+                *s.body_mut() = Some(x.body());
+            }
+
+            match self.client.execute(s).await {
                 Ok(r) => match r.error_for_status_ref() {
                     Ok(_) if r.status().is_success() => return Ok(r),
                     Ok(r) if r.status() == StatusCode::NOT_MODIFIED => {
@@ -195,47 +223,44 @@ fn send_retry_impl(
                         })
                     }
                     Ok(r) => {
-                        let is_bare_redirect = r.status().is_redirection() && !r.headers().contains_key(LOCATION);
+                        let is_bare_redirect =
+                            r.status().is_redirection() && !r.headers().contains_key(LOCATION);
                         return match is_bare_redirect {
                             true => Err(Error::BareRedirect),
                             // Not actually sure if this is reachable, but here for completeness
                             false => Err(Error::Client {
                                 body: None,
                                 status: r.status(),
-                            })
-                        }
+                            }),
+                        };
                     }
                     Err(e) => {
                         let status = r.status();
                         if retries == max_retries
                             || now.elapsed() > retry_timeout
-                            || !status.is_server_error() {
-
+                            || !status.is_server_error()
+                        {
                             return Err(match status.is_client_error() {
                                 true => match r.text().await {
-                                    Ok(body) => {
-                                        Error::Client {
-                                            body: Some(body).filter(|b| !b.is_empty()),
-                                            status,
-                                        }
-                                    }
-                                    Err(e) => {
-                                        Error::Reqwest {
-                                            retries,
-                                            max_retries,
-                                            elapsed: now.elapsed(),
-                                            retry_timeout,
-                                            source: e,
-                                        }
-                                    }
-                                }
+                                    Ok(body) => Error::Client {
+                                        body: Some(body).filter(|b| !b.is_empty()),
+                                        status,
+                                    },
+                                    Err(e) => Error::Reqwest {
+                                        retries,
+                                        max_retries,
+                                        elapsed: now.elapsed(),
+                                        retry_timeout,
+                                        source: e,
+                                    },
+                                },
                                 false => Error::Reqwest {
                                     retries,
                                     max_retries,
                                     elapsed: now.elapsed(),
                                     retry_timeout,
                                     source: e,
-                                }
+                                },
                             });
                         }
 
@@ -251,13 +276,13 @@ fn send_retry_impl(
                         tokio::time::sleep(sleep).await;
                     }
                 },
-                Err(e) =>
-                {
+                Err(e) => {
                     let mut do_retry = false;
                     if e.is_connect()
                         || e.is_body()
                         || (e.is_request() && !e.is_timeout())
-                        || (is_idempotent && e.is_timeout()) {
+                        || (is_idempotent && e.is_timeout())
+                    {
                         do_retry = true
                     } else {
                         let mut source = e.source();
@@ -267,7 +292,7 @@ fn send_retry_impl(
                                     || e.is_incomplete_message()
                                     || e.is_body_write_aborted()
                                     || (is_idempotent && e.is_timeout());
-                                break
+                                break;
                             }
                             if let Some(e) = e.downcast_ref::<std::io::Error>() {
                                 if e.kind() == std::io::ErrorKind::TimedOut {
@@ -276,9 +301,9 @@ fn send_retry_impl(
                                     do_retry = matches!(
                                         e.kind(),
                                         std::io::ErrorKind::ConnectionReset
-                                        | std::io::ErrorKind::ConnectionAborted
-                                        | std::io::ErrorKind::BrokenPipe
-                                        | std::io::ErrorKind::UnexpectedEof
+                                            | std::io::ErrorKind::ConnectionAborted
+                                            | std::io::ErrorKind::BrokenPipe
+                                            | std::io::ErrorKind::UnexpectedEof
                                     );
                                 }
                                 break;
@@ -287,17 +312,14 @@ fn send_retry_impl(
                         }
                     }
 
-                    if retries == max_retries
-                        || now.elapsed() > retry_timeout
-                        || !do_retry {
-
+                    if retries == max_retries || now.elapsed() > retry_timeout || !do_retry {
                         return Err(Error::Reqwest {
                             retries,
                             max_retries,
                             elapsed: now.elapsed(),
                             retry_timeout,
                             source: e,
-                        })
+                        });
                     }
                     let sleep = backoff.next();
                     retries += 1;
@@ -313,39 +335,39 @@ fn send_retry_impl(
             }
         }
     }
-    .boxed()
 }
 
 pub trait RetryExt {
+    /// Return a [`RetryableRequest`]
+    fn retryable(self, config: &RetryConfig) -> RetryableRequest;
+
     /// Dispatch a request with the given retry configuration
     ///
     /// # Panic
     ///
     /// This will panic if the request body is a stream
     fn send_retry(self, config: &RetryConfig) -> BoxFuture<'static, Result<Response>>;
-
-    /// Dispatch a request with the given retry configuration and idempotency
-    ///
-    /// # Panic
-    ///
-    /// This will panic if the request body is a stream
-    fn send_retry_with_idempotency(
-        self,
-        config: &RetryConfig,
-        is_idempotent: bool,
-    ) -> BoxFuture<'static, Result<Response>>;
 }
 
 impl RetryExt for reqwest::RequestBuilder {
-    fn send_retry(self, config: &RetryConfig) -> BoxFuture<'static, Result<Response>> {
-        send_retry_impl(self, config, None)
+    fn retryable(self, config: &RetryConfig) -> RetryableRequest {
+        let (client, request) = self.build_split();
+        let request = request.expect("request must be valid");
+
+        RetryableRequest {
+            client,
+            request,
+            max_retries: config.max_retries,
+            retry_timeout: config.retry_timeout,
+            backoff: Backoff::new(&config.backoff),
+            idempotent: None,
+            payload: None,
+        }
     }
-    fn send_retry_with_idempotency(
-        self,
-        config: &RetryConfig,
-        is_idempotent: bool,
-    ) -> BoxFuture<'static, Result<Response>> {
-        send_retry_impl(self, config, Some(is_idempotent))
+
+    fn send_retry(self, config: &RetryConfig) -> BoxFuture<'static, Result<Response>> {
+        let request = self.retryable(config);
+        Box::pin(async move { request.send().await })
     }
 }
 

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -623,7 +623,9 @@ impl TokenProvider for AuthorizedUserCredentials {
                 ("client_secret", &self.client_secret),
                 ("refresh_token", &self.refresh_token),
             ])
-            .send_retry_with_idempotency(retry, true)
+            .retryable(retry)
+            .idempotent(true)
+            .send()
             .await
             .context(TokenRequestSnafu)?
             .json::<TokenResponse>()

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -251,9 +251,8 @@
 //!
 //! ```
 //! # use object_store::local::LocalFileSystem;
-//! # use object_store::ObjectStore;
+//! # use object_store::{ObjectStore, PutPayload};
 //! # use std::sync::Arc;
-//! # use bytes::Bytes;
 //! # use object_store::path::Path;
 //! # fn get_object_store() -> Arc<dyn ObjectStore> {
 //! #   Arc::new(LocalFileSystem::new())
@@ -262,8 +261,8 @@
 //! #
 //! let object_store: Arc<dyn ObjectStore> = get_object_store();
 //! let path = Path::from("data/file1");
-//! let bytes = Bytes::from_static(b"hello");
-//! object_store.put(&path, bytes).await.unwrap();
+//! let payload = PutPayload::from_static(b"hello");
+//! object_store.put(&path, payload).await.unwrap();
 //! # }
 //! ```
 //!
@@ -427,7 +426,7 @@
 //!     let new = do_update(r.bytes().await.unwrap());
 //!
 //!     // Attempt to commit transaction
-//!     match store.put_opts(&path, new, PutMode::Update(version).into()).await {
+//!     match store.put_opts(&path, new.into(), PutMode::Update(version).into()).await {
 //!         Ok(_) => break, // Successfully committed
 //!         Err(Error::Precondition { .. }) => continue, // Object has changed, try again
 //!         Err(e) => panic!("{e}")
@@ -498,17 +497,18 @@ pub use tags::TagSet;
 
 pub mod multipart;
 mod parse;
+mod payload;
 mod upload;
 mod util;
 
 pub use parse::{parse_url, parse_url_opts};
+pub use payload::*;
 pub use upload::*;
-pub use util::GetRange;
+pub use util::{coalesce_ranges, collect_bytes, GetRange, OBJECT_STORE_COALESCE_DEFAULT};
 
 use crate::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::util::maybe_spawn_blocking;
-pub use crate::util::{coalesce_ranges, collect_bytes, OBJECT_STORE_COALESCE_DEFAULT};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -532,14 +532,20 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// Save the provided bytes to the specified location
     ///
     /// The operation is guaranteed to be atomic, it will either successfully
-    /// write the entirety of `bytes` to `location`, or fail. No clients
+    /// write the entirety of `payload` to `location`, or fail. No clients
     /// should be able to observe a partially written object
-    async fn put(&self, location: &Path, bytes: Bytes) -> Result<PutResult> {
-        self.put_opts(location, bytes, PutOptions::default()).await
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        self.put_opts(location, payload, PutOptions::default())
+            .await
     }
 
-    /// Save the provided bytes to the specified location with the given options
-    async fn put_opts(&self, location: &Path, bytes: Bytes, opts: PutOptions) -> Result<PutResult>;
+    /// Save the provided `payload` to `location` with the given options
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult>;
 
     /// Perform a multipart upload
     ///
@@ -616,11 +622,10 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// # use object_store::{ObjectStore, ObjectMeta};
     /// # use object_store::path::Path;
     /// # use futures::{StreamExt, TryStreamExt};
-    /// # use bytes::Bytes;
     /// #
     /// // Create two objects
-    /// store.put(&Path::from("foo"), Bytes::from("foo")).await?;
-    /// store.put(&Path::from("bar"), Bytes::from("bar")).await?;
+    /// store.put(&Path::from("foo"), "foo".into()).await?;
+    /// store.put(&Path::from("bar"), "bar".into()).await?;
     ///
     /// // List object
     /// let locations = store.list(None).map_ok(|m| m.location).boxed();
@@ -717,17 +722,17 @@ macro_rules! as_ref_impl {
     ($type:ty) => {
         #[async_trait]
         impl ObjectStore for $type {
-            async fn put(&self, location: &Path, bytes: Bytes) -> Result<PutResult> {
-                self.as_ref().put(location, bytes).await
+            async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+                self.as_ref().put(location, payload).await
             }
 
             async fn put_opts(
                 &self,
                 location: &Path,
-                bytes: Bytes,
+                payload: PutPayload,
                 opts: PutOptions,
             ) -> Result<PutResult> {
-                self.as_ref().put_opts(location, bytes, opts).await
+                self.as_ref().put_opts(location, payload, opts).await
             }
 
             async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
@@ -1219,8 +1224,7 @@ mod tests {
         let location = Path::from("test_dir/test_file.json");
 
         let data = Bytes::from("arbitrary data");
-        let expected_data = data.clone();
-        storage.put(&location, data).await.unwrap();
+        storage.put(&location, data.clone().into()).await.unwrap();
 
         let root = Path::from("/");
 
@@ -1263,14 +1267,14 @@ mod tests {
         assert!(content_list.is_empty());
 
         let read_data = storage.get(&location).await.unwrap().bytes().await.unwrap();
-        assert_eq!(&*read_data, expected_data);
+        assert_eq!(&*read_data, data);
 
         // Test range request
         let range = 3..7;
         let range_result = storage.get_range(&location, range.clone()).await;
 
         let bytes = range_result.unwrap();
-        assert_eq!(bytes, expected_data.slice(range.clone()));
+        assert_eq!(bytes, data.slice(range.clone()));
 
         let opts = GetOptions {
             range: Some(GetRange::Bounded(2..5)),
@@ -1348,11 +1352,11 @@ mod tests {
         let ranges = vec![0..1, 2..3, 0..5];
         let bytes = storage.get_ranges(&location, &ranges).await.unwrap();
         for (range, bytes) in ranges.iter().zip(bytes) {
-            assert_eq!(bytes, expected_data.slice(range.clone()))
+            assert_eq!(bytes, data.slice(range.clone()))
         }
 
         let head = storage.head(&location).await.unwrap();
-        assert_eq!(head.size, expected_data.len());
+        assert_eq!(head.size, data.len());
 
         storage.delete(&location).await.unwrap();
 
@@ -1369,7 +1373,7 @@ mod tests {
 
         let file_with_delimiter = Path::from_iter(["a", "b/c", "foo.file"]);
         storage
-            .put(&file_with_delimiter, Bytes::from("arbitrary"))
+            .put(&file_with_delimiter, "arbitrary".into())
             .await
             .unwrap();
 
@@ -1409,10 +1413,7 @@ mod tests {
 
         let emoji_prefix = Path::from("🙀");
         let emoji_file = Path::from("🙀/😀.parquet");
-        storage
-            .put(&emoji_file, Bytes::from("arbitrary"))
-            .await
-            .unwrap();
+        storage.put(&emoji_file, "arbitrary".into()).await.unwrap();
 
         storage.head(&emoji_file).await.unwrap();
         storage
@@ -1464,7 +1465,7 @@ mod tests {
         let hello_prefix = Path::parse("%48%45%4C%4C%4F").unwrap();
         let path = hello_prefix.child("foo.parquet");
 
-        storage.put(&path, Bytes::from(vec![0, 1])).await.unwrap();
+        storage.put(&path, vec![0, 1].into()).await.unwrap();
         let files = flatten_list_stream(storage, Some(&hello_prefix))
             .await
             .unwrap();
@@ -1504,7 +1505,7 @@ mod tests {
 
         // Can also write non-percent encoded sequences
         let path = Path::parse("%Q.parquet").unwrap();
-        storage.put(&path, Bytes::from(vec![0, 1])).await.unwrap();
+        storage.put(&path, vec![0, 1].into()).await.unwrap();
 
         let files = flatten_list_stream(storage, None).await.unwrap();
         assert_eq!(files, vec![path.clone()]);
@@ -1512,7 +1513,7 @@ mod tests {
         storage.delete(&path).await.unwrap();
 
         let path = Path::parse("foo bar/I contain spaces.parquet").unwrap();
-        storage.put(&path, Bytes::from(vec![0, 1])).await.unwrap();
+        storage.put(&path, vec![0, 1].into()).await.unwrap();
         storage.head(&path).await.unwrap();
 
         let files = flatten_list_stream(storage, Some(&Path::from("foo bar")))
@@ -1622,7 +1623,7 @@ mod tests {
         delete_fixtures(storage).await;
 
         let path = Path::from("empty");
-        storage.put(&path, Bytes::new()).await.unwrap();
+        storage.put(&path, PutPayload::default()).await.unwrap();
         let meta = storage.head(&path).await.unwrap();
         assert_eq!(meta.size, 0);
         let data = storage.get(&path).await.unwrap().bytes().await.unwrap();
@@ -1879,7 +1880,7 @@ mod tests {
         let data = get_chunks(5 * 1024 * 1024, 3);
         let bytes_expected = data.concat();
         let mut upload = storage.put_multipart(&location).await.unwrap();
-        let uploads = data.into_iter().map(|x| upload.put_part(x));
+        let uploads = data.into_iter().map(|x| upload.put_part(x.into()));
         futures::future::try_join_all(uploads).await.unwrap();
 
         // Object should not yet exist in store
@@ -1928,7 +1929,7 @@ mod tests {
         // We can abort an in-progress write
         let mut upload = storage.put_multipart(&location).await.unwrap();
         upload
-            .put_part(data.first().unwrap().clone())
+            .put_part(data.first().unwrap().clone().into())
             .await
             .unwrap();
 
@@ -1953,7 +1954,7 @@ mod tests {
         let location1 = Path::from("foo/x.json");
         let location2 = Path::from("foo.bar/y.json");
 
-        let data = Bytes::from("arbitrary data");
+        let data = PutPayload::from("arbitrary data");
         storage.put(&location1, data.clone()).await.unwrap();
         storage.put(&location2, data).await.unwrap();
 
@@ -2011,8 +2012,7 @@ mod tests {
         .collect();
 
         for f in &files {
-            let data = data.clone();
-            storage.put(f, data).await.unwrap();
+            storage.put(f, data.clone().into()).await.unwrap();
         }
 
         // ==================== check: prefix-list `mydb/wb` (directory) ====================
@@ -2076,15 +2076,15 @@ mod tests {
         let contents2 = Bytes::from("dogs");
 
         // copy() make both objects identical
-        storage.put(&path1, contents1.clone()).await.unwrap();
-        storage.put(&path2, contents2.clone()).await.unwrap();
+        storage.put(&path1, contents1.clone().into()).await.unwrap();
+        storage.put(&path2, contents2.clone().into()).await.unwrap();
         storage.copy(&path1, &path2).await.unwrap();
         let new_contents = storage.get(&path2).await.unwrap().bytes().await.unwrap();
         assert_eq!(&new_contents, &contents1);
 
         // rename() copies contents and deletes original
-        storage.put(&path1, contents1.clone()).await.unwrap();
-        storage.put(&path2, contents2.clone()).await.unwrap();
+        storage.put(&path1, contents1.clone().into()).await.unwrap();
+        storage.put(&path2, contents2.clone().into()).await.unwrap();
         storage.rename(&path1, &path2).await.unwrap();
         let new_contents = storage.get(&path2).await.unwrap().bytes().await.unwrap();
         assert_eq!(&new_contents, &contents1);
@@ -2104,8 +2104,8 @@ mod tests {
         let contents2 = Bytes::from("dogs");
 
         // copy_if_not_exists() errors if destination already exists
-        storage.put(&path1, contents1.clone()).await.unwrap();
-        storage.put(&path2, contents2.clone()).await.unwrap();
+        storage.put(&path1, contents1.clone().into()).await.unwrap();
+        storage.put(&path2, contents2.clone().into()).await.unwrap();
         let result = storage.copy_if_not_exists(&path1, &path2).await;
         assert!(result.is_err());
         assert!(matches!(
@@ -2133,7 +2133,7 @@ mod tests {
 
         // Create destination object
         let path2 = Path::from("test2");
-        storage.put(&path2, Bytes::from("hello")).await.unwrap();
+        storage.put(&path2, "hello".into()).await.unwrap();
 
         // copy() errors if source does not exist
         let result = storage.copy(&path1, &path2).await;
@@ -2164,7 +2164,7 @@ mod tests {
 
         let parts: Vec<_> = futures::stream::iter(chunks)
             .enumerate()
-            .map(|(idx, b)| multipart.put_part(&path, &id, idx, b))
+            .map(|(idx, b)| multipart.put_part(&path, &id, idx, b.into()))
             .buffered(2)
             .try_collect()
             .await
@@ -2204,7 +2204,7 @@ mod tests {
 
         let data = Bytes::from("hello world");
         let path = Path::from("file.txt");
-        integration.put(&path, data.clone()).await.unwrap();
+        integration.put(&path, data.clone().into()).await.unwrap();
 
         let signed = integration
             .signed_url(Method::GET, &path, Duration::from_secs(60))

--- a/object_store/src/limit.rs
+++ b/object_store/src/limit.rs
@@ -19,7 +19,7 @@
 
 use crate::{
     BoxStream, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, Path, PutOptions, PutResult, Result, StreamExt, UploadPart,
+    ObjectStore, Path, PutOptions, PutPayload, PutResult, Result, StreamExt, UploadPart,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -70,14 +70,19 @@ impl<T: ObjectStore> std::fmt::Display for LimitStore<T> {
 
 #[async_trait]
 impl<T: ObjectStore> ObjectStore for LimitStore<T> {
-    async fn put(&self, location: &Path, bytes: Bytes) -> Result<PutResult> {
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
         let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.put(location, bytes).await
+        self.inner.put(location, payload).await
     }
 
-    async fn put_opts(&self, location: &Path, bytes: Bytes, opts: PutOptions) -> Result<PutResult> {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
         let _permit = self.semaphore.acquire().await.unwrap();
-        self.inner.put_opts(location, bytes, opts).await
+        self.inner.put_opts(location, payload, opts).await
     }
     async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
         let upload = self.inner.put_multipart(location).await?;
@@ -232,7 +237,7 @@ impl LimitUpload {
 
 #[async_trait]
 impl MultipartUpload for LimitUpload {
-    fn put_part(&mut self, data: Bytes) -> UploadPart {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
         let upload = self.upload.put_part(data);
         let s = Arc::clone(&self.semaphore);
         Box::pin(async move {

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -39,7 +39,7 @@ use crate::{
     path::{absolute_path_to_url, Path},
     util::InvalidGetRange,
     GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMode, PutOptions, PutResult, Result, UploadPart,
+    PutMode, PutOptions, PutPayload, PutResult, Result, UploadPart,
 };
 
 /// A specialized `Error` for filesystem object store-related errors
@@ -336,7 +336,12 @@ fn is_valid_file_path(path: &Path) -> bool {
 
 #[async_trait]
 impl ObjectStore for LocalFileSystem {
-    async fn put_opts(&self, location: &Path, bytes: Bytes, opts: PutOptions) -> Result<PutResult> {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
         if matches!(opts.mode, PutMode::Update(_)) {
             return Err(crate::Error::NotImplemented);
         }
@@ -346,7 +351,7 @@ impl ObjectStore for LocalFileSystem {
             let (mut file, staging_path) = new_staged_upload(&path)?;
             let mut e_tag = None;
 
-            let err = match file.write_all(&bytes) {
+            let err = match payload.iter().try_for_each(|x| file.write_all(x)) {
                 Ok(_) => {
                     let metadata = file.metadata().map_err(|e| Error::Metadata {
                         source: e.into(),
@@ -724,9 +729,9 @@ impl LocalUpload {
 
 #[async_trait]
 impl MultipartUpload for LocalUpload {
-    fn put_part(&mut self, data: Bytes) -> UploadPart {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
         let offset = self.offset;
-        self.offset += data.len() as u64;
+        self.offset += data.content_length() as u64;
 
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
@@ -734,7 +739,11 @@ impl MultipartUpload for LocalUpload {
             let file = f.as_mut().context(AbortedSnafu)?;
             file.seek(SeekFrom::Start(offset))
                 .context(SeekSnafu { path: &s.dest })?;
-            file.write_all(&data).context(UnableToCopyDataToFileSnafu)?;
+
+            data.iter()
+                .try_for_each(|x| file.write_all(x))
+                .context(UnableToCopyDataToFileSnafu)?;
+
             Ok(())
         })
         .boxed()
@@ -1016,8 +1025,8 @@ mod tests {
             // Can't use stream_get test as WriteMultipart uses a tokio JoinSet
             let p = Path::from("manual_upload");
             let mut upload = integration.put_multipart(&p).await.unwrap();
-            upload.put_part(Bytes::from_static(b"123")).await.unwrap();
-            upload.put_part(Bytes::from_static(b"45678")).await.unwrap();
+            upload.put_part("123".into()).await.unwrap();
+            upload.put_part("45678".into()).await.unwrap();
             let r = upload.complete().await.unwrap();
 
             let get = integration.get(&p).await.unwrap();
@@ -1035,9 +1044,11 @@ mod tests {
         let location = Path::from("nested/file/test_file");
 
         let data = Bytes::from("arbitrary data");
-        let expected_data = data.clone();
 
-        integration.put(&location, data).await.unwrap();
+        integration
+            .put(&location, data.clone().into())
+            .await
+            .unwrap();
 
         let read_data = integration
             .get(&location)
@@ -1046,7 +1057,7 @@ mod tests {
             .bytes()
             .await
             .unwrap();
-        assert_eq!(&*read_data, expected_data);
+        assert_eq!(&*read_data, data);
     }
 
     #[tokio::test]
@@ -1057,9 +1068,11 @@ mod tests {
         let location = Path::from("some_file");
 
         let data = Bytes::from("arbitrary data");
-        let expected_data = data.clone();
 
-        integration.put(&location, data).await.unwrap();
+        integration
+            .put(&location, data.clone().into())
+            .await
+            .unwrap();
 
         let read_data = integration
             .get(&location)
@@ -1068,7 +1081,7 @@ mod tests {
             .bytes()
             .await
             .unwrap();
-        assert_eq!(&*read_data, expected_data);
+        assert_eq!(&*read_data, data);
     }
 
     #[tokio::test]
@@ -1260,7 +1273,7 @@ mod tests {
 
         // Adding a file through a symlink creates in both paths
         integration
-            .put(&Path::from("b/file.parquet"), Bytes::from(vec![0, 1, 2]))
+            .put(&Path::from("b/file.parquet"), vec![0, 1, 2].into())
             .await
             .unwrap();
 
@@ -1279,7 +1292,7 @@ mod tests {
         let directory = Path::from("directory");
         let object = directory.child("child.txt");
         let data = Bytes::from("arbitrary");
-        integration.put(&object, data.clone()).await.unwrap();
+        integration.put(&object, data.clone().into()).await.unwrap();
         integration.head(&object).await.unwrap();
         let result = integration.get(&object).await.unwrap();
         assert_eq!(result.bytes().await.unwrap(), data);
@@ -1319,7 +1332,7 @@ mod tests {
         let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
         let location = Path::from("some_file");
 
-        let data = Bytes::from("arbitrary data");
+        let data = PutPayload::from("arbitrary data");
         let mut u1 = integration.put_multipart(&location).await.unwrap();
         u1.put_part(data.clone()).await.unwrap();
 
@@ -1418,12 +1431,10 @@ mod tests {
 #[cfg(test)]
 mod not_wasm_tests {
     use std::time::Duration;
-
-    use bytes::Bytes;
     use tempfile::TempDir;
 
     use crate::local::LocalFileSystem;
-    use crate::{ObjectStore, Path};
+    use crate::{ObjectStore, Path, PutPayload};
 
     #[tokio::test]
     async fn test_cleanup_intermediate_files() {
@@ -1431,7 +1442,7 @@ mod not_wasm_tests {
         let integration = LocalFileSystem::new_with_prefix(root.path()).unwrap();
 
         let location = Path::from("some_file");
-        let data = Bytes::from_static(b"hello");
+        let data = PutPayload::from_static(b"hello");
         let mut upload = integration.put_multipart(&location).await.unwrap();
         upload.put_part(data).await.unwrap();
 

--- a/object_store/src/multipart.rs
+++ b/object_store/src/multipart.rs
@@ -22,10 +22,9 @@
 //! especially useful when dealing with large files or high-throughput systems.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use crate::path::Path;
-use crate::{MultipartId, PutResult, Result};
+use crate::{MultipartId, PutPayload, PutResult, Result};
 
 /// Represents a part of a file that has been successfully uploaded in a multipart upload process.
 #[derive(Debug, Clone)]
@@ -64,7 +63,7 @@ pub trait MultipartStore: Send + Sync + 'static {
         path: &Path,
         id: &MultipartId,
         part_idx: usize,
-        data: Bytes,
+        data: PutPayload,
     ) -> Result<PartId>;
 
     /// Completes a multipart upload

--- a/object_store/src/payload.rs
+++ b/object_store/src/payload.rs
@@ -1,0 +1,298 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Bytes;
+use std::sync::Arc;
+
+/// A cheaply cloneable, ordered collection of [`Bytes`]
+#[derive(Debug, Clone)]
+pub struct PutPayload(Arc<[Bytes]>);
+
+impl Default for PutPayload {
+    fn default() -> Self {
+        Self(Arc::new([]))
+    }
+}
+
+impl PutPayload {
+    /// Create a new empty [`PutPayload`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a [`PutPayload`] from a static slice
+    pub fn from_static(s: &'static [u8]) -> Self {
+        s.into()
+    }
+
+    /// Creates a [`PutPayload`] from a [`Bytes`]
+    pub fn from_bytes(s: Bytes) -> Self {
+        s.into()
+    }
+
+    #[cfg(feature = "cloud")]
+    pub(crate) fn body(&self) -> reqwest::Body {
+        reqwest::Body::wrap_stream(futures::stream::iter(
+            self.clone().into_iter().map(Ok::<_, crate::Error>),
+        ))
+    }
+
+    /// Returns the total length of the [`Bytes`] in this payload
+    pub fn content_length(&self) -> usize {
+        self.0.iter().map(|b| b.len()).sum()
+    }
+
+    /// Returns an iterator over the [`Bytes`] in this payload
+    pub fn iter(&self) -> PutPayloadIter<'_> {
+        PutPayloadIter(self.0.iter())
+    }
+}
+
+impl AsRef<[Bytes]> for PutPayload {
+    fn as_ref(&self) -> &[Bytes] {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> IntoIterator for &'a PutPayload {
+    type Item = &'a Bytes;
+    type IntoIter = PutPayloadIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for PutPayload {
+    type Item = Bytes;
+    type IntoIter = PutPayloadIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PutPayloadIntoIter {
+            payload: self,
+            idx: 0,
+        }
+    }
+}
+
+/// An iterator over [`PutPayload`]
+#[derive(Debug)]
+pub struct PutPayloadIter<'a>(std::slice::Iter<'a, Bytes>);
+
+impl<'a> Iterator for PutPayloadIter<'a> {
+    type Item = &'a Bytes;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+/// An owning iterator of [`PutPayload`]
+#[derive(Debug)]
+pub struct PutPayloadIntoIter {
+    payload: PutPayload,
+    idx: usize,
+}
+
+impl Iterator for PutPayloadIntoIter {
+    type Item = Bytes;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let p = self.payload.0.get(self.idx)?.clone();
+        self.idx += 1;
+        Some(p)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let l = self.payload.0.len() - self.idx;
+        (l, Some(l))
+    }
+}
+
+impl From<Bytes> for PutPayload {
+    fn from(value: Bytes) -> Self {
+        Self(Arc::new([value]))
+    }
+}
+
+impl From<Vec<u8>> for PutPayload {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Arc::new([value.into()]))
+    }
+}
+
+impl From<&'static str> for PutPayload {
+    fn from(value: &'static str) -> Self {
+        Bytes::from(value).into()
+    }
+}
+
+impl From<&'static [u8]> for PutPayload {
+    fn from(value: &'static [u8]) -> Self {
+        Bytes::from(value).into()
+    }
+}
+
+impl From<String> for PutPayload {
+    fn from(value: String) -> Self {
+        Bytes::from(value).into()
+    }
+}
+
+impl FromIterator<u8> for PutPayload {
+    fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
+        Bytes::from_iter(iter).into()
+    }
+}
+
+impl FromIterator<Bytes> for PutPayload {
+    fn from_iter<T: IntoIterator<Item = Bytes>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl From<PutPayload> for Bytes {
+    fn from(value: PutPayload) -> Self {
+        match value.0.len() {
+            0 => Self::new(),
+            1 => value.0[0].clone(),
+            _ => {
+                let mut buf = Vec::with_capacity(value.content_length());
+                value.iter().for_each(|x| buf.extend_from_slice(x));
+                buf.into()
+            }
+        }
+    }
+}
+
+/// A builder for [`PutPayload`] that allocates memory in chunks
+#[derive(Debug)]
+pub struct PutPayloadMut {
+    len: usize,
+    completed: Vec<Bytes>,
+    in_progress: Vec<u8>,
+    min_block_size: usize,
+}
+
+impl Default for PutPayloadMut {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            completed: vec![],
+            in_progress: vec![],
+
+            min_block_size: 8 * 1024,
+        }
+    }
+}
+
+impl PutPayloadMut {
+    /// Create a new [`PutPayloadMut`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the minimum allocation size
+    pub(crate) fn with_block_size(self, min_block_size: usize) -> Self {
+        Self {
+            min_block_size,
+            ..self
+        }
+    }
+
+    /// Write bytes into this [`PutPayloadMut`]
+    pub fn extend_from_slice(&mut self, slice: &[u8]) {
+        let remaining = self.in_progress.capacity() - self.in_progress.len();
+        let to_copy = remaining.min(slice.len());
+
+        self.in_progress.extend_from_slice(&slice[..to_copy]);
+        if self.in_progress.capacity() == self.in_progress.len() {
+            let new_cap = self.min_block_size.max(slice.len() - to_copy);
+            let completed = std::mem::replace(&mut self.in_progress, Vec::with_capacity(new_cap));
+            if !completed.is_empty() {
+                self.completed.push(completed.into())
+            }
+            self.in_progress.extend_from_slice(&slice[to_copy..])
+        }
+        self.len += slice.len();
+    }
+
+    /// Append a [`Bytes`] to this [`PutPayloadMut`]
+    pub fn push(&mut self, bytes: Bytes) {
+        if !self.in_progress.is_empty() {
+            let completed = std::mem::take(&mut self.in_progress);
+            self.completed.push(completed.into())
+        }
+        self.completed.push(bytes)
+    }
+
+    /// Returns `true` if this [`PutPayloadMut`] contains no bytes
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the total length of the [`Bytes`] in this payload
+    #[inline]
+    pub fn content_length(&self) -> usize {
+        self.len
+    }
+
+    pub fn freeze(mut self) -> PutPayload {
+        if !self.in_progress.is_empty() {
+            let completed = std::mem::take(&mut self.in_progress).into();
+            self.completed.push(completed);
+        }
+        PutPayload(self.completed.into())
+    }
+}
+
+impl From<PutPayloadMut> for PutPayload {
+    fn from(value: PutPayloadMut) -> Self {
+        value.freeze()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::PutPayloadMut;
+
+    #[test]
+    fn test_put_payload() {
+        let mut chunk = PutPayloadMut::new().with_block_size(23);
+        chunk.extend_from_slice(&[1; 16]);
+        chunk.extend_from_slice(&[2; 32]);
+        chunk.extend_from_slice(&[2; 5]);
+        chunk.extend_from_slice(&[2; 21]);
+        chunk.extend_from_slice(&[2; 40]);
+        let payload = chunk.freeze();
+        assert_eq!(payload.content_length(), 114);
+
+        let chunks = payload.as_ref();
+        assert_eq!(chunks.len(), 5);
+
+        assert_eq!(chunks[0].len(), 23);
+        assert_eq!(chunks[1].len(), 25); // 32 - (23 - 16)
+        assert_eq!(chunks[2].len(), 23);
+        assert_eq!(chunks[3].len(), 23);
+        assert_eq!(chunks[4].len(), 20);
+    }
+}

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -17,13 +17,12 @@
 
 use std::task::{Context, Poll};
 
+use crate::{PutPayload, PutPayloadMut, PutResult, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::ready;
 use tokio::task::JoinSet;
-
-use crate::{PutResult, Result};
 
 /// An upload part request
 pub type UploadPart = BoxFuture<'static, Result<()>>;
@@ -65,7 +64,7 @@ pub trait MultipartUpload: Send + std::fmt::Debug {
     /// ```
     ///
     /// [R2]: https://developers.cloudflare.com/r2/objects/multipart-objects/#limitations
-    fn put_part(&mut self, data: Bytes) -> UploadPart;
+    fn put_part(&mut self, data: PutPayload) -> UploadPart;
 
     /// Complete the multipart upload
     ///
@@ -106,7 +105,9 @@ pub trait MultipartUpload: Send + std::fmt::Debug {
 pub struct WriteMultipart {
     upload: Box<dyn MultipartUpload>,
 
-    buffer: Vec<u8>,
+    buffer: PutPayloadMut,
+
+    chunk_size: usize,
 
     tasks: JoinSet<Result<()>>,
 }
@@ -121,7 +122,8 @@ impl WriteMultipart {
     pub fn new_with_chunk_size(upload: Box<dyn MultipartUpload>, chunk_size: usize) -> Self {
         Self {
             upload,
-            buffer: Vec::with_capacity(chunk_size),
+            chunk_size,
+            buffer: PutPayloadMut::new(),
             tasks: Default::default(),
         }
     }
@@ -157,19 +159,34 @@ impl WriteMultipart {
     /// [`Self::wait_for_capacity`] prior to calling this method
     pub fn write(&mut self, mut buf: &[u8]) {
         while !buf.is_empty() {
-            let capacity = self.buffer.capacity();
-            let remaining = capacity - self.buffer.len();
+            let remaining = self.chunk_size - self.buffer.content_length();
             let to_read = buf.len().min(remaining);
             self.buffer.extend_from_slice(&buf[..to_read]);
             if to_read == remaining {
-                let part = std::mem::replace(&mut self.buffer, Vec::with_capacity(capacity));
-                self.put_part(part.into())
+                let buffer = std::mem::take(&mut self.buffer);
+                self.put_part(buffer.into())
             }
             buf = &buf[to_read..]
         }
     }
 
-    fn put_part(&mut self, part: Bytes) {
+    /// Put a chunk of data into this [`WriteMultipart`]
+    ///
+    /// See [`Self::write`] for information on backpressure
+    pub fn put(&mut self, mut bytes: Bytes) {
+        while !bytes.is_empty() {
+            let remaining = self.chunk_size - self.buffer.content_length();
+            if bytes.len() < remaining {
+                self.buffer.push(bytes);
+                return;
+            }
+            self.buffer.push(bytes.split_to(remaining));
+            let buffer = std::mem::take(&mut self.buffer);
+            self.put_part(buffer.into())
+        }
+    }
+
+    pub(crate) fn put_part(&mut self, part: PutPayload) {
         self.tasks.spawn(self.upload.put_part(part));
     }
 

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -151,6 +151,9 @@ impl WriteMultipart {
 
     /// Write data to this [`WriteMultipart`]
     ///
+    /// Data is buffered using [`PutPayloadMut::extend_from_slice`]. Implementations looking to
+    /// write data from owned buffers may prefer [`Self::put`] as this avoids copying.
+    ///
     /// Note this method is synchronous (not `async`) and will immediately
     /// start new uploads as soon as the internal `chunk_size` is hit,
     /// regardless of how many outstanding uploads are already in progress.
@@ -170,7 +173,11 @@ impl WriteMultipart {
         }
     }
 
-    /// Put a chunk of data into this [`WriteMultipart`]
+    /// Put a chunk of data into this [`WriteMultipart`] without copying
+    ///
+    /// Data is buffered using [`PutPayloadMut::push`]. Implementations looking to
+    /// perform writes from non-owned buffers should prefer [`Self::write`] as this
+    /// will allow multiple calls to share the same underlying allocation.
     ///
     /// See [`Self::write`] for information on backpressure
     pub fn put(&mut self, mut bytes: Bytes) {

--- a/object_store/tests/get_range_file.rs
+++ b/object_store/tests/get_range_file.rs
@@ -37,8 +37,13 @@ impl std::fmt::Display for MyStore {
 
 #[async_trait]
 impl ObjectStore for MyStore {
-    async fn put_opts(&self, path: &Path, data: Bytes, opts: PutOptions) -> Result<PutResult> {
-        self.0.put_opts(path, data, opts).await
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        self.0.put_opts(location, payload, opts).await
     }
 
     async fn put_multipart(&self, _location: &Path) -> Result<Box<dyn MultipartUpload>> {
@@ -77,7 +82,7 @@ async fn test_get_range() {
     let path = Path::from("foo");
 
     let expected = Bytes::from_static(b"hello world");
-    store.put(&path, expected.clone()).await.unwrap();
+    store.put(&path, expected.clone().into()).await.unwrap();
     let fetched = store.get(&path).await.unwrap().bytes().await.unwrap();
     assert_eq!(expected, fetched);
 
@@ -101,7 +106,7 @@ async fn test_get_opts_over_range() {
     let path = Path::from("foo");
 
     let expected = Bytes::from_static(b"hello world");
-    store.put(&path, expected.clone()).await.unwrap();
+    store.put(&path, expected.clone().into()).await.unwrap();
 
     let opts = GetOptions {
         range: Some(GetRange::Bounded(0..(expected.len() * 2))),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5514

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Allowing non-contiguous payloads avoids needing to bump allocate buffers when writing data where the size isn't known up front. This can be significantly more efficient.

It will also open up interesting possibilities for the parquet writer, where the data is already buffered in chunks

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

FYI @roeap @wjones127 @alamb 
