### PR TITLE
filter for run end array

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -375,6 +375,7 @@ fn filter_array(values: &dyn Array, predicate: &FilterPredicate) -> Result<Array
     }
 }
 
+/// Filter a [`RunArray`] based on a [`FilterPredicate`]
 fn filter_run_end_array(
     re_arr: &RunArray<Int64Type>,
     pred: &FilterPredicate,


### PR DESCRIPTION
# Which issue does this PR close?

Related to #3520 

# Rationale for this change
 
Attempt at adding filter support for RunArray for i64 run_ends

# What changes are included in this PR?

Support for filtering RunArray

# Are there any user-facing changes?

the filter function now works for RunArray
