### PR TITLE
Expose ArrowReaderMetadata::try_new

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -270,10 +270,7 @@ impl ArrowReaderMetadata {
         Self::try_new(Arc::new(metadata), options)
     }
 
-    pub(crate) fn try_new(
-        metadata: Arc<ParquetMetaData>,
-        options: ArrowReaderOptions,
-    ) -> Result<Self> {
+    pub fn try_new(metadata: Arc<ParquetMetaData>, options: ArrowReaderOptions) -> Result<Self> {
         let kv_metadata = match options.skip_arrow_metadata {
             true => None,
             false => metadata.file_metadata().key_value_metadata(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5582.

# Rationale for this change

Enable constructing `ArrowReaderMetadata` from external metadata.

# What changes are included in this PR?

Make `ArrowReaderMetadata::try_new` public.

# Are there any user-facing changes?

No breaking changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
