### PR TITLE
Add Send + Sync traits for Datum

### DIFF
--- a/arrow-array/src/scalar.rs
+++ b/arrow-array/src/scalar.rs
@@ -75,7 +75,7 @@ use crate::Array;
 /// let r = eq(&a, &b).unwrap();
 /// let values: Vec<_> = r.values().iter().collect();
 /// assert_eq!(values, &[true, false, false, false, false]);
-pub trait Datum {
+pub trait Datum: Send + Sync {
     /// Returns the value for this [`Datum`] and a boolean indicating if the value is scalar
     fn get(&self) -> (&dyn Array, bool);
 }
@@ -144,3 +144,6 @@ impl<T: Array> Datum for Scalar<T> {
         (&self.0, true)
     }
 }
+
+unsafe impl<T: Array> Send for Scalar<T> {}
+unsafe impl<T: Array> Sync for Scalar<T> {}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

While working on https://github.com/apache/iceberg-rust/pull/295, I faced an issue that a `Datum` (it is a `Scalar` behind the trait) cannot be moved into a closure.

```
error[E0277]: `dyn arrow_array::Datum` cannot be sent between threads safely
   --> crates/iceberg/src/arrow/reader.rs:451:17
    |
449 |               PredicateOperator::NotEq => Ok(Box::new(ArrowPredicateFn::new(
    |                                                       --------------------- required by a bound introduced by this call
450 |                   self.projection_mask.clone(),
451 | /                 move |batch| {
452 | |                     let left = batch.column(term_index);
453 | |                     neq(left, literal.as_ref())
454 | |                 },
    | |_________________^ `dyn arrow_array::Datum` cannot be sent between threads safely
    |
```

Because the function to return `Datum` may return `Result` to propagate error, I cannot put it into the closure.

I'm wondering if we can make `Datum` also `Send` + `Sync`? 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
