### PR TITLE
Minor: Add docs for GenericBinaryBuilder, links to `GenericStringBuilder`

### DIFF
--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -26,6 +26,9 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 /// Builder for [`GenericByteArray`]
+///
+/// For building strings, see docs on [`GenericStringBuilder`].
+/// For building binary, see docs on [`GenericBinaryBuilder`].
 pub struct GenericByteBuilder<T: ByteArrayType> {
     value_builder: UInt8BufferBuilder,
     offsets_builder: BufferBuilder<T::Offset>,
@@ -222,11 +225,12 @@ impl<T: ByteArrayType, V: AsRef<T::Native>> Extend<Option<V>> for GenericByteBui
 /// Array builder for [`GenericStringArray`][crate::GenericStringArray]
 ///
 /// Values can be appended using [`GenericByteBuilder::append_value`], and nulls with
-/// [`GenericByteBuilder::append_null`] as normal.
+/// [`GenericByteBuilder::append_null`].
 ///
-/// Additionally implements [`std::fmt::Write`] with any written data included in the next
+/// Additionally, implements [`std::fmt::Write`] with any written data included in the next
 /// appended value. This allows use with [`std::fmt::Display`] without intermediate allocations
 ///
+/// # Example
 /// ```
 /// # use std::fmt::Write;
 /// # use arrow_array::builder::GenericStringBuilder;
@@ -257,6 +261,27 @@ impl<O: OffsetSizeTrait> Write for GenericStringBuilder<O> {
 }
 
 ///  Array builder for [`GenericBinaryArray`][crate::GenericBinaryArray]
+///
+/// Values can be appended using [`GenericByteBuilder::append_value`], and nulls with
+/// [`GenericByteBuilder::append_null`].
+///
+/// # Example
+/// ```
+/// # use std::fmt::Write;
+/// # use arrow_array::builder::GenericBinaryBuilder;
+/// let mut builder = GenericBinaryBuilder::<i32>::new();
+///
+/// // Write data
+/// builder.append_value("foo");
+///
+/// // Write second value
+/// builder.append_value(&[0,1,2]);
+///
+/// let array = builder.finish();
+/// // binary values
+/// assert_eq!(array.value(0), b"foo");
+/// assert_eq!(array.value(1), b"\x00\x01\x02");
+/// ```
 pub type GenericBinaryBuilder<O> = GenericByteBuilder<GenericBinaryType<O>>;
 
 #[cfg(test)]

--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -267,7 +267,6 @@ impl<O: OffsetSizeTrait> Write for GenericStringBuilder<O> {
 ///
 /// # Example
 /// ```
-/// # use std::fmt::Write;
 /// # use arrow_array::builder::GenericBinaryBuilder;
 /// let mut builder = GenericBinaryBuilder::<i32>::new();
 ///

--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -305,13 +305,21 @@ pub type ListBuilder<T> = GenericListBuilder<i32, T>;
 pub type LargeListBuilder<T> = GenericListBuilder<i64, T>;
 
 /// Builder for [`BinaryArray`](crate::array::BinaryArray)
+///
+/// See examples on [`GenericBinaryBuilder`]
 pub type BinaryBuilder = GenericBinaryBuilder<i32>;
 
 /// Builder for [`LargeBinaryArray`](crate::array::LargeBinaryArray)
+///
+/// See examples on [`GenericBinaryBuilder`]
 pub type LargeBinaryBuilder = GenericBinaryBuilder<i64>;
 
 /// Builder for [`StringArray`](crate::array::StringArray)
+///
+/// See examples on [`GenericStringBuilder`]
 pub type StringBuilder = GenericStringBuilder<i32>;
 
 /// Builder for [`LargeStringArray`](crate::array::LargeStringArray)
+///
+/// See examples on [`GenericStringBuilder`]
 pub type LargeStringBuilder = GenericStringBuilder<i64>;


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
While working on https://github.com/apache/arrow-datafusion/pull/9973 with @kevinmingtarja I couldn't immediately find the examples for `GenericStringBuilder` because it the typedef is expanded out
 
![Screenshot 2024-04-06 at 7 04 12 AM](https://github.com/apache/arrow-rs/assets/490673/aa35401c-b7de-4acc-8089-8380bbae5070)


# What changes are included in this PR?
1. Add doc links to the examples
2. Add an example for `GenericBinaryBuilder` for symmetry

# Are there any user-facing changes?
Better docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
