### PR TITLE
Panic when displaying dates on 32-bit platforms

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1097,7 +1097,7 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
         write!(f, "PrimitiveArray<{data_type:?}>\n[\n")?;
         print_long_array(self, f, |array, index, f| match data_type {
             DataType::Date32 | DataType::Date64 => {
-                let v = self.value(index).to_isize().unwrap() as i64;
+                let v = self.value(index).to_i64().unwrap();
                 match as_date::<T>(v) {
                     Some(date) => write!(f, "{date:?}"),
                     None => {
@@ -1109,7 +1109,7 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                 }
             }
             DataType::Time32(_) | DataType::Time64(_) => {
-                let v = self.value(index).to_isize().unwrap() as i64;
+                let v = self.value(index).to_i64().unwrap();
                 match as_time::<T>(v) {
                     Some(time) => write!(f, "{time:?}"),
                     None => {
@@ -1121,7 +1121,7 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                 }
             }
             DataType::Timestamp(_, tz_string_opt) => {
-                let v = self.value(index).to_isize().unwrap() as i64;
+                let v = self.value(index).to_i64().unwrap();
                 match tz_string_opt {
                     // for Timestamp with TimeZone
                     Some(tz_string) => {

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -75,6 +75,12 @@ pub trait ArrowNativeType:
     /// in truncation/overflow
     fn to_isize(self) -> Option<isize>;
 
+    /// Convert native type to i64.
+    ///
+    /// Returns `None` if [`Self`] is not an integer or conversion would result
+    /// in truncation/overflow
+    fn to_i64(self) -> Option<i64>;
+
     /// Convert native type from i32.
     ///
     /// Returns `None` if [`Self`] is not `i32`
@@ -116,6 +122,11 @@ macro_rules! native_integer {
 
             #[inline]
             fn to_isize(self) -> Option<isize> {
+                self.try_into().ok()
+            }
+
+            #[inline]
+            fn to_i64(self) -> Option<i64> {
                 self.try_into().ok()
             }
 
@@ -171,6 +182,11 @@ macro_rules! native_float {
             }
 
             #[inline]
+            fn to_i64(self) -> Option<i64> {
+                None
+            }
+
+            #[inline]
             fn as_usize($s) -> usize {
                 $as_usize
             }
@@ -210,6 +226,10 @@ impl ArrowNativeType for i256 {
     }
 
     fn to_isize(self) -> Option<isize> {
+        self.to_i128()?.try_into().ok()
+    }
+
+    fn to_i64(self) -> Option<i64> {
         self.to_i128()?.try_into().ok()
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5599.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The `isize` type is dependent on the platform where the code is running, so in webassembly isize is 32 bits, casting values larger than 32bits can fit will be an undesirable behavior.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use `i64` to convert the native types such as `Date64` and `Timestamp` instead of isize, this allows the code to work on 32bit platforms ie: webassembly in the browser.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
