### PR TITLE
feat: add `try_field()` to Schema

### DIFF
--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -335,6 +335,10 @@ impl Schema {
         &self.fields[i]
     }
 
+    pub fn try_field(&self, i: usize) -> Option<&Field> {
+        self.fields.get(i).map(|f| f.as_ref())
+    }
+
     /// Returns an immutable reference of a specific [`Field`] instance selected by name.
     pub fn field_with_name(&self, name: &str) -> Result<&Field, ArrowError> {
         Ok(&self.fields[self.index_of(name)?])
@@ -648,6 +652,13 @@ mod tests {
         assert_eq!(schema.index_of("first_name").unwrap(), 0);
         assert_eq!(schema.index_of("last_name").unwrap(), 1);
         schema.index_of("nickname").unwrap();
+    }
+
+    #[test]
+    fn schema_try_field() {
+        let schema = person_schema();
+        assert!(schema.try_field(0).is_some());
+        assert!(schema.try_field(99999).is_none());
     }
 
     #[test]

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -331,10 +331,16 @@ impl Schema {
 
     /// Returns an immutable reference of a specific [`Field`] instance selected using an
     /// offset within the internal `fields` vector.
+    ///
+    /// Also consider using `try_field()` method with bounds check.
     pub fn field(&self, i: usize) -> &Field {
         &self.fields[i]
     }
 
+    /// Like `field()` but with bound check.
+    ///
+    /// Returns an immutable reference of a specific [`Field`] instance selected using an
+    /// offset within the internal `fields` vector. And `None` if the index is out of bounds.
     pub fn try_field(&self, i: usize) -> Option<&Field> {
         self.fields.get(i).map(|f| f.as_ref())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`Schema::field()` would panic when the index is out of bounds. This patch adds a safer method `try_field()` that would perform the bound check.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A new method `try_field()` on `Schema`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
