### PR TITLE
Update Flight crate README version

### DIFF
--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -31,7 +31,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-arrow-flight = "39.0.0"
+arrow-flight = "51.0.0"
 ```
 
 Apache Arrow Flight is a gRPC based protocol for exchanging Arrow data between processes. See the blog post [Introducing Apache Arrow Flight: A Framework for Fast Data Transport](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/) for more information.


### PR DESCRIPTION
Updates the Flight crate README version to a more recent one.

# Which issue does this PR close?

N/A

# Rationale for this change

Makes it easier to copy/paste from crates and get a current version. 

# What changes are included in this PR?

Changes the version of the `arrow-flight` crate in the README from 39 -> 51.

# Are there any user-facing changes?

N/A