### PR TITLE
feat: encode FixedSizeBinary in JSON as hex string

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1.27", default-features = false, features = ["io-util"] }
 bytes = "1.4"
 criterion = { version = "0.5", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+hex = "0.4.3"
 
 [[bench]]
 name = "serde"

--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -56,7 +56,6 @@ tokio = { version = "1.27", default-features = false, features = ["io-util"] }
 bytes = "1.4"
 criterion = { version = "0.5", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-hex = "0.4.3"
 
 [[bench]]
 name = "serde"

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -101,7 +101,7 @@ fn make_encoder_impl<'a>(
 
         DataType::FixedSizeBinary(_) => {
             let array = array.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
-            (Box::new(FixedSizeBinaryEncoder::new(array.clone(), options)) as _, array.nulls().cloned())
+            (Box::new(FixedSizeBinaryEncoder::new(array, options)) as _, array.nulls().cloned())
         }
 
         DataType::Struct(fields) => {
@@ -449,13 +449,13 @@ impl<'a> Encoder for MapEncoder<'a> {
     }
 }
 
-struct FixedSizeBinaryEncoder {
-    array: FixedSizeBinaryArray,
+struct FixedSizeBinaryEncoder<'a> {
+    array: &'a FixedSizeBinaryArray,
     explicit_nulls: bool,
 }
 
-impl FixedSizeBinaryEncoder {
-    fn new(array: FixedSizeBinaryArray, options: &EncoderOptions) -> Self {
+impl<'a> FixedSizeBinaryEncoder<'a> {
+    fn new(array: &'a FixedSizeBinaryArray, options: &EncoderOptions) -> Self {
         Self {
             array,
             explicit_nulls: options.explicit_nulls,
@@ -463,7 +463,7 @@ impl FixedSizeBinaryEncoder {
     }
 }
 
-impl Encoder for FixedSizeBinaryEncoder {
+impl<'a> Encoder for FixedSizeBinaryEncoder<'a> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         if self.array.is_valid(idx) {
             let v = self.array.value(idx);

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -101,7 +101,7 @@ fn make_encoder_impl<'a>(
 
         DataType::FixedSizeBinary(_) => {
             let array = array.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
-            (Box::new(FixedSizeBinaryEncoder(array.clone())) as _, array.nulls().cloned())
+            (Box::new(FixedSizeBinaryEncoder::new(array.clone(), options)) as _, array.nulls().cloned())
         }
 
         DataType::Struct(fields) => {
@@ -449,16 +449,32 @@ impl<'a> Encoder for MapEncoder<'a> {
     }
 }
 
-struct FixedSizeBinaryEncoder(FixedSizeBinaryArray);
+struct FixedSizeBinaryEncoder {
+    array: FixedSizeBinaryArray,
+    explicit_nulls: bool,
+}
+
+impl FixedSizeBinaryEncoder {
+    fn new(array: FixedSizeBinaryArray, options: &EncoderOptions) -> Self {
+        Self {
+            array,
+            explicit_nulls: options.explicit_nulls,
+        }
+    }
+}
 
 impl Encoder for FixedSizeBinaryEncoder {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
-        let v = self.0.value(idx);
-        out.push(b'"');
-        for byte in v {
-            // this write is infallible
-            write!(out, "{byte:02x}").unwrap();
+        if self.array.is_valid(idx) {
+            let v = self.array.value(idx);
+            out.push(b'"');
+            for byte in v {
+                // this write is infallible
+                write!(out, "{byte:02x}").unwrap();
+            }
+            out.push(b'"');
+        } else if self.explicit_nulls {
+            out.extend_from_slice(b"null");
         }
-        out.push(b'"');
     }
 }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -454,9 +454,11 @@ struct FixedSizeBinaryEncoder(FixedSizeBinaryArray);
 impl Encoder for FixedSizeBinaryEncoder {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         let v = self.0.value(idx);
+        out.push(b'"');
         for byte in v {
             // this write is infallible
             write!(out, "{byte:02x}").unwrap();
         }
+        out.push(b'"');
     }
 }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -101,7 +101,7 @@ fn make_encoder_impl<'a>(
 
         DataType::FixedSizeBinary(_) => {
             let array = array.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
-            (Box::new(FixedSizeBinaryEncoder::new(array, options)) as _, array.nulls().cloned())
+            (Box::new(FixedSizeBinaryEncoder::new(array)) as _, array.nulls().cloned())
         }
 
         DataType::Struct(fields) => {
@@ -449,32 +449,21 @@ impl<'a> Encoder for MapEncoder<'a> {
     }
 }
 
-struct FixedSizeBinaryEncoder<'a> {
-    array: &'a FixedSizeBinaryArray,
-    explicit_nulls: bool,
-}
+struct FixedSizeBinaryEncoder<'a>(&'a FixedSizeBinaryArray);
 
 impl<'a> FixedSizeBinaryEncoder<'a> {
-    fn new(array: &'a FixedSizeBinaryArray, options: &EncoderOptions) -> Self {
-        Self {
-            array,
-            explicit_nulls: options.explicit_nulls,
-        }
+    fn new(array: &'a FixedSizeBinaryArray) -> Self {
+        Self(array)
     }
 }
 
 impl<'a> Encoder for FixedSizeBinaryEncoder<'a> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
-        if self.array.is_valid(idx) {
-            let v = self.array.value(idx);
-            out.push(b'"');
-            for byte in v {
-                // this write is infallible
-                write!(out, "{byte:02x}").unwrap();
-            }
-            out.push(b'"');
-        } else if self.explicit_nulls {
-            out.extend_from_slice(b"null");
+        out.push(b'"');
+        for byte in self.0.value(idx) {
+            // this write is infallible
+            write!(out, "{byte:02x}").unwrap();
         }
+        out.push(b'"');
     }
 }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -69,16 +69,16 @@ fn make_encoder_impl<'a>(
         DataType::Float64 => primitive_helper!(Float64Type),
         DataType::Boolean => {
             let array = array.as_boolean();
-            (Box::new(BooleanEncoder(array.clone())), array.nulls().cloned())
+            (Box::new(BooleanEncoder(array)), array.nulls().cloned())
         }
         DataType::Null => (Box::new(NullEncoder), array.logical_nulls()),
         DataType::Utf8 => {
             let array = array.as_string::<i32>();
-            (Box::new(StringEncoder(array.clone())) as _, array.nulls().cloned())
+            (Box::new(StringEncoder(array)) as _, array.nulls().cloned())
         }
         DataType::LargeUtf8 => {
             let array = array.as_string::<i64>();
-            (Box::new(StringEncoder(array.clone())) as _, array.nulls().cloned())
+            (Box::new(StringEncoder(array)) as _, array.nulls().cloned())
         }
         DataType::List(_) => {
             let array = array.as_list::<i32>();
@@ -264,9 +264,9 @@ impl<N: PrimitiveEncode> Encoder for PrimitiveEncoder<N> {
     }
 }
 
-struct BooleanEncoder(BooleanArray);
+struct BooleanEncoder<'a>(&'a BooleanArray);
 
-impl Encoder for BooleanEncoder {
+impl<'a> Encoder for BooleanEncoder<'a> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         match self.0.value(idx) {
             true => out.extend_from_slice(b"true"),
@@ -275,9 +275,9 @@ impl Encoder for BooleanEncoder {
     }
 }
 
-struct StringEncoder<O: OffsetSizeTrait>(GenericStringArray<O>);
+struct StringEncoder<'a, O: OffsetSizeTrait>(&'a GenericStringArray<O>);
 
-impl<O: OffsetSizeTrait> Encoder for StringEncoder<O> {
+impl<'a, O: OffsetSizeTrait> Encoder for StringEncoder<'a, O> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         encode_string(self.0.value(idx), out);
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5620.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
See #5620.

# What changes are included in this PR?

Adds encoding support to the JSON writer for the `FixedSizeBinary` data type.

A simple test was added as well. I can add more extensive testing if needed.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Potentially some documentation to state that `FixedSizeBinary` is encoded as hex strings.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
