### PR TITLE
Add more invalid utf8 parquet reader tests

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -2233,7 +2233,6 @@ mod tests {
 
             // data is not valid utf8 we can not construct a correct StringArray
             // safely, so purposely create an invalid StringArray
-
             let array = unsafe {
                 StringViewArray::new_unchecked(
                     array.views().clone(),
@@ -2260,18 +2259,14 @@ mod tests {
     /// returns a BinaryArray with invalid UTF8 data in a character other than
     /// the first (this is checked in a special codepath)
     fn invalid_utf8_later_char<O: OffsetSizeTrait>() -> GenericBinaryArray<O> {
-        // invalid sequence in the first character
+        // invalid sequence in NOT the first character
         // https://stackoverflow.com/questions/1301402/example-invalid-utf8-string
         let valid: &[u8] = b"   ";
         let invalid: &[u8] = &[0x20, 0x20, 0x20, 0xa0, 0xa1, 0x20, 0x20];
         GenericBinaryArray::<O>::from_iter(vec![None, Some(valid), None, Some(invalid)])
     }
 
-    //let invalid_utf8_last_char: &[u8] = &[0x20, 0x20, 0x20, 0x20, 0xa0, 0xa1];
-
-    //
-
-    // writes the array as a column parquet file
+    // writes the array into a single column parquet file
     fn write_to_parquet(array: ArrayRef) -> Vec<u8> {
         let batch = RecordBatch::try_from_iter(vec![("c", array)]).unwrap();
         let mut data = vec![];
@@ -2286,6 +2281,7 @@ mod tests {
         data
     }
 
+    /// read the parquet file into a record batch
     fn read_from_parquet(data: Vec<u8>) -> Result<Vec<RecordBatch>, ArrowError> {
         let reader = ArrowReaderBuilder::try_new(bytes::Bytes::from(data))
             .unwrap()


### PR DESCRIPTION
# Which issue does this PR close?

part of https://github.com/apache/arrow-rs/issues/5530


# Rationale for this change
While reviewing https://github.com/apache/arrow-rs/pull/5557 from @ariesdevil  it was clear we did not have sufficient invalid utf8 validation tests for reading invalid data from parquet

# What changes are included in this PR?

Add error checks for reading invalid utf8 data - both as the first character and embedded characters. 

# Are there any user-facing changes?

No (I didn't find any bugs 😅 )

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
