### PR TITLE
Flip interval field ordering (#5654)

### DIFF
--- a/arrow-arith/src/numeric.rs
+++ b/arrow-arith/src/numeric.rs
@@ -1346,8 +1346,10 @@ mod tests {
                 IntervalMonthDayNanoType::make_value(35, -19, 41899000000000000)
             ])
         );
-        let a = IntervalMonthDayNanoArray::from(vec![i64::MAX as i128]);
-        let b = IntervalMonthDayNanoArray::from(vec![1]);
+        let max_nanos = IntervalMonthDayNanoType::make_value(0, 0, i64::MAX);
+        let a = IntervalMonthDayNanoArray::from(vec![max_nanos]);
+        let one_nanos = IntervalMonthDayNanoType::make_value(0, 0, 1);
+        let b = IntervalMonthDayNanoArray::from(vec![one_nanos]);
         let err = add(&a, &b).unwrap_err().to_string();
         assert_eq!(
             err,

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -660,19 +660,16 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalYearMonthType> {
 
 impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
     fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
-        let value: u64 = self.value(idx) as u64;
+        let (days, millis) = IntervalDayTimeType::to_parts(self.value(idx));
 
-        let days_parts: i32 = ((value & 0xFFFFFFFF00000000) >> 32) as i32;
-        let milliseconds_part: i32 = (value & 0xFFFFFFFF) as i32;
-
-        let secs = milliseconds_part / 1_000;
+        let secs = millis / 1_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let milliseconds = milliseconds_part % 1_000;
+        let milliseconds = millis % 1_000;
 
         let secs_sign = if secs < 0 || milliseconds < 0 {
             "-"
@@ -683,7 +680,7 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
         write!(
             f,
             "0 years 0 mons {} days {} hours {} mins {}{}.{:03} secs",
-            days_parts,
+            days,
             hours,
             mins,
             secs_sign,
@@ -696,28 +693,23 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
 
 impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalMonthDayNanoType> {
     fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
-        let value: u128 = self.value(idx) as u128;
-
-        let months_part: i32 = ((value & 0xFFFFFFFF000000000000000000000000) >> 96) as i32;
-        let days_part: i32 = ((value & 0xFFFFFFFF0000000000000000) >> 64) as i32;
-        let nanoseconds_part: i64 = (value & 0xFFFFFFFFFFFFFFFF) as i64;
-
-        let secs = nanoseconds_part / 1_000_000_000;
+        let (months, days, nanos) = IntervalMonthDayNanoType::to_parts(self.value(idx));
+        let secs = nanos / 1_000_000_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let nanoseconds = nanoseconds_part % 1_000_000_000;
+        let nanoseconds = nanos % 1_000_000_000;
 
         let secs_sign = if secs < 0 || nanoseconds < 0 { "-" } else { "" };
 
         write!(
             f,
             "0 years {} mons {} days {} hours {} mins {}{}.{:09} secs",
-            months_part,
-            days_part,
+            months,
+            days,
             hours,
             mins,
             secs_sign,

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -1714,18 +1714,17 @@ mod tests {
                 IntervalDayTimeType::make_value(1, 3000),
                 // 90M milliseconds
                 IntervalDayTimeType::make_value(0, 90_000_000),
+                IntervalDayTimeType::make_value(4, 10),
             ],
             vec![
                 IntervalDayTimeType::make_value(0, 1000),
                 IntervalDayTimeType::make_value(1, 0),
                 IntervalDayTimeType::make_value(10, 0),
                 IntervalDayTimeType::make_value(2, 1),
-                // NB even though 1 day is less than 90M milliseconds long,
-                // it compares as greater because the underlying type stores
-                // days and milliseconds as different fields
                 IntervalDayTimeType::make_value(0, 12),
+                IntervalDayTimeType::make_value(56, 10),
             ],
-            vec![false, true, true, true ,false]
+            vec![true, false, false, false, false, true]
         );
 
         cmp_vec!(
@@ -1771,7 +1770,7 @@ mod tests {
                 // 100 days (note is treated as greater than 1 month as the underlying integer representation)
                 IntervalMonthDayNanoType::make_value(0, 100, 0),
             ],
-            vec![false, false, true, false, false]
+            vec![false, true, true, true, true]
         );
     }
 

--- a/arrow-ord/src/ord.rs
+++ b/arrow-ord/src/ord.rs
@@ -227,14 +227,12 @@ pub mod tests {
 
         let cmp = build_compare(&array, &array).unwrap();
 
-        assert_eq!(Ordering::Less, cmp(0, 1));
-        assert_eq!(Ordering::Greater, cmp(1, 0));
-
-        // somewhat confusingly, while 90M milliseconds is more than 1 day,
-        // it will compare less as the comparison is done on the underlying
-        // values not field by field
-        assert_eq!(Ordering::Greater, cmp(1, 2));
-        assert_eq!(Ordering::Less, cmp(2, 1));
+        // Ordering is based on the underlying values
+        // leading to potentially surprising results
+        assert_eq!(Ordering::Greater, cmp(0, 1));
+        assert_eq!(Ordering::Less, cmp(1, 0));
+        assert_eq!(Ordering::Less, cmp(1, 2));
+        assert_eq!(Ordering::Greater, cmp(2, 1));
     }
 
     #[test]
@@ -271,14 +269,12 @@ pub mod tests {
 
         let cmp = build_compare(&array, &array).unwrap();
 
-        assert_eq!(Ordering::Less, cmp(0, 1));
-        assert_eq!(Ordering::Greater, cmp(1, 0));
-
-        // somewhat confusingly, while 100 days is more than 1 month in all cases
-        // it will compare less as the comparison is done on the underlying
-        // values not field by field
-        assert_eq!(Ordering::Greater, cmp(1, 2));
-        assert_eq!(Ordering::Less, cmp(2, 1));
+        // Ordering is based on the underlying values
+        // leading to potentially surprising results
+        assert_eq!(Ordering::Greater, cmp(0, 1));
+        assert_eq!(Ordering::Less, cmp(1, 0));
+        assert_eq!(Ordering::Less, cmp(1, 2));
+        assert_eq!(Ordering::Greater, cmp(2, 1));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5654

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There have been reports that the definition we use is backwards, and whilst the specification is kind of ambiguous, we should probably follow what arrow-cpp does.

This is a draft as I think we should look to get integration test coverage in first to make sure that this is actually correct.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Aside from the obvious there are a couple of potentially problematic changes that result from this:

* The ordering of intervals changes, as this is an arbitrary order driven by the bit representation
* Data in IPC files will be interpreted differently

The order was already arbitrary so the first may not be too problematic, but the latter is potentially. I do, however, suspect that few people are encoding intervals in IPC files else we would have had reports of this before

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
