### PR TITLE
Arrow Flight SQL example JDBC driver incompatibility

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -54,7 +54,7 @@ use arrow_flight::utils::batches_to_flight_data;
 use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
     FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse,
-    IpcMessage, Location, SchemaAsIpc, Ticket,
+    IpcMessage, SchemaAsIpc, Ticket,
 };
 use arrow_ipc::writer::IpcWriteOptions;
 use arrow_schema::{ArrowError, DataType, Field, Schema};

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -108,9 +108,7 @@ static INSTANCE_XBDC_DATA: Lazy<XdbcTypeInfoData> = Lazy::new(|| {
 static TABLES: Lazy<Vec<&'static str>> = Lazy::new(|| vec!["flight_sql.example.table"]);
 
 #[derive(Clone)]
-pub struct FlightSqlServiceImpl {
-    location: String,
-}
+pub struct FlightSqlServiceImpl {}
 
 impl FlightSqlServiceImpl {
     fn check_token<T>(&self, req: &Request<T>) -> Result<(), Status> {
@@ -252,9 +250,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let schema = (*batch.schema()).clone();
         let num_rows = batch.num_rows();
         let num_bytes = batch.get_array_memory_size();
-        let loc = Location {
-            uri: self.location.clone(),
-        };
+
         let fetch = FetchResults {
             handle: handle.to_string(),
         };
@@ -262,7 +258,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let ticket = Ticket { ticket: buf };
         let endpoint = FlightEndpoint {
             ticket: Some(ticket),
-            location: vec![loc],
+            location: vec![],
             expiration_time: None,
             app_metadata: vec![].into(),
         };
@@ -746,9 +742,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let key = std::fs::read_to_string("arrow-flight/examples/data/server.key")?;
         let client_ca = std::fs::read_to_string("arrow-flight/examples/data/client_ca.pem")?;
 
-        let svc = FlightServiceServer::new(FlightSqlServiceImpl {
-            location: format!("grpc+tls://{}", addr_str),
-        });
+        let svc = FlightServiceServer::new(FlightSqlServiceImpl {});
         let tls_config = ServerTlsConfig::new()
             .identity(Identity::from_pem(&cert, &key))
             .client_ca_root(Certificate::from_pem(&client_ca));
@@ -759,9 +753,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .serve(addr)
             .await?;
     } else {
-        let svc = FlightServiceServer::new(FlightSqlServiceImpl {
-            location: format!("grpc+tcp://{}", addr_str),
-        });
+        let svc = FlightServiceServer::new(FlightSqlServiceImpl {});
 
         Server::builder().add_service(svc).serve(addr).await?;
     }
@@ -845,9 +837,7 @@ mod tests {
         let uds = UnixListener::bind(path.clone()).unwrap();
         let stream = UnixListenerStream::new(uds);
 
-        let service = FlightSqlServiceImpl {
-            location: format!("grpc+unix://{}", path.clone()),
-        };
+        let service = FlightSqlServiceImpl {};
         let serve_future = Server::builder()
             .add_service(FlightServiceServer::new(service))
             .serve_with_incoming(stream);
@@ -877,9 +867,7 @@ mod tests {
         let (incoming, addr) = bind_tcp().await;
         let uri = format!("http://{}:{}", addr.ip(), addr.port());
 
-        let service = FlightSqlServiceImpl {
-            location: format!("grpc+tcp://{}:{}", addr.ip(), addr.port()),
-        };
+        let service = FlightSqlServiceImpl {};
         let serve_future = Server::builder()
             .add_service(FlightServiceServer::new(service))
             .serve_with_incoming(incoming);
@@ -913,9 +901,7 @@ mod tests {
         let (incoming, addr) = bind_tcp().await;
         let uri = format!("https://{}:{}", addr.ip(), addr.port());
 
-        let svc = FlightServiceServer::new(FlightSqlServiceImpl {
-            location: format!("grc+tls://{}:{}", addr.ip(), addr.port()),
-        });
+        let svc = FlightServiceServer::new(FlightSqlServiceImpl {});
 
         let serve_future = Server::builder()
             .tls_config(tls_config)

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -190,14 +190,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let output = futures::stream::iter(vec![result]);
 
         let token = format!("Bearer {}", FAKE_TOKEN);
-        let mut response: Response<
-            Pin<
-                Box<
-                    dyn Stream<Item = std::result::Result<HandshakeResponse, Status>>
-                        + std::marker::Send,
-                >,
-            >,
-        > = Response::new(Box::pin(output));
+        let mut response: Response<Pin<Box<dyn Stream<Item = _> + Send>>> =
+            Response::new(Box::pin(output));
         response.metadata_mut().append(
             "authorization",
             MetadataValue::from_str(token.as_str()).unwrap(),

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -732,7 +732,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
 /// This example shows how to run a FlightSql server
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr_str = "127.0.0.1:50051";
+    let addr_str = "0.0.0.0:50051";
     let addr = addr_str.parse()?;
 
     println!("Listening on {:?}", addr);

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -97,6 +97,11 @@ impl FlightSqlServiceClient<Channel> {
         self.token = Some(token);
     }
 
+    /// Clear the auth token.
+    pub fn clear_token(&mut self) {
+        self.token = None;
+    }
+
     /// Set header value.
     pub fn set_header(&mut self, key: impl Into<String>, value: impl Into<String>) {
         let key: String = key.into();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5665 
Closes #5669 

# Rationale for this change

It would be great if the example Flight SQL server would support integration with the Arrow JDBC driver. This would demonstrate the cross-platform nature of Arrow quite well. 

This PR changes the example flight_sql_server so we can query it from Java using the Arrow JDBC driver. 

# What changes are included in this PR?

1. authorization header is returned with contents "Bearer <token>"
2. Added `clear_token()` to `FlightSqlServiceClient` to give the client the ability to re-authenticate. 
3. The location field returned by get_flight_info_prepared_statement uses a "grpc+tcp://127.0.0.1" as its location. Instead it should include the host and the port.
4. do_action_close_prepared_statement needs to include at least an empty stub (return  Ok(())).

# Are there any user-facing changes?

No

