### PR TITLE
Use `ScalarBuffer<u8>` instead of `Buffer` for `FixedSizeBinaryArray`

### DIFF
--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_fixed_size_binary() {
-        let array = FixedSizeBinaryArray::new(4, [0; 16].into(), None);
+        let array = FixedSizeBinaryArray::new(4, [0; 16].into_iter().collect(), None);
         let result = length(&array).unwrap();
         assert_eq!(result.as_ref(), &Int32Array::from(vec![4; 4]));
 


### PR DESCRIPTION
# Rationale for this change
 
Prefer the strongly-typed `ScalarBuffer` over the untyped `Buffer`. It helps when trying to construct this array from other typed buffers like `Vec<u8>` because this conversion is not directly supported for `Buffer` (because of https://github.com/apache/arrow-rs/pull/3756#discussion_r1115780349).

# What changes are included in this PR?

Changed `value_data` field of `FixedSizeBinaryArray` from `Buffer` to `ScalarBuffer<u8>`.

# Are there any user-facing changes?

`FixedSizeBinaryArray` `new`/`try_new` and `into_parts` now use `ScalarBuffer` instead of `Buffer`.

This is a breaking change.