### PR TITLE
Add support for flexible column lengths

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1164,9 +1164,11 @@ impl ReaderBuilder {
     /// Builds a decoder that can be used to decode CSV from an arbitrary byte stream
     pub fn build_decoder(self) -> Decoder {
         let delimiter = self.format.build_parser();
-        let mut record_decoder = RecordDecoder::new(delimiter, self.schema.fields().len());
-
-        record_decoder.set_truncated_rows(self.format.truncated_rows);
+        let record_decoder = RecordDecoder::new(
+            delimiter,
+            self.schema.fields().len(),
+            self.format.truncated_rows,
+        );
 
         let header = self.format.header as usize;
 
@@ -2207,10 +2209,9 @@ mod tests {
 
         let batches = reader.collect::<Result<Vec<_>, _>>();
         assert!(batches.is_ok());
-        let batch = batches.unwrap().into_iter().nth(0).unwrap();
+        let batch = batches.unwrap().into_iter().next().unwrap();
         // Empty rows are skipped by the underlying csv parser
         assert_eq!(batch.num_rows(), 3);
-
 
         let reader = ReaderBuilder::new(schema.clone())
             .with_header(true)

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -231,6 +231,7 @@ pub struct Format {
     quote: Option<u8>,
     terminator: Option<u8>,
     null_regex: NullRegex,
+    truncated_rows: bool,
 }
 
 impl Format {
@@ -262,6 +263,17 @@ impl Format {
     /// Provide a regex to match null values, defaults to `^$`
     pub fn with_null_regex(mut self, null_regex: Regex) -> Self {
         self.null_regex = NullRegex(Some(null_regex));
+        self
+    }
+
+    /// Whether to allow truncated rows when parsing.
+    ///
+    /// By default this is set to `false` and will error if the CSV rows have different lengths.
+    /// When set to true then it will allow records with less than the expected number of columns
+    /// and fill the missing columns with nulls. If the record's schema is not nullable, then it
+    /// will still return an error.
+    pub fn with_truncated_rows(mut self, allow: bool) -> Self {
+        self.truncated_rows = allow;
         self
     }
 
@@ -329,6 +341,7 @@ impl Format {
     fn build_reader<R: Read>(&self, reader: R) -> csv::Reader<R> {
         let mut builder = csv::ReaderBuilder::new();
         builder.has_headers(self.header);
+        builder.flexible(self.truncated_rows);
 
         if let Some(c) = self.delimiter {
             builder.delimiter(c);
@@ -1121,6 +1134,17 @@ impl ReaderBuilder {
         self
     }
 
+    /// Whether to allow truncated rows when parsing.
+    ///
+    /// By default this is set to `false` and will error if the CSV rows have different lengths.
+    /// When set to true then it will allow records with less than the expected number of columns
+    /// and fill the missing columns with nulls. If the record's schema is not nullable, then it
+    /// will still return an error.
+    pub fn with_truncated_rows(mut self, allow: bool) -> Self {
+        self.format.truncated_rows = allow;
+        self
+    }
+
     /// Create a new `Reader` from a non-buffered reader
     ///
     /// If `R: BufRead` consider using [`Self::build_buffered`] to avoid unnecessary additional
@@ -1140,7 +1164,9 @@ impl ReaderBuilder {
     /// Builds a decoder that can be used to decode CSV from an arbitrary byte stream
     pub fn build_decoder(self) -> Decoder {
         let delimiter = self.format.build_parser();
-        let record_decoder = RecordDecoder::new(delimiter, self.schema.fields().len());
+        let mut record_decoder = RecordDecoder::new(delimiter, self.schema.fields().len());
+
+        record_decoder.set_truncated_rows(self.format.truncated_rows);
 
         let header = self.format.header as usize;
 
@@ -2162,6 +2188,134 @@ mod tests {
         assert!(c.value(1));
         assert!(c.value(2));
         assert!(c.is_null(3));
+    }
+
+    #[test]
+    fn test_truncated_rows() {
+        let data = "a,b,c\n1,2,3\n4,5\n\n6,7,8";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+        ]));
+
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(true)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let batches = reader.collect::<Result<Vec<_>, _>>();
+        assert!(batches.is_ok());
+        let batch = batches.unwrap().into_iter().nth(0).unwrap();
+        // Empty rows are skipped by the underlying csv parser
+        assert_eq!(batch.num_rows(), 3);
+
+
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(false)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let batches = reader.collect::<Result<Vec<_>, _>>();
+        assert!(match batches {
+            Err(ArrowError::CsvError(e)) => e.to_string().contains("incorrect number of fields"),
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_truncated_rows_csv() {
+        let file = File::open("test/data/truncated_rows.csv").unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("Name", DataType::Utf8, true),
+            Field::new("Age", DataType::UInt32, true),
+            Field::new("Occupation", DataType::Utf8, true),
+            Field::new("DOB", DataType::Date32, true),
+        ]));
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_batch_size(24)
+            .with_truncated_rows(true);
+        let csv = reader.build(file).unwrap();
+        let batches = csv.collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 6);
+        assert_eq!(batch.num_columns(), 4);
+        let name = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let age = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let occupation = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let dob = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Date32Array>()
+            .unwrap();
+
+        assert_eq!(name.value(0), "A1");
+        assert_eq!(name.value(1), "B2");
+        assert!(name.is_null(2));
+        assert_eq!(name.value(3), "C3");
+        assert_eq!(name.value(4), "D4");
+        assert_eq!(name.value(5), "E5");
+
+        assert_eq!(age.value(0), 34);
+        assert_eq!(age.value(1), 29);
+        assert!(age.is_null(2));
+        assert_eq!(age.value(3), 45);
+        assert!(age.is_null(4));
+        assert_eq!(age.value(5), 31);
+
+        assert_eq!(occupation.value(0), "Engineer");
+        assert_eq!(occupation.value(1), "Doctor");
+        assert!(occupation.is_null(2));
+        assert_eq!(occupation.value(3), "Artist");
+        assert!(occupation.is_null(4));
+        assert!(occupation.is_null(5));
+
+        assert_eq!(dob.value(0), 5675);
+        assert!(dob.is_null(1));
+        assert!(dob.is_null(2));
+        assert_eq!(dob.value(3), -1858);
+        assert!(dob.is_null(4));
+        assert!(dob.is_null(5));
+    }
+
+    #[test]
+    fn test_truncated_rows_not_nullable_error() {
+        let data = "a,b,c\n1,2,3\n4,5";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(true)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let batches = reader.collect::<Result<Vec<_>, _>>();
+        assert!(match batches {
+            Err(ArrowError::InvalidArgumentError(e)) =>
+                e.to_string().contains("contains null values"),
+            _ => false,
+        });
     }
 
     #[test]

--- a/arrow-csv/test/data/truncated_rows.csv
+++ b/arrow-csv/test/data/truncated_rows.csv
@@ -1,0 +1,8 @@
+Name,Age,Occupation,DOB
+A1,34,Engineer,1985-07-16
+B2,29,Doctor
+,
+C3,45,Artist,1964-11-30
+
+D4
+E5,31,,


### PR DESCRIPTION
Similar to what is supported in the csv crate, as well as the pandas, arrow-cpp and polars crates. A subset of CSV files treat missing columns at the end of rows as null (if the schema allows it). This commit adds support to optionally enable treating such missing columns as null. The default behavior is still to treat an incorrect number of columns as an error.

# Which issue does this PR close?

Closes #5678
 

# What changes are included in this PR?

Added boolean config fields to Format and Decoder to allow for specifying whether flexible columns are desired. And provide the ability to set when via builder methods.
The change also passes down the new flexible fields to the rust csv config.
The change also updates the decoder such that if flexible columns are enabled it will pad the offset buffers with empty offsets in order to allow for null values to be interpreted at parsing.
The change also adds unit tests for verify the new behavior.

# Are there any user-facing changes?

Yes, it extends the API surface of the Format struct and ReaderBuilder struct. It also adds a set_flexible_lengths method to the RecordDecoder struct since adding the field to the `new` constructor would be a public api break. I believe the changes are only semantically minor.