### PR TITLE
Feature gate arrow-flight client

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -80,7 +80,7 @@ tower = "0.4.13"
 
 [[example]]
 name = "flight_sql_server"
-required-features = ["flight-sql-experimental", "tls"]
+required-features = ["client", "flight-sql-experimental", "tls"]
 
 [[bin]]
 name = "flight_sql_client"

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -48,7 +48,7 @@ prost = { version = "0.12.3", default-features = false, features = ["prost-deriv
 # For Timestamp type
 prost-types = { version = "0.12.3", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
-tonic = { version = "0.11.0", default-features = false, features = ["transport", "codegen", "prost"] }
+tonic = { version = "0.11.0", default-features = false, features = ["codegen", "prost"] }
 
 # CLI-related dependencies
 anyhow = { version = "1.0", optional = true }
@@ -63,6 +63,7 @@ all-features = true
 default = []
 flight-sql-experimental = ["arrow-arith", "arrow-data", "arrow-ord", "arrow-row", "arrow-select", "arrow-string", "once_cell"]
 tls = ["tonic/tls"]
+client = ["tonic/transport"]
 
 # Enable CLI tools
 cli = ["anyhow", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
@@ -83,9 +84,15 @@ required-features = ["flight-sql-experimental", "tls"]
 
 [[bin]]
 name = "flight_sql_client"
-required-features = ["cli", "flight-sql-experimental", "tls"]
+required-features = ["client", "cli", "flight-sql-experimental", "tls"]
 
 [[test]]
 name = "flight_sql_client_cli"
 path = "tests/flight_sql_client_cli.rs"
-required-features = ["cli", "flight-sql-experimental", "tls"]
+required-features = ["client", "cli", "flight-sql-experimental", "tls"]
+
+
+[[test]]
+name = "client"
+path = "tests/client.rs"
+required-features = ["client"]

--- a/arrow-flight/gen/src/main.rs
+++ b/arrow-flight/gen/src/main.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // protoc in unbuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src")
+        .client_mod_attribute("arrow.flight.protocol", "#[cfg(feature = \"client\")]")
         .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
     // read file contents to string

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -436,6 +436,7 @@ impl CancelStatus {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "client")]
 pub mod flight_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -63,6 +63,7 @@ pub mod flight_descriptor {
 }
 
 /// Low Level [tonic] [`FlightServiceClient`](gen::flight_service_client::FlightServiceClient).
+#[cfg(feature = "client")]
 pub mod flight_service_client {
     use super::gen;
     pub use gen::flight_service_client::FlightServiceClient;
@@ -76,8 +77,11 @@ pub mod flight_service_server {
     pub use gen::flight_service_server::FlightServiceServer;
 }
 
-/// Mid Level [`FlightClient`]
+/// Mid Level [`FlightClient`].
+#[cfg(feature = "client")]
 pub mod client;
+
+#[cfg(feature = "client")]
 pub use client::FlightClient;
 
 /// Decoder to create [`RecordBatch`](arrow_array::RecordBatch) streams from [`FlightData`] streams.

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -35,7 +35,7 @@ logging = ["tracing-subscriber"]
 
 [dependencies]
 arrow = { path = "../arrow", default-features = false, features = ["test_utils", "ipc", "ipc_compression", "json", "ffi"] }
-arrow-flight = { path = "../arrow-flight", default-features = false }
+arrow-flight = { path = "../arrow-flight", default-features = false, features = ["client"] }
 arrow-buffer = { path = "../arrow-buffer", default-features = false }
 arrow-integration-test = { path = "../arrow-integration-test", default-features = false }
 async-trait = { version = "0.1.41", default-features = false }


### PR DESCRIPTION
The `tonic/transport` tonic feature, which has large dependencies like hyper and axum, is now feature gated by a `client` feature on the `arrow-flight` crate. This allows users that only want the flight server to avoid dependency bloat.

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/5682.

# Are there any user-facing changes?

This will break users who are using the client. The fix is for them to specify the new feature flag. I did not include the `client` feature in the default features, but I have no particular opinion there.