### PR TITLE
Add the ability for Maps to cast to another case where the field names are different

### DIFF
--- a/arrow-cast/src/cast/map.rs
+++ b/arrow-cast/src/cast/map.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::cast::*;
+
+
+/// Helper function that takes a map container and casts the inner datatype.
+pub(crate) fn cast_map_values(
+    from: &MapArray,
+    to_data_type: &DataType,
+    cast_options: &CastOptions,
+    to_ordered: bool,
+) -> Result<ArrayRef, ArrowError> {
+    let key_array = cast_with_options(from.keys(), &to_data_type.key_type().ok_or(ArrowError::CastError("map is missing key type".to_string()))?, cast_options)?;
+    let value_array = cast_with_options(from.values(), &to_data_type.value_type().ok_or(ArrowError::CastError("map is missing value type".to_string()))?, cast_options)?;
+
+    let to_fields = Fields::from(vec![
+        to_data_type.key_field().ok_or(ArrowError::CastError("map is missing key field".to_string()))?,
+        to_data_type.value_field().ok_or(ArrowError::CastError("map is missing value field".to_string()))?,
+    ]);
+
+    let entries_field = if let DataType::Map(entries_field, _) = to_data_type {
+        Some(entries_field)
+    } else {
+        None
+    }.ok_or(ArrowError::CastError("to_data_type is not a map type.".to_string()))?;
+
+    Ok(Arc::new(MapArray::new(
+        entries_field.clone(),
+        from.offsets().clone(),
+        StructArray::new(to_fields, vec![key_array, value_array], from.nulls().cloned()),
+        from.nulls().cloned(),
+        to_ordered,
+    )))
+}

--- a/arrow-cast/src/cast/map.rs
+++ b/arrow-cast/src/cast/map.rs
@@ -48,7 +48,7 @@ pub(crate) fn cast_map_values(
         StructArray::new(
             Fields::from(vec![key_field, value_field]),
             vec![key_array, value_array],
-            from.nulls().cloned(),
+            from.entries().nulls().cloned(),
         ),
         from.nulls().cloned(),
         to_ordered,

--- a/arrow-cast/src/cast/map.rs
+++ b/arrow-cast/src/cast/map.rs
@@ -36,8 +36,8 @@ pub(crate) fn cast_map_values(
     let entries_field = if let DataType::Map(entries_field, _) = to_data_type {
         Some(entries_field)
     } else {
-        None
-    }.ok_or(ArrowError::CastError("to_data_type is not a map type.".to_string()))?;
+       return Err(ArrowError::CastError("Internal Error: to_data_type is not a map type.".to_string())))
+    };
 
     Ok(Arc::new(MapArray::new(
         entries_field.clone(),

--- a/arrow-cast/src/cast/map.rs
+++ b/arrow-cast/src/cast/map.rs
@@ -17,7 +17,6 @@
 
 use crate::cast::*;
 
-
 /// Helper function that takes a map container and casts the inner datatype.
 pub(crate) fn cast_map_values(
     from: &MapArray,
@@ -28,11 +27,17 @@ pub(crate) fn cast_map_values(
     let entries_field = if let DataType::Map(entries_field, _) = to_data_type {
         entries_field
     } else {
-        return Err(ArrowError::CastError("Internal Error: to_data_type is not a map type.".to_string()));
+        return Err(ArrowError::CastError(
+            "Internal Error: to_data_type is not a map type.".to_string(),
+        ));
     };
 
-    let key_field = key_field(entries_field).ok_or(ArrowError::CastError("map is missing key field".to_string()))?;
-    let value_field = value_field(entries_field).ok_or(ArrowError::CastError("map is missing value field".to_string()))?;
+    let key_field = key_field(entries_field).ok_or(ArrowError::CastError(
+        "map is missing key field".to_string(),
+    ))?;
+    let value_field = value_field(entries_field).ok_or(ArrowError::CastError(
+        "map is missing value field".to_string(),
+    ))?;
 
     let key_array = cast_with_options(from.keys(), key_field.data_type(), cast_options)?;
     let value_array = cast_with_options(from.values(), value_field.data_type(), cast_options)?;
@@ -40,7 +45,11 @@ pub(crate) fn cast_map_values(
     Ok(Arc::new(MapArray::new(
         entries_field.clone(),
         from.offsets().clone(),
-        StructArray::new(Fields::from(vec![key_field, value_field]), vec![key_array, value_array], from.nulls().cloned()),
+        StructArray::new(
+            Fields::from(vec![key_field, value_field]),
+            vec![key_array, value_array],
+            from.nulls().cloned(),
+        ),
         from.nulls().cloned(),
         to_ordered,
     )))
@@ -49,7 +58,7 @@ pub(crate) fn cast_map_values(
 /// Gets the key field from the entries of a map.  For all other types returns None.
 pub(crate) fn key_field(entries_field: &FieldRef) -> Option<FieldRef> {
     if let DataType::Struct(fields) = entries_field.data_type() {
-        fields.get(0).cloned()
+        fields.first().cloned()
     } else {
         None
     }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -7382,13 +7382,13 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = StringBuilder::new();
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames{
+            Some(MapFieldNames {
                 entry: "entries".to_string(),
                 key: "key".to_string(),
                 value: "value".to_string(),
             }),
             string_builder,
-            value_builder
+            value_builder,
         );
 
         builder.keys().append_value("0");
@@ -7405,7 +7405,7 @@ mod tests {
         let new_type = DataType::Map(Arc::new(Field::new("entries", DataType::Struct(
             vec![
                 Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Utf8, false)
+                Field::new("value", DataType::Utf8, false),
             ].into()
         ), false)), new_ordered);
 
@@ -7421,13 +7421,13 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = IntervalDayTimeArray::builder(2);
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames{
+            Some(MapFieldNames {
                 entry: "entries".to_string(),
                 key: "key".to_string(),
                 value: "value".to_string(),
             }),
             string_builder,
-            value_builder
+            value_builder,
         );
 
         builder.keys().append_value("0");
@@ -7444,7 +7444,7 @@ mod tests {
         let new_type = DataType::Map(Arc::new(Field::new("entries", DataType::Struct(
             vec![
                 Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Duration(TimeUnit::Second), false)
+                Field::new("value", DataType::Duration(TimeUnit::Second), false),
             ].into()
         ), false)), new_ordered);
 
@@ -7460,13 +7460,13 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = StringBuilder::new();
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames{
+            Some(MapFieldNames {
                 entry: "entries".to_string(),
                 key: "key".to_string(),
                 value: "value".to_string(),
             }),
             string_builder,
-            value_builder
+            value_builder,
         );
 
         builder.keys().append_value("0");
@@ -7481,7 +7481,7 @@ mod tests {
         let new_type = DataType::Map(Arc::new(Field::new("entries_new", DataType::Struct(
             vec![
                 Field::new("key_new", DataType::Utf8, false),
-                Field::new("value_values", DataType::Utf8, false)
+                Field::new("value_values", DataType::Utf8, false),
             ].into()
         ), false)), false);
 
@@ -7523,13 +7523,13 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = Int8Builder::new();
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames{
+            Some(MapFieldNames {
                 entry: "entries".to_string(),
                 key: "key".to_string(),
                 value: "value".to_string(),
             }),
             string_builder,
-            value_builder
+            value_builder,
         );
 
         builder.keys().append_value("0");
@@ -7544,7 +7544,7 @@ mod tests {
         let new_type = DataType::Map(Arc::new(Field::new("entries", DataType::Struct(
             vec![
                 Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Utf8, false)
+                Field::new("value", DataType::Utf8, false),
             ].into()
         ), false)), false);
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -7434,10 +7434,10 @@ mod tests {
         );
 
         builder.keys().append_value("0");
-        builder.values().append_value(1);
+        builder.values().append_value(IntervalDayTime::new(1, 1));
         builder.append(true).unwrap();
         builder.keys().append_value("1");
-        builder.values().append_value(2);
+        builder.values().append_value(IntervalDayTime::new(2, 2));
         builder.append(true).unwrap();
 
         // map builder returns unsorted map by default
@@ -7486,6 +7486,7 @@ mod tests {
         builder.keys().append_value("1");
         builder.values().append_value("test_val_2");
         builder.append(true).unwrap();
+        builder.append(false).unwrap();
 
         let array = builder.finish();
 
@@ -7532,6 +7533,11 @@ mod tests {
             .flatten()
             .collect::<Vec<_>>();
         assert_eq!(&values_string, &vec!["test_val_1", "test_val_2"]);
+
+        assert_eq!(
+            map_array.nulls(),
+            Some(&NullBuffer::from(vec![true, true, false]))
+        );
     }
 
     #[test]

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -670,42 +670,6 @@ impl DataType {
     pub fn new_fixed_size_list(data_type: DataType, size: i32, nullable: bool) -> Self {
         DataType::FixedSizeList(Arc::new(Field::new_list_field(data_type, nullable)), size)
     }
-
-    /// Gets the key field in a map data type.  For all other types returns None.
-    pub fn key_field(&self) -> Option<FieldRef> {
-        if let DataType::Map(entries_field, _) = self {
-            if let DataType::Struct(fields) = entries_field.data_type() {
-                fields.get(0).cloned()
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    /// Gets the value field in a map data type.  For all other types returns None.
-    pub fn value_field(&self) -> Option<FieldRef> {
-        if let DataType::Map(entries_field, _) = self {
-            if let DataType::Struct(fields) = entries_field.data_type() {
-                fields.get(1).cloned()
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }
-
-    /// Gets the data type of the keys in a map data type.  For all other types returns None.
-    pub fn key_type(&self) -> Option<DataType> {
-        self.key_field().map(|f| f.data_type().clone())
-    }
-
-    /// Gets the data type of the values in a map data type.  For all other types returns None.
-    pub fn value_type(&self) -> Option<DataType> {
-        self.value_field().map(|f| f.data_type().clone())
-    }
 }
 
 /// The maximum precision for [DataType::Decimal128] values

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -670,6 +670,42 @@ impl DataType {
     pub fn new_fixed_size_list(data_type: DataType, size: i32, nullable: bool) -> Self {
         DataType::FixedSizeList(Arc::new(Field::new_list_field(data_type, nullable)), size)
     }
+
+    /// Gets the key field in a map data type.  For all other types returns None.
+    pub fn key_field(&self) -> Option<FieldRef> {
+        if let DataType::Map(entries_field, _) = self {
+            if let DataType::Struct(fields) = entries_field.data_type() {
+                fields.get(0).cloned()
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Gets the value field in a map data type.  For all other types returns None.
+    pub fn value_field(&self) -> Option<FieldRef> {
+        if let DataType::Map(entries_field, _) = self {
+            if let DataType::Struct(fields) = entries_field.data_type() {
+                fields.get(1).cloned()
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Gets the data type of the keys in a map data type.  For all other types returns None.
+    pub fn key_type(&self) -> Option<DataType> {
+        self.key_field().map(|f| f.data_type().clone())
+    }
+
+    /// Gets the data type of the values in a map data type.  For all other types returns None.
+    pub fn value_type(&self) -> Option<DataType> {
+        self.value_field().map(|f| f.data_type().clone())
+    }
 }
 
 /// The maximum precision for [DataType::Decimal128] values


### PR DESCRIPTION
Arrow Maps have field names for the elements of the fields, the field names are allowed to be any value and do not affect the type of the data.

This allows a Map where the field names are key_value, key, value to be mapped to a entries, keys, values.

This can be helpful in merging record batches that may have come from different sources.  This also makes maps behave similar to lists which also have a field to distinguish their elements.

# Which issue does this PR close?

Closes #5702.

# Rationale for this change
 
Arrow has field names for list elements and map elements. arrow-rs can cast lists with one name for elements (like elements) to another name like `items). But this is not supported for the map type which has field names, one for the elements, one for the keys and one for the values. This can be a limitation for anyone using arrays of Maps from different sources.

# What changes are included in this PR?

The cast functions now support casting from one Map type to another Map type where nothing is different other than the root field elements name, the key field name and value field name.

# Are there any user-facing changes?

No, I would not consider this a user breaking change unless some client was expecting an error when map root level field names did not match.

