### PR TITLE
docs: add sizing explanation to bloom filter docs in parquet

### DIFF
--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -21,8 +21,8 @@
 //! # Bloom Filter Size
 //!
 //! Parquet uses the [Split Block Bloom Filter][sbbf-paper] (SBBF) as its bloom filter
-//! implementation. For each column upon which bloom filters are enabled, there will be an SBBF
-//! stored in the metadata for each row group in the parquet file. The size of each filter is
+//! implementation. For each column upon which bloom filters are enabled, the offset and length of an SBBF
+//! is stored in  the metadata for each row group in the parquet file. The size of each filter is
 //! initialized using a calculation based on the desired number of distinct values (NDV) and false
 //! positive probability (FPP). The FPP for a SBBF can be approximated as<sup>[1][bf-formulae]</sup>:
 //!

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -50,7 +50,7 @@
 //!
 //! Here is a table of calculated sizes for various FPP and NDV:
 //!
-//! | NDV       | FPP       | Nb      | Size (KB) |
+//! | NDV       | FPP       | b       | Size (KB) |
 //! |-----------|-----------|---------|-----------|
 //! | 10,000    | 0.1       | 256     | 8         |
 //! | 10,000    | 0.01      | 512     | 16        |

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -16,7 +16,61 @@
 // under the License.
 
 //! Bloom filter implementation specific to Parquet, as described
-//! in the [spec](https://github.com/apache/parquet-format/blob/master/BloomFilter.md).
+//! in the [spec][parquet-bf-spec].
+//!
+//! # Bloom Filter Size
+//!
+//! Parquet uses the [Split Block Bloom Filter][sbbf-paper] (SBBF) as its bloom filter
+//! implementation. For each column upon which bloom filters are enabled, there will be an SBBF
+//! stored in the metadata for each row group in the parquet file. The size of each filter is
+//! initialized using a calculation based on the desired number of distinct values (NDV) and false
+//! positive probability (FPP). The FPP for a SBBF can be approximated as<sup>[1][bf-formulae]</sup>:
+//!
+//! ```text
+//! f = (1 - e^(-k * n / m))^k
+//! ```
+//!
+//! Where, `f` is the FPP, `k` the number of hash functions, `n` the NDV, and `m` the total number
+//! of bits in the bloom filter. This can be re-arranged to determine the total number of bits
+//! required to achieve a given FPP and NDV:
+//!
+//! ```text
+//! m = -k * n / ln(1 - f^(1/k))
+//! ```
+//!
+//! SBBFs use eight hash functions to cleanly fit in SIMD lanes<sup>[2][sbbf-paper]</sup>, therefore
+//! `k` is set to 8. The SBBF will spread those `m` bits accross a set of `b` blocks that
+//! are each 256 bits, i.e., 32 bytes, in size. The number of blocks is chosen as:
+//!
+//! ```text
+//! b = NP2(m/8) / 32
+//! ```
+//!
+//! Where, `NP2` denotes *the next power of two*, and `m` is divided by 8 to be represented as bytes.
+//!
+//! Here is a table of calculated sizes for various FPP and NDV:
+//!
+//! | NDV       | FPP       | Nb      | Size (KB) |
+//! |-----------|-----------|---------|-----------|
+//! | 10,000    | 0.1       | 256     | 8         |
+//! | 10,000    | 0.01      | 512     | 16        |
+//! | 10,000    | 0.001     | 1,024   | 32        |
+//! | 10,000    | 0.0001    | 1,024   | 32        |
+//! | 100,000   | 0.1       | 4,096   | 128       |
+//! | 100,000   | 0.01      | 4,096   | 128       |
+//! | 100,000   | 0.001     | 8,192   | 256       |
+//! | 100,000   | 0.0001    | 16,384  | 512       |
+//! | 100,000   | 0.00001   | 16,384  | 512       |
+//! | 1,000,000 | 0.1       | 32,768  | 1,024     |
+//! | 1,000,000 | 0.01      | 65,536  | 2,048     |
+//! | 1,000,000 | 0.001     | 65,536  | 2,048     |
+//! | 1,000,000 | 0.0001    | 131,072 | 4,096     |
+//! | 1,000,000 | 0.00001   | 131,072 | 4,096     |
+//! | 1,000,000 | 0.000001  | 262,144 | 8,192     |
+//!
+//! [parquet-bf-spec]: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
+//! [sbbf-paper]: https://arxiv.org/pdf/2101.01719
+//! [bf-formulae]: http://tfk.mit.edu/pdf/bloom.pdf
 
 use crate::data_type::AsBytes;
 use crate::errors::ParquetError;


### PR DESCRIPTION
Added documentation detailing the sizing of bloom filters in the parquet crate.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

There is currently no issue for this change.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There is a storage penalty for using bloom filters in parquet, so I felt having the explanation of how they are sized, based on the chosen FPP and NDV parameters, would be helpful to users.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This only includes documentation changes to the `bloom_filter` module within the `parquet` crate.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

This is a documentation change, so will be user-facing.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
