### PR TITLE
Fix Rustdocs (amd64, nightly)" CI check

### DIFF
--- a/arrow-buffer/src/alloc/alignment.rs
+++ b/arrow-buffer/src/alloc/alignment.rs
@@ -80,15 +80,6 @@ pub const ALIGNMENT: usize = 1 << 5;
 #[cfg(target_arch = "sparc64")]
 pub const ALIGNMENT: usize = 1 << 6;
 
-// On ARM cache line sizes are fixed. both v6 and v7.
-// Need to add board specific or platform specific things later.
-/// Cache and allocation multiple alignment size
-#[cfg(target_arch = "thumbv6")]
-pub const ALIGNMENT: usize = 1 << 5;
-/// Cache and allocation multiple alignment size
-#[cfg(target_arch = "thumbv7")]
-pub const ALIGNMENT: usize = 1 << 5;
-
 // Operating Systems cache size determines this.
 // Currently no way to determine this without runtime inference.
 /// Cache and allocation multiple alignment size
@@ -106,9 +97,6 @@ pub const ALIGNMENT: usize = 1 << 5;
 // Prevent chunk optimizations better to go to the default size.
 // If you have smaller data with less padded functionality then use 32 with force option.
 // - https://devtalk.nvidia.com/default/topic/803600/variable-cache-line-width-/
-/// Cache and allocation multiple alignment size
-#[cfg(target_arch = "nvptx")]
-pub const ALIGNMENT: usize = 1 << 7;
 /// Cache and allocation multiple alignment size
 #[cfg(target_arch = "nvptx64")]
 pub const ALIGNMENT: usize = 1 << 7;

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -5,7 +5,8 @@
 #![allow(unused_imports)]
 #![allow(unused_extern_crates)]
 #![allow(clippy::too_many_arguments, clippy::type_complexity, clippy::vec_box, clippy::wrong_self_convention)]
-#![cfg_attr(rustfmt, rustfmt_skip)]
+// Fix unexpected `cfg` condition name: `rustfmt` https://github.com/apache/arrow-rs/issues/5725
+//#![cfg_attr(rustfmt, rustfmt_skip)]
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -107,6 +107,8 @@ pub mod basic;
 /// Automatically generated code for reading parquet thrift definition.
 // see parquet/CONTRIBUTING.md for instructions on regenerating
 #[allow(clippy::derivable_impls, clippy::match_single_binding)]
+// Don't try and format auto generated code
+#[rustfmt::skip]
 pub mod format;
 
 #[macro_use]


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/5725

# Rationale for this change
 
Nightly clippy got more stringent

# What changes are included in this PR?
1. Remove some targets which don't exists
2. Change how rustfmt is disabled for parquet format file

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
