### PR TITLE
Improve error message for timestamp queries outside supported range

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -8061,20 +8061,29 @@ mod tests {
     fn test_cast_outside_supported_range_for_nanoseconds() {
         const EXPECTED_ERROR_MESSAGE: &str = "The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804";
 
-        let array = StringArray::from(vec![
-            Some("1650-01-01 01:01:01.000001"),
-        ]);
-    
+        let array = StringArray::from(vec![Some("1650-01-01 01:01:01.000001")]);
+
         let cast_options = CastOptions {
             safe: false,
             format_options: FormatOptions::default(),
         };
 
-        let result = cast_string_to_timestamp::<i32, TimestampNanosecondType>(&array, &None::<Arc<str>>, &cast_options);
-    
+        let result = cast_string_to_timestamp::<i32, TimestampNanosecondType>(
+            &array,
+            &None::<Arc<str>>,
+            &cast_options,
+        );
+
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.to_string(), format!("Cast error: Overflow converting {} to Nanosecond. {}", array.value(0), EXPECTED_ERROR_MESSAGE));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "Cast error: Overflow converting {} to Nanosecond. {}",
+                array.value(0),
+                EXPECTED_ERROR_MESSAGE
+            )
+        );
     }
 
     #[test]

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -8074,7 +8074,6 @@ mod tests {
             &cast_options,
         );
 
-        assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(
             err.to_string(),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -8058,6 +8058,26 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_outside_supported_range_for_nanoseconds() {
+        const EXPECTED_ERROR_MESSAGE: &str = "The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804";
+
+        let array = StringArray::from(vec![
+            Some("1650-01-01 01:01:01.000001"),
+        ]);
+    
+        let cast_options = CastOptions {
+            safe: false,
+            format_options: FormatOptions::default(),
+        };
+
+        let result = cast_string_to_timestamp::<i32, TimestampNanosecondType>(&array, &None::<Arc<str>>, &cast_options);
+    
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), format!("Cast error: Overflow converting {} to Nanosecond. {}", array.value(0), EXPECTED_ERROR_MESSAGE));
+    }
+
+    #[test]
     fn test_cast_date32_to_timestamp() {
         let a = Date32Array::from(vec![Some(18628), Some(18993), None]); // 2021-1-1, 2022-1-1
         let array = Arc::new(a) as ArrayRef;

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -112,8 +112,11 @@ fn cast_string_to_timestamp_impl<O: OffsetSizeTrait, T: ArrowTimestampType, Tz: 
             .map(|v| {
                 v.map(|v| {
                     let naive = string_to_datetime(tz, v)?.naive_utc();
-                    T::make_value(naive).ok_or_else(|| {
-                        ArrowError::CastError(format!(
+                    T::make_value(naive).ok_or_else(|| match T::UNIT {
+                        TimeUnit::Nanosecond => ArrowError::CastError(format!(
+                            "Overflow converting {naive} to Nanosecond. The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804"
+                        )),
+                        _ => ArrowError::CastError(format!(
                             "Overflow converting {naive} to {:?}",
                             T::UNIT
                         ))


### PR DESCRIPTION
# Which issue does this PR close?

## Closes #5581

# Rationale for this change

### This change improves the error message handling for timestamp queries outside the supported range in Datafusion. Currently, users receive confusing error messages about nanosecond overflow, which do not clearly explain the limitation of timestamp queries. This change enhances the user experience and reduces confusion by providing clearer guidance.

# What changes are included in this PR?

### This PR updates the error message handling for timestamp queries to provide clearer guidance when timestamps fall outside the supported range.

# Are there any user-facing changes?

### Users will receive more informative error messages when executing timestamp queries outside the supported range.

