### PR TITLE
Document planned release cadence for arrow/parquet/etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example:
 | Jun 2024         | `52.0.0` | Major, potentially breaking API changes |
 | Jul 2024         | `52.1.0` | Minor, NO breaking API changes          |
 | Aug 2024         | `52.2.0` | Minor, NO breaking API changes          |
-| Sep 2024         | `52.0.0` | Major, potentially breaking API changes |
+| Sep 2024         | `53.0.0` | Major, potentially breaking API changes |
 
 [this ticket]: https://github.com/apache/arrow-rs/issues/5368
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,29 @@ This repo contains the following main components:
 
 The current development version the API documentation in this repo can be found [here](https://arrow.apache.org/rust).
 
-There are two related crates in a different repository
+## Release Versioning and Schedule
+
+The Arrow Rust project releases approximately monthly and follows [Semantic
+Versioning](https://semver.org/).
+
+Starting June 2024, we plan to release new major versions with potentially
+breaking API changes once a quarter, and release incremental minor versions in
+the intervening months. See [this ticket] for more details.
+
+For example:
+
+| Approximate Date | Version  | Notes                                   |
+|------------------|----------|-----------------------------------------|
+| Jun 2024         | `52.0.0` | Major, potentially breaking API changes |
+| Jul 2024         | `52.1.0` | Minor, NO breaking API changes          |
+| Aug 2024         | `52.2.0` | Minor, NO breaking API changes          |
+| Sep 2024         | `52.0.0` | Major, potentially breaking API changes |
+
+[this ticket]: https://github.com/apache/arrow-rs/issues/5368
+
+## Related Projects
+
+There are two related crates in different repositories
 
 | Crate      | Description                             | Documentation                 |
 | ---------- | --------------------------------------- | ----------------------------- |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Due to available maintainer and testing bandwidth, `arrow` crates (`arrow`,
 as the `parquet` and `parquet-derive` crates.
 
 Starting June 2024, we plan to release new major versions with potentially
-breaking API changes once a quarter, and release incremental minor versions in
+breaking API changes at most once a quarter, and release incremental minor versions in
 the intervening months. See [this ticket] for more details.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the intervening months. See [this ticket] for more details.
 For example:
 
 | Approximate Date | Version  | Notes                                   |
-|------------------|----------|-----------------------------------------|
+| ---------------- | -------- | --------------------------------------- |
 | Jun 2024         | `52.0.0` | Major, potentially breaking API changes |
 | Jul 2024         | `52.1.0` | Minor, NO breaking API changes          |
 | Aug 2024         | `52.2.0` | Minor, NO breaking API changes          |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The current development version the API documentation in this repo can be found 
 The Arrow Rust project releases approximately monthly and follows [Semantic
 Versioning](https://semver.org/).
 
+Due to available maintainer and testing bandwidth, `arrow` crates (`arrow`,
+`arrow-flight`, etc.) are released on the same schedule with the same versions
+as the `parquet` and `parquet-derive` crates.
+
 Starting June 2024, we plan to release new major versions with potentially
 breaking API changes once a quarter, and release incremental minor versions in
 the intervening months. See [this ticket] for more details.

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -35,9 +35,18 @@ This crate is tested with the latest stable version of Rust. We do not currently
 
 ## Versioning / Releases
 
-The arrow crate follows the [SemVer standard](https://doc.rust-lang.org/cargo/reference/semver.html) defined by Cargo and works well within the Rust crate ecosystem.
+The `arrow` crate follows the [SemVer standard] defined by Cargo and works well
+within the Rust crate ecosystem. See the [repository README] for more details on
+the release schedule and version.
 
-However, for historical reasons, this crate uses versions with major numbers greater than `0.x` (e.g. `39.0.0`), unlike many other crates in the Rust ecosystem which spend extended time releasing versions `0.x` to signal planned ongoing API changes. Minor arrow releases contain only compatible changes, while major releases may contain breaking API changes.
+[SemVer standard]: https://doc.rust-lang.org/cargo/reference/semver.html
+[repository README]: https://github.com/apache/arrow-rs
+
+Note that for historical reasons, this crate uses versions with major numbers
+greater than `0.x` (e.g. `19.0.0`), unlike many other crates in the Rust
+ecosystem which spend extended time releasing versions `0.x` to signal planned
+ongoing API changes. Minor arrow releases contain only compatible changes, while
+major releases may contain breaking API changes.
 
 ## Feature Flags
 

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -38,8 +38,8 @@ The `parquet` crate follows the [SemVer standard] defined by Cargo and works wel
 within the Rust crate ecosystem. See the [repository README] for more details on
 the release schedule and version.
 
-[SemVer standard]: https://doc.rust-lang.org/cargo/reference/semver.html 
-[repository README]: https://github.com/apache/arrow-rs
+[semver standard]: https://doc.rust-lang.org/cargo/reference/semver.html
+[repository readme]: https://github.com/apache/arrow-rs
 
 Note that for historical reasons, this crate uses versions with major numbers
 greater than `0.x` (e.g. `19.0.0`), unlike many other crates in the Rust

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -34,9 +34,18 @@ This crate is tested with the latest stable version of Rust. We do not currently
 
 ## Versioning / Releases
 
-The arrow crate follows the [SemVer standard](https://doc.rust-lang.org/cargo/reference/semver.html) defined by Cargo and works well within the Rust crate ecosystem.
+The `parquet` crate follows the [SemVer standard] defined by Cargo and works well
+within the Rust crate ecosystem. See the [repository README] for more details on
+the release schedule and version.
 
-However, for historical reasons, this crate uses versions with major numbers greater than `0.x` (e.g. `19.0.0`), unlike many other crates in the Rust ecosystem which spend extended time releasing versions `0.x` to signal planned ongoing API changes. Minor arrow releases contain only compatible changes, while major releases may contain breaking API changes.
+[SemVer standard]: https://doc.rust-lang.org/cargo/reference/semver.html 
+[repository README]: https://github.com/apache/arrow-rs
+
+Note that for historical reasons, this crate uses versions with major numbers
+greater than `0.x` (e.g. `19.0.0`), unlike many other crates in the Rust
+ecosystem which spend extended time releasing versions `0.x` to signal planned
+ongoing API changes. Minor arrow releases contain only compatible changes, while
+major releases may contain breaking API changes.
 
 ## Feature Flags
 


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/5368

# Rationale for this change
 
We spent a while discussing release cadence in https://github.com/apache/arrow-rs/issues/5368 so let's document that clearly on in the readmes

# What changes are included in this PR?

Document the planed release cadence. 

Add links in parquet / arrow-rs readme

# Are there any user-facing changes?

Documentation, no functional changes