### PR TITLE
fix: parse string to decimal when scale is 0

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -860,7 +860,7 @@ pub fn parse_decimal<T: DecimalType>(
                             "can't parse the string value {s} to decimal"
                         )));
                     }
-                    if fractionals == scale {
+                    if fractionals == scale && scale != 0 {
                         // We have processed all the digits that we need. All that
                         // is left is to validate that the rest of the string contains
                         // valid digits.
@@ -2407,6 +2407,8 @@ mod tests {
             ("0.12e+6", "120000", 10),
             ("000000000001e0", "000000000001", 3),
             ("000001.1034567002e0", "000001.1034567002", 3),
+            ("1.234e16", "12340000000000000", 0),
+            ("123.4e16", "1234000000000000000", 0)
         ];
         for (e, d, scale) in e_notation_tests {
             let result_128_e = parse_decimal::<Decimal128Type>(e, 20, scale);
@@ -2445,17 +2447,19 @@ mod tests {
             );
         }
         let overflow_parse_tests = [
-            "12345678",
-            "1.2345678e7",
-            "12345678.9",
-            "1.23456789e+7",
-            "99999999.99",
-            "9.999999999e7",
-            "12345678908765.123456",
-            "123456789087651234.56e-4",
+            ("12345678", 3),
+            ("1.2345678e7", 3),
+            ("12345678.9", 3),
+            ("1.23456789e+7", 3),
+            ("99999999.99", 3),
+            ("9.999999999e7", 3),
+            ("12345678908765.123456", 3),
+            ("123456789087651234.56e-4", 3),
+            ("1234560000000", 0),
+            ("1.23456e12", 0),
         ];
-        for s in overflow_parse_tests {
-            let result_128 = parse_decimal::<Decimal128Type>(s, 10, 3);
+        for (s, scale) in overflow_parse_tests {
+            let result_128 = parse_decimal::<Decimal128Type>(s, 10, scale);
             let expected_128 = "Parser error: parse decimal overflow";
             let actual_128 = result_128.unwrap_err().to_string();
 
@@ -2464,7 +2468,7 @@ mod tests {
                 "actual: '{actual_128}', expected: '{expected_128}'"
             );
 
-            let result_256 = parse_decimal::<Decimal256Type>(s, 10, 3);
+            let result_256 = parse_decimal::<Decimal256Type>(s, 10, scale);
             let expected_256 = "Parser error: parse decimal overflow";
             let actual_256 = result_256.unwrap_err().to_string();
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5739.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Unable to parse scientific notation string when the scale is 0.
```rust
parse_decimal::<Decimal128Type>("1.234e16", 20, 0).unwrap()
```

```
called `Result::unwrap()` on an `Err` value: ParseError("can't parse the string value 1.234e16 to decimal")
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Bug fix and also tests.

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
