### PR TITLE
Compute data buffer length by using start and end values in offset buffer

### DIFF
--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -425,7 +425,8 @@ impl<'a> ImportedArrowArray<'a> {
                 (length + 1) * (bits / 8)
             }
             (DataType::Utf8, 2) | (DataType::Binary, 2) => {
-                // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
+                // the len of the data buffer (buffer 2) equals the difference between the last value
+                // and the first value of the offset buffer (buffer 1).
                 let len = self.buffer_len(1, dt)?;
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i32`, as Utf8 uses `i32` offsets.
@@ -438,7 +439,8 @@ impl<'a> ImportedArrowArray<'a> {
                 end - start
             }
             (DataType::LargeUtf8, 2) | (DataType::LargeBinary, 2) => {
-                // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
+                // the len of the data buffer (buffer 2) equals the difference between the last value
+                // and the first value of the offset buffer (buffer 1).
                 let len = self.buffer_len(1, dt)?;
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i64`, as Large uses `i64` offsets.

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1456,6 +1456,8 @@ mod tests_from_ffi {
         assert_eq!(offset_buf_len, 4);
         assert_eq!(data_buf_len, 0);
 
+        test_round_trip(&imported_array.consume()?);
+
         Ok(())
     }
 }

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1456,8 +1456,6 @@ mod tests_from_ffi {
         assert_eq!(offset_buf_len, 4);
         assert_eq!(data_buf_len, 0);
 
-        test_round_trip(&imported_array.consume()?);
-
-        Ok(())
+        test_round_trip(&imported_array.consume()?)
     }
 }

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -431,8 +431,11 @@ impl<'a> ImportedArrowArray<'a> {
                 // we assume that pointer is aligned for `i32`, as Utf8 uses `i32` offsets.
                 #[allow(clippy::cast_ptr_alignment)]
                 let offset_buffer = self.array.buffer(1) as *const i32;
+                // get first offset
+                let start = (unsafe { *offset_buffer.add(0) }) as usize;
                 // get last offset
-                (unsafe { *offset_buffer.add(len / size_of::<i32>() - 1) }) as usize
+                let end = (unsafe { *offset_buffer.add(len / size_of::<i32>() - 1) }) as usize;
+                end - start
             }
             (DataType::LargeUtf8, 2) | (DataType::LargeBinary, 2) => {
                 // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
@@ -441,8 +444,11 @@ impl<'a> ImportedArrowArray<'a> {
                 // we assume that pointer is aligned for `i64`, as Large uses `i64` offsets.
                 #[allow(clippy::cast_ptr_alignment)]
                 let offset_buffer = self.array.buffer(1) as *const i64;
+                // get first offset
+                let start = (unsafe { *offset_buffer.add(0) }) as usize;
                 // get last offset
-                (unsafe { *offset_buffer.add(len / size_of::<i64>() - 1) }) as usize
+                let end = (unsafe { *offset_buffer.add(len / size_of::<i64>() - 1) }) as usize;
+                end - start
             }
             // buffer len of primitive types
             _ => {

--- a/arrow-data/src/equal/variable_size.rs
+++ b/arrow-data/src/equal/variable_size.rs
@@ -32,17 +32,18 @@ fn offset_value_equal<T: ArrowNativeType + Integer>(
 ) -> bool {
     let lhs_start = lhs_offsets[lhs_pos].as_usize();
     let rhs_start = rhs_offsets[rhs_pos].as_usize();
-    let lhs_len = lhs_offsets[lhs_pos + len] - lhs_offsets[lhs_pos];
-    let rhs_len = rhs_offsets[rhs_pos + len] - rhs_offsets[rhs_pos];
+    let lhs_len = (lhs_offsets[lhs_pos + len] - lhs_offsets[lhs_pos])
+        .to_usize()
+        .unwrap();
+    let rhs_len = (rhs_offsets[rhs_pos + len] - rhs_offsets[rhs_pos])
+        .to_usize()
+        .unwrap();
 
-    lhs_len == rhs_len
-        && equal_len(
-            lhs_values,
-            rhs_values,
-            lhs_start,
-            rhs_start,
-            lhs_len.to_usize().unwrap(),
-        )
+    if lhs_len == 0 && rhs_len == 0 {
+        return true;
+    }
+
+    lhs_len == rhs_len && equal_len(lhs_values, rhs_values, lhs_start, rhs_start, lhs_len)
 }
 
 pub(super) fn variable_sized_equal<T: ArrowNativeType + Integer>(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5756.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Encountered an issue when importing empty variable-size binary layout array (e.g., string) from Java Arrow.

There is difference between Java Arrow and arrow-rs when computing the length of data buffer: https://github.com/apache/arrow/pull/41610#issuecomment-2103964293

This is how Java Arrow imports an Utf8 array:

```
try (ArrowBuf offsets = importOffsets(type, VarCharVector.OFFSET_WIDTH)) {
      final int start = offsets.getInt(0);
      final int end = offsets.getInt(fieldNode.getLength() * (long) VarCharVector.OFFSET_WIDTH);
      final int len = end - start;
      ...
}
```

So even the offset buffer is not initialized, for empty array with one element offset buffer, `end - start` is always 0 that is the length of data buffer. That is why the added roundtrip tests are passed.

But in arrow-rs, it takes the last value of the offset buffer as the length of data buffer, i.e., `end`. If the value is not initialized to zero, the computed length of data buffer is incorrect.

That is what I found for the first offset value from the [spec](https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-layout):

```
Generally the first slot in the offsets array is 0, and the last slot is the length of the values array.
When serializing this layout, we recommend normalizing the offsets to start at 0.
```

It looks like the first value doesn't have to be 0, although generally it is. So seems Java Arrow's approach is (more) correct.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changing the way to compute the length of data buffer when importing an empty variable-size binary layout array.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

No
