### PR TITLE
Fix PutPayloadMut::push not updating content_length (#5743)

### DIFF
--- a/object_store/src/integration.rs
+++ b/object_store/src/integration.rs
@@ -789,6 +789,16 @@ pub async fn stream_get(storage: &DynObjectStore) {
     let bytes_written = storage.get(&location).await.unwrap().bytes().await.unwrap();
     assert_eq!(bytes_expected, bytes_written);
 
+    let location = Path::from("test_dir/test_put_part.txt");
+    let upload = storage.put_multipart(&location).await.unwrap();
+    let mut write = WriteMultipart::new(upload);
+    write.put(vec![0; 2].into());
+    write.put(vec![3; 4].into());
+    write.finish().await.unwrap();
+
+    let meta = storage.head(&location).await.unwrap();
+    assert_eq!(meta.size, 6);
+
     // We can abort an empty write
     let location = Path::from("test_dir/test_abort_upload.txt");
     let mut upload = storage.put_multipart(&location).await.unwrap();

--- a/object_store/src/payload.rs
+++ b/object_store/src/payload.rs
@@ -252,7 +252,8 @@ impl PutPayloadMut {
             let completed = std::mem::take(&mut self.in_progress);
             self.completed.push(completed.into())
         }
-        self.completed.push(bytes)
+        self.len += bytes.len();
+        self.completed.push(bytes);
     }
 
     /// Returns `true` if this [`PutPayloadMut`] contains no bytes
@@ -310,5 +311,18 @@ mod test {
         assert_eq!(chunks[3].len(), 23);
         assert_eq!(chunks[4].len(), 20);
         assert_eq!(chunks[5].len(), 6);
+    }
+
+    #[test]
+    fn test_content_length() {
+        let mut chunk = PutPayloadMut::new();
+        chunk.push(vec![0; 23].into());
+        assert_eq!(chunk.content_length(), 23);
+        chunk.extend_from_slice(&[0; 4]);
+        assert_eq!(chunk.content_length(), 27);
+        chunk.push(vec![0; 121].into());
+        assert_eq!(chunk.content_length(), 148);
+        let payload = chunk.freeze();
+        assert_eq!(payload.content_length(), 148);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5743

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

PutPayloadMut was not correctly updating its content size, so WriteMultipart if solely used with `put` was incorrectly thinking that there was nothing to write and never uploading anything. Our existing tests always used a combination of push and extend_from_slice and so didn't run into this.

As this is a pretty major bug introduced in 0.10.0, once merged I intend to prepare a patch release, and once cut will yank the broken release

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
