### PR TITLE
s3 region: Enable buckets that contain periods in their name for fetc…

### DIFF
--- a/object_store/src/aws/resolve.rs
+++ b/object_store/src/aws/resolve.rs
@@ -51,7 +51,7 @@ impl From<Error> for crate::Error {
 pub async fn resolve_bucket_region(bucket: &str, client_options: &ClientOptions) -> Result<String> {
     use reqwest::StatusCode;
 
-    let endpoint = format!("https://{}.s3.amazonaws.com", bucket);
+    let endpoint = format!("https://s3.amazonaws.com/{}/", bucket);
 
     let client = client_options.client()?;
 


### PR DESCRIPTION
…hing region

# Which issue does this PR close?

#5748

Closes #.

# Rationale for this change
 
Currently we use the endpoint -     let endpoint = format!("https://{}.s3.amazonaws.com", bucket);

This breaks down for buckets that have periods in them, since the certificates dont exist appropriately. By switching to the URL https://s3.amazonaws.com/{}/ we are able to ALSo support buckets with periods


# Are there any user-facing changes?

No


