### PR TITLE
Document object store release cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ The current development version the API documentation in this repo can be found 
 
 ## Release Versioning and Schedule
 
+### `arrow` and `parquet` crates
+
 The Arrow Rust project releases approximately monthly and follows [Semantic
-Versioning](https://semver.org/).
+Versioning].
 
 Due to available maintainer and testing bandwidth, `arrow` crates (`arrow`,
 `arrow-flight`, etc.) are released on the same schedule with the same versions
@@ -57,6 +59,15 @@ For example:
 | Sep 2024         | `53.0.0` | Major, potentially breaking API changes |
 
 [this ticket]: https://github.com/apache/arrow-rs/issues/5368
+[semantic versioning]: https://semver.org/
+
+### `object_store` crate
+
+The [`object_store`] crate is released independently of the `arrow` and
+`parquet` crates and follows [Semantic Versioning]. We aim to release new
+versions approximately every 2 months.
+
+[`object_store`]: https://crates.io/crates/object_store
 
 ## Related Projects
 


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-rs/pull/5737
Related to https://github.com/apache/arrow-rs/issues/5368


# Rationale for this change
 
@Xuanwo had the excellent suggestion we document the release cadence of object_store as well here https://github.com/apache/arrow-rs/pull/5737#issuecomment-2102788926

From what I can tell from past history, we have done so every 2 months https://crates.io/crates/object_store/versions 

# What changes are included in this PR?
1. Documented planned release cadence
2. See rendered version https://github.com/alamb/arrow-rs/blob/alamb/os_release_cadence/README.md


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
