### PR TITLE
Expose the null buffer of every builder that has one

### DIFF
--- a/arrow-array/src/builder/fixed_size_binary_builder.rs
+++ b/arrow-array/src/builder/fixed_size_binary_builder.rs
@@ -115,6 +115,11 @@ impl FixedSizeBinaryBuilder {
         let array_data = unsafe { array_data_builder.build_unchecked() };
         FixedSizeBinaryArray::from(array_data)
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 impl ArrayBuilder for FixedSizeBinaryBuilder {

--- a/arrow-array/src/builder/fixed_size_list_builder.rs
+++ b/arrow-array/src/builder/fixed_size_list_builder.rs
@@ -208,6 +208,11 @@ where
 
         FixedSizeListArray::new(field, self.list_len, values, nulls)
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 #[cfg(test)]

--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -299,6 +299,11 @@ where
 
         DictionaryArray::from(unsafe { builder.build_unchecked() })
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.keys_builder.validity_slice()
+    }
 }
 
 impl<K: ArrowDictionaryKeyType, T: ByteArrayType, V: AsRef<T::Native>> Extend<Option<V>>

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -146,6 +146,11 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         // SAFETY: valid by construction
         unsafe { GenericByteViewArray::new_unchecked(views, completed, nulls) }
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 impl<T: ByteViewType + ?Sized> Default for GenericByteViewBuilder<T> {

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -326,6 +326,11 @@ where
     pub fn offsets_slice(&self) -> &[OffsetSize] {
         self.offsets_builder.as_slice()
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 impl<O, B, V, E> Extend<Option<V>> for GenericListBuilder<O, B>

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -226,6 +226,11 @@ impl<K: ArrayBuilder, V: ArrayBuilder> MapBuilder<K, V> {
 
         MapArray::from(array_data)
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 impl<K: ArrayBuilder, V: ArrayBuilder> ArrayBuilder for MapBuilder<K, V> {

--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -302,6 +302,11 @@ where
     pub fn values_slice_mut(&mut self) -> &mut [V::Native] {
         self.values_builder.values_slice_mut()
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.keys_builder.validity_slice()
+    }
 }
 
 impl<K: ArrowDictionaryKeyType, P: ArrowPrimitiveType> Extend<Option<P::Native>>

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -381,6 +381,11 @@ impl StructBuilder {
             }
         });
     }
+
+    /// Returns the current null buffer as a slice
+    pub fn validity_slice(&self) -> Option<&[u8]> {
+        self.null_buffer_builder.as_slice()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5749.

# Rationale for this change

This makes the interface of different builder types more consistent, and enables exposing builder contents as a slice in more cases in my prototype for #5700.

# What changes are included in this PR?

Overall, my general process was to look at what `append_null()`/`append(false)` pushes the null into, and expose the corresponding null buffer.

- For each builder which has an inner null buffer builder, it is exposed as already done in `BooleanBuilder` and `PrimitiveBuilder`.
- For builders that use a dictionary-like (key, value) layout, the null buffer of keys is treated as the overall null buffer of the builder, following the example of `append_null()`.

This only leaves the following builders **without** a null buffer accessor after this PR:

- `XyzRunBuilder`: For these builder types, the null buffer is per-run, not per-element. It is not yet clear to me if/how that should be exposed, so I'm leaving this for a future PR.
- `UnionBuilder`: For this builder type, each variant has its own null buffer, so there is no notion of builder-wide null buffer.  This would be best handled by exposing some sort of access to the storage of individual variants, but again, this requires more design work, so I'm leaving it for a future PR.

# Are there any user-facing changes?

More builders expose a `validity_slice(&self) -> Option<&[u8]>` method. Since the semantics are identical to pre-existing methods from other builders with this name, the documentation was copy-pasted from there.