### PR TITLE
Expose boolean builder contents

### DIFF
--- a/arrow-array/src/builder/boolean_builder.rs
+++ b/arrow-array/src/builder/boolean_builder.rs
@@ -166,6 +166,14 @@ impl BooleanBuilder {
         BooleanArray::from(array_data)
     }
 
+    /// Returns the current values buffer as a slice
+    ///
+    /// Boolean values are bit-packed into bytes, so to read the i-th boolean,
+    /// you must compute `values_slice[i / 8] & (1 << (i % 8)) == 0`.
+    pub fn values_slice(&self) -> &[u8] {
+        self.values_builder.as_slice()
+    }
+
     /// Returns the current null buffer as a slice
     pub fn validity_slice(&self) -> Option<&[u8]> {
         self.null_buffer_builder.as_slice()

--- a/arrow-array/src/builder/boolean_builder.rs
+++ b/arrow-array/src/builder/boolean_builder.rs
@@ -168,8 +168,8 @@ impl BooleanBuilder {
 
     /// Returns the current values buffer as a slice
     ///
-    /// Boolean values are bit-packed into bytes, so to read the i-th boolean,
-    /// you must compute `values_slice[i / 8] & (1 << (i % 8)) == 0`.
+    /// Boolean values are bit-packed into bytes. To extract the i-th boolean
+    /// from the bytes, you can use `arrow_buffer::bit_util::get_bit()`.
     pub fn values_slice(&self) -> &[u8] {
         self.values_builder.as_slice()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5757.

# Rationale for this change
 
This lets me expose a more consistent interface in my prototype for #5700, where builder contents can be accessed in place as a slice for more types.

# What changes are included in this PR?

Boolean builder contents are exposed as a slice of bytes, as suggested by @tustvold in #5757.

# Are there any user-facing changes?

This adds a `values_slice()` to `BooleanBuilder`, which exposes the bit-packed data as a slice of bytes. Since that's a bit different from other `values_slice()` methods due to the bitpacking involved, I added a one-liner explanation of how one would access the i-th boolean from this slice to the docs.