### PR TITLE
Add environment variable definitions to run the nanoarrow integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,8 +57,7 @@ jobs:
     env:
       ARROW_USE_CCACHE: OFF
       ARROW_CPP_EXE_PATH: /build/cpp/debug
-      ARROW_NANOARROW_PATH: "${{ github.workspace }}/nanoarrow"
-      ARROW_NANOARROW_EXE_PATH: /build/nanoarrow
+      ARROW_NANOARROW_PATH: /build/nanoarrow
       ARROW_RUST_EXE_PATH: /build/rust/debug
       BUILD_DOCS_CPP: OFF
       ARROW_INTEGRATION_CPP: ON


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5763.

# Rationale for this change
 
It seems that the intention was to run nanoarrow's integration test suite (thanks!); however, the tests were not running.

# What changes are included in this PR?

The requisite environment variable definitions were added for the tests to run.

# Are there any user-facing changes?

No!
