### PR TITLE
Structured interval types for `IntervalMonthDayNano` or `IntervalDayTime`  (#3125) (#5654)

### DIFF
--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_buffer::{i256, ArrowNativeType};
+use arrow_buffer::{i256, ArrowNativeType, IntervalDayTime, IntervalMonthDayNano};
 use arrow_schema::ArrowError;
 use half::f16;
 use num::complex::ComplexFloat;
@@ -139,7 +139,10 @@ pub trait ArrowNativeTypeOp: ArrowNativeType {
 
 macro_rules! native_type_op {
     ($t:tt) => {
-        native_type_op!($t, 0, 1, $t::MIN, $t::MAX);
+        native_type_op!($t, 0, 1);
+    };
+    ($t:tt, $zero:expr, $one: expr) => {
+        native_type_op!($t, $zero, $one, $t::MIN, $t::MAX);
     };
     ($t:tt, $zero:expr, $one: expr, $min: expr, $max: expr) => {
         impl ArrowNativeTypeOp for $t {
@@ -283,6 +286,13 @@ native_type_op!(u16);
 native_type_op!(u32);
 native_type_op!(u64);
 native_type_op!(i256, i256::ZERO, i256::ONE, i256::MIN, i256::MAX);
+
+native_type_op!(IntervalDayTime, IntervalDayTime::ZERO, IntervalDayTime::ONE);
+native_type_op!(
+    IntervalMonthDayNano,
+    IntervalMonthDayNano::ZERO,
+    IntervalMonthDayNano::ONE
+);
 
 macro_rules! native_type_float_op {
     ($t:tt, $zero:expr, $one:expr, $min:expr, $max:expr) => {

--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -946,7 +946,7 @@ where
 ///         return Ok(d.with_values(r));
 ///     }
 ///     downcast_primitive_array! {
-///         a => Ok(Arc::new(a.iter().map(|x| x.map(|x| x.to_string())).collect::<StringArray>())),
+///         a => Ok(Arc::new(a.iter().map(|x| x.map(|x| format!("{x:?}"))).collect::<StringArray>())),
 ///         d => Err(ArrowError::InvalidArgumentError(format!("{d:?} not supported")))
 ///     }
 /// }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1502,6 +1502,7 @@ mod tests {
     use crate::builder::{Decimal128Builder, Decimal256Builder};
     use crate::cast::downcast_array;
     use crate::BooleanArray;
+    use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
     use arrow_schema::TimeUnit;
 
     #[test]
@@ -1624,33 +1625,46 @@ mod tests {
         assert_eq!(-5, arr.value(2));
         assert_eq!(-5, arr.values()[2]);
 
-        // a day_time interval contains days and milliseconds, but we do not yet have accessors for the values
-        let arr = IntervalDayTimeArray::from(vec![Some(1), None, Some(-5)]);
-        assert_eq!(3, arr.len());
-        assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
-        assert_eq!(1, arr.value(0));
-        assert_eq!(1, arr.values()[0]);
-        assert!(arr.is_null(1));
-        assert_eq!(-5, arr.value(2));
-        assert_eq!(-5, arr.values()[2]);
+        let v0 = IntervalDayTime {
+            days: 34,
+            milliseconds: 1,
+        };
+        let v2 = IntervalDayTime {
+            days: -2,
+            milliseconds: -5,
+        };
 
-        // a month_day_nano interval contains months, days and nanoseconds,
-        // but we do not yet have accessors for the values.
-        // TODO: implement month, day, and nanos access method for month_day_nano.
-        let arr = IntervalMonthDayNanoArray::from(vec![
-            Some(100000000000000000000),
-            None,
-            Some(-500000000000000000000),
-        ]);
+        let arr = IntervalDayTimeArray::from(vec![Some(v0), None, Some(v2)]);
+
         assert_eq!(3, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(1, arr.null_count());
-        assert_eq!(100000000000000000000, arr.value(0));
-        assert_eq!(100000000000000000000, arr.values()[0]);
+        assert_eq!(v0, arr.value(0));
+        assert_eq!(v0, arr.values()[0]);
         assert!(arr.is_null(1));
-        assert_eq!(-500000000000000000000, arr.value(2));
-        assert_eq!(-500000000000000000000, arr.values()[2]);
+        assert_eq!(v2, arr.value(2));
+        assert_eq!(v2, arr.values()[2]);
+
+        let v0 = IntervalMonthDayNano {
+            months: 2,
+            days: 34,
+            nanoseconds: -1,
+        };
+        let v2 = IntervalMonthDayNano {
+            months: -3,
+            days: -2,
+            nanoseconds: 4,
+        };
+
+        let arr = IntervalMonthDayNanoArray::from(vec![Some(v0), None, Some(v2)]);
+        assert_eq!(3, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        assert_eq!(v0, arr.value(0));
+        assert_eq!(v0, arr.values()[0]);
+        assert!(arr.is_null(1));
+        assert_eq!(v2, arr.value(2));
+        assert_eq!(v2, arr.values()[2]);
     }
 
     #[test]
@@ -2460,7 +2474,7 @@ mod tests {
         expected = "PrimitiveArray expected data type Interval(MonthDayNano) got Interval(DayTime)"
     )]
     fn test_invalid_interval_type() {
-        let array = IntervalDayTimeArray::from(vec![1, 2, 3]);
+        let array = IntervalDayTimeArray::from(vec![IntervalDayTime::ZERO]);
         let _ = IntervalMonthDayNanoArray::from(array.into_data());
     }
 

--- a/arrow-buffer/src/arith.rs
+++ b/arrow-buffer/src/arith.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Derives `std::ops::$op` for `$ty` calling `$wrapping` or `$checked` variants
+/// based on if debug_assertions enabled
 macro_rules! derive_arith {
     ($ty:ty, $t:ident, $op:ident, $wrapping:ident, $checked:ident) => {
         impl std::ops::$t for $ty {

--- a/arrow-buffer/src/arith.rs
+++ b/arrow-buffer/src/arith.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+macro_rules! derive_arith {
+    ($ty:ty, $t:ident, $op:ident, $wrapping:ident, $checked:ident) => {
+        impl std::ops::$t for $ty {
+            type Output = $ty;
+
+            #[cfg(debug_assertions)]
+            fn $op(self, rhs: Self) -> Self::Output {
+                self.$checked(rhs)
+                    .expect(concat!(stringify!($ty), " overflow"))
+            }
+
+            #[cfg(not(debug_assertions))]
+            fn $op(self, rhs: Self) -> Self::Output {
+                self.$wrapping(rhs)
+            }
+        }
+
+        impl<'a> std::ops::$t<$ty> for &'a $ty {
+            type Output = $ty;
+
+            fn $op(self, rhs: $ty) -> Self::Output {
+                (*self).$op(rhs)
+            }
+        }
+
+        impl<'a> std::ops::$t<&'a $ty> for $ty {
+            type Output = $ty;
+
+            fn $op(self, rhs: &'a $ty) -> Self::Output {
+                self.$op(*rhs)
+            }
+        }
+
+        impl<'a, 'b> std::ops::$t<&'b $ty> for &'a $ty {
+            type Output = $ty;
+
+            fn $op(self, rhs: &'b $ty) -> Self::Output {
+                (*self).$op(*rhs)
+            }
+        }
+    };
+}
+
+pub(crate) use derive_arith;

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::arith::derive_arith;
 use crate::bigint::div::div_rem;
 use num::cast::AsPrimitive;
 use num::{BigInt, FromPrimitive, ToPrimitive};
@@ -638,55 +639,13 @@ fn mulx(a: u128, b: u128) -> (u128, u128) {
     (low, high)
 }
 
-macro_rules! derive_op {
-    ($t:ident, $op:ident, $wrapping:ident, $checked:ident) => {
-        impl std::ops::$t for i256 {
-            type Output = i256;
+derive_arith!(i256, Add, add, wrapping_add, checked_add);
+derive_arith!(i256, Sub, sub, wrapping_sub, checked_sub);
+derive_arith!(i256, Mul, mul, wrapping_mul, checked_mul);
+derive_arith!(i256, Div, div, wrapping_div, checked_div);
+derive_arith!(i256, Rem, rem, wrapping_rem, checked_rem);
 
-            #[cfg(debug_assertions)]
-            fn $op(self, rhs: Self) -> Self::Output {
-                self.$checked(rhs).expect("i256 overflow")
-            }
-
-            #[cfg(not(debug_assertions))]
-            fn $op(self, rhs: Self) -> Self::Output {
-                self.$wrapping(rhs)
-            }
-        }
-
-        impl<'a> std::ops::$t<i256> for &'a i256 {
-            type Output = i256;
-
-            fn $op(self, rhs: i256) -> Self::Output {
-                (*self).$op(rhs)
-            }
-        }
-
-        impl<'a> std::ops::$t<&'a i256> for i256 {
-            type Output = i256;
-
-            fn $op(self, rhs: &'a i256) -> Self::Output {
-                self.$op(*rhs)
-            }
-        }
-
-        impl<'a, 'b> std::ops::$t<&'b i256> for &'a i256 {
-            type Output = i256;
-
-            fn $op(self, rhs: &'b i256) -> Self::Output {
-                (*self).$op(*rhs)
-            }
-        }
-    };
-}
-
-derive_op!(Add, add, wrapping_add, checked_add);
-derive_op!(Sub, sub, wrapping_sub, checked_sub);
-derive_op!(Mul, mul, wrapping_mul, checked_mul);
-derive_op!(Div, div, wrapping_div, checked_div);
-derive_op!(Rem, rem, wrapping_rem, checked_rem);
-
-impl std::ops::Neg for i256 {
+impl Neg for i256 {
     type Output = i256;
 
     #[cfg(debug_assertions)]

--- a/arrow-buffer/src/interval.rs
+++ b/arrow-buffer/src/interval.rs
@@ -1,0 +1,424 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::arith::derive_arith;
+use std::ops::Neg;
+
+/// Value of an IntervalMonthDayNano array
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
+pub struct IntervalMonthDayNano {
+    pub months: i32,
+    pub days: i32,
+    pub nanoseconds: i64,
+}
+
+impl IntervalMonthDayNano {
+    /// The additive identity i.e. `0`.
+    pub const ZERO: Self = Self::new(0, 0, 0);
+
+    /// The multiplicative identity, i.e. `1`.
+    pub const ONE: Self = Self::new(1, 1, 1);
+
+    /// The multiplicative inverse, i.e. `-1`.
+    pub const MINUS_ONE: Self = Self::new(-1, -1, -1);
+
+    /// The maximum value that can be represented
+    pub const MAX: Self = Self::new(i32::MAX, i32::MAX, i64::MAX);
+
+    /// The minimum value that can be represented
+    pub const MIN: Self = Self::new(i32::MIN, i32::MIN, i64::MIN);
+
+    /// Create a new [`IntervalMonthDayNano`]
+    #[inline]
+    pub const fn new(months: i32, days: i32, nanoseconds: i64) -> Self {
+        Self {
+            months,
+            days,
+            nanoseconds,
+        }
+    }
+
+    /// Computes the absolute value
+    #[inline]
+    pub fn wrapping_abs(self) -> Self {
+        Self {
+            months: self.months.wrapping_abs(),
+            days: self.days.wrapping_abs(),
+            nanoseconds: self.nanoseconds.wrapping_abs(),
+        }
+    }
+
+    /// Computes the absolute value
+    #[inline]
+    pub fn checked_abs(self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_abs()?,
+            days: self.days.checked_abs()?,
+            nanoseconds: self.nanoseconds.checked_abs()?,
+        })
+    }
+
+    /// Negates the value
+    #[inline]
+    pub fn wrapping_neg(self) -> Self {
+        Self {
+            months: self.months.wrapping_neg(),
+            days: self.days.wrapping_neg(),
+            nanoseconds: self.nanoseconds.wrapping_neg(),
+        }
+    }
+
+    /// Negates the value
+    #[inline]
+    pub fn checked_neg(self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_neg()?,
+            days: self.days.checked_neg()?,
+            nanoseconds: self.nanoseconds.checked_neg()?,
+        })
+    }
+
+    /// Performs wrapping addition
+    #[inline]
+    pub fn wrapping_add(self, other: Self) -> Self {
+        Self {
+            months: self.months.wrapping_add(other.months),
+            days: self.days.wrapping_add(other.days),
+            nanoseconds: self.nanoseconds.wrapping_add(other.nanoseconds),
+        }
+    }
+
+    /// Performs checked addition
+    #[inline]
+    pub fn checked_add(self, other: Self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_add(other.months)?,
+            days: self.days.checked_add(other.days)?,
+            nanoseconds: self.nanoseconds.checked_add(other.nanoseconds)?,
+        })
+    }
+
+    /// Performs wrapping subtraction
+    #[inline]
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        Self {
+            months: self.months.wrapping_sub(other.months),
+            days: self.days.wrapping_sub(other.days),
+            nanoseconds: self.nanoseconds.wrapping_sub(other.nanoseconds),
+        }
+    }
+
+    /// Performs checked subtraction
+    #[inline]
+    pub fn checked_sub(self, other: Self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_sub(other.months)?,
+            days: self.days.checked_sub(other.days)?,
+            nanoseconds: self.nanoseconds.checked_sub(other.nanoseconds)?,
+        })
+    }
+
+    /// Performs wrapping multiplication
+    #[inline]
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        Self {
+            months: self.months.wrapping_mul(other.months),
+            days: self.days.wrapping_mul(other.days),
+            nanoseconds: self.nanoseconds.wrapping_mul(other.nanoseconds),
+        }
+    }
+
+    /// Performs checked multiplication
+    pub fn checked_mul(self, other: Self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_mul(other.months)?,
+            days: self.days.checked_mul(other.days)?,
+            nanoseconds: self.nanoseconds.checked_mul(other.nanoseconds)?,
+        })
+    }
+
+    /// Performs wrapping division
+    #[inline]
+    pub fn wrapping_div(self, other: Self) -> Self {
+        Self {
+            months: self.months.wrapping_div(other.months),
+            days: self.days.wrapping_div(other.days),
+            nanoseconds: self.nanoseconds.wrapping_div(other.nanoseconds),
+        }
+    }
+
+    /// Performs checked division
+    pub fn checked_div(self, other: Self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_div(other.months)?,
+            days: self.days.checked_div(other.days)?,
+            nanoseconds: self.nanoseconds.checked_div(other.nanoseconds)?,
+        })
+    }
+
+    /// Performs wrapping remainder
+    #[inline]
+    pub fn wrapping_rem(self, other: Self) -> Self {
+        Self {
+            months: self.months.wrapping_rem(other.months),
+            days: self.days.wrapping_rem(other.days),
+            nanoseconds: self.nanoseconds.wrapping_rem(other.nanoseconds),
+        }
+    }
+
+    /// Performs checked remainder
+    pub fn checked_rem(self, other: Self) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_rem(other.months)?,
+            days: self.days.checked_rem(other.days)?,
+            nanoseconds: self.nanoseconds.checked_rem(other.nanoseconds)?,
+        })
+    }
+
+    /// Performs wrapping exponentiation
+    #[inline]
+    pub fn wrapping_pow(self, exp: u32) -> Self {
+        Self {
+            months: self.months.wrapping_pow(exp),
+            days: self.days.wrapping_pow(exp),
+            nanoseconds: self.nanoseconds.wrapping_pow(exp),
+        }
+    }
+
+    /// Performs checked exponentiation
+    #[inline]
+    pub fn checked_pow(self, exp: u32) -> Option<Self> {
+        Some(Self {
+            months: self.months.checked_pow(exp)?,
+            days: self.days.checked_pow(exp)?,
+            nanoseconds: self.nanoseconds.checked_pow(exp)?,
+        })
+    }
+}
+
+impl Neg for IntervalMonthDayNano {
+    type Output = Self;
+
+    #[cfg(debug_assertions)]
+    fn neg(self) -> Self::Output {
+        self.checked_neg().expect("IntervalMonthDayNano overflow")
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn neg(self) -> Self::Output {
+        self.wrapping_neg()
+    }
+}
+
+derive_arith!(IntervalMonthDayNano, Add, add, wrapping_add, checked_add);
+derive_arith!(IntervalMonthDayNano, Sub, sub, wrapping_sub, checked_sub);
+derive_arith!(IntervalMonthDayNano, Mul, mul, wrapping_mul, checked_mul);
+derive_arith!(IntervalMonthDayNano, Div, div, wrapping_div, checked_div);
+derive_arith!(IntervalMonthDayNano, Rem, rem, wrapping_rem, checked_rem);
+
+/// Value of an IntervalDayTime array
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
+pub struct IntervalDayTime {
+    pub days: i32,
+    pub milliseconds: i32,
+}
+
+impl IntervalDayTime {
+    /// The additive identity i.e. `0`.
+    pub const ZERO: Self = Self::new(0, 0);
+
+    /// The multiplicative identity, i.e. `1`.
+    pub const ONE: Self = Self::new(1, 1);
+
+    /// The multiplicative inverse, i.e. `-1`.
+    pub const MINUS_ONE: Self = Self::new(-1, -1);
+
+    /// The maximum value that can be represented
+    pub const MAX: Self = Self::new(i32::MAX, i32::MAX);
+
+    /// The minimum value that can be represented
+    pub const MIN: Self = Self::new(i32::MIN, i32::MIN);
+
+    /// Create a new [`IntervalDayTime`]
+    #[inline]
+    pub const fn new(days: i32, milliseconds: i32) -> Self {
+        Self { days, milliseconds }
+    }
+
+    /// Computes the absolute value
+    #[inline]
+    pub fn wrapping_abs(self) -> Self {
+        Self {
+            days: self.days.wrapping_abs(),
+            milliseconds: self.milliseconds.wrapping_abs(),
+        }
+    }
+
+    /// Computes the absolute value
+    #[inline]
+    pub fn checked_abs(self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_abs()?,
+            milliseconds: self.milliseconds.checked_abs()?,
+        })
+    }
+
+    /// Negates the value
+    #[inline]
+    pub fn wrapping_neg(self) -> Self {
+        Self {
+            days: self.days.wrapping_neg(),
+            milliseconds: self.milliseconds.wrapping_neg(),
+        }
+    }
+
+    /// Negates the value
+    #[inline]
+    pub fn checked_neg(self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_neg()?,
+            milliseconds: self.milliseconds.checked_neg()?,
+        })
+    }
+
+    /// Performs wrapping addition
+    #[inline]
+    pub fn wrapping_add(self, other: Self) -> Self {
+        Self {
+            days: self.days.wrapping_add(other.days),
+            milliseconds: self.milliseconds.wrapping_add(other.milliseconds),
+        }
+    }
+
+    /// Performs checked addition
+    #[inline]
+    pub fn checked_add(self, other: Self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_add(other.days)?,
+            milliseconds: self.milliseconds.checked_add(other.milliseconds)?,
+        })
+    }
+
+    /// Performs wrapping subtraction
+    #[inline]
+    pub fn wrapping_sub(self, other: Self) -> Self {
+        Self {
+            days: self.days.wrapping_sub(other.days),
+            milliseconds: self.milliseconds.wrapping_sub(other.milliseconds),
+        }
+    }
+
+    /// Performs checked subtraction
+    #[inline]
+    pub fn checked_sub(self, other: Self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_sub(other.days)?,
+            milliseconds: self.milliseconds.checked_sub(other.milliseconds)?,
+        })
+    }
+
+    /// Performs wrapping multiplication
+    #[inline]
+    pub fn wrapping_mul(self, other: Self) -> Self {
+        Self {
+            days: self.days.wrapping_mul(other.days),
+            milliseconds: self.milliseconds.wrapping_mul(other.milliseconds),
+        }
+    }
+
+    /// Performs checked multiplication
+    pub fn checked_mul(self, other: Self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_mul(other.days)?,
+            milliseconds: self.milliseconds.checked_mul(other.milliseconds)?,
+        })
+    }
+
+    /// Performs wrapping division
+    #[inline]
+    pub fn wrapping_div(self, other: Self) -> Self {
+        Self {
+            days: self.days.wrapping_div(other.days),
+            milliseconds: self.milliseconds.wrapping_div(other.milliseconds),
+        }
+    }
+
+    /// Performs checked division
+    pub fn checked_div(self, other: Self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_div(other.days)?,
+            milliseconds: self.milliseconds.checked_div(other.milliseconds)?,
+        })
+    }
+
+    /// Performs wrapping remainder
+    #[inline]
+    pub fn wrapping_rem(self, other: Self) -> Self {
+        Self {
+            days: self.days.wrapping_rem(other.days),
+            milliseconds: self.milliseconds.wrapping_rem(other.milliseconds),
+        }
+    }
+
+    /// Performs checked remainder
+    pub fn checked_rem(self, other: Self) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_rem(other.days)?,
+            milliseconds: self.milliseconds.checked_rem(other.milliseconds)?,
+        })
+    }
+
+    /// Performs wrapping exponentiation
+    #[inline]
+    pub fn wrapping_pow(self, exp: u32) -> Self {
+        Self {
+            days: self.days.wrapping_pow(exp),
+            milliseconds: self.milliseconds.wrapping_pow(exp),
+        }
+    }
+
+    /// Performs checked exponentiation
+    #[inline]
+    pub fn checked_pow(self, exp: u32) -> Option<Self> {
+        Some(Self {
+            days: self.days.checked_pow(exp)?,
+            milliseconds: self.milliseconds.checked_pow(exp)?,
+        })
+    }
+}
+
+impl Neg for IntervalDayTime {
+    type Output = Self;
+
+    #[cfg(debug_assertions)]
+    fn neg(self) -> Self::Output {
+        self.checked_neg().expect("IntervalDayMillisecond overflow")
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn neg(self) -> Self::Output {
+        self.wrapping_neg()
+    }
+}
+
+derive_arith!(IntervalDayTime, Add, add, wrapping_add, checked_add);
+derive_arith!(IntervalDayTime, Sub, sub, wrapping_sub, checked_sub);
+derive_arith!(IntervalDayTime, Mul, mul, wrapping_mul, checked_mul);
+derive_arith!(IntervalDayTime, Div, div, wrapping_div, checked_div);
+derive_arith!(IntervalDayTime, Rem, rem, wrapping_rem, checked_rem);

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -28,10 +28,17 @@ pub mod builder;
 pub use builder::*;
 
 mod bigint;
-mod bytes;
-mod native;
 pub use bigint::i256;
 
+mod bytes;
+
+mod native;
 pub use native::*;
+
 mod util;
 pub use util::*;
+
+mod interval;
+pub use interval::*;
+
+mod arith;

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::i256;
+use crate::{i256, IntervalDayTime, IntervalMonthDayNano};
 use half::f16;
 
 mod private {
@@ -239,6 +239,60 @@ impl ArrowNativeType for i256 {
     }
 }
 
+impl private::Sealed for IntervalMonthDayNano {}
+impl ArrowNativeType for IntervalMonthDayNano {
+    fn from_usize(_: usize) -> Option<Self> {
+        None
+    }
+
+    fn as_usize(self) -> usize {
+        (self.months as usize) | ((self.days as usize) << 32)
+    }
+
+    fn usize_as(i: usize) -> Self {
+        Self::new(i as _, (i >> 32) as _, 0)
+    }
+
+    fn to_usize(self) -> Option<usize> {
+        None
+    }
+
+    fn to_isize(self) -> Option<isize> {
+        None
+    }
+
+    fn to_i64(self) -> Option<i64> {
+        None
+    }
+}
+
+impl private::Sealed for IntervalDayTime {}
+impl ArrowNativeType for IntervalDayTime {
+    fn from_usize(_: usize) -> Option<Self> {
+        None
+    }
+
+    fn as_usize(self) -> usize {
+        (self.days as usize) | ((self.milliseconds as usize) << 32)
+    }
+
+    fn usize_as(i: usize) -> Self {
+        Self::new(i as _, (i >> 32) as _)
+    }
+
+    fn to_usize(self) -> Option<usize> {
+        None
+    }
+
+    fn to_isize(self) -> Option<isize> {
+        None
+    }
+
+    fn to_i64(self) -> Option<i64> {
+        None
+    }
+}
+
 /// Allows conversion from supported Arrow types to a byte slice.
 pub trait ToByteSlice {
     /// Converts this instance into a byte slice
@@ -281,5 +335,19 @@ mod tests {
         assert_eq!(a.as_usize(), usize::MAX);
         assert!(a.to_usize().is_none());
         assert_eq!(a.to_isize().unwrap(), -1);
+    }
+
+    #[test]
+    fn test_interval_usize() {
+        assert_eq!(IntervalDayTime::new(1, 0).as_usize(), 1);
+        assert_eq!(IntervalMonthDayNano::new(1, 0, 0).as_usize(), 1);
+
+        let a = IntervalDayTime::new(23, 53);
+        let b = IntervalDayTime::usize_as(a.as_usize());
+        assert_eq!(a, b);
+
+        let a = IntervalMonthDayNano::new(23, 53, 0);
+        let b = IntervalMonthDayNano::usize_as(a.as_usize());
+        assert_eq!(a, b);
     }
 }

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -246,11 +246,11 @@ impl ArrowNativeType for IntervalMonthDayNano {
     }
 
     fn as_usize(self) -> usize {
-        (self.months as usize) | ((self.days as usize) << 32)
+        ((self.months as u64) | ((self.days as u64) << 32)) as usize
     }
 
     fn usize_as(i: usize) -> Self {
-        Self::new(i as _, (i >> 32) as _, 0)
+        Self::new(i as _, ((i as u64) >> 32) as _, 0)
     }
 
     fn to_usize(self) -> Option<usize> {
@@ -273,11 +273,11 @@ impl ArrowNativeType for IntervalDayTime {
     }
 
     fn as_usize(self) -> usize {
-        (self.days as usize) | ((self.milliseconds as usize) << 32)
+        ((self.days as u64) | ((self.milliseconds as u64) << 32)) as usize
     }
 
     fn usize_as(i: usize) -> Self {
-        Self::new(i as _, (i >> 32) as _)
+        Self::new(i as _, ((i as u64) >> 32) as _)
     }
 
     fn to_usize(self) -> Option<usize> {

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -660,19 +660,16 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalYearMonthType> {
 
 impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
     fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
-        let value: u64 = self.value(idx) as u64;
+        let value = self.value(idx);
 
-        let days_parts: i32 = ((value & 0xFFFFFFFF00000000) >> 32) as i32;
-        let milliseconds_part: i32 = (value & 0xFFFFFFFF) as i32;
-
-        let secs = milliseconds_part / 1_000;
+        let secs = value.milliseconds / 1_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let milliseconds = milliseconds_part % 1_000;
+        let milliseconds = value.milliseconds % 1_000;
 
         let secs_sign = if secs < 0 || milliseconds < 0 {
             "-"
@@ -683,7 +680,7 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
         write!(
             f,
             "0 years 0 mons {} days {} hours {} mins {}{}.{:03} secs",
-            days_parts,
+            value.days,
             hours,
             mins,
             secs_sign,
@@ -696,28 +693,24 @@ impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalDayTimeType> {
 
 impl<'a> DisplayIndex for &'a PrimitiveArray<IntervalMonthDayNanoType> {
     fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
-        let value: u128 = self.value(idx) as u128;
+        let value = self.value(idx);
 
-        let months_part: i32 = ((value & 0xFFFFFFFF000000000000000000000000) >> 96) as i32;
-        let days_part: i32 = ((value & 0xFFFFFFFF0000000000000000) >> 64) as i32;
-        let nanoseconds_part: i64 = (value & 0xFFFFFFFFFFFFFFFF) as i64;
-
-        let secs = nanoseconds_part / 1_000_000_000;
+        let secs = value.nanoseconds / 1_000_000_000;
         let mins = secs / 60;
         let hours = mins / 60;
 
         let secs = secs - (mins * 60);
         let mins = mins - (hours * 60);
 
-        let nanoseconds = nanoseconds_part % 1_000_000_000;
+        let nanoseconds = value.nanoseconds % 1_000_000_000;
 
         let secs_sign = if secs < 0 || nanoseconds < 0 { "-" } else { "" };
 
         write!(
             f,
             "0 years {} mons {} days {} hours {} mins {}{}.{:09} secs",
-            months_part,
-            days_part,
+            value.months,
+            value.days,
             hours,
             mins,
             secs_sign,

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -142,7 +142,7 @@ mod tests {
     use arrow_array::builder::*;
     use arrow_array::types::*;
     use arrow_array::*;
-    use arrow_buffer::ScalarBuffer;
+    use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
     use arrow_schema::*;
 
     use crate::display::array_value_to_string;
@@ -963,12 +963,12 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_day_time() {
         let arr = Arc::new(arrow_array::IntervalDayTimeArray::from(vec![
-            Some(-600000),
-            Some(4294966295),
-            Some(4294967295),
-            Some(1),
-            Some(10),
-            Some(100),
+            Some(IntervalDayTime::new(-1, -600_000)),
+            Some(IntervalDayTime::new(0, -1001)),
+            Some(IntervalDayTime::new(0, -1)),
+            Some(IntervalDayTime::new(0, 1)),
+            Some(IntervalDayTime::new(0, 10)),
+            Some(IntervalDayTime::new(0, 100)),
         ]));
 
         let schema = Arc::new(Schema::new(vec![Field::new(
@@ -1002,19 +1002,19 @@ mod tests {
     #[test]
     fn test_pretty_format_interval_month_day_nano_array() {
         let arr = Arc::new(arrow_array::IntervalMonthDayNanoArray::from(vec![
-            Some(-600000000000),
-            Some(18446744072709551615),
-            Some(18446744073709551615),
-            Some(1),
-            Some(10),
-            Some(100),
-            Some(1_000),
-            Some(10_000),
-            Some(100_000),
-            Some(1_000_000),
-            Some(10_000_000),
-            Some(100_000_000),
-            Some(1_000_000_000),
+            Some(IntervalMonthDayNano::new(-1, -1, -600_000_000_000)),
+            Some(IntervalMonthDayNano::new(0, 0, -1_000_000_001)),
+            Some(IntervalMonthDayNano::new(0, 0, -1)),
+            Some(IntervalMonthDayNano::new(0, 0, 1)),
+            Some(IntervalMonthDayNano::new(0, 0, 10)),
+            Some(IntervalMonthDayNano::new(0, 0, 100)),
+            Some(IntervalMonthDayNano::new(0, 0, 1_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 10_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 100_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 1_000_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 10_000_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 100_000_000)),
+            Some(IntervalMonthDayNano::new(0, 0, 1_000_000_000)),
         ]));
 
         let schema = Arc::new(Schema::new(vec![Field::new(

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -20,7 +20,9 @@
 
 use crate::bit_iterator::BitSliceIterator;
 use arrow_buffer::buffer::{BooleanBuffer, NullBuffer};
-use arrow_buffer::{bit_util, i256, ArrowNativeType, Buffer, MutableBuffer};
+use arrow_buffer::{
+    bit_util, i256, ArrowNativeType, Buffer, IntervalDayTime, IntervalMonthDayNano, MutableBuffer,
+};
 use arrow_schema::{ArrowError, DataType, UnionMode};
 use std::ops::Range;
 use std::sync::Arc;
@@ -1568,8 +1570,10 @@ pub fn layout(data_type: &DataType) -> DataTypeLayout {
         DataType::Time32(_) => DataTypeLayout::new_fixed_width::<i32>(),
         DataType::Time64(_) => DataTypeLayout::new_fixed_width::<i64>(),
         DataType::Interval(YearMonth) => DataTypeLayout::new_fixed_width::<i32>(),
-        DataType::Interval(DayTime) => DataTypeLayout::new_fixed_width::<i64>(),
-        DataType::Interval(MonthDayNano) => DataTypeLayout::new_fixed_width::<i128>(),
+        DataType::Interval(DayTime) => DataTypeLayout::new_fixed_width::<IntervalDayTime>(),
+        DataType::Interval(MonthDayNano) => {
+            DataTypeLayout::new_fixed_width::<IntervalMonthDayNano>()
+        }
         DataType::Duration(_) => DataTypeLayout::new_fixed_width::<i64>(),
         DataType::Decimal128(_, _) => DataTypeLayout::new_fixed_width::<i128>(),
         DataType::Decimal256(_, _) => DataTypeLayout::new_fixed_width::<i256>(),

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! This is not a canonical format, but provides a human-readable way of verifying language implementations
 
-use arrow_buffer::ScalarBuffer;
+use arrow_buffer::{IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;
 use num::BigInt;
 use num::Signed;
@@ -523,11 +523,7 @@ pub fn array_from_json(
                                     let months = months.as_i64().unwrap() as i32;
                                     let days = days.as_i64().unwrap() as i32;
                                     let nanoseconds = nanoseconds.as_i64().unwrap();
-                                    let months_days_ns: i128 =
-                                        ((nanoseconds as i128) & 0xFFFFFFFFFFFFFFFF) << 64
-                                            | ((days as i128) & 0xFFFFFFFF) << 32
-                                            | ((months as i128) & 0xFFFFFFFF);
-                                    months_days_ns
+                                    IntervalMonthDayNano::new(months, days, nanoseconds)
                                 }
                                 (_, _, _) => {
                                     panic!("Unable to parse {v:?} as MonthDayNano")

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! This is not a canonical format, but provides a human-readable way of verifying language implementations
 
-use arrow_buffer::{IntervalMonthDayNano, ScalarBuffer};
+use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;
 use num::BigInt;
 use num::Signed;
@@ -32,7 +32,6 @@ use std::sync::Arc;
 
 use arrow::array::*;
 use arrow::buffer::{Buffer, MutableBuffer};
-use arrow::compute;
 use arrow::datatypes::*;
 use arrow::error::{ArrowError, Result};
 use arrow::util::bit_util;
@@ -349,10 +348,7 @@ pub fn array_from_json(
             }
             Ok(Arc::new(b.finish()))
         }
-        DataType::Int32
-        | DataType::Date32
-        | DataType::Time32(_)
-        | DataType::Interval(IntervalUnit::YearMonth) => {
+        DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
             let mut b = Int32Builder::with_capacity(json_col.count);
             for (is_valid, value) in json_col
                 .validity
@@ -367,14 +363,29 @@ pub fn array_from_json(
                 };
             }
             let array = Arc::new(b.finish()) as ArrayRef;
-            compute::cast(&array, field.data_type())
+            arrow::compute::cast(&array, field.data_type())
+        }
+        DataType::Interval(IntervalUnit::YearMonth) => {
+            let mut b = IntervalYearMonthBuilder::with_capacity(json_col.count);
+            for (is_valid, value) in json_col
+                .validity
+                .as_ref()
+                .unwrap()
+                .iter()
+                .zip(json_col.data.unwrap())
+            {
+                match is_valid {
+                    1 => b.append_value(value.as_i64().unwrap() as i32),
+                    _ => b.append_null(),
+                };
+            }
+            Ok(Arc::new(b.finish()))
         }
         DataType::Int64
         | DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
-        | DataType::Duration(_)
-        | DataType::Interval(IntervalUnit::DayTime) => {
+        | DataType::Duration(_) => {
             let mut b = Int64Builder::with_capacity(json_col.count);
             for (is_valid, value) in json_col
                 .validity
@@ -387,6 +398,25 @@ pub fn array_from_json(
                     1 => b.append_value(match value {
                         Value::Number(n) => n.as_i64().unwrap(),
                         Value::String(s) => s.parse().expect("Unable to parse string as i64"),
+                        _ => panic!("Unable to parse {value:?} as number"),
+                    }),
+                    _ => b.append_null(),
+                };
+            }
+            let array = Arc::new(b.finish()) as ArrayRef;
+            arrow::compute::cast(&array, field.data_type())
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            let mut b = IntervalDayTimeBuilder::with_capacity(json_col.count);
+            for (is_valid, value) in json_col
+                .validity
+                .as_ref()
+                .unwrap()
+                .iter()
+                .zip(json_col.data.unwrap())
+            {
+                match is_valid {
+                    1 => b.append_value(match value {
                         Value::Object(ref map)
                             if map.contains_key("days") && map.contains_key("milliseconds") =>
                         {
@@ -397,13 +427,9 @@ pub fn array_from_json(
 
                                     match (days, milliseconds) {
                                         (Value::Number(d), Value::Number(m)) => {
-                                            let mut bytes = [0_u8; 8];
-                                            let m = (m.as_i64().unwrap() as i32).to_le_bytes();
-                                            let d = (d.as_i64().unwrap() as i32).to_le_bytes();
-
-                                            let c = [d, m].concat();
-                                            bytes.copy_from_slice(c.as_slice());
-                                            i64::from_le_bytes(bytes)
+                                            let days = d.as_i64().unwrap() as _;
+                                            let millis = m.as_i64().unwrap() as _;
+                                            IntervalDayTime::new(days, millis)
                                         }
                                         _ => {
                                             panic!("Unable to parse {value:?} as interval daytime")
@@ -418,8 +444,7 @@ pub fn array_from_json(
                     _ => b.append_null(),
                 };
             }
-            let array = Arc::new(b.finish()) as ArrayRef;
-            compute::cast(&array, field.data_type())
+            Ok(Arc::new(b.finish()))
         }
         DataType::UInt8 => {
             let mut b = UInt8Builder::with_capacity(json_col.count);

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -845,6 +845,7 @@ pub fn take_record_batch(
 mod tests {
     use super::*;
     use arrow_array::builder::*;
+    use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
     use arrow_schema::{Field, Fields, TimeUnit};
 
     fn test_take_decimal_arrays(
@@ -1158,20 +1159,26 @@ mod tests {
         .unwrap();
 
         // interval_day_time
+        let v1 = IntervalDayTime::new(0, 0);
+        let v2 = IntervalDayTime::new(2, 0);
+        let v3 = IntervalDayTime::new(-15, 0);
         test_take_primitive_arrays::<IntervalDayTimeType>(
-            vec![Some(0), None, Some(2), Some(-15), None],
+            vec![Some(v1), None, Some(v2), Some(v3), None],
             &index,
             None,
-            vec![Some(-15), None, None, Some(-15), Some(2)],
+            vec![Some(v3), None, None, Some(v3), Some(v2)],
         )
         .unwrap();
 
         // interval_month_day_nano
+        let v1 = IntervalMonthDayNano::new(0, 0, 0);
+        let v2 = IntervalMonthDayNano::new(2, 0, 0);
+        let v3 = IntervalMonthDayNano::new(-15, 0, 0);
         test_take_primitive_arrays::<IntervalMonthDayNanoType>(
-            vec![Some(0), None, Some(2), Some(-15), None],
+            vec![Some(v1), None, Some(v2), Some(v3), None],
             &index,
             None,
-            vec![Some(-15), None, None, Some(-15), Some(2)],
+            vec![Some(v3), None, None, Some(v3), Some(v2)],
         )
         .unwrap();
 

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -22,9 +22,9 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::compute::kernels::cmp::*;
-use arrow::datatypes::IntervalMonthDayNanoType;
 use arrow::util::bench_util::*;
 use arrow::{array::*, datatypes::Float32Type, datatypes::Int32Type};
+use arrow_buffer::IntervalMonthDayNano;
 use arrow_string::like::*;
 use arrow_string::regexp::regexp_is_match_utf8_scalar;
 
@@ -59,10 +59,8 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array_with_seed::<Float32Type>(SIZE, 0.0, 42);
     let arr_b = create_primitive_array_with_seed::<Float32Type>(SIZE, 0.0, 43);
 
-    let arr_month_day_nano_a =
-        create_primitive_array_with_seed::<IntervalMonthDayNanoType>(SIZE, 0.0, 43);
-    let arr_month_day_nano_b =
-        create_primitive_array_with_seed::<IntervalMonthDayNanoType>(SIZE, 0.0, 43);
+    let arr_month_day_nano_a = create_month_day_nano_array_with_seed(SIZE, 0.0, 43);
+    let arr_month_day_nano_b = create_month_day_nano_array_with_seed(SIZE, 0.0, 43);
 
     let arr_string = create_string_array::<i32>(SIZE, 0.0);
     let scalar = Float32Array::from(vec![1.0]);
@@ -134,7 +132,7 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("eq MonthDayNano", |b| {
         b.iter(|| eq(&arr_month_day_nano_a, &arr_month_day_nano_b))
     });
-    let scalar = IntervalMonthDayNanoArray::new_scalar(123);
+    let scalar = IntervalMonthDayNanoArray::new_scalar(IntervalMonthDayNano::new(123, 0, 0));
 
     c.bench_function("eq scalar MonthDayNano", |b| {
         b.iter(|| eq(&arr_month_day_nano_b, &scalar).unwrap())

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -20,7 +20,7 @@
 use crate::array::*;
 use crate::datatypes::*;
 use crate::util::test_util::seedable_rng;
-use arrow_buffer::Buffer;
+use arrow_buffer::{Buffer, IntervalMonthDayNano};
 use rand::distributions::uniform::SampleUniform;
 use rand::thread_rng;
 use rand::Rng;
@@ -67,6 +67,24 @@ where
                 None
             } else {
                 Some(rng.gen())
+            }
+        })
+        .collect()
+}
+
+pub fn create_month_day_nano_array_with_seed(
+    size: usize,
+    null_density: f32,
+    seed: u64,
+) -> IntervalMonthDayNanoArray {
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    (0..size)
+        .map(|_| {
+            if rng.gen::<f32>() < null_density {
+                None
+            } else {
+                Some(IntervalMonthDayNano::new(rng.gen(), rng.gen(), rng.gen()))
             }
         })
         .collect()

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -32,7 +32,7 @@ use arrow_array::{
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
     TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array, UnionArray,
 };
-use arrow_buffer::{i256, Buffer};
+use arrow_buffer::{i256, Buffer, IntervalDayTime, IntervalMonthDayNano};
 use arrow_cast::pretty::pretty_format_columns;
 use arrow_cast::{can_cast_types, cast};
 use arrow_data::ArrayData;
@@ -249,8 +249,14 @@ fn get_arrays_of_all_types() -> Vec<ArrayRef> {
         Arc::new(Time64MicrosecondArray::from(vec![1000, 2000])),
         Arc::new(Time64NanosecondArray::from(vec![1000, 2000])),
         Arc::new(IntervalYearMonthArray::from(vec![1000, 2000])),
-        Arc::new(IntervalDayTimeArray::from(vec![1000, 2000])),
-        Arc::new(IntervalMonthDayNanoArray::from(vec![1000, 2000])),
+        Arc::new(IntervalDayTimeArray::from(vec![
+            IntervalDayTime::new(0, 1000),
+            IntervalDayTime::new(0, 2000),
+        ])),
+        Arc::new(IntervalMonthDayNanoArray::from(vec![
+            IntervalMonthDayNano::new(0, 0, 1000),
+            IntervalMonthDayNano::new(0, 0, 1000),
+        ])),
         Arc::new(DurationSecondArray::from(vec![1000, 2000])),
         Arc::new(DurationMillisecondArray::from(vec![1000, 2000])),
         Arc::new(DurationMicrosecondArray::from(vec![1000, 2000])),

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -30,7 +30,7 @@ use arrow_array::{
     ArrayRef, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array,
     IntervalDayTimeArray, IntervalYearMonthArray,
 };
-use arrow_buffer::{i256, Buffer};
+use arrow_buffer::{i256, Buffer, IntervalDayTime};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, IntervalUnit};
 use bytes::Bytes;
@@ -195,7 +195,14 @@ impl ArrayReader for FixedLenByteArrayReader {
                     IntervalUnit::DayTime => Arc::new(
                         binary
                             .iter()
-                            .map(|o| o.map(|b| i64::from_le_bytes(b[4..12].try_into().unwrap())))
+                            .map(|o| {
+                                o.map(|b| {
+                                    IntervalDayTime::new(
+                                        i32::from_le_bytes(b[4..8].try_into().unwrap()),
+                                        i32::from_le_bytes(b[8..12].try_into().unwrap()),
+                                    )
+                                })
+                            })
                             .collect::<IntervalDayTimeArray>(),
                     ) as ArrayRef,
                     IntervalUnit::MonthDayNano => {

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -750,7 +750,7 @@ mod tests {
         Decimal128Type, Decimal256Type, DecimalType, Float16Type, Float32Type, Float64Type,
     };
     use arrow_array::*;
-    use arrow_buffer::{i256, ArrowNativeType, Buffer};
+    use arrow_buffer::{i256, ArrowNativeType, Buffer, IntervalDayTime};
     use arrow_data::ArrayDataBuilder;
     use arrow_schema::{ArrowError, DataType as ArrowDataType, Field, Fields, Schema};
     use arrow_select::concat::concat_batches;
@@ -1060,8 +1060,12 @@ mod tests {
                 Arc::new(
                     vals.iter()
                         .map(|x| {
-                            x.as_ref()
-                                .map(|b| i64::from_le_bytes(b.as_ref()[4..12].try_into().unwrap()))
+                            x.as_ref().map(|b| IntervalDayTime {
+                                days: i32::from_le_bytes(b.as_ref()[4..8].try_into().unwrap()),
+                                milliseconds: i32::from_le_bytes(
+                                    b.as_ref()[8..12].try_into().unwrap(),
+                                ),
+                            })
                         })
                         .collect::<IntervalDayTimeArray>(),
                 )


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3125
Closes #5654

# Rationale for this change
 The current interval implementation in rust is incorrect (the bit fields are wrong) as explained on #5654

Due to the fact that intervals are stored as `i128` simply updating construction and access for reading the fields  would have at least two unpleasant effects:
1. Downstream code that use intervals might silently break / start working very differently
2. Sorting would become somewhat nonsensical as 

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
1. Make `IntervalMonthDayNano`and `IntervalDayTime` structured types
2. Update `IntervalMonthDayNanoArray` and `IntervalDayTimeArray` appropriately
3. Remove cast support from the Int64Arrays to/from those types

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes, this is a major breaking change for anyone who uses `IntervalMonthDayNano` or `IntervalDayTime` 
