### PR TITLE
fix broken link to ballista crate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are two related crates in different repositories
 | [`ballista`]   | Distributed query execution             | [(README)][ballista-readme]   |
 
 [`datafusion`]: https://crates.io/crates/datafusion
-[`ballista`]: https://crates.io/crates/datafusion-ballista
+[`ballista`]: https://crates.io/crates/ballista
 
 Collectively, these crates support a wider array of functionality for analytic computations in Rust.
 


### PR DESCRIPTION
# Which issue does this PR close?

trivial change - fixing broken link in the README.md to the `ballista` crate.

# Are there any user-facing changes?

No.  Nothing beyond the link in `README.md`