### PR TITLE
feat(arrow-json): encode `Binary` and `LargeBinary` types as hex when writing JSON

### DIFF
--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1565,6 +1565,85 @@ mod tests {
         Ok(())
     }
 
+    macro_rules! binary_encoding_test {
+        ($data_type:path, $builder:ident) => {
+            // set up schema
+            let schema = SchemaRef::new(Schema::new(vec![Field::new("bytes", $data_type, true)]));
+
+            // build record batch:
+            let mut builder = $builder::new();
+            let values = [Some(b"Ned Flanders"), None, Some(b"Troy McClure")];
+            for value in values {
+                match value {
+                    Some(v) => builder.append_value(v),
+                    None => builder.append_null(),
+                }
+            }
+            let array = Arc::new(builder.finish()) as ArrayRef;
+            let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+            // encode and check JSON with explicit nulls:
+            {
+                let mut buf = Vec::new();
+                let json_value: Value = {
+                    let mut writer = WriterBuilder::new()
+                        .with_explicit_nulls(true)
+                        .build::<_, JsonArray>(&mut buf);
+                    writer.write(&batch).unwrap();
+                    writer.close().unwrap();
+                    serde_json::from_slice(&buf).unwrap()
+                };
+
+                assert_eq!(
+                    json!([
+                        {
+                            "bytes": "4e656420466c616e64657273"
+                        },
+                        {
+                            "bytes": null // the explicit null
+                        },
+                        {
+                            "bytes": "54726f79204d63436c757265"
+                        }
+                    ]),
+                    json_value,
+                );
+            }
+
+            // encode and check JSON with no explicit nulls:
+            {
+                let mut buf = Vec::new();
+                let json_value: Value = {
+                    // explicit nulls are off by default, so we don't need
+                    // to set that when creating the writer:
+                    let mut writer = ArrayWriter::new(&mut buf);
+                    writer.write(&batch).unwrap();
+                    writer.close().unwrap();
+                    serde_json::from_slice(&buf).unwrap()
+                };
+
+                assert_eq!(
+                    json!([
+                        {
+                            "bytes": "4e656420466c616e64657273"
+                        },
+                        {}, // empty because nulls are omitted
+                        {
+                            "bytes": "54726f79204d63436c757265"
+                        }
+                    ]),
+                    json_value
+                );
+            }
+        };
+    }
+
+    #[test]
+    fn test_writer_binary() {
+        binary_encoding_test!(DataType::Binary, BinaryBuilder);
+        binary_encoding_test!(DataType::LargeBinary, LargeBinaryBuilder);
+    }
+
     #[test]
     fn test_writer_fixed_size_binary() {
         // set up schema:

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1565,9 +1565,13 @@ mod tests {
         Ok(())
     }
 
-    fn binary_encoding_test<O: OffsetSizeTrait>(data_type: DataType) {
+    fn binary_encoding_test<O: OffsetSizeTrait>() {
         // set up schema
-        let schema = SchemaRef::new(Schema::new(vec![Field::new("bytes", data_type, true)]));
+        let schema = SchemaRef::new(Schema::new(vec![Field::new(
+            "bytes",
+            GenericBinaryType::<O>::DATA_TYPE,
+            true,
+        )]));
 
         // build record batch:
         let mut builder = GenericByteBuilder::<GenericBinaryType<O>>::new();
@@ -1638,8 +1642,10 @@ mod tests {
 
     #[test]
     fn test_writer_binary() {
-        binary_encoding_test::<i32>(DataType::Binary);
-        binary_encoding_test::<i64>(DataType::LargeBinary);
+        // Binary:
+        binary_encoding_test::<i32>();
+        // LargeBinary:
+        binary_encoding_test::<i64>();
     }
 
     #[test]

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1565,83 +1565,81 @@ mod tests {
         Ok(())
     }
 
-    macro_rules! binary_encoding_test {
-        ($data_type:path, $builder:ident) => {
-            // set up schema
-            let schema = SchemaRef::new(Schema::new(vec![Field::new("bytes", $data_type, true)]));
+    fn binary_encoding_test<O: OffsetSizeTrait>(data_type: DataType) {
+        // set up schema
+        let schema = SchemaRef::new(Schema::new(vec![Field::new("bytes", data_type, true)]));
 
-            // build record batch:
-            let mut builder = $builder::new();
-            let values = [Some(b"Ned Flanders"), None, Some(b"Troy McClure")];
-            for value in values {
-                match value {
-                    Some(v) => builder.append_value(v),
-                    None => builder.append_null(),
-                }
+        // build record batch:
+        let mut builder = GenericByteBuilder::<GenericBinaryType<O>>::new();
+        let values = [Some(b"Ned Flanders"), None, Some(b"Troy McClure")];
+        for value in values {
+            match value {
+                Some(v) => builder.append_value(v),
+                None => builder.append_null(),
             }
-            let array = Arc::new(builder.finish()) as ArrayRef;
-            let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+        }
+        let array = Arc::new(builder.finish()) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
 
-            // encode and check JSON with explicit nulls:
-            {
-                let mut buf = Vec::new();
-                let json_value: Value = {
-                    let mut writer = WriterBuilder::new()
-                        .with_explicit_nulls(true)
-                        .build::<_, JsonArray>(&mut buf);
-                    writer.write(&batch).unwrap();
-                    writer.close().unwrap();
-                    serde_json::from_slice(&buf).unwrap()
-                };
+        // encode and check JSON with explicit nulls:
+        {
+            let mut buf = Vec::new();
+            let json_value: Value = {
+                let mut writer = WriterBuilder::new()
+                    .with_explicit_nulls(true)
+                    .build::<_, JsonArray>(&mut buf);
+                writer.write(&batch).unwrap();
+                writer.close().unwrap();
+                serde_json::from_slice(&buf).unwrap()
+            };
 
-                assert_eq!(
-                    json!([
-                        {
-                            "bytes": "4e656420466c616e64657273"
-                        },
-                        {
-                            "bytes": null // the explicit null
-                        },
-                        {
-                            "bytes": "54726f79204d63436c757265"
-                        }
-                    ]),
-                    json_value,
-                );
-            }
+            assert_eq!(
+                json!([
+                    {
+                        "bytes": "4e656420466c616e64657273"
+                    },
+                    {
+                        "bytes": null // the explicit null
+                    },
+                    {
+                        "bytes": "54726f79204d63436c757265"
+                    }
+                ]),
+                json_value,
+            );
+        }
 
-            // encode and check JSON with no explicit nulls:
-            {
-                let mut buf = Vec::new();
-                let json_value: Value = {
-                    // explicit nulls are off by default, so we don't need
-                    // to set that when creating the writer:
-                    let mut writer = ArrayWriter::new(&mut buf);
-                    writer.write(&batch).unwrap();
-                    writer.close().unwrap();
-                    serde_json::from_slice(&buf).unwrap()
-                };
+        // encode and check JSON with no explicit nulls:
+        {
+            let mut buf = Vec::new();
+            let json_value: Value = {
+                // explicit nulls are off by default, so we don't need
+                // to set that when creating the writer:
+                let mut writer = ArrayWriter::new(&mut buf);
+                writer.write(&batch).unwrap();
+                writer.close().unwrap();
+                serde_json::from_slice(&buf).unwrap()
+            };
 
-                assert_eq!(
-                    json!([
-                        {
-                            "bytes": "4e656420466c616e64657273"
-                        },
-                        {}, // empty because nulls are omitted
-                        {
-                            "bytes": "54726f79204d63436c757265"
-                        }
-                    ]),
-                    json_value
-                );
-            }
-        };
+            assert_eq!(
+                json!([
+                    {
+                        "bytes": "4e656420466c616e64657273"
+                    },
+                    {}, // empty because nulls are omitted
+                    {
+                        "bytes": "54726f79204d63436c757265"
+                    }
+                ]),
+                json_value
+            );
+        }
     }
 
     #[test]
     fn test_writer_binary() {
-        binary_encoding_test!(DataType::Binary, BinaryBuilder);
-        binary_encoding_test!(DataType::LargeBinary, LargeBinaryBuilder);
+        binary_encoding_test::<i32>(DataType::Binary);
+        binary_encoding_test::<i64>(DataType::LargeBinary);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5783.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

See #5783.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Extend the JSON writer to encode `Binary` and `LargeBinary` types as hex. This follows the behaviour for `FixedSizeBinary`.
* A test was added to check functionality for both `Binary` and `LargeBinary`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
Some documentation could be added to the writer to indicate that binary types are encoded as hex. If that belongs on this PR or a follow-on I can make it so.

These should not be breaking changes as previously the JSON writer would throw an error when attempting to encode `Binary` and `LargeBinary` types.