### PR TITLE
chore: update docs to delineate which ObjectStore lists are recursive

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -716,7 +716,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// List all the objects with the given prefix.
     ///
     /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
-    /// `foo/bar_baz/x`.
+    /// `foo/bar_baz/x`. List is recursive, i.e. `foo/bar/more/x` will be included.
     ///
     /// Note: the order of returned [`ObjectMeta`] is not guaranteed
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>>;
@@ -743,7 +743,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// metadata.
     ///
     /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
-    /// `foo/bar_baz/x`.
+    /// `foo/bar_baz/x`. List is not recursive, i.e. `foo/bar/more/x` will not be included.
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult>;
 
     /// Copy an object from one path to another in the same object store.


### PR DESCRIPTION
# Which issue does this PR close?

No issue. Is updating the docs to clarify expected behavior (confirmed expected per @tustvold ).

# Rationale for this change
 
Make sure it's clear for others as well.

# What changes are included in this PR?

Minor doc updates.

# Are there any user-facing changes?

No APIs, no logic changes. Only docs.