### PR TITLE
Allow constructing ByteViewArray from existing blocks

### DIFF
--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -1386,6 +1386,8 @@ pub(crate) mod bytes {
     impl<O: OffsetSizeTrait> ByteArrayTypeSealed for GenericBinaryType<O> {}
 
     pub trait ByteArrayNativeType: std::fmt::Debug + Send + Sync {
+        fn from_bytes_checked(b: &[u8]) -> Option<&Self>;
+
         /// # Safety
         ///
         /// `b` must be a valid byte sequence for `Self`
@@ -1394,12 +1396,22 @@ pub(crate) mod bytes {
 
     impl ByteArrayNativeType for [u8] {
         #[inline]
+        fn from_bytes_checked(b: &[u8]) -> Option<&Self> {
+            Some(b)
+        }
+
+        #[inline]
         unsafe fn from_bytes_unchecked(b: &[u8]) -> &Self {
             b
         }
     }
 
     impl ByteArrayNativeType for str {
+        #[inline]
+        fn from_bytes_checked(b: &[u8]) -> Option<&Self> {
+            std::str::from_utf8(b).ok()
+        }
+
         #[inline]
         unsafe fn from_bytes_unchecked(b: &[u8]) -> &Self {
             std::str::from_utf8_unchecked(b)


### PR DESCRIPTION
_Draft as needs more testing, creating for feedback_

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #5736
Relates to #5530
Relates to #5735

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Whilst working on #5736 I struggled to devise a coherent interface for constructing byte views, because views can't really really be constructed independently of the data buffers. In particular small strings need to be inlined in the view, but longer strings need to be added to a data buffer. As a result any interface that exposes the view abstraction is naturally leaky, and quite fiddly to use correctly.

Fortunately we already have a builder that abstracts away the view shenanigans, and with some minor tweaks we can extend it to allow using existing buffers, I think this provides for a much more coherent abstraction.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
