### PR TITLE
Fix issue 5396

### DIFF
--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -136,7 +136,7 @@ pub struct AmazonS3Builder {
     /// Url
     url: Option<String>,
     /// Request context
-    request_context: RequestContext,
+    request_ctx: RequestContext,
     /// When set to true, fallback to IMDSv1
     imdsv1_fallback: ConfigValue<bool>,
     /// When set to true, virtual hosted style request has to be used
@@ -695,7 +695,7 @@ impl AmazonS3Builder {
 
     /// Set the retry configuration
     pub fn with_retry(mut self, retry_config: RetryConfig) -> Self {
-        self.request_context.config = retry_config;
+        self.request_ctx.config = retry_config;
         self
     }
 
@@ -827,7 +827,7 @@ impl AmazonS3Builder {
 
     /// Docs
     pub fn with_sempahore_permits(mut self, permits: usize) -> Self {
-        self.request_context.semaphore = Arc::new(Semaphore::new(permits));
+        self.request_ctx.semaphore = Arc::new(Semaphore::new(permits));
         self
     }
 
@@ -890,13 +890,13 @@ impl AmazonS3Builder {
             Arc::new(TokenCredentialProvider::new(
                 token,
                 client,
-                self.request_context.clone(),
+                self.request_ctx.clone(),
             )) as _
         } else if let Some(uri) = self.container_credentials_relative_uri {
             info!("Using Task credential provider");
             Arc::new(TaskCredentialProvider {
                 url: format!("http://169.254.170.2{uri}"),
-                request_ctx: self.request_context.clone(),
+                request_ctx: self.request_ctx.clone(),
                 // The instance metadata endpoint is access over HTTP
                 client: self.client_options.clone().with_allow_http(true).client()?,
                 cache: Default::default(),
@@ -915,7 +915,7 @@ impl AmazonS3Builder {
             Arc::new(TokenCredentialProvider::new(
                 token,
                 self.client_options.metadata_client()?,
-                self.request_context.clone(),
+                self.request_ctx.clone(),
             )) as _
         };
 
@@ -934,7 +934,7 @@ impl AmazonS3Builder {
                             credentials: Arc::clone(&credentials),
                         },
                         self.client_options.client()?,
-                        self.request_context.clone(),
+                        self.request_ctx.clone(),
                     )
                     .with_min_ttl(Duration::from_secs(60)), // Credentials only valid for 5 minutes
                 );
@@ -973,7 +973,7 @@ impl AmazonS3Builder {
             bucket_endpoint,
             credentials,
             session_provider,
-            request_context: self.request_context,
+            request_ctx: self.request_ctx,
             client_options: self.client_options,
             sign_payload: !self.unsigned_payload.get()?,
             skip_signature: self.skip_signature.get()?,

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -25,15 +25,17 @@ use crate::aws::{
 };
 use crate::client::TokenCredentialProvider;
 use crate::config::ConfigValue;
-use crate::{ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider};
+use crate::{
+    ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider,
+};
 use itertools::Itertools;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::sync::Semaphore;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Semaphore;
 use tracing::info;
 use url::Url;
 
@@ -825,7 +827,7 @@ impl AmazonS3Builder {
         self
     }
 
-    /// Docs
+    /// Set the number of permits for the semaphore controlling concurrency.
     pub fn with_sempahore_permits(mut self, permits: usize) -> Self {
         self.request_ctx.semaphore = Arc::new(Semaphore::new(permits));
         self

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -172,7 +172,7 @@ pub struct S3Config {
     pub bucket_endpoint: String,
     pub credentials: AwsCredentialProvider,
     pub session_provider: Option<AwsCredentialProvider>,
-    pub request_context: RequestContext,
+    pub request_ctx: RequestContext,
     pub client_options: ClientOptions,
     pub sign_payload: bool,
     pub skip_signature: bool,
@@ -373,7 +373,7 @@ impl<'a> Request<'a> {
         let path = self.path.as_ref();
         self.builder
             .with_aws_sigv4(credential.authorizer(), sha)
-            .retryable(&self.config.request_context.config)
+            .retryable(&self.config.request_ctx.config)
             .idempotent(self.idempotent)
             .payload(self.payload)
             .send()
@@ -483,7 +483,7 @@ impl S3Client {
             .header(CONTENT_TYPE, "application/xml")
             .body(body)
             .with_aws_sigv4(credential.authorizer(), Some(digest.as_ref()))
-            .send_retry(&self.config.request_context)
+            .send_retry(&self.config.request_ctx)
             .await
             .context(DeleteObjectsRequestSnafu {})?
             .bytes()
@@ -597,7 +597,7 @@ impl S3Client {
             .query(&[("uploadId", upload_id)])
             .body(body)
             .with_aws_sigv4(credential.authorizer(), None)
-            .retryable(&self.config.request_context.config)
+            .retryable(&self.config.request_ctx.config)
             .idempotent(true)
             .send()
             .await
@@ -627,7 +627,7 @@ impl S3Client {
             .client
             .request(Method::GET, url)
             .with_aws_sigv4(credential.authorizer(), None)
-            .send_retry(&self.config.request_context)
+            .send_retry(&self.config.request_ctx)
             .await
             .map_err(|e| e.error(STORE, path.to_string()))?;
         Ok(response)
@@ -662,7 +662,7 @@ impl GetClient for S3Client {
         let response = builder
             .with_get_options(options)
             .with_aws_sigv4(credential.authorizer(), None)
-            .send_retry(&self.config.request_context)
+            .send_retry(&self.config.request_ctx)
             .await
             .map_err(|e| e.error(STORE, path.to_string()))?;
 
@@ -708,7 +708,7 @@ impl ListClient for S3Client {
             .request(Method::GET, &url)
             .query(&query)
             .with_aws_sigv4(credential.authorizer(), None)
-            .send_retry(&self.config.request_context)
+            .send_retry(&self.config.request_ctx)
             .await
             .context(ListRequestSnafu)?
             .bytes()

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -438,12 +438,17 @@ impl TokenProvider for InstanceCredentialProvider {
         client: &Client,
         request_ctx: &RequestContext,
     ) -> Result<TemporaryToken<Arc<AwsCredential>>> {
-        instance_creds(client, request_ctx, &self.metadata_endpoint, self.imdsv1_fallback)
-            .await
-            .map_err(|source| crate::Error::Generic {
-                store: STORE,
-                source,
-            })
+        instance_creds(
+            client,
+            request_ctx,
+            &self.metadata_endpoint,
+            self.imdsv1_fallback,
+        )
+        .await
+        .map_err(|source| crate::Error::Generic {
+            store: STORE,
+            source,
+        })
     }
 }
 
@@ -661,7 +666,12 @@ async fn task_credential(
     request_ctx: &RequestContext,
     url: &str,
 ) -> Result<TemporaryToken<Arc<AwsCredential>>, StdError> {
-    let creds: InstanceCredentials = client.get(url).send_retry(request_ctx).await?.json().await?;
+    let creds: InstanceCredentials = client
+        .get(url)
+        .send_retry(request_ctx)
+        .await?
+        .json()
+        .await?;
 
     let now = Utc::now();
     let ttl = (creds.expiration - now).to_std().unwrap_or_default();

--- a/object_store/src/aws/dynamo.rs
+++ b/object_store/src/aws/dynamo.rs
@@ -334,7 +334,7 @@ impl DynamoCommit {
             .json(&req)
             .header("X-Amz-Target", target)
             .with_aws_sigv4(authorizer, None)
-            .send_retry(&s3.config.retry_config)
+            .send_retry(&s3.config.request_context)
             .await
     }
 }

--- a/object_store/src/aws/dynamo.rs
+++ b/object_store/src/aws/dynamo.rs
@@ -334,7 +334,7 @@ impl DynamoCommit {
             .json(&req)
             .header("X-Amz-Target", target)
             .with_aws_sigv4(authorizer, None)
-            .send_retry(&s3.config.request_context)
+            .send_retry(&s3.config.request_ctx)
             .await
     }
 }

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -23,13 +23,15 @@ use crate::azure::credential::{
 use crate::azure::{AzureCredential, AzureCredentialProvider, MicrosoftAzure, STORE};
 use crate::client::TokenCredentialProvider;
 use crate::config::ConfigValue;
-use crate::{ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider};
+use crate::{
+    ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider,
+};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::sync::Semaphore;
 use std::str::FromStr;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 use url::Url;
 
 /// The well-known account used by Azurite and the legacy Azure Storage Emulator.
@@ -807,7 +809,7 @@ impl MicrosoftAzureBuilder {
         self
     }
 
-    /// Docs
+    /// Set the number of permits for the semaphore controlling concurrency.
     pub fn with_sempahore_permits(mut self, permits: usize) -> Self {
         self.request_ctx.semaphore = Arc::new(Semaphore::new(permits));
         self

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -27,7 +27,8 @@ use crate::multipart::PartId;
 use crate::path::DELIMITER;
 use crate::util::{deserialize_rfc1123, GetRange};
 use crate::{
-    Attribute, Attributes, ClientOptions, GetOptions, ListResult, ObjectMeta, Path, PutMode, PutMultipartOpts, PutOptions, PutPayload, PutResult, RequestContext, Result, TagSet
+    Attribute, Attributes, ClientOptions, GetOptions, ListResult, ObjectMeta, Path, PutMode,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult, RequestContext, Result, TagSet,
 };
 use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -992,10 +992,7 @@ mod tests {
             Some(format!("{endpoint}/metadata/identity/oauth2/token")),
         );
 
-        let token = credential
-            .fetch_token(&client, &request_ctx)
-            .await
-            .unwrap();
+        let token = credential.fetch_token(&client, &request_ctx).await.unwrap();
 
         assert_eq!(
             token.token.as_ref(),
@@ -1044,10 +1041,7 @@ mod tests {
             Some(endpoint.to_string()),
         );
 
-        let token = credential
-            .fetch_token(&client, &request_ctx)
-            .await
-            .unwrap();
+        let token = credential.fetch_token(&client, &request_ctx).await.unwrap();
 
         assert_eq!(
             token.token.as_ref(),

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -942,7 +942,6 @@ mod tests {
     use super::*;
     use crate::azure::MicrosoftAzureBuilder;
     use crate::client::mock_server::MockServer;
-    use crate::RetryConfig;
     use crate::{ObjectStore, Path};
 
     #[tokio::test]

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -953,7 +953,7 @@ mod tests {
 
         let endpoint = server.url();
         let client = Client::new();
-        let retry_config = RetryConfig::default();
+        let request_ctx = RequestContext::default();
 
         // Test IMDS
         server.push_fn(|req| {
@@ -993,7 +993,7 @@ mod tests {
         );
 
         let token = credential
-            .fetch_token(&client, &retry_config)
+            .fetch_token(&client, &request_ctx)
             .await
             .unwrap();
 
@@ -1012,7 +1012,7 @@ mod tests {
 
         let endpoint = server.url();
         let client = Client::new();
-        let retry_config = RetryConfig::default();
+        let request_ctx = RequestContext::default();
 
         // Test IMDS
         server.push_fn(move |req| {
@@ -1045,7 +1045,7 @@ mod tests {
         );
 
         let token = credential
-            .fetch_token(&client, &retry_config)
+            .fetch_token(&client, &request_ctx)
             .await
             .unwrap();
 

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -662,23 +662,23 @@ where
 mod cloud {
     use super::*;
     use crate::client::token::{TemporaryToken, TokenCache};
-    use crate::RetryConfig;
+    use crate::RequestContext;
 
     /// A [`CredentialProvider`] that uses [`Client`] to fetch temporary tokens
     #[derive(Debug)]
     pub struct TokenCredentialProvider<T: TokenProvider> {
         inner: T,
         client: Client,
-        retry: RetryConfig,
+        request_ctx: RequestContext,
         cache: TokenCache<Arc<T::Credential>>,
     }
 
     impl<T: TokenProvider> TokenCredentialProvider<T> {
-        pub fn new(inner: T, client: Client, retry: RetryConfig) -> Self {
+        pub fn new(inner: T, client: Client, request_ctx: RequestContext) -> Self {
             Self {
                 inner,
                 client,
-                retry,
+                request_ctx,
                 cache: Default::default(),
             }
         }
@@ -697,7 +697,7 @@ mod cloud {
 
         async fn get_credential(&self) -> Result<Arc<Self::Credential>> {
             self.cache
-                .get_or_insert_with(|| self.inner.fetch_token(&self.client, &self.retry))
+                .get_or_insert_with(|| self.inner.fetch_token(&self.client, &self.request_ctx))
                 .await
         }
     }
@@ -709,7 +709,7 @@ mod cloud {
         async fn fetch_token(
             &self,
             client: &Client,
-            retry: &RetryConfig,
+            request_ctx: &RequestContext,
         ) -> Result<TemporaryToken<Arc<Self::Credential>>>;
     }
 }

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -121,8 +121,12 @@ impl From<Error> for std::io::Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Docs
+#[derive(Debug)]
 pub struct RequestContext {
+    /// Retry configuration
     pub config: RetryConfig,
+    /// Semaphore that limits the number of retry requests
     pub semaphore: Arc<Semaphore>,
 }
 

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -24,7 +24,9 @@ use reqwest::header::LOCATION;
 use reqwest::{Client, Request, Response, StatusCode};
 use snafu::Error as SnafuError;
 use snafu::Snafu;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
 use tracing::info;
 
 /// Retry request error
@@ -118,6 +120,20 @@ impl From<Error> for std::io::Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct RequestContext {
+    pub config: RetryConfig,
+    pub semaphore: Arc<Semaphore>,
+}
+
+impl Default for RequestContext {
+    fn default() -> Self {
+        RequestContext {
+            config: RetryConfig::default(),
+            semaphore: Arc::new(Semaphore::new(5)),
+        }
+    }
+}
 
 /// The configuration for how to respond to request errors
 ///

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -122,7 +122,7 @@ impl From<Error> for std::io::Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Docs
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RequestContext {
     /// Retry configuration
     pub config: RetryConfig,

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -25,12 +25,14 @@ use crate::gcp::{
     credential, GcpCredential, GcpCredentialProvider, GcpSigningCredential,
     GcpSigningCredentialProvider, GoogleCloudStorage, STORE,
 };
-use crate::{ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider};
+use crate::{
+    ClientConfigKey, ClientOptions, RequestContext, Result, RetryConfig, StaticCredentialProvider,
+};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::sync::Semaphore;
 use std::str::FromStr;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 use url::Url;
 
 use super::credential::{AuthorizedUserSigningCredentials, InstanceSigningCredentialProvider};
@@ -414,7 +416,7 @@ impl GoogleCloudStorageBuilder {
         self
     }
 
-    /// Docs
+    /// Set the number of permits for the semaphore controlling concurrency.
     pub fn with_sempahore_permits(mut self, permits: usize) -> Self {
         self.request_ctx.semaphore = Arc::new(Semaphore::new(permits));
         self

--- a/object_store/src/gcp/credential.rs
+++ b/object_store/src/gcp/credential.rs
@@ -570,7 +570,11 @@ impl AuthorizedUserSigningCredentials {
         Ok(Self { credential })
     }
 
-    async fn client_email(&self, client: &Client, request_ctx: &RequestContext) -> crate::Result<String> {
+    async fn client_email(
+        &self,
+        client: &Client,
+        request_ctx: &RequestContext,
+    ) -> crate::Result<String> {
         let response = client
             .request(Method::GET, "https://oauth2.googleapis.com/tokeninfo")
             .query(&[("access_token", &self.credential.refresh_token)])

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -44,7 +44,8 @@ use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
     ClientConfigKey, ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, PutMode, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result, RetryConfig,
+    ObjectStore, PutMode, PutMultipartOpts, PutOptions, PutPayload, PutResult, RequestContext,
+    Result, RetryConfig,
 };
 
 mod client;
@@ -200,7 +201,7 @@ impl ObjectStore for HttpStore {
 pub struct HttpBuilder {
     url: Option<String>,
     client_options: ClientOptions,
-    retry_config: RetryConfig,
+    request_ctx: RequestContext,
 }
 
 impl HttpBuilder {
@@ -217,7 +218,7 @@ impl HttpBuilder {
 
     /// Set the retry configuration
     pub fn with_retry(mut self, retry_config: RetryConfig) -> Self {
-        self.retry_config = retry_config;
+        self.request_ctx.config = retry_config;
         self
     }
 
@@ -239,7 +240,7 @@ impl HttpBuilder {
         let parsed = Url::parse(&url).context(UnableToParseUrlSnafu { url })?;
 
         Ok(HttpStore {
-            client: Client::new(parsed, self.client_options, self.retry_config)?,
+            client: Client::new(parsed, self.client_options, self.request_ctx)?,
         })
     }
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -526,8 +526,8 @@ mod client;
 
 #[cfg(feature = "cloud")]
 pub use client::{
-    backoff::BackoffConfig, retry::RetryConfig, retry::RequestContext ,ClientConfigKey, ClientOptions, CredentialProvider,
-    StaticCredentialProvider,
+    backoff::BackoffConfig, retry::RequestContext, retry::RetryConfig, ClientConfigKey,
+    ClientOptions, CredentialProvider, StaticCredentialProvider,
 };
 
 #[cfg(feature = "cloud")]

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -526,7 +526,7 @@ mod client;
 
 #[cfg(feature = "cloud")]
 pub use client::{
-    backoff::BackoffConfig, retry::RetryConfig, ClientConfigKey, ClientOptions, CredentialProvider,
+    backoff::BackoffConfig, retry::RetryConfig, retry::RequestContext ,ClientConfigKey, ClientOptions, CredentialProvider,
     StaticCredentialProvider,
 };
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5396 

# What changes are included in this PR?
This PR introduces a new `RequestContext` struct that encapsulates the `RetryConfig` and a semaphore to limit the number of concurrent retry requests. This replaces the previous use of `RetryConfig` alone. The semaphore is used in the `send_retry` method. 

- `RequestContext`: Combines `RetryConfig` and a semaphore.
- Concurrency Control: Semaphore in `send_retry` limits simultaneous retry requests.
- Client Update: Clients like `S3Client` now use `RequestContext` instead of `RetryConfig` in its `S3Config`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

All clients now use `RequestContext`, meaning all relevant new methods will require `RequestContext` instead of `RetryConfig`. This change impacts how clients are initialized and configured, necessitating updates to existing client initialization code.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
