### PR TITLE
Minor: Clarify docs on `EnabledStatistics`

### DIFF
--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -675,7 +675,7 @@ impl WriterPropertiesBuilder {
 /// Enabling statistics makes the resulting Parquet file larger and requires
 /// more time to read the parquet footer.
 ///
-/// Statistics can be used to improve query performance by efficient row groups
+/// Statistics can be used to improve query performance by pruning row groups
 /// and pages during query execution if the query engine supports evaluating the
 /// predicate using the statistics.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -680,11 +680,19 @@ impl WriterPropertiesBuilder {
 /// predicate using the statistics.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EnabledStatistics {
-    /// Compute no statistics
+    /// Compute no statistics.
     None,
     /// Compute column chunk-level statistics but not page-level.
+    ///
+    /// Setting this option will store one set of statistics for each relevant
+    /// column for each row group. The more row groups written, the more
+    /// statistics will be stored.
     Chunk,
-    /// Compute page-level and column chunk-level statistics
+    /// Compute page-level and column chunk-level statistics.
+    ///
+    /// Setting this option will store one set of statistics for each relevant
+    /// column for each page and row group. The more row groups and the more
+    /// pages written, the more statistics will be stored.
     Page,
 }
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -669,14 +669,22 @@ impl WriterPropertiesBuilder {
     }
 }
 
-/// Controls the level of statistics to be computed by the writer
+/// Controls the level of statistics to be computed by the writer and stored in
+/// the parquet file.
+///
+/// Enabling statistics makes the resulting Parquet file larger and requires
+/// more time to read the parquet footer.
+///
+/// Statistics can be used to improve query performance by efficient row groups
+/// and pages during query execution if the query engine supports evaluating the
+/// predicate using the statistics.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EnabledStatistics {
     /// Compute no statistics
     None,
-    /// Compute chunk-level statistics but not page-level
+    /// Compute column chunk-level statistics but not page-level.
     Chunk,
-    /// Compute page-level and chunk-level statistics
+    /// Compute page-level and column chunk-level statistics
     Page,
 }
 


### PR DESCRIPTION
# Which issue does this PR close?



# Rationale for this change
 
While working to add an example of pruning with these statistics in DataFusion https://github.com/apache/datafusion/pull/10701 I ran across the term "chunk statistics"

I think from the context this means "column chunk" which would be good to clarify for the casual reader

# What changes are included in this PR?
1. Clarify docs

# Are there any user-facing changes?

This is only a documentation change. There are no functional changes.