### PR TITLE
Minor: Add examples for ColumnPath::from

### DIFF
--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -665,6 +665,23 @@ impl BasicTypeInfo {
 // Parquet descriptor definitions
 
 /// Represents the location of a column in a Parquet schema
+///
+/// # Example: refer to column named `'my_column'`
+/// ```
+/// # use parquet::schema::types::ColumnPath;
+/// let column_path = ColumnPath::from("my_column");
+/// ```
+///
+/// # Example: refer to column named `c` in a nested struct `{a: {b: {c: ...}}}`
+/// ```
+/// # use parquet::schema::types::ColumnPath;
+/// // form path 'a.b.c'
+/// let column_path = ColumnPath::from(vec![
+///   String::from("a"),
+///   String::from("b"),
+///   String::from("c")
+/// ]);
+/// ```
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub struct ColumnPath {
     parts: Vec<String>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

While working to add an example of pruning with these statistics in DataFusion https://github.com/apache/datafusion/pull/10701 I ran across `ColumnPath` and didn't immediately find `ColumnPath::from` for creating a reference to single columns

It would be nice to add some examples to reduce  the cognitive load

# What changes are included in this PR?
Add some examples
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Only docs, no functional changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
