### PR TITLE
Minor: Document timestamp with/without cast behavior

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -629,8 +629,8 @@ fn timestamp_to_date32<T: ArrowTimestampType>(
 /// # Casting timestamps without timezone to timestamps with timezone
 ///
 /// When casting from a timestamp without timezone to a timestamp with
-/// timezone, the cast kernel treats the underlying timestamp values as being in
-/// UTC and adjusts them to the provided timezone.
+/// timezone, the cast kernel interprets the timestamp values as being in
+/// the destination timezone and then adjusts the underlying value to UTC as required
 ///
 /// However, note that when casting from a timestamp with timezone BACK to a
 /// timestamp without timezone the cast kernel does not adjust the values.

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -623,7 +623,7 @@ fn timestamp_to_date32<T: ArrowTimestampType>(
 /// let b = cast(&a, &data_type).unwrap();
 /// let b = b.as_primitive::<TimestampSecondType>(); // downcast to result type
 /// assert_eq!(2_000_000_000, b.value(1)); // values are still the same
-/// // They are displayed in the target timezone (note the offset -05:00)
+/// // displayed in the target timezone (note the offset -05:00)
 /// assert_eq!("2033-05-17T22:33:20-05:00", display::array_value_to_string(&b, 1).unwrap());
 /// ```
 /// # Casting timestamps without timezone to timestamps with timezone
@@ -651,21 +651,21 @@ fn timestamp_to_date32<T: ArrowTimestampType>(
 /// let b = cast(&a, &data_type).unwrap(); // cast to timestamp without timezone
 /// let b = b.as_primitive::<TimestampSecondType>(); // downcast to result type
 /// assert_eq!(2_000_000_000, b.value(1)); // values are still the same
-/// // They are displayed without a timezone (note lack of offset or Z)
+/// // displayed without a timezone (note lack of offset or Z)
 /// assert_eq!("2033-05-18T03:33:20", display::array_value_to_string(&b, 1).unwrap());
 ///
 /// // Convert timestamps without a timezone to timestamps with a timezone
 /// let c = cast(&b, &data_type_tz).unwrap();
 /// let c = c.as_primitive::<TimestampSecondType>(); // downcast to result type
 /// assert_eq!(2_000_018_000, c.value(1)); // value has been adjusted by offset
-/// // When displayed, they are displayed without a timezone (note lack of offset or Z)
+/// // displayed with the target timezone offset (-05:00)
 /// assert_eq!("2033-05-18T03:33:20-05:00", display::array_value_to_string(&c, 1).unwrap());
 ///
 /// // Convert from timestamp with timezone back to timestamp without timezone
 /// let d = cast(&c, &data_type).unwrap();
 /// let d = d.as_primitive::<TimestampSecondType>(); // downcast to result type
 /// assert_eq!(2_000_018_000, d.value(1)); // value has not been adjusted
-/// // When displayed, the timestamp is adjusted (08:33:20 instead of 03:33:20 as in previous example)
+/// // NOTE: the timestamp is adjusted (08:33:20 instead of 03:33:20 as in previous example)
 /// assert_eq!("2033-05-18T08:33:20", display::array_value_to_string(&d, 1).unwrap());
 /// ```
 pub fn cast_with_options(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
The behavior of casting timestamps to/from timezones is quite subtle and I spent quite some time testing them out in the context of https://github.com/apache/datafusion/issues/10602

Thus I thought it would be good to document this behavior in the arrow crate itself so I don't have to do that next time (and hopefully) others can benefit from it as well.


# What changes are included in this PR?
Document, with examples, what happens when one casts `timestamp with timezone` to/from `timestamp without timezone`

# Are there any user-facing changes?
Documentation. No changes to code

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
