### PR TITLE
Relax zstd-sys Version Pin

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -53,9 +53,7 @@ brotli = { version = "6.0", default-features = false, features = ["std"], option
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
-# TODO: temporary to fix parquet wasm build
-# upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = ">=2.0.0, <2.0.10", optional = true, default-features = false }
+zstd-sys = { version = "2.0", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -80,9 +78,7 @@ brotli = { version = "6.0", default-features = false, features = ["std"] }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
 zstd = { version = "0.13", default-features = false }
-# TODO: temporary to fix parquet wasm build
-# upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = ">=2.0.0, <2.0.10", default-features = false }
+zstd-sys = { version = "2.0", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -55,7 +55,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13.0", optional = true, default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "=2.0.7", optional = true, default-features = false }
+zstd-sys = { version = "<=2.0.9", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -82,7 +82,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13", default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "=2.0.7", default-features = false }
+zstd-sys = { version = "<=2.0.9", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -53,7 +53,6 @@ brotli = { version = "6.0", default-features = false, features = ["std"], option
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
-zstd-sys = { version = "2.0", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -78,12 +77,19 @@ brotli = { version = "6.0", default-features = false, features = ["std"] }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
 zstd = { version = "0.13", default-features = false }
-zstd-sys = { version = "2.0", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 object_store = { version = "0.10.0", default-features = false, features = ["azure"] }
+
+# TODO: temporary to fix parquet wasm build
+# upstream issue: https://github.com/gyscos/zstd-rs/issues/269
+[target.'cfg(target_family = "wasm")'.dependencies]
+zstd-sys = { version = ">=2.0.0, <2.0.10", optional = true, default-features = false }
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+zstd-sys = { version = ">=2.0.0, <2.0.10", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -55,7 +55,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13.0", optional = true, default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "=2.0.9", optional = true, default-features = false }
+zstd-sys = { version = "=2.0.7", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -82,7 +82,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13", default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "=2.0.9", default-features = false }
+zstd-sys = { version = "=2.0.7", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -55,7 +55,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13.0", optional = true, default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "<=2.0.9", optional = true, default-features = false }
+zstd-sys = { version = "<2.0.10", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -82,7 +82,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13", default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd-sys = { version = "<=2.0.9", default-features = false }
+zstd-sys = { version = "<2.0.10", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -52,10 +52,10 @@ snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "6.0", default-features = false, features = ["std"], optional = true }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
+zstd = { version = "0.13", optional = true, default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd = { version = "<0.13.1", optional = true, default-features = false }
-zstd-sys = { version = "<2.0.10", optional = true, default-features = false }
+zstd-sys = { version = ">=2.0.0, <2.0.10", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
@@ -79,10 +79,10 @@ tempfile = { version = "3.0", default-features = false }
 brotli = { version = "6.0", default-features = false, features = ["std"] }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
+zstd = { version = "0.13", default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-zstd = { version = "<0.13.1", default-features = false }
-zstd-sys = { version = "<2.0.10", default-features = false }
+zstd-sys = { version = ">=2.0.0, <2.0.10", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -52,9 +52,9 @@ snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "6.0", default-features = false, features = ["std"], optional = true }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
-zstd = { version = "0.13.0", optional = true, default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
+zstd = { version = "<0.13.1", optional = true, default-features = false }
 zstd-sys = { version = "<2.0.10", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
@@ -79,9 +79,9 @@ tempfile = { version = "3.0", default-features = false }
 brotli = { version = "6.0", default-features = false, features = ["std"] }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
-zstd = { version = "0.13", default-features = false }
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
+zstd = { version = "<0.13.1", default-features = false }
 zstd-sys = { version = "<2.0.10", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I hit this while trying to upgrade arrow for datafusion.

Parquet depends on `zstd-sys` and datafusion depends on `async-compression` which then depends on `zstd-sys` via `zstd-safe`.

Parquet cannot use `zstd-sys` beyond `2.0.9` due to https://github.com/gyscos/zstd-rs/issues/269. And `zstd-safe` has two available versions `7.0.0` which depends on `zstd-sys` `2.0.7` and `7.1.0` on `zstd-sys` `2.10.0`. 

So to make parquet be compatible with projects use `async-compression`, the only available version to `zstd-sys` is `2.0.7`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Downgrade and pin `zstd-sys` to `2.0.7`

# Are there any user-facing changes?


Yes, the dependences

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

This patch needs to be included in the next release https://github.com/apache/arrow-rs/issues/5688 if possible
