### PR TITLE
feat: impl *Assign ops for types in arrow-buffer

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -37,6 +37,7 @@ bench = false
 bytes = { version = "1.4" }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false }
+paste = { version = "1.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -37,7 +37,6 @@ bench = false
 bytes = { version = "1.4" }
 num = { version = "0.4", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false }
-paste = { version = "1.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/arrow-buffer/src/arith.rs
+++ b/arrow-buffer/src/arith.rs
@@ -18,7 +18,7 @@
 /// Derives `std::ops::$t` for `$ty` calling `$wrapping` or `$checked` variants
 /// based on if debug_assertions enabled
 macro_rules! derive_arith {
-    ($ty:ty, $t:ident, $op:ident, $wrapping:ident, $checked:ident) => {
+    ($ty:ty, $t:ident, $t_assign:ident, $op:ident, $op_assign:ident, $wrapping:ident, $checked:ident) => {
         impl std::ops::$t for $ty {
             type Output = $ty;
 
@@ -34,17 +34,17 @@ macro_rules! derive_arith {
             }
         }
 
-        ::paste::paste! {
-            impl std::ops::[< $t Assign >] for $ty {
-                #[cfg(debug_assertions)]
-                fn [< $op _assign >](&mut self, rhs: Self) {
-                    *self = self.$checked(rhs).expect(concat!(stringify!($ty), " overflow"));
-                }
+        impl std::ops::$t_assign for $ty {
+            #[cfg(debug_assertions)]
+            fn $op_assign(&mut self, rhs: Self) {
+                *self = self
+                    .$checked(rhs)
+                    .expect(concat!(stringify!($ty), " overflow"));
+            }
 
-                #[cfg(not(debug_assertions))]
-                fn [< $op _assign >](&mut self, rhs: Self) {
-                    *self = self.$wrapping(rhs);
-                }
+            #[cfg(not(debug_assertions))]
+            fn $op_assign(&mut self, rhs: Self) {
+                *self = self.$wrapping(rhs);
             }
         }
 

--- a/arrow-buffer/src/arith.rs
+++ b/arrow-buffer/src/arith.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Derives `std::ops::$op` for `$ty` calling `$wrapping` or `$checked` variants
+/// Derives `std::ops::$t` for `$ty` calling `$wrapping` or `$checked` variants
 /// based on if debug_assertions enabled
 macro_rules! derive_arith {
     ($ty:ty, $t:ident, $op:ident, $wrapping:ident, $checked:ident) => {
@@ -31,6 +31,20 @@ macro_rules! derive_arith {
             #[cfg(not(debug_assertions))]
             fn $op(self, rhs: Self) -> Self::Output {
                 self.$wrapping(rhs)
+            }
+        }
+
+        ::paste::paste! {
+            impl std::ops::[< $t Assign >] for $ty {
+                #[cfg(debug_assertions)]
+                fn [< $op _assign >](&mut self, rhs: Self) {
+                    *self = self.$checked(rhs).expect(concat!(stringify!($ty), " overflow"));
+                }
+
+                #[cfg(not(debug_assertions))]
+                fn [< $op _assign >](&mut self, rhs: Self) {
+                    *self = self.$wrapping(rhs);
+                }
             }
         }
 

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -639,11 +639,51 @@ fn mulx(a: u128, b: u128) -> (u128, u128) {
     (low, high)
 }
 
-derive_arith!(i256, Add, add, wrapping_add, checked_add);
-derive_arith!(i256, Sub, sub, wrapping_sub, checked_sub);
-derive_arith!(i256, Mul, mul, wrapping_mul, checked_mul);
-derive_arith!(i256, Div, div, wrapping_div, checked_div);
-derive_arith!(i256, Rem, rem, wrapping_rem, checked_rem);
+derive_arith!(
+    i256,
+    Add,
+    AddAssign,
+    add,
+    add_assign,
+    wrapping_add,
+    checked_add
+);
+derive_arith!(
+    i256,
+    Sub,
+    SubAssign,
+    sub,
+    sub_assign,
+    wrapping_sub,
+    checked_sub
+);
+derive_arith!(
+    i256,
+    Mul,
+    MulAssign,
+    mul,
+    mul_assign,
+    wrapping_mul,
+    checked_mul
+);
+derive_arith!(
+    i256,
+    Div,
+    DivAssign,
+    div,
+    div_assign,
+    wrapping_div,
+    checked_div
+);
+derive_arith!(
+    i256,
+    Rem,
+    RemAssign,
+    rem,
+    rem_assign,
+    wrapping_rem,
+    checked_rem
+);
 
 impl Neg for i256 {
     type Output = i256;

--- a/arrow-buffer/src/interval.rs
+++ b/arrow-buffer/src/interval.rs
@@ -225,11 +225,51 @@ impl Neg for IntervalMonthDayNano {
     }
 }
 
-derive_arith!(IntervalMonthDayNano, Add, add, wrapping_add, checked_add);
-derive_arith!(IntervalMonthDayNano, Sub, sub, wrapping_sub, checked_sub);
-derive_arith!(IntervalMonthDayNano, Mul, mul, wrapping_mul, checked_mul);
-derive_arith!(IntervalMonthDayNano, Div, div, wrapping_div, checked_div);
-derive_arith!(IntervalMonthDayNano, Rem, rem, wrapping_rem, checked_rem);
+derive_arith!(
+    IntervalMonthDayNano,
+    Add,
+    AddAssign,
+    add,
+    add_assign,
+    wrapping_add,
+    checked_add
+);
+derive_arith!(
+    IntervalMonthDayNano,
+    Sub,
+    SubAssign,
+    sub,
+    sub_assign,
+    wrapping_sub,
+    checked_sub
+);
+derive_arith!(
+    IntervalMonthDayNano,
+    Mul,
+    MulAssign,
+    mul,
+    mul_assign,
+    wrapping_mul,
+    checked_mul
+);
+derive_arith!(
+    IntervalMonthDayNano,
+    Div,
+    DivAssign,
+    div,
+    div_assign,
+    wrapping_div,
+    checked_div
+);
+derive_arith!(
+    IntervalMonthDayNano,
+    Rem,
+    RemAssign,
+    rem,
+    rem_assign,
+    wrapping_rem,
+    checked_rem
+);
 
 /// Value of an IntervalDayTime array
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -417,8 +457,48 @@ impl Neg for IntervalDayTime {
     }
 }
 
-derive_arith!(IntervalDayTime, Add, add, wrapping_add, checked_add);
-derive_arith!(IntervalDayTime, Sub, sub, wrapping_sub, checked_sub);
-derive_arith!(IntervalDayTime, Mul, mul, wrapping_mul, checked_mul);
-derive_arith!(IntervalDayTime, Div, div, wrapping_div, checked_div);
-derive_arith!(IntervalDayTime, Rem, rem, wrapping_rem, checked_rem);
+derive_arith!(
+    IntervalDayTime,
+    Add,
+    AddAssign,
+    add,
+    add_assign,
+    wrapping_add,
+    checked_add
+);
+derive_arith!(
+    IntervalDayTime,
+    Sub,
+    SubAssign,
+    sub,
+    sub_assign,
+    wrapping_sub,
+    checked_sub
+);
+derive_arith!(
+    IntervalDayTime,
+    Mul,
+    MulAssign,
+    mul,
+    mul_assign,
+    wrapping_mul,
+    checked_mul
+);
+derive_arith!(
+    IntervalDayTime,
+    Div,
+    DivAssign,
+    div,
+    div_assign,
+    wrapping_div,
+    checked_div
+);
+derive_arith!(
+    IntervalDayTime,
+    Rem,
+    RemAssign,
+    rem,
+    rem_assign,
+    wrapping_rem,
+    checked_rem
+);

--- a/arrow-buffer/src/interval.rs
+++ b/arrow-buffer/src/interval.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::arith::derive_arith;
-use std::ops::Neg;
+use std::ops::{AddAssign, Neg, SubAssign};
 
 /// Value of an IntervalMonthDayNano array
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -225,6 +225,34 @@ impl Neg for IntervalMonthDayNano {
     }
 }
 
+impl AddAssign for IntervalMonthDayNano {
+    #[cfg(debug_assertions)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = self
+            .checked_add(rhs)
+            .expect("IntervalMonthDayNano overflow");
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = self.wrapping_add(rhs);
+    }
+}
+
+impl SubAssign for IntervalMonthDayNano {
+    #[cfg(debug_assertions)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self
+            .checked_sub(rhs)
+            .expect("IntervalMonthDayNano underflow");
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.wrapping_sub(rhs);
+    }
+}
+
 derive_arith!(IntervalMonthDayNano, Add, add, wrapping_add, checked_add);
 derive_arith!(IntervalMonthDayNano, Sub, sub, wrapping_sub, checked_sub);
 derive_arith!(IntervalMonthDayNano, Mul, mul, wrapping_mul, checked_mul);
@@ -414,6 +442,30 @@ impl Neg for IntervalDayTime {
     #[cfg(not(debug_assertions))]
     fn neg(self) -> Self::Output {
         self.wrapping_neg()
+    }
+}
+
+impl AddAssign for IntervalDayTime {
+    #[cfg(debug_assertions)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = self.checked_add(rhs).expect("IntervalDayTime overflow");
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = self.wrapping_add(rhs);
+    }
+}
+
+impl SubAssign for IntervalDayTime {
+    #[cfg(debug_assertions)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.checked_sub(rhs).expect("IntervalDayTime underflow");
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.wrapping_sub(rhs);
     }
 }
 

--- a/arrow-buffer/src/interval.rs
+++ b/arrow-buffer/src/interval.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::arith::derive_arith;
-use std::ops::{AddAssign, Neg, SubAssign};
+use std::ops::Neg;
 
 /// Value of an IntervalMonthDayNano array
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -225,34 +225,6 @@ impl Neg for IntervalMonthDayNano {
     }
 }
 
-impl AddAssign for IntervalMonthDayNano {
-    #[cfg(debug_assertions)]
-    fn add_assign(&mut self, rhs: Self) {
-        *self = self
-            .checked_add(rhs)
-            .expect("IntervalMonthDayNano overflow");
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn add_assign(&mut self, rhs: Self) {
-        *self = self.wrapping_add(rhs);
-    }
-}
-
-impl SubAssign for IntervalMonthDayNano {
-    #[cfg(debug_assertions)]
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = self
-            .checked_sub(rhs)
-            .expect("IntervalMonthDayNano underflow");
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = self.wrapping_sub(rhs);
-    }
-}
-
 derive_arith!(IntervalMonthDayNano, Add, add, wrapping_add, checked_add);
 derive_arith!(IntervalMonthDayNano, Sub, sub, wrapping_sub, checked_sub);
 derive_arith!(IntervalMonthDayNano, Mul, mul, wrapping_mul, checked_mul);
@@ -442,30 +414,6 @@ impl Neg for IntervalDayTime {
     #[cfg(not(debug_assertions))]
     fn neg(self) -> Self::Output {
         self.wrapping_neg()
-    }
-}
-
-impl AddAssign for IntervalDayTime {
-    #[cfg(debug_assertions)]
-    fn add_assign(&mut self, rhs: Self) {
-        *self = self.checked_add(rhs).expect("IntervalDayTime overflow");
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn add_assign(&mut self, rhs: Self) {
-        *self = self.wrapping_add(rhs);
-    }
-}
-
-impl SubAssign for IntervalDayTime {
-    #[cfg(debug_assertions)]
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = self.checked_sub(rhs).expect("IntervalDayTime underflow");
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = self.wrapping_sub(rhs);
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Impl `std::ops::*Assign` (like `AddAssign`) for `i256`, `IntervalDayTime` and `IntervalMonthDayNano`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- new trait impl

The first commit ([95da017](https://github.com/apache/arrow-rs/pull/5832/commits/95da017492f5c24d881de2063803b296caa475a1)) contains the plain implementation of `AddAssign` and `SubAssign` as examples

# Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
