### PR TITLE
Make RowSelection's from_consecutive_ranges public

### DIFF
--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -81,6 +81,13 @@ impl RowSelector {
 ///
 /// let actual: Vec<RowSelector> = selection.into();
 /// assert_eq!(actual, expected);
+///
+/// // you can also create a selection from consecutive ranges
+/// let ranges = vec![5..10, 10..15];
+/// let selection =
+///   RowSelection::from_consecutive_ranges(ranges.into_iter(), Some(20));
+/// let actual: Vec<RowSelector> = selection.into();
+/// assert_eq!(actual, expected);
 /// ```
 ///
 /// A [`RowSelection`] maintains the following invariants:
@@ -111,13 +118,13 @@ impl RowSelection {
             SlicesIterator::new(filter).map(move |(start, end)| start + offset..end + offset)
         });
 
-        Self::from_consecutive_ranges(iter, total_rows)
+        Self::from_consecutive_ranges(iter, Some(total_rows))
     }
 
     /// Creates a [`RowSelection`] from an iterator of consecutive ranges to keep
-    pub(crate) fn from_consecutive_ranges<I: Iterator<Item = Range<usize>>>(
+    pub fn from_consecutive_ranges<I: Iterator<Item = Range<usize>>>(
         ranges: I,
-        total_rows: usize,
+        total_rows_opt: Option<usize>,
     ) -> Self {
         let mut selectors: Vec<RowSelector> = Vec::with_capacity(ranges.size_hint().0);
         let mut last_end = 0;
@@ -141,8 +148,10 @@ impl RowSelection {
             last_end = range.end;
         }
 
-        if last_end != total_rows {
-            selectors.push(RowSelector::skip(total_rows - last_end))
+        if let Some(total_rows) = total_rows_opt {
+            if last_end != total_rows {
+                selectors.push(RowSelector::skip(total_rows - last_end))
+            }
         }
 
         Self { selectors }
@@ -1136,9 +1145,9 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_ranges() {
+    fn test_from_ranges() {
         let ranges = [1..3, 4..6, 6..6, 8..8, 9..10];
-        let selection = RowSelection::from_consecutive_ranges(ranges.into_iter(), 10);
+        let selection = RowSelection::from_consecutive_ranges(ranges.into_iter(), Some(10));
         assert_eq!(
             selection.selectors,
             vec![
@@ -1149,7 +1158,27 @@ mod tests {
                 RowSelector::skip(3),
                 RowSelector::select(1)
             ]
-        )
+        );
+
+        let out_of_order_ranges = [1..3, 8..10, 4..7];
+        let result = std::panic::catch_unwind(|| {
+            RowSelection::from_consecutive_ranges(out_of_order_ranges.into_iter(), Some(10))
+        });
+        assert!(result.is_err());
+
+        // test without total rows specified
+        let ranges = [1..3, 4..6];
+        let selection = RowSelection::from_consecutive_ranges(ranges.into_iter(), None);
+
+        assert_eq!(
+            selection.selectors,
+            vec![
+                RowSelector::skip(1),
+                RowSelector::select(2),
+                RowSelector::skip(1),
+                RowSelector::select(2),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?
Closes #5846 

# Rationale for this change
 This constructor method should be easier to use.

# What changes are included in this PR?
1. make the `from_consecutive_ranges` function public
2. tweak a bit and makes the total rows optional
3. update the tests.

# Are there any user-facing changes?
NO.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
