### PR TITLE
Minor: refine row selection example more

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -155,23 +155,42 @@ impl<T> ArrowReaderBuilder<T> {
     ///
     /// # Example
     ///
-    /// Given a parquet file with 3 row groups, and a row group filter of
-    /// `[0, 2]`, in order to only scan rows 50-100 in row group 2:
+    /// Given a parquet file with 4 row groups, and a row group filter of `[0,
+    /// 2, 3]`, in order to scan rows 50-100 in row group 2 and rows 200-300 in
+    /// row group 3:
     ///
     /// ```text
     ///   Row Group 0, 1000 rows (selected)
     ///   Row Group 1, 1000 rows (skipped)
     ///   Row Group 2, 1000 rows (selected, but want to only scan rows 50-100)
+    ///   Row Group 3, 1000 rows (selected, but want to only scan rows 200-300)
     /// ```
     ///
-    /// You would pass the following [`RowSelection`]:
+    /// You could pass the following [`RowSelection`]:
     ///
     /// ```text
     ///  Select 1000    (scan all rows in row group 0)
-    ///  Select 50-100 (scan rows 50-100 in row group 2)
+    ///  Skip 50        (skip the first 50 rows in row group 2)
+    ///  Select 50      (scan rows 50-100 in row group 2)
+    ///  Skip 900       (skip the remaining rows in row group 2)
+    ///  Skip 200       (skip the first 200 rows in row group 3)
+    ///  Select 100     (scan rows 200-300 in row group 3)
+    ///  Skip 700       (skip the remaining rows in row group 3)
+    /// ```
+    /// Note there is no entry for the (entirely) skipped row group 1.
+    ///
+    /// Note you can represent the same selection with fewer entries. Instead of
+    ///
+    /// ```text
+    ///  Skip 900       (skip the remaining rows in row group 2)
+    ///  Skip 200       (skip the first 200 rows in row group 3)
     /// ```
     ///
-    /// Note there is no entry for the (entirely) skipped row group 1.
+    /// you could use
+    ///
+    /// ```text
+    /// Skip 1100      (skip the remaining 900 rows in row group 2 and the first 200 rows in row group 3)
+    /// ```
     ///
     /// [`Index`]: crate::file::page_index::index::Index
     pub fn with_row_selection(self, selection: RowSelection) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to https://github.com/apache/arrow-rs/pull/5824

# Rationale for this change
 
In discussing how row selections interacted with the row group selection with @advancedxy  on   https://github.com/apache/datafusion/pull/10738 (see https://github.com/apache/datafusion/pull/10738/files#r1628074742) it became clear that the example could be improved to better explain what is going on 

# What changes are included in this PR?

Refine example added in https://github.com/apache/arrow-rs/pull/5824 to better show how how skip / select works at the end of a row group. 

# Are there any user-facing changes?
Moar docs, no functional change

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
