### PR TITLE
POC: small optimizations to reduce parquet metadata decoding time by 40%

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -70,6 +70,7 @@ hashbrown = { version = "0.14", default-features = false }
 twox-hash = { version = "1.6", default-features = false }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
+varint-simd = { version = "0.4.0", features = ["native-optimizations"] }
 
 [dev-dependencies]
 base64 = { version = "0.22", default-features = false, features = ["std"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -71,6 +71,7 @@ twox-hash = { version = "1.6", default-features = false }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 varint-simd = { version = "0.4.0", features = ["native-optimizations"] }
+mimalloc = { version = "*", optional = true }
 
 [dev-dependencies]
 base64 = { version = "0.22", default-features = false, features = ["std"] }

--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -20,6 +20,11 @@ use criterion::*;
 use parquet::file::reader::SerializedFileReader;
 use parquet::file::serialized_reader::ReadOptionsBuilder;
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 fn criterion_benchmark(c: &mut Criterion) {
     // Read file into memory to isolate filesystem performance
     let file = "../parquet-testing/data/alltypes_tiny_pages.parquet";

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -768,7 +768,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
         // update column and offset index
         self.update_column_offset_index(page_statistics.as_ref());
-        let page_statistics = page_statistics.map(Statistics::from);
+        let page_statistics = page_statistics.map(Statistics::from).map(Box::new);
 
         let compressed_page = match self.props.writer_version() {
             WriterVersion::PARQUET_1_0 => {

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -496,7 +496,7 @@ pub struct ColumnChunkMetaData {
     data_page_offset: i64,
     index_page_offset: Option<i64>,
     dictionary_page_offset: Option<i64>,
-    statistics: Option<Statistics>,
+    statistics: Option<Box<Statistics>>,
     encoding_stats: Option<Vec<PageEncodingStats>>,
     bloom_filter_offset: Option<i64>,
     bloom_filter_length: Option<i32>,
@@ -603,7 +603,7 @@ impl ColumnChunkMetaData {
     /// Returns statistics that are set for this column chunk,
     /// or `None` if no statistics are available.
     pub fn statistics(&self) -> Option<&Statistics> {
-        self.statistics.as_ref()
+        self.statistics.as_ref().map(|x| x.as_ref())
     }
 
     /// Returns the offset for the page encoding stats,
@@ -749,7 +749,7 @@ impl ColumnChunkMetaData {
             data_page_offset: self.data_page_offset,
             index_page_offset: self.index_page_offset,
             dictionary_page_offset: self.dictionary_page_offset,
-            statistics: statistics::to_thrift(self.statistics.as_ref()),
+            statistics: statistics::to_thrift(self.statistics.as_ref().map(|x| x.as_ref())),
             encoding_stats: self
                 .encoding_stats
                 .as_ref()
@@ -856,7 +856,7 @@ impl ColumnChunkMetaDataBuilder {
 
     /// Sets statistics for this column chunk.
     pub fn set_statistics(mut self, value: Statistics) -> Self {
-        self.0.statistics = Some(value);
+        self.0.statistics = Some(Box::new(value));
         self
     }
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1176,7 +1176,7 @@ mod tests {
                 encoding: Encoding::DELTA_BINARY_PACKED,
                 def_level_encoding: Encoding::RLE,
                 rep_level_encoding: Encoding::RLE,
-                statistics: Some(Statistics::int32(Some(1), Some(3), None, 7, true)),
+                statistics: Some(Box::new(Statistics::int32(Some(1), Some(3), None, 7, true))),
             },
             Page::DataPageV2 {
                 buf: Bytes::from(vec![4; 128]),
@@ -1187,7 +1187,7 @@ mod tests {
                 def_levels_byte_len: 24,
                 rep_levels_byte_len: 32,
                 is_compressed: false,
-                statistics: Some(Statistics::int32(Some(1), Some(3), None, 7, true)),
+                statistics: Some(Box::new(Statistics::int32(Some(1), Some(3), None, 7, true))),
             },
         ];
 
@@ -1210,7 +1210,7 @@ mod tests {
                 encoding: Encoding::DELTA_BINARY_PACKED,
                 def_level_encoding: Encoding::RLE,
                 rep_level_encoding: Encoding::RLE,
-                statistics: Some(Statistics::int32(Some(1), Some(3), None, 7, true)),
+                statistics: Some(Box::new(Statistics::int32(Some(1), Some(3), None, 7, true))),
             },
             Page::DataPageV2 {
                 buf: Bytes::from(vec![4; 128]),
@@ -1261,8 +1261,11 @@ mod tests {
                         encoding,
                         def_level_encoding,
                         rep_level_encoding,
-                        statistics: from_thrift(physical_type, to_thrift(statistics.as_ref()))
-                            .unwrap(),
+                        statistics: from_thrift(
+                            physical_type,
+                            to_thrift(statistics.as_ref().map(|x| x.as_ref())),
+                        )
+                        .unwrap(),
                     }
                 }
                 Page::DataPageV2 {
@@ -1291,8 +1294,11 @@ mod tests {
                         def_levels_byte_len,
                         rep_levels_byte_len,
                         is_compressed: compressor.is_some(),
-                        statistics: from_thrift(physical_type, to_thrift(statistics.as_ref()))
-                            .unwrap(),
+                        statistics: from_thrift(
+                            physical_type,
+                            to_thrift(statistics.as_ref().map(|x| x.as_ref())),
+                        )
+                        .unwrap(),
                     }
                 }
                 Page::DictionaryPage {

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -2155,11 +2155,11 @@ pub struct DataPageHeader {
   /// Encoding used for repetition levels *
   pub repetition_level_encoding: Encoding,
   /// Optional statistics for the data in this page*
-  pub statistics: Option<Statistics>,
+  pub statistics: Option<Box<Statistics>>,
 }
 
 impl DataPageHeader {
-  pub fn new<F5>(num_values: i32, encoding: Encoding, definition_level_encoding: Encoding, repetition_level_encoding: Encoding, statistics: F5) -> DataPageHeader where F5: Into<Option<Statistics>> {
+  pub fn new<F5>(num_values: i32, encoding: Encoding, definition_level_encoding: Encoding, repetition_level_encoding: Encoding, statistics: F5) -> DataPageHeader where F5: Into<Option<Box<Statistics>>> {
     DataPageHeader {
       num_values,
       encoding,
@@ -2177,7 +2177,7 @@ impl crate::thrift::TSerializable for DataPageHeader {
     let mut f_2: Option<Encoding> = None;
     let mut f_3: Option<Encoding> = None;
     let mut f_4: Option<Encoding> = None;
-    let mut f_5: Option<Statistics> = None;
+    let mut f_5: Option<Box<Statistics>> = None;
     loop {
       let field_ident = i_prot.read_field_begin()?;
       if field_ident.field_type == TType::Stop {
@@ -2202,7 +2202,7 @@ impl crate::thrift::TSerializable for DataPageHeader {
           f_4 = Some(val);
         },
         5 => {
-          let val = Statistics::read_from_in_protocol(i_prot)?;
+          let val = Box::new(Statistics::read_from_in_protocol(i_prot)?);
           f_5 = Some(val);
         },
         _ => {
@@ -2405,11 +2405,11 @@ pub struct DataPageHeaderV2 {
   /// If missing it is considered compressed
   pub is_compressed: Option<bool>,
   /// optional statistics for the data in this page *
-  pub statistics: Option<Statistics>,
+  pub statistics: Option<Box<Statistics>>,
 }
 
 impl DataPageHeaderV2 {
-  pub fn new<F7, F8>(num_values: i32, num_nulls: i32, num_rows: i32, encoding: Encoding, definition_levels_byte_length: i32, repetition_levels_byte_length: i32, is_compressed: F7, statistics: F8) -> DataPageHeaderV2 where F7: Into<Option<bool>>, F8: Into<Option<Statistics>> {
+  pub fn new<F7, F8>(num_values: i32, num_nulls: i32, num_rows: i32, encoding: Encoding, definition_levels_byte_length: i32, repetition_levels_byte_length: i32, is_compressed: F7, statistics: F8) -> DataPageHeaderV2 where F7: Into<Option<bool>>, F8: Into<Option<Box<Statistics>>> {
     DataPageHeaderV2 {
       num_values,
       num_nulls,
@@ -2433,7 +2433,7 @@ impl crate::thrift::TSerializable for DataPageHeaderV2 {
     let mut f_5: Option<i32> = None;
     let mut f_6: Option<i32> = None;
     let mut f_7: Option<bool> = None;
-    let mut f_8: Option<Statistics> = None;
+    let mut f_8: Option<Box<Statistics>> = None;
     loop {
       let field_ident = i_prot.read_field_begin()?;
       if field_ident.field_type == TType::Stop {
@@ -2470,7 +2470,7 @@ impl crate::thrift::TSerializable for DataPageHeaderV2 {
           f_7 = Some(val);
         },
         8 => {
-          let val = Statistics::read_from_in_protocol(i_prot)?;
+          let val = Box::new(Statistics::read_from_in_protocol(i_prot)?);
           f_8 = Some(val);
         },
         _ => {
@@ -3404,7 +3404,7 @@ pub struct ColumnMetaData {
   /// Byte offset from the beginning of file to first (only) dictionary page *
   pub dictionary_page_offset: Option<i64>,
   /// optional statistics for this column chunk
-  pub statistics: Option<Statistics>,
+  pub statistics: Option<Box<Statistics>>,
   /// Set of all encodings used for pages in this column chunk.
   /// This information can be used to determine if all data pages are
   /// dictionary encoded for example *
@@ -3420,7 +3420,7 @@ pub struct ColumnMetaData {
 }
 
 impl ColumnMetaData {
-  pub fn new<F8, F10, F11, F12, F13, F14, F15>(type_: Type, encodings: Vec<Encoding>, path_in_schema: Vec<String>, codec: CompressionCodec, num_values: i64, total_uncompressed_size: i64, total_compressed_size: i64, key_value_metadata: F8, data_page_offset: i64, index_page_offset: F10, dictionary_page_offset: F11, statistics: F12, encoding_stats: F13, bloom_filter_offset: F14, bloom_filter_length: F15) -> ColumnMetaData where F8: Into<Option<Vec<KeyValue>>>, F10: Into<Option<i64>>, F11: Into<Option<i64>>, F12: Into<Option<Statistics>>, F13: Into<Option<Vec<PageEncodingStats>>>, F14: Into<Option<i64>>, F15: Into<Option<i32>> {
+  pub fn new<F8, F10, F11, F12, F13, F14, F15>(type_: Type, encodings: Vec<Encoding>, path_in_schema: Vec<String>, codec: CompressionCodec, num_values: i64, total_uncompressed_size: i64, total_compressed_size: i64, key_value_metadata: F8, data_page_offset: i64, index_page_offset: F10, dictionary_page_offset: F11, statistics: F12, encoding_stats: F13, bloom_filter_offset: F14, bloom_filter_length: F15) -> ColumnMetaData where F8: Into<Option<Vec<KeyValue>>>, F10: Into<Option<i64>>, F11: Into<Option<i64>>, F12: Into<Option<Box<Statistics>>>, F13: Into<Option<Vec<PageEncodingStats>>>, F14: Into<Option<i64>>, F15: Into<Option<i32>> {
     ColumnMetaData {
       type_,
       encodings,
@@ -3455,7 +3455,7 @@ impl crate::thrift::TSerializable for ColumnMetaData {
     let mut f_9: Option<i64> = None;
     let mut f_10: Option<i64> = None;
     let mut f_11: Option<i64> = None;
-    let mut f_12: Option<Statistics> = None;
+    let mut f_12: Option<Box<Statistics>> = None;
     let mut f_13: Option<Vec<PageEncodingStats>> = None;
     let mut f_14: Option<i64> = None;
     let mut f_15: Option<i32> = None;
@@ -3529,7 +3529,7 @@ impl crate::thrift::TSerializable for ColumnMetaData {
           f_11 = Some(val);
         },
         12 => {
-          let val = Statistics::read_from_in_protocol(i_prot)?;
+          let val =  Box::new(Statistics::read_from_in_protocol(i_prot)?);
           f_12 = Some(val);
         },
         13 => {


### PR DESCRIPTION

# Rationale for this change

This draft PR is not meant to be merged. Instead, it serves as a record for people who want to improve parquet metadata decoding performance. 

It demonstrates three hacks that can easily improve decoding time by 40%:
(1) Use a better allocator (e.g., [mimalloc](https://crates.io/crates/mimalloc))
(2) Move [statistics](https://docs.rs/parquet/latest/parquet/file/statistics/enum.Statistics.html) to heap, i.e., reduce stack memory movement.
(3) Use SIMD to accelerate decoding varint, as provided by [varint-simd](https://github.com/as-com/varint-simd) crate.


