### PR TITLE
Added panic message to docs.

### DIFF
--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -331,6 +331,10 @@ impl Schema {
 
     /// Returns an immutable reference of a specific [`Field`] instance selected using an
     /// offset within the internal `fields` vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index out of bounds
     pub fn field(&self, i: usize) -> &Field {
         &self.fields[i]
     }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Schema::field does not indicate that it panics in the current docs. It does panic though (not that this is particularly surprising!). 

Here's an example that will panic:

```
use arrow::datatypes::SchemaBuilder;
fn main() {
    let mut builder = SchemaBuilder::new();
    let schema = builder.finish();
    let my_field = schema.field(2); // <-- Panics here because index OOB. 
}
```

# What changes are included in this PR?

Just a docstring.

# Are there any user-facing changes?

Nope, but perhaps in future, field should either return a result, or we add a try_field function that returns a result (to prevent people needing to change  code  relying on Schema::field  already)