### PR TITLE
Faster primitive arrays encoding into row format

### DIFF
--- a/arrow-row/src/fixed.rs
+++ b/arrow-row/src/fixed.rs
@@ -222,7 +222,9 @@ pub fn encode<T: FixedLengthEncoding, I: IntoIterator<Item = Option<T>>>(
     i: I,
     opts: SortOptions,
 ) {
-    for (offset, maybe_val) in offsets.iter_mut().skip(1).zip(i) {
+    let mut offset_idx = 1;
+    for maybe_val in i {
+        let offset = &mut offsets[offset_idx];
         let end_offset = *offset + T::ENCODED_LEN;
         if let Some(val) = maybe_val {
             let to_write = &mut data[*offset..end_offset];
@@ -237,6 +239,7 @@ pub fn encode<T: FixedLengthEncoding, I: IntoIterator<Item = Option<T>>>(
             data[*offset] = null_sentinel(opts);
         }
         *offset = end_offset;
+        offset_idx += 1;
     }
 }
 
@@ -247,7 +250,9 @@ pub fn encode_fixed_size_binary(
     opts: SortOptions,
 ) {
     let len = array.value_length() as usize;
-    for (offset, maybe_val) in offsets.iter_mut().skip(1).zip(array.iter()) {
+    let mut offset_idx = 1;
+    for maybe_val in array {
+        let offset = &mut offsets[offset_idx];
         let end_offset = *offset + len + 1;
         if let Some(val) = maybe_val {
             let to_write = &mut data[*offset..end_offset];
@@ -261,6 +266,7 @@ pub fn encode_fixed_size_binary(
             data[*offset] = null_sentinel(opts);
         }
         *offset = end_offset;
+        offset_idx += 1;
     }
 }
 

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1146,9 +1146,21 @@ fn encode_column(
     match encoder {
         Encoder::Stateless => {
             downcast_primitive_array! {
-                column => fixed::encode(data, offsets, column, opts),
+                column => {
+                    if column.is_nullable(){
+                        fixed::encode(data, offsets, column, opts)
+                    } else {
+                        fixed::encode_not_null(data, offsets, column, opts)
+                    }
+                }
                 DataType::Null => {}
-                DataType::Boolean => fixed::encode(data, offsets, column.as_boolean(), opts),
+                DataType::Boolean => {
+                    if column.is_nullable(){
+                        fixed::encode_bool(data, offsets, column.as_boolean(), opts)
+                    } else {
+                        fixed::encode_bool_not_null(data, offsets, column.as_boolean(), opts)
+                    }
+                }
                 DataType::Binary => {
                     variable::encode(data, offsets, as_generic_binary_array::<i32>(column).iter(), opts)
                 }

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1147,18 +1147,18 @@ fn encode_column(
         Encoder::Stateless => {
             downcast_primitive_array! {
                 column => {
-                    if column.is_nullable(){
-                        fixed::encode(data, offsets, column, opts)
+                    if let Some(nulls) = column.nulls().filter(|n| n.null_count() > 0){
+                        fixed::encode(data, offsets, column.values(), nulls, opts)
                     } else {
-                        fixed::encode_not_null(data, offsets, column, opts)
+                        fixed::encode_not_null(data, offsets, column.values(), opts)
                     }
                 }
                 DataType::Null => {}
                 DataType::Boolean => {
-                    if column.is_nullable(){
-                        fixed::encode_bool(data, offsets, column.as_boolean(), opts)
+                    if let Some(nulls) = column.nulls().filter(|n| n.null_count() > 0){
+                        fixed::encode_boolean(data, offsets, column.as_boolean().values(), nulls, opts)
                     } else {
-                        fixed::encode_bool_not_null(data, offsets, column.as_boolean(), opts)
+                        fixed::encode_boolean_not_null(data, offsets, column.as_boolean().values(), opts)
                     }
                 }
                 DataType::Binary => {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

--

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Performance improvements for encoding primitive arrays into row format

<details>
<summary>cargo bench</summary>

```
eduard@Aspire-A515-58M:~/projects/arrow-rs$ cargo bench --bench row_format -- "4096 (u64|i64|bool)\(.+\)$" --baseline master
   Compiling arrow-row v52.0.0 (/home/eduard/projects/arrow-rs/arrow-row)
   Compiling arrow v52.0.0 (/home/eduard/projects/arrow-rs/arrow)
    Finished `bench` profile [optimized] target(s) in 3.73s
     Running benches/row_format.rs (target/release/deps/row_format-fa578ffd3df1630f)
convert_columns 4096 u64(0)
                        time:   [8.0609 µs 8.0699 µs 8.0791 µs]
                        change: [-53.318% -53.191% -53.061%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

convert_columns_prepared 4096 u64(0)
                        time:   [7.7778 µs 7.7872 µs 7.7972 µs]
                        change: [-54.520% -54.429% -54.345%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

convert_rows 4096 u64(0)
                        time:   [27.487 µs 27.495 µs 27.503 µs]
                        change: [-0.1673% -0.0151% +0.0911%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

convert_columns 4096 u64(0.3)
                        time:   [13.647 µs 13.663 µs 13.678 µs]
                        change: [-32.089% -31.925% -31.755%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) low mild

convert_columns_prepared 4096 u64(0.3)
                        time:   [13.807 µs 13.819 µs 13.831 µs]
                        change: [-34.109% -32.018% -30.597%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild

convert_rows 4096 u64(0.3)
                        time:   [28.066 µs 28.079 µs 28.093 µs]
                        change: [-1.8794% +0.0417% +1.4081%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

convert_columns 4096 i64(0)
                        time:   [8.0324 µs 8.0352 µs 8.0381 µs]
                        change: [-53.139% -53.071% -52.969%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

convert_columns_prepared 4096 i64(0)
                        time:   [7.9678 µs 7.9719 µs 7.9761 µs]
                        change: [-55.284% -54.859% -54.449%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

convert_rows 4096 i64(0)
                        time:   [27.541 µs 27.549 µs 27.556 µs]
                        change: [-0.0051% +0.1256% +0.2436%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

convert_columns 4096 i64(0.3)
                        time:   [13.129 µs 13.131 µs 13.134 µs]
                        change: [-19.818% -19.751% -19.683%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

convert_columns_prepared 4096 i64(0.3)
                        time:   [13.095 µs 13.101 µs 13.106 µs]
                        change: [-21.096% -20.958% -20.828%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe

convert_rows 4096 i64(0.3)
                        time:   [27.968 µs 27.977 µs 27.987 µs]
                        change: [+0.0320% +0.1985% +0.3580%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe

convert_columns 4096 bool(0, 0.5)
                        time:   [7.8909 µs 7.8948 µs 7.8991 µs]
                        change: [-22.996% -22.855% -22.751%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild

convert_columns_prepared 4096 bool(0, 0.5)
                        time:   [7.9600 µs 7.9637 µs 7.9679 µs]
                        change: [-22.409% -22.205% -22.021%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

convert_rows 4096 bool(0, 0.5)
                        time:   [17.700 µs 17.711 µs 17.722 µs]
                        change: [-3.4067% -3.1262% -2.8614%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

convert_columns 4096 bool(0.3, 0.5)
                        time:   [10.999 µs 11.003 µs 11.009 µs]
                        change: [-8.1531% -8.0434% -7.9374%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

convert_columns_prepared 4096 bool(0.3, 0.5)
                        time:   [11.021 µs 11.036 µs 11.051 µs]
                        change: [-6.6325% -6.2628% -5.9016%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

convert_rows 4096 bool(0.3, 0.5)
                        time:   [17.712 µs 17.720 µs 17.728 µs]
                        change: [-2.0989% -1.8996% -1.7319%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
```

</details>

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- In some cases, `skip()` iterator may noticeably affect performance -- encoding primitive arrays into Arrow rows is one of them -- removing `skip().zip()` shows significant improvement over current master. (FWIW: +- same trick for fixed binary / string columns didn't show any meaningful / stable improvements.)
- Special casing non-nullable primitive arrays -- iterating over `values` allows not to perform null-checks, which also noticeably speeds things up.

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
