### PR TITLE
Preallocate for `FixedSizeList` in `concat`

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -516,9 +516,7 @@ impl<'a> MutableArrayData<'a> {
                     .map(|array| &array.child_data()[0])
                     .collect::<Vec<_>>();
                 let capacities =
-                    if let Capacities::FixedSizeList(capacity, ref child_capacities) =
-                        capacities
-                    {
+                    if let Capacities::FixedSizeList(capacity, ref child_capacities) = capacities {
                         child_capacities
                             .clone()
                             .map(|c| *c)

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -504,7 +504,7 @@ impl<'a> MutableArrayData<'a> {
                     MutableArrayData::new(value_child, use_nulls, array_capacity),
                 ]
             }
-            DataType::FixedSizeList(_, _) => {
+            DataType::FixedSizeList(_, size) => {
                 let children = arrays
                     .iter()
                     .map(|array| &array.child_data()[0])
@@ -514,9 +514,9 @@ impl<'a> MutableArrayData<'a> {
                         child_capacities
                             .clone()
                             .map(|c| *c)
-                            .unwrap_or(Capacities::Array(capacity))
+                            .unwrap_or(Capacities::Array(capacity * *size as usize))
                     } else {
-                        Capacities::Array(array_capacity)
+                        Capacities::Array(array_capacity * *size as usize)
                     };
                 vec![MutableArrayData::with_capacities(
                     children, use_nulls, capacities,

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -320,11 +320,6 @@ pub enum Capacities {
     /// * the capacity of the array offsets
     /// * the capacity of the child data
     List(usize, Option<Box<Capacities>>),
-    /// FixedSizeList data type
-    /// Define
-    /// * the capacity of the array
-    /// * the capacity of the child data
-    FixedSizeList(usize, Option<Box<Capacities>>),
     /// Struct type
     /// * the capacity of the array
     /// * the capacities of the fields
@@ -390,11 +385,10 @@ impl<'a> MutableArrayData<'a> {
                 array_capacity = *capacity;
                 new_buffers(data_type, *capacity)
             }
-            (DataType::List(_) | DataType::LargeList(_), Capacities::List(capacity, _)) => {
-                array_capacity = *capacity;
-                new_buffers(data_type, *capacity)
-            }
-            (DataType::FixedSizeList(_, _), Capacities::FixedSizeList(capacity, _)) => {
+            (
+                DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _),
+                Capacities::List(capacity, _),
+            ) => {
                 array_capacity = *capacity;
                 new_buffers(data_type, *capacity)
             }
@@ -516,7 +510,7 @@ impl<'a> MutableArrayData<'a> {
                     .map(|array| &array.child_data()[0])
                     .collect::<Vec<_>>();
                 let capacities =
-                    if let Capacities::FixedSizeList(capacity, ref child_capacities) = capacities {
+                    if let Capacities::List(capacity, ref child_capacities) = capacities {
                         child_capacities
                             .clone()
                             .map(|c| *c)

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -140,7 +140,7 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef, ArrowError> {
                 item_capacity,
                 Some(Box::new(Capacities::Array(item_capacity * *size as usize))),
             )
-        },
+        }
         _ => Capacities::Array(arrays.iter().map(|a| a.len()).sum()),
     };
 

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -61,7 +61,7 @@ fn fixed_size_list_capacity(arrays: &[&dyn Array], data_type: &DataType) -> Capa
             .iter()
             .map(|a| a.as_fixed_size_list().values().as_ref())
             .collect();
-        Capacities::FixedSizeList(
+        Capacities::List(
             item_capacity,
             Some(Box::new(get_capacity(&values, f.data_type()))),
         )

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -74,7 +74,7 @@ fn fixed_size_list_capacity(arrays: &[&dyn Array], data_type: &DataType) -> Capa
                     item_capacity,
                     Some(Box::new(get_capacity(&values, child_data_type))),
                 )
-            },
+            }
             _ => Capacities::Array(item_capacity),
         }
     } else {

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -134,6 +134,13 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef, ArrowError> {
             k.as_ref() => (dict_helper, arrays),
             _ => unreachable!("illegal dictionary key type {k}")
         },
+        DataType::FixedSizeList(_, size) => {
+            let item_capacity = arrays.iter().map(|a| a.len()).sum();
+            Capacities::FixedSizeList(
+                item_capacity,
+                Some(Box::new(Capacities::Array(item_capacity * *size as usize))),
+            )
+        },
         _ => Capacities::Array(arrays.iter().map(|a| a.len()).sum()),
     };
 

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -374,6 +374,37 @@ mod tests {
     }
 
     #[test]
+    fn test_concat_primitive_fixed_size_list_arrays() {
+        let list1 = vec![
+            Some(vec![Some(-1), None]),
+            None,
+            Some(vec![Some(10), Some(20)]),
+        ];
+        let list1_array =
+            FixedSizeListArray::from_iter_primitive::<Int64Type, _, _>(list1.clone(), 2);
+
+        let list2 = vec![
+            None,
+            Some(vec![Some(100), None]),
+            Some(vec![Some(102), Some(103)]),
+        ];
+        let list2_array =
+            FixedSizeListArray::from_iter_primitive::<Int64Type, _, _>(list2.clone(), 2);
+
+        let list3 = vec![Some(vec![Some(1000), Some(1001)])];
+        let list3_array =
+            FixedSizeListArray::from_iter_primitive::<Int64Type, _, _>(list3.clone(), 2);
+
+        let array_result = concat(&[&list1_array, &list2_array, &list3_array]).unwrap();
+
+        let expected = list1.into_iter().chain(list2).chain(list3);
+        let array_expected =
+            FixedSizeListArray::from_iter_primitive::<Int64Type, _, _>(expected, 2);
+
+        assert_eq!(array_result.as_ref(), &array_expected as &dyn Array);
+    }
+
+    #[test]
     fn test_concat_struct_arrays() {
         let field = Arc::new(Field::new("field", DataType::Int64, true));
         let input_primitive_1: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![

--- a/arrow/benches/concatenate_kernel.rs
+++ b/arrow/benches/concatenate_kernel.rs
@@ -90,13 +90,15 @@ fn add_benchmark(c: &mut Criterion) {
         2,
         Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
         None,
-    ).unwrap();
+    )
+    .unwrap();
     let v2 = FixedSizeListArray::try_new(
         Arc::new(Field::new("item", DataType::Int32, true)),
         2,
         Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
         None,
-    ).unwrap();
+    )
+    .unwrap();
     c.bench_function("concat fixed size lists", |b| {
         b.iter(|| bench_concat(&v1, &v2))
     });

--- a/arrow/benches/concatenate_kernel.rs
+++ b/arrow/benches/concatenate_kernel.rs
@@ -17,6 +17,8 @@
 
 #[macro_use]
 extern crate criterion;
+use std::sync::Arc;
+
 use criterion::Criterion;
 
 extern crate arrow;
@@ -80,6 +82,22 @@ fn add_benchmark(c: &mut Criterion) {
     let v1 = create_string_array::<i32>(1024, 0.5);
     let v2 = create_string_array::<i32>(1024, 0.5);
     c.bench_function("concat str nulls 1024", |b| {
+        b.iter(|| bench_concat(&v1, &v2))
+    });
+
+    let v1 = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        2,
+        Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
+        None,
+    ).unwrap();
+    let v2 = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        2,
+        Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
+        None,
+    ).unwrap();
+    c.bench_function("concat fixed size lists", |b| {
         b.iter(|| bench_concat(&v1, &v2))
     });
 }

--- a/arrow/benches/concatenate_kernel.rs
+++ b/arrow/benches/concatenate_kernel.rs
@@ -87,15 +87,15 @@ fn add_benchmark(c: &mut Criterion) {
 
     let v1 = FixedSizeListArray::try_new(
         Arc::new(Field::new("item", DataType::Int32, true)),
-        2,
-        Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
+        1024,
+        Arc::new(create_primitive_array::<Int32Type>(1024 * 1024, 0.0)),
         None,
     )
     .unwrap();
     let v2 = FixedSizeListArray::try_new(
         Arc::new(Field::new("item", DataType::Int32, true)),
-        2,
-        Arc::new(create_primitive_array::<Int32Type>(1024, 0.0)),
+        1024,
+        Arc::new(create_primitive_array::<Int32Type>(1024 * 1024, 0.0)),
         None,
     )
     .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4897

# Rationale for this change
 
This is my first contribution to the project and also my first contribution in Rust so I'd appreciate all input and/or pointers! 

These changes aim to make it so that memory is pre-allocated the values array of `FixedListArray`s which are concatenated.


# Are there any user-facing changes?

No.