### PR TITLE
Document parquet ArrowWriter type limitations

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -116,10 +116,10 @@ mod levels;
 ///
 /// * [`IntervalMonthDayNanoArray`]: Parquet does not [support nanosecond intervals].
 ///
-/// [`DataType`]: arrow::datatypes::DataType
-/// [`StructArray`]: arrow::array::StructArray
-/// [`ListArray`]: arrow::array::ListArray
-/// [`IntervalMonthDayNanoArray`]: arrow::array::IntervalMonthDayNanoArray
+/// [`DataType`]: https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html
+/// [`StructArray`]: https://docs.rs/arrow/latest/arrow/array/struct.StructArray.html
+/// [`ListArray`]: https://docs.rs/arrow/latest/arrow/array/type.ListArray.html
+/// [`IntervalMonthDayNanoArray`]: https://docs.rs/arrow/latest/arrow/array/type.IntervalMonthDayNanoArray.html
 /// [support nanosecond intervals]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
 pub struct ArrowWriter<W: Write> {
     /// Underlying Parquet writer

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -107,6 +107,20 @@ mod levels;
 /// }
 /// ```
 ///
+/// ## Type Support
+///
+/// The writer supports writing all Arrow [`DataType`]s that have a direct mapping to
+/// Parquet types including  [`StructArray`] and [`ListArray`].
+///
+/// The following are not supported:
+///
+/// * [`IntervalMonthDayNanoArray`]: Parquet does not [support nanosecond intervals].
+///
+/// [`DataType`]: arrow::datatypes::DataType
+/// [`StructArray`]: arrow::array::StructArray
+/// [`ListArray`]: arrow::array::ListArray
+/// [`IntervalMonthDayNanoArray`]: arrow::array::IntervalMonthDayNanoArray
+/// [support nanosecond intervals]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
 pub struct ArrowWriter<W: Write> {
     /// Underlying Parquet writer
     writer: SerializedFileWriter<W>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/5849
Closes https://github.com/apache/arrow-rs/pull/5868

# Rationale for this change
It was not clear that the parquet writer is not able to write IntervalMonthDayNano data rather than it was not yet implemented

# What changes are included in this PR?
Add documentiation explaining type support to `ArrowWriter`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Docs only

