### PR TITLE
Avoid copy/allocation when read view types from parquet

### DIFF
--- a/parquet/src/arrow/buffer/offset_buffer.rs
+++ b/parquet/src/arrow/buffer/offset_buffer.rs
@@ -156,16 +156,19 @@ impl<I: OffsetSizeTrait> OffsetBuffer<I> {
 
     fn build_generic_byte_view(self) -> GenericByteViewBuilder<BinaryViewType> {
         let mut builder = GenericByteViewBuilder::<BinaryViewType>::with_capacity(self.len());
-        let mut values = self.values;
+        let buffer = self.values.into();
+        builder.append_block(buffer);
         for window in self.offsets.windows(2) {
             let start = window[0];
             let end = window[1];
             let len = (end - start).to_usize().unwrap();
-            let b = values.drain(..len).collect::<Vec<u8>>();
-            if b.is_empty() {
-                builder.append_null();
+
+            if len != 0 {
+                builder
+                    .try_append_view(0, start.as_usize() as u32, len as u32)
+                    .unwrap();
             } else {
-                builder.append_value(b);
+                builder.append_null();
             }
         }
         builder

--- a/parquet/src/arrow/buffer/offset_buffer.rs
+++ b/parquet/src/arrow/buffer/offset_buffer.rs
@@ -157,7 +157,7 @@ impl<I: OffsetSizeTrait> OffsetBuffer<I> {
     fn build_generic_byte_view(self) -> GenericByteViewBuilder<BinaryViewType> {
         let mut builder = GenericByteViewBuilder::<BinaryViewType>::with_capacity(self.len());
         let buffer = self.values.into();
-        builder.append_block(buffer);
+        let block = builder.append_block(buffer);
         for window in self.offsets.windows(2) {
             let start = window[0];
             let end = window[1];
@@ -165,7 +165,7 @@ impl<I: OffsetSizeTrait> OffsetBuffer<I> {
 
             if len != 0 {
                 builder
-                    .try_append_view(0, start.as_usize() as u32, len as u32)
+                    .try_append_view(block, start.as_usize() as u32, len as u32)
                     .unwrap();
             } else {
                 builder.append_null();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of  #5530.

An alternative implementation (maybe subset) of #5557 

# Rationale for this change
 
This change is very simple -- only 8 lines, but gives us many performance improvements (10-80x):


```
arrow_array_reader/StringViewArray/plain encoded, mandatory, no NULLs
                        time:   [274.71 µs 275.03 µs 275.35 µs]
                        change: [-98.842% -98.837% -98.829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
arrow_array_reader/StringViewArray/plain encoded, optional, no NULLs
                        time:   [275.04 µs 275.41 µs 275.75 µs]
                        change: [-98.848% -98.843% -98.839%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 27 outliers among 100 measurements (27.00%)
  12 (12.00%) low severe
  6 (6.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
arrow_array_reader/StringViewArray/plain encoded, optional, half NULLs
                        time:   [319.11 µs 319.48 µs 319.98 µs]
                        change: [-94.940% -94.934% -94.926%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe
arrow_array_reader/StringViewArray/dictionary encoded, mandatory, no NULLs
                        time:   [259.89 µs 260.22 µs 260.65 µs]
                        change: [-97.848% -97.846% -97.842%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
arrow_array_reader/StringViewArray/dictionary encoded, optional, no NULLs
                        time:   [267.99 µs 268.26 µs 268.56 µs]
                        change: [-97.762% -97.760% -97.757%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
arrow_array_reader/StringViewArray/dictionary encoded, optional, half NULLs
                        time:   [301.73 µs 302.40 µs 303.20 µs]
                        change: [-90.950% -90.895% -90.852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

To reproduce: 
```bash
cd parquet
cargo bench --bench arrow_reader --features="arrow test_common experimental" "arrow_array_reader/StringViewArray"
```

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
