### PR TITLE
Minor: Clarify when page index structures are read

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -271,12 +271,18 @@ impl ArrowReaderOptions {
         }
     }
 
-    /// Enable decoding of the [`PageIndex`], if present (defaults to `false`)
+    /// Enable reading [`PageIndex`], if present (defaults to `false`)
     ///
     /// The `PageIndex` can be used to push down predicates to the parquet scan,
     /// potentially eliminating unnecessary IO, by some query engines.
     ///
+    /// If this is enabled, [`ParquetMetaData::column_index`] and
+    /// [`ParquetMetaData::offset_index`] will be populated if the corresponding
+    /// information is present in the file.
+    ///
     /// [`PageIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+    /// [`ParquetMetaData::column_index`]: crate::file::metadata::ParquetMetaData::column_index
+    /// [`ParquetMetaData::offset_index`]: crate::file::metadata::ParquetMetaData::offset_index
     pub fn with_page_index(self, page_index: bool) -> Self {
         Self { page_index, ..self }
     }

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -29,8 +29,6 @@
 //! * [`ColumnChunkMetaData`]: Metadata for each column chunk (primitive leaf)
 //!   within a Row Group including encoding and compression information,
 //!   number of values, statistics, etc.
-
-use crate::arrow::arrow_reader::ArrowReaderOptions;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -156,6 +154,8 @@ impl ParquetMetaData {
     ///
     /// Returns `None` if the parquet file does not have a `ColumnIndex` or
     /// [ArrowReaderOptions::with_page_index] was set to false.
+    ///
+    /// [ArrowReaderOptions::with_page_index]: https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ArrowReaderOptions.html#method.with_page_index
     pub fn column_index(&self) -> Option<&ParquetColumnIndex> {
         self.column_index.as_ref()
     }
@@ -170,6 +170,8 @@ impl ParquetMetaData {
     ///
     /// Returns `None` if the parquet file does not have a `OffsetIndex` or
     /// [ArrowReaderOptions::with_page_index] was set to false.
+    ///
+    /// [ArrowReaderOptions::with_page_index]: https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ArrowReaderOptions.html#method.with_page_index
     pub fn offset_index(&self) -> Option<&ParquetOffsetIndex> {
         self.offset_index.as_ref()
     }

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -73,8 +73,8 @@ pub fn read_columns_indexes<R: ChunkReader>(
         .collect()
 }
 
-/// Reads per-page [`PageLocation`] for all columns of a row group by
-/// decoding the [`OffsetIndex`].
+/// Reads [`OffsetIndex`],  per-page [`PageLocation`] for all columns of a row
+/// group.
 ///
 /// Returns a vector of `location[column_number][page_number]`
 ///


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5770 

# Rationale for this change
 
I found understanding when certain paruet structures are read to be confusing, so I did some code speluking and would like to save myself from doing that in the future (as well as others)

# What changes are included in this PR?

Update doc strings to make it more clear when `OffsetIndex` and `ColumnIndex` are populated

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
