### PR TITLE
chore: Remove not used cache in InstanceCredentialProvider

### DIFF
--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -898,7 +898,6 @@ impl AmazonS3Builder {
             info!("Using Instance credential provider");
 
             let token = InstanceCredentialProvider {
-                cache: Default::default(),
                 imdsv1_fallback: self.imdsv1_fallback.get()?,
                 metadata_endpoint: self
                     .metadata_endpoint

--- a/object_store/src/aws/credential.rs
+++ b/object_store/src/aws/credential.rs
@@ -424,9 +424,6 @@ fn canonicalize_headers(header_map: &HeaderMap) -> (String, String) {
 /// <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>
 #[derive(Debug)]
 pub struct InstanceCredentialProvider {
-    // https://github.com/apache/arrow-rs/issues/5884
-    #[allow(dead_code)]
-    pub cache: TokenCache<Arc<AwsCredential>>,
     pub imdsv1_fallback: bool,
     pub metadata_endpoint: String,
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/5884.

# Rationale for this change
 
I have confirmed that this cache is not used.

# What changes are included in this PR?

Remove `cache` in `InstanceCredentialProvider`

# Are there any user-facing changes?

None
