### PR TITLE
chore: implement parquet error handling for object_store

### DIFF
--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -25,7 +25,7 @@ use futures::{FutureExt, TryFutureExt};
 use object_store::{ObjectMeta, ObjectStore};
 
 use crate::arrow::async_reader::{AsyncFileReader, MetadataLoader};
-use crate::errors::{ParquetError, Result};
+use crate::errors::Result;
 use crate::file::metadata::ParquetMetaData;
 
 /// Reads Parquet files in object storage using [`ObjectStore`].
@@ -105,7 +105,7 @@ impl AsyncFileReader for ParquetObjectReader {
     fn get_bytes(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>> {
         self.store
             .get_range(&self.meta.location, range)
-            .map_err(|e| ParquetError::General(format!("AsyncChunkReader::get_bytes error: {e}")))
+            .map_err(|e| e.into())
             .boxed()
     }
 
@@ -117,11 +117,7 @@ impl AsyncFileReader for ParquetObjectReader {
             self.store
                 .get_ranges(&self.meta.location, &ranges)
                 .await
-                .map_err(|e| {
-                    ParquetError::General(format!(
-                        "ParquetObjectReader::get_byte_ranges error: {e}"
-                    ))
-                })
+                .map_err(|e| e.into())
         }
         .boxed()
     }

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -112,6 +112,13 @@ impl From<ArrowError> for ParquetError {
     }
 }
 
+#[cfg(feature = "object_store")]
+impl From<object_store::Error> for ParquetError {
+    fn from(e: object_store::Error) -> ParquetError {
+        ParquetError::External(Box::new(e))
+    }
+}
+
 /// A specialized `Result` for Parquet errors.
 pub type Result<T, E = ParquetError> = result::Result<T, E>;
 


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change
 
Very small change I made when I was working on implementing `ParquetObjectWriter`, but someone else already had it so I want to upstream this small fix I made.

# What changes are included in this PR?

Implements `object_store::Error` for ParquetError. In delta-rs, `ParquetRecordBatchStreamBuilder` is failing pretty often (#5882) when dealing with large tables on s3, so this turns that error into a BoxedError that can be propagated upwards and inspected.

# Are there any user-facing changes?

No