### PR TITLE
Minor: expose timestamp_tz_format for csv writing

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -799,9 +799,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555,23:46:03,foo
         let mut writer = WriterBuilder::new()
             .with_timestamp_tz_format("%M:%H".to_string())
             .build(&mut file);
-        for batch in vec![&batch] {
-            writer.write(batch).unwrap();
-        }
+        writer.write(&batch).unwrap();
 
         drop(writer);
         file.rewind().unwrap();

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -375,6 +375,17 @@ impl WriterBuilder {
         self.timestamp_format.as_deref()
     }
 
+    /// Set the CSV file's timestamp tz format
+    pub fn with_timestamp_tz_format(mut self, tz_format: String) -> Self {
+        self.timestamp_tz_format = Some(tz_format);
+        self
+    }
+
+    /// Get the CSV file's timestamp tz format if set, defaults to RFC3339
+    pub fn timestamp_tz_format(&self) -> Option<&str> {
+        self.timestamp_tz_format.as_deref()
+    }
+
     /// Set the value to represent null in output
     pub fn with_null(mut self, null_value: String) -> Self {
         self.null_value = Some(null_value);


### PR DESCRIPTION
# Which issue does this PR close?

Pre-requisite for closing https://github.com/apache/datafusion/issues/8640

# What changes are included in this PR?

We just add a get/set for timestamp_tz_format to csv writer builder, similarly to other fields. Probably was an omission.

# Are there any user-facing changes?

No.