### PR TITLE
fix: Adjust FFI_ArrowArray offset based on the offset of offset buffer

### DIFF
--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1461,7 +1461,7 @@ mod tests_from_ffi {
         test_round_trip(&imported_array.consume()?)
     }
 
-    fn export_string(array: StringArray) -> StringArray {
+    fn roundtrip_string_array(array: StringArray) -> StringArray {
         let data = array.into_data();
 
         let array = FFI_ArrowArray::new(&data);
@@ -1490,7 +1490,7 @@ mod tests_from_ffi {
 
         let string_array = StringArray::from(strings);
 
-        let imported = export_string(string_array.clone());
+        let imported = roundtrip_string_array(string_array.clone());
         assert_eq!(imported.len(), 1000);
         assert_eq!(imported.value(0), "string: 0");
         assert_eq!(imported.value(499), "string: 499");
@@ -1503,7 +1503,7 @@ mod tests_from_ffi {
 
         let slice = string_array.slice(500, 500);
 
-        let imported = export_string(slice);
+        let imported = roundtrip_string_array(slice);
         assert_eq!(imported.len(), 500);
         assert_eq!(imported.value(0), "string: 500");
         assert_eq!(imported.value(499), "string: 999");

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -74,14 +74,9 @@ impl Buffer {
     /// Returns the offset, in bytes, of `Self::ptr` to `Self::data`
     ///
     /// self.ptr and self.data can be different after slicing or advancing the buffer.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe as it uses unsafe function `offset_from`. Under certain
-    /// conditions, this function can cause undefined behavior. See the documentation of
-    /// `offset_from` for more information.
-    pub unsafe fn ptr_offset(&self) -> usize {
-        self.ptr.offset_from(self.data.ptr().as_ptr()) as usize
+    pub fn ptr_offset(&self) -> usize {
+        // Safety: `ptr` is always in bounds of `data`.
+        unsafe { self.ptr.offset_from(self.data.ptr().as_ptr()) as usize }
     }
 
     /// Returns the pointer to the start of the buffer without the offset.

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -71,9 +71,16 @@ impl Buffer {
         }
     }
 
-    /// Returns the internal byte buffer.
-    pub fn get_bytes(&self) -> Arc<Bytes> {
-        self.data.clone()
+    /// Returns the offset, in bytes, of `Self::ptr` to `Self::data`
+    ///
+    /// self.ptr and self.data can be different after slicing or advancing the buffer.
+    pub unsafe fn ptr_offset(&self) -> usize {
+        self.ptr.offset_from(self.data.ptr().as_ptr()) as usize
+    }
+
+    /// Returns the pointer to the start of the buffer without the offset.
+    pub fn data_ptr(&self) -> NonNull<u8> {
+        self.data.ptr()
     }
 
     /// Create a [`Buffer`] from the provided [`Vec`] without copying

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -74,6 +74,12 @@ impl Buffer {
     /// Returns the offset, in bytes, of `Self::ptr` to `Self::data`
     ///
     /// self.ptr and self.data can be different after slicing or advancing the buffer.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe as it uses unsafe function `offset_from`. Under certain
+    /// conditions, this function can cause undefined behavior. See the documentation of
+    /// `offset_from` for more information.
     pub unsafe fn ptr_offset(&self) -> usize {
         self.ptr.offset_from(self.data.ptr().as_ptr()) as usize
     }

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -71,6 +71,11 @@ impl Buffer {
         }
     }
 
+    /// Returns the internal byte buffer.
+    pub fn get_bytes(&self) -> Arc<Bytes> {
+        self.data.clone()
+    }
+
     /// Create a [`Buffer`] from the provided [`Vec`] without copying
     #[inline]
     pub fn from_vec<T: ArrowNativeType>(vec: Vec<T>) -> Self {

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -141,8 +141,7 @@ impl FFI_ArrowArray {
                 // the `FFI_ArrowArray` offset field.
                 Some(unsafe {
                     let b = &data.buffers()[0];
-                    b.as_ptr().offset_from(b.get_bytes().ptr().as_ptr()) as usize
-                        / std::mem::size_of::<i32>()
+                    b.ptr_offset() / std::mem::size_of::<i32>()
                 })
             }
             DataType::LargeUtf8 | DataType::LargeBinary => {
@@ -153,8 +152,7 @@ impl FFI_ArrowArray {
                 // the `FFI_ArrowArray` offset field.
                 Some(unsafe {
                     let b = &data.buffers()[0];
-                    b.as_ptr().offset_from(b.get_bytes().ptr().as_ptr()) as usize
-                        / std::mem::size_of::<i64>()
+                    b.ptr_offset() / std::mem::size_of::<i64>()
                 })
             }
             _ => None,
@@ -195,7 +193,7 @@ impl FFI_ArrowArray {
                         ) => {
                             // For offset buffer, take original pointer without offset.
                             // Buffer offset should be handled by `FFI_ArrowArray` offset field.
-                            Some(b.get_bytes().ptr().as_ptr() as *const c_void)
+                            Some(b.data_ptr().as_ptr() as *const c_void)
                         }
                         // For other buffers, note that `raw_data` takes into account the buffer's offset
                         _ => Some(b.as_ptr() as *const c_void),

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -139,10 +139,7 @@ impl FFI_ArrowArray {
                 // the consumer to calculate incorrect length of data buffer (buffer 1).
                 // We need to get the offset of the offset buffer and fill it in
                 // the `FFI_ArrowArray` offset field.
-                Some(unsafe {
-                    let b = &data.buffers()[0];
-                    b.ptr_offset() / std::mem::size_of::<i32>()
-                })
+                Some(data.buffers()[0].ptr_offset() / std::mem::size_of::<i32>())
             }
             DataType::LargeUtf8 | DataType::LargeBinary => {
                 // Offset buffer is possible a slice of the buffer.
@@ -150,10 +147,7 @@ impl FFI_ArrowArray {
                 // the consumer to calculate incorrect length of data buffer (buffer 1).
                 // We need to get the offset of the offset buffer and fill it in
                 // the `FFI_ArrowArray` offset field.
-                Some(unsafe {
-                    let b = &data.buffers()[0];
-                    b.ptr_offset() / std::mem::size_of::<i64>()
-                })
+                Some(data.buffers()[0].ptr_offset() / std::mem::size_of::<i64>())
             }
             _ => None,
         };

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -131,6 +131,45 @@ impl FFI_ArrowArray {
             data.buffers().iter().map(|b| Some(b.clone())).collect()
         };
 
+        // Handle buffer offset for offset buffer.
+        let offset_offset = match data.data_type() {
+            DataType::Utf8 | DataType::Binary => {
+                // Offset buffer is possible a slice of the buffer.
+                // If we use slice pointer as exported buffer pointer, it will cause
+                // the consumer to calculate incorrect length of data buffer (buffer 1).
+                // We need to get the offset of the offset buffer and fill it in
+                // the `FFI_ArrowArray` offset field.
+                Some(unsafe {
+                    let b = &data.buffers()[0];
+                    b.as_ptr().offset_from(b.get_bytes().ptr().as_ptr()) as usize
+                        / std::mem::size_of::<i32>()
+                })
+            }
+            DataType::LargeUtf8 | DataType::LargeBinary => {
+                // Offset buffer is possible a slice of the buffer.
+                // If we use slice pointer as exported buffer pointer, it will cause
+                // the consumer to calculate incorrect length of data buffer (buffer 1).
+                // We need to get the offset of the offset buffer and fill it in
+                // the `FFI_ArrowArray` offset field.
+                Some(unsafe {
+                    let b = &data.buffers()[0];
+                    b.as_ptr().offset_from(b.get_bytes().ptr().as_ptr()) as usize
+                        / std::mem::size_of::<i64>()
+                })
+            }
+            _ => None,
+        };
+
+        let offset = if let Some(offset) = offset_offset {
+            if data.offset() != 0 {
+                // TODO: Adjust for data offset
+                panic!("The ArrayData of a slice offset buffer should not have offset");
+            }
+            offset
+        } else {
+            data.offset()
+        };
+
         // `n_buffers` is the number of buffers by the spec.
         let n_buffers = {
             data_layout.buffers.len() + {
@@ -143,9 +182,25 @@ impl FFI_ArrowArray {
 
         let buffers_ptr = buffers
             .iter()
-            .flat_map(|maybe_buffer| match maybe_buffer {
-                // note that `raw_data` takes into account the buffer's offset
-                Some(b) => Some(b.as_ptr() as *const c_void),
+            .enumerate()
+            .flat_map(|(buffer_idx, maybe_buffer)| match maybe_buffer {
+                Some(b) => {
+                    match (data.data_type(), buffer_idx) {
+                        (
+                            DataType::Utf8
+                            | DataType::LargeUtf8
+                            | DataType::Binary
+                            | DataType::LargeBinary,
+                            1,
+                        ) => {
+                            // For offset buffer, take original pointer without offset.
+                            // Buffer offset should be handled by `FFI_ArrowArray` offset field.
+                            Some(b.get_bytes().ptr().as_ptr() as *const c_void)
+                        }
+                        // For other buffers, note that `raw_data` takes into account the buffer's offset
+                        _ => Some(b.as_ptr() as *const c_void),
+                    }
+                }
                 // This is for null buffer. We only put a null pointer for
                 // null buffer if by spec it can contain null mask.
                 None if data_layout.can_contain_null_mask => Some(std::ptr::null()),
@@ -186,7 +241,7 @@ impl FFI_ArrowArray {
         Self {
             length: data.len() as i64,
             null_count: null_count as i64,
-            offset: data.offset() as i64,
+            offset: offset as i64,
             n_buffers,
             n_children,
             buffers: private_data.buffers_ptr.as_mut_ptr(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5896.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
