### PR TITLE
fix: prevent potential out-of-range access in FixedSizeListArray

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -35,14 +35,10 @@ bench = false
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = [
-    "compile-time-rng",
-] }
+ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = [
-    "runtime-rng",
-] }
+ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 
 [dependencies]
 arrow-buffer = { workspace = true }
@@ -58,10 +54,7 @@ hashbrown = { version = "0.14", default-features = false }
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]
 
 [dev-dependencies]
-rand = { version = "0.8", default-features = false, features = [
-    "std",
-    "std_rng",
-] }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 criterion = { version = "0.5", default-features = false }
 
 [build-dependencies]

--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -35,10 +35,14 @@ bench = false
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "runtime-rng",
+] }
 
 [dependencies]
 arrow-buffer = { workspace = true }
@@ -54,7 +58,10 @@ hashbrown = { version = "0.14", default-features = false }
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]
 
 [dev-dependencies]
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.8", default-features = false, features = [
+    "std",
+    "std_rng",
+] }
 criterion = { version = "0.5", default-features = false }
 
 [build-dependencies]
@@ -65,4 +72,8 @@ harness = false
 
 [[bench]]
 name = "gc_view_types"
+harness = false
+
+[[bench]]
+name = "fixed_size_list_array"
 harness = false

--- a/arrow-array/benches/fixed_size_list_array.rs
+++ b/arrow-array/benches/fixed_size_list_array.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::{Array, FixedSizeListArray, Int32Array};
+use arrow_schema::Field;
+use criterion::*;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+fn gen_fsl(len: usize, value_len: usize) -> FixedSizeListArray {
+    let mut rng = thread_rng();
+    let values = Arc::new(Int32Array::from(
+        (0..len).map(|_| rng.gen::<i32>()).collect::<Vec<_>>(),
+    ));
+    let field = Arc::new(Field::new("item", values.data_type().clone(), true));
+    FixedSizeListArray::new(field, value_len as i32, values, None)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let len = 4096;
+    for value_len in [1, 32, 1024] {
+        let fsl = gen_fsl(len, value_len);
+        c.bench_function(
+            &format!("fixed_size_list_array(len: {len}, value_len: {value_len})"),
+            |b| {
+                b.iter(|| {
+                    for i in 0..len / value_len {
+                        black_box(fsl.value(i));
+                    }
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -244,10 +244,8 @@ impl FixedSizeListArray {
 
     /// Returns ith value of this list array.
     pub fn value(&self, i: usize) -> ArrayRef {
-        self.values.slice(
-            self.value_offset_at(i) as usize,
-            self.value_length() as usize,
-        )
+        self.values
+            .slice(self.value_offset_at(i), self.value_length() as usize)
     }
 
     /// Returns the offset for value at index `i`.

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -244,8 +244,10 @@ impl FixedSizeListArray {
 
     /// Returns ith value of this list array.
     pub fn value(&self, i: usize) -> ArrayRef {
-        self.values
-            .slice(self.value_offset(i) as usize, self.value_length() as usize)
+        self.values.slice(
+            self.value_offset_at(i) as usize,
+            self.value_length() as usize,
+        )
     }
 
     /// Returns the offset for value at index `i`.
@@ -253,7 +255,7 @@ impl FixedSizeListArray {
     /// Note this doesn't do any bound checking, for performance reason.
     #[inline]
     pub fn value_offset(&self, i: usize) -> i32 {
-        self.value_offset_at(i)
+        self.value_offset_at(i) as i32
     }
 
     /// Returns the length for an element.
@@ -265,8 +267,8 @@ impl FixedSizeListArray {
     }
 
     #[inline]
-    const fn value_offset_at(&self, i: usize) -> i32 {
-        i as i32 * self.value_length
+    const fn value_offset_at(&self, i: usize) -> usize {
+        i * self.value_length as usize
     }
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.


### PR DESCRIPTION
# Which issue does this PR close?
Closes #5901 

# Rationale for this change
`fsl.value(i)` gets out of range if `i * value_length` is over `i32::MAX`
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

changed `value_offset_at(i)` return type from `i32` to `usize`,
and make `value(i)` access the underlying values by offset from `value_offset_at(i)` so it still work if `i * value_length` is over i32 but within `usize`

# Are there any user-facing changes?
No

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
