### PR TITLE
Add user defined metadata

### DIFF
--- a/object_store/src/attributes.rs
+++ b/object_store/src/attributes.rs
@@ -48,7 +48,7 @@ pub enum Attribute {
     /// Specifies a user-defined metadata field for the object
     ///
     /// The String is a user-defined key
-    Metadata(String),
+    Metadata(Cow<'static, str>),
 }
 
 /// The value of an [`Attribute`]
@@ -198,7 +198,7 @@ mod tests {
             (Attribute::ContentLanguage, "en-US"),
             (Attribute::ContentType, "test"),
             (Attribute::CacheControl, "control"),
-            (Attribute::Metadata("key1".to_string()), "value1"),
+            (Attribute::Metadata("key1".into()), "value1"),
         ]);
 
         assert!(!attributes.is_empty());
@@ -241,7 +241,7 @@ mod tests {
             Some(&"en-US".into())
         );
         assert_eq!(
-            attributes.get(&Attribute::Metadata("key1".to_string())),
+            attributes.get(&Attribute::Metadata("key1".into())),
             Some(&"value1".into())
         );
     }

--- a/object_store/src/attributes.rs
+++ b/object_store/src/attributes.rs
@@ -45,6 +45,10 @@ pub enum Attribute {
     ///
     /// See [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
     CacheControl,
+    /// Specifies a user-defined metadata field for the object
+    ///
+    /// The String is a user-defined key
+    Metadata(String),
 }
 
 /// The value of an [`Attribute`]
@@ -194,10 +198,11 @@ mod tests {
             (Attribute::ContentLanguage, "en-US"),
             (Attribute::ContentType, "test"),
             (Attribute::CacheControl, "control"),
+            (Attribute::Metadata("key1".to_string()), "value1"),
         ]);
 
         assert!(!attributes.is_empty());
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(attributes.len(), 6);
 
         assert_eq!(
             attributes.get(&Attribute::ContentType),
@@ -210,18 +215,18 @@ mod tests {
             attributes.insert(Attribute::CacheControl, "v1".into()),
             Some(metav)
         );
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(attributes.len(), 6);
 
         assert_eq!(
             attributes.remove(&Attribute::CacheControl).unwrap(),
             "v1".into()
         );
-        assert_eq!(attributes.len(), 4);
+        assert_eq!(attributes.len(), 5);
 
         let metav: AttributeValue = "v2".into();
         attributes.insert(Attribute::CacheControl, metav.clone());
         assert_eq!(attributes.get(&Attribute::CacheControl), Some(&metav));
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(attributes.len(), 6);
 
         assert_eq!(
             attributes.get(&Attribute::ContentDisposition),
@@ -234,6 +239,10 @@ mod tests {
         assert_eq!(
             attributes.get(&Attribute::ContentLanguage),
             Some(&"en-US".into())
+        );
+        assert_eq!(
+            attributes.get(&Attribute::Metadata("key1".to_string())),
+            Some(&"value1".into())
         );
     }
 }

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -327,9 +327,10 @@ impl<'a> Request<'a> {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k_suffix) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
-                }
+                Attribute::Metadata(k_suffix) => builder.header(
+                    &format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix),
+                    v.as_ref(),
+                ),
             };
         }
 

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -61,8 +61,7 @@ use std::sync::Arc;
 
 const VERSION_HEADER: &str = "x-amz-version-id";
 const SHA256_CHECKSUM: &str = "x-amz-checksum-sha256";
-
-static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-amz-meta-");
+const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-amz-meta-";
 
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
@@ -328,8 +327,8 @@ impl<'a> Request<'a> {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
+                Attribute::Metadata(k_suffix) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
                 }
             };
         }
@@ -647,6 +646,7 @@ impl GetClient for S3Client {
         etag_required: false,
         last_modified_required: false,
         version_header: Some(VERSION_HEADER),
+        user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };
 
     /// Make an S3 GET request <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -62,6 +62,8 @@ use std::sync::Arc;
 const VERSION_HEADER: &str = "x-amz-version-id";
 const SHA256_CHECKSUM: &str = "x-amz-checksum-sha256";
 
+static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-amz-meta-");
+
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
 #[allow(missing_docs)]
@@ -325,6 +327,9 @@ impl<'a> Request<'a> {
                 Attribute::ContentType => {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
+                }
+                Attribute::Metadata(k) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
                 }
             };
         }

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -48,6 +48,7 @@ use std::time::Duration;
 use url::Url;
 
 const VERSION_HEADER: &str = "x-ms-version-id";
+const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-ms-meta-";
 static MS_CACHE_CONTROL: HeaderName = HeaderName::from_static("x-ms-blob-cache-control");
 static MS_CONTENT_TYPE: HeaderName = HeaderName::from_static("x-ms-blob-content-type");
 static MS_CONTENT_DISPOSITION: HeaderName =
@@ -56,7 +57,6 @@ static MS_CONTENT_ENCODING: HeaderName = HeaderName::from_static("x-ms-blob-cont
 static MS_CONTENT_LANGUAGE: HeaderName = HeaderName::from_static("x-ms-blob-content-language");
 
 static TAGS_HEADER: HeaderName = HeaderName::from_static("x-ms-tags");
-static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-ms-meta-");
 
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
@@ -209,8 +209,8 @@ impl<'a> PutRequest<'a> {
                     has_content_type = true;
                     builder.header(&MS_CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
+                Attribute::Metadata(k_suffix) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
                 }
             };
         }
@@ -503,6 +503,7 @@ impl GetClient for AzureClient {
         etag_required: true,
         last_modified_required: true,
         version_header: Some(VERSION_HEADER),
+        user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };
 
     /// Make an Azure GET request

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -209,9 +209,10 @@ impl<'a> PutRequest<'a> {
                     has_content_type = true;
                     builder.header(&MS_CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k_suffix) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
-                }
+                Attribute::Metadata(k_suffix) => builder.header(
+                    &format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix),
+                    v.as_ref(),
+                ),
             };
         }
 

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -56,6 +56,7 @@ static MS_CONTENT_ENCODING: HeaderName = HeaderName::from_static("x-ms-blob-cont
 static MS_CONTENT_LANGUAGE: HeaderName = HeaderName::from_static("x-ms-blob-content-language");
 
 static TAGS_HEADER: HeaderName = HeaderName::from_static("x-ms-tags");
+static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-ms-meta-");
 
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
@@ -207,6 +208,9 @@ impl<'a> PutRequest<'a> {
                 Attribute::ContentType => {
                     has_content_type = true;
                     builder.header(&MS_CONTENT_TYPE, v.as_ref())
+                }
+                Attribute::Metadata(k) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
                 }
             };
         }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -229,7 +229,7 @@ fn get_result<T: GetClient>(
                 let suffix = key.as_str()[prefix.len()..].to_string();
                 attributes.insert(
                     Attribute::Metadata(suffix),
-                    val.to_str().unwrap().to_string().into()
+                    val.to_str().unwrap().to_string().into(),
                 );
             }
         }
@@ -418,7 +418,10 @@ mod tests {
         let res = get_result::<TestClient>(&path, None, resp).unwrap();
         assert_eq!(res.meta.size, 12);
         assert_eq!(res.range, 0..12);
-        assert_eq!(res.attributes.get(&Attribute::Metadata("foo".to_string())), Some(&"bar".into()));
+        assert_eq!(
+            res.attributes.get(&Attribute::Metadata("foo".to_string())),
+            Some(&"bar".into())
+        );
         let bytes = res.bytes().await.unwrap();
         assert_eq!(bytes.len(), 12);
     }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -236,8 +236,7 @@ fn get_result<T: GetClient>(
                 } else {
                     return Err(GetResultError::InvalidMetadata {
                         key: key.to_string(),
-                    }
-                    .into());
+                    });
                 }
             }
         }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -135,6 +135,9 @@ enum GetResultError {
     #[snafu(display("Content-Type header contained non UTF-8 characters"))]
     InvalidContentType { source: ToStrError },
 
+    #[snafu(display("Metadata value for \"{key:?}\" contained non UTF-8 characters"))]
+    InvalidMetadata { key: String },
+
     #[snafu(display("Requested {expected:?}, got {actual:?}"))]
     UnexpectedRange {
         expected: Range<usize>,
@@ -230,6 +233,11 @@ fn get_result<T: GetClient>(
                         Attribute::Metadata(suffix.to_string().into()),
                         val_str.to_string().into(),
                     );
+                } else {
+                    return Err(GetResultError::InvalidMetadata {
+                        key: key.to_string(),
+                    }
+                    .into());
                 }
             }
         }

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -227,7 +227,7 @@ fn get_result<T: GetClient>(
             if let Some(suffix) = key.as_str().strip_prefix(prefix) {
                 if let Ok(val_str) = val.to_str() {
                     attributes.insert(
-                        Attribute::Metadata(suffix.to_string()),
+                        Attribute::Metadata(suffix.to_string().into()),
                         val_str.to_string().into(),
                     );
                 }
@@ -416,7 +416,7 @@ mod tests {
         assert_eq!(res.meta.size, 12);
         assert_eq!(res.range, 0..12);
         assert_eq!(
-            res.attributes.get(&Attribute::Metadata("foo".to_string())),
+            res.attributes.get(&Attribute::Metadata("foo".into())),
             Some(&"bar".into())
         );
         let bytes = res.bytes().await.unwrap();

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -31,6 +31,7 @@ pub struct HeaderConfig {
     ///
     /// Defaults to `true`
     pub etag_required: bool,
+
     /// Whether to require a Last-Modified header when extracting [`ObjectMeta`] from headers.
     ///
     /// Defaults to `true`
@@ -38,6 +39,9 @@ pub struct HeaderConfig {
 
     /// The version header name if any
     pub version_header: Option<&'static str>,
+
+    /// The user defined metadata prefix if any
+    pub user_defined_metadata_prefix: Option<&'static str>,
 }
 
 #[derive(Debug, Snafu)]

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -201,7 +201,8 @@ impl<'a> Request<'a> {
                     builder.header(CONTENT_TYPE, v.as_ref())
                 }
                 Attribute::Metadata(k_suffix) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())                }
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
+                }
             };
         }
 

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -51,6 +51,7 @@ const VERSION_HEADER: &str = "x-goog-generation";
 const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
+static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-goog-meta-");
 
 #[derive(Debug, Snafu)]
 enum Error {
@@ -198,6 +199,9 @@ impl<'a> Request<'a> {
                 Attribute::ContentType => {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
+                }
+                Attribute::Metadata(k) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
                 }
             };
         }

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -200,9 +200,10 @@ impl<'a> Request<'a> {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k_suffix) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())
-                }
+                Attribute::Metadata(k_suffix) => builder.header(
+                    &format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix),
+                    v.as_ref(),
+                ),
             };
         }
 

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -49,9 +49,9 @@ use std::sync::Arc;
 
 const VERSION_HEADER: &str = "x-goog-generation";
 const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
+const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-goog-meta-";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
-static USER_DEFINED_METADATA_HEADER_PREFIX: HeaderName = HeaderName::from_static("x-goog-meta-");
 
 #[derive(Debug, Snafu)]
 enum Error {
@@ -200,9 +200,8 @@ impl<'a> Request<'a> {
                     has_content_type = true;
                     builder.header(CONTENT_TYPE, v.as_ref())
                 }
-                Attribute::Metadata(k) => {
-                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, key), value);
-                }
+                Attribute::Metadata(k_suffix) => {
+                    builder.header(&format!("{}{}", USER_DEFINED_METADATA_HEADER_PREFIX, k_suffix), v.as_ref())                }
             };
         }
 
@@ -571,6 +570,7 @@ impl GetClient for GoogleCloudStorageClient {
         etag_required: true,
         last_modified_required: true,
         version_header: Some(VERSION_HEADER),
+        user_defined_metadata_prefix: Some(USER_DEFINED_METADATA_HEADER_PREFIX),
     };
 
     /// Perform a get request <https://cloud.google.com/storage/docs/xml-api/get-object-download>

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -182,7 +182,7 @@ impl Client {
                     Attribute::ContentType => {
                         has_content_type = true;
                         builder.header(CONTENT_TYPE, v.as_ref())
-                    },
+                    }
                     // Ignore metadata attributes
                     Attribute::Metadata(_) => builder,
                 };

--- a/object_store/src/http/client.rs
+++ b/object_store/src/http/client.rs
@@ -182,7 +182,9 @@ impl Client {
                     Attribute::ContentType => {
                         has_content_type = true;
                         builder.header(CONTENT_TYPE, v.as_ref())
-                    }
+                    },
+                    // Ignore metadata attributes
+                    Attribute::Metadata(_) => builder,
                 };
             }
 
@@ -319,6 +321,7 @@ impl GetClient for Client {
         etag_required: false,
         last_modified_required: false,
         version_header: None,
+        user_defined_metadata_prefix: None,
     };
 
     async fn get_request(&self, path: &Path, options: GetOptions) -> Result<Response> {

--- a/object_store/src/integration.rs
+++ b/object_store/src/integration.rs
@@ -480,7 +480,7 @@ pub async fn put_get_attributes(integration: &dyn ObjectStore) {
         (Attribute::ContentEncoding, "gzip"),
         (Attribute::ContentLanguage, "en-US"),
         (Attribute::ContentType, "text/html; charset=utf-8"),
-        (Attribute::Metadata("test_key".to_string()), "test_value"),
+        (Attribute::Metadata("test_key".into()), "test_value"),
     ]);
 
     let path = Path::from("attributes");

--- a/object_store/src/integration.rs
+++ b/object_store/src/integration.rs
@@ -480,6 +480,7 @@ pub async fn put_get_attributes(integration: &dyn ObjectStore) {
         (Attribute::ContentEncoding, "gzip"),
         (Attribute::ContentLanguage, "en-US"),
         (Attribute::ContentType, "text/html; charset=utf-8"),
+        (Attribute::Metadata("test_key".to_string()), "test_value"),
     ]);
 
     let path = Path::from("attributes");


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4754

# Rationale for this change
 
We would like to be able to read and write user-defined metadata for AWS, GCP, and Azure. This use-case is mentioned briefly in #4754 before the conversation shifts to tags. It appears that tags were implemented, but user-defined metadata has not yet been.

# What changes are included in this PR?

- Add user-defined metadata for AWS, GCP, and Azure clients.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

I've added a `Metadata(String)` attribute to the `Attribute` enum. Other than that I don't believe there are any user-facing changes.

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

I do not believe there are any breaking changes. The user-facing change (`Attributes::Metadata(String)`) is additive and should be compatible. The one caveat here is I'm not sure how Rust handles enums (open vs. closed). If it handles them the way Java does (i.e. adding new enums can break old code) then this would be a breaking change. I'll leave it to the Rust experts to clarify this.