### PR TITLE
docs: Add object_store_opendal as related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ versions approximately every 2 months.
 
 ## Related Projects
 
-There are two related crates in different repositories
+There are several related crates in different repositories
 
 | Crate                    | Description                                 | Documentation                           |
 | ------------------------ | ------------------------------------------- | --------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -81,13 +81,17 @@ versions approximately every 2 months.
 
 There are two related crates in different repositories
 
-| Crate          | Description                             | Documentation                 |
-| -------------- | --------------------------------------- | ----------------------------- |
-| [`datafusion`] | In-memory query engine with SQL support | [(README)][datafusion-readme] |
-| [`ballista`]   | Distributed query execution             | [(README)][ballista-readme]   |
+| Crate                    | Description                                 | Documentation                           |
+| ------------------------ | ------------------------------------------- | --------------------------------------- |
+| [`datafusion`]           | In-memory query engine with SQL support     | [(README)][datafusion-readme]           |
+| [`ballista`]             | Distributed query execution                 | [(README)][ballista-readme]             |
+| [`object_store_opendal`] | Use [`opendal`] as [`object_store`] backend | [(README)][object_store_opendal-readme] |
 
 [`datafusion`]: https://crates.io/crates/datafusion
 [`ballista`]: https://crates.io/crates/ballista
+[`object_store_opendal`]: https://crates.io/crates/object_store_opendal
+[`opendal`]: https://crates.io/crates/opendal
+[`object_store_opendal-readme`]: https://github.com/apache/opendal/blob/main/integrations/object_store/README.md
 
 Collectively, these crates support a wider array of functionality for analytic computations in Rust.
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/5925.

# Rationale for this change
 
Add [`object_store_opendal`](https://crates.io/crates/object_store_opendal) as an integration to `object_store`

# What changes are included in this PR?

Add links in README.

# Are there any user-facing changes?

None.