### PR TITLE
Update snafu

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,7 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = "0.7"
+snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -103,7 +103,7 @@ enum GetResultError {
         source: crate::client::header::Error,
     },
 
-    #[snafu(context(false))]
+    #[snafu(transparent)]
     InvalidRangeRequest {
         source: crate::util::InvalidGetRange,
     },
@@ -353,7 +353,7 @@ mod tests {
         let err = get_result::<TestClient>(&path, Some(get_range.clone()), resp).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "InvalidRangeRequest: Wanted range starting at 2, but object was only 2 bytes long"
+            "Wanted range starting at 2, but object was only 2 bytes long"
         );
 
         let resp = make_response(


### PR DESCRIPTION
# Which issue does this PR close?

-

# Rationale for this change
 
This removes the last use of `syn` 1 from this repo. For many projects, this
may remove `syn` 1 from the dependency tree altogether, which can save a significant
amount of compile time.

# What changes are included in this PR?

Updates `snafu` to `0.8` in `object_store`, excluding the `rust_1_65` feature to avoid increasing this crate's MSRV.

# Are there any user-facing changes?

[snafu changelog](https://github.com/shepmaster/snafu/blob/main/CHANGELOG.md)
> The item type of the ChainCompat iterator is now &'a (dyn Error + 'b) to allow downcasting the error trait object to a concrete type. This is a breaking change.
