### PR TITLE
[object_store] Add retries for 200 responses which contain an error

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -33,6 +33,7 @@ all-features = true
 async-trait = "0.1.53"
 bytes = "1.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
+encoding_rs = "0.8"
 futures = "0.3"
 humantime = "2.1"
 itertools = "0.13.0"

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -253,7 +253,9 @@ impl RetryableRequest {
 
                                     let mut hyper_headers = hyper::HeaderMap::new();
                                     for (header_name, header_value) in headers {
-                                        hyper_headers.insert(header_name.unwrap(), header_value);
+                                        if let Some(name) = header_name {
+                                            hyper_headers.insert(name, header_value);
+                                        }
                                     }
 
                                     *success_response.headers_mut() = hyper_headers;


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
Retry mechanism does not exist for 200 responses with errors, an edge case which is known and acknlowledged by AWS. Handling this in the client is imperative for applications to continue functioning smoothly when running into these cases.

# What changes are included in this PR?
As per [this post](https://repost.aws/knowledge-center/s3-resolve-200-internalerror), it is possible for the CopyObject, UploadPartCopy, or CompleteMultipartUpload operations to return a status code of 200 but actually fail to perform the expected operation.

Applications are instructed to handle this appropriately by retrying the requested operation in this event. This requires parsing the response body, identifying an error occurred , and retrying the request.

For example, a CopyObject request that failed silently could have a response body that looks like:

`<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message><RequestId>123</RequestId><HostId>456</HostId></Error>`

Note that CopyObject and UploadPartCopy are PUT requests and CompleteMultipartUpload is a POST request.

# Are there any user-facing changes?
No