### PR TITLE
minor: row format benches for bool & nullable int

### DIFF
--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -23,8 +23,8 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::{Int64Type, UInt64Type};
 use arrow::row::{RowConverter, SortField};
 use arrow::util::bench_util::{
-    create_dict_from_values, create_primitive_array, create_string_array_with_len,
-    create_string_dict_array,
+    create_boolean_array, create_dict_from_values, create_primitive_array,
+    create_string_array_with_len, create_string_dict_array,
 };
 use arrow_array::types::Int32Type;
 use arrow_array::Array;
@@ -60,8 +60,20 @@ fn row_bench(c: &mut Criterion) {
     let cols = vec![Arc::new(create_primitive_array::<UInt64Type>(4096, 0.)) as ArrayRef];
     do_bench(c, "4096 u64(0)", cols);
 
+    let cols = vec![Arc::new(create_primitive_array::<UInt64Type>(4096, 0.3)) as ArrayRef];
+    do_bench(c, "4096 u64(0.3)", cols);
+
     let cols = vec![Arc::new(create_primitive_array::<Int64Type>(4096, 0.)) as ArrayRef];
     do_bench(c, "4096 i64(0)", cols);
+
+    let cols = vec![Arc::new(create_primitive_array::<Int64Type>(4096, 0.3)) as ArrayRef];
+    do_bench(c, "4096 i64(0.3)", cols);
+
+    let cols = vec![Arc::new(create_boolean_array(4096, 0., 0.5)) as ArrayRef];
+    do_bench(c, "4096 bool(0, 0.5)", cols);
+
+    let cols = vec![Arc::new(create_boolean_array(4096, 0.3, 0.5)) as ArrayRef];
+    do_bench(c, "4096 bool(0.3, 0.5)", cols);
 
     let cols = vec![Arc::new(create_string_array_with_len::<i32>(4096, 0., 10)) as ArrayRef];
     do_bench(c, "4096 string(10, 0)", cols);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

--

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Related to #5858 -- adding benchmarks by separate commit, to reduce amount of actions required to compare benchmark results on feature/master branch.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Row format benchmarks for boolean arrays and nullable primitive arrays (u64/i64)

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
