### PR TITLE
test: Add unit test for extending slice of list array

### DIFF
--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1530,10 +1530,10 @@ mod tests_from_ffi {
     fn test_extend_imported_list_slice() {
         let mut data = vec![];
 
-        for _i in 0..1000 {
+        for i in 0..1000 {
             let mut list = vec![];
             for j in 0..100 {
-                list.push(Some(j));
+                list.push(Some(i * 1000 + j));
             }
             data.push(Some(list));
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

A follow up of #5895

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In #5895, we found there is an issue in variable binary layout on `slice` it.
List array also has offset buffer and its `slice` function also "slice" offset buffer. But due to its layout is different to variable binary, it doesn't have similar issue (it doesn't use offset difference to decide data buffer length). This patch adds an unit test to verify it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
