### PR TITLE
feat: add max_bytes and min_bytes on PageIndex

### DIFF
--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -19,7 +19,7 @@
 
 use crate::basic::Type;
 use crate::data_type::private::ParquetValueType;
-use crate::data_type::{ByteArray, FixedLenByteArray, Int96};
+use crate::data_type::{AsBytes, ByteArray, FixedLenByteArray, Int96};
 use crate::errors::ParquetError;
 use crate::format::{BoundaryOrder, ColumnIndex};
 use crate::util::bit_util::from_le_slice;
@@ -52,6 +52,19 @@ impl<T> PageIndex<T> {
     }
     pub fn null_count(&self) -> Option<i64> {
         self.null_count
+    }
+}
+
+impl<T> PageIndex<T>
+where
+    T: AsBytes,
+{
+    pub fn max_bytes(&self) -> Option<&[u8]> {
+        self.max.as_ref().map(|x| x.as_bytes())
+    }
+
+    pub fn min_bytes(&self) -> Option<&[u8]> {
+        self.min.as_ref().map(|x| x.as_bytes())
     }
 }
 
@@ -154,5 +167,40 @@ impl<T: ParquetValueType> NativeIndex<T> {
             indexes,
             boundary_order: index.boundary_order,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_page_index_min_max_null() {
+        let page_index = PageIndex {
+            min: Some(-123),
+            max: Some(234),
+            null_count: Some(0),
+        };
+
+        assert_eq!(page_index.min().unwrap(), &-123);
+        assert_eq!(page_index.max().unwrap(), &234);
+        assert_eq!(page_index.min_bytes().unwrap(), (-123).as_bytes());
+        assert_eq!(page_index.max_bytes().unwrap(), 234.as_bytes());
+        assert_eq!(page_index.null_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_page_index_min_max_null_none() {
+        let page_index: PageIndex<i32> = PageIndex {
+            min: None,
+            max: None,
+            null_count: None,
+        };
+
+        assert_eq!(page_index.min(), None);
+        assert_eq!(page_index.max(), None);
+        assert_eq!(page_index.min_bytes(), None);
+        assert_eq!(page_index.max_bytes(), None);
+        assert_eq!(page_index.null_count(), None);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5949

# Rationale for this change

`PageIndex` currently doesn't have methods for `max_bytes` and `min_bytes` though this leaves it bit out of parity w/ `Statistics` as it does support this.

I also considered doing something like: `impl<T: ParquetValueType> ValueStatistics<T>` which I think would also make `T` have `AsBytes`. 

# What changes are included in this PR?

Adding `max_bytes` and `min_bytes` to `PageIndex` when the inner type has `AsBytes` implemented.

Adding tests for `PageIndex` to cover this new functionality as well as some existing stuff.

# Are there any user-facing changes?

No