### PR TITLE
Document process for PRs with breaking changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,10 +131,10 @@ cargo +stable fmt --all -- --check
 Our [release schedule] allows breaking API changes only in major releases.
 This means that if your PR has a breaking API change, it should be marked as
 `api-change` and it will not be merged until development opens for the next
-major release.
+major release. See [this ticket] for details.
 
 [release schedule]: README.md#release-versioning-and-schedule
-
+[this ticket]:https://github.com/apache/arrow-rs/issues/5907
 
 ## Clippy Lints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,16 @@ PR be sure to run the following and check for lint issues:
 cargo +stable fmt --all -- --check
 ```
 
+## Breaking Changes
+
+Our [release schedule] allows breaking API changes only in major releases.
+This means that if your PR has a breaking API change, it should be marked as
+`api-change` and it will not be merged until development opens for the next
+major release.
+
+[release schedule]: README.md#release-versioning-and-schedule
+
+
 ## Clippy Lints
 
 We recommend using `clippy` for checking lints during development. While we do not yet enforce `clippy` checks, we recommend not introducing new `clippy` errors or warnings.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Starting June 2024, we plan to release new major versions with potentially
 breaking API changes at most once a quarter, and release incremental minor versions in
 the intervening months. See [this ticket] for more details.
 
+To keep our maintenance burden down, we do regularly scheduled releases (major
+and minor) from the `master` branch. How we handle PRs with breaking API changes
+is described in the [contributing] guide.
+
+[contributing]: CONTRIBUTING.md#breaking-changes
+
 For example:
 
 | Approximate Date | Version  | Notes                                   |


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/5907

# Rationale for this change
 
See https://github.com/apache/arrow-rs/issues/5907

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes, to docs

See rendered versions: 
* https://github.com/alamb/arrow-rs/blob/alamb/breaking_changes2/CONTRIBUTING.md#breaking-changes
* https://github.com/alamb/arrow-rs/tree/alamb/breaking_changes2?tab=readme-ov-file#release-versioning-and-schedule

