### PR TITLE
Improve error message for unsupported nested comparison

### DIFF
--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -232,7 +232,11 @@ fn compare_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, 
     let r = r_v.map(|x| x.values().as_ref()).unwrap_or(r);
     let r_t = r.data_type();
 
-    if l_t != r_t || l_t.is_nested() {
+    if r_t.is_nested() || l_t.is_nested() {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Nested comparison: {l_t} {op} {r_t} (hint: use make_comparator instead)"
+        )));
+    } else if l_t != r_t || l_t.is_nested() {
         return Err(ArrowError::InvalidArgumentError(format!(
             "Invalid comparison operation: {l_t} {op} {r_t}"
         )));

--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -236,7 +236,7 @@ fn compare_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, 
         return Err(ArrowError::InvalidArgumentError(format!(
             "Nested comparison: {l_t} {op} {r_t} (hint: use make_comparator instead)"
         )));
-    } else if l_t != r_t || l_t.is_nested() {
+    } else if l_t != r_t {
         return Err(ArrowError::InvalidArgumentError(format!(
             "Invalid comparison operation: {l_t} {op} {r_t}"
         )));


### PR DESCRIPTION
# Which issue does this PR close?
Closes https://github.com/apache/arrow-rs/issues/5960


# Rationale for this change
 
comparison kernels are not supported for nested types and never will be (see https://github.com/apache/arrow-rs/issues/5960#issuecomment-2190252011) . 

@tustvold  added docs in https://github.com/apache/arrow-rs/pull/5942 , but let's also make this clearer in the error message

# What changes are included in this PR?

Add a specific error message + hint if comparing nested types

# Are there any user-facing changes?
Better error message

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
