### PR TITLE
feat(5851): ArrowWriter memory usage

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -308,6 +308,11 @@ impl Storage for ByteArrayStorage {
 
         key as u64
     }
+
+    fn estimated_memory_size(&self) -> usize {
+        self.page.capacity() * std::mem::size_of::<u8>()
+            + self.values.capacity() * std::mem::size_of::<std::ops::Range<usize>>()
+    }
 }
 
 /// A dictionary encoder for byte array data
@@ -339,7 +344,7 @@ impl DictEncoder {
     }
 
     fn estimated_memory_size(&self) -> usize {
-        self.interner.storage().page.len() + self.indices.len() * 8
+        self.interner.estimated_memory_size() + self.indices.capacity() * std::mem::size_of::<u64>()
     }
 
     fn estimated_data_page_size(&self) -> usize {
@@ -462,7 +467,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
         let bloom_filter_size = self
             .bloom_filter
             .as_ref()
-            .map(|bf| bf.byte_size())
+            .map(|bf| bf.memory_size())
             .unwrap_or_default();
 
         let stats_size = self.min_value.as_ref().map(|v| v.len()).unwrap_or_default()

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -309,6 +309,7 @@ impl Storage for ByteArrayStorage {
         key as u64
     }
 
+    #[cfg(arrow)]
     fn estimated_memory_size(&self) -> usize {
         self.page.capacity() * std::mem::size_of::<u8>()
             + self.values.capacity() * std::mem::size_of::<std::ops::Range<usize>>()

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -334,6 +334,10 @@ impl DictEncoder {
         num_required_bits(length.saturating_sub(1) as u64)
     }
 
+    fn estimated_memory_size(&self) -> usize {
+        self.interner.storage().page.len() + self.indices.len() * 8
+    }
+
     fn estimated_data_page_size(&self) -> usize {
         let bit_width = self.bit_width();
         1 + RleEncoder::max_buffer_size(bit_width, self.indices.len())
@@ -441,6 +445,13 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
     fn has_dictionary(&self) -> bool {
         self.dict_encoder.is_some()
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        match &self.dict_encoder {
+            Some(encoder) => encoder.estimated_memory_size(),
+            None => self.fallback.estimated_data_page_size(),
+        }
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -452,12 +452,20 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn estimated_memory_size(&self) -> usize {
-        match &self.dict_encoder {
+        let encoder_size = match &self.dict_encoder {
             Some(encoder) => encoder.estimated_memory_size(),
             // For the FallbackEncoder, these unflushed bytes are already encoded.
             // Therefore, the size should be the same as estimated_data_page_size.
             None => self.fallback.estimated_data_page_size(),
-        }
+        };
+
+        let bloom_filter_size = self
+            .bloom_filter
+            .as_ref()
+            .map(|bf| bf.byte_size())
+            .unwrap_or_default();
+
+        encoder_size + bloom_filter_size
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -309,7 +309,7 @@ impl Storage for ByteArrayStorage {
         key as u64
     }
 
-    #[cfg(arrow)]
+    #[allow(dead_code)] // not used in parquet_derive, so is dead there
     fn estimated_memory_size(&self) -> usize {
         self.page.capacity() * std::mem::size_of::<u8>()
             + self.values.capacity() * std::mem::size_of::<std::ops::Range<usize>>()

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -467,7 +467,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
         let bloom_filter_size = self
             .bloom_filter
             .as_ref()
-            .map(|bf| bf.memory_size())
+            .map(|bf| bf.estimated_memory_size())
             .unwrap_or_default();
 
         let stats_size = self.min_value.as_ref().map(|v| v.len()).unwrap_or_default()

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -465,7 +465,10 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             .map(|bf| bf.byte_size())
             .unwrap_or_default();
 
-        encoder_size + bloom_filter_size
+        let stats_size = self.min_value.as_ref().map(|v| v.len()).unwrap_or_default()
+            + self.max_value.as_ref().map(|v| v.len()).unwrap_or_default();
+
+        encoder_size + bloom_filter_size + stats_size
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -210,6 +210,10 @@ impl FallbackEncoder {
         }
     }
 
+    /// Returns an estimate of the data page size in bytes
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     fn estimated_data_page_size(&self) -> usize {
         match &self.encoder {
             FallbackEncoderImpl::Plain { buffer, .. } => buffer.len(),
@@ -450,6 +454,8 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     fn estimated_memory_size(&self) -> usize {
         match &self.dict_encoder {
             Some(encoder) => encoder.estimated_memory_size(),
+            // For the FallbackEncoder, these unflushed bytes are already encoded.
+            // Therefore, the size should be the same as estimated_data_page_size.
             None => self.fallback.estimated_data_page_size(),
         }
     }
@@ -458,6 +464,10 @@ impl ColumnValueEncoder for ByteArrayEncoder {
         Some(self.dict_encoder.as_ref()?.estimated_dict_page_size())
     }
 
+    /// Returns an estimate of the data page size in bytes
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     fn estimated_data_page_size(&self) -> usize {
         match &self.dict_encoder {
             Some(encoder) => encoder.estimated_data_page_size(),

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -205,8 +205,10 @@ impl<W: Write + Send> ArrowWriter<W> {
 
     /// Returns the estimated memory usage of the current in progress row group.
     ///
-    /// This includes the current encoded size of written bytes, as well as
-    /// the size of the unencoded data not yet flushed.
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes> + <bytes_associated_with_processing>
+    ///
+    /// In the vast majority of cases our unflushed bytes are already encoded.
     pub fn memory_size(&self) -> usize {
         match &self.in_progress {
             Some(in_progress) => in_progress.writers.iter().map(|x| x.memory_size()).sum(),
@@ -216,8 +218,8 @@ impl<W: Write + Send> ArrowWriter<W> {
 
     /// Returns the estimated length in encoded bytes of the current in progress row group.
     ///
-    /// This includes an estimate of any data that has not yet been flushed to a page,
-    /// based on it's anticipated encoded size.
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     pub fn in_progress_size(&self) -> usize {
         match &self.in_progress {
             Some(in_progress) => in_progress
@@ -647,6 +649,11 @@ impl ArrowColumnWriter {
     ///
     /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
     /// of the current memory usage and not it's anticipated encoded size.
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes> + <bytes_associated_with_processing>
+    ///
+    /// In the vast majority of cases our unflushed bytes are already encoded.
     pub fn memory_size(&self) -> usize {
         match &self.writer {
             ArrowColumnWriterImpl::ByteArray(c) => c.memory_size(),
@@ -656,8 +663,8 @@ impl ArrowColumnWriter {
 
     /// Returns the estimated total encoded bytes for this column writer.
     ///
-    /// This includes an estimate of any data that has not yet been flushed to a page,
-    /// based on it's anticipated encoded size.
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     pub fn get_estimated_total_bytes(&self) -> usize {
         match &self.writer {
             ArrowColumnWriterImpl::ByteArray(c) => c.get_estimated_total_bytes() as _,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2922,6 +2922,7 @@ mod tests {
         // starts empty
         assert_eq!(writer.in_progress_size(), 0);
         assert_eq!(writer.in_progress_rows(), 0);
+        assert_eq!(writer.memory_size(), 0);
         assert_eq!(writer.bytes_written(), 4); // Initial header
         writer.write(&batch).unwrap();
 
@@ -2929,17 +2930,20 @@ mod tests {
         let initial_size = writer.in_progress_size();
         assert!(initial_size > 0);
         assert_eq!(writer.in_progress_rows(), 5);
+        let initial_memory = writer.memory_size();
+        assert!(initial_memory > 0);
 
         // updated on second write
         writer.write(&batch).unwrap();
         assert!(writer.in_progress_size() > initial_size);
         assert_eq!(writer.in_progress_rows(), 10);
+        assert!(writer.memory_size() > initial_memory);
 
         // in progress tracking is cleared, but the overall data written is updated
         let pre_flush_bytes_written = writer.bytes_written();
         writer.flush().unwrap();
         assert_eq!(writer.in_progress_size(), 0);
-        assert_eq!(writer.in_progress_rows(), 0);
+        assert_eq!(writer.memory_size(), 0);
         assert!(writer.bytes_written() > pre_flush_bytes_written);
 
         writer.close().unwrap();

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2947,12 +2947,23 @@ mod tests {
         assert_eq!(writer.in_progress_rows(), 5);
         let initial_memory = writer.memory_size();
         assert!(initial_memory > 0);
+        // memory estimate is larger than estimated encoded size
+        assert!(
+            initial_size <= initial_memory,
+            "{initial_size} <= {initial_memory}"
+        );
 
         // updated on second write
         writer.write(&batch).unwrap();
         assert!(writer.in_progress_size() > initial_size);
         assert_eq!(writer.in_progress_rows(), 10);
         assert!(writer.memory_size() > initial_memory);
+        assert!(
+            writer.in_progress_size() <= writer.memory_size(),
+            "in_progress_size {} <= memory_size {}",
+            writer.in_progress_size(),
+            writer.memory_size()
+        );
 
         // in progress tracking is cleared, but the overall data written is updated
         let pre_flush_bytes_written = writer.bytes_written();

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -210,7 +210,8 @@ impl<W: Write + Send> ArrowWriter<W> {
 
     /// Estimated memory usage, in bytes, of this `ArrowWriter`
     ///
-    /// See [`ArrowColumnWriter::memory_size`] for details
+    /// This estimate is formed bu summing the values of
+    /// [`ArrowColumnWriter::memory_size`] all in progress columns.
     pub fn memory_size(&self) -> usize {
         match &self.in_progress {
             Some(in_progress) => in_progress.writers.iter().map(|x| x.memory_size()).sum(),

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -176,7 +176,16 @@ impl<W: AsyncFileWriter> AsyncArrowWriter<W> {
         self.sync_writer.flushed_row_groups()
     }
 
-    /// Returns the estimated length in bytes of the current in progress row group
+    /// Estimated memory usage, in bytes, of this `ArrowWriter`
+    ///
+    /// See [ArrowWriter::memory_size] for more information.
+    pub fn memory_size(&self) -> usize {
+        self.sync_writer.memory_size()
+    }
+
+    /// Anticipated encoded size of the in progress row group.
+    ///
+    /// See [ArrowWriter::memory_size] for more information.
     pub fn in_progress_size(&self) -> usize {
         self.sync_writer.in_progress_size()
     }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -385,7 +385,7 @@ impl Sbbf {
     }
 
     /// Return the total in memory size of this bloom filter in bytes
-    pub(crate) fn memory_size(&self) -> usize {
+    pub(crate) fn estimated_memory_size(&self) -> usize {
         self.0.capacity() * std::mem::size_of::<Block>()
     }
 }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -384,9 +384,9 @@ impl Sbbf {
         self.0[block_index].check(hash as u32)
     }
 
-    pub(crate) fn byte_size(&self) -> usize {
-        // each block = [u32; 8]
-        self.0.len() * 4 * 8
+    /// Return the total in memory size of this bloom filter in bytes
+    pub(crate) fn memory_size(&self) -> usize {
+        self.0.capacity() * std::mem::size_of::<Block>()
     }
 }
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -383,6 +383,11 @@ impl Sbbf {
         let block_index = self.hash_to_block_index(hash);
         self.0[block_index].check(hash as u32)
     }
+
+    pub(crate) fn byte_size(&self) -> usize {
+        // each block = [u32; 8]
+        self.0.len() * 4 * 8
+    }
 }
 
 // per spec we use xxHash with seed=0

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -93,6 +93,9 @@ pub trait ColumnValueEncoder {
     /// Returns true if this encoder has a dictionary page
     fn has_dictionary(&self) -> bool;
 
+    /// Returns the estimated total memory usage of the encoder
+    fn estimated_memory_size(&self) -> usize;
+
     /// Returns an estimate of the dictionary page size in bytes, or `None` if no dictionary
     fn estimated_dict_page_size(&self) -> Option<usize>;
 
@@ -225,6 +228,15 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn has_dictionary(&self) -> bool {
         self.dict_encoder.is_some()
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        match &self.dict_encoder {
+            Some(encoder) => encoder.estimated_memory_size(),
+            // TODO: for now, we are ignoring the memory overhead for unflushed data
+            // in the other encoders (besides DictEncoder)
+            _ => self.encoder.estimated_data_encoded_size(),
+        }
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -235,7 +235,9 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn estimated_memory_size(&self) -> usize {
-        let encoder_size = self
+        let encoder_size = self.encoder.estimated_memory_size();
+
+        let dict_encoder_size = self
             .dict_encoder
             .as_ref()
             .map(|encoder| encoder.estimated_memory_size())
@@ -247,7 +249,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
             .map(|bf| bf.estimated_memory_size())
             .unwrap_or_default();
 
-        encoder_size + bloom_filter_size
+        encoder_size + dict_encoder_size + bloom_filter_size
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -237,13 +237,21 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn estimated_memory_size(&self) -> usize {
-        match &self.dict_encoder {
+        let encoder_size = match &self.dict_encoder {
             // For this DictEncoder, we have unencoded bytes in the buffer.
             Some(encoder) => encoder.estimated_memory_size(),
             // Whereas for all other encoders the buffer contains encoded bytes.
             // Therefore, we can use the estimated_data_encoded_size.
             _ => self.encoder.estimated_data_encoded_size(),
-        }
+        };
+
+        let bloom_filter_size = self
+            .bloom_filter
+            .as_ref()
+            .map(|bf| bf.byte_size())
+            .unwrap_or_default();
+
+        encoder_size + bloom_filter_size
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -246,7 +246,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         let bloom_filter_size = self
             .bloom_filter
             .as_ref()
-            .map(|bf| bf.byte_size())
+            .map(|bf| bf.memory_size())
             .unwrap_or_default();
 
         encoder_size + bloom_filter_size

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -235,18 +235,16 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn estimated_memory_size(&self) -> usize {
-        let encoder_size = match &self.dict_encoder {
-            // For this DictEncoder, we have unencoded bytes in the buffer.
-            Some(encoder) => encoder.estimated_memory_size(),
-            // Whereas for all other encoders the buffer contains encoded bytes.
-            // Therefore, we can use the estimated_data_encoded_size.
-            _ => self.encoder.estimated_data_encoded_size(),
-        };
+        let encoder_size = self
+            .dict_encoder
+            .as_ref()
+            .map(|encoder| encoder.estimated_memory_size())
+            .unwrap_or_default();
 
         let bloom_filter_size = self
             .bloom_filter
             .as_ref()
-            .map(|bf| bf.memory_size())
+            .map(|bf| bf.estimated_memory_size())
             .unwrap_or_default();
 
         encoder_size + bloom_filter_size

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -95,14 +95,12 @@ pub trait ColumnValueEncoder {
 
     /// Returns the estimated total memory usage of the encoder
     ///
-    /// This should include:
-    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes> + <bytes_associated_with_processing>
     fn estimated_memory_size(&self) -> usize;
 
-    /// Returns an estimate of the dictionary page size in bytes, or `None` if no dictionary
+    /// Returns an estimate of the encoded size of dictionary page size in bytes, or `None` if no dictionary
     fn estimated_dict_page_size(&self) -> Option<usize>;
 
-    /// Returns an estimate of the data page size in bytes
+    /// Returns an estimate of the encoded data page size in bytes
     ///
     /// This should include:
     /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -429,6 +429,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     ///
     /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
     /// of the current memory usage and not it's anticipated encoded size.
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes> + <bytes_associated_with_processing>
+    ///
+    /// In the vast majority of cases our unflushed bytes are already encoded.
     #[cfg(feature = "arrow")]
     pub(crate) fn memory_size(&self) -> usize {
         self.column_metrics.total_bytes_written as usize + self.encoder.estimated_memory_size()
@@ -448,6 +453,9 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// Unlike [`Self::get_total_bytes_written`] this includes an estimate
     /// of any data that has not yet been flushed to a page, based on it's
     /// anticipated encoded size.
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         self.column_metrics.total_bytes_written

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -428,12 +428,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// Returns the estimated total memory usage.
     ///
     /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
-    /// of the current memory usage and not it's anticipated encoded size.
-    ///
-    /// This includes:
-    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes> + <bytes_associated_with_processing>
-    ///
-    /// In the vast majority of cases our unflushed bytes are already encoded.
+    /// of the current memory usage and not the final anticipated encoded size.
     #[cfg(feature = "arrow")]
     pub(crate) fn memory_size(&self) -> usize {
         self.column_metrics.total_bytes_written as usize + self.encoder.estimated_memory_size()
@@ -453,9 +448,6 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// Unlike [`Self::get_total_bytes_written`] this includes an estimate
     /// of any data that has not yet been flushed to a page, based on it's
     /// anticipated encoded size.
-    ///
-    /// This includes:
-    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         self.column_metrics.total_bytes_written

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -72,7 +72,13 @@ pub enum ColumnWriter<'a> {
 }
 
 impl<'a> ColumnWriter<'a> {
-    /// Returns the estimated total bytes for this column writer
+    /// Returns the estimated total memory usage
+    #[cfg(feature = "arrow")]
+    pub(crate) fn memory_size(&self) -> usize {
+        downcast_writer!(self, typed, typed.memory_size())
+    }
+
+    /// Returns the estimated total encoded bytes for this column writer
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         downcast_writer!(self, typed, typed.get_estimated_total_bytes())
@@ -419,6 +425,15 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         )
     }
 
+    /// Returns the estimated total memory usage.
+    ///
+    /// Unlike [`Self::get_estimated_total_bytes`] this is an estimate
+    /// of the current memory usage and not it's anticipated encoded size.
+    #[cfg(feature = "arrow")]
+    pub(crate) fn memory_size(&self) -> usize {
+        todo!("TODO in next commit")
+    }
+
     /// Returns total number of bytes written by this column writer so far.
     /// This value is also returned when column writer is closed.
     ///
@@ -428,10 +443,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         self.column_metrics.total_bytes_written
     }
 
-    /// Returns the estimated total bytes for this column writer
+    /// Returns the estimated total encoded bytes for this column writer.
     ///
     /// Unlike [`Self::get_total_bytes_written`] this includes an estimate
-    /// of any data that has not yet been flushed to a page
+    /// of any data that has not yet been flushed to a page, based on it's
+    /// anticipated encoded size.
     #[cfg(feature = "arrow")]
     pub(crate) fn get_estimated_total_bytes(&self) -> u64 {
         self.column_metrics.total_bytes_written

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -431,7 +431,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// of the current memory usage and not it's anticipated encoded size.
     #[cfg(feature = "arrow")]
     pub(crate) fn memory_size(&self) -> usize {
-        todo!("TODO in next commit")
+        self.column_metrics.total_bytes_written as usize + self.encoder.estimated_memory_size()
     }
 
     /// Returns total number of bytes written by this column writer so far.

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -90,4 +90,9 @@ impl<T: DataType> Encoder<T> for ByteStreamSplitEncoder<T> {
         self.buffer.clear();
         Ok(encoded.into())
     }
+
+    /// return the estimated memory size of this encoder.
+    fn estimated_memory_size(&self) -> usize {
+        self.buffer.capacity() * std::mem::size_of::<u8>()
+    }
 }

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -149,15 +149,6 @@ impl<T: DataType> DictEncoder<T> {
         num_required_bits(self.num_entries().saturating_sub(1) as u64)
     }
 
-    /// Returns the estimated total memory usage
-    ///
-    /// For this encoder, the indices are unencoded bytes (refer to [`Self::write_indices`]).
-    /// 
-    /// Therefore, we have a specific memory estimate (during encoding) of:
-    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes>
-    pub(crate) fn estimated_memory_size(&self) -> usize {
-        self.interner.storage().size_in_bytes + self.indices.len() * 8
-    }
 }
 
 impl<T: DataType> Encoder<T> for DictEncoder<T> {
@@ -187,5 +178,12 @@ impl<T: DataType> Encoder<T> for DictEncoder<T> {
 
     fn flush_buffer(&mut self) -> Result<Bytes> {
         self.write_indices()
+    }
+
+    /// Returns the estimated total memory usage
+    ///
+    /// For this encoder, the indices are unencoded bytes (refer to [`Self::write_indices`]).
+    fn estimated_memory_size(&self) -> usize {
+        self.interner.storage().size_in_bytes + self.indices.len() * 8
     }
 }

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -143,6 +143,11 @@ impl<T: DataType> DictEncoder<T> {
     fn bit_width(&self) -> u8 {
         num_required_bits(self.num_entries().saturating_sub(1) as u64)
     }
+
+    /// Returns the estimated total memory usage
+    pub(crate) fn estimated_memory_size(&self) -> usize {
+        self.interner.storage().size_in_bytes + self.indices.len() * 8
+    }
 }
 
 impl<T: DataType> Encoder<T> for DictEncoder<T> {

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -34,6 +34,7 @@ use crate::util::interner::{Interner, Storage};
 struct KeyStorage<T: DataType> {
     uniques: Vec<T::T>,
 
+    /// size of unique values (keys) in the dictionary, in bytes.
     size_in_bytes: usize,
 
     type_length: usize,
@@ -60,6 +61,10 @@ impl<T: DataType> Storage for KeyStorage<T> {
         let key = self.uniques.len() as u64;
         self.uniques.push(value.clone());
         key
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        self.size_in_bytes + self.uniques.capacity() * std::mem::size_of::<T::T>()
     }
 }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -184,6 +184,6 @@ impl<T: DataType> Encoder<T> for DictEncoder<T> {
     ///
     /// For this encoder, the indices are unencoded bytes (refer to [`Self::write_indices`]).
     fn estimated_memory_size(&self) -> usize {
-        self.interner.storage().size_in_bytes + self.indices.len() * 8
+        self.interner.storage().size_in_bytes + self.indices.len() * std::mem::size_of::<usize>()
     }
 }

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -145,6 +145,11 @@ impl<T: DataType> DictEncoder<T> {
     }
 
     /// Returns the estimated total memory usage
+    ///
+    /// For this encoder, the indices are unencoded bytes (refer to [`Self::write_indices`]).
+    /// 
+    /// Therefore, we have a specific memory estimate (during encoding) of:
+    /// <already_written_encoded_byte_size> + <current_memory_size_of_unflushed_bytes>
     pub(crate) fn estimated_memory_size(&self) -> usize {
         self.interner.storage().size_in_bytes + self.indices.len() * 8
     }
@@ -166,6 +171,10 @@ impl<T: DataType> Encoder<T> for DictEncoder<T> {
         Encoding::PLAIN_DICTIONARY
     }
 
+    /// Returns an estimate of the data page size in bytes
+    ///
+    /// This includes:
+    /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     fn estimated_data_encoded_size(&self) -> usize {
         let bit_width = self.bit_width();
         RleEncoder::max_buffer_size(bit_width, self.indices.len())

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -286,6 +286,13 @@ impl RleEncoder {
         }
         self.repeat_count = 0;
     }
+
+    /// return the estimated memory size of this encoder.
+    pub(crate) fn estimated_memory_size(&self) -> usize {
+        self.bit_writer.estimated_memory_size()
+        + std::mem::size_of::<Self>()
+
+    }
 }
 
 /// Size, in number of `i32s` of buffer to use for RLE batch reading

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -329,6 +329,11 @@ impl BitWriter {
         let u: u64 = ((v << 1) ^ (v >> 63)) as u64;
         self.put_vlq_int(u)
     }
+
+    /// Returns an estimate of the memory used, in bytes
+    pub fn estimated_memory_size(&self) -> usize {
+        self.buffer.capacity() * size_of::<u8>()
+    }
 }
 
 /// Maximum byte length for a VLQ encoded integer

--- a/parquet/src/util/interner.rs
+++ b/parquet/src/util/interner.rs
@@ -32,6 +32,9 @@ pub trait Storage {
 
     /// Adds a new element, returning the key
     fn push(&mut self, value: &Self::Value) -> Self::Key;
+
+    /// Return an estimate of the memory used in this storage, in bytes
+   fn estimated_memory_size(&self) -> usize;
 }
 
 /// A generic value interner supporting various different [`Storage`]
@@ -80,6 +83,13 @@ impl<S: Storage> Interner<S> {
                     .0
             }
         }
+    }
+
+    /// Return estimate of the memory used, in bytes
+    pub fn estimated_memory_size(&self) -> usize {
+        self.storage.estimated_memory_size() +
+            // estimate size of dedup hashmap as just th size of the keys
+            self.dedup.capacity() + std::mem::size_of::<S::Key>()
     }
 
     /// Returns the storage for this interner

--- a/parquet/src/util/interner.rs
+++ b/parquet/src/util/interner.rs
@@ -34,6 +34,7 @@ pub trait Storage {
     fn push(&mut self, value: &Self::Value) -> Self::Key;
 
     /// Return an estimate of the memory used in this storage, in bytes
+    #[allow(dead_code)] // not used in parquet_derive, so is dead there
    fn estimated_memory_size(&self) -> usize;
 }
 
@@ -86,6 +87,7 @@ impl<S: Storage> Interner<S> {
     }
 
     /// Return estimate of the memory used, in bytes
+    #[allow(dead_code)] // not used in parquet_derive, so is dead there
     pub fn estimated_memory_size(&self) -> usize {
         self.storage.estimated_memory_size() +
             // estimate size of dedup hashmap as just th size of the keys


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5851 
(Altho followup PRs may add bytes to the accounting.)

# Rationale for this change
 
We have several profiling test cases which compare datafusion's tracked [MemoryReservation](https://github.com/apache/datafusion/blob/2d1e8505eacc77137425cc0fed2076bdb6af91a0/datafusion/execution/src/memory_pool/mod.rs#L186)s with the actual peak memory usage. The largest single difference was in the tracking of memory used during the parquet encoding (via ArrowWriter). Here is a summary of the discrepancy per test case:

| Use case                       | root caller              | profiled heap peak (actual used) | peak reserved bytes (datafusion estimate) | difference (actual - estimate) |
| ------------------------------ | ------------------------ | -------------------------------- | ----------------------------------------- | ------------------------------ |
| test case 1, incl 61 columns   | TrackedMemoryArrowWriter | 798.9 MB                         | 49.4 MB                                   | -749.5 MB                      |
| test case 2, incl 4869 columns | TrackedMemoryArrowWriter | 4.1 GB                           | 220.1 MB                                  | -3.9 GB                        |
| test case 3, incl 1042 colums  | TrackedMemoryArrowWriter | 3.3 GB 	                       | 98.7 MB 	                               | -3.2 GB                        |

These^^ results provided significant motivation to fulfill the existing upstream feature request, to provide an ArrowWriter API for memory size used during encoding (refer to https://github.com/apache/arrow-rs/issues/5851). Currently, we have been reserving memory bytes based upon the anticipated encoded (compressed) size, as that was the only API available on the ArrowWriter. 

This PR introduce a new `memory_size()` API, defined as both the already encoded size plus the uncompressed/unflushed bytes in buffer. Next, we limited our accounting of unflushed bytes to [the DictEncoder](https://github.com/apache/arrow-rs/blob/0a4d8a14b58e45ef92e31541f0b51a5b25de5f10/parquet/src/encodings/encoding/dict_encoder.rs#L80), (although future PRs may expand this accounting). This change alone had a significant impact on our test case 3:

| Use case                        | root caller              | profiled heap peak (actual used) | peak reserved bytes (datafusion estimate) | difference (actual - estimate) |
| ------------------------------- | ------------------------ | -------------------------------- | ----------------------------------------- | ------------------------------ |
| test case 3, CONTROL            | TrackedMemoryArrowWriter | 3.3 GB 	                        | 98.7 MB 	                                | -3.2 GB                        |
| test case 3, WITH THESE CHANGES | TrackedMemoryArrowWriter | 3.3 GB                           | 2.2 GB                                    | -1.1 GB                        |

Accounting for the DictEncoder unflushed bytes has improved our memory tracking by ~2 GBs in this test case. We anticipate followup PRs which expand this `memory_size()` accounting to cover our other test cases as well.


# What changes are included in this PR?

* Delineate two APIs: the existing method for the anticipated encoded size, vs the new API for the memory size during encoding.
* Then implement the new memory to include accounting for unflushed DictEncoder bytes.

# Are there any user-facing changes?

Yes, the new `ArrowWriter::memory_size()` API.
