### PR TITLE
Implement dictionary support for reading ByteView from parquet

### DIFF
--- a/parquet/src/arrow/buffer/view_buffer.rs
+++ b/parquet/src/arrow/buffer/view_buffer.rs
@@ -33,6 +33,10 @@ pub struct ViewBuffer {
 }
 
 impl ViewBuffer {
+    pub fn is_empty(&self) -> bool {
+        self.views.is_empty()
+    }
+
     #[allow(unused)]
     pub fn append_block(&mut self, block: Buffer) -> u32 {
         let block_id = self.buffers.len() as u32;
@@ -54,6 +58,15 @@ impl ViewBuffer {
         let view = make_view(b, block, offset);
 
         self.views.push(view);
+    }
+
+    /// Directly append a view to the view array.
+    /// This is used when we create a StringViewArray from a dictionary whose values are StringViewArray.
+    ///
+    /// # Safety
+    /// The `view` must be a valid view as per the ByteView spec.
+    pub unsafe fn append_raw_view_unchecked(&mut self, view: &u128) {
+        self.views.push(*view);
     }
 
     /// Converts this into an [`ArrayRef`] with the provided `data_type` and `null_buffer`


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-rs/issues/5904 , sequel to https://github.com/apache/arrow-rs/pull/5968 and https://github.com/apache/arrow-rs/pull/5970 and #5972

~This PR is not ready to review until the above PRs are merged.~

# Rationale for this change
 Implement dictionary encoding support for reading ByteView from parquet.

To show that reading ByteViewArray is faster than reading ByteArray:
```rust
cargo bench --bench arrow_reader --features="arrow test_common experimental" "arrow_array_reader/Binary.*Array/dictionary encoded"
```

We should get something like (~3x faster than ByteArray, many times faster than current implementation):
```
arrow_array_reader/BinaryArray/dictionary encoded, mandatory, no NULLs
                        time:   [270.32 µs 270.34 µs 270.36 µs]

arrow_array_reader/BinaryArray/dictionary encoded, optional, no NULLs
                        time:   [268.11 µs 268.14 µs 268.18 µs]

arrow_array_reader/BinaryArray/dictionary encoded, optional, half NULLs
                        time:   [372.87 µs 372.91 µs 372.95 µs]

arrow_array_reader/BinaryViewArray/dictionary encoded, mandatory, no NULLs
                        time:   [110.81 µs 110.82 µs 110.83 µs]

arrow_array_reader/BinaryViewArray/dictionary encoded, optional, no NULLs
                        time:   [111.89 µs 111.91 µs 111.92 µs]

arrow_array_reader/BinaryViewArray/dictionary encoded, optional, half NULLs
                        time:   [115.55 µs 115.56 µs 115.57 µs]

```

This is expected as the new implementation never copies data; it tries its best to reuse the buffer from the parquet decoder.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
This PR is (even) less straightforward than the previous ones, mostly because we need to map the dictionary view buffer indexes to the output view buffer indexes. Please let me know if any point of the code is too difficult to maintain!


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
