### PR TITLE
Relax WriteMultipart methods signatures

### DIFF
--- a/object_store/src/buffered.rs
+++ b/object_store/src/buffered.rs
@@ -438,7 +438,12 @@ impl AsyncWrite for BufWriter {
                 }
                 BufWriterState::Flush(f) => return f.poll_unpin(cx).map_err(std::io::Error::from),
                 BufWriterState::Write(x) => {
-                    let upload = x.take().unwrap();
+                    let mut upload = x.take().ok_or({
+                        std::io::Error::new(
+                            ErrorKind::InvalidInput,
+                            "Cannot shutdown a writer that has already been shut down",
+                        )
+                    })?;
                     self.state = BufWriterState::Flush(
                         async move {
                             upload.finish().await?;

--- a/object_store/src/buffered.rs
+++ b/object_store/src/buffered.rs
@@ -438,7 +438,7 @@ impl AsyncWrite for BufWriter {
                 }
                 BufWriterState::Flush(f) => return f.poll_unpin(cx).map_err(std::io::Error::from),
                 BufWriterState::Write(x) => {
-                    let mut upload = x.take().ok_or({
+                    let mut upload = x.take().ok_or_else(|| {
                         std::io::Error::new(
                             ErrorKind::InvalidInput,
                             "Cannot shutdown a writer that has already been shut down",

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -748,6 +748,7 @@ impl MultipartUpload for LocalUpload {
 
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
+            println!("Writing part: {}", data.content_length());
             let mut f = s.file.lock();
             let file = f.as_mut().context(AbortedSnafu)?;
             file.seek(SeekFrom::Start(offset))
@@ -767,6 +768,7 @@ impl MultipartUpload for LocalUpload {
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             // Ensure no inflight writes
+            println!("Completing");
             let f = s.file.lock().take().context(AbortedSnafu)?;
             std::fs::rename(&src, &s.dest).context(UnableToRenameFileSnafu)?;
             let metadata = f.metadata().map_err(|e| Error::Metadata {

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -757,7 +757,13 @@ impl MultipartUpload for LocalUpload {
             data.iter()
                 .try_for_each(|x| {
                     println!("write all");
-                    (&*file).write_all(x)
+                    match (&*file).write(x) {
+                        Ok(_) => Ok(()),
+                        Err(e) => {
+                            println!("write all error: {:?}", e);
+                            Err(e)
+                        }
+                    }
                 })
                 .context(UnableToCopyDataToFileSnafu)?;
 

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -204,7 +204,7 @@ impl WriteMultipart {
     }
 
     /// Flush final chunk, and await completion of all in-flight requests
-    pub async fn finish(mut self) -> Result<PutResult> {
+    pub async fn finish(&mut self) -> Result<PutResult> {
         if !self.buffer.is_empty() {
             let part = std::mem::take(&mut self.buffer);
             self.put_part(part.into())

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -205,13 +205,19 @@ impl WriteMultipart {
 
     /// Flush final chunk, and await completion of all in-flight requests
     pub async fn finish(&mut self) -> Result<PutResult> {
+        println!("finishing");
         if !self.buffer.is_empty() {
+            println!("finishing -- not empty");
             let part = std::mem::take(&mut self.buffer);
             self.put_part(part.into())
         }
 
+        println!("finishing -- waiting for capacity");
         self.wait_for_capacity(0).await?;
-        self.upload.complete().await
+        println!("finishing -- complete");
+        let result = self.upload.complete().await;
+        println!("finishing -- done");
+        result
     }
 }
 

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -205,19 +205,13 @@ impl WriteMultipart {
 
     /// Flush final chunk, and await completion of all in-flight requests
     pub async fn finish(&mut self) -> Result<PutResult> {
-        println!("finishing");
         if !self.buffer.is_empty() {
-            println!("finishing -- not empty");
             let part = std::mem::take(&mut self.buffer);
             self.put_part(part.into())
         }
 
-        println!("finishing -- waiting for capacity");
         self.wait_for_capacity(0).await?;
-        println!("finishing -- complete");
-        let result = self.upload.complete().await;
-        println!("finishing -- done");
-        result
+        self.upload.complete().await
     }
 }
 

--- a/object_store/src/upload.rs
+++ b/object_store/src/upload.rs
@@ -198,7 +198,7 @@ impl WriteMultipart {
     }
 
     /// Abort this upload, attempting to clean up any successfully uploaded parts
-    pub async fn abort(mut self) -> Result<()> {
+    pub async fn abort(&mut self) -> Result<()> {
         self.tasks.shutdown().await;
         self.upload.abort().await
     }


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
During a time of migration to a new object store (0.10+), I discovered that some of the api methods can be relaxed for more ergonomic usage

# What changes are included in this PR?

Some methods of signature update, relaxing ownership constraints

# Are there any user-facing changes?

Yes
