### PR TITLE
Automatically cleanup empty dirs in LocalFileSystem

### DIFF
--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -300,8 +300,8 @@ impl LocalFileSystem {
     }
 
     /// Enable automatic cleanup of empty directories when deleting files
-    pub fn with_automatic_cleanup(mut self) -> Self {
-        self.automatic_cleanup = true;
+    pub fn with_automatic_cleanup(mut self, automatic_cleanup: bool) -> Self {
+        self.automatic_cleanup = automatic_cleanup;
         self
     }
 }

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -240,6 +240,7 @@ impl From<Error> for super::Error {
 #[derive(Debug)]
 pub struct LocalFileSystem {
     config: Arc<Config>,
+    // if you want to delete empty directories when deleting files
     automatic_cleanup: bool,
 }
 
@@ -488,6 +489,8 @@ impl ObjectStore for LocalFileSystem {
                 let root = root
                     .to_file_path()
                     .map_err(|_| Error::InvalidUrl { url: root.clone() })?;
+
+                // here we will try to traverse up and delete an empty dir if possible until we reach the root or get an error
                 let mut parent = path.parent();
 
                 while let Some(loc) = parent {

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -1044,7 +1044,6 @@ mod tests {
     use std::fs;
 
     use futures::TryStreamExt;
-    use itertools::Itertools;
     use tempfile::{NamedTempFile, TempDir};
 
     use crate::integration::*;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5976 
Closes https://github.com/apache/arrow-rs/pull/5975

# Rationale for this change
 
We want to automatically clean empty directories

# What changes are included in this PR?

Update for delete method implementation for `LocalFileSystem`

# Are there any user-facing changes?

Yes
