### PR TITLE
Reduce repo size by removing accumulative commits in CI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,3 +95,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build
           publish_branch: asf-site
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,4 +95,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build
           publish_branch: asf-site
+          # Avoid accumulating history of in progress API jobs: https://github.com/apache/arrow-rs/issues/5908
           force_orphan: true


### PR DESCRIPTION
Closes #5908 

The `arrow-rs` repo size grows very huge due to this CI job: 

https://github.com/apache/arrow-rs/blob/master/.github/workflows/docs.yml#L72-L97

Basically, whenever a PR is merged into master, this job will be triggered and will publish a new commit to the branch `asf-site`. Each commit contains files extracted from the tarball file (which contains the rust doc). This gradually grows the repo size since commit is accumulative on previous one and thus the repo overall gets larger.

This PR proposes to use the option `force_orphan` available [here](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan) which allows us to publish our commit with only the latest commit.