### PR TITLE
Minor: fix clippy complaint in parquet_derive

### DIFF
--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -248,7 +248,7 @@ mod tests {
             maybe_u64: Some(4563424),
             isize: -365,
             float: 3.5,
-            double: std::f64::NAN,
+            double: f64::NAN,
             now: chrono::Utc::now().naive_local(),
             date: chrono::naive::NaiveDate::from_ymd_opt(2015, 3, 14).unwrap(),
             uuid: uuid::Uuid::new_v4(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
I ran clippy locally and it was complaining about:

```shell
error: usage of a legacy numeric constant
   --> parquet_derive_test/src/lib.rs:251:21
    |
251 |             double: std::f64::NAN,
    |                     ^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
    = note: `-D clippy::legacy-numeric-constants` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::legacy_numeric_constants)]`
help: use the associated constant instead
    |
251 |             double: f64::NAN,
    |                     ~~~~~~~~

```

# What changes are included in this PR?

do what clippy says

# Are there any user-facing changes?

No -- this is test only
