### PR TITLE
Complete `StringViewArray` and `BinaryViewArray` parquet decoder:  implement delta byte array and delta length byte array encoding

### DIFF
--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use arrow_schema::{DataType, Fields, SchemaBuilder};
 
-use crate::arrow::array_reader::byte_array::make_byte_view_array_reader;
+use crate::arrow::array_reader::byte_view_array::make_byte_view_array_reader;
 use crate::arrow::array_reader::empty_array::make_empty_array_reader;
 use crate::arrow::array_reader::fixed_len_byte_array::make_fixed_len_byte_array_reader;
 use crate::arrow::array_reader::{

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -617,7 +617,7 @@ impl ByteViewArrayDecoderDelta {
         let read = self.decoder.read(len, |bytes| {
             let offset = array_buffer.len();
             let view = make_view(bytes, buffer_id, offset as u32);
-            if len > 12 {
+            if bytes.len() > 12 {
                 // only copy the data to buffer if the string can not be inlined.
                 array_buffer.extend_from_slice(bytes);
             }
@@ -651,15 +651,6 @@ impl ByteViewArrayDecoderDelta {
 
 /// Check that `val` is a valid UTF-8 sequence
 pub fn check_valid_utf8(val: &[u8]) -> Result<()> {
-    if let Some(&b) = val.first() {
-        // A valid code-point iff it does not start with 0b10xxxxxx
-        // Bit-magic taken from `std::str::is_char_boundary`
-        if (b as i8) < -0x40 {
-            return Err(ParquetError::General(
-                "encountered non UTF-8 data".to_string(),
-            ));
-        }
-    }
     match std::str::from_utf8(val) {
         Ok(_) => Ok(()),
         Err(e) => Err(general_err!("encountered non UTF-8 data: {}", e)),

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -598,7 +598,14 @@ impl ByteViewArrayDecoderDelta {
         })
     }
 
-    // Unlike other encodings, we need to copy the data because we can not reuse the DeltaByteArray data in Arrow.
+    // Unlike other encodings, we need to copy the data.
+    //
+    //  DeltaByteArray data is stored using shared prefixes/suffixes, 
+    // which results in potentially non-contiguous
+    // strings, while Arrow encodings require contiguous strings
+    //
+    // <https://parquet.apache.org/docs/file-format/data-pages/encodings/#delta-strings-delta_byte_array--7>
+    
     fn read(&mut self, output: &mut ViewBuffer, len: usize) -> Result<usize> {
         output.views.reserve(len.min(self.decoder.remaining()));
 

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -2460,22 +2460,12 @@ mod tests {
             ),
             (
                 invalid_utf8_later_char::<i32>(),
-                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 6",
+                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 3",
             ),
         ];
         for (array, expected_error) in cases {
-            // cast not yet implemented for BinaryView
-            // https://github.com/apache/arrow-rs/issues/5508
-            // so copy directly
-            let mut builder = BinaryViewBuilder::with_capacity(100);
-            for v in array.iter() {
-                if let Some(v) = v {
-                    builder.append_value(v);
-                } else {
-                    builder.append_null();
-                }
-            }
-            let array = builder.finish();
+            let array = arrow_cast::cast(&array, &ArrowDataType::BinaryView).unwrap();
+            let array = array.as_binary_view();
 
             // data is not valid utf8 we can not construct a correct StringArray
             // safely, so purposely create an invalid StringArray

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -2456,7 +2456,7 @@ mod tests {
         let cases = [
             (
                 invalid_utf8_first_char::<i32>(),
-                "Parquet argument error: Parquet error: encountered non UTF-8 data",
+                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 0",
             ),
             (
                 invalid_utf8_later_char::<i32>(),

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -2456,11 +2456,11 @@ mod tests {
         let cases = [
             (
                 invalid_utf8_first_char::<i32>(),
-                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 0",
+                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 11",
             ),
             (
                 invalid_utf8_later_char::<i32>(),
-                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 3",
+                "Parquet argument error: Parquet error: encountered non UTF-8 data: invalid utf-8 sequence of 1 bytes from index 14",
             ),
         ];
         for (array, expected_error) in cases {

--- a/parquet/src/arrow/buffer/view_buffer.rs
+++ b/parquet/src/arrow/buffer/view_buffer.rs
@@ -37,7 +37,6 @@ impl ViewBuffer {
         self.views.is_empty()
     }
 
-    #[allow(unused)]
     pub fn append_block(&mut self, block: Buffer) -> u32 {
         let block_id = self.buffers.len() as u32;
         self.buffers.push(block);
@@ -49,7 +48,6 @@ impl ViewBuffer {
     /// - `block` is a valid index, i.e., the return value of `append_block`
     /// - `offset` and `offset + len` are valid indices into the buffer
     /// - The `(offset, offset + len)` is valid value for the native type.
-    #[allow(unused)]
     pub unsafe fn append_view_unchecked(&mut self, block: u32, offset: u32, len: u32) {
         let b = self.buffers.get_unchecked(block as usize);
         let end = offset.saturating_add(len);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5904.

# Rationale for this change
 Implement the remaining two encodings for view types. Notably, the `DELTA_BYTE_ARRAY` encoding must recreate a buffer because its layout is incompatible with the arrow layout.

The new byte_view_array reader is now feature complete and it is much faster than previous implementation.
I  updated the code and made the final switch to the new implementation. Now reading string view will always use the most optimized version.


<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
