### PR TITLE
Deduplicate strings/binarys when building view types

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -326,7 +326,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     /// array is significantly smaller than when it is originally created, e.g., after filtering or slicing.
     pub fn gc(&self) -> Self {
         let mut builder =
-            GenericByteViewBuilder::<T>::with_capacity(self.len()).deduplicate_strings();
+            GenericByteViewBuilder::<T>::with_capacity(self.len()).with_deduplicate_strings();
 
         for v in self.iter() {
             builder.append_option(v);

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -325,7 +325,8 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     /// Use with caution as this can be an expensive operation, only use it when you are sure that the view
     /// array is significantly smaller than when it is originally created, e.g., after filtering or slicing.
     pub fn gc(&self) -> Self {
-        let mut builder = GenericByteViewBuilder::<T>::with_capacity(self.len());
+        let mut builder =
+            GenericByteViewBuilder::<T>::with_capacity(self.len()).deduplicate_strings();
 
         for v in self.iter() {
             builder.append_option(v);

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -449,7 +449,7 @@ mod tests {
             ]
         );
 
-        let view0 = array.views().get(0).unwrap();
+        let view0 = array.views().first().unwrap();
         let view2 = array.views().get(2).unwrap();
         let view4 = array.views().get(4).unwrap();
 

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -58,7 +58,9 @@ pub struct GenericByteViewBuilder<T: ByteViewType + ?Sized> {
     completed: Vec<Buffer>,
     in_progress: Vec<u8>,
     block_size: u32,
-    string_tracker: Option<(HashTable<usize>, ahash::RandomState)>, // map <string hash> -> <index to the views>
+    /// Some if deduplicating strings
+    /// map `<string hash> -> <index to the views>`
+    string_tracker: Option<(HashTable<usize>, ahash::RandomState)>
     phantom: PhantomData<T>,
 }
 
@@ -87,6 +89,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     }
 
     /// Deduplicate strings while building the array
+    ///
     /// This will potentially decrease the memory usage if the array have repeated strings
     /// It will also increase the time to build the array as it needs to hash the strings
     pub fn deduplicate_strings(self) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5910.

# Rationale for this change
As discussed in #5910, when the array of strings have low number of unique values, it makes sense to deduplicate them while building it, especially when invoking `gc`

This pr implements an optional mechanism to deduplicate the strings. This is turned off by default, as it may slow down building array if the array is mostly unique.
However, the `gc` will by default enable it, so that gc generates an optimal layout.  
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
