### PR TITLE
Fast utf8 validation when loading string view from parquet

### DIFF
--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -347,7 +347,7 @@ impl ByteViewArrayDecoderPlain {
                 //     I.e., the validation cannot validate the buffer in one pass, but instead, validate strings chunk by chunk.
                 //
                 // Given the above observations, the goal is to do batch validation as much as possible.
-                // The key idea is that if the length is smaller than 128 (99% of the case), then the length bytes are valid utf-8, as reasoned blow:
+                // The key idea is that if the length is smaller than 128 (99% of the case), then the length bytes are valid utf-8, as reasoned below:
                 // If the length is smaller than 128, its 4-byte encoding are [0, 0, 0, len].
                 // Each of the byte is a valid ASCII character, so they are valid utf-8.
                 // Since they are all smaller than 128, the won't break a utf-8 code point (won't mess with later bytes).

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -314,6 +314,8 @@ impl ByteViewArrayDecoderPlain {
         let buf = self.buf.as_ref();
         let mut read = 0;
         output.views.reserve(to_read);
+
+        let mut utf8_validation_begin = self.offset;
         while self.offset < self.buf.len() && read != to_read {
             if self.offset + 4 > self.buf.len() {
                 return Err(ParquetError::EOF("eof decoding byte array".into()));
@@ -332,7 +334,34 @@ impl ByteViewArrayDecoderPlain {
             }
 
             if self.validate_utf8 {
-                check_valid_utf8(unsafe { buf.get_unchecked(start_offset..end_offset) })?;
+                // It seems you are trying to understand what's going on here, take a breath and be patient.
+                // Utf-8 validation is a non-trivial task, here are some background facts:
+                // (1) Validating one 100 bytes of utf-8 is much faster than validating ten 10 bytes of utf-8.
+                //     Potentially because of the auto SIMD by compiler, someone please confirm this :)
+                // (2) Practical strings are short, 99% of strings are smaller than 100 bytes, as shown in paper:
+                //     https://www.vldb.org/pvldb/vol17/p148-zeng.pdf, Figure 5f.
+                // (3) Parquet plain encoding makes utf-8 validation harder,
+                //     because it stores the length of each string right before the string.
+                //     This means naive utf-8 validation will be slow, because the validation need to skip the length bytes.
+                //     I.e., the validation cannot validate the buffer in one pass, but instead, validate strings chunk by chunk.
+                //
+                // Given the above observations, the goal is to do batch validation as much as possible.
+                // The key idea is that if the length is smaller than 128 (99% of the case), then the length bytes are valid utf-8 (bc they are ASCII).
+                //
+                // The implementation keeps a water mark `utf8_validation_begin` to track the beginning of the buffer that is not validated.
+                // If the length is smaller than 128, then we continue to next string.
+                // If the length is larger than 128, then we validate the buffer before the length bytes, and move the water mark to the beginning of next string.
+                if len < 128 {
+                    // fast path, move to next string.
+                    // the len bytes are valid utf8.
+                } else {
+                    // unfortunately, the len bytes may not be valid utf8, we need to wrap up and validate everything before it.
+                    check_valid_utf8(unsafe {
+                        buf.get_unchecked(utf8_validation_begin..self.offset)
+                    })?;
+                    // move the cursor to skip the len bytes.
+                    utf8_validation_begin = start_offset;
+                }
             }
 
             unsafe {
@@ -340,6 +369,11 @@ impl ByteViewArrayDecoderPlain {
             }
             self.offset = end_offset;
             read += 1;
+        }
+
+        // validate the last part of the buffer
+        if self.validate_utf8 {
+            check_valid_utf8(unsafe { buf.get_unchecked(utf8_validation_begin..self.offset) })?;
         }
 
         self.max_remaining_values -= to_read;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5995.

# Rationale for this change

Current utf-8 validation for string view is super slow, even slower than reading StringArray from parquet, which copies & consolidates the strings to a new buffer.

It does not have to be slow, but making it fast requires a bit of art. I tried many approaches, and this PR is the most simple and easy to understand one.

Please check the comments to see if they make sense (and helps understanding what's going on).

To run the benchmark:
```bash
cargo bench --bench arrow_reader --features="arrow test_common experimental" "arrow_array_reader/String.*Array/plain"
```

We will get this:
```
arrow_array_reader/StringViewArray/plain encoded, mandatory, no NULLs
                        time:   [287.81 µs 288.21 µs 288.66 µs]
                        change: [-84.308% -84.292% -84.273%] (p = 0.00 < 0.05)
                        Performance has improved.

arrow_array_reader/StringViewArray/plain encoded, optional, no NULLs
                        time:   [289.25 µs 289.60 µs 289.95 µs]
                        change: [-84.303% -84.286% -84.268%] (p = 0.00 < 0.05)
                        Performance has improved.

arrow_array_reader/StringViewArray/plain encoded, optional, half NULLs
                        time:   [207.22 µs 207.39 µs 207.54 µs]
                        change: [-78.958% -78.940% -78.924%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Not only does loading StringViewArray 5x faster than the previous implementation, but also almost 2x faster than loading StringArray:

```
arrow_array_reader/StringArray/plain encoded, mandatory, no NULLs
                        time:   [345.03 µs 345.54 µs 346.20 µs]

arrow_array_reader/StringArray/plain encoded, optional, no NULLs
                        time:   [366.46 µs 368.51 µs 370.30 µs]

arrow_array_reader/StringArray/plain encoded, optional, half NULLs
                        time:   [427.10 µs 427.21 µs 427.32 µs]
```
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The code change is quite small, just some small tweaks to adjust the timing of utf-8 validation.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
