### PR TITLE
Do not write `ColumnIndex` for null columns when not writing page statistics

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -260,6 +260,12 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         // Used for level information
         encodings.insert(Encoding::RLE);
 
+        // Disable column_index_builder if not collecting page statistics.
+        let mut column_index_builder = ColumnIndexBuilder::new();
+        if statistics_enabled != EnabledStatistics::Page {
+            column_index_builder.to_invalid()
+        }
+
         Self {
             descr,
             props,
@@ -289,7 +295,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                 num_column_nulls: 0,
                 column_distinct_count: None,
             },
-            column_index_builder: ColumnIndexBuilder::new(),
+            column_index_builder,
             offset_index_builder: OffsetIndexBuilder::new(),
             encodings,
             data_page_boundary_ascending: true,

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -3037,7 +3037,7 @@ mod tests {
                 .set_statistics_enabled(EnabledStatistics::None)
                 .build(),
         );
-        let column_writer = get_column_writer(descr.clone(), props, get_test_page_writer());
+        let column_writer = get_column_writer(descr, props, get_test_page_writer());
         let mut writer = get_typed_column_writer::<Int32Type>(column_writer);
 
         let data = Vec::new();


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6010.

# Rationale for this change
The `ColumnIndex` for an all-nulls column will be written even when page statistics are disabled. This is not the case for columns that have non-null values.

# What changes are included in this PR?
This PR calls `to_invalid()` on the constructed `ColumnIndexBuilder` when page statistics are not requested (`statistics_enabled != EnabledStatistics::Page`). This allows for not writing the null-column statistics in `update_column_offset_index()`. https://github.com/apache/arrow-rs/blob/bed37466af718be3deff00f1b21c7b38d37eb8a5/parquet/src/column/writer/mod.rs#L643-L650.

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
