### PR TITLE
Add slice support for `Rows` struct

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -873,7 +873,7 @@ impl Rows {
         let mut new_buffers = vec![];
         let mut new_offsets = vec![0];
         for idx in offset..offset+n {
-            new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]]);
+            new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]].to_vec());
             new_offsets.push(new_buffers.len());
         }
         Self{

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -883,6 +883,11 @@ impl Rows {
             config: self.config.clone(),
         }
     }
+
+    pub fn print(&self) {
+        println!("self.buffer: {:?}", self.buffer);
+        println!("self.offsets: {:?}", self.offsets);
+    }
 }
 
 impl<'a> IntoIterator for &'a Rows {

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -873,6 +873,7 @@ impl Rows {
         let mut new_buffers = vec![];
         let mut new_offsets = vec![0];
         for idx in offset..offset+n {
+            println!("idx: {:?}", idx);
             new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]].to_vec());
             new_offsets.push(new_buffers.len());
         }

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -876,6 +876,7 @@ impl Rows {
             new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]].to_vec());
             new_offsets.push(new_buffers.len());
         }
+        debug_assert_eq!(new_offsets.len(), n+1);
         Self{
             buffer: new_buffers,
             offsets: new_offsets,

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -871,7 +871,7 @@ impl Rows {
 
     pub fn slice(&self, offset: usize, n: usize) -> Rows{
         let mut new_buffers = vec![];
-        let mut new_offsets: vec![0];
+        let mut new_offsets = vec![0];
         for idx in offset..offset+n {
             new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]]);
             new_offsets.push(new_buffers.len());

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -868,6 +868,20 @@ impl Rows {
             + self.buffer.len()
             + self.offsets.len() * std::mem::size_of::<usize>()
     }
+
+    pub fn slice(&self, offset: usize, n: usize) -> Rows{
+        let mut new_buffers = vec![];
+        let mut new_offsets: vec![0];
+        for idx in offset..offset+n {
+            new_buffers.extend(self.buffer[self.offsets[idx]..self.offsets[idx+1]]);
+            new_offsets.push(new_buffers.len());
+        }
+        Self{
+            buffer: new_buffers,
+            offsets: new_offsets,
+            config: self.config.clone(),
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a Rows {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 `Rows` struct is a row representation of the some of the columns in a `RecordBatch`. This is generally used to compare rows in more optimized way. For instance, when a `RecordBatch` is converted to the `Rows`. They will have same number of rows and `Rows.row(idx)` API will return the row `idx` in the original `RecordBatch` (or subset of the columns depends on the construction).

I am working on the Checkpointing using Datafusion. In my use case, I sometimes use a slice of the `RecordBatch`. To be able to keep `Rows`, `RecordBatch` in sync. I need to have `.slice` support for `Rows` struct also (Similar to `RecordBatch`). 

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
