### PR TITLE
MINOR: Fix `hashbrown` version in `arrow-array`, remove from `arrow-row`

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -48,7 +48,7 @@ chrono = { workspace = true }
 chrono-tz = { version = "0.9", optional = true }
 num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-hashbrown = { version = "0.14", default-features = false }
+hashbrown = { version = "0.14.2", default-features = false }
 
 [features]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]

--- a/arrow-row/Cargo.toml
+++ b/arrow-row/Cargo.toml
@@ -46,7 +46,6 @@ arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
 
 half = { version = "2.1", default-features = false }
-hashbrown = { version = "0.14", default-features = false }
 
 [dev-dependencies]
 arrow-cast = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
`arrow-array` uses the `HashTable` introduced in `hashbrown` `0.14.2` (https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0142---2023-10-19).

# What changes are included in this PR?

Bumps the requirement to `0.14.2`.

# Are there any user-facing changes?

Also removed the unused `hashbrown` dependency from `arrow-row`.