### PR TITLE
Remove `impl<T: AsRef<[u8]>> From<T> for Buffer`  that easily accidentally copies data

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -356,6 +356,14 @@ impl Buffer {
     }
 }
 
+/// Note that here we deliberately do not implement
+/// `impl<T: AsRef<[u8]>> From<T> for Buffer`
+/// As it would accept `Buffer::from(vec![...])` that would cause an unexpected copy.
+/// Instead, we ask user to be explicit when copying is occurring, e.g., `Buffer::from(vec![...].to_byte_slice())`.
+/// For zero-copy conversion, user should use `Buffer::from_vec(vec![...])`.
+///
+/// Since we removed impl for `AsRef<u8>`, we added the following three specific implementations to reduce API breakage.
+/// See https://github.com/apache/arrow-rs/issues/6033 for more discussion on this.
 impl From<&[u8]> for Buffer {
     fn from(p: &[u8]) -> Self {
         Self::from_slice_ref(p)

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -363,7 +363,7 @@ impl Buffer {
 /// For zero-copy conversion, user should use `Buffer::from_vec(vec![...])`.
 ///
 /// Since we removed impl for `AsRef<u8>`, we added the following three specific implementations to reduce API breakage.
-/// See https://github.com/apache/arrow-rs/issues/6033 for more discussion on this.
+/// See <https://github.com/apache/arrow-rs/issues/6033> for more discussion on this.
 impl From<&[u8]> for Buffer {
     fn from(p: &[u8]) -> Self {
         Self::from_slice_ref(p)

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -356,16 +356,21 @@ impl Buffer {
     }
 }
 
-/// Creating a `Buffer` instance by copying the memory from a `AsRef<[u8]>` into a newly
-/// allocated memory region.
-impl<T: AsRef<[u8]>> From<T> for Buffer {
-    fn from(p: T) -> Self {
-        // allocate aligned memory buffer
-        let slice = p.as_ref();
-        let len = slice.len();
-        let mut buffer = MutableBuffer::new(len);
-        buffer.extend_from_slice(slice);
-        buffer.into()
+impl From<&[u8]> for Buffer {
+    fn from(p: &[u8]) -> Self {
+        Self::from_slice_ref(p)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Buffer {
+    fn from(p: [u8; N]) -> Self {
+        Self::from_slice_ref(p)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for Buffer {
+    fn from(p: &[u8; N]) -> Self {
+        Self::from_slice_ref(p)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change


This API makes it easy to accidentally copy data as described in #6033. For example 

```rust
let data = vec![...]
let buffer = Buffer::from(vec);
```
Would copy the bytes in the vec rather than taking ownership.

#6039 removed uses of this API in the arrow-rs codebase. 

We should also remove the API






# What changes are included in this PR?
1. Removes `impl<T: AsRef<[u8]>> From<T> for Buffer` 
2. Add some APIs to ease the migration for existing codebase (like `impl From<[u8]>`)


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
