### PR TITLE
Directly decode String/BinaryView types from arrow-row format

### DIFF
--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -349,12 +349,11 @@ pub unsafe fn decode_string_view(
     validate_utf8: bool,
 ) -> StringViewArray {
     let decoded = decode_binary_view(rows, options);
-    return decoded.to_string_view_unchecked();
-    // if !validate_utf8 {
-    //     return decoded.to_string_view_unchecked();
-    // }
+    if !validate_utf8 {
+        return decoded.to_string_view_unchecked();
+    }
 
-    // decoded
-    //     .to_string_view()
-    //     .expect("Decoding string view encountered invalid utf8!")
+    decoded
+        .to_string_view()
+        .expect("Decoding string view encountered invalid utf8!")
 }

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -20,7 +20,7 @@ use arrow_array::builder::BufferBuilder;
 use arrow_array::*;
 use arrow_buffer::bit_util::ceil;
 use arrow_buffer::MutableBuffer;
-use arrow_data::{ArrayDataBuilder, ByteView};
+use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType, SortOptions};
 use builder::make_view;
 
@@ -259,54 +259,56 @@ fn decode_binary_view_inner(
         valid
     });
 
-    let values_capacity: usize = rows.iter().map(|row| decoded_len(row, options)).sum();
-    let mut values = MutableBuffer::new(values_capacity);
+    // we create two buffer, the inline buffer is used for quick utf8 validation.
+    let mut output_buffer_cap = 0;
+    let mut inline_buffer_cap = 0;
+    for r in rows.iter() {
+        let len = decoded_len(r, options);
+        if len > 12 {
+            output_buffer_cap += len;
+        } else {
+            inline_buffer_cap += len;
+        }
+    }
+
+    let mut output_buffer = MutableBuffer::new(output_buffer_cap);
+    let mut inline_buffer = MutableBuffer::new(inline_buffer_cap);
     let mut views = BufferBuilder::<u128>::new(len);
 
     for row in rows {
-        let start_offset = values.len();
-        let offset = decode_blocks(row, options, |b| values.extend_from_slice(b));
+        let start_offset = output_buffer.len();
+        let offset = decode_blocks(row, options, |b| {
+            let val = if b.len() <= 12 {
+                let old_len = inline_buffer.len();
+                inline_buffer.extend_from_slice(b);
+                // Safety: we just extended the buffer with the length of `b`
+                unsafe { inline_buffer.get_unchecked_mut(old_len..) }
+            } else {
+                output_buffer.extend_from_slice(b);
+                debug_assert_eq!(b, &output_buffer[start_offset..]);
+                // Safety: we just extended the buffer with the length of `b`
+                unsafe { output_buffer.get_unchecked_mut(start_offset..) }
+            };
+            if options.descending {
+                val.iter_mut().for_each(|o| *o = !*o);
+            }
+
+            let view = make_view(val, 0, start_offset as u32);
+            views.append(view);
+        });
         if row[0] == null_sentinel(options) {
             debug_assert_eq!(offset, 1);
-            debug_assert_eq!(start_offset, values.len());
+            debug_assert_eq!(start_offset, output_buffer.len());
             views.append(0);
-        } else {
-            let view = make_view(
-                unsafe { values.get_unchecked(start_offset..) },
-                0,
-                start_offset as u32,
-            );
-            views.append(view);
         }
         *row = &row[offset..];
     }
 
-    if options.descending {
-        values.as_slice_mut().iter_mut().for_each(|o| *o = !*o);
-        for view in views.as_slice_mut() {
-            let len = *view as u32;
-            if len <= 12 {
-                let mut bytes = view.to_le_bytes();
-                bytes
-                    .iter_mut()
-                    .skip(4)
-                    .take(len as usize)
-                    .for_each(|o| *o = !*o);
-                *view = u128::from_le_bytes(bytes);
-            } else {
-                let mut byte_view = ByteView::from(*view);
-                let mut prefix = byte_view.prefix.to_le_bytes();
-                prefix.iter_mut().for_each(|o| *o = !*o);
-                byte_view.prefix = u32::from_le_bytes(prefix);
-                *view = byte_view.into();
-            }
-        }
-    }
-
     if check_utf8 {
-        // the values contains all data, no matter if it is short or long
-        // we can validate utf8 in one go.
-        std::str::from_utf8(values.as_slice()).unwrap();
+        // We validate the utf8 of the output buffer and the inline buffer
+        // This is much faster than validating each string individually
+        std::str::from_utf8(output_buffer.as_slice()).unwrap();
+        std::str::from_utf8(inline_buffer.as_slice()).unwrap();
     }
 
     let builder = ArrayDataBuilder::new(DataType::BinaryView)
@@ -314,7 +316,7 @@ fn decode_binary_view_inner(
         .null_count(null_count)
         .null_bit_buffer(Some(nulls.into()))
         .add_buffer(views.finish())
-        .add_buffer(values.into());
+        .add_buffer(output_buffer.into());
 
     // SAFETY:
     // Valid by construction above

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -263,16 +263,16 @@ fn decode_binary_view_inner(
     let mut output_buffer_cap = 0;
     let mut inline_buffer_cap = 0;
     for r in rows.iter() {
-        let len = decoded_len(r, options);
-        if len > 12 {
-            output_buffer_cap += len;
+        let l = decoded_len(r, options);
+        if l <= 12 {
+            inline_buffer_cap += l;
         } else {
-            inline_buffer_cap += len;
+            output_buffer_cap += l;
         }
     }
 
-    let mut output_buffer = MutableBuffer::new(output_buffer_cap);
     let mut inline_buffer = MutableBuffer::new(inline_buffer_cap);
+    let mut output_buffer = MutableBuffer::new(output_buffer_cap);
     let mut views = BufferBuilder::<u128>::new(len);
 
     for row in rows {
@@ -307,8 +307,8 @@ fn decode_binary_view_inner(
     if check_utf8 {
         // We validate the utf8 of the output buffer and the inline buffer
         // This is much faster than validating each string individually
-        std::str::from_utf8(output_buffer.as_slice()).unwrap();
         std::str::from_utf8(inline_buffer.as_slice()).unwrap();
+        std::str::from_utf8(output_buffer.as_slice()).unwrap();
     }
 
     let builder = ArrayDataBuilder::new(DataType::BinaryView)

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::{Int64Type, UInt64Type};
 use arrow::row::{RowConverter, SortField};
 use arrow::util::bench_util::{
     create_boolean_array, create_dict_from_values, create_primitive_array,
-    create_string_array_with_len, create_string_dict_array,
+    create_string_array_with_len, create_string_dict_array, create_string_view_array_with_len,
 };
 use arrow_array::types::Int32Type;
 use arrow_array::Array;
@@ -86,6 +86,18 @@ fn row_bench(c: &mut Criterion) {
 
     let cols = vec![Arc::new(create_string_array_with_len::<i32>(4096, 0.5, 100)) as ArrayRef];
     do_bench(c, "4096 string(100, 0.5)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 10, false)) as ArrayRef];
+    do_bench(c, "4096 string view(10, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef];
+    do_bench(c, "4096 string view(30, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 100, false)) as ArrayRef];
+    do_bench(c, "4096 string view(100, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0.5, 100, false)) as ArrayRef];
+    do_bench(c, "4096 string view(100, 0.5)", cols);
 
     let cols = vec![Arc::new(create_string_dict_array::<Int32Type>(4096, 0., 10)) as ArrayRef];
     do_bench(c, "4096 string_dictionary(10, 0)", cols);

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -93,8 +93,8 @@ fn row_bench(c: &mut Criterion) {
     let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef];
     do_bench(c, "4096 string view(30, 0)", cols);
 
-    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 100, false)) as ArrayRef];
-    do_bench(c, "4096 string view(100, 0)", cols);
+    let cols = vec![Arc::new(create_string_view_array_with_len(40960, 0., 100, false)) as ArrayRef];
+    do_bench(c, "40960 string view(100, 0)", cols);
 
     let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0.5, 100, false)) as ArrayRef];
     do_bench(c, "4096 string view(100, 0.5)", cols);

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -46,7 +46,7 @@ walkdir = "2"
 # Cloud storage support
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
 hyper = { version = "1.2", default-features = false, optional = true }
-quick-xml = { version = "0.35.0", features = ["serialize", "overlapped-lists"], optional = true }
+quick-xml = { version = "0.36.0", features = ["serialize", "overlapped-lists"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5945.

# Rationale for this change
Previous implementation was lazy: first decode to StringArray, then cast StringArray to StringViewArray.
I thought it should be fine, but it turns out to be a performance blocker as well, bc even if casting does not copy the underlying buffer, we waste time building the offset buffer.

This pr directly build StringViewArray from arrow-row format. Now its performance is similar to StringArray -- why still a little slower? bc the offset array of StringArray is 4 byte for each string, but the view is 16 byte for each string.



<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
1. Benchmark for decoding StringView from arrow-row format.
2. implementation that directly builds StringView from arrow-row format.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
