### PR TITLE
StringView support in arrow-csv

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -795,6 +795,14 @@ fn parse(
                         })
                         .collect::<StringArray>(),
                 ) as ArrayRef),
+                DataType::Utf8View => Ok(Arc::new(
+                    rows.iter()
+                        .map(|row| {
+                            let s = row.get(i);
+                            (!null_regex.is_null(s)).then_some(s)
+                        })
+                        .collect::<StringViewArray>(),
+                ) as ArrayRef),
                 DataType::Dictionary(key_type, value_type)
                     if value_type.as_ref() == &DataType::Utf8 =>
                 {
@@ -2380,17 +2388,27 @@ mod tests {
     }
 
     fn err_test(csv: &[u8], expected: &str) {
-        let schema = Arc::new(Schema::new(vec![
+        fn err_test_with_schema(csv: &[u8], expected: &str, schema: Arc<Schema>) {
+            let buffer = std::io::BufReader::with_capacity(2, Cursor::new(csv));
+            let b = ReaderBuilder::new(schema)
+                .with_batch_size(2)
+                .build_buffered(buffer)
+                .unwrap();
+            let err = b.collect::<Result<Vec<_>, _>>().unwrap_err().to_string();
+            assert_eq!(err, expected)
+        }
+
+        let schema_utf8 = Arc::new(Schema::new(vec![
             Field::new("text1", DataType::Utf8, true),
             Field::new("text2", DataType::Utf8, true),
         ]));
-        let buffer = std::io::BufReader::with_capacity(2, Cursor::new(csv));
-        let b = ReaderBuilder::new(schema)
-            .with_batch_size(2)
-            .build_buffered(buffer)
-            .unwrap();
-        let err = b.collect::<Result<Vec<_>, _>>().unwrap_err().to_string();
-        assert_eq!(err, expected)
+        err_test_with_schema(csv, expected, schema_utf8);
+
+        let schema_utf8view = Arc::new(Schema::new(vec![
+            Field::new("text1", DataType::Utf8View, true),
+            Field::new("text2", DataType::Utf8View, true),
+        ]));
+        err_test_with_schema(csv, expected, schema_utf8view);
     }
 
     #[test]
@@ -2586,5 +2604,65 @@ mod tests {
                 .values(),
             &vec![2, 22]
         );
+    }
+
+    #[test]
+    fn test_parse_string_view_1() {
+        let csv = ["foo", "something_cannot_be_inlined", "foobar"].join("\n");
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "c1",
+            DataType::Utf8View,
+            true,
+        )]));
+
+        let mut decoder = ReaderBuilder::new(schema).build_decoder();
+
+        let decoded = decoder.decode(csv.as_bytes()).unwrap();
+        assert_eq!(decoded, csv.len());
+        decoder.decode(&[]).unwrap();
+
+        let batch = decoder.flush().unwrap().unwrap();
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.num_rows(), 3);
+        let col = batch.column(0).as_string_view();
+        assert_eq!(col.data_type(), &DataType::Utf8View);
+        assert_eq!(col.value(0), "foo");
+        assert_eq!(col.value(1), "something_cannot_be_inlined");
+        assert_eq!(col.value(2), "foobar");
+    }
+
+    #[test]
+    fn test_parse_string_view_2() {
+        let csv = ["foo,", ",something_cannot_be_inlined", "foobarfoobar,bar"].join("\n");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("c1", DataType::Utf8View, true),
+            Field::new("c2", DataType::Utf8View, true),
+        ]));
+
+        let mut decoder = ReaderBuilder::new(schema).build_decoder();
+
+        let decoded = decoder.decode(csv.as_bytes()).unwrap();
+        assert_eq!(decoded, csv.len());
+        decoder.decode(&[]).unwrap();
+
+        let batch = decoder.flush().unwrap().unwrap();
+        assert_eq!(batch.num_columns(), 2);
+        assert_eq!(batch.num_rows(), 3);
+        let c1 = batch.column(0).as_string_view();
+        let c2 = batch.column(1).as_string_view();
+        assert_eq!(c1.data_type(), &DataType::Utf8View);
+        assert_eq!(c2.data_type(), &DataType::Utf8View);
+
+        assert!(!c1.is_null(0));
+        assert!(c1.is_null(1));
+        assert!(!c1.is_null(2));
+        assert_eq!(c1.value(0), "foo");
+        assert_eq!(c1.value(2), "foobarfoobar");
+
+        assert!(c2.is_null(0));
+        assert!(!c2.is_null(1));
+        assert!(!c2.is_null(2));
+        assert_eq!(c2.value(1), "something_cannot_be_inlined");
+        assert_eq!(c2.value(2), "bar");
     }
 }

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -2607,7 +2607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_string_view_1() {
+    fn test_parse_string_view_single_column() {
         let csv = ["foo", "something_cannot_be_inlined", "foobar"].join("\n");
         let schema = Arc::new(Schema::new(vec![Field::new(
             "c1",
@@ -2632,7 +2632,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_string_view_2() {
+    fn test_parse_string_view_multi_column() {
         let csv = ["foo,", ",something_cannot_be_inlined", "foobarfoobar,bar"].join("\n");
         let schema = Arc::new(Schema::new(vec![
             Field::new("c1", DataType::Utf8View, true),

--- a/arrow/benches/csv_reader.rs
+++ b/arrow/benches/csv_reader.rs
@@ -21,6 +21,7 @@ extern crate criterion;
 use std::io::Cursor;
 use std::sync::Arc;
 
+use arrow::util::bench_util::create_string_view_array_with_len;
 use criterion::*;
 use rand::Rng;
 
@@ -59,6 +60,7 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = seedable_rng();
 
+    // Single Primitive Column tests
     let values = Int32Array::from_iter_values((0..4096).map(|_| rng.gen_range(0..1024)));
     let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 i32_small(0)", cols);
@@ -101,6 +103,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let cols = vec![Arc::new(values) as ArrayRef];
     do_bench(c, "4096 f64(0)", cols);
 
+    // Single String Column tests
     let cols = vec![Arc::new(create_string_array_with_len::<i32>(4096, 0., 10)) as ArrayRef];
     do_bench(c, "4096 string(10, 0)", cols);
 
@@ -113,6 +116,20 @@ fn criterion_benchmark(c: &mut Criterion) {
     let cols = vec![Arc::new(create_string_array_with_len::<i32>(4096, 0.5, 100)) as ArrayRef];
     do_bench(c, "4096 string(100, 0.5)", cols);
 
+    // Single StringView Column tests
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 10, false)) as ArrayRef];
+    do_bench(c, "4096 StringView(10, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef];
+    do_bench(c, "4096 StringView(30, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 100, false)) as ArrayRef];
+    do_bench(c, "4096 StringView(100, 0)", cols);
+
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0.5, 100, false)) as ArrayRef];
+    do_bench(c, "4096 StringView(100, 0.5)", cols);
+
+    // Multi-Column(with String) tests
     let cols = vec![
         Arc::new(create_string_array_with_len::<i32>(4096, 0.5, 20)) as ArrayRef,
         Arc::new(create_string_array_with_len::<i32>(4096, 0., 30)) as ArrayRef,
@@ -134,6 +151,31 @@ fn criterion_benchmark(c: &mut Criterion) {
     do_bench(
         c,
         "4096 string(20, 0.5), string(30, 0), f64(0), i64(0)",
+        cols,
+    );
+
+    // Multi-Column(with StringView) tests
+    let cols = vec![
+        Arc::new(create_string_view_array_with_len(4096, 0.5, 20, false)) as ArrayRef,
+        Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef,
+        Arc::new(create_string_view_array_with_len(4096, 0., 100, false)) as ArrayRef,
+        Arc::new(create_primitive_array::<Int64Type>(4096, 0.)) as ArrayRef,
+    ];
+    do_bench(
+        c,
+        "4096 StringView(20, 0.5), StringView(30, 0), StringView(100, 0), i64(0)",
+        cols,
+    );
+
+    let cols = vec![
+        Arc::new(create_string_view_array_with_len(4096, 0.5, 20, false)) as ArrayRef,
+        Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef,
+        Arc::new(create_primitive_array::<Float64Type>(4096, 0.)) as ArrayRef,
+        Arc::new(create_primitive_array::<Int64Type>(4096, 0.)) as ArrayRef,
+    ];
+    do_bench(
+        c,
+        "4096 StringView(20, 0.5), StringView(30, 0), f64(0), i64(0)",
         cols,
     );
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/arrow-rs/issues/5374

(Actual code change in this PR is < 10 lines)

# Rationale for this change
 
Let arrow-csv able to read csv file and generate `StringViewArray` as output.

Here is a quick benchmark, and the result looks reasonable.
Benchmark is reading 3 string columns in TPCH-lineitem table (char(10), char(25), varchar(44)), parsing them all to `StringViewArray`/`StringArray` and do nothing, the result is:
```
Time to read String columns(char(10), char(25), varchar(44)) from lineitem.csv: 2.493634399s
Time to read StringView columns(char(10), char(25), varchar(44)) from lineitem.csv: 2.618616989s
```
<details><summary>Benchmark Code</summary>
<p>

```rust
extern crate arrow;
extern crate criterion;

use std::fs::File;
use std::sync::Arc;
use std::time::Instant;

use arrow::csv::ReaderBuilder;
use arrow::datatypes::*;

fn read_string() {
    let file = File::open("/Users/yongting/Desktop/code/my_datafusion/arrow-datafusion/benchmarks/data/tpch_sf1/lineitem.tbl").unwrap();
    let schema = Arc::new(Schema::new(vec![
        Field::new("l_orderkey", DataType::Int64, false),
        Field::new("l_partkey", DataType::Int64, false),
        Field::new("l_suppkey", DataType::Int64, false),
        Field::new("l_linenumber", DataType::Int32, false),
        Field::new("l_quantity", DataType::Decimal128(15, 2), false),
        Field::new("l_extendedprice", DataType::Decimal128(15, 2), false),
        Field::new("l_discount", DataType::Decimal128(15, 2), false),
        Field::new("l_tax", DataType::Decimal128(15, 2), false),
        Field::new("l_returnflag", DataType::Utf8, false),
        Field::new("l_linestatus", DataType::Utf8, false),
        Field::new("l_shipdate", DataType::Date32, false),
        Field::new("l_commitdate", DataType::Date32, false),
        Field::new("l_receiptdate", DataType::Date32, false),
        Field::new("l_shipinstruct", DataType::Utf8, false),
        Field::new("l_shipmode", DataType::Utf8, false),
        Field::new("l_comment", DataType::Utf8, false),
        Field::new("placeholder", DataType::Int64, true),
    ]));

    let csv_reader_string = ReaderBuilder::new(schema.clone())
        .with_delimiter(b'|')
        .with_projection(vec![13, 14, 15])
        .build(file)
        .unwrap();

    csv_reader_string.collect::<Result<Vec<_>, _>>().unwrap();
}

fn read_stringview() {
    let file = File::open("/Users/yongting/Desktop/code/my_datafusion/arrow-datafusion/benchmarks/data/tpch_sf1/lineitem.tbl").unwrap();
    let schema = Arc::new(Schema::new(vec![
        Field::new("l_orderkey", DataType::Int64, false),
        Field::new("l_partkey", DataType::Int64, false),
        Field::new("l_suppkey", DataType::Int64, false),
        Field::new("l_linenumber", DataType::Int32, false),
        Field::new("l_quantity", DataType::Decimal128(15, 2), false),
        Field::new("l_extendedprice", DataType::Decimal128(15, 2), false),
        Field::new("l_discount", DataType::Decimal128(15, 2), false),
        Field::new("l_tax", DataType::Decimal128(15, 2), false),
        Field::new("l_returnflag", DataType::Utf8, false),
        Field::new("l_linestatus", DataType::Utf8, false),
        Field::new("l_shipdate", DataType::Date32, false),
        Field::new("l_commitdate", DataType::Date32, false),
        Field::new("l_receiptdate", DataType::Date32, false),
        Field::new("l_shipinstruct", DataType::Utf8View, false),
        Field::new("l_shipmode", DataType::Utf8View, false),
        Field::new("l_comment", DataType::Utf8View, false),
        Field::new("placeholder", DataType::Int64, true),
    ]));

    let csv_reader_string = ReaderBuilder::new(schema.clone())
        .with_delimiter(b'|')
        .with_projection(vec![13, 14, 15])
        .build(file)
        .unwrap();

    csv_reader_string.collect::<Result<Vec<_>, _>>().unwrap();
}

fn main() {
    let n_warmcache_run = 2;
    let n_run = 3;

    for _ in 1..=n_warmcache_run {
        read_string();
    }
    let start_time1 = Instant::now();
    for _ in 1..=n_run {
        read_string();
    }
    let duration1 = start_time1.elapsed();

    for _ in 1..=n_warmcache_run {
        read_stringview();
    }
    let start_time2 = Instant::now();
    for _ in 1..=n_run {
        read_stringview();
    }
    let duration2 = start_time2.elapsed();

    println!(
        "Time to read String columns(char(10), char(25), varchar(44)) from lineitem.csv: {:?}",
        duration1 / n_run
    );
    println!(
        "Time to read StringView columns(char(10), char(25), varchar(44)) from lineitem.csv: {:?}",
        duration2 / n_run
    );
}

```

</p>
</details> 

I can also add more micro benchmarks as a follow on task in https://github.com/apache/arrow-rs/blob/master/arrow/benches/csv_reader.rs if it's necessary.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Adding one type branch in `arrow-csv`'s parsing logic
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
