### PR TITLE
WIP: Document dev branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,13 +128,33 @@ cargo +stable fmt --all -- --check
 
 ## Breaking Changes
 
-Our [release schedule] allows breaking API changes only in major releases.
-This means that if your PR has a breaking API change, it should be marked as
-`api-change` and it will not be merged until development opens for the next
-major release. See [this ticket] for details.
+Our [release schedule] allows breaking API changes only in major releases. This
+means that if your PR has a breaking API change, it should be marked with the
+labels: `api-change` and `next-major-release` and it will not be merged to
+`master` until development opens for the next major release. See [this ticket] for
+details.
 
 [release schedule]: README.md#release-versioning-and-schedule
 [this ticket]: https://github.com/apache/arrow-rs/issues/5907
+
+## Branching
+
+As described above, we use the `main` branch as the default branch for
+development, and prefer to merge all PRs to that branch. However, as described
+above, we only merge PRs with API changes on a set schedule. Between releases,
+we may either hold PRs as draft or merge them to a `dev` branch.
+
+For example, for the `53.0.0` release, we merged several breaking API changes to
+the `53.0.0-dev` dev branch. We then merged these commits into `master` once we had successfully released `52.2.0`.
+
+The command used:
+```shell
+## TODO update this command
+git checkout master
+git pull 
+git merge apache/53.0.0-dev
+git push -u apache
+```
 
 ## Clippy Lints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,11 @@ For example, for the `53.0.0` release, we merged several breaking API changes to
 the `53.0.0-dev` dev branch. We then merged these commits into `master` once we had successfully released `52.2.0`.
 
 The command used:
+
 ```shell
 ## TODO update this command
 git checkout master
-git pull 
+git pull
 git merge apache/53.0.0-dev
 git push -u apache
 ```


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/6050
Related to https://github.com/apache/arrow-rs/issues/6016

# Rationale for this change
 
We ended up with many PRs stacked up waiting to merge to `main` that could not because they had breaking changes (see discussion on https://github.com/apache/arrow-rs/issues/6050)
 
For `53.0.0` we tried making a feature branch, `53.0.0-dev`, to collect PRs with breaking changes before `master` opens.

This PR documents how that worked

I plan to update it as we 


# What changes are included in this PR?
Update `CONTRIBUTING.md` document

# Are there any user-facing changes?
Docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
