### PR TITLE
Revert "Update snafu (#5930)"

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,7 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
+snafu = "0.7"
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -103,7 +103,7 @@ enum GetResultError {
         source: crate::client::header::Error,
     },
 
-    #[snafu(transparent)]
+    #[snafu(context(false))]
     InvalidRangeRequest {
         source: crate::util::InvalidGetRange,
     },
@@ -386,7 +386,7 @@ mod tests {
         let err = get_result::<TestClient>(&path, Some(get_range.clone()), resp).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "Wanted range starting at 2, but object was only 2 bytes long"
+            "InvalidRangeRequest: Wanted range starting at 2, but object was only 2 bytes long"
         );
 
         let resp = make_response(


### PR DESCRIPTION
This reverts commit 756b1fb26d1702f36f446faf9bb40a4869c3e840.

Targets the `53.0.0-dev` branch. 

I accidentally merged https://github.com/apache/arrow-rs/pull/5930 which was a object store change, not an arrow change, to the arrow branch