### PR TITLE
Update snafu to `0.8.0` in object_store (#5930)

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,7 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = "0.7"
+snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = "2"

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -103,7 +103,7 @@ enum GetResultError {
         source: crate::client::header::Error,
     },
 
-    #[snafu(context(false))]
+    #[snafu(transparent)]
     InvalidRangeRequest {
         source: crate::util::InvalidGetRange,
     },
@@ -386,7 +386,7 @@ mod tests {
         let err = get_result::<TestClient>(&path, Some(get_range.clone()), resp).unwrap_err();
         assert_eq!(
             err.to_string(),
-            "InvalidRangeRequest: Wanted range starting at 2, but object was only 2 bytes long"
+            "Wanted range starting at 2, but object was only 2 bytes long"
         );
 
         let resp = make_response(


### PR DESCRIPTION
# Which issue does this PR close?




# Rationale for this change
 
This reapplies the commit from @Jesse-Bakker from  https://github.com/apache/arrow-rs/pull/5930 which I accidentally merged into the wrong branch

# What changes are included in this PR?
Update snafu to `0.8.0` for object_store

Per comments on https://github.com/apache/arrow-rs/pull/5930 it is a breaking API change so labeling it thusly

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
