### PR TITLE
Update pyo3 requirement from 0.21.1 to 0.22.1 (fixed)

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -34,4 +34,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { path = "../arrow", features = ["pyarrow"] }
-pyo3 = { version = "0.21.1", features = ["extension-module"] }
+pyo3 = { version = "0.22", features = ["extension-module"] }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -54,7 +54,7 @@ arrow-select = { workspace = true }
 arrow-string = { workspace = true }
 
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
-pyo3 = { version = "0.21.1", default-features = false, optional = true }
+pyo3 = { version = "0.22.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 features = ["prettyprint", "ipc_compression", "ffi", "pyarrow"]

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -83,11 +83,6 @@ fn to_py_err(err: ArrowError) -> PyErr {
 }
 
 pub trait FromPyArrow: Sized {
-    #[deprecated(since = "52.0.0", note = "Use from_pyarrow_bound")]
-    fn from_pyarrow(value: &PyAny) -> PyResult<Self> {
-        Self::from_pyarrow_bound(&value.as_borrowed())
-    }
-
     fn from_pyarrow_bound(value: &Bound<PyAny>) -> PyResult<Self>;
 }
 


### PR DESCRIPTION
targets dev branch

# Which issue does this PR close?
Closes #6018.

# Rationale for this change
Track upstream depenency.

# What changes are included in this PR?
Version update, plus removal of deprecated API (since the "GIL Ref" API is phased out upstream).

# Are there any user-facing changes?
`FromPyArrow::from_pyarrow` is gone.
