### PR TITLE
fix panic in `ParquetMetadata::memory_size`: check has_min_max_set before invoking min()/max()

### DIFF
--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -174,11 +174,11 @@ impl<T: ParquetValueType> HeapSize for PageIndex<T> {
 impl<T: ParquetValueType> HeapSize for ValueStatistics<T> {
     fn heap_size(&self) -> usize {
         if self.has_min_max_set() {
-            return self.min().heap_size() + self.max().heap_size()
+            return self.min().heap_size() + self.max().heap_size();
         } else if self.min_is_exact() {
-            return self.min().heap_size()
+            return self.min().heap_size();
         } else if self.max_is_exact() {
-            return self.max().heap_size()
+            return self.max().heap_size();
         }
         0
     }

--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -173,7 +173,14 @@ impl<T: ParquetValueType> HeapSize for PageIndex<T> {
 
 impl<T: ParquetValueType> HeapSize for ValueStatistics<T> {
     fn heap_size(&self) -> usize {
-        self.min().heap_size() + self.max().heap_size()
+        if self.has_min_max_set() {
+            return self.min().heap_size() + self.max().heap_size()
+        } else if self.min_is_exact() {
+            return self.min().heap_size()
+        } else if self.max_is_exact() {
+            return self.max().heap_size()
+        }
+        0
     }
 }
 impl HeapSize for bool {

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1324,11 +1324,8 @@ mod tests {
             schema_descr.clone(),
             column_orders,
         );
-        let parquet_meta = ParquetMetaData::new(file_metadata.clone(), row_group_meta.clone());
-        let base_expected_size = 1320;
-        assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
-        //Now, add in Exact Statistics
+        // Now, add in Exact Statistics
         let columns_with_stats = schema_descr
             .columns()
             .iter()
@@ -1348,7 +1345,7 @@ mod tests {
         let row_group_meta_with_stats = vec![row_group_meta_with_stats];
 
         let parquet_meta = ParquetMetaData::new(file_metadata.clone(), row_group_meta_with_stats);
-        //no heap allocations for i32 statistics
+        let base_expected_size = 2024;
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
         let mut column_index = ColumnIndexBuilder::new();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6091.

# Rationale for this change
 When column is null in parquet,the ValueStatistics's min max will be set None,so if we call ValueStatistics.min()/max() directly, the program will panic
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
use `ValueStatistics.has_min_max_set()` to check before invoking min/max

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
