### PR TITLE
Optimize `max_boolean` by operating on u64 chunks

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -763,6 +763,7 @@ where
 mod tests {
     use super::*;
     use arrow_array::types::*;
+    use builder::BooleanBuilder;
     use std::sync::Arc;
 
     #[test]
@@ -1360,6 +1361,92 @@ mod tests {
         let a = BooleanArray::from(vec![Some(true)]);
         assert_eq!(Some(true), min_boolean(&a));
         assert_eq!(Some(true), max_boolean(&a));
+    }
+
+    #[test]
+    fn test_boolean_min_max_64_true_64_false() {
+        let mut no_nulls = BooleanBuilder::new();
+        no_nulls.append_slice(&[true; 64]);
+        no_nulls.append_slice(&[false; 64]);
+        let no_nulls = no_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&no_nulls));
+        assert_eq!(Some(true), max_boolean(&no_nulls));
+
+        let mut with_nulls = BooleanBuilder::new();
+        with_nulls.append_slice(&[true; 31]);
+        with_nulls.append_null();
+        with_nulls.append_slice(&[true; 32]);
+        with_nulls.append_slice(&[false; 1]);
+        with_nulls.append_nulls(63);
+        let with_nulls = with_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&with_nulls));
+        assert_eq!(Some(true), max_boolean(&with_nulls));
+    }
+
+    #[test]
+    fn test_boolean_min_max_64_false_64_true() {
+        let mut no_nulls = BooleanBuilder::new();
+        no_nulls.append_slice(&[false; 64]);
+        no_nulls.append_slice(&[true; 64]);
+        let no_nulls = no_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&no_nulls));
+        assert_eq!(Some(true), max_boolean(&no_nulls));
+
+        let mut with_nulls = BooleanBuilder::new();
+        with_nulls.append_slice(&[false; 31]);
+        with_nulls.append_null();
+        with_nulls.append_slice(&[false; 32]);
+        with_nulls.append_slice(&[true; 1]);
+        with_nulls.append_nulls(63);
+        let with_nulls = with_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&with_nulls));
+        assert_eq!(Some(true), max_boolean(&with_nulls));
+    }
+
+    #[test]
+    fn test_boolean_min_max_96_true() {
+        let mut no_nulls = BooleanBuilder::new();
+        no_nulls.append_slice(&[true; 96]);
+        let no_nulls = no_nulls.finish();
+
+        assert_eq!(Some(true), min_boolean(&no_nulls));
+        assert_eq!(Some(true), max_boolean(&no_nulls));
+
+        let mut with_nulls = BooleanBuilder::new();
+        with_nulls.append_slice(&[true; 31]);
+        with_nulls.append_null();
+        with_nulls.append_slice(&[true; 32]);
+        with_nulls.append_slice(&[true; 31]);
+        with_nulls.append_null();
+        let with_nulls = with_nulls.finish();
+
+        assert_eq!(Some(true), min_boolean(&with_nulls));
+        assert_eq!(Some(true), max_boolean(&with_nulls));
+    }
+
+    #[test]
+    fn test_boolean_min_max_96_false() {
+        let mut no_nulls = BooleanBuilder::new();
+        no_nulls.append_slice(&[false; 96]);
+        let no_nulls = no_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&no_nulls));
+        assert_eq!(Some(false), max_boolean(&no_nulls));
+
+        let mut with_nulls = BooleanBuilder::new();
+        with_nulls.append_slice(&[false; 31]);
+        with_nulls.append_null();
+        with_nulls.append_slice(&[false; 32]);
+        with_nulls.append_slice(&[false; 31]);
+        with_nulls.append_null();
+        let with_nulls = with_nulls.finish();
+
+        assert_eq!(Some(false), min_boolean(&with_nulls));
+        assert_eq!(Some(false), max_boolean(&with_nulls));
     }
 
     #[test]

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -66,6 +66,53 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("min nullable", |b| b.iter(|| min_string(&nullable_strings)))
             .bench_function("max nullable", |b| b.iter(|| max_string(&nullable_strings)));
     }
+
+    {
+        let nonnull_bools_mixed = create_boolean_array(BATCH_SIZE, 0.0, 0.5);
+        let nonnull_bools_all_false = create_boolean_array(BATCH_SIZE, 0.0, 0.0);
+        let nonnull_bools_all_true = create_boolean_array(BATCH_SIZE, 0.0, 1.0);
+        let nullable_bool_mixed = create_boolean_array(BATCH_SIZE, 0.5, 0.5);
+        let nullable_bool_all_false = create_boolean_array(BATCH_SIZE, 0.5, 0.0);
+        let nullable_bool_all_true = create_boolean_array(BATCH_SIZE, 0.5, 1.0);
+        c.benchmark_group("bool")
+            .throughput(Throughput::Elements(BATCH_SIZE as u64))
+            .bench_function("min nonnull mixed", |b| {
+                b.iter(|| min_boolean(&nonnull_bools_mixed))
+            })
+            .bench_function("max nonnull mixed", |b| {
+                b.iter(|| max_boolean(&nonnull_bools_mixed))
+            })
+            .bench_function("min nonnull false", |b| {
+                b.iter(|| min_boolean(&nonnull_bools_all_false))
+            })
+            .bench_function("max nonnull false", |b| {
+                b.iter(|| max_boolean(&nonnull_bools_all_false))
+            })
+            .bench_function("min nonnull true", |b| {
+                b.iter(|| min_boolean(&nonnull_bools_all_true))
+            })
+            .bench_function("max nonnull true", |b| {
+                b.iter(|| max_boolean(&nonnull_bools_all_true))
+            })
+            .bench_function("min nullable mixed", |b| {
+                b.iter(|| min_boolean(&nullable_bool_mixed))
+            })
+            .bench_function("max nullable mixed", |b| {
+                b.iter(|| max_boolean(&nullable_bool_mixed))
+            })
+            .bench_function("min nullable false", |b| {
+                b.iter(|| min_boolean(&nullable_bool_all_false))
+            })
+            .bench_function("max nullable false", |b| {
+                b.iter(|| max_boolean(&nullable_bool_all_false))
+            })
+            .bench_function("min nullable true", |b| {
+                b.iter(|| min_boolean(&nullable_bool_all_true))
+            })
+            .bench_function("max nullable true", |b| {
+                b.iter(|| max_boolean(&nullable_bool_all_true))
+            });
+    }
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION




# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Vectorizing boolean operations using u64 chunks is generally more efficient.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Adds benchmarks for boolean min/max
- Operate on bit chunks instead of individual booleans, which can lead to massive speedups while not regressing the short-circuiting behavior of the existing implementation.

`cargo bench --bench aggregate_kernels -- "bool/max"` shows throughput improvements between 50% to 23390% on my machine.

<details><summary>Full benchmark results:</summary>

```
cargo bench --bench aggregate_kernels -- "bool/max"
bool/max nonnull mixed  time:   [4.9617 ns 4.9934 ns 5.0338 ns]
                        thrpt:  [ 13019 Gelem/s  13125 Gelem/s  13208 Gelem/s]
                 change:
                        time:   [-36.288% -34.043% -31.678%] (p = 0.00 < 0.05)
                        thrpt:  [+46.365% +51.614% +56.957%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
bool/max nonnull false  time:   [565.07 ns 588.68 ns 611.85 ns]
                        thrpt:  [107.11 Gelem/s 111.33 Gelem/s 115.98 Gelem/s]
                 change:
                        time:   [-98.893% -98.849% -98.802%] (p = 0.00 < 0.05)
                        thrpt:  [+8243.8% +8589.5% +8936.8%]
                        Performance has improved.
bool/max nonnull true   time:   [5.0621 ns 5.0978 ns 5.1435 ns]
                        thrpt:  [ 12741 Gelem/s  12856 Gelem/s  12946 Gelem/s]
                 change:
                        time:   [-4.7786% -1.8889% +1.1654%] (p = 0.23 > 0.05)
                        thrpt:  [-1.1520% +1.9253% +5.0184%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
bool/max nullable mixed time:   [9.4018 ns 9.5263 ns 9.6842 ns]
                        thrpt:  [6767.3 Gelem/s 6879.5 Gelem/s 6970.6 Gelem/s]
                 change:
                        time:   [-41.198% -38.405% -35.720%] (p = 0.00 < 0.05)
                        thrpt:  [+55.568% +62.350% +70.063%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
bool/max nullable false time:   [1.1109 µs 1.1591 µs 1.2086 µs]
                        thrpt:  [54.223 Gelem/s 56.539 Gelem/s 58.994 Gelem/s]
                 change:
                        time:   [-99.592% -99.574% -99.556%] (p = 0.00 < 0.05)
                        thrpt:  [+22422% +23392% +24407%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
bool/max nullable true  time:   [9.0433 ns 9.0830 ns 9.1284 ns]
                        thrpt:  [7179.4 Gelem/s 7215.3 Gelem/s 7246.9 Gelem/s]
                 change:
                        time:   [-39.120% -37.104% -34.921%] (p = 0.00 < 0.05)
                        thrpt:  [+53.659% +58.992% +64.257%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe
```

</details>

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Faster `max_boolean`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
