### PR TITLE
Optimize `bool_or` using `max_boolean`

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -674,10 +674,7 @@ pub fn bool_and(array: &BooleanArray) -> Option<bool> {
 ///
 /// Returns `None` if the array is empty or only contains null values.
 pub fn bool_or(array: &BooleanArray) -> Option<bool> {
-    if array.null_count() == array.len() {
-        return None;
-    }
-    Some(array.true_count() != 0)
+    max_boolean(array)
 }
 
 /// Returns the sum of values in the primitive array.

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -82,11 +82,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nonnull mixed", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_mixed))
             })
+            .bench_function("or nonnull mixed", |b| {
+                b.iter(|| bool_or(&nonnull_bools_mixed))
+            })
             .bench_function("min nonnull false", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_false))
             })
             .bench_function("max nonnull false", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_all_false))
+            })
+            .bench_function("or nonnull false", |b| {
+                b.iter(|| bool_or(&nonnull_bools_all_false))
             })
             .bench_function("min nonnull true", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_true))
@@ -94,11 +100,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nonnull true", |b| {
                 b.iter(|| max_boolean(&nonnull_bools_all_true))
             })
+            .bench_function("or nonnull true", |b| {
+                b.iter(|| bool_or(&nonnull_bools_all_true))
+            })
             .bench_function("min nullable mixed", |b| {
                 b.iter(|| min_boolean(&nullable_bool_mixed))
             })
             .bench_function("max nullable mixed", |b| {
                 b.iter(|| max_boolean(&nullable_bool_mixed))
+            })
+            .bench_function("or nullable mixed", |b| {
+                b.iter(|| bool_or(&nullable_bool_mixed))
             })
             .bench_function("min nullable false", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_false))
@@ -106,11 +118,17 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("max nullable false", |b| {
                 b.iter(|| max_boolean(&nullable_bool_all_false))
             })
+            .bench_function("or nullable false", |b| {
+                b.iter(|| bool_or(&nullable_bool_all_false))
+            })
             .bench_function("min nullable true", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_true))
             })
             .bench_function("max nullable true", |b| {
                 b.iter(|| max_boolean(&nullable_bool_all_true))
+            })
+            .bench_function("or nullable true", |b| {
+                b.iter(|| bool_or(&nullable_bool_all_true))
             });
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

After optimizing `max_boolean` in https://github.com/apache/arrow-rs/pull/6098, I noticed that `bool_or` is AFAICT the same operation. So we might as well re-use that optimized function.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

(Depends on https://github.com/apache/arrow-rs/pull/6098)

- Make `bool_or` an alias for `max_boolean`
- Add `bool_or` benchmarks

`cargo bench --bench aggregate_kernels -- "bool/or"` shows throughput improvements between 68%-22366% on my machine.

<details><summary>Full benchmark results:</summary>

```
cargo bench --bench aggregate_kernels -- "bool/or"
bool/or nonnull mixed   time:   [5.4610 ns 5.5037 ns 5.5515 ns]
                        thrpt:  [ 11805 Gelem/s  11908 Gelem/s  12001 Gelem/s]
                 change:
                        time:   [-99.220% -99.189% -99.157%] (p = 0.00 < 0.05)
                        thrpt:  [+11766% +12236% +12723%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
bool/or nonnull false   time:   [367.84 ns 381.18 ns 394.94 ns]
                        thrpt:  [165.94 Gelem/s 171.93 Gelem/s 178.16 Gelem/s]
                 change:
                        time:   [-42.777% -40.455% -38.300%] (p = 0.00 < 0.05)
                        thrpt:  [+62.075% +67.939% +74.754%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  12 (12.00%) high mild
  6 (6.00%) high severe
bool/or nonnull true    time:   [5.5665 ns 5.6436 ns 5.7398 ns]
                        thrpt:  [ 11418 Gelem/s  11612 Gelem/s  11773 Gelem/s]
                 change:
                        time:   [-99.123% -99.088% -99.048%] (p = 0.00 < 0.05)
                        thrpt:  [+10406% +10865% +11297%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
bool/or nullable mixed  time:   [9.5163 ns 9.5980 ns 9.6975 ns]
                        thrpt:  [6758.1 Gelem/s 6828.1 Gelem/s 6886.7 Gelem/s]
                 change:
                        time:   [-99.572% -99.555% -99.537%] (p = 0.00 < 0.05)
                        thrpt:  [+21509% +22366% +23247%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe
bool/or nullable false  time:   [1.0237 µs 1.0348 µs 1.0481 µs]
                        thrpt:  [62.528 Gelem/s 63.331 Gelem/s 64.017 Gelem/s]
                 change:
                        time:   [-50.620% -48.865% -47.217%] (p = 0.00 < 0.05)
                        thrpt:  [+89.454% +95.562% +102.51%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
bool/or nullable true   time:   [9.7835 ns 9.9299 ns 10.108 ns]
                        thrpt:  [6483.6 Gelem/s 6599.9 Gelem/s 6698.6 Gelem/s]
                 change:
                        time:   [-99.505% -99.484% -99.463%] (p = 0.00 < 0.05)
                        thrpt:  [+18515% +19298% +20115%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

</details>

# Are there any user-facing changes?

Faster `bool_or`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
