### PR TITLE
Update object store MSRV to `1.64`

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 description = "A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files."
 keywords = ["object", "storage", "cloud"]
 repository = "https://github.com/apache/arrow-rs/tree/master/object_store"
-rust-version = "1.62.1"
+rust-version = "1.64.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/object_store/src/client/mock_server.rs
+++ b/object_store/src/client/mock_server.rs
@@ -60,8 +60,6 @@ impl MockServer {
             let mut set = JoinSet::new();
 
             loop {
-                // https://github.com/apache/arrow-rs/issues/6122
-                #[allow(clippy::incompatible_msrv)]
                 let (stream, _) = tokio::select! {
                     conn = listener.accept() => conn.unwrap(),
                     _ = &mut rx => break,


### PR DESCRIPTION

# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6122

# Rationale for this change
 
Clippy found that some of our code actually requires `1.64` so let's update Cargo to say that

# What changes are included in this PR?

Update object store MSRV to `1.64`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
