### PR TITLE
Minor: Update release schedule in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ is described in the [contributing] guide.
 [contributing]: CONTRIBUTING.md#breaking-changes
 
 Anticipated Schedule
-| Approximate Date | Version  | Notes                                   |
+| Approximate Date | Version | Notes |
 | ---------------- | -------- | --------------------------------------- |
-| Sep 2024         | `53.0.0` | Major, potentially breaking API changes |
-| Oct 2024         | `53.1.0` | Minor, NO breaking API changes          |
-| Nov 2024         | `53.2.0` | Minor, NO breaking API changes          |
-| Dec 2024         | `54.0.0` | Major, potentially breaking API changes |
+| Sep 2024 | `53.0.0` | Major, potentially breaking API changes |
+| Oct 2024 | `53.1.0` | Minor, NO breaking API changes |
+| Nov 2024 | `53.2.0` | Minor, NO breaking API changes |
+| Dec 2024 | `54.0.0` | Major, potentially breaking API changes |
 
 [this ticket]: https://github.com/apache/arrow-rs/issues/5368
 [semantic versioning]: https://semver.org/

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Due to available maintainer and testing bandwidth, [`arrow`] crates ([`arrow`],
 [`arrow-flight`], etc.) are released on the same schedule with the same versions
 as the [`parquet`] and [`parquet-derive`] crates.
 
-Starting June 2024, we plan to release new major versions with potentially
-breaking API changes at most once a quarter, and release incremental minor versions in
-the intervening months. See [this ticket] for more details.
+This crate releases every month. We release new major versions (with potentially
+breaking API changes) at most once a quarter, and release incremental minor
+versions in the intervening months. See [this ticket] for more details.
 
 To keep our maintenance burden down, we do regularly scheduled releases (major
 and minor) from the `master` branch. How we handle PRs with breaking API changes
@@ -63,14 +63,13 @@ is described in the [contributing] guide.
 
 [contributing]: CONTRIBUTING.md#breaking-changes
 
-For example:
-
+Anticipated Schedule
 | Approximate Date | Version  | Notes                                   |
 | ---------------- | -------- | --------------------------------------- |
-| Jun 2024         | `52.0.0` | Major, potentially breaking API changes |
-| Jul 2024         | `52.1.0` | Minor, NO breaking API changes          |
-| Aug 2024         | `52.2.0` | Minor, NO breaking API changes          |
 | Sep 2024         | `53.0.0` | Major, potentially breaking API changes |
+| Oct 2024         | `53.1.0` | Minor, NO breaking API changes          |
+| Nov 2024         | `53.2.0` | Minor, NO breaking API changes          |
+| Dec 2024         | `54.0.0` | Major, potentially breaking API changes |
 
 [this ticket]: https://github.com/apache/arrow-rs/issues/5368
 [semantic versioning]: https://semver.org/

--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ is described in the [contributing] guide.
 
 [contributing]: CONTRIBUTING.md#breaking-changes
 
-Anticipated Schedule
-| Approximate Date | Version | Notes |
+Planned Release Schedule
+
+| Approximate Date | Version  | Notes                                   |
 | ---------------- | -------- | --------------------------------------- |
-| Sep 2024 | `53.0.0` | Major, potentially breaking API changes |
-| Oct 2024 | `53.1.0` | Minor, NO breaking API changes |
-| Nov 2024 | `53.2.0` | Minor, NO breaking API changes |
-| Dec 2024 | `54.0.0` | Major, potentially breaking API changes |
+| Sep 2024         | `53.0.0` | Major, potentially breaking API changes |
+| Oct 2024         | `53.1.0` | Minor, NO breaking API changes          |
+| Nov 2024         | `53.2.0` | Minor, NO breaking API changes          |
+| Dec 2024         | `54.0.0` | Major, potentially breaking API changes |
 
 [this ticket]: https://github.com/apache/arrow-rs/issues/5368
 [semantic versioning]: https://semver.org/


### PR DESCRIPTION
# Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/6016

# Rationale for this change
 
Update the calendar with the anticipated release schedule so downstream crates can plan

# What changes are included in this PR?

Update README with release schedule

# Are there any user-facing changes?
Just docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
