### PR TITLE
Add `IContains` for case insensitive`ILIKE`: improve performance for "contains" where the needle is ASCII

### DIFF
--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -149,7 +149,9 @@ fn icontains(haystack: &str, needle: &str) -> bool {
     let mut index: usize = 0;
 
     while let Some(hay_byte) = hay_iter.next() {
-        if equals_ignore_ascii_case_kernel((needle_first, hay_byte)) && rest_match(needle_rest, hay_iter.clone()) {
+        if equals_ignore_ascii_case_kernel((needle_first, hay_byte))
+            && rest_match(needle_rest, hay_iter.clone())
+        {
             return true;
         } else {
             if index >= stop_at {
@@ -161,10 +163,7 @@ fn icontains(haystack: &str, needle: &str) -> bool {
     false
 }
 
-fn rest_match<'a>(
-    needle_rest: &[u8],
-    hay_iter: impl Iterator<Item = &'a u8>,
-) -> bool {
+fn rest_match<'a>(needle_rest: &[u8], hay_iter: impl Iterator<Item = &'a u8>) -> bool {
     std::iter::zip(needle_rest, hay_iter).all(equals_ignore_ascii_case_kernel)
 }
 

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -29,6 +29,8 @@ pub enum Predicate<'a> {
 
     /// Equality ignoring ASCII case
     IEqAscii(&'a str),
+    /// Contains ignoring ASCII case
+    IContains(&'a str),
     /// Starts with ignoring ASCII case
     IStartsWithAscii(&'a str),
     /// Ends with ignoring ASCII case
@@ -49,11 +51,7 @@ impl<'a> Predicate<'a> {
             Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
         } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
             Ok(Self::EndsWith(&pattern[1..]))
-        } else if pattern.starts_with('%')
-            && pattern.ends_with('%')
-            && !pattern.ends_with("\\%")
-            && !contains_like_pattern(&pattern[1..pattern.len() - 1])
-        {
+        } else if is_contains_pattern(pattern) {
             Ok(Self::Contains(&pattern[1..pattern.len() - 1]))
         } else {
             Ok(Self::Regex(regex_like(pattern, false)?))
@@ -72,6 +70,8 @@ impl<'a> Predicate<'a> {
                 return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
             } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
                 return Ok(Self::IEndsWithAscii(&pattern[1..]));
+            } else if is_contains_pattern(pattern) {
+                return Ok(Self::IContains(&pattern[1..pattern.len() - 1]));
             }
         }
         Ok(Self::Regex(regex_like(pattern, true)?))
@@ -83,6 +83,7 @@ impl<'a> Predicate<'a> {
             Predicate::Eq(v) => *v == haystack,
             Predicate::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
             Predicate::Contains(v) => haystack.contains(v),
+            Predicate::IContains(v) => icontains(haystack, v),
             Predicate::StartsWith(v) => haystack.starts_with(v),
             Predicate::IStartsWithAscii(v) => starts_with_ignore_ascii_case(haystack, v),
             Predicate::EndsWith(v) => haystack.ends_with(v),
@@ -109,6 +110,9 @@ impl<'a> Predicate<'a> {
             Predicate::Contains(v) => {
                 BooleanArray::from_unary(array, |haystack| haystack.contains(v) != negate)
             }
+            Predicate::IContains(v) => {
+                BooleanArray::from_unary(array, |haystack| icontains(haystack, v) != negate)
+            }
             Predicate::StartsWith(v) => {
                 BooleanArray::from_unary(array, |haystack| haystack.starts_with(v) != negate)
             }
@@ -128,6 +132,42 @@ impl<'a> Predicate<'a> {
     }
 }
 
+fn icontains(haystack: &str, needle: &str) -> bool {
+    let Some((needle_first, needle_rest)) = needle.as_bytes().split_first() else {
+        // needle is empty, contains always true, matches `str.contains()` behaviour
+        return true;
+    };
+    let mut hay_iter = haystack.as_bytes().iter();
+    if needle_rest.is_empty() {
+        return hay_iter.any(|h| equals_ignore_ascii_case_kernel((needle_first, h)));
+    }
+
+    let Some(stop_at) = haystack.len().checked_sub(needle.len()) else {
+        // needle is longer than haystack
+        return false;
+    };
+    let mut index: usize = 0;
+
+    while let Some(hay_byte) = hay_iter.next() {
+        if equals_ignore_ascii_case_kernel((needle_first, hay_byte)) && rest_match(needle_rest, hay_iter.clone()) {
+            return true;
+        } else {
+            if index >= stop_at {
+                break;
+            }
+            index += 1;
+        }
+    }
+    false
+}
+
+fn rest_match<'a>(
+    needle_rest: &[u8],
+    hay_iter: impl Iterator<Item = &'a u8>,
+) -> bool {
+    std::iter::zip(needle_rest, hay_iter).all(equals_ignore_ascii_case_kernel)
+}
+
 fn starts_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     let end = haystack.len().min(needle.len());
     haystack.is_char_boundary(end) && needle.eq_ignore_ascii_case(&haystack[..end])
@@ -136,6 +176,10 @@ fn starts_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
 fn ends_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     let start = haystack.len().saturating_sub(needle.len());
     haystack.is_char_boundary(start) && needle.eq_ignore_ascii_case(&haystack[start..])
+}
+
+fn equals_ignore_ascii_case_kernel((n, h): (&u8, &u8)) -> bool {
+    n.to_ascii_lowercase() == h.to_ascii_lowercase()
 }
 
 /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
@@ -184,6 +228,13 @@ fn regex_like(pattern: &str, case_insensitive: bool) -> Result<Regex, ArrowError
         })
 }
 
+fn is_contains_pattern(pattern: &str) -> bool {
+    pattern.starts_with('%')
+        && pattern.ends_with('%')
+        && !pattern.ends_with("\\%")
+        && !contains_like_pattern(&pattern[1..pattern.len() - 1])
+}
+
 fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
 }
@@ -201,6 +252,14 @@ mod tests {
         let a_eq = "_%";
         let expected = "^..*$";
         let r = regex_like(a_eq, false).unwrap();
+        assert_eq!(r.to_string(), expected);
+    }
+
+    #[test]
+    fn test_foobar() {
+        let a_eq = "%spanner%";
+        let expected = "^..*$";
+        let r = regex_like(a_eq, true).unwrap();
         assert_eq!(r.to_string(), expected);
     }
 


### PR DESCRIPTION
# DO NOT MERGE

This is superseded by #6145, even if we keep this, we should special case the method defined here to only be used for small haystacks.

---

# Which issue does this PR close?

This continues work from #6118 and #6128 and will require them to be merged before it's fixed, it's the final part of #6107 I think.

# Rationale for this change
 
Lots of context in #6107, this makes `ILIKE` queries which are simply "contains" significantly faster.

Benchmarks:

```bash
➤ cargo bench -p arrow --bench comparison_kernels -F test_utils -- 'ilike.*contains'
   Compiling arrow-string v52.2.0 (/Users/samuel/code/arrow-rs/arrow-string)
   Compiling arrow v52.2.0 (/Users/samuel/code/arrow-rs/arrow)
    Finished `bench` profile [optimized] target(s) in 3.99s
     Running benches/comparison_kernels.rs (target/release/deps/comparison_kernels-95ab196215ed59e6)
ilike_utf8 scalar contains
                        time:   [125.84 µs 125.89 µs 125.95 µs]
                        change: [-80.870% -80.819% -80.764%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

nilike_utf8 scalar contains
                        time:   [125.79 µs 126.06 µs 126.49 µs]
                        change: [-80.842% -80.809% -80.776%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  12 (12.00%) high severe
```

Note, in theory the current regex approach could be faster for very large haystacks, but from my experiments that case will be quite rare, and in many cases the regex will be far far slower, see https://github.com/samuelcolvin/quick-strings/pull/1:

```
prefix-length=10    needle-length=10    — icontains=10.600 ns regex=23.766 ns
prefix-length=100   needle-length=10    — icontains=54.671 ns regex=122.80 ns
prefix-length=1_000 needle-length=10    — icontains=494.05 ns regex=820.21 ns
prefix-length=2_000 needle-length=10    — icontains=1.0769 µs regex=1.1335 µs
prefix-length=5_000 needle-length=10    — icontains=2.6704 µs regex=2.0020 µs
prefix-length=10    needle-length=1_000 — icontains=564.89 ns regex=1.5671 µs
prefix-length=10    needle-length=2_000 — icontains=1.1176 µs regex=11.945 ms
prefix-length=10    needle-length=5_000 — icontains=2.7539 µs regex=74.793 ms
```

I therefore think it's better to stick to a single implementation than have a branch for very large haystacks.

# What changes are included in this PR?

New special case for "case insensitive ascii contains".

# Are there any user-facing changes?

No AFAIK,