### PR TITLE
Optimize `min_boolean` and `bool_and`

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -350,11 +350,42 @@ pub fn min_boolean(array: &BooleanArray) -> Option<bool> {
     }
 
     // Note the min bool is false (0), so short circuit as soon as we see it
-    array
-        .iter()
-        .find(|&b| b == Some(false))
-        .flatten()
-        .or(Some(true))
+    match array.nulls() {
+        None => {
+            let bit_chunks = array.values().bit_chunks();
+            for x in bit_chunks.iter() {
+                // u64::MAX has all bits set, so if the value is not that, then there is a false
+                if x != u64::MAX {
+                    return Some(false);
+                }
+            }
+            // If the remainder bits are not all set, then there is a false
+            if bit_chunks.remainder_bits().count_ones() as usize != bit_chunks.remainder_len() {
+                Some(false)
+            } else {
+                Some(true)
+            }
+        }
+        Some(nulls) => {
+            let validity_chunks = nulls.inner().bit_chunks();
+            let value_chunks = array.values().bit_chunks();
+
+            for (value, validity) in value_chunks.iter().zip(validity_chunks.iter()) {
+                // We are looking for a false value, but because applying the validity mask
+                // can create a false for a true value (e.g. value: true, validity: false), we instead invert the value, so that we have to look for a true.
+                if (!value & validity) != 0 {
+                    return Some(false);
+                }
+            }
+
+            // Same trick as above: Instead of looking for a false, we invert the value bits and look for a true
+            if (!value_chunks.remainder_bits() & validity_chunks.remainder_bits()) != 0 {
+                Some(false)
+            } else {
+                Some(true)
+            }
+        }
+    }
 }
 
 /// Returns the maximum value in the boolean array
@@ -707,10 +738,7 @@ bit_operation!(
 ///
 /// Returns `None` if the array is empty or only contains null values.
 pub fn bool_and(array: &BooleanArray) -> Option<bool> {
-    if array.null_count() == array.len() {
-        return None;
-    }
-    Some(array.false_count() == 0)
+    min_boolean(array)
 }
 
 /// Returns true if any non-null input value is true, otherwise false.
@@ -1380,6 +1408,14 @@ mod tests {
         assert_eq!(Some(true), max_boolean(&a));
 
         let a = BooleanArray::from(vec![Some(false), None]);
+        assert_eq!(Some(false), min_boolean(&a));
+        assert_eq!(Some(false), max_boolean(&a));
+
+        let a = BooleanArray::from(vec![Some(true)]);
+        assert_eq!(Some(true), min_boolean(&a));
+        assert_eq!(Some(true), max_boolean(&a));
+
+        let a = BooleanArray::from(vec![Some(false)]);
         assert_eq!(Some(false), min_boolean(&a));
         assert_eq!(Some(false), max_boolean(&a));
     }

--- a/arrow/benches/aggregate_kernels.rs
+++ b/arrow/benches/aggregate_kernels.rs
@@ -104,6 +104,9 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("or nonnull mixed", |b| {
                 b.iter(|| bool_or(&nonnull_bools_mixed))
             })
+            .bench_function("and nonnull mixed", |b| {
+                b.iter(|| bool_and(&nonnull_bools_mixed))
+            })
             .bench_function("min nonnull false", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_false))
             })
@@ -112,6 +115,9 @@ fn add_benchmark(c: &mut Criterion) {
             })
             .bench_function("or nonnull false", |b| {
                 b.iter(|| bool_or(&nonnull_bools_all_false))
+            })
+            .bench_function("and nonnull false", |b| {
+                b.iter(|| bool_and(&nonnull_bools_all_false))
             })
             .bench_function("min nonnull true", |b| {
                 b.iter(|| min_boolean(&nonnull_bools_all_true))
@@ -122,6 +128,9 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("or nonnull true", |b| {
                 b.iter(|| bool_or(&nonnull_bools_all_true))
             })
+            .bench_function("and nonnull true", |b| {
+                b.iter(|| bool_and(&nonnull_bools_all_true))
+            })
             .bench_function("min nullable mixed", |b| {
                 b.iter(|| min_boolean(&nullable_bool_mixed))
             })
@@ -130,6 +139,9 @@ fn add_benchmark(c: &mut Criterion) {
             })
             .bench_function("or nullable mixed", |b| {
                 b.iter(|| bool_or(&nullable_bool_mixed))
+            })
+            .bench_function("and nullable mixed", |b| {
+                b.iter(|| bool_and(&nullable_bool_mixed))
             })
             .bench_function("min nullable false", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_false))
@@ -140,6 +152,9 @@ fn add_benchmark(c: &mut Criterion) {
             .bench_function("or nullable false", |b| {
                 b.iter(|| bool_or(&nullable_bool_all_false))
             })
+            .bench_function("and nullable false", |b| {
+                b.iter(|| bool_and(&nullable_bool_all_false))
+            })
             .bench_function("min nullable true", |b| {
                 b.iter(|| min_boolean(&nullable_bool_all_true))
             })
@@ -148,6 +163,9 @@ fn add_benchmark(c: &mut Criterion) {
             })
             .bench_function("or nullable true", |b| {
                 b.iter(|| bool_or(&nullable_bool_all_true))
+            })
+            .bench_function("and nullable true", |b| {
+                b.iter(|| bool_and(&nullable_bool_all_true))
             });
     }
 }


### PR DESCRIPTION




# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #https://github.com/apache/arrow-rs/issues/6103

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Similar to https://github.com/apache/arrow-rs/pull/6100 and https://github.com/apache/arrow-rs/pull/6098

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The below benchmark results are a bit weird/noisy - I ran them on a laptop. It would be great if someone with a more reliable setup could verify
- "bool/min nonnull false" regresses. This is definitely possible, but might also just be noise
- bool/max improvements are weird since didn't change that function
- bool/and improvements look valid, since we are now short cicuiting

<details><summary>Full benchmark results:</summary>

```
cargo bench --bench aggregate_kernels -- "bool"
bool/min nonnull mixed  time:   [4.9401 ns 4.9476 ns 4.9565 ns]
                        thrpt:  [ 13222 Gelem/s  13246 Gelem/s  13266 Gelem/s]
                 change:
                        time:   [+9.3684% +10.839% +12.075%] (p = 0.00 < 0.05)
                        thrpt:  [-10.774% -9.7791% -8.5659%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
bool/max nonnull mixed  time:   [5.3833 ns 5.3884 ns 5.3938 ns]
                        thrpt:  [ 12150 Gelem/s  12163 Gelem/s  12174 Gelem/s]
                 change:
                        time:   [+0.8418% +1.1237% +1.3626%] (p = 0.00 < 0.05)
                        thrpt:  [-1.3443% -1.1112% -0.8348%]
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
bool/or nonnull mixed   time:   [5.6379 ns 5.6455 ns 5.6553 ns]
                        thrpt:  [ 11589 Gelem/s  11609 Gelem/s  11624 Gelem/s]
                 change:
                        time:   [+2.0612% +2.3602% +2.6501%] (p = 0.00 < 0.05)
                        thrpt:  [-2.5817% -2.3058% -2.0196%]
                        Performance has regressed.
bool/and nonnull mixed  time:   [5.1582 ns 5.1634 ns 5.1692 ns]
                        thrpt:  [ 12678 Gelem/s  12692 Gelem/s  12705 Gelem/s]
                 change:
                        time:   [-99.196% -99.181% -99.171%] (p = 0.00 < 0.05)
                        thrpt:  [+11965% +12103% +12334%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe
bool/min nonnull false  time:   [4.9138 ns 4.9298 ns 4.9500 ns]
                        thrpt:  [ 13240 Gelem/s  13294 Gelem/s  13337 Gelem/s]
                 change:
                        time:   [+12.204% +12.833% +13.431%] (p = 0.00 < 0.05)
                        thrpt:  [-11.841% -11.373% -10.877%]
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe
bool/max nonnull false  time:   [344.18 ns 344.82 ns 345.63 ns]
                        thrpt:  [189.61 Gelem/s 190.06 Gelem/s 190.41 Gelem/s]
                 change:
                        time:   [-31.643% -31.449% -31.257%] (p = 0.00 < 0.05)
                        thrpt:  [+45.469% +45.878% +46.291%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
bool/or nonnull false   time:   [345.24 ns 346.77 ns 349.36 ns]
                        thrpt:  [187.59 Gelem/s 188.99 Gelem/s 189.83 Gelem/s]
                 change:
                        time:   [-33.865% -32.809% -32.072%] (p = 0.00 < 0.05)
                        thrpt:  [+47.214% +48.829% +51.207%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
bool/and nonnull false  time:   [5.1528 ns 5.1574 ns 5.1627 ns]
                        thrpt:  [ 12694 Gelem/s  12707 Gelem/s  12718 Gelem/s]
                 change:
                        time:   [-99.159% -99.157% -99.155%] (p = 0.00 < 0.05)
                        thrpt:  [+11730% +11764% +11797%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
bool/min nonnull true   time:   [350.67 ns 350.99 ns 351.35 ns]
                        thrpt:  [186.53 Gelem/s 186.72 Gelem/s 186.89 Gelem/s]
                 change:
                        time:   [-99.268% -99.264% -99.261%] (p = 0.00 < 0.05)
                        thrpt:  [+13430% +13487% +13560%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
bool/max nonnull true   time:   [5.4131 ns 5.4336 ns 5.4603 ns]
                        thrpt:  [ 12002 Gelem/s  12061 Gelem/s  12107 Gelem/s]
                 change:
                        time:   [-0.3416% +0.9975% +1.8531%] (p = 0.06 > 0.05)
                        thrpt:  [-1.8194% -0.9877% +0.3428%]
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
bool/or nonnull true    time:   [5.6351 ns 5.6745 ns 5.7376 ns]
                        thrpt:  [ 11422 Gelem/s  11549 Gelem/s  11630 Gelem/s]
                 change:
                        time:   [+1.0717% +1.5656% +2.2512%] (p = 0.00 < 0.05)
                        thrpt:  [-2.2016% -1.5415% -1.0603%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  8 (8.00%) high severe
bool/and nonnull true   time:   [349.18 ns 349.62 ns 350.11 ns]
                        thrpt:  [187.18 Gelem/s 187.45 Gelem/s 187.69 Gelem/s]
                 change:
                        time:   [-42.540% -42.295% -42.059%] (p = 0.00 < 0.05)
                        thrpt:  [+72.589% +73.294% +74.034%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
bool/min nullable mixed time:   [8.2445 ns 8.2590 ns 8.2779 ns]
                        thrpt:  [7917.0 Gelem/s 7935.1 Gelem/s 7949.1 Gelem/s]
                 change:
                        time:   [-52.522% -52.360% -52.201%] (p = 0.00 < 0.05)
                        thrpt:  [+109.21% +109.91% +110.62%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe
bool/max nullable mixed time:   [9.2787 ns 9.2927 ns 9.3107 ns]
                        thrpt:  [7038.8 Gelem/s 7052.4 Gelem/s 7063.0 Gelem/s]
                 change:
                        time:   [-1.3594% -1.0699% -0.7734%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7794% +1.0815% +1.3781%]
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
bool/or nullable mixed  time:   [9.5603 ns 9.5701 ns 9.5810 ns]
                        thrpt:  [6840.2 Gelem/s 6848.0 Gelem/s 6855.0 Gelem/s]
                 change:
                        time:   [-0.4859% -0.1051% +0.2716%] (p = 0.61 > 0.05)
                        thrpt:  [-0.2709% +0.1052% +0.4883%]
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe
bool/and nullable mixed time:   [8.3697 ns 8.3790 ns 8.3894 ns]
                        thrpt:  [7811.7 Gelem/s 7821.5 Gelem/s 7830.1 Gelem/s]
                 change:
                        time:   [-99.580% -99.578% -99.576%] (p = 0.00 < 0.05)
                        thrpt:  [+23499% +23601% +23701%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  1 (1.00%) low severe
  9 (9.00%) high mild
  8 (8.00%) high severe
bool/min nullable false time:   [8.5713 ns 8.5892 ns 8.6119 ns]
                        thrpt:  [7609.9 Gelem/s 7630.0 Gelem/s 7646.0 Gelem/s]
                 change:
                        time:   [-49.180% -48.532% -47.963%] (p = 0.00 < 0.05)
                        thrpt:  [+92.173% +94.297% +96.773%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
bool/max nullable false time:   [777.14 ns 785.22 ns 800.48 ns]
                        thrpt:  [81.871 Gelem/s 83.462 Gelem/s 84.329 Gelem/s]
                 change:
                        time:   [-22.375% -21.072% -19.085%] (p = 0.00 < 0.05)
                        thrpt:  [+23.587% +26.697% +28.824%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
bool/or nullable false  time:   [768.70 ns 770.15 ns 771.99 ns]
                        thrpt:  [84.893 Gelem/s 85.095 Gelem/s 85.255 Gelem/s]
                 change:
                        time:   [-23.039% -22.708% -22.372%] (p = 0.00 < 0.05)
                        thrpt:  [+28.820% +29.379% +29.936%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) high mild
  6 (6.00%) high severe
bool/and nullable false time:   [8.7063 ns 8.7273 ns 8.7476 ns]
                        thrpt:  [7491.9 Gelem/s 7509.3 Gelem/s 7527.4 Gelem/s]
                 change:
                        time:   [-99.580% -99.572% -99.567%] (p = 0.00 < 0.05)
                        thrpt:  [+23007% +23266% +23686%]
                        Performance has improved.
bool/min nullable true  time:   [518.03 ns 529.29 ns 543.02 ns]
                        thrpt:  [120.69 Gelem/s 123.82 Gelem/s 126.51 Gelem/s]
                 change:
                        time:   [-99.806% -99.804% -99.802%] (p = 0.00 < 0.05)
                        thrpt:  [+50329% +50922% +51523%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
bool/max nullable true  time:   [9.3098 ns 9.3208 ns 9.3321 ns]
                        thrpt:  [7022.6 Gelem/s 7031.2 Gelem/s 7039.4 Gelem/s]
                 change:
                        time:   [-0.8606% -0.0889% +1.1845%] (p = 0.90 > 0.05)
                        thrpt:  [-1.1706% +0.0890% +0.8681%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
bool/or nullable true   time:   [9.4815 ns 9.4955 ns 9.5120 ns]
                        thrpt:  [6889.8 Gelem/s 6901.8 Gelem/s 6912.0 Gelem/s]
                 change:
                        time:   [-4.7918% -3.2023% -2.1386%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1853% +3.3082% +5.0330%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
bool/and nullable true  time:   [511.29 ns 520.12 ns 537.16 ns]
                        thrpt:  [122.01 Gelem/s 126.00 Gelem/s 128.18 Gelem/s]
                 change:
                        time:   [-74.478% -74.268% -73.923%] (p = 0.00 < 0.05)
                        thrpt:  [+283.48% +288.62% +291.82%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

</details>

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
