### PR TITLE
Optimization of filter operation on ByteViewArray

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -99,6 +99,12 @@ impl Buffer {
         buffer.into()
     }
 
+    /// Initializes a empty [Buffer].
+    pub fn new_empty() -> Self {
+        let empty_slice: &[u8] = &[];
+        Self::from_slice_ref(empty_slice)
+    }
+
     /// Creates a buffer from an existing aligned memory region (must already be byte-aligned), this
     /// `Buffer` will free this piece of memory when dropped.
     ///

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -30,7 +30,7 @@ use arrow_buffer::{bit_util, ArrowNativeType, BooleanBuffer, NullBuffer, RunEndB
 use arrow_buffer::{Buffer, MutableBuffer};
 use arrow_data::bit_iterator::{BitIndexIterator, BitSliceIterator};
 use arrow_data::transform::MutableArrayData;
-use arrow_data::{ArrayData, ArrayDataBuilder};
+use arrow_data::{ArrayData, ArrayDataBuilder, ByteView};
 use arrow_schema::*;
 
 /// If the filter selects more than this fraction of rows, use
@@ -551,6 +551,58 @@ fn filter_native<T: ArrowNativeType>(values: &[T], predicate: &FilterPredicate) 
     buffer.into()
 }
 
+#[inline(never)]
+fn filter_native_for_byte_view<F: FnMut(&u128)>(
+    values: &[u128],
+    predicate: &FilterPredicate,
+    mut for_left_view: F,
+) -> Buffer {
+    assert!(values.len() >= predicate.filter.len());
+
+    let buffer = match &predicate.strategy {
+        IterationStrategy::SlicesIterator => {
+            let mut buffer = MutableBuffer::with_capacity(predicate.count * u128::get_byte_width());
+            for (start, end) in SlicesIterator::new(&predicate.filter) {
+                let left_views = &values[start..end];
+                left_views.iter().for_each(&mut for_left_view);
+                buffer.extend_from_slice(left_views);
+            }
+            buffer
+        }
+        IterationStrategy::Slices(slices) => {
+            let mut buffer = MutableBuffer::with_capacity(predicate.count * u128::get_byte_width());
+            for (start, end) in slices {
+                let left_views = &values[*start..*end];
+                left_views.iter().for_each(&mut for_left_view);
+                buffer.extend_from_slice(left_views);
+            }
+            buffer
+        }
+        IterationStrategy::IndexIterator => {
+            let wrap_map_lambda = |x: usize| {
+                for_left_view(&values[x]);
+                values[x]
+            };
+            let iter = IndexIterator::new(&predicate.filter, predicate.count).map(wrap_map_lambda);
+            // SAFETY: IndexIterator is trusted length
+            unsafe { MutableBuffer::from_trusted_len_iter(iter) }
+        }
+        IterationStrategy::Indices(indices) => {
+            let wrap_map_lambda = |x: &usize| {
+                for_left_view(&values[*x]);
+                values[*x]
+            };
+            let iter = indices.iter().map(wrap_map_lambda);
+
+            // SAFETY: `Vec::iter` is trusted length
+            unsafe { MutableBuffer::from_trusted_len_iter(iter) }
+        }
+        IterationStrategy::All | IterationStrategy::None => unreachable!(),
+    };
+
+    buffer.into()
+}
+
 /// `filter` implementation for primitive arrays
 pub(crate) fn filter_primitive<T>(
     array: &PrimitiveArray<T>,
@@ -693,12 +745,41 @@ fn filter_byte_view<T: ByteViewType>(
     array: &GenericByteViewArray<T>,
     predicate: &FilterPredicate,
 ) -> GenericByteViewArray<T> {
-    let new_view_buffer = filter_native(array.views(), predicate);
+    let mut left_buffers = vec![false; array.data_buffers().len()];
+    let get_left_buffer = |view: &u128| {
+        let byte_view = ByteView::from(*view);
+        if byte_view.length <= 12 {
+            return;
+        }
+        let buffer_index = byte_view.buffer_index as usize;
+        // SAFETY: left_buffers are initialized to the same length as data_buffers, so the index in the view is always valid.
+        unsafe {
+            *left_buffers.get_unchecked_mut(buffer_index) = true;
+        };
+    };
+    let new_view_buffer = filter_native_for_byte_view(array.views(), predicate, get_left_buffer);
+
+    let new_buffers = array.data_buffers().to_vec();
+    assert!(left_buffers.len() == new_buffers.len());
+    // Replace the buffers marked as false with empty ones to preserve the mapping relationship between views and buffers.
+    let new_buffers = new_buffers
+        .into_iter()
+        .zip(left_buffers.into_iter())
+        .map(
+            |(buffer, left)| {
+                if left {
+                    buffer
+                } else {
+                    Buffer::new_empty()
+                }
+            },
+        )
+        .collect();
 
     let mut builder = ArrayDataBuilder::new(T::DATA_TYPE)
         .len(predicate.count)
         .add_buffer(new_view_buffer)
-        .add_buffers(array.data_buffers().to_vec());
+        .add_buffers(new_buffers);
 
     if let Some((null_count, nulls)) = filter_null_mask(array.nulls(), predicate) {
         builder = builder.null_count(null_count).null_bit_buffer(Some(nulls));

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -764,7 +764,7 @@ fn filter_byte_view<T: ByteViewType>(
     // Replace the buffers marked as false with empty ones to preserve the mapping relationship between views and buffers.
     let new_buffers = new_buffers
         .into_iter()
-        .zip(left_buffers.into_iter())
+        .zip(left_buffers)
         .map(
             |(buffer, left)| {
                 if left {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Performing a `filter` operation on `ByteViewArray` only filters its `view` data members, but clones the entire `buffers`, which may result in the `ByteViewArray` holding some unnecessary `buffers`, which may prevent some memory resources from being released in a timely manner.
This PR records whether each `buffer` needs to be retained while filtering `view` data members, and updates the `buffers` of `ByteViewArray` using the recorded information.
The reason why this PR replaces unwanted `buffers` with empty `buffers` instead of deleting them directly is that this processing preserves the mapping relationship between `views` and `buffers`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
