### PR TITLE
feat(object_store): publicly expose client error

### DIFF
--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -79,7 +79,7 @@ impl Error {
         }
     }
 
-    pub fn error(self, store: &'static str, path: String) -> crate::Error {
+    pub(crate) fn error(self, store: &'static str, path: String) -> crate::Error {
         match self.status() {
             Some(StatusCode::NOT_FOUND) => crate::Error::NotFound {
                 path,

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -79,6 +79,7 @@ impl Error {
         }
     }
 
+    #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
     pub(crate) fn error(self, store: &'static str, path: String) -> crate::Error {
         match self.status() {
             Some(StatusCode::NOT_FOUND) => crate::Error::NotFound {

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -30,21 +30,32 @@ use tracing::info;
 /// Retry request error
 #[derive(Debug, Snafu)]
 pub enum Error {
+    /// The response sent by the cloud provider was a redirect without a
+    /// location header. This normally indicates an incorrectly configured region.
     #[snafu(display("Received redirect without LOCATION, this normally indicates an incorrectly configured region"))]
     BareRedirect,
 
+    /// The client received an error response that cannot be retried.
     #[snafu(display("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
     Client {
+        /// The HTTP status code.
         status: StatusCode,
+        /// The error body.
         body: Option<String>,
     },
 
+    /// The number of retries was exhausted or the time limit was reached.
     #[snafu(display("Error after {retries} retries in {elapsed:?}, max_retries:{max_retries}, retry_timeout:{retry_timeout:?}, source:{source}"))]
     Reqwest {
+        /// The number of retries attempted.
         retries: usize,
+        /// The maximum number of retries allowed.
         max_retries: usize,
+        /// The time elapsed since the first attempt.
         elapsed: Duration,
+        /// The maximum amount of time to spend retrying.
         retry_timeout: Duration,
+        /// The error that occurred while processing a Request.
         source: reqwest::Error,
     },
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -526,8 +526,8 @@ mod client;
 
 #[cfg(feature = "cloud")]
 pub use client::{
-    backoff::BackoffConfig, retry::RetryConfig, ClientConfigKey, ClientOptions, CredentialProvider,
-    StaticCredentialProvider,
+    backoff::BackoffConfig, retry::Error as ClientError, retry::RetryConfig, ClientConfigKey,
+    ClientOptions, CredentialProvider, StaticCredentialProvider,
 };
 
 #[cfg(feature = "cloud")]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5345.

# Rationale for this change
 
Exposing the client error publicly allows accessing the status code of the response associated with the error. This gives the user more control over error handling, such as special handling for authn/authz errors.

```
let err = store.head(&path).await.unwrap_err();
let source = err
    .source()
    .unwrap()
    .downcast_ref::<object_store::ClientError>().unwrap();
let status = source.status().unwrap();
```

# What changes are included in this PR?

expose `client::Error as ClientError`

# Are there any user-facing changes?

Yes

# Notes

- Should the error type or its variants be renamed?
- Alternatively, a `PermissionDenied` variant could be added to `crate::Error`.
- Alternatively, `source` could be changed to `reqwest::Error` when the client error is converted to `crate::Error`. (Would allow downcasting directly to reqwest::Error.)