### PR TITLE
Optimize `take` kernel for `BinaryViewArray` and `StringViewArray`

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -485,13 +485,20 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
     array: &GenericByteViewArray<T>,
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
+    let data_len = indices.len();
+
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
-    Ok(GenericByteViewArray::new(
-        new_views,
-        array.data_buffers().to_vec(),
-        new_nulls,
-    ))
+
+    let array_data = ArrayData::builder(T::DATA_TYPE)
+        .len(data_len)
+        .add_buffer(new_views.into_inner())
+        .add_buffers(array.data_buffers().to_vec())
+        .nulls(new_nulls);
+
+    let array_data = unsafe { array_data.build_unchecked() };
+
+    Ok(GenericByteViewArray::from(array_data))
 }
 
 /// `take` implementation for list arrays

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -487,6 +487,7 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
+    // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
     Ok(unsafe {
         GenericByteViewArray::new_unchecked(new_views, array.data_buffers().to_vec(), new_nulls)
     })

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -485,20 +485,11 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
     array: &GenericByteViewArray<T>,
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
-    let data_len = indices.len();
-
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
-
-    let array_data = ArrayData::builder(T::DATA_TYPE)
-        .len(data_len)
-        .add_buffer(new_views.into_inner())
-        .add_buffers(array.data_buffers().to_vec())
-        .nulls(new_nulls);
-
-    let array_data = unsafe { array_data.build_unchecked() };
-
-    Ok(GenericByteViewArray::from(array_data))
+    Ok(unsafe {
+        GenericByteViewArray::new_unchecked(new_views, array.data_buffers().to_vec(), new_nulls)
+    })
 }
 
 /// `take` implementation for list arrays

--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -149,6 +149,42 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_take(&values, &indices))
     });
 
+    let values = create_string_view_array(512, 0.0);
+    let indices = create_random_index(512, 0.0);
+    c.bench_function("take stringview 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(1024, 0.0);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take stringview 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(512, 0.0);
+    let indices = create_random_index(512, 0.5);
+    c.bench_function("take stringview null indices 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(1024, 0.0);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take stringview null indices 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(1024, 0.5);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take stringview null values 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(1024, 0.5);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take stringview null values null indices 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
     let values = create_primitive_run_array::<Int32Type, Int32Type>(1024, 512);
     let indices = create_random_index(1024, 0.0);
     c.bench_function(

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -160,6 +160,34 @@ pub fn create_string_array_with_len<Offset: OffsetSizeTrait>(
         .collect()
 }
 
+/// Creates a random (but fixed-seeded) string view array of a given size and null density.
+///
+/// See `create_string_array` above for more details.
+pub fn create_string_view_array(size: usize, null_density: f32) -> StringViewArray {
+    create_string_view_array_with_max_len(size, null_density, 400)
+}
+
+/// Creates a random (but fixed-seeded) array of rand size with a given max size, null density and length
+fn create_string_view_array_with_max_len(
+    size: usize,
+    null_density: f32,
+    max_str_len: usize,
+) -> StringViewArray {
+    let rng = &mut seedable_rng();
+    (0..size)
+        .map(|_| {
+            if rng.gen::<f32>() < null_density {
+                None
+            } else {
+                let str_len = rng.gen_range(0..max_str_len);
+                let value = rng.sample_iter(&Alphanumeric).take(str_len).collect();
+                let value = String::from_utf8(value).unwrap();
+                Some(value)
+            }
+        })
+        .collect()
+}
+
 /// Creates a random (but fixed-seeded) array of a given size, null density and length
 pub fn create_string_view_array_with_len(
     size: usize,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6167 .


# Rationale for this change

Improve the performance of take for `Utf8View` and `BinaryView` by up to 16x. Here's benchmark results comparing before and after this change, taken with my M2 MBP:

```
$ critcmp 2905ce6796cad396 2905ce6796cad396-unsafe-v2
group                                            2905ce6796cad396                       2905ce6796cad396-unsafe-v2
-----                                            ----------------                       --------------------------
take str 1024                                    1.15     13.9±2.33µs        ? ?/sec    1.00     12.1±0.28µs        ? ?/sec
take str 512                                     1.00      6.1±0.06µs        ? ?/sec    1.34      8.1±1.49µs        ? ?/sec
take str null indices 1024                       1.02      8.0±0.06µs        ? ?/sec    1.00      7.8±0.08µs        ? ?/sec
take str null indices 512                        1.03      3.7±0.07µs        ? ?/sec    1.00      3.6±0.06µs        ? ?/sec
take str null values 1024                        1.00      7.6±0.06µs        ? ?/sec    1.01      7.7±0.06µs        ? ?/sec
take str null values null indices 1024           1.00      4.6±0.03µs        ? ?/sec    1.06      4.9±0.02µs        ? ?/sec
take stringview 1024                             16.84    14.1±0.17µs        ? ?/sec    1.00    835.0±5.36ns        ? ?/sec
take stringview 512                              12.86     6.3±0.10µs        ? ?/sec    1.00    488.9±4.04ns        ? ?/sec
take stringview null indices 1024                13.79    11.7±0.16µs        ? ?/sec    1.00   848.3±19.98ns        ? ?/sec
take stringview null indices 512                 10.81     5.4±0.07µs        ? ?/sec    1.00    498.2±6.71ns        ? ?/sec
take stringview null values 1024                 5.34      9.1±0.08µs        ? ?/sec    1.00  1708.9±11.28ns        ? ?/sec
take stringview null values null indices 1024    3.01      6.9±0.08µs        ? ?/sec    1.00      2.3±0.06µs        ? ?/sec
``` 

# What changes are included in this PR?

* Mirror `take_byte` implementation for `take_byte_view` by doing a no-validation construction of the array data
* Add stringview to the existing take kernel benchmark suite

# Are there any user-facing changes?

No behavior changes just performance.
