### PR TITLE
Use reconstructed ListBlobs marker to provide list offset support in `MicrosoftAzure` store

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -67,6 +67,7 @@ aws = ["cloud", "md-5"]
 http = ["cloud"]
 tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 integration = []
+experimental-azure-list-offset = []
 
 [dev-dependencies] # In alphabetical order
 futures-test = "0.3"

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -562,7 +562,7 @@ impl GetClient for AzureClient {
 #[cfg(feature = "experimental-azure-list-offset")]
 fn marker_for_offset(offset: &str, is_emulator: bool) -> String {
     if is_emulator {
-        return offset.to_string();
+        offset.to_string()
     } else {
         // Here we reconstruct an Azure marker (continuation token) from a key to be able to seek
         // into an arbitrary position in the key space.
@@ -598,11 +598,15 @@ fn marker_for_offset(offset: &str, is_emulator: bool) -> String {
         // `start_at` behavior into a `start_after` behavior as the space character is the first valid character
         // in the lexicographical order.
 
-        let encoded_part = BASE64_STANDARD.encode(
-            &format!("{:06}!{} !000028!9999-12-31T23:59:59.9999999Z!", offset.len() + 1, offset)
-        ).replace("=", "-");
+        let encoded_part = BASE64_STANDARD
+            .encode(&format!(
+                "{:06}!{} !000028!9999-12-31T23:59:59.9999999Z!",
+                offset.len() + 1,
+                offset,
+            ))
+            .replace("=", "-");
         let length_string = format!("{}", encoded_part.len());
-        return format!("{}!{}!{}", length_string.len(), length_string, encoded_part);
+        format!("{}!{}!{}", length_string.len(), length_string, encoded_part)
     }
 }
 
@@ -636,15 +640,9 @@ impl ListClient for AzureClient {
 
         #[cfg(feature = "experimental-azure-list-offset")]
         let token_string = match (token, offset) {
-            (Some(token), _) => {
-                Some(token.to_string())
-            }
-            (None, Some(offset)) => {
-                Some(marker_for_offset(offset, self.config.is_emulator))
-            }
-            (None, None) => {
-                None
-            }
+            (Some(token), _) => Some(token.to_string()),
+            (None, Some(offset)) => Some(marker_for_offset(offset, self.config.is_emulator)),
+            (None, None) => None,
         };
 
         #[cfg(feature = "experimental-azure-list-offset")]
@@ -1037,7 +1035,10 @@ mod tests {
     fn test_marker_for_offset() {
         // BlobStorage
         let marker = marker_for_offset("file.txt", false);
-        assert_eq!(marker, "2!72!MDAwMDA5IWZpbGUudHh0ICEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-");
+        assert_eq!(
+            marker,
+            "2!72!MDAwMDA5IWZpbGUudHh0ICEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
+        );
 
         // Azurite
         let marker = marker_for_offset("file.txt", true);

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -123,6 +123,15 @@ impl ObjectStore for MicrosoftAzure {
         self.client.list(prefix)
     }
 
+    #[cfg(feature = "experimental-azure-list-offset")]
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.client.list_with_offset(prefix, offset)
+    }
+
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
         self.client.list_with_delimiter(prefix).await
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6173.

# Rationale for this change
 
The opaque token provided as a `marker` to ListBlobs is a trivial encoding of the key to start listing from (see `marker_for_offset` code comment). In this PR we propose an experimental feature flag that implements offset behavior for listing by relying on this fact.