### PR TITLE
feat(object_store):  add `PermissionDenied` variant to top-level error

### DIFF
--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -86,12 +86,13 @@ impl Error {
                 path,
                 source: Box::new(self),
             },
-            Some(StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
-                crate::Error::PermissionDernied {
-                    path,
-                    source: Box::new(self),
-                }
-            }
+            Some(StatusCode::FORBIDDEN) => crate::Error::PermissionDenied {
+                path,
+                source: Box::new(self),
+            },
+            Some(StatusCode::UNAUTHORIZED) => crate::Error::Unauthenticated {
+                source: Box::new(self),
+            },
             _ => crate::Error::Generic {
                 store,
                 source: Box::new(self),

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -91,6 +91,7 @@ impl Error {
                 source: Box::new(self),
             },
             Some(StatusCode::UNAUTHORIZED) => crate::Error::Unauthenticated {
+                path,
                 source: Box::new(self),
             },
             _ => crate::Error::Generic {

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -86,6 +86,12 @@ impl Error {
                 path,
                 source: Box::new(self),
             },
+            Some(StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
+                crate::Error::PermissionDernied {
+                    path,
+                    source: Box::new(self),
+                }
+            }
             _ => crate::Error::Generic {
                 store,
                 source: Box::new(self),
@@ -106,6 +112,10 @@ impl From<Error> for std::io::Error {
                 status: StatusCode::BAD_REQUEST,
                 ..
             } => Self::new(ErrorKind::InvalidInput, err),
+            Error::Client {
+                status: StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN,
+                ..
+            } => Self::new(ErrorKind::PermissionDenied, err),
             Error::Reqwest { source, .. } if source.is_timeout() => {
                 Self::new(ErrorKind::TimedOut, err)
             }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1274,6 +1274,16 @@ pub enum Error {
     #[snafu(display("Operation not yet implemented."))]
     NotImplemented,
 
+    #[snafu(display(
+        "The operation lacked the necessary privileges to complete for path {}: {}",
+        path,
+        source
+    ))]
+    PermissionDernied {
+        path: String,
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
     #[snafu(display("Configuration key: '{}' is not valid for store '{}'.", key, store))]
     UnknownConfigurationKey { store: &'static str, key: String },
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1279,7 +1279,7 @@ pub enum Error {
         path,
         source
     ))]
-    PermissionDernied {
+    PermissionDenied {
         path: String,
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1284,8 +1284,13 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
-    #[snafu(display("The operation lacked valid authentication credentials: {}", source))]
+    #[snafu(display(
+        "The operation lacked valid authentication credentials for path {}: {}",
+        path,
+        source
+    ))]
     Unauthenticated {
+        path: String,
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1284,6 +1284,11 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
+    #[snafu(display("The operation lacked valid authentication credentials: {}", source))]
+    Unauthenticated {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
     #[snafu(display("Configuration key: '{}' is not valid for store '{}'.", key, store))]
     UnknownConfigurationKey { store: &'static str, key: String },
 }


### PR DESCRIPTION
# Which issue does this PR close?

Follow up to #6158 and closes #5345.

# Rationale for this change
 
Exposes permission errors as a top-level error variant.

# What changes are included in this PR?

- Adds new `PermissionDenied` variant to the top-level error enum
- Converts client errors with 401/403 status code to PermissionDenied errors instead of `Generic` errors

# Are there any user-facing changes?

Yes.
