### PR TITLE
Add benchmarks for `BYTE_STREAM_SPLIT` encoded Parquet `FIXED_LEN_BYTE_ARRAY` data 

### DIFF
--- a/parquet/benches/encoding.rs
+++ b/parquet/benches/encoding.rs
@@ -16,15 +16,23 @@
 // under the License.
 
 use criterion::*;
+use half::f16;
 use parquet::basic::Encoding;
-use parquet::data_type::{DataType, DoubleType, FloatType};
+use parquet::data_type::{
+    DataType, DoubleType, FixedLenByteArray, FixedLenByteArrayType, FloatType,
+};
 use parquet::decoding::{get_decoder, Decoder};
 use parquet::encoding::get_encoder;
 use parquet::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type};
 use rand::prelude::*;
 use std::sync::Arc;
 
-fn bench_typed<T: DataType>(c: &mut Criterion, values: &[T::T], encoding: Encoding) {
+fn bench_typed<T: DataType>(
+    c: &mut Criterion,
+    values: &[T::T],
+    encoding: Encoding,
+    type_length: i32,
+) {
     let name = format!(
         "dtype={}, encoding={:?}",
         std::any::type_name::<T::T>(),
@@ -33,6 +41,7 @@ fn bench_typed<T: DataType>(c: &mut Criterion, values: &[T::T], encoding: Encodi
     let column_desc_ptr = ColumnDescPtr::new(ColumnDescriptor::new(
         Arc::new(
             Type::primitive_type_builder("", T::get_physical_type())
+                .with_length(type_length)
                 .build()
                 .unwrap(),
         ),
@@ -68,15 +77,20 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0);
     let n = 16 * 1024;
 
+    let mut f16s = Vec::new();
     let mut f32s = Vec::new();
     let mut f64s = Vec::new();
     for _ in 0..n {
+        f16s.push(FixedLenByteArray::from(
+            f16::from_f32(rng.gen::<f32>()).to_le_bytes().to_vec(),
+        ));
         f32s.push(rng.gen::<f32>());
         f64s.push(rng.gen::<f64>());
     }
 
-    bench_typed::<FloatType>(c, &f32s, Encoding::BYTE_STREAM_SPLIT);
-    bench_typed::<DoubleType>(c, &f64s, Encoding::BYTE_STREAM_SPLIT);
+    bench_typed::<FloatType>(c, &f32s, Encoding::BYTE_STREAM_SPLIT, 0);
+    bench_typed::<DoubleType>(c, &f64s, Encoding::BYTE_STREAM_SPLIT, 0);
+    bench_typed::<FixedLenByteArrayType>(c, &f16s, Encoding::BYTE_STREAM_SPLIT, 2);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/parquet/benches/encoding.rs
+++ b/parquet/benches/encoding.rs
@@ -80,17 +80,22 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut f16s = Vec::new();
     let mut f32s = Vec::new();
     let mut f64s = Vec::new();
+    let mut d128s = Vec::new();
     for _ in 0..n {
         f16s.push(FixedLenByteArray::from(
             f16::from_f32(rng.gen::<f32>()).to_le_bytes().to_vec(),
         ));
         f32s.push(rng.gen::<f32>());
         f64s.push(rng.gen::<f64>());
+        d128s.push(FixedLenByteArray::from(
+            rng.gen::<i128>().to_be_bytes().to_vec(),
+        ));
     }
 
     bench_typed::<FloatType>(c, &f32s, Encoding::BYTE_STREAM_SPLIT, 0);
     bench_typed::<DoubleType>(c, &f64s, Encoding::BYTE_STREAM_SPLIT, 0);
     bench_typed::<FixedLenByteArrayType>(c, &f16s, Encoding::BYTE_STREAM_SPLIT, 2);
+    bench_typed::<FixedLenByteArrayType>(c, &d128s, Encoding::BYTE_STREAM_SPLIT, 16);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/parquet/src/util/test_common/page_util.rs
+++ b/parquet/src/util/test_common/page_util.rs
@@ -51,13 +51,14 @@ pub struct DataPageBuilderImpl {
     rep_levels_byte_len: u32,
     def_levels_byte_len: u32,
     datapage_v2: bool,
+    type_width: i32,
 }
 
 impl DataPageBuilderImpl {
     // `num_values` is the number of non-null values to put in the data page.
     // `datapage_v2` flag is used to indicate if the generated data page should use V2
     // format or not.
-    pub fn new(_desc: ColumnDescPtr, num_values: u32, datapage_v2: bool) -> Self {
+    pub fn new(desc: ColumnDescPtr, num_values: u32, datapage_v2: bool) -> Self {
         DataPageBuilderImpl {
             encoding: None,
             num_values,
@@ -65,6 +66,7 @@ impl DataPageBuilderImpl {
             rep_levels_byte_len: 0,
             def_levels_byte_len: 0,
             datapage_v2,
+            type_width: desc.type_length(),
         }
     }
 
@@ -111,7 +113,7 @@ impl DataPageBuilder for DataPageBuilderImpl {
         // Create test column descriptor.
         let desc = {
             let ty = SchemaType::primitive_type_builder("t", T::get_physical_type())
-                .with_length(0)
+                .with_length(self.type_width)
                 .build()
                 .unwrap();
             Arc::new(ColumnDescriptor::new(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6203.


# What changes are included in this PR?
Adds new benches to `arrow_reader` and `encoding` in `parquet/benches`.

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
