### PR TITLE
fix: Correctly handle take on dense union of a single selected type

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -552,7 +552,7 @@ fn filter_native<T: ArrowNativeType>(values: &[T], predicate: &FilterPredicate) 
 }
 
 /// `filter` implementation for primitive arrays
-pub(crate) fn filter_primitive<T>(
+fn filter_primitive<T>(
     array: &PrimitiveArray<T>,
     predicate: &FilterPredicate,
 ) -> PrimitiveArray<T>

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -552,10 +552,7 @@ fn filter_native<T: ArrowNativeType>(values: &[T], predicate: &FilterPredicate) 
 }
 
 /// `filter` implementation for primitive arrays
-fn filter_primitive<T>(
-    array: &PrimitiveArray<T>,
-    predicate: &FilterPredicate,
-) -> PrimitiveArray<T>
+fn filter_primitive<T>(array: &PrimitiveArray<T>, predicate: &FilterPredicate) -> PrimitiveArray<T>
 where
     T: ArrowPrimitiveType,
 {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -2313,7 +2313,7 @@ mod tests {
 
         let array = UnionArray::try_new(
             fields,
-            ScalarBuffer::from_iter(vec![0_i8, 0, 0, 0, 0].into_iter()),
+            ScalarBuffer::from(vec![0_i8, 0, 0, 0, 0]),
             Some(ScalarBuffer::from_iter(0_i32..5)),
             vec![ints],
         )

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -2308,10 +2308,9 @@ mod tests {
 
     #[test]
     fn test_take_union_dense_all_match_issue_6206() {
-
         let fields = UnionFields::new(vec![0], vec![Field::new("a", DataType::Int64, false)]);
         let ints = Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5]));
-    
+
         let array = UnionArray::try_new(
             fields,
             ScalarBuffer::from_iter(vec![0_i8, 0, 0, 0, 0].into_iter()),
@@ -2319,10 +2318,9 @@ mod tests {
             vec![ints],
         )
         .unwrap();
-    
+
         let indicies = Int64Array::from(vec![0, 2, 4]);
         let array = take(&array, &indicies, None).unwrap();
         assert_eq!(array.len(), 3);
-
     }
 }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -31,8 +31,6 @@ use arrow_schema::{ArrowError, DataType, FieldRef, UnionMode};
 
 use num::{One, Zero};
 
-use crate::filter::{filter_primitive, FilterBuilder};
-
 /// Take elements by index from [Array], creating a new [Array] from those indexes.
 ///
 /// ```text
@@ -251,13 +249,12 @@ fn take_impl<IndexType: ArrowPrimitiveType>(
             let children = fields.iter()
                 .map(|(field_type_id, _)| {
                     let mask = BooleanArray::from_unary(&type_ids, |value_type_id| value_type_id == field_type_id);
-                    let predicate = FilterBuilder::new(&mask).build();
 
-                    let indices = filter_primitive(&offsets, &predicate);
+                    let indices = crate::filter::filter(&offsets, &mask)?;
 
                     let values = values.child(field_type_id);
 
-                    take_impl(values, &indices)
+                    take_impl(values, indices.as_primitive::<Int32Type>())
                 })
                 .collect::<Result<_, _>>()?;
 
@@ -885,7 +882,7 @@ mod tests {
     use super::*;
     use arrow_array::builder::*;
     use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
-    use arrow_schema::{Field, Fields, TimeUnit};
+    use arrow_schema::{Field, Fields, TimeUnit, UnionFields};
 
     fn test_take_decimal_arrays(
         data: Vec<Option<i128>>,
@@ -2307,5 +2304,25 @@ mod tests {
             taken.to_data(),
             take(&union, &indices, None).unwrap().to_data()
         );
+    }
+
+    #[test]
+    fn test_take_union_dense_all_match_issue_6206() {
+
+        let fields = UnionFields::new(vec![0], vec![Field::new("a", DataType::Int64, false)]);
+        let ints = Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5]));
+    
+        let array = UnionArray::try_new(
+            fields,
+            ScalarBuffer::from_iter(vec![0_i8, 0, 0, 0, 0].into_iter()),
+            Some(ScalarBuffer::from_iter(0_i32..5)),
+            vec![ints],
+        )
+        .unwrap();
+    
+        let indicies = Int64Array::from(vec![0, 2, 4]);
+        let array = take(&array, &indicies, None).unwrap();
+        assert_eq!(array.len(), 3);
+
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6206.

# What changes are included in this PR?

At #5873, I naively called `filter_primitive` instead of `filter` to avoid arcing and downcasting, but this bypass the [check for when all values match the predicate](https://github.com/apache/arrow-rs/blob/49840ec0f110da5e9a21ce97affd32313d0b720f/arrow-select/src/filter.rs#L322), which `filter_primitive` expects to happen, leading `unreachable!()` to be [hit](https://github.com/apache/arrow-rs/blob/49840ec0f110da5e9a21ce97affd32313d0b720f/arrow-select/src/filter.rs#L548)

This PR calls `filter` instead of `filter_primitive`, and removes the added `pub(crate)` from `filter_primitive` to avoid future misuse.

# Are there any user-facing changes?

No

