### PR TITLE
use spaces not tabs everywhere

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -193,7 +193,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
                     // cast kernel will return error.
                     can_cast_types(f1.data_type(), f2.data_type())
                 })
-		}
+        }
         (Struct(_), _) => false,
         (_, Struct(_)) => false,
         (_, Boolean) => {

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -638,10 +638,10 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555,23:46:03,foo
         file.read_to_end(&mut buffer).unwrap();
 
         assert_eq!(
-			"c1,c2,c3,c4,c6\n\"Lorem ipsum \ndolor sit amet\",123.564532,3,true,00:20:34\n\"consectetur $\"adipiscing$\" elit\",,2,false,06:51:20\nsed do eiusmod tempor,-556132.25,1,,23:46:03\n"
-			.to_string(),
-			String::from_utf8(buffer).unwrap()
-		);
+            "c1,c2,c3,c4,c6\n\"Lorem ipsum \ndolor sit amet\",123.564532,3,true,00:20:34\n\"consectetur $\"adipiscing$\" elit\",,2,false,06:51:20\nsed do eiusmod tempor,-556132.25,1,,23:46:03\n"
+            .to_string(),
+            String::from_utf8(buffer).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Seems very weird that we have tabs in just a couple of places.

I checked and there's no way to get `rustfmt` to enforce spaces instead of tabs.