### PR TITLE
Support casting to and from unions

### DIFF
--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -241,6 +241,27 @@ impl UnionArray {
         boxed.as_ref().expect("invalid type id")
     }
 
+    /// Get a member of the union as an array, this is equivalent to [`self::child`] for sparse unions.
+    ///
+    /// # Panics
+    /// Panics if `type_id` is not present in the union.
+    pub fn member_array(&self, type_id: i8) -> &ArrayRef {
+        let child = self.child(type_id);
+        match &self.offsets {
+            Some(_offsets) => {
+                todo!("I'm not sure what to do here");
+                // offsets.iter().zip(self.type_ids.iter()).map(|(offset, id)| {
+                //     if id == &type_id {
+                //         child.value(*offset as usize)
+                //     } else {
+                //         None
+                //     }
+                // })
+            }
+            None => child,
+        }
+    }
+
     /// Returns the `type_id` for the array slot at `index`.
     ///
     /// # Panics
@@ -296,7 +317,7 @@ impl UnionArray {
     }
 
     /// Returns whether the `UnionArray` is dense (or sparse if `false`).
-    fn is_dense(&self) -> bool {
+    pub fn is_dense(&self) -> bool {
         match self.data_type() {
             DataType::Union(_, mode) => mode == &UnionMode::Dense,
             _ => unreachable!("Union array's data type is not a union!"),

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -241,27 +241,6 @@ impl UnionArray {
         boxed.as_ref().expect("invalid type id")
     }
 
-    /// Get a member of the union as an array, this is equivalent to [`self::child`] for sparse unions.
-    ///
-    /// # Panics
-    /// Panics if `type_id` is not present in the union.
-    pub fn member_array(&self, type_id: i8) -> &ArrayRef {
-        let child = self.child(type_id);
-        match &self.offsets {
-            Some(_offsets) => {
-                todo!("I'm not sure what to do here");
-                // offsets.iter().zip(self.type_ids.iter()).map(|(offset, id)| {
-                //     if id == &type_id {
-                //         child.value(*offset as usize)
-                //     } else {
-                //         None
-                //     }
-                // })
-            }
-            None => child,
-        }
-    }
-
     /// Returns the `type_id` for the array slot at `index`.
     ///
     /// # Panics

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -1245,7 +1245,7 @@ pub fn cast_with_options(
                             cast_with_options(array, f.data_type(), cast_options)
                         } else {
                             // create empty ArrayRef's for other fields
-                            Ok(new_empty_array(&f.data_type()))
+                            Ok(new_empty_array(f.data_type()))
                         }
                     })
                     .collect::<Result<Vec<_>, ArrowError>>()?;
@@ -1259,7 +1259,7 @@ pub fn cast_with_options(
                             cast_with_options(array, f.data_type(), cast_options)
                         } else {
                             // create empty ArrayRef's for other fields
-                            Ok(new_null_array(&f.data_type(), array.len()))
+                            Ok(new_null_array(f.data_type(), array.len()))
                         }
                     })
                     .collect::<Result<Vec<_>, ArrowError>>()?;
@@ -9747,7 +9747,6 @@ mod tests {
         assert_eq!(as_int_vec::<Int32Type>(&as_union.value(0)), vec![Some(1)]);
         assert_eq!(as_int_vec::<Int32Type>(&as_union.value(1)), vec![Some(2)]);
         assert_eq!(as_int_vec::<Int32Type>(&as_union.value(2)), vec![Some(3)]);
-
 
         let strings = StringArray::from_iter_values(vec!["a", "b", "c"].into_iter());
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/10180.

# Rationale for this change
 
I want to cast from unions to primitive types (I've also added support for casting to a union here).

# What changes are included in this PR?

Support casting to and from unions (hopefully), tests.

Casting between unions is not yet supported.

# Are there any user-facing changes?

no