### PR TITLE
Improve performance of `FixedLengthBinary` decoding 

### DIFF
--- a/parquet/benches/encoding.rs
+++ b/parquet/benches/encoding.rs
@@ -17,7 +17,7 @@
 
 use criterion::*;
 use half::f16;
-use parquet::basic::Encoding;
+use parquet::basic::{Encoding, Type as ParquetType};
 use parquet::data_type::{
     DataType, DoubleType, FixedLenByteArray, FixedLenByteArrayType, FloatType,
 };
@@ -35,7 +35,10 @@ fn bench_typed<T: DataType>(
 ) {
     let name = format!(
         "dtype={}, encoding={:?}",
-        std::any::type_name::<T::T>(),
+        match T::get_physical_type() {
+            ParquetType::FIXED_LEN_BYTE_ARRAY => format!("FixedLenByteArray({type_length})"),
+            _ => std::any::type_name::<T::T>().to_string(),
+        },
         encoding
     );
     let column_desc_ptr = ColumnDescPtr::new(ColumnDescriptor::new(

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -674,6 +674,13 @@ pub(crate) mod private {
 
         /// Return the value as an mutable Any to allow for downcasts without transmutation
         fn as_mut_any(&mut self) -> &mut dyn std::any::Any;
+
+        /// Sets the value of this object from the provided [`Bytes`]
+        ///
+        /// Only implemented for `ByteArray` and `FixedLenByteArray`. Will panic for other types.
+        fn set_from_bytes(&mut self, _data: Bytes) {
+            unimplemented!();
+        }
     }
 
     impl ParquetValueType for bool {
@@ -953,9 +960,7 @@ pub(crate) mod private {
                     return Err(eof_err!("Not enough bytes to decode"));
                 }
 
-                let val: &mut Self = val_array.as_mut_any().downcast_mut().unwrap();
-
-                val.set_data(data.slice(decoder.start..decoder.start + len));
+                val_array.set_data(data.slice(decoder.start..decoder.start + len));
                 decoder.start += len;
             }
             decoder.num_values -= num_values;
@@ -997,6 +1002,11 @@ pub(crate) mod private {
         #[inline]
         fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
             self
+        }
+
+        #[inline]
+        fn set_from_bytes(&mut self, data: Bytes) {
+            self.set_data(data);
         }
     }
 
@@ -1092,6 +1102,11 @@ pub(crate) mod private {
         #[inline]
         fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
             self
+        }
+
+        #[inline]
+        fn set_from_bytes(&mut self, data: Bytes) {
+            self.set_data(data);
         }
     }
 

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -21,7 +21,7 @@ use bytes::Bytes;
 
 use crate::basic::{Encoding, Type};
 use crate::data_type::private::ParquetValueType;
-use crate::data_type::{DataType, FixedLenByteArray, SliceAsBytes};
+use crate::data_type::{DataType, SliceAsBytes};
 use crate::errors::{ParquetError, Result};
 
 use super::Decoder;
@@ -234,12 +234,7 @@ impl<T: DataType> Decoder<T> for VariableWidthByteStreamSplitDecoder<T> {
         for (i, bi) in buffer.iter_mut().enumerate().take(num_values) {
             // Get a view into the data, without also copying the bytes
             let data = bytes_with_data.slice(i * type_size..(i + 1) * type_size);
-            // TODO: perhaps add a `set_from_bytes` method to `DataType` to avoid downcasting
-            let bi = bi
-                .as_mut_any()
-                .downcast_mut::<FixedLenByteArray>()
-                .expect("Decoding fixed length byte array");
-            bi.set_data(data);
+            bi.set_from_bytes(data);
         }
 
         Ok(num_values)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Tangentially related to #6219.

# Rationale for this change
 
Following up on https://github.com/apache/arrow-rs/pull/6159#discussion_r1702114084, this adds `set_from_bytes` to the private `ParquetValueType` trait. This avoids the need for downcasting for byte array types.

# What changes are included in this PR?
In addition to the above, it also changes the formatting in the encoding benchmark to distinguish between `FixedLenByteArray(2)` and `FixedLenByteArray(16)`. Without this critcmp overwrites the `FLBA(2)` results.

# Are there any user-facing changes?

No, changes are to private interfaces.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
