### PR TITLE
Modest improvement to FixedLenByteArray BYTE_STREAM_SPLIT arrow decoder

### DIFF
--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -456,8 +456,9 @@ fn read_byte_stream_split(
     dst.resize(idx + num_values * data_width, 0u8);
     let dst_slc = &mut dst[idx..idx + num_values * data_width];
     for j in 0..data_width {
+        let src_slc = &src[offset + j * stride..offset + j * stride + num_values];
         for i in 0..num_values {
-            dst_slc[i * data_width + j] = src[offset + j * stride + i];
+            dst_slc[i * data_width + j] = src_slc[i];
         }
     }
 }

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -33,7 +33,7 @@ use arrow_array::{
 use arrow_buffer::{i256, Buffer, IntervalDayTime};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, IntervalUnit};
-use bytes::{BufMut, Bytes};
+use bytes::Bytes;
 use half::f16;
 use std::any::Any;
 use std::sync::Arc;

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -33,7 +33,7 @@ use arrow_array::{
 use arrow_buffer::{i256, Buffer, IntervalDayTime};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, IntervalUnit};
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 use half::f16;
 use std::any::Any;
 use std::sync::Arc;
@@ -410,7 +410,6 @@ impl ColumnValueDecoder for ValueDecoder {
                 // so `offset` should be the value offset, not the byte offset
                 let total_values = buf.len() / self.byte_length;
                 let to_read = num_values.min(total_values - *offset);
-                out.buffer.reserve(to_read * self.byte_length);
 
                 // now read the n streams and reassemble values into the output buffer
                 read_byte_stream_split(&mut out.buffer, buf, *offset, to_read, self.byte_length);
@@ -453,9 +452,12 @@ fn read_byte_stream_split(
     data_width: usize,
 ) {
     let stride = src.len() / data_width;
-    for i in 0..num_values {
-        for j in 0..data_width {
-            dst.push(src[offset + j * stride + i]);
+    let idx = dst.len();
+    dst.resize(idx + num_values * data_width, 0u8);
+    let dst_slc = &mut dst[idx..idx + num_values * data_width];
+    for j in 0..data_width {
+        for i in 0..num_values {
+            dst_slc[i * data_width + j] = src[offset + j * stride + i];
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Related to #6219.

# Rationale for this change
 
When this decoder was added, little thought was given to performance. The changes here have an impact that varies by architecture.

Old 2.2GHz Core i7
```
group                                                                                                   master                                 opt_read
-----                                                                                                   ------                                 --------
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, mandatory, no NULLs                        1.00      2.2±0.04ms        ? ?/sec    1.03      2.3±0.48ms        ? ?/sec
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, optional, half NULLs                       1.00      2.3±0.04ms        ? ?/sec    1.01      2.3±0.04ms        ? ?/sec
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, optional, no NULLs                         1.00      2.2±0.09ms        ? ?/sec    1.00      2.2±0.04ms        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, mandatory, no NULLs     1.74      3.3±0.07ms        ? ?/sec    1.00  1904.9±45.03µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, optional, half NULLs    1.29      3.1±0.05ms        ? ?/sec    1.00      2.4±0.05ms        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, optional, no NULLs      1.72      3.3±0.06ms        ? ?/sec    1.00  1923.3±37.33µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, mandatory, no NULLs        1.28   831.4±14.84µs        ? ?/sec    1.00   651.8±13.35µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, optional, half NULLs       1.12  1473.3±33.07µs        ? ?/sec    1.00  1314.2±26.78µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, optional, no NULLs         1.27   841.0±17.96µs        ? ?/sec    1.00   659.7±13.25µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, mandatory, no NULLs           1.00  1027.5±24.48µs        ? ?/sec    1.00  1028.8±24.90µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, optional, half NULLs          1.00  1927.8±45.32µs        ? ?/sec    1.00  1927.2±38.97µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, optional, no NULLs            1.00  1034.4±27.58µs        ? ?/sec    1.00  1034.2±32.82µs        ? ?/sec
```

newer 3.6GHz Core i7-12700K
```
group                                                                                                   master                                 opt_read
-----                                                                                                   ------                                 --------
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, mandatory, no NULLs                        1.00    873.0±8.77µs        ? ?/sec    1.00    875.9±5.62µs        ? ?/sec
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, optional, half NULLs                       1.00   1039.7±7.19µs        ? ?/sec    1.01   1048.3±6.85µs        ? ?/sec
arrow_array_reader/BYTE_ARRAY/Decimal128Array/plain encoded, optional, no NULLs                         1.00    874.6±4.54µs        ? ?/sec    1.00    878.5±9.08µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, mandatory, no NULLs     1.30   963.5±10.85µs        ? ?/sec    1.00    743.8±3.88µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, optional, half NULLs    1.10  1216.2±16.67µs        ? ?/sec    1.00   1103.1±6.30µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Decimal128Array/byte_stream_split encoded, optional, no NULLs      1.29    966.9±7.71µs        ? ?/sec    1.00    747.5±3.44µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, mandatory, no NULLs        1.36    347.3±2.89µs        ? ?/sec    1.00    255.5±2.11µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, optional, half NULLs       1.04    684.2±2.43µs        ? ?/sec    1.00    655.9±4.87µs        ? ?/sec
arrow_array_reader/BYTE_STREAM_SPLIT/Float16Array/byte_stream_split encoded, optional, no NULLs         1.37    347.6±5.69µs        ? ?/sec    1.00    254.5±1.07µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, mandatory, no NULLs           1.01    367.8±5.65µs        ? ?/sec    1.00    365.7±2.58µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, optional, half NULLs          1.01    927.8±8.27µs        ? ?/sec    1.00    919.6±4.94µs        ? ?/sec
arrow_array_reader/FIXED_LENGTH_BYTE_ARRAY/Decimal128Array/plain encoded, optional, no NULLs            1.00    373.1±3.23µs        ? ?/sec    1.00    373.0±5.44µs        ? ?/sec
```

# What changes are included in this PR?

Replaces the use of `Vec::push` with direct access via slices.

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
