### PR TITLE
Avoid infinite loop in bad parquet by checking the number of rep levels 

### DIFF
--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -240,6 +240,12 @@ where
                     let (mut records_read, levels_read) =
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
+                    if levels_read == 0 {
+                        // Tha fact that we're still looping implies there must be some levels to read.
+                        return Err(general_err!(
+                            "Insufficient repetition levels read from column"
+                        ));
+                    }
                     if levels_read == remaining_levels && self.has_record_delimiter {
                         // Reached end of page, which implies records_read < remaining_records
                         // as otherwise would have stopped reading before reaching the end

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -241,7 +241,7 @@ where
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
                     if levels_read == 0 {
-                        // Tha fact that we're still looping implies there must be some levels to read.
+                        // The fact that we're still looping implies there must be some levels to read.
                         return Err(general_err!(
                             "Insufficient repetition levels read from column"
                         ));

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -240,7 +240,7 @@ where
                     let (mut records_read, levels_read) =
                         reader.read_rep_levels(out, remaining_records, remaining_levels)?;
 
-                    if levels_read == 0 {
+                    if records_read == 0 && levels_read == 0 {
                         // The fact that we're still looping implies there must be some levels to read.
                         return Err(general_err!(
                             "Insufficient repetition levels read from column"


### PR DESCRIPTION
# Which issue does this PR close?

This fixes one case of #6228.

# Rationale for this change
 
In read_records, the number of rep levels read from page can be 0 if the file is corrupted. But currently we don't check that and in that case the execution will stuck in the read_records, keeping reading but reading nothing.

# What changes are included in this PR?

Error out if reading 0 rep level.

# Are there any user-facing changes?

not really.
