### PR TITLE
Add examples to `StringViewBuilder` and `BinaryViewBuilder`

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -65,7 +65,7 @@ impl BlockSizeGrowthStrategy {
 /// # Append Values
 ///
 /// To avoid bump allocating, this builder allocates data in fixed size blocks, configurable
-/// using [`GenericByteViewBuilder::with_block_size`]. [`GenericByteViewBuilder::append_value`]
+/// using [`GenericByteViewBuilder::with_fixed_block_size`]. [`GenericByteViewBuilder::append_value`]
 /// writes values larger than 12 bytes to the current in-progress block, with values smaller
 /// than 12 bytes inlined into the views. If a value is appended that will not fit in the
 /// in-progress block, it will be closed, and a new block of sufficient size allocated
@@ -462,12 +462,43 @@ impl<T: ByteViewType + ?Sized, V: AsRef<T::Native>> Extend<Option<V>>
 ///
 /// Values can be appended using [`GenericByteViewBuilder::append_value`], and nulls with
 /// [`GenericByteViewBuilder::append_null`] as normal.
+///
+/// # Example
+/// ```
+/// # use arrow_array::builder::StringViewBuilder;
+/// # use arrow_array::StringViewArray;
+/// let mut builder = StringViewBuilder::new();
+/// builder.append_value("hello");
+/// builder.append_null();
+/// builder.append_value("world");
+/// let array = builder.finish();
+///
+/// let expected = vec![Some("hello"), None, Some("world")];
+/// let actual: Vec<_> = array.iter().collect();
+/// assert_eq!(expected, actual);
+/// ```
 pub type StringViewBuilder = GenericByteViewBuilder<StringViewType>;
 
 ///  Array builder for [`BinaryViewArray`][crate::BinaryViewArray]
 ///
 /// Values can be appended using [`GenericByteViewBuilder::append_value`], and nulls with
 /// [`GenericByteViewBuilder::append_null`] as normal.
+///
+/// # Example
+/// ```
+/// # use arrow_array::builder::BinaryViewBuilder;
+/// use arrow_array::BinaryViewArray;
+/// let mut builder = BinaryViewBuilder::new();
+/// builder.append_value("hello");
+/// builder.append_null();
+/// builder.append_value("world");
+/// let array = builder.finish();
+///
+/// let expected: Vec<Option<&[u8]>> = vec![Some(b"hello"), None, Some(b"world")];
+/// let actual: Vec<_> = array.iter().collect();
+/// assert_eq!(expected, actual);
+/// ```
+///
 pub type BinaryViewBuilder = GenericByteViewBuilder<BinaryViewType>;
 
 /// Creates a view from a fixed length input (the compiler can generate

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -60,6 +60,8 @@ impl BlockSizeGrowthStrategy {
 /// A [`GenericByteViewArray`] consists of a list of data blocks containing string data,
 /// and a list of views into those buffers.
 ///
+/// See examples on [`StringViewBuilder`] and [`BinaryViewBuilder`]
+///
 /// This builder can be used in two ways
 ///
 /// # Append Values


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
While reviewing https://github.com/apache/datafusion/pull/11962/files  in DataFusion and wanted to point at this builder for creating `StringView` and `BinaryView` arrays as a way to improve
performance. However, I noticed that the docs for these builders did not have examples.

# What changes are included in this PR?

1. Add examples to `StringViewBuilder` and `BinaryViewBuilder`
2. Tweak docs

# Are there any user-facing changes?
Docs only, no functinal change

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
