### PR TITLE
Use `unary()` for array conversion in Parquet array readers, speed up `Decimal128`, `Decimal256` and `Float16` 

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -468,9 +468,9 @@ impl FixedSizeBinaryArray {
     }
 
     /// Applies a unary infallible function to a fixed-size binary array, producing a
-    /// new array of potentially different type.
+    /// new primitive array.
     ///
-    /// This is the fastest way to perform an operation on a primitive array
+    /// This is the fastest way to perform an operation on a fixed-size binary array
     /// when the benefits of a vectorized operation outweigh the cost of
     /// branching nulls and non-nulls.
     ///

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -15,13 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::primitive_array::PrimitiveArray;
 use crate::array::print_long_array;
 use crate::iterator::FixedSizeBinaryIter;
-use crate::types::ArrowPrimitiveType;
 use crate::{Array, ArrayAccessor, ArrayRef, FixedSizeListArray, Scalar};
 use arrow_buffer::buffer::NullBuffer;
-use arrow_buffer::{bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, ScalarBuffer};
+use arrow_buffer::{bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};
 use std::any::Any;
@@ -465,42 +463,6 @@ impl FixedSizeBinaryArray {
     /// constructs a new iterator
     pub fn iter(&self) -> FixedSizeBinaryIter<'_> {
         FixedSizeBinaryIter::new(self)
-    }
-
-    /// Applies a unary infallible function to a fixed-size binary array, producing a
-    /// new primitive array.
-    ///
-    /// This is the fastest way to perform an operation on a fixed-size binary array
-    /// when the benefits of a vectorized operation outweigh the cost of
-    /// branching nulls and non-nulls.
-    ///
-    /// # Null Handling
-    ///
-    /// Applies the function for all values, including those on null slots. This
-    /// will often allow the compiler to generate faster vectorized code, but
-    /// requires that the operation must be infallible (not error/panic) for any
-    /// value of the corresponding type or this function may panic.
-    pub fn unary<F, O>(&self, op: F) -> PrimitiveArray<O>
-    where
-        O: ArrowPrimitiveType,
-        F: Fn(&[u8]) -> O::Native,
-    {
-        let num_vals = self.len();
-        let length = self.value_length as usize;
-        let src = self.value_data.as_slice();
-        let mut dst = vec![O::Native::default(); num_vals];
-
-        // Performance note: not using src.chunks() as that was considerably slower than
-        // calculating slices of src directly.
-        for (i, dsti) in dst.iter_mut().enumerate().take(num_vals) {
-            let idx = length * i;
-            *dsti = op(&src[idx..idx + length])
-        }
-
-        PrimitiveArray::new(
-            ScalarBuffer::new(Buffer::from_vec(dst), 0, num_vals),
-            self.nulls().cloned(),
-        )
     }
 }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1021,10 +1021,17 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     ///
     /// # Null Handling
     ///
-    /// Applies the function for all values, including those on null slots. This
-    /// will often allow the compiler to generate faster vectorized code, but
-    /// requires that the operation must be infallible (not error/panic) for any
-    /// value of the corresponding type or this function may panic.
+    /// See [`Self::unary`] for more information on null handling.
+    ///
+    /// # Example: create an [`Int16Array`] from a [`FixedSizeBinaryArray`]
+    ///
+    /// ```
+    /// use arrow_array::{Array, FixedSizeBinaryArray, Int16Array};
+    /// let input_arg = vec![ vec![1, 0], vec![2, 0], vec![3, 0] ];
+    /// let arr = FixedSizeBinaryArray::try_from_iter(input_arg.into_iter()).unwrap();
+    /// let c = Int16Array::from_unary(&arr, |x| i16::from_le_bytes(x[..2].try_into().unwrap()));
+    /// assert_eq!(c, Int16Array::from(vec![Some(1i16), Some(2i16), Some(3i16)]));
+    /// ```
     pub fn from_unary<U: ArrayAccessor, F>(left: U, mut op: F) -> Self
     where
         F: FnMut(U::Item) -> T::Native,

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1023,8 +1023,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     ///
     /// See [`Self::unary`] for more information on null handling.
     ///
-    /// # Example: create an [`Int16Array`] from a [`FixedSizeBinaryArray`]
-    ///
+    /// # Example: create an [`Int16Array`] from an [`ArrayAccessor`] with item type `&[u8]`
     /// ```
     /// use arrow_array::{Array, FixedSizeBinaryArray, Int16Array};
     /// let input_arg = vec![ vec![1, 0], vec![2, 0], vec![3, 0] ];

--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -120,6 +120,9 @@ impl<I: OffsetSizeTrait> ArrayReader for ByteArrayReader<I> {
         self.record_reader.reset();
 
         let array: ArrayRef = match self.data_type {
+            // Apply conversion to all elements regardless of null slots as the conversions
+            // are infallible. This improves performance by avoiding a branch in the inner
+            // loop (see docs for `PrimitiveArray::from_unary`).
             ArrowType::Decimal128(p, s) => {
                 let array = buffer.into_array(null_buffer, ArrowType::Binary);
                 let binary = array.as_any().downcast_ref::<BinaryArray>().unwrap();

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -163,6 +163,9 @@ impl ArrayReader for FixedLenByteArrayReader {
         let binary = FixedSizeBinaryArray::from(unsafe { array_data.build_unchecked() });
 
         // TODO: An improvement might be to do this conversion on read
+        // Note the conversions below apply to all elements regardless of null slots as the
+        // conversion lambdas are all infallible. This improves performance by avoiding a branch in
+        // the inner loop (see docs for `PrimitiveArray::from_unary`).
         let array: ArrayRef = match &self.data_type {
             ArrowType::Decimal128(p, s) => {
                 let f = |b: &[u8]| i128::from_be_bytes(sign_extend_be(b));

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -166,12 +166,12 @@ impl ArrayReader for FixedLenByteArrayReader {
         let array: ArrayRef = match &self.data_type {
             ArrowType::Decimal128(p, s) => {
                 let f = |b: &[u8]| i128::from_be_bytes(sign_extend_be(b));
-                Arc::new((binary.unary(&f) as Decimal128Array).with_precision_and_scale(*p, *s)?)
+                Arc::new(Decimal128Array::from_unary(&binary, f).with_precision_and_scale(*p, *s)?)
                     as ArrayRef
             }
             ArrowType::Decimal256(p, s) => {
                 let f = |b: &[u8]| i256::from_be_bytes(sign_extend_be(b));
-                Arc::new((binary.unary(&f) as Decimal256Array).with_precision_and_scale(*p, *s)?)
+                Arc::new(Decimal256Array::from_unary(&binary, f).with_precision_and_scale(*p, *s)?)
                     as ArrayRef
             }
             ArrowType::Interval(unit) => {
@@ -180,7 +180,7 @@ impl ArrayReader for FixedLenByteArrayReader {
                 match unit {
                     IntervalUnit::YearMonth => {
                         let f = |b: &[u8]| i32::from_le_bytes(b[0..4].try_into().unwrap());
-                        Arc::new(binary.unary(&f) as IntervalYearMonthArray) as ArrayRef
+                        Arc::new(IntervalYearMonthArray::from_unary(&binary, f)) as ArrayRef
                     }
                     IntervalUnit::DayTime => {
                         let f = |b: &[u8]| {
@@ -189,7 +189,7 @@ impl ArrayReader for FixedLenByteArrayReader {
                                 i32::from_le_bytes(b[8..12].try_into().unwrap()),
                             )
                         };
-                        Arc::new(binary.unary(&f) as IntervalDayTimeArray) as ArrayRef
+                        Arc::new(IntervalDayTimeArray::from_unary(&binary, f)) as ArrayRef
                     }
                     IntervalUnit::MonthDayNano => {
                         return Err(nyi_err!("MonthDayNano intervals not supported"));
@@ -197,8 +197,8 @@ impl ArrayReader for FixedLenByteArrayReader {
                 }
             }
             ArrowType::Float16 => {
-                let f = |b: &[u8]| f16::from_le_bytes(b.try_into().unwrap());
-                Arc::new(binary.unary(&f) as Float16Array) as ArrayRef
+                let f = |b: &[u8]| f16::from_le_bytes(b[..2].try_into().unwrap());
+                Arc::new(Float16Array::from_unary(&binary, f)) as ArrayRef
             }
             _ => Arc::new(binary) as ArrayRef,
         };

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -217,35 +217,19 @@ where
                 arrow_cast::cast(&a, target_type)?
             }
             ArrowType::Decimal128(p, s) => {
-                // We can simply reuse the null buffer from `array` rather than recomputing it
-                // (as was the case when we simply used `collect` to produce the new array).
-                let nulls = array.nulls().cloned();
                 let array = match array.data_type() {
-                    ArrowType::Int32 => {
-                        let decimal = array
-                            .as_any()
-                            .downcast_ref::<Int32Array>()
-                            .unwrap()
-                            .iter()
-                            .map(|v| match v {
-                                Some(i) => i as i128,
-                                None => i128::default(),
-                            });
-                        Decimal128Array::from_iter_values_with_nulls(decimal, nulls)
-                    }
-
-                    ArrowType::Int64 => {
-                        let decimal = array
-                            .as_any()
-                            .downcast_ref::<Int64Array>()
-                            .unwrap()
-                            .iter()
-                            .map(|v| match v {
-                                Some(i) => i as i128,
-                                None => i128::default(),
-                            });
-                        Decimal128Array::from_iter_values_with_nulls(decimal, nulls)
-                    }
+                    ArrowType::Int32 => array
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap()
+                        .unary(|i| i as i128)
+                        as Decimal128Array,
+                    ArrowType::Int64 => array
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap()
+                        .unary(|i| i as i128)
+                        as Decimal128Array,
                     _ => {
                         return Err(arrow_err!(
                             "Cannot convert {:?} to decimal",
@@ -258,35 +242,19 @@ where
                 Arc::new(array) as ArrayRef
             }
             ArrowType::Decimal256(p, s) => {
-                // We can simply reuse the null buffer from `array` rather than recomputing it
-                // (as was the case when we simply used `collect` to produce the new array).
-                let nulls = array.nulls().cloned();
                 let array = match array.data_type() {
-                    ArrowType::Int32 => {
-                        let decimal = array
-                            .as_any()
-                            .downcast_ref::<Int32Array>()
-                            .unwrap()
-                            .iter()
-                            .map(|v| match v {
-                                Some(i) => i256::from_i128(i as i128),
-                                None => i256::default(),
-                            });
-                        Decimal256Array::from_iter_values_with_nulls(decimal, nulls)
-                    }
-
-                    ArrowType::Int64 => {
-                        let decimal = array
-                            .as_any()
-                            .downcast_ref::<Int64Array>()
-                            .unwrap()
-                            .iter()
-                            .map(|v| match v {
-                                Some(i) => i256::from_i128(i as i128),
-                                None => i256::default(),
-                            });
-                        Decimal256Array::from_iter_values_with_nulls(decimal, nulls)
-                    }
+                    ArrowType::Int32 => array
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap()
+                        .unary(|i| i256::from_i128(i as i128))
+                        as Decimal256Array,
+                    ArrowType::Int64 => array
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap()
+                        .unary(|i| i256::from_i128(i as i128))
+                        as Decimal256Array,
                     _ => {
                         return Err(arrow_err!(
                             "Cannot convert {:?} to decimal",

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -217,6 +217,9 @@ where
                 arrow_cast::cast(&a, target_type)?
             }
             ArrowType::Decimal128(p, s) => {
+                // Apply conversion to all elements regardless of null slots as the conversion
+                // to `i128` is infallible. This improves performance by avoiding a branch in
+                // the inner loop (see docs for `PrimitiveArray::unary`).
                 let array = match array.data_type() {
                     ArrowType::Int32 => array
                         .as_any()
@@ -242,6 +245,7 @@ where
                 Arc::new(array) as ArrayRef
             }
             ArrowType::Decimal256(p, s) => {
+                // See above comment. Conversion to `i256` is likewise infallible.
                 let array = match array.data_type() {
                     ArrowType::Int32 => array
                         .as_any()


### PR DESCRIPTION
# Which issue does this PR close?
Related to #6243

# Rationale for this change
 While reviewing #6244 a suggestion was made to move some processing to `FixedSizeBinaryArray` (see https://github.com/apache/arrow-rs/pull/6244#discussion_r1715925061 and following).

# What changes are included in this PR?
This PR adds `from_unary()` to `PrimitiveArray` and uses it while transforming byte arrays to primitive arrays. Also makes use of `PrimitiveArray::unary()` for transformations from one primitive type to another.

Note that by using `unary()/from_unary()`, we are now skipping special handling for null slots. This should be ok since all of the transformations will not panic (unless the fixed-size input is of the wrong size, which would panic anyway).

# Are there any user-facing changes?
Adds function to the `PrimitiveArray` interface.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
