### PR TITLE
fix(object_store): only add encryption headers for SSE-C in get request

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -705,7 +705,14 @@ impl GetClient for S3Client {
         };
 
         let mut builder = self.client.request(method, url);
-        builder = builder.headers(self.config.encryption_headers.clone().into());
+        if self
+            .config
+            .encryption_headers
+            .0
+            .contains_key("x-amz-server-side-encryption-customer-algorithm")
+        {
+            builder = builder.headers(self.config.encryption_headers.clone().into());
+        }
 
         if let Some(v) = &options.version {
             builder = builder.query(&[("versionId", v)])


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up https://github.com/apache/arrow-rs/pull/6230.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Make the previous PR safer.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In GET request, only include the encryption headers if it's SSE-C.

Checking https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax, the GET only expects headers for these. If it's using other encryptions like sse-kms or sse:kms:dsse, we don't need to attach the headers.

```
x-amz-server-side-encryption-customer-algorithm: SSECustomerAlgorithm
x-amz-server-side-encryption-customer-key: SSECustomerKey
x-amz-server-side-encryption-customer-key-MD5: SSECustomerKeyMD5
```


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
