### PR TITLE
object_store/delimited: Fix `TrailingEscape` condition

### DIFF
--- a/object_store/src/delimited.rs
+++ b/object_store/src/delimited.rs
@@ -126,7 +126,7 @@ impl LineDelimiter {
     fn finish(&mut self) -> Result<bool> {
         if !self.remainder.is_empty() {
             ensure!(!self.is_quote, UnterminatedStringSnafu);
-            ensure!(!self.is_quote, TrailingEscapeSnafu);
+            ensure!(!self.is_escape, TrailingEscapeSnafu);
 
             self.complete
                 .push_back(Bytes::from(std::mem::take(&mut self.remainder)))


### PR DESCRIPTION
This seems like a copy-paste mistake since checking `is_quote` twice is probably wrong...

