### PR TITLE
object_store: Migrate from `snafu` to `thiserror`

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -39,6 +39,7 @@ itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
+thiserror = "2.0.2"
 tracing = { version = "0.1" }
 url = "2.2"
 walkdir = { version = "2", optional = true }

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -38,7 +38,6 @@ humantime = "2.1"
 itertools = "0.13.0"
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
-snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
 thiserror = "2.0.2"
 tracing = { version = "0.1" }
 url = "2.2"

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -42,7 +42,6 @@ use reqwest::{
     Client as ReqwestClient, Method, RequestBuilder, Response,
 };
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,84 +59,84 @@ static MS_CONTENT_LANGUAGE: HeaderName = HeaderName::from_static("x-ms-blob-cont
 static TAGS_HEADER: HeaderName = HeaderName::from_static("x-ms-tags");
 
 /// A specialized `Error` for object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[snafu(display("Error performing get request {}: {}", path, source))]
+    #[error("Error performing get request {}: {}", path, source)]
     GetRequest {
         source: crate::client::retry::Error,
         path: String,
     },
 
-    #[snafu(display("Error performing put request {}: {}", path, source))]
+    #[error("Error performing put request {}: {}", path, source)]
     PutRequest {
         source: crate::client::retry::Error,
         path: String,
     },
 
-    #[snafu(display("Error performing delete request {}: {}", path, source))]
+    #[error("Error performing delete request {}: {}", path, source)]
     DeleteRequest {
         source: crate::client::retry::Error,
         path: String,
     },
 
-    #[snafu(display("Error performing bulk delete request: {}", source))]
+    #[error("Error performing bulk delete request: {}", source)]
     BulkDeleteRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error receiving bulk delete request body: {}", source))]
+    #[error("Error receiving bulk delete request body: {}", source)]
     BulkDeleteRequestBody { source: reqwest::Error },
 
-    #[snafu(display(
+    #[error(
         "Bulk delete request failed due to invalid input: {} (code: {})",
         reason,
         code
-    ))]
+    )]
     BulkDeleteRequestInvalidInput { code: String, reason: String },
 
-    #[snafu(display("Got invalid bulk delete response: {}", reason))]
+    #[error("Got invalid bulk delete response: {}", reason)]
     InvalidBulkDeleteResponse { reason: String },
 
-    #[snafu(display(
+    #[error(
         "Bulk delete request failed for key {}: {} (code: {})",
         path,
         reason,
         code
-    ))]
+    )]
     DeleteFailed {
         path: String,
         code: String,
         reason: String,
     },
 
-    #[snafu(display("Error performing list request: {}", source))]
+    #[error("Error performing list request: {}", source)]
     ListRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting list response body: {}", source))]
+    #[error("Error getting list response body: {}", source)]
     ListResponseBody { source: reqwest::Error },
 
-    #[snafu(display("Got invalid list response: {}", source))]
+    #[error("Got invalid list response: {}", source)]
     InvalidListResponse { source: quick_xml::de::DeError },
 
-    #[snafu(display("Unable to extract metadata from headers: {}", source))]
+    #[error("Unable to extract metadata from headers: {}", source)]
     Metadata {
         source: crate::client::header::Error,
     },
 
-    #[snafu(display("ETag required for conditional update"))]
+    #[error("ETag required for conditional update")]
     MissingETag,
 
-    #[snafu(display("Error requesting user delegation key: {}", source))]
+    #[error("Error requesting user delegation key: {}", source)]
     DelegationKeyRequest { source: crate::client::retry::Error },
 
-    #[snafu(display("Error getting user delegation key response body: {}", source))]
+    #[error("Error getting user delegation key response body: {}", source)]
     DelegationKeyResponseBody { source: reqwest::Error },
 
-    #[snafu(display("Got invalid user delegation key response: {}", source))]
+    #[error("Got invalid user delegation key response: {}", source)]
     DelegationKeyResponse { source: quick_xml::de::DeError },
 
-    #[snafu(display("Generating SAS keys with SAS tokens auth is not supported"))]
+    #[error("Generating SAS keys with SAS tokens auth is not supported")]
     SASforSASNotSupported,
 
-    #[snafu(display("Generating SAS keys while skipping signatures is not supported"))]
+    #[error("Generating SAS keys while skipping signatures is not supported")]
     SASwithSkipSignature,
 }
 
@@ -268,8 +267,9 @@ impl<'a> PutRequest<'a> {
             .payload(Some(self.payload))
             .send()
             .await
-            .context(PutRequestSnafu {
-                path: self.path.as_ref(),
+            .map_err(|source| {
+                let path = self.path.as_ref().into();
+                Error::PutRequest { path, source }
             })?;
 
         Ok(response)
@@ -544,13 +544,14 @@ impl AzureClient {
             PutMode::Overwrite => builder.idempotent(true),
             PutMode::Create => builder.header(&IF_NONE_MATCH, "*"),
             PutMode::Update(v) => {
-                let etag = v.e_tag.as_ref().context(MissingETagSnafu)?;
+                let etag = v.e_tag.as_ref().ok_or(Error::MissingETag)?;
                 builder.header(&IF_MATCH, etag)
             }
         };
 
         let response = builder.header(&BLOB_TYPE, "BlockBlob").send().await?;
-        Ok(get_put_result(response.headers(), VERSION_HEADER).context(MetadataSnafu)?)
+        Ok(get_put_result(response.headers(), VERSION_HEADER)
+            .map_err(|source| Error::Metadata { source })?)
     }
 
     /// PUT a block <https://learn.microsoft.com/en-us/rest/api/storageservices/put-block>
@@ -595,7 +596,8 @@ impl AzureClient {
             .send()
             .await?;
 
-        Ok(get_put_result(response.headers(), VERSION_HEADER).context(MetadataSnafu)?)
+        Ok(get_put_result(response.headers(), VERSION_HEADER)
+            .map_err(|source| Error::Metadata { source })?)
     }
 
     /// Make an Azure Delete request <https://docs.microsoft.com/en-us/rest/api/storageservices/delete-blob>
@@ -620,8 +622,9 @@ impl AzureClient {
             .sensitive(sensitive)
             .send()
             .await
-            .context(DeleteRequestSnafu {
-                path: path.as_ref(),
+            .map_err(|source| {
+                let path = path.as_ref().into();
+                Error::DeleteRequest { source, path }
             })?;
 
         Ok(())
@@ -693,14 +696,14 @@ impl AzureClient {
             .with_azure_authorization(&credential, &self.config.account)
             .send_retry(&self.config.retry_config)
             .await
-            .context(BulkDeleteRequestSnafu {})?;
+            .map_err(|source| Error::BulkDeleteRequest { source })?;
 
         let boundary = parse_multipart_response_boundary(&batch_response)?;
 
         let batch_body = batch_response
             .bytes()
             .await
-            .context(BulkDeleteRequestBodySnafu {})?;
+            .map_err(|source| Error::BulkDeleteRequestBody { source })?;
 
         let results = parse_blob_batch_delete_body(batch_body, boundary, &paths).await?;
 
@@ -780,13 +783,13 @@ impl AzureClient {
             .idempotent(true)
             .send()
             .await
-            .context(DelegationKeyRequestSnafu)?
+            .map_err(|source| Error::DelegationKeyRequest { source })?
             .bytes()
             .await
-            .context(DelegationKeyResponseBodySnafu)?;
+            .map_err(|source| Error::DelegationKeyResponseBody { source })?;
 
-        let response: UserDelegationKey =
-            quick_xml::de::from_reader(response.reader()).context(DelegationKeyResponseSnafu)?;
+        let response: UserDelegationKey = quick_xml::de::from_reader(response.reader())
+            .map_err(|source| Error::DelegationKeyResponse { source })?;
 
         Ok(response)
     }
@@ -842,9 +845,11 @@ impl AzureClient {
             .sensitive(sensitive)
             .send()
             .await
-            .context(GetRequestSnafu {
-                path: path.as_ref(),
+            .map_err(|source| {
+                let path = path.as_ref().into();
+                Error::GetRequest { source, path }
             })?;
+
         Ok(response)
     }
 }
@@ -900,8 +905,9 @@ impl GetClient for AzureClient {
             .sensitive(sensitive)
             .send()
             .await
-            .context(GetRequestSnafu {
-                path: path.as_ref(),
+            .map_err(|source| {
+                let path = path.as_ref().into();
+                Error::GetRequest { source, path }
             })?;
 
         match response.headers().get("x-ms-resource-type") {
@@ -962,13 +968,14 @@ impl ListClient for AzureClient {
             .sensitive(sensitive)
             .send()
             .await
-            .context(ListRequestSnafu)?
+            .map_err(|source| Error::ListRequest { source })?
             .bytes()
             .await
-            .context(ListResponseBodySnafu)?;
+            .map_err(|source| Error::ListResponseBody { source })?;
 
-        let mut response: ListResultInternal =
-            quick_xml::de::from_reader(response.reader()).context(InvalidListResponseSnafu)?;
+        let mut response: ListResultInternal = quick_xml::de::from_reader(response.reader())
+            .map_err(|source| Error::InvalidListResponse { source })?;
+
         let token = response.next_marker.take();
 
         Ok((to_list_result(response, prefix)?, token))

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -22,30 +22,29 @@ use crate::PutPayload;
 use futures::future::BoxFuture;
 use reqwest::header::LOCATION;
 use reqwest::{Client, Request, Response, StatusCode};
-use snafu::Error as SnafuError;
-use snafu::Snafu;
+use std::error::Error as StdError;
 use std::time::{Duration, Instant};
 use tracing::info;
 
 /// Retry request error
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("Received redirect without LOCATION, this normally indicates an incorrectly configured region"))]
+    #[error("Received redirect without LOCATION, this normally indicates an incorrectly configured region")]
     BareRedirect,
 
-    #[snafu(display("Server error, body contains Error, with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
+    #[error("Server error, body contains Error, with status {status}: {}", body.as_deref().unwrap_or("No Body"))]
     Server {
         status: StatusCode,
         body: Option<String>,
     },
 
-    #[snafu(display("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
+    #[error("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body"))]
     Client {
         status: StatusCode,
         body: Option<String>,
     },
 
-    #[snafu(display("Error after {retries} retries in {elapsed:?}, max_retries:{max_retries}, retry_timeout:{retry_timeout:?}, source:{source}"))]
+    #[error("Error after {retries} retries in {elapsed:?}, max_retries:{max_retries}, retry_timeout:{retry_timeout:?}, source:{source}")]
     Reqwest {
         retries: usize,
         max_retries: usize,

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -35,7 +35,6 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
-use snafu::{OptionExt, ResultExt, Snafu};
 use url::Url;
 
 use crate::client::get::GetClientExt;
@@ -49,18 +48,18 @@ use crate::{
 
 mod client;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 enum Error {
-    #[snafu(display("Must specify a URL"))]
+    #[error("Must specify a URL")]
     MissingUrl,
 
-    #[snafu(display("Unable parse source url. Url: {}, Error: {}", url, source))]
+    #[error("Unable parse source url. Url: {}, Error: {}", url, source)]
     UnableToParseUrl {
         source: url::ParseError,
         url: String,
     },
 
-    #[snafu(display("Unable to extract metadata from headers: {}", source))]
+    #[error("Unable to extract metadata from headers: {}", source)]
     Metadata {
         source: crate::client::header::Error,
     },
@@ -235,8 +234,8 @@ impl HttpBuilder {
 
     /// Build an [`HttpStore`] with the configured options
     pub fn build(self) -> Result<HttpStore> {
-        let url = self.url.context(MissingUrlSnafu)?;
-        let parsed = Url::parse(&url).context(UnableToParseUrlSnafu { url })?;
+        let url = self.url.ok_or(Error::MissingUrl)?;
+        let parsed = Url::parse(&url).map_err(|source| Error::UnableToParseUrl { url, source })?;
 
         Ok(HttpStore {
             client: Client::new(parsed, self.client_options, self.retry_config)?,

--- a/object_store/src/local.rs
+++ b/object_store/src/local.rs
@@ -30,7 +30,6 @@ use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use futures::{FutureExt, TryStreamExt};
 use parking_lot::Mutex;
-use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use url::Url;
 use walkdir::{DirEntry, WalkDir};
 
@@ -43,117 +42,80 @@ use crate::{
 };
 
 /// A specialized `Error` for filesystem object store-related errors
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[snafu(display("File size for {} did not fit in a usize: {}", path, source))]
+    #[error("File size for {} did not fit in a usize: {}", path, source)]
     FileSizeOverflowedUsize {
         source: std::num::TryFromIntError,
         path: String,
     },
 
-    #[snafu(display("Unable to walk dir: {}", source))]
-    UnableToWalkDir {
-        source: walkdir::Error,
-    },
+    #[error("Unable to walk dir: {}", source)]
+    UnableToWalkDir { source: walkdir::Error },
 
-    #[snafu(display("Unable to access metadata for {}: {}", path, source))]
+    #[error("Unable to access metadata for {}: {}", path, source)]
     Metadata {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
         path: String,
     },
 
-    #[snafu(display("Unable to copy data to file: {}", source))]
-    UnableToCopyDataToFile {
-        source: io::Error,
-    },
+    #[error("Unable to copy data to file: {}", source)]
+    UnableToCopyDataToFile { source: io::Error },
 
-    #[snafu(display("Unable to rename file: {}", source))]
-    UnableToRenameFile {
-        source: io::Error,
-    },
+    #[error("Unable to rename file: {}", source)]
+    UnableToRenameFile { source: io::Error },
 
-    #[snafu(display("Unable to create dir {}: {}", path.display(), source))]
-    UnableToCreateDir {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to create dir {}: {}", path.display(), source)]
+    UnableToCreateDir { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to create file {}: {}", path.display(), source))]
-    UnableToCreateFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to create file {}: {}", path.display(), source)]
+    UnableToCreateFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to delete file {}: {}", path.display(), source))]
-    UnableToDeleteFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to delete file {}: {}", path.display(), source)]
+    UnableToDeleteFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to open file {}: {}", path.display(), source))]
-    UnableToOpenFile {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to open file {}: {}", path.display(), source)]
+    UnableToOpenFile { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to read data from file {}: {}", path.display(), source))]
-    UnableToReadBytes {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Unable to read data from file {}: {}", path.display(), source)]
+    UnableToReadBytes { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Out of range of file {}, expected: {}, actual: {}", path.display(), expected, actual))]
+    #[error("Out of range of file {}, expected: {}, actual: {}", path.display(), expected, actual)]
     OutOfRange {
         path: PathBuf,
         expected: usize,
         actual: usize,
     },
 
-    #[snafu(display("Requested range was invalid"))]
-    InvalidRange {
-        source: InvalidGetRange,
-    },
+    #[error("Requested range was invalid")]
+    InvalidRange { source: InvalidGetRange },
 
-    #[snafu(display("Unable to copy file from {} to {}: {}", from.display(), to.display(), source))]
+    #[error("Unable to copy file from {} to {}: {}", from.display(), to.display(), source)]
     UnableToCopyFile {
         from: PathBuf,
         to: PathBuf,
         source: io::Error,
     },
 
-    NotFound {
-        path: PathBuf,
-        source: io::Error,
-    },
+    #[error("NotFound")]
+    NotFound { path: PathBuf, source: io::Error },
 
-    #[snafu(display("Error seeking file {}: {}", path.display(), source))]
-    Seek {
-        source: io::Error,
-        path: PathBuf,
-    },
+    #[error("Error seeking file {}: {}", path.display(), source)]
+    Seek { source: io::Error, path: PathBuf },
 
-    #[snafu(display("Unable to convert URL \"{}\" to filesystem path", url))]
-    InvalidUrl {
-        url: Url,
-    },
+    #[error("Unable to convert URL \"{}\" to filesystem path", url)]
+    InvalidUrl { url: Url },
 
-    AlreadyExists {
-        path: String,
-        source: io::Error,
-    },
+    #[error("AlreadyExists")]
+    AlreadyExists { path: String, source: io::Error },
 
-    #[snafu(display("Unable to canonicalize filesystem root: {}", path.display()))]
-    UnableToCanonicalize {
-        path: PathBuf,
-        source: io::Error,
-    },
+    #[error("Unable to canonicalize filesystem root: {}", path.display())]
+    UnableToCanonicalize { path: PathBuf, source: io::Error },
 
-    #[snafu(display("Filenames containing trailing '/#\\d+/' are not supported: {}", path))]
-    InvalidPath {
-        path: String,
-    },
+    #[error("Filenames containing trailing '/#\\d+/' are not supported: {}", path)]
+    InvalidPath { path: String },
 
-    #[snafu(display("Upload aborted"))]
+    #[error("Upload aborted")]
     Aborted,
 }
 
@@ -276,8 +238,9 @@ impl LocalFileSystem {
     /// Returns an error if the path does not exist
     ///
     pub fn new_with_prefix(prefix: impl AsRef<std::path::Path>) -> Result<Self> {
-        let path = std::fs::canonicalize(&prefix).context(UnableToCanonicalizeSnafu {
-            path: prefix.as_ref(),
+        let path = std::fs::canonicalize(&prefix).map_err(|source| {
+            let path = prefix.as_ref().into();
+            Error::UnableToCanonicalize { source, path }
         })?;
 
         Ok(Self {
@@ -290,12 +253,12 @@ impl LocalFileSystem {
 
     /// Return an absolute filesystem path of the given file location
     pub fn path_to_filesystem(&self, location: &Path) -> Result<PathBuf> {
-        ensure!(
-            is_valid_file_path(location),
-            InvalidPathSnafu {
-                path: location.as_ref()
-            }
-        );
+        if !is_valid_file_path(location) {
+            let path = location.as_ref().into();
+            let error = Error::InvalidPath { path };
+            return Err(error.into());
+        }
+
         let path = self.config.prefix_to_filesystem(location)?;
 
         #[cfg(target_os = "windows")]
@@ -451,7 +414,9 @@ impl ObjectStore for LocalFileSystem {
             options.check_preconditions(&meta)?;
 
             let range = match options.range {
-                Some(r) => r.as_range(meta.size).context(InvalidRangeSnafu)?,
+                Some(r) => r
+                    .as_range(meta.size)
+                    .map_err(|source| Error::InvalidRange { source })?,
                 None => 0..meta.size,
             };
 
@@ -721,12 +686,15 @@ impl ObjectStore for LocalFileSystem {
 
 /// Creates the parent directories of `path` or returns an error based on `source` if no parent
 fn create_parent_dirs(path: &std::path::Path, source: io::Error) -> Result<()> {
-    let parent = path.parent().ok_or_else(|| Error::UnableToCreateFile {
-        path: path.to_path_buf(),
-        source,
+    let parent = path.parent().ok_or_else(|| {
+        let path = path.to_path_buf();
+        Error::UnableToCreateFile { path, source }
     })?;
 
-    std::fs::create_dir_all(parent).context(UnableToCreateDirSnafu { path: parent })?;
+    std::fs::create_dir_all(parent).map_err(|source| {
+        let path = parent.into();
+        Error::UnableToCreateDir { source, path }
+    })?;
     Ok(())
 }
 
@@ -796,12 +764,14 @@ impl MultipartUpload for LocalUpload {
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             let mut file = s.file.lock();
-            file.seek(SeekFrom::Start(offset))
-                .context(SeekSnafu { path: &s.dest })?;
+            file.seek(SeekFrom::Start(offset)).map_err(|source| {
+                let path = s.dest.clone();
+                Error::Seek { source, path }
+            })?;
 
             data.iter()
                 .try_for_each(|x| file.write_all(x))
-                .context(UnableToCopyDataToFileSnafu)?;
+                .map_err(|source| Error::UnableToCopyDataToFile { source })?;
 
             Ok(())
         })
@@ -809,12 +779,13 @@ impl MultipartUpload for LocalUpload {
     }
 
     async fn complete(&mut self) -> Result<PutResult> {
-        let src = self.src.take().context(AbortedSnafu)?;
+        let src = self.src.take().ok_or(Error::Aborted)?;
         let s = Arc::clone(&self.state);
         maybe_spawn_blocking(move || {
             // Ensure no inflight writes
             let file = s.file.lock();
-            std::fs::rename(&src, &s.dest).context(UnableToRenameFileSnafu)?;
+            std::fs::rename(&src, &s.dest)
+                .map_err(|source| Error::UnableToRenameFile { source })?;
             let metadata = file.metadata().map_err(|e| Error::Metadata {
                 source: e.into(),
                 path: src.to_string_lossy().to_string(),
@@ -829,9 +800,10 @@ impl MultipartUpload for LocalUpload {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        let src = self.src.take().context(AbortedSnafu)?;
+        let src = self.src.take().ok_or(Error::Aborted)?;
         maybe_spawn_blocking(move || {
-            std::fs::remove_file(&src).context(UnableToDeleteFileSnafu { path: &src })?;
+            std::fs::remove_file(&src)
+                .map_err(|source| Error::UnableToDeleteFile { source, path: src })?;
             Ok(())
         })
         .await
@@ -898,22 +870,30 @@ pub(crate) fn chunked_stream(
 pub(crate) fn read_range(file: &mut File, path: &PathBuf, range: Range<usize>) -> Result<Bytes> {
     let to_read = range.end - range.start;
     file.seek(SeekFrom::Start(range.start as u64))
-        .context(SeekSnafu { path })?;
+        .map_err(|source| {
+            let path = path.into();
+            Error::Seek { source, path }
+        })?;
 
     let mut buf = Vec::with_capacity(to_read);
     let read = file
         .take(to_read as u64)
         .read_to_end(&mut buf)
-        .context(UnableToReadBytesSnafu { path })?;
+        .map_err(|source| {
+            let path = path.into();
+            Error::UnableToReadBytes { source, path }
+        })?;
 
-    ensure!(
-        read == to_read,
-        OutOfRangeSnafu {
-            path,
+    if read != to_read {
+        let error = Error::OutOfRange {
+            path: path.into(),
             expected: to_read,
-            actual: read
-        }
-    );
+            actual: read,
+        };
+
+        return Err(error.into());
+    }
+
     Ok(buf.into())
 }
 
@@ -982,8 +962,9 @@ fn get_etag(metadata: &Metadata) -> String {
 
 fn convert_metadata(metadata: Metadata, location: Path) -> Result<ObjectMeta> {
     let last_modified = last_modified(&metadata);
-    let size = usize::try_from(metadata.len()).context(FileSizeOverflowedUsizeSnafu {
-        path: location.as_ref(),
+    let size = usize::try_from(metadata.len()).map_err(|source| {
+        let path = location.as_ref().into();
+        Error::FileSizeOverflowedUsize { source, path }
     })?;
 
     Ok(ObjectMeta {

--- a/object_store/src/parse.rs
+++ b/object_store/src/parse.rs
@@ -20,16 +20,18 @@ use crate::local::LocalFileSystem;
 use crate::memory::InMemory;
 use crate::path::Path;
 use crate::ObjectStore;
-use snafu::Snafu;
 use url::Url;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[snafu(display("Unable to recognise URL \"{}\"", url))]
+    #[error("Unable to recognise URL \"{}\"", url)]
     Unrecognised { url: Url },
 
-    #[snafu(context(false))]
-    Path { source: crate::path::Error },
+    #[error(transparent)]
+    Path {
+        #[from]
+        source: crate::path::Error,
+    },
 }
 
 impl From<Error> for super::Error {

--- a/object_store/src/path/mod.rs
+++ b/object_store/src/path/mod.rs
@@ -19,7 +19,6 @@
 
 use itertools::Itertools;
 use percent_encoding::percent_decode;
-use snafu::{ensure, ResultExt, Snafu};
 use std::fmt::Formatter;
 #[cfg(not(target_arch = "wasm32"))]
 use url::Url;
@@ -35,18 +34,18 @@ mod parts;
 pub use parts::{InvalidPart, PathPart};
 
 /// Error returned by [`Path::parse`]
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
     /// Error when there's an empty segment between two slashes `/` in the path
-    #[snafu(display("Path \"{}\" contained empty path segment", path))]
+    #[error("Path \"{}\" contained empty path segment", path)]
     EmptySegment {
         /// The source path
         path: String,
     },
 
     /// Error when an invalid segment is encountered in the given path
-    #[snafu(display("Error parsing Path \"{}\": {}", path, source))]
+    #[error("Error parsing Path \"{}\": {}", path, source)]
     BadSegment {
         /// The source path
         path: String,
@@ -55,7 +54,7 @@ pub enum Error {
     },
 
     /// Error when path cannot be canonicalized
-    #[snafu(display("Failed to canonicalize path \"{}\": {}", path.display(), source))]
+    #[error("Failed to canonicalize path \"{}\": {}", path.display(), source)]
     Canonicalize {
         /// The source path
         path: std::path::PathBuf,
@@ -64,14 +63,14 @@ pub enum Error {
     },
 
     /// Error when the path is not a valid URL
-    #[snafu(display("Unable to convert path \"{}\" to URL", path.display()))]
+    #[error("Unable to convert path \"{}\" to URL", path.display())]
     InvalidPath {
         /// The source path
         path: std::path::PathBuf,
     },
 
     /// Error when a path contains non-unicode characters
-    #[snafu(display("Path \"{}\" contained non-unicode characters: {}", path, source))]
+    #[error("Path \"{}\" contained non-unicode characters: {}", path, source)]
     NonUnicode {
         /// The source path
         path: String,
@@ -80,7 +79,7 @@ pub enum Error {
     },
 
     /// Error when the a path doesn't start with given prefix
-    #[snafu(display("Path {} does not start with prefix {}", path, prefix))]
+    #[error("Path {} does not start with prefix {}", path, prefix)]
     PrefixMismatch {
         /// The source path
         path: String,
@@ -173,8 +172,14 @@ impl Path {
         let stripped = stripped.strip_suffix(DELIMITER).unwrap_or(stripped);
 
         for segment in stripped.split(DELIMITER) {
-            ensure!(!segment.is_empty(), EmptySegmentSnafu { path });
-            PathPart::parse(segment).context(BadSegmentSnafu { path })?;
+            if segment.is_empty() {
+                return Err(Error::EmptySegment { path: path.into() });
+            }
+
+            PathPart::parse(segment).map_err(|source| {
+                let path = path.into();
+                Error::BadSegment { source, path }
+            })?;
         }
 
         Ok(Self {
@@ -190,8 +195,9 @@ impl Path {
     ///
     /// Note: this will canonicalize the provided path, resolving any symlinks
     pub fn from_filesystem_path(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
-        let absolute = std::fs::canonicalize(&path).context(CanonicalizeSnafu {
-            path: path.as_ref(),
+        let absolute = std::fs::canonicalize(&path).map_err(|source| {
+            let path = path.as_ref().into();
+            Error::Canonicalize { source, path }
         })?;
 
         Self::from_absolute_path(absolute)
@@ -241,7 +247,10 @@ impl Path {
         let path = path.as_ref();
         let decoded = percent_decode(path.as_bytes())
             .decode_utf8()
-            .context(NonUnicodeSnafu { path })?;
+            .map_err(|source| {
+                let path = path.into();
+                Error::NonUnicode { source, path }
+            })?;
 
         Self::parse(decoded)
     }

--- a/object_store/src/path/parts.rs
+++ b/object_store/src/path/parts.rs
@@ -19,15 +19,14 @@ use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use std::borrow::Cow;
 
 use crate::path::DELIMITER_BYTE;
-use snafu::Snafu;
 
 /// Error returned by [`PathPart::parse`]
-#[derive(Debug, Snafu)]
-#[snafu(display(
+#[derive(Debug, thiserror::Error)]
+#[error(
     "Encountered illegal character sequence \"{}\" whilst parsing path segment \"{}\"",
     illegal,
     segment
-))]
+)]
 #[allow(missing_copy_implementations)]
 pub struct InvalidPart {
     segment: String,

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -24,7 +24,6 @@ use std::{
 use super::Result;
 use bytes::Bytes;
 use futures::{stream::StreamExt, Stream, TryStreamExt};
-use snafu::Snafu;
 
 #[cfg(any(feature = "azure", feature = "http"))]
 pub(crate) static RFC1123_FMT: &str = "%a, %d %h %Y %T GMT";
@@ -204,14 +203,12 @@ pub enum GetRange {
     Suffix(usize),
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum InvalidGetRange {
-    #[snafu(display(
-        "Wanted range starting at {requested}, but object was only {length} bytes long"
-    ))]
+    #[error("Wanted range starting at {requested}, but object was only {length} bytes long")]
     StartTooLarge { requested: usize, length: usize },
 
-    #[snafu(display("Range started at {start} and ended at {end}"))]
+    #[error("Range started at {start} and ended at {end}")]
     Inconsistent { start: usize, end: usize },
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

https://github.com/apache/arrow-rs/issues/6166, though only partially, since the PR is only targeting the `object_store` crate.

# Rationale for this change
 
The rationale is explained in the linked issue :)

# What changes are included in this PR?

The first commit in the PR adds a dependency on `thiserror`, the following commits incrementally port all error enums from `snafu` to `thiserror`, and then the final commit removes the now obsolete `snafu` dependency.

Note that this PR also includes https://github.com/apache/arrow-rs/pull/6265 to avoid merge conflicts from the bugfix.

# Are there any user-facing changes?

As the linked issue mentions, some of the `snafu` type may leak to the outside and this PR will remove them so this should probably be treated as a breaking change, even though these types have been considered private API before.
