### PR TITLE
Do not print compression level in schema printer

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -358,6 +358,14 @@ pub enum Compression {
     LZ4_RAW,
 }
 
+impl Compression {
+    /// Returns the codec type of this compression setting as a string, without the compression
+    /// level.
+    pub(crate) fn codec_to_string(self) -> String {
+        format!("{:?}", self).split('(').next().unwrap().to_owned()
+    }
+}
+
 fn split_compression_string(str_setting: &str) -> Result<(&str, Option<u32>), ParquetError> {
     let split_setting = str_setting.split_once('(');
 
@@ -1912,6 +1920,15 @@ mod tests {
         assert_eq!(
             parquet::Encoding::DELTA_BYTE_ARRAY,
             Encoding::DELTA_BYTE_ARRAY.into()
+        );
+    }
+
+    #[test]
+    fn test_compression_codec_to_string() {
+        assert_eq!(Compression::UNCOMPRESSED.codec_to_string(), "UNCOMPRESSED");
+        assert_eq!(
+            Compression::ZSTD(ZstdLevel::default()).codec_to_string(),
+            "ZSTD"
         );
     }
 

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -130,7 +130,11 @@ fn print_column_chunk_metadata(out: &mut dyn io::Write, cc_metadata: &ColumnChun
     writeln!(out, "file path: {file_path_str}");
     writeln!(out, "file offset: {}", cc_metadata.file_offset());
     writeln!(out, "num of values: {}", cc_metadata.num_values());
-    writeln!(out, "compression: {}", cc_metadata.compression());
+    writeln!(
+        out,
+        "compression: {}",
+        cc_metadata.compression().codec_to_string()
+    );
     writeln!(
         out,
         "total compressed size (in bytes): {}",


### PR DESCRIPTION
The compression level is only used during compression, not decompression, and isn't actually stored in the metadata. Printing it is misleading.

# Which issue does this PR close?

Closes #6270.

# Rationale for this change
 
Theoretically, there should be a `Compression` enum that doesn't store the level, but that doesn't seem worth the trouble and API breakage.

Instead, I just added a method `codec_to_string()` that returns the `Debug` output up to the first `(`. This is easier to maintain and hopefully less error-prone than adding a `match`. It's less efficient, but efficiency doesn't matter much here.

# Are there any user-facing changes?

No. The output of `print_parquet_metadata` is neither documented nor tested, and should therefore not be considered stable.