### PR TITLE
Fix accessing name from ffi schema

### DIFF
--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -261,12 +261,17 @@ impl FFI_ArrowSchema {
     }
 
     /// returns the name of this schema.
-    pub fn name(&self) -> &str {
-        assert!(!self.name.is_null());
-        // safe because the lifetime of `self.name` equals `self`
-        unsafe { CStr::from_ptr(self.name) }
-            .to_str()
-            .expect("The external API has a non-utf8 as name")
+    pub fn name(&self) -> Option<&str> {
+        if self.name.is_null() {
+            None
+        } else {
+            // safe because the lifetime of `self.name` equals `self`
+            Some(
+                unsafe { CStr::from_ptr(self.name) }
+                    .to_str()
+                    .expect("The external API has a non-utf8 as name"),
+            )
+        }
     }
 
     pub fn flags(&self) -> Option<Flags> {
@@ -582,7 +587,7 @@ impl TryFrom<&FFI_ArrowSchema> for Field {
 
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self, ArrowError> {
         let dtype = DataType::try_from(c_schema)?;
-        let mut field = Field::new(c_schema.name(), dtype, c_schema.nullable());
+        let mut field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable());
         field.set_metadata(c_schema.metadata()?);
         Ok(field)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6251.

# Rationale for this change

Reading from `FFI_ArrowSchema` should not panic on spec-valid input.

# What changes are included in this PR?

- Convert return value of `name()` to `Option<&str>`
- Default to empty string when importing `FFI_ArrowSchema` to `Field`

# Are there any user-facing changes?

Yes

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
