### PR TITLE
Fix panic in comparison_kernel benchmarks

### DIFF
--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -167,9 +167,10 @@ fn add_benchmark(c: &mut Criterion) {
     let string_right = StringArray::from_iter(array_gen);
     let string_view_right = StringViewArray::from_iter(string_right.iter());
 
-    let scalar = StringArray::new_scalar("xxxx");
+    let string_view_scalar = StringViewArray::new_scalar("xxxx");
+    let string_scalar = StringArray::new_scalar("xxxx");
     c.bench_function("eq scalar StringArray", |b| {
-        b.iter(|| eq(&scalar, &string_left).unwrap())
+        b.iter(|| eq(&string_scalar, &string_left).unwrap())
     });
 
     c.bench_function("lt scalar StringViewArray", |b| {
@@ -193,7 +194,7 @@ fn add_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("eq scalar StringViewArray", |b| {
-        b.iter(|| eq(&scalar, &string_view_left).unwrap())
+        b.iter(|| eq(&string_view_scalar, &string_view_left).unwrap())
     });
 
     c.bench_function("eq StringArray StringArray", |b| {
@@ -240,8 +241,16 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xxxx"))
     });
 
-    c.bench_function("like_utf8view scalar starts with", |b| {
+    c.bench_function("like_utf8view scalar starts with less than 4 bytes", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxx%"))
+    });
+
+    c.bench_function("like_utf8view scalar starts with more than 4 bytes", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxxxx%"))
+    });
+
+    c.bench_function("like_utf8view scalar starts with more than 12 bytes", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxxxxxxxxxxx%"))
     });
 
     c.bench_function("like_utf8view scalar complex", |b| {

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -237,19 +237,28 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xxxx%"))
     });
 
-    c.bench_function("like_utf8view scalar ends with", |b| {
+    // StringView has special handling for strings with length <= 12 and length <= 4
+    c.bench_function("like_utf8view scalar ends with 4 bytes", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xxxx"))
     });
 
-    c.bench_function("like_utf8view scalar starts with less than 4 bytes", |b| {
+    c.bench_function("like_utf8view scalar ends with 6 bytes", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xxxxxx"))
+    });
+
+    c.bench_function("like_utf8view scalar ends with 13 bytes", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&string_view_left, "%xxxxxxxxxxxxx"))
+    });
+
+    c.bench_function("like_utf8view scalar starts with 4 bytes", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxx%"))
     });
 
-    c.bench_function("like_utf8view scalar starts with more than 4 bytes", |b| {
+    c.bench_function("like_utf8view scalar starts with 6 bytes", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxxxx%"))
     });
 
-    c.bench_function("like_utf8view scalar starts with more than 12 bytes", |b| {
+    c.bench_function("like_utf8view scalar starts with 13 bytes", |b| {
         b.iter(|| bench_like_utf8view_scalar(&string_view_left, "xxxxxxxxxxxxx%"))
     });
 

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -167,7 +167,6 @@ fn add_benchmark(c: &mut Criterion) {
     let string_right = StringArray::from_iter(array_gen);
     let string_view_right = StringViewArray::from_iter(string_right.iter());
 
-    let string_view_scalar = StringViewArray::new_scalar("xxxx");
     let string_scalar = StringArray::new_scalar("xxxx");
     c.bench_function("eq scalar StringArray", |b| {
         b.iter(|| eq(&string_scalar, &string_left).unwrap())
@@ -193,7 +192,19 @@ fn add_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("eq scalar StringViewArray", |b| {
+    // StringViewArray has special handling for strings with length <= 12 and length <= 4
+    let string_view_scalar = StringViewArray::new_scalar("xxxx");
+    c.bench_function("eq scalar StringViewArray 4 bytes", |b| {
+        b.iter(|| eq(&string_view_scalar, &string_view_left).unwrap())
+    });
+
+    let string_view_scalar = StringViewArray::new_scalar("xxxxxx");
+    c.bench_function("eq scalar StringViewArray 6 bytes", |b| {
+        b.iter(|| eq(&string_view_scalar, &string_view_left).unwrap())
+    });
+
+    let string_view_scalar = StringViewArray::new_scalar("xxxxxxxxxxxxx");
+    c.bench_function("eq scalar StringViewArray 13 bytes", |b| {
         b.iter(|| eq(&string_view_scalar, &string_view_left).unwrap())
     });
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6283

# Rationale for this change
 
Benchmark was panic'ing

Also having benchmarks in main ahead of  a proposed code change makes it easier for my scripts to compare performance before/after code change

# What changes are included in this PR?

Also, adds benchmarks for code in https://github.com/apache/arrow-rs/pull/6231 to make it easier to verify performance.


# Are there any user-facing changes?
No, this is development tooling only
