### PR TITLE
fix reference in doctest to size_of which is not imported by default

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -115,7 +115,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
 /// let arr1  = i32_array(&[1, 2, 3, 4, 5]);
 /// let arr2  = i32_array(&[6, 7, 8, 9, 10]);
 /// // Create a mutable array for copying values from arr1 and arr2, with a capacity for 6 elements
-/// let capacity = 3 * size_of::<i32>();
+/// let capacity = 3 * std::mem::size_of::<i32>();
 /// let mut mutable = MutableArrayData::new(vec![&arr1, &arr2], false, 10);
 /// // Copy the first 3 elements from arr1
 /// mutable.extend(0, 0, 3);


### PR DESCRIPTION
This corrects an issue with this doctest noticed on FreeBSD/amd64 with rustc 1.77.1

```
11:01:41     Doc-tests arrow_data
11:01:41  
11:01:41  running 2 tests
11:01:41  test arrow-data/src/transform/mod.rs - transform::MutableArrayData (line 107) ... FAILED
11:01:41  test arrow-data/src/ffi.rs - ffi::FFI_ArrowArray (line 30) ... ok
11:01:41  
11:01:41  failures:
11:01:41  
11:01:41  ---- arrow-data/src/transform/mod.rs - transform::MutableArrayData (line 107) stdout ----
11:01:41  error[E0425]: cannot find function `size_of` in this scope
11:01:41    --> arrow-data/src/transform/mod.rs:119:20
11:01:41     |
11:01:41  15 | let capacity = 3 * size_of::<i32>();
11:01:41     |                    ^^^^^^^ not found in this scope
11:01:41     |
11:01:41  help: consider importing one of these items
11:01:41     |
11:01:41  2  + use core::mem::size_of;
11:01:41     |
11:01:41  2  + use std::mem::size_of;
11:01:41     |
11:01:41  
11:01:41  error: aborting due to 1 previous error
11:01:41  
11:01:41  For more information about this error, try `rustc --explain E0425`.
11:01:41  Couldn't compile the test.
11:01:41  
11:01:41  failures:
11:01:41      arrow-data/src/transform/mod.rs - transform::MutableArrayData (line 107)
```