### PR TITLE
Add an API to append view by u128 in for view_builder

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -205,6 +205,19 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         self.null_buffer_builder.append_non_null();
     }
 
+    /// Append the given `u128` as a view
+    ///
+    /// # Safety
+    /// (1) The block of the given view must have been added
+    /// (2) The range `offset...offset+length` of the given view
+    /// must be within the bounds of the block
+    /// (3) The data in the block must be valid type `T`
+    /// (4) The view must be not null
+    pub unsafe fn append_view_u128_unchecked(&mut self, view: u128) {
+        self.views_builder.append(view);
+        self.null_buffer_builder.append_non_null();
+    }
+
     /// Try to append a view of the given `block`, `offset` and `length`
     ///
     /// See [`Self::append_block`]


### PR DESCRIPTION
# Which issue does this PR close?
None
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
 The idea is to make the builder a way to append a view by a given u128 (unchecked). Check out this [comment](https://github.com/apache/datafusion/pull/12044#discussion_r1727098779).
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
A function is added to the view builder.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
