### PR TITLE
Safely Write IntervalMonthDayNanoArray to parquet or Throw error

### DIFF
--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -27,10 +27,9 @@ use crate::column::reader::decoder::ColumnValueDecoder;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 use arrow_array::{
-    ArrayRef, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array,
-    IntervalDayTimeArray, IntervalYearMonthArray,
+    ArrayRef, Decimal128Array, Decimal256Array, FixedSizeBinaryArray, Float16Array, IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray
 };
-use arrow_buffer::{i256, Buffer, IntervalDayTime};
+use arrow_buffer::{i256, Buffer, IntervalDayTime, IntervalMonthDayNano};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, IntervalUnit};
 use bytes::Bytes;
@@ -195,7 +194,14 @@ impl ArrayReader for FixedLenByteArrayReader {
                         Arc::new(IntervalDayTimeArray::from_unary(&binary, f)) as ArrayRef
                     }
                     IntervalUnit::MonthDayNano => {
-                        return Err(nyi_err!("MonthDayNano intervals not supported"));
+                        let f = |b: &[u8]| {
+                            IntervalMonthDayNano::new(
+                                i32::from_le_bytes(b[0..4].try_into().unwrap()),
+                                i32::from_le_bytes(b[4..8].try_into().unwrap()),
+                                i32::from_le_bytes(b[8..12].try_into().unwrap()) as i64,
+                            )
+                        };
+                        Arc::new(IntervalMonthDayNanoArray::from_unary(&binary, f)) as ArrayRef
                     }
                 }
             }

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -1767,6 +1767,8 @@ mod tests {
                     false, // fails to roundtrip keys_sorted
                     false,
                 ),
+                Field::new("42", DataType::Interval(IntervalUnit::MonthDayNano), false),
+                Field::new("43", DataType::Interval(IntervalUnit::MonthDayNano), true),
             ],
             meta(&[("Key", "Value")]),
         );


### PR DESCRIPTION
Supports writing `IntervalMonthNanoArray` to parquet only if its `nanoseconds` part does not exceed `i32::MAX`. (since interval logical type, in parquet, is represented as 4 bytes months + 4 bytes days + 4 bytes milliseconds = 12 bytes.)

When the `nanoseconds` part does not exceed `i32::MAX`, then it is safe to write it to parquet after truncating it to 4 bytes. Otherwise, we throw error as we lose precision.

# Which issue does this PR close?
Closes #6298.

# Rationale for this change
This unblocks the ones who needs to write arrow `IntervalMonthDayNano` with milliseconds precision to parquet. It currently always throws error even if it is safe to write the value to parquet.

# What changes are included in this PR?
When the `nanoseconds` part does not exceed `i32::MAX`, then it is safe to write it to parquet after truncating it to 4 bytes.
When the `nanoseconds` part exceeds `i32::MAX`, then we throw error.

# Are there any user-facing changes?
No.
