### PR TITLE
Pass empty vectors as min/max for all null pages when building ColumnIndex

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -2669,6 +2669,26 @@ mod tests {
     }
 
     #[test]
+    fn test_column_index_with_null_pages() {
+        let page_writer = get_test_page_writer();
+        let props = Default::default();
+        let mut writer = get_test_column_writer::<Int32Type>(page_writer, 1, 0, props);
+        writer.write_batch(&[], Some(&[0, 0, 0, 0]), None).unwrap();
+
+        let r = writer.close().unwrap();
+        assert!(r.column_index.is_some());
+        let col_idx = r.column_index.unwrap();
+        assert!(col_idx.null_pages[0]);
+        assert_eq!(col_idx.min_values[0].len(), 0);
+        assert_eq!(col_idx.max_values[0].len(), 0);
+        assert!(col_idx.null_counts.is_some());
+        assert_eq!(col_idx.null_counts.as_ref().unwrap()[0], 4);
+        assert!(col_idx.repetition_level_histograms.is_none());
+        assert!(col_idx.definition_level_histograms.is_some());
+        assert_eq!(col_idx.definition_level_histograms.unwrap(), &[4, 0]);
+    }
+
+    #[test]
     fn test_column_offset_index_metadata() {
         // write data
         // and check the offset index and column index

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -2670,6 +2670,7 @@ mod tests {
 
     #[test]
     fn test_column_index_with_null_pages() {
+        // write a single page of all nulls
         let page_writer = get_test_page_writer();
         let props = Default::default();
         let mut writer = get_test_column_writer::<Int32Type>(page_writer, 1, 0, props);
@@ -2678,12 +2679,17 @@ mod tests {
         let r = writer.close().unwrap();
         assert!(r.column_index.is_some());
         let col_idx = r.column_index.unwrap();
+        // null_pages should be true for page 0
         assert!(col_idx.null_pages[0]);
+        // min and max should be empty byte arrays
         assert_eq!(col_idx.min_values[0].len(), 0);
         assert_eq!(col_idx.max_values[0].len(), 0);
+        // null_counts should be defined and be 4 for page 0
         assert!(col_idx.null_counts.is_some());
         assert_eq!(col_idx.null_counts.as_ref().unwrap()[0], 4);
+        // there is no repetition so rep histogram should be absent
         assert!(col_idx.repetition_level_histograms.is_none());
+        // definition_level_histogram should be present and should be 0:4, 1:0
         assert!(col_idx.definition_level_histograms.is_some());
         assert_eq!(col_idx.definition_level_histograms.unwrap(), &[4, 0]);
     }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -756,8 +756,8 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         if null_page && self.column_index_builder.valid() {
             self.column_index_builder.append(
                 null_page,
-                vec![0; 1],
-                vec![0; 1],
+                vec![],
+                vec![],
                 self.page_metrics.num_page_nulls as i64,
             );
         } else if self.column_index_builder.valid() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6315.

# Rationale for this change
 
Pages with all null values should write an empty array for min and max to the ColumnIndex. The current behavior is to write one `0` byte for each.

# What changes are included in this PR?

Pass empty vectors to `ColumnIndexBuilder::append`.

# Are there any user-facing changes?

No, since min/max statistics should be ignored for pages with all nulls.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label. This change simply saves some space.
-->
