### PR TITLE
Fix writing of invalid  Parquet ColumnIndex when row group contains null pages

### DIFF
--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -390,7 +390,6 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
 #[cfg(feature = "arrow")]
 #[cfg(feature = "async")]
 mod tests {
-    use std::i32;
     use std::sync::Arc;
 
     use crate::file::footer::parse_metadata;

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -592,8 +592,8 @@ mod tests {
         assert_eq!(left.compressed_size(), right.compressed_size());
         assert_eq!(left.data_page_offset(), right.data_page_offset());
         assert_eq!(left.statistics(), right.statistics());
-        // assert_eq!(left.offset_index_length(), right.offset_index_length());
-        // assert_eq!(left.column_index_length(), right.column_index_length());
+        assert_eq!(left.offset_index_length(), right.offset_index_length());
+        assert_eq!(left.column_index_length(), right.column_index_length());
         assert_eq!(
             left.unencoded_byte_array_data_bytes(),
             right.unencoded_byte_array_data_bytes()

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -227,19 +227,16 @@ impl<T: ParquetValueType> NativeIndex<T> {
     }
 
     pub(crate) fn to_thrift(&self) -> ColumnIndex {
-        let min_values = self
-            .indexes
-            .iter()
-            .map(|x| x.min_bytes().map(|x| x.to_vec()))
-            .collect::<Option<Vec<_>>>()
-            .unwrap_or_else(|| vec![vec![]; self.indexes.len()]);
-
-        let max_values = self
-            .indexes
-            .iter()
-            .map(|x| x.max_bytes().map(|x| x.to_vec()))
-            .collect::<Option<Vec<_>>>()
-            .unwrap_or_else(|| vec![vec![]; self.indexes.len()]);
+        let mut min_values = vec![vec![]; self.indexes.len()];
+        let mut max_values = vec![vec![]; self.indexes.len()];
+        for (i, index) in self.indexes.iter().enumerate() {
+            if let Some(min) = index.min_bytes() {
+                min_values[i].extend_from_slice(min);
+            }
+            if let Some(max) = index.max_bytes() {
+                max_values[i].extend_from_slice(max);
+            }
+        }
 
         let null_counts = self
             .indexes

--- a/parquet/src/file/page_index/index.rs
+++ b/parquet/src/file/page_index/index.rs
@@ -227,16 +227,17 @@ impl<T: ParquetValueType> NativeIndex<T> {
     }
 
     pub(crate) fn to_thrift(&self) -> ColumnIndex {
-        let mut min_values = vec![vec![]; self.indexes.len()];
-        let mut max_values = vec![vec![]; self.indexes.len()];
-        for (i, index) in self.indexes.iter().enumerate() {
-            if let Some(min) = index.min_bytes() {
-                min_values[i].extend_from_slice(min);
-            }
-            if let Some(max) = index.max_bytes() {
-                max_values[i].extend_from_slice(max);
-            }
-        }
+        let min_values = self
+            .indexes
+            .iter()
+            .map(|x| x.min_bytes().unwrap_or(&[]).to_vec())
+            .collect::<Vec<_>>();
+
+        let max_values = self
+            .indexes
+            .iter()
+            .map(|x| x.max_bytes().unwrap_or(&[]).to_vec())
+            .collect::<Vec<_>>();
 
         let null_counts = self
             .indexes


### PR DESCRIPTION
Fixes https://github.com/apache/arrow-rs/issues/6310. All credit goes to @etseidl.