### PR TITLE
Support zero column `RecordBatch`es in pyarrow integration (use RecordBatchOptions when converting a pyarrow RecordBatch)

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -501,6 +501,8 @@ def test_empty_recordbatch_with_row_count():
     assert b.schema == batch.schema
     assert b.schema.metadata == batch.schema.metadata
 
+    assert b.num_rows == num_rows
+    
     del b
 
 def test_record_batch_reader():

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -482,26 +482,18 @@ def test_empty_recordbatch_with_row_count():
     The result of a `count` on a dataset is a RecordBatch with no columns but with `num_rows` set
     """
 
-    # If you know how to create an empty RecordBatch with a specific number of rows, please share
     # Create an empty schema with no fields
-    schema = pa.schema([])
+    batch = pa.RecordBatch.from_pydict({"a": [1, 2, 3, 4]}).select([])
+    num_rows = 4
+    assert batch.num_rows == num_rows
+    assert batch.num_columns == 0
 
-    # Create an empty RecordBatch with 0 columns
-    record_batch = pa.RecordBatch.from_arrays([], schema=schema)
-
-    # Set the desired number of rows by creating a table and slicing
-    num_rows = 5  # Replace with your desired number of rows
-    empty_table = pa.Table.from_batches([record_batch]).slice(0, num_rows)
-
-    # Get the first batch from the table which will have the desired number of rows
-    batch = empty_table.to_batches()[0]
-    
     b = rust.round_trip_record_batch(batch)
     assert b == batch
     assert b.schema == batch.schema
     assert b.schema.metadata == batch.schema.metadata
 
-    assert b.num_rows == num_rows
+    assert b.num_rows == batch.num_rows
     
     del b
 

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -479,7 +479,9 @@ def test_tensor_array():
 
 def test_empty_recordbatch_with_row_count():
     """
-    The result of a `count` on a dataset is a RecordBatch with no columns but with `num_rows` set
+    A pyarrow.RecordBatch with no columns but with `num_rows` set.
+
+    `datafusion-python` gets this as the result of a `count(*)` query.  
     """
 
     # Create an empty schema with no fields

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -476,6 +476,33 @@ def test_tensor_array():
 
     del b
 
+
+def test_empty_recordbatch_with_row_count():
+    """
+    The result of a `count` on a dataset is a RecordBatch with no columns but with `num_rows` set
+    """
+
+    # If you know how to create an empty RecordBatch with a specific number of rows, please share
+    # Create an empty schema with no fields
+    schema = pa.schema([])
+
+    # Create an empty RecordBatch with 0 columns
+    record_batch = pa.RecordBatch.from_arrays([], schema=schema)
+
+    # Set the desired number of rows by creating a table and slicing
+    num_rows = 5  # Replace with your desired number of rows
+    empty_table = pa.Table.from_batches([record_batch]).slice(0, num_rows)
+
+    # Get the first batch from the table which will have the desired number of rows
+    batch = empty_table.to_batches()[0]
+    
+    b = rust.round_trip_record_batch(batch)
+    assert b == batch
+    assert b.schema == batch.schema
+    assert b.schema.metadata == batch.schema.metadata
+
+    del b
+
 def test_record_batch_reader():
     """
     Python -> Rust -> Python

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -333,11 +333,13 @@ impl<T: ToPyArrow> ToPyArrow for Vec<T> {
 
 impl FromPyArrow for RecordBatch {
     fn from_pyarrow_bound(value: &Bound<PyAny>) -> PyResult<Self> {
+        // Technically `num_rows` is an attribute on `pyarrow.RecordBatch`
+        // If other python classes can use the PyCapsule interface and do not have this attribute,
+        // then this will have no effect.
         let row_count = value
             .getattr("num_rows")
             .ok()
             .and_then(|x| x.extract().ok());
-        println!("USING row_count: {:?}", row_count);
         let options = RecordBatchOptions::default().with_row_count(row_count);
 
         // Newer versions of PyArrow as well as other libraries with Arrow data implement this


### PR DESCRIPTION


# Which issue does this PR close?

Closes #6318.

# Rationale for this change
 
`arrow-rs` already has the capability of handling RecordBatches with no columns or data but non-zero row counts https://github.com/apache/arrow-rs/pull/1552.

However, `from_pyarrow_bound` for `RecordBatch` does not currently take advantage of it, which causes an error when running `select count(*)` from pyarrow datasets in `datafusion-python` https://github.com/apache/datafusion-python/issues/800.

# What changes are included in this PR?

This updates the `impl FromPyarrowBound` for `RecordBatch` to use `try_new_with_options` instead of the default `try_new`.

# Are there any user-facing changes?

Yes, `from_pyarrow_bound` will now succeed for a RecordBatch with no columns but a row-count set.