### PR TITLE
fix: azure sas token visible in logs

### DIFF
--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -130,6 +130,18 @@ pub enum AzureCredential {
     BearerToken(String),
 }
 
+impl AzureCredential {
+    /// Determines if the credential requires the request be treated as sensitive
+    pub fn sensitive_request(&self) -> bool {
+        match self {
+            Self::AccessKey(_) => false,
+            Self::BearerToken(_) => false,
+            // SAS tokens are sent as query parameters in the url
+            Self::SASToken(_) => true,
+        }
+    }
+}
+
 /// A list of known Azure authority hosts
 pub mod authority_hosts {
     /// China-based Azure Authority Host


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6322

# Rationale for this change
SasTokens, while they do expire, are a credential and should not be logged.

# What changes are included in this PR?
Sets is_sensitive = true on retryable requests in AzureClient when SasToken credential is used.

# Are there any user-facing changes?
No
