### PR TITLE
docs[object_store]: clarify the backoff strategy that is actually implemented

### DIFF
--- a/object_store/src/client/backoff.rs
+++ b/object_store/src/client/backoff.rs
@@ -18,7 +18,12 @@
 use rand::prelude::*;
 use std::time::Duration;
 
-/// Exponential backoff with jitter
+/// Backoff with decorrelated jitter algorithm
+///
+/// The first backoff will always be `init_backoff`.
+///
+/// Subsequent backoffs will pick a random value between `init_backoff` and
+/// `base * previous` where `previous` is the duration of the previous backoff
 ///
 /// See <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
 #[allow(missing_copy_implementations)]
@@ -28,7 +33,7 @@ pub struct BackoffConfig {
     pub init_backoff: Duration,
     /// The maximum backoff duration
     pub max_backoff: Duration,
-    /// The base of the exponential to use
+    /// The multiplier to use for the next backoff duration
     pub base: f64,
 }
 

--- a/object_store/src/client/backoff.rs
+++ b/object_store/src/client/backoff.rs
@@ -18,7 +18,7 @@
 use rand::prelude::*;
 use std::time::Duration;
 
-/// Backoff with decorrelated jitter algorithm
+/// Exponential backoff with decorrelated jitter algorithm
 ///
 /// The first backoff will always be `init_backoff`.
 ///


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6324 

# Rationale for this change
 
This changes the description in the docs to match the implementation.

# What changes are included in this PR?

Docs clarification

# Are there any user-facing changes?

No