### PR TITLE
[object_store] Propagate env vars as object store client options

### DIFF
--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -1460,7 +1460,10 @@ mod tests {
     fn aws_test_client_opts() {
         let key = "AWS_PROXY_URL";
         if let Ok(config_key) = key.to_ascii_lowercase().parse() {
-            assert_eq!(AmazonS3ConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+            assert_eq!(
+                AmazonS3ConfigKey::Client(ClientConfigKey::ProxyUrl),
+                config_key
+            );
         } else {
             panic!("{} not propagated as ClientConfigKey", key);
         }

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -402,7 +402,7 @@ impl FromStr for AmazonS3ConfigKey {
             "aws_sse_customer_key_base64" => Ok(Self::Encryption(
                 S3EncryptionConfigKey::CustomerEncryptionKey,
             )),
-            _ => match s.parse() {
+            _ => match s.strip_prefix("aws_").unwrap_or(s).parse() {
                 Ok(key) => Ok(Self::Client(key)),
                 Err(_) => Err(Error::UnknownConfigurationKey { key: s.into() }.into()),
             },
@@ -1453,6 +1453,16 @@ mod tests {
 
         for (bucket, expected) in cases {
             assert_eq!(parse_bucket_az(bucket), expected)
+        }
+    }
+
+    #[test]
+    fn aws_test_client_opts() {
+        let key = "AWS_PROXY_URL";
+        if let Ok(config_key) = key.to_ascii_lowercase().parse() {
+            assert_eq!(AmazonS3ConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+        } else {
+            panic!("{} not propagated as ClientConfigKey", key);
         }
     }
 }

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -408,7 +408,7 @@ impl FromStr for AzureConfigKey {
             "azure_disable_tagging" | "disable_tagging" => Ok(Self::DisableTagging),
             // Backwards compatibility
             "azure_allow_http" => Ok(Self::Client(ClientConfigKey::AllowHttp)),
-            _ => match s.parse() {
+            _ => match s.strip_prefix("azure_").unwrap_or(s).parse() {
                 Ok(key) => Ok(Self::Client(key)),
                 Err(_) => Err(Error::UnknownConfigurationKey { key: s.into() }.into()),
             },
@@ -1102,5 +1102,15 @@ mod tests {
         ];
         let pairs = split_sas(raw_sas).unwrap();
         assert_eq!(expected, pairs);
+    }
+
+    #[test]
+    fn azure_test_client_opts() {
+        let key = "AZURE_PROXY_URL";
+        if let Ok(config_key) = key.to_ascii_lowercase().parse() {
+            assert_eq!(AzureConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+        } else {
+            panic!("{} not propagated as ClientConfigKey", key);
+        }
     }
 }

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -1108,7 +1108,10 @@ mod tests {
     fn azure_test_client_opts() {
         let key = "AZURE_PROXY_URL";
         if let Ok(config_key) = key.to_ascii_lowercase().parse() {
-            assert_eq!(AzureConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+            assert_eq!(
+                AzureConfigKey::Client(ClientConfigKey::ProxyUrl),
+                config_key
+            );
         } else {
             panic!("{} not propagated as ClientConfigKey", key);
         }

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -157,6 +157,8 @@ impl FromStr for ClientConfigKey {
             "pool_idle_timeout" => Ok(Self::PoolIdleTimeout),
             "pool_max_idle_per_host" => Ok(Self::PoolMaxIdlePerHost),
             "proxy_url" => Ok(Self::ProxyUrl),
+            "proxy_ca_certificate" => Ok(Self::ProxyCaCertificate),
+            "proxy_excludes" => Ok(Self::ProxyExcludes),
             "timeout" => Ok(Self::Timeout),
             "user_agent" => Ok(Self::UserAgent),
             _ => Err(super::Error::UnknownConfigurationKey {

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -185,7 +185,7 @@ impl FromStr for GoogleConfigKey {
             "google_service_account_key" | "service_account_key" => Ok(Self::ServiceAccountKey),
             "google_bucket" | "google_bucket_name" | "bucket" | "bucket_name" => Ok(Self::Bucket),
             "google_application_credentials" => Ok(Self::ApplicationCredentials),
-            _ => match s.parse() {
+            _ => match s.strip_prefix("google_").unwrap_or(s).parse() {
                 Ok(key) => Ok(Self::Client(key)),
                 Err(_) => Err(Error::UnknownConfigurationKey { key: s.into() }.into()),
             },
@@ -671,4 +671,16 @@ mod tests {
             google_bucket_name
         );
     }
+
+
+    #[test]
+    fn gcp_test_client_opts() {
+        let key = "GOOGLE_PROXY_URL";
+        if let Ok(config_key) = key.to_ascii_lowercase().parse() {
+            assert_eq!(GoogleConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+        } else {
+            panic!("{} not propagated as ClientConfigKey", key);
+        }
+    }
+
 }

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -672,15 +672,16 @@ mod tests {
         );
     }
 
-
     #[test]
     fn gcp_test_client_opts() {
         let key = "GOOGLE_PROXY_URL";
         if let Ok(config_key) = key.to_ascii_lowercase().parse() {
-            assert_eq!(GoogleConfigKey::Client(ClientConfigKey::ProxyUrl), config_key);
+            assert_eq!(
+                GoogleConfigKey::Client(ClientConfigKey::ProxyUrl),
+                config_key
+            );
         } else {
             panic!("{} not propagated as ClientConfigKey", key);
         }
     }
-
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6333 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Minimal patch to allow passing environment variables as client options to the underlying HTTP client of object stores,
allowing different settings per cloud provider.

# What changes are included in this PR?

Trim down the object store prefix (if present) before attempting to parse env vars as client options.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

