### PR TITLE
feat: add `Allocator` type param to `MutableBuffer`

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -33,6 +33,9 @@ name = "arrow_buffer"
 path = "src/lib.rs"
 bench = false
 
+[features]
+allocator_api = []
+
 [dependencies]
 bytes = { version = "1.4" }
 num = { version = "0.4", default-features = false, features = ["std"] }

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -19,6 +19,7 @@
 
 // used by [`buffer::mutable::dangling_ptr`]
 #![cfg_attr(miri, feature(strict_provenance))]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 pub mod alloc;
 pub mod buffer;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #3960 


# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I find #3960 for the same reason -- tracking memory consumption with `Array`s. The most straightforward way is to use the unstable `Allocator` API.

By adding a decoration layer to `Allocator` we can keep track of the real-time memory consumption of each container instance. There is a tiny tool that implements this https://github.com/waynexia/unkai

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The most important changes in this PR are
- add a feature gate `allocator_api`, same name as the unstable rust feature
- add an optional type parameter `A: Allocator = Global` to `MutableBuffer` like `Vec`

Since this requires an unstable rust feature, `allocator_api` can only be used in the nightly toolchain. To keep this library still working in the stable toolchain when the feature gate is disabled, this PR defines many dummy structs like `Global` and `Allocator` to substitute those from std lib as they are not referencable without unstable feature.

When `allocator_api` is enabled, users can either appoint their `Allocator` by new APIs `new_in` and `with_capacity_in` or invoking `From<Vec<T, A>>` which will inherit the allocator from vec.

This PR is tested with MIRI:
```shell
cargo +nightly miri nextest run -p arrow-buffer -F allocator_api
cargo +nightly miri nextest run -p arrow-buffer
```

# Are there any user-facing changes?

New APIs as described above

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
