### PR TITLE
Workaround new bad file in parquet-testing

### DIFF
--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -27,6 +27,7 @@ static KNOWN_FILES: &[&str] = &[
     "PARQUET-1481.parquet",
     "ARROW-GH-41317.parquet",
     "ARROW-GH-41321.parquet",
+    "ARROW-GH-43605.parquet",
     "ARROW-RS-GH-6229-DICTHEADER.parquet",
     "ARROW-RS-GH-6229-LEVELS.parquet",
     "README.md",


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-rs/issues/6343

# Rationale for this change
 
New file causes release verification test to fail

# What changes are included in this PR?

Add file to list

# Are there any user-facing changes?


No

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
