### PR TITLE
fix: clippy warnings from nightly rust 1.82

### DIFF
--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -324,6 +324,6 @@ mod tests {
 
         assert_eq!(0, private_data.buffers_ptr.len());
 
-        Box::into_raw(private_data);
+        let _ = Box::into_raw(private_data);
     }
 }

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -2572,7 +2572,7 @@ mod tests {
             let mut fields = Vec::new();
             let mut arrays = Vec::new();
             for i in 0..num_cols {
-                let field = Field::new(&format!("col_{}", i), DataType::Decimal128(38, 10), true);
+                let field = Field::new(format!("col_{}", i), DataType::Decimal128(38, 10), true);
                 let array = Decimal128Array::from(vec![num_cols as i128; num_rows]);
                 fields.push(field);
                 arrays.push(Arc::new(array) as Arc<dyn Array>);
@@ -2627,7 +2627,7 @@ mod tests {
         let mut fields = Vec::new();
         let mut arrays = Vec::new();
         for i in 0..num_cols {
-            let field = Field::new(&format!("col_{}", i), DataType::Decimal128(38, 10), true);
+            let field = Field::new(format!("col_{}", i), DataType::Decimal128(38, 10), true);
             let array = Decimal128Array::from(vec![num_cols as i128; num_rows]);
             fields.push(field);
             arrays.push(Arc::new(array) as Arc<dyn Array>);
@@ -2682,7 +2682,7 @@ mod tests {
         let mut fields = Vec::new();
         let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5).unwrap();
         for i in 0..num_cols {
-            let field = Field::new(&format!("col_{}", i), DataType::Decimal128(38, 10), true);
+            let field = Field::new(format!("col_{}", i), DataType::Decimal128(38, 10), true);
             fields.push(field);
         }
         let schema = Schema::new(fields);

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -403,7 +403,7 @@ fn sort_fixed_size_list(
 }
 
 #[inline(never)]
-fn sort_impl<T: ?Sized + Copy>(
+fn sort_impl<T: Copy>(
     options: SortOptions,
     valids: &mut [(u32, T)],
     nulls: &[u32],

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -389,14 +389,13 @@ impl UnionFields {
         let mut set = 0_u128;
         type_ids
             .into_iter()
-            .map(|idx| {
+            .inspect(|&idx| {
                 let mask = 1_u128 << idx;
                 if (set & mask) != 0 {
                     panic!("duplicate type id: {}", idx);
                 } else {
                     set |= mask;
                 }
-                idx
             })
             .zip(fields)
             .collect()

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -568,13 +568,9 @@ macro_rules! make_data_page_stats_iterator {
                 let next = self.iter.next();
                 match next {
                     Some((len, index)) => match index {
-                        $index_type(native_index) => Some(
-                            native_index
-                                .indexes
-                                .iter()
-                                .map(|x| $func(x))
-                                .collect::<Vec<_>>(),
-                        ),
+                        $index_type(native_index) => {
+                            Some(native_index.indexes.iter().map($func).collect::<Vec<_>>())
+                        }
                         // No matching `Index` found;
                         // thus no statistics that can be extracted.
                         // We return vec![None; len] to effectively

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3082,8 +3082,8 @@ mod tests {
             let min = byte_array_stats.min_opt().unwrap();
             let max = byte_array_stats.max_opt().unwrap();
 
-            assert_eq!(min.as_bytes(), &[b'a']);
-            assert_eq!(max.as_bytes(), &[b'd']);
+            assert_eq!(min.as_bytes(), b"a");
+            assert_eq!(max.as_bytes(), b"d");
         } else {
             panic!("expecting Statistics::ByteArray");
         }
@@ -3154,8 +3154,8 @@ mod tests {
             let min = byte_array_stats.min_opt().unwrap();
             let max = byte_array_stats.max_opt().unwrap();
 
-            assert_eq!(min.as_bytes(), &[b'a']);
-            assert_eq!(max.as_bytes(), &[b'd']);
+            assert_eq!(min.as_bytes(), b"a");
+            assert_eq!(max.as_bytes(), b"d");
         } else {
             panic!("expecting Statistics::ByteArray");
         }

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -1298,11 +1298,8 @@ mod tests {
 
     #[test]
     fn test_byte_array_from() {
-        assert_eq!(
-            ByteArray::from(vec![b'A', b'B', b'C']).data(),
-            &[b'A', b'B', b'C']
-        );
-        assert_eq!(ByteArray::from("ABC").data(), &[b'A', b'B', b'C']);
+        assert_eq!(ByteArray::from(b"ABC".to_vec()).data(), b"ABC");
+        assert_eq!(ByteArray::from("ABC").data(), b"ABC");
         assert_eq!(
             ByteArray::from(Bytes::from(vec![1u8, 2u8, 3u8, 4u8, 5u8])).data(),
             &[1u8, 2u8, 3u8, 4u8, 5u8]

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -55,18 +55,14 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // write offset index to the file
         for (row_group_idx, row_group) in self.row_groups.iter_mut().enumerate() {
             for (column_idx, column_metadata) in row_group.columns.iter_mut().enumerate() {
-                match &offset_indexes[row_group_idx][column_idx] {
-                    Some(offset_index) => {
-                        let start_offset = self.buf.bytes_written();
-                        let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
-                        offset_index.write_to_out_protocol(&mut protocol)?;
-                        let end_offset = self.buf.bytes_written();
-                        // set offset and index for offset index
-                        column_metadata.offset_index_offset = Some(start_offset as i64);
-                        column_metadata.offset_index_length =
-                            Some((end_offset - start_offset) as i32);
-                    }
-                    None => {}
+                if let Some(offset_index) = &offset_indexes[row_group_idx][column_idx] {
+                    let start_offset = self.buf.bytes_written();
+                    let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
+                    offset_index.write_to_out_protocol(&mut protocol)?;
+                    let end_offset = self.buf.bytes_written();
+                    // set offset and index for offset index
+                    column_metadata.offset_index_offset = Some(start_offset as i64);
+                    column_metadata.offset_index_length = Some((end_offset - start_offset) as i32);
                 }
             }
         }
@@ -84,18 +80,14 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // write column index to the file
         for (row_group_idx, row_group) in self.row_groups.iter_mut().enumerate() {
             for (column_idx, column_metadata) in row_group.columns.iter_mut().enumerate() {
-                match &column_indexes[row_group_idx][column_idx] {
-                    Some(column_index) => {
-                        let start_offset = self.buf.bytes_written();
-                        let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
-                        column_index.write_to_out_protocol(&mut protocol)?;
-                        let end_offset = self.buf.bytes_written();
-                        // set offset and index for offset index
-                        column_metadata.column_index_offset = Some(start_offset as i64);
-                        column_metadata.column_index_length =
-                            Some((end_offset - start_offset) as i32);
-                    }
-                    None => {}
+                if let Some(column_index) = &column_indexes[row_group_idx][column_idx] {
+                    let start_offset = self.buf.bytes_written();
+                    let mut protocol = TCompactOutputProtocol::new(&mut self.buf);
+                    column_index.write_to_out_protocol(&mut protocol)?;
+                    let end_offset = self.buf.bytes_written();
+                    // set offset and index for offset index
+                    column_metadata.column_index_offset = Some(start_offset as i64);
+                    column_metadata.column_index_length = Some((end_offset - start_offset) as i32);
                 }
             }
         }
@@ -524,7 +516,6 @@ mod tests {
     async fn load_metadata_from_bytes(file_size: usize, data: Bytes) -> ParquetMetaData {
         use crate::arrow::async_reader::{MetadataFetch, MetadataLoader};
         use crate::errors::Result as ParquetResult;
-        use bytes::Bytes;
         use futures::future::BoxFuture;
         use futures::FutureExt;
         use std::ops::Range;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Find those warnings when working with nightly toolchain in #6336

# What changes are included in this PR?

Fix new clippy warnings.

One rule I didn't touch is [`too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph). This does make sense in some scenarios but lots of the reported doc comment have a long first sentence... 🙈 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
