### PR TITLE
impl `From<Vec<T>>` for `Buffer`

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -382,6 +382,12 @@ impl<const N: usize> From<&[u8; N]> for Buffer {
     }
 }
 
+impl<T: ArrowNativeType> From<Vec<T>> for Buffer {
+    fn from(value: Vec<T>) -> Self {
+        Self::from_vec(value)
+    }
+}
+
 /// Creating a `Buffer` instance by storing the boolean values into the buffer
 impl FromIterator<bool> for Buffer {
     fn from_iter<I>(iter: I) -> Self


### PR DESCRIPTION
With the removal of the generic `impl<T: AsRef<[u8]>> From<T> for Buffer` in #6043 we can now add `impl<T: ArrowNativeType> From<Vec<T>> for Buffer`.