### PR TITLE
`object_store::GetOptions` derive `Clone`

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -911,7 +911,7 @@ pub struct ObjectMeta {
 }
 
 /// Options for a get request, such as range
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct GetOptions {
     /// Request will succeed if the `ObjectMeta::e_tag` matches
     /// otherwise returning [`Error::Precondition`]


### PR DESCRIPTION
Pretty self-explanatory ... we need to be able to clone `object_store::GetOptions`, we're currently doing it manually as every field is clonable, but it would be nice if we could just `get_options.clone()`.