### PR TITLE
stop panic in `MetadataLoader` on invalid data

### DIFF
--- a/parquet/src/arrow/async_reader/metadata.rs
+++ b/parquet/src/arrow/async_reader/metadata.rs
@@ -21,6 +21,7 @@ use crate::file::footer::{decode_footer, decode_metadata};
 use crate::file::metadata::ParquetMetaData;
 use crate::file::page_index::index::Index;
 use crate::file::page_index::index_reader::{acc_range, decode_column_index, decode_offset_index};
+use crate::file::FOOTER_SIZE;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::FutureExt;
@@ -47,8 +48,6 @@ pub struct MetadataLoader<F> {
     /// The offset and bytes of remaining unparsed data
     remainder: Option<(usize, Bytes)>,
 }
-
-const FOOTER_SIZE: usize = 8;
 
 impl<F: MetadataFetch> MetadataLoader<F> {
     /// Create a new [`MetadataLoader`] by reading the footer information

--- a/parquet/src/arrow/async_reader/metadata.rs
+++ b/parquet/src/arrow/async_reader/metadata.rs
@@ -71,7 +71,10 @@ impl<F: MetadataFetch> MetadataLoader<F> {
         let suffix_len = suffix.len();
 
         let mut footer = [0; 8];
-        footer.copy_from_slice(&suffix[suffix_len - 8..suffix_len]);
+        let Some(footer_start) = suffix_len.checked_sub(8) else {
+            return Err(ParquetError::General("Invalid Parquet file. Corrupt footer".to_string()));
+        };
+        footer.copy_from_slice(&suffix[footer_start..]);
 
         let length = decode_footer(&footer)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
While messing with our `object_store` implementation I sent invalid data to `MetadataEncoder` and got a panic:

```
thread 'tokio-runtime-worker' panicked at /Users/samuel/.cargo/git/checkouts/arrow-rs-3b86e19e889d5acc/ee2f75a/parquet/src/arrow/async_reader/metadata.rs:74:40:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
```

Looking at the code I'm pretty sure it's because `suffix_len` is <8 causing the subtract to fail.

# What changes are included in this PR?

return an error instead of panicing. I don't know how to reproduce this in a test, hence just the change. LMK if this requires a test?

# Are there any user-facing changes?

no.
