### PR TITLE
Support StringViewArray interop with python: fix lingering C Data Interface issues for *ViewArray

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         rust: [stable]
         # PyArrow 13 was the last version prior to introduction to Arrow PyCapsules
-        pyarrow: ["13", "14", "17"]
+        pyarrow: ["15", "16", "17"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,6 @@ on:
       - arrow/**
 
 jobs:
-
   integration:
     name: Archery test With other arrows
     runs-on: ubuntu-latest
@@ -118,9 +117,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ stable ]
+        rust: [stable]
         # PyArrow 13 was the last version prior to introduction to Arrow PyCapsules
-        pyarrow: [ "13", "14" ]
+        pyarrow: ["13", "14", "17"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        # PyArrow 13 was the last version prior to introduction to Arrow PyCapsules
+        # PyArrow 15 was the first version to introduce StringView/BinaryView support
         pyarrow: ["15", "16", "17"]
     steps:
       - uses: actions/checkout@v4

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1271,10 +1271,14 @@ mod tests_from_ffi {
     use super::{ImportedArrowArray, Result};
     use crate::builder::GenericByteViewBuilder;
     use crate::types::{BinaryViewType, ByteViewType, Int32Type, StringViewType};
-    use crate::{array::{
-        Array, BooleanArray, DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray,
-        Int32Array, Int64Array, StringArray, StructArray, UInt32Array, UInt64Array,
-    }, ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema}, make_array, ArrayRef, GenericByteViewArray, ListArray};
+    use crate::{
+        array::{
+            Array, BooleanArray, DictionaryArray, FixedSizeBinaryArray, FixedSizeListArray,
+            Int32Array, Int64Array, StringArray, StructArray, UInt32Array, UInt64Array,
+        },
+        ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema},
+        make_array, ArrayRef, GenericByteViewArray, ListArray,
+    };
 
     fn test_round_trip(expected: &ArrayData) -> Result<()> {
         // here we export the array
@@ -1507,7 +1511,9 @@ mod tests_from_ffi {
         StringArray::from(array)
     }
 
-    fn roundtrip_byte_view_array<T: ByteViewType>(array: GenericByteViewArray<T>) -> GenericByteViewArray<T> {
+    fn roundtrip_byte_view_array<T: ByteViewType>(
+        array: GenericByteViewArray<T>,
+    ) -> GenericByteViewArray<T> {
         let data = array.into_data();
 
         let array = FFI_ArrowArray::new(&data);
@@ -1631,7 +1637,10 @@ mod tests_from_ffi {
 
                     let copied = extend_array(&imported);
                     assert_eq!(
-                        copied.as_any().downcast_ref::<GenericByteViewArray<T>>().unwrap(),
+                        copied
+                            .as_any()
+                            .downcast_ref::<GenericByteViewArray<T>>()
+                            .unwrap(),
                         &imported
                     );
                 }};
@@ -1654,22 +1663,24 @@ mod tests_from_ffi {
             let mixed_one_variadic = {
                 let mut builder = GenericByteViewBuilder::<T>::new();
                 builder.append_value(T::Native::from_str("inlined"));
-                let block_id = builder.append_block(Buffer::from("non-inlined-string-buffer".as_bytes()));
+                let block_id =
+                    builder.append_block(Buffer::from("non-inlined-string-buffer".as_bytes()));
                 builder.try_append_view(block_id, 0, 25).unwrap();
                 builder.finish()
             };
             assert_eq!(mixed_one_variadic.data_buffers().len(), 1);
             run_test_case!(mixed_one_variadic);
 
-
             // inlined + non-inlined, 2 variadic buffers.
             let mixed_two_variadic = {
                 let mut builder = GenericByteViewBuilder::<T>::new();
                 builder.append_value(T::Native::from_str("inlined"));
-                let block_id = builder.append_block(Buffer::from("non-inlined-string-buffer".as_bytes()));
+                let block_id =
+                    builder.append_block(Buffer::from("non-inlined-string-buffer".as_bytes()));
                 builder.try_append_view(block_id, 0, 25).unwrap();
 
-                let block_id = builder.append_block(Buffer::from("another-non-inlined-string-buffer".as_bytes()));
+                let block_id = builder
+                    .append_block(Buffer::from("another-non-inlined-string-buffer".as_bytes()));
                 builder.try_append_view(block_id, 0, 33).unwrap();
                 builder.finish()
             };

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -139,7 +139,7 @@ pub unsafe fn export_array_into_raw(
 
 // returns the number of bits that buffer `i` (in the C data interface) is expected to have.
 // This is set by the Arrow specification
-fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
+fn bit_width(data_type: &DataType, i: usize, num_buffers: usize) -> Result<usize> {
     if let Some(primitive) = data_type.primitive_width() {
         return match i {
             0 => Err(ArrowError::CDataInterface(format!(
@@ -161,7 +161,7 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
         }
         (DataType::FixedSizeBinary(num_bytes), 1) => *num_bytes as usize * u8::BITS as usize,
         (DataType::FixedSizeList(f, num_elems), 1) => {
-            let child_bit_width = bit_width(f.data_type(), 1)?;
+            let child_bit_width = bit_width(f.data_type(), 1, num_buffers)?;
             child_bit_width * (*num_elems as usize)
         },
         (DataType::FixedSizeBinary(_), _) | (DataType::FixedSizeList(_, _), _) => {
@@ -192,6 +192,19 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
             return Err(ArrowError::CDataInterface(format!(
                 "The datatype \"{data_type:?}\" expects 3 buffers, but requested {i}. Please verify that the C data interface is correctly implemented."
             )))
+        }
+        // Variable-sized views: have 3 or more buffers.
+        // Buffer 1 is u128 views
+        // Buffers 2...N-1 are u8
+        // Buffer N is i64
+        (DataType::Utf8View, 1) | (DataType::BinaryView,1) => {
+            u128::BITS as _
+        }
+        (DataType::Utf8View, i) | (DataType::BinaryView, i) if i < num_buffers - 1  =>{
+            u8::BITS as _
+        }
+        (DataType::Utf8View, i) | (DataType::BinaryView, i) if i == num_buffers - 1 => {
+            i64::BITS as _
         }
         // type ids. UnionArray doesn't have null bitmap so buffer index begins with 0.
         (DataType::Union(_, _), 0) => i8::BITS as _,
@@ -378,7 +391,7 @@ impl<'a> ImportedArrowArray<'a> {
         let buffer_begin = can_contain_null_mask as usize;
         (buffer_begin..self.array.num_buffers())
             .map(|index| {
-                let len = self.buffer_len(index, &self.data_type)?;
+                let len = self.buffer_len(index, self.array.num_buffers(), &self.data_type)?;
 
                 match unsafe { create_buffer(self.owner.clone(), self.array, index, len) } {
                     Some(buf) => Ok(buf),
@@ -399,7 +412,7 @@ impl<'a> ImportedArrowArray<'a> {
     /// Rust implementation uses fixed-sized buffers, which require knowledge of their `len`.
     /// for variable-sized buffers, such as the second buffer of a stringArray, we need
     /// to fetch offset buffer's len to build the second buffer.
-    fn buffer_len(&self, i: usize, dt: &DataType) -> Result<usize> {
+    fn buffer_len(&self, i: usize, num_buffers: usize, dt: &DataType) -> Result<usize> {
         // Special handling for dictionary type as we only care about the key type in the case.
         let data_type = match dt {
             DataType::Dictionary(key_data_type, _) => key_data_type.as_ref(),
@@ -420,7 +433,7 @@ impl<'a> ImportedArrowArray<'a> {
             | (DataType::LargeList(_), 1)
             | (DataType::Map(_, _), 1) => {
                 // the len of the offset buffer (buffer 1) equals length + 1
-                let bits = bit_width(data_type, i)?;
+                let bits = bit_width(data_type, i, num_buffers)?;
                 debug_assert_eq!(bits % 8, 0);
                 (length + 1) * (bits / 8)
             }
@@ -430,7 +443,7 @@ impl<'a> ImportedArrowArray<'a> {
                 }
 
                 // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
-                let len = self.buffer_len(1, dt)?;
+                let len = self.buffer_len(1, num_buffers, dt)?;
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i32`, as Utf8 uses `i32` offsets.
                 #[allow(clippy::cast_ptr_alignment)]
@@ -444,7 +457,7 @@ impl<'a> ImportedArrowArray<'a> {
                 }
 
                 // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
-                let len = self.buffer_len(1, dt)?;
+                let len = self.buffer_len(1, num_buffers, dt)?;
                 // first buffer is the null buffer => add(1)
                 // we assume that pointer is aligned for `i64`, as Large uses `i64` offsets.
                 #[allow(clippy::cast_ptr_alignment)]
@@ -452,9 +465,27 @@ impl<'a> ImportedArrowArray<'a> {
                 // get last offset
                 (unsafe { *offset_buffer.add(len / size_of::<i64>() - 1) }) as usize
             }
+            // View types: these have variadic buffers.
+            // Buffer 1 is the views buffer, which is the same as the length of the array.
+            // Buffers 2..N-1 are the buffers holding the byte data. Their lengths are variable.
+            // Buffer N is of length (N - 2) and stores i64 containing the lengths of buffers 2..N-1
+            (DataType::Utf8View, 1) | (DataType::BinaryView, 1) => length,
+            (DataType::Utf8View, i) | (DataType::BinaryView, i) if i < num_buffers - 1 => {
+                // Read the length of buffer N out of the last buffer.
+                // first buffer is the null buffer => add(1)
+                // we assume that pointer is aligned for `i32`, as Utf8 uses `i32` offsets.
+                #[allow(clippy::cast_ptr_alignment)]
+                let variadic_buffer_lengths = self.array.buffer(num_buffers - 1) as *const i64;
+                // get last offset
+                (unsafe { *variadic_buffer_lengths.add(i - 2) }) as usize
+            }
+            (DataType::Utf8View, i) | (DataType::BinaryView, i) if i == num_buffers - 1 => {
+                // Length is equal to number of buffers.
+                num_buffers - 2
+            }
             // buffer len of primitive types
             _ => {
-                let bits = bit_width(data_type, i)?;
+                let bits = bit_width(data_type, i, num_buffers)?;
                 bit_util::ceil(length * bits, 8)
             }
         })
@@ -1453,8 +1484,10 @@ mod tests_from_ffi {
             owner: &array,
         };
 
-        let offset_buf_len = imported_array.buffer_len(1, &imported_array.data_type)?;
-        let data_buf_len = imported_array.buffer_len(2, &imported_array.data_type)?;
+        let offset_buf_len =
+            imported_array.buffer_len(1, array.num_buffers(), &imported_array.data_type)?;
+        let data_buf_len =
+            imported_array.buffer_len(2, array.num_buffers(), &imported_array.data_type)?;
 
         assert_eq!(offset_buf_len, 4);
         assert_eq!(data_buf_len, 0);

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -223,7 +223,8 @@ impl Buffer {
     pub fn slice_with_length(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset.saturating_add(length) <= self.length,
-            "the offset of the new Buffer cannot exceed the existing length: slice offset={offset} length={length}"
+            "the offset of the new Buffer cannot exceed the existing length: slice offset={offset} length={length} selflen={}",
+            self.length
         );
         // Safety:
         // offset + length <= self.length

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -203,7 +203,9 @@ impl Buffer {
     pub fn advance(&mut self, offset: usize) {
         assert!(
             offset <= self.length,
-            "the offset of the new Buffer cannot exceed the existing length"
+            "the offset of the new Buffer cannot exceed the existing length: offset={} length={}",
+            offset,
+            self.length
         );
         self.length -= offset;
         // Safety:
@@ -221,7 +223,7 @@ impl Buffer {
     pub fn slice_with_length(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset.saturating_add(length) <= self.length,
-            "the offset of the new Buffer cannot exceed the existing length"
+            "the offset of the new Buffer cannot exceed the existing length: slice offset={offset} length={length}"
         );
         // Safety:
         // offset + length <= self.length

--- a/arrow/src/pyarrow.rs
+++ b/arrow/src/pyarrow.rs
@@ -354,7 +354,7 @@ impl FromPyArrow for RecordBatch {
             validate_pycapsule(array_capsule, "arrow_array")?;
 
             let schema_ptr = unsafe { schema_capsule.reference::<FFI_ArrowSchema>() };
-            let ffi_array = unsafe { FFI_ArrowArray::from_raw(array_capsule.pointer() as _) };
+            let ffi_array = unsafe { FFI_ArrowArray::from_raw(array_capsule.pointer().cast()) };
             let array_data = unsafe { ffi::from_ffi(ffi_array, schema_ptr) }.map_err(to_py_err)?;
             if !matches!(array_data.data_type(), DataType::Struct(_)) {
                 return Err(PyTypeError::new_err(

--- a/arrow/tests/pyarrow.rs
+++ b/arrow/tests/pyarrow.rs
@@ -18,6 +18,7 @@
 use arrow::array::{ArrayRef, Int32Array, StringArray};
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow::record_batch::RecordBatch;
+use arrow_array::StringViewArray;
 use pyo3::Python;
 use std::sync::Arc;
 
@@ -27,7 +28,8 @@ fn test_to_pyarrow() {
 
     let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
     let b: ArrayRef = Arc::new(StringArray::from(vec!["a", "b"]));
-    let input = RecordBatch::try_from_iter(vec![("a", a), ("b", b)]).unwrap();
+    let c: ArrayRef = Arc::new(StringViewArray::from(vec!["a", "b"]));
+    let input = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
     println!("input: {:?}", input);
 
     let res = Python::with_gil(|py| {

--- a/arrow/tests/pyarrow.rs
+++ b/arrow/tests/pyarrow.rs
@@ -28,7 +28,8 @@ fn test_to_pyarrow() {
 
     let a: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
     let b: ArrayRef = Arc::new(StringArray::from(vec!["a", "b"]));
-    let c: ArrayRef = Arc::new(StringViewArray::from(vec!["a", "b"]));
+    // The "very long string" will not be inlined, and force the creation of a data buffer.
+    let c: ArrayRef = Arc::new(StringViewArray::from(vec!["short", "a very long string"]));
     let input = RecordBatch::try_from_iter(vec![("a", a), ("b", b), ("c", c)]).unwrap();
     println!("input: {:?}", input);
 

--- a/arrow/tests/pyarrow.rs
+++ b/arrow/tests/pyarrow.rs
@@ -18,7 +18,8 @@
 use arrow::array::{ArrayRef, Int32Array, StringArray};
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow::record_batch::RecordBatch;
-use arrow_array::StringViewArray;
+use arrow_array::builder::{BinaryViewBuilder, StringViewBuilder};
+use arrow_array::{Array, BinaryViewArray, StringViewArray};
 use pyo3::Python;
 use std::sync::Arc;
 
@@ -42,4 +43,67 @@ fn test_to_pyarrow() {
     .unwrap();
 
     assert_eq!(input, res);
+}
+
+#[test]
+fn test_to_pyarrow_byte_view() {
+    pyo3::prepare_freethreaded_python();
+
+    for num_variadic_buffers in 0..=2 {
+        let string_view: ArrayRef = Arc::new(string_view_column(num_variadic_buffers));
+        let binary_view: ArrayRef = Arc::new(binary_view_column(num_variadic_buffers));
+
+        let input = RecordBatch::try_from_iter(vec![
+            ("string_view", string_view),
+            ("binary_view", binary_view),
+        ])
+        .unwrap();
+
+        println!("input: {:?}", input);
+        let res = Python::with_gil(|py| {
+            let py_input = input.to_pyarrow(py)?;
+            let records = RecordBatch::from_pyarrow_bound(py_input.bind(py))?;
+            let py_records = records.to_pyarrow(py)?;
+            RecordBatch::from_pyarrow_bound(py_records.bind(py))
+        })
+        .unwrap();
+
+        assert_eq!(input, res);
+    }
+}
+
+fn binary_view_column(num_variadic_buffers: usize) -> BinaryViewArray {
+    let long_scalar = b"but soft what light through yonder window breaks".as_slice();
+    let mut builder = BinaryViewBuilder::new().with_fixed_block_size(long_scalar.len() as u32);
+    // Make sure there is at least one non-inlined value.
+    builder.append_value("inlined".as_bytes());
+
+    for _ in 0..num_variadic_buffers {
+        builder.append_value(long_scalar);
+    }
+
+    let result = builder.finish();
+
+    assert_eq!(result.data_buffers().len(), num_variadic_buffers);
+    assert_eq!(result.len(), num_variadic_buffers + 1);
+
+    result
+}
+
+fn string_view_column(num_variadic_buffers: usize) -> StringViewArray {
+    let long_scalar = "but soft what light through yonder window breaks";
+    let mut builder = StringViewBuilder::new().with_fixed_block_size(long_scalar.len() as u32);
+    // Make sure there is at least one non-inlined value.
+    builder.append_value("inlined");
+
+    for _ in 0..num_variadic_buffers {
+        builder.append_value(long_scalar);
+    }
+
+    let result = builder.finish();
+
+    assert_eq!(result.data_buffers().len(), num_variadic_buffers);
+    assert_eq!(result.len(), num_variadic_buffers + 1);
+
+    result
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6366 

# Rationale for this change

Previously, StringViewArrays and BinaryViewArrays sent to PyArrow will panic.

If you use the updated `test_to_pyarrow()` from this PR without the additional changes, it will fail.

# What changes are included in this PR?

The specification states that the C Data Interface format for StringViewArray and BinaryViewArray includes an extra `variadic_buffer_sizes` buffer at the end of the various output values.

We were not including that before. There was a prior PR to add it for the IPC format, but not for the C Data Interface.

I cribbed the relevant C++ code for this: https://github.com/apache/arrow/blob/ab0a40ee34217070f14027776682074c55d0b507/cpp/src/arrow/c/bridge.cc#L584-L609

# Are there any user-facing changes?

It should now be possible to share StringViewArray and BinaryViewArray over C Data Interface.
