### PR TITLE
Implement native support StringViewArray for `regexp_is_match` and `regexp_is_match_scalar` function, deprecate `regexp_is_match_utf8` and `regexp_is_match_utf8_scalar`

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -155,7 +155,7 @@ fn like_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, Arr
 ///
 /// This trait helps to abstract over the different types of string arrays
 /// so that we don't need to duplicate the implementation for each type.
-trait StringArrayType<'a>: ArrayAccessor<Item = &'a str> + Sized {
+pub trait StringArrayType<'a>: ArrayAccessor<Item = &'a str> + Sized {
     fn is_ascii(&self) -> bool;
     fn iter(&self) -> ArrayIter<Self>;
 }

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -642,11 +642,27 @@ mod tests {
     );
     test_flag_utf8!(
         test_utf8_array_regexp_is_match_insensitive_2,
-        StringViewArray::from(vec!["arrow", "arrow", "arrow", "arrow", "arrow", "arrow"]),
-        StringViewArray::from(vec!["^ar", "^AR", "ow$", "OW$", "foo", ""]),
-        StringArray::from(vec!["i"; 6]),
-        regexp_is_match_utf8::<StringViewArray, StringViewArray, GenericStringArray<i32>>,
-        [true, true, true, true, false, true]
+        StringViewArray::from(vec![
+            "Official Rust implementation of Apache Arrow",
+            "apache/arrow-rs",
+            "apache/arrow-rs",
+            "parquet",
+            "parquet",
+            "row",
+            "row",
+        ]),
+        StringViewArray::from(vec![
+            ".*rust implement.*",
+            "^ap",
+            "^AP",
+            "et$",
+            "ET$",
+            "foo",
+            ""
+        ]),
+        StringViewArray::from(vec!["i"; 7]),
+        regexp_is_match_utf8::<StringViewArray, StringViewArray, StringViewArray>,
+        [true, true, true, true, true, false, true]
     );
     test_flag_utf8!(
         test_utf8_array_regexp_is_match_insensitive_3,
@@ -666,8 +682,13 @@ mod tests {
     );
     test_flag_utf8_scalar!(
         test_utf8_array_regexp_is_match_scalar_2,
-        StringViewArray::from(vec!["arrow", "ARROW", "parquet", "PARQUET"]),
-        "^ar",
+        StringViewArray::from(vec![
+            "apache/arrow-rs",
+            "APACHE/ARROW-RS",
+            "parquet",
+            "PARQUET",
+        ]),
+        "^ap",
         regexp_is_match_utf8_scalar::<StringViewArray>,
         [true, false, false, false]
     );
@@ -681,7 +702,12 @@ mod tests {
     );
     test_flag_utf8_scalar!(
         test_utf8_array_regexp_is_match_empty_scalar_2,
-        StringViewArray::from(vec!["arrow", "ARROW", "parquet", "PARQUET"]),
+        StringViewArray::from(vec![
+            "apache/arrow-rs",
+            "APACHE/ARROW-RS",
+            "parquet",
+            "PARQUET",
+        ]),
         "",
         regexp_is_match_utf8_scalar::<StringViewArray>,
         [true, true, true, true]
@@ -697,8 +723,13 @@ mod tests {
     );
     test_flag_utf8_scalar!(
         test_utf8_array_regexp_is_match_insensitive_scalar_2,
-        StringViewArray::from(vec!["arrow", "ARROW", "parquet", "PARQUET"]),
-        "^ar",
+        StringViewArray::from(vec![
+            "apache/arrow-rs",
+            "APACHE/ARROW-RS",
+            "parquet",
+            "PARQUET",
+        ]),
+        "^ap",
         "i",
         regexp_is_match_utf8_scalar::<StringViewArray>,
         [true, true, false, false]

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -25,7 +25,7 @@ use arrow::util::test_util::seedable_rng;
 use arrow::{array::*, datatypes::Float32Type, datatypes::Int32Type};
 use arrow_buffer::IntervalMonthDayNano;
 use arrow_string::like::*;
-use arrow_string::regexp::{regexp_is_match_scalar, regexp_is_match_utf8_scalar};
+use arrow_string::regexp::regexp_is_match_scalar;
 use criterion::Criterion;
 use rand::rngs::StdRng;
 use rand::Rng;
@@ -52,7 +52,7 @@ fn bench_nilike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     nilike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
 }
 
-fn bench_regexp_is_match_scalar(arr_a: &StringViewArray, value_b: &str) {
+fn bench_stringview_regexp_is_match_scalar(arr_a: &StringViewArray, value_b: &str) {
     regexp_is_match_scalar(
         criterion::black_box(arr_a),
         criterion::black_box(value_b),
@@ -61,8 +61,8 @@ fn bench_regexp_is_match_scalar(arr_a: &StringViewArray, value_b: &str) {
     .unwrap();
 }
 
-fn bench_regexp_is_match_utf8_scalar(arr_a: &StringArray, value_b: &str) {
-    regexp_is_match_utf8_scalar(
+fn bench_string_regexp_is_match_scalar(arr_a: &StringArray, value_b: &str) {
+    regexp_is_match_scalar(
         criterion::black_box(arr_a),
         criterion::black_box(value_b),
         None,
@@ -358,16 +358,16 @@ fn add_benchmark(c: &mut Criterion) {
 
     group
         .bench_function("regexp_matches_utf8 scalar starts with", |b| {
-            b.iter(|| bench_regexp_is_match_utf8_scalar(&arr_string, "^xx"))
+            b.iter(|| bench_string_regexp_is_match_scalar(&arr_string, "^xx"))
         })
         .bench_function("regexp_matches_utf8 scalar contains", |b| {
-            b.iter(|| bench_regexp_is_match_utf8_scalar(&arr_string, ".*xxXX.*"))
+            b.iter(|| bench_string_regexp_is_match_scalar(&arr_string, ".*xxXX.*"))
         })
         .bench_function("regexp_matches_utf8 scalar ends with", |b| {
-            b.iter(|| bench_regexp_is_match_utf8_scalar(&arr_string, "xx$"))
+            b.iter(|| bench_string_regexp_is_match_scalar(&arr_string, "xx$"))
         })
         .bench_function("regexp_matches_utf8 scalar complex", |b| {
-            b.iter(|| bench_regexp_is_match_utf8_scalar(&arr_string, ".*x{2}.xX.*xXX"))
+            b.iter(|| bench_string_regexp_is_match_scalar(&arr_string, ".*x{2}.xX.*xXX"))
         });
 
     group.finish();
@@ -378,16 +378,16 @@ fn add_benchmark(c: &mut Criterion) {
 
     group
         .bench_function("regexp_matches_utf8view scalar starts with", |b| {
-            b.iter(|| bench_regexp_is_match_scalar(&arr_string_view, "^xx"))
+            b.iter(|| bench_stringview_regexp_is_match_scalar(&arr_string_view, "^xx"))
         })
         .bench_function("regexp_matches_utf8view scalar contains", |b| {
-            b.iter(|| bench_regexp_is_match_scalar(&arr_string_view, ".*xxXX.*"))
+            b.iter(|| bench_stringview_regexp_is_match_scalar(&arr_string_view, ".*xxXX.*"))
         })
         .bench_function("regexp_matches_utf8view scalar ends with", |b| {
-            b.iter(|| bench_regexp_is_match_scalar(&arr_string_view, "xx$"))
+            b.iter(|| bench_stringview_regexp_is_match_scalar(&arr_string_view, "xx$"))
         })
         .bench_function("regexp_matches_utf8view scalar complex", |b| {
-            b.iter(|| bench_regexp_is_match_scalar(&arr_string_view, ".*x{2}.xX.*xXX"))
+            b.iter(|| bench_stringview_regexp_is_match_scalar(&arr_string_view, ".*x{2}.xX.*xXX"))
         });
 
     group.finish();

--- a/arrow/src/compute/kernels.rs
+++ b/arrow/src/compute/kernels.rs
@@ -28,5 +28,8 @@ pub use arrow_string::{concat_elements, length, regexp, substring};
 pub mod comparison {
     pub use arrow_ord::comparison::*;
     pub use arrow_string::like::*;
+    // continue to export deprecated methods until they are removed
+    pub use arrow_string::regexp::{regexp_is_match, regexp_is_match_scalar};
+    #[allow(deprecated)]
     pub use arrow_string::regexp::{regexp_is_match_utf8, regexp_is_match_utf8_scalar};
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6370.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
1. Natively operate on StringViewArray without having to convert first to StringArray
2. (Potentially) take advantage of the new string view layout

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Introduce `regexp_is_match` and `regexp_is_match_scalar` (which can replace `regexp_is_match_utf8` and `regexp_is_match_utf8_scalar`) can perform on `StringArray` / `LargeStringArray` / `StringViewArray` arguments.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
