### PR TITLE
Add `ARROW_VERSION` const

### DIFF
--- a/arrow/examples/README.md
+++ b/arrow/examples/README.md
@@ -25,3 +25,4 @@
 - [`read_csv.rs`](read_csv.rs): Reading CSV files with explicit schema, pretty printing Arrays
 - [`read_csv_infer_schema.rs`](read_csv_infer_schema.rs): Reading CSV files, pretty printing Arrays
 - [`tensor_builder.rs`](tensor_builder.rs): Using tensor builder
+- [`version.rs`](version.rs): Print the arrow version and exit

--- a/arrow/examples/version.rs
+++ b/arrow/examples/version.rs
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Print the arrow version and exit
+
+use arrow::ARROW_VERSION;
+
+fn main() {
+    println!("arrow version: {ARROW_VERSION}");
+}

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -361,7 +361,6 @@
 //! [Apache Parquet]: https://parquet.apache.org/
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [issue tracker]: https://github.com/apache/arrow-rs/issues
-//!
 
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
@@ -369,6 +368,9 @@
 pub use arrow_array::{downcast_dictionary_array, downcast_primitive_array};
 
 pub use arrow_buffer::{alloc, buffer};
+
+/// Arrow crate version
+pub const ARROW_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod array;
 pub mod compute;


### PR DESCRIPTION
# Rationale for this change
 
See https://github.com/apache/datafusion/pull/12429 for rationale.

# What changes are included in this PR?

* add `ARROW_VERSION` public `const` to arrow, similar to [`datafusion::DATAFUSION_VERSION`](https://docs.rs/datafusion/latest/datafusion/constant.DATAFUSION_VERSION.html)

# Are there any user-facing changes?

non except new const.