### PR TITLE
object_score: Support Azure Fabric OAuth Provider

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "object_store"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "object_store"
-version = "0.11.0"
+version = "0.10.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -55,13 +55,14 @@ ring = { version = "0.17", default-features = false, features = ["std"], optiona
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
+jsonwebtoken = { version = "9.3.0", default-features = false, optional = true }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.29.0", features = ["fs"] }
 
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
-azure = ["cloud"]
+azure = ["cloud", "jsonwebtoken"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud", "md-5"]
 http = ["cloud"]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -55,14 +55,13 @@ ring = { version = "0.17", default-features = false, features = ["std"], optiona
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.25.0", features = ["sync", "macros", "rt", "time", "io-util"] }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
-jsonwebtoken = { version = "9.3.0", default-features = false, optional = true }
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.29.0", features = ["fs"] }
 
 [features]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
-azure = ["cloud", "jsonwebtoken"]
+azure = ["cloud"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud", "md-5"]
 http = ["cloud"]

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -17,8 +17,8 @@
 
 use crate::azure::client::{AzureClient, AzureConfig};
 use crate::azure::credential::{
-    AzureAccessKey, AzureCliCredential, ClientSecretOAuthProvider, ImdsManagedIdentityProvider,
-    WorkloadIdentityOAuthProvider,
+    AzureAccessKey, AzureCliCredential, ClientSecretOAuthProvider, FabricTokenOAuthProvider,
+    ImdsManagedIdentityProvider, WorkloadIdentityOAuthProvider,
 };
 use crate::azure::{AzureCredential, AzureCredentialProvider, MicrosoftAzure, STORE};
 use crate::client::TokenCredentialProvider;
@@ -172,6 +172,14 @@ pub struct MicrosoftAzureBuilder {
     use_fabric_endpoint: ConfigValue<bool>,
     /// When set to true, skips tagging objects
     disable_tagging: ConfigValue<bool>,
+    /// Fabric token service url
+    fabric_token_service_url: Option<String>,
+    /// Fabric workload host
+    fabric_workload_host: Option<String>,
+    /// Fabric session token
+    fabric_session_token: Option<String>,
+    /// Fabric cluster identifier
+    fabric_cluster_identifier: Option<String>,
 }
 
 /// Configuration keys for [`MicrosoftAzureBuilder`]
@@ -336,6 +344,34 @@ pub enum AzureConfigKey {
     /// - `disable_tagging`
     DisableTagging,
 
+    /// Fabric token service url
+    ///
+    /// Supported keys:
+    /// - `azure_fabric_token_service_url`
+    /// - `fabric_token_service_url`
+    FabricTokenServiceUrl,
+
+    /// Fabric workload host
+    ///
+    /// Supported keys:
+    /// - `azure_fabric_workload_host`
+    /// - `fabric_workload_host`
+    FabricWorkloadHost,
+
+    /// Fabric session token
+    ///
+    /// Supported keys:
+    /// - `azure_fabric_session_token`
+    /// - `fabric_session_token`
+    FabricSessionToken,
+
+    /// Fabric cluster identifier
+    ///
+    /// Supported keys:
+    /// - `azure_fabric_cluster_identifier`
+    /// - `fabric_cluster_identifier`
+    FabricClusterIdentifier,
+
     /// Client options
     Client(ClientConfigKey),
 }
@@ -361,6 +397,10 @@ impl AsRef<str> for AzureConfigKey {
             Self::SkipSignature => "azure_skip_signature",
             Self::ContainerName => "azure_container_name",
             Self::DisableTagging => "azure_disable_tagging",
+            Self::FabricTokenServiceUrl => "azure_fabric_token_service_url",
+            Self::FabricWorkloadHost => "azure_fabric_workload_host",
+            Self::FabricSessionToken => "azure_fabric_session_token",
+            Self::FabricClusterIdentifier => "azure_fabric_cluster_identifier",
             Self::Client(key) => key.as_ref(),
         }
     }
@@ -406,6 +446,14 @@ impl FromStr for AzureConfigKey {
             "azure_skip_signature" | "skip_signature" => Ok(Self::SkipSignature),
             "azure_container_name" | "container_name" => Ok(Self::ContainerName),
             "azure_disable_tagging" | "disable_tagging" => Ok(Self::DisableTagging),
+            "azure_fabric_token_service_url" | "fabric_token_service_url" => {
+                Ok(Self::FabricTokenServiceUrl)
+            }
+            "azure_fabric_workload_host" | "fabric_workload_host" => Ok(Self::FabricWorkloadHost),
+            "azure_fabric_session_token" | "fabric_session_token" => Ok(Self::FabricSessionToken),
+            "azure_fabric_cluster_identifier" | "fabric_cluster_identifier" => {
+                Ok(Self::FabricClusterIdentifier)
+            }
             // Backwards compatibility
             "azure_allow_http" => Ok(Self::Client(ClientConfigKey::AllowHttp)),
             _ => match s.strip_prefix("azure_").unwrap_or(s).parse() {
@@ -525,6 +573,14 @@ impl MicrosoftAzureBuilder {
             }
             AzureConfigKey::ContainerName => self.container_name = Some(value.into()),
             AzureConfigKey::DisableTagging => self.disable_tagging.parse(value),
+            AzureConfigKey::FabricTokenServiceUrl => {
+                self.fabric_token_service_url = Some(value.into())
+            }
+            AzureConfigKey::FabricWorkloadHost => self.fabric_workload_host = Some(value.into()),
+            AzureConfigKey::FabricSessionToken => self.fabric_session_token = Some(value.into()),
+            AzureConfigKey::FabricClusterIdentifier => {
+                self.fabric_cluster_identifier = Some(value.into())
+            }
         };
         self
     }
@@ -561,6 +617,10 @@ impl MicrosoftAzureBuilder {
             AzureConfigKey::Client(key) => self.client_options.get_config_value(key),
             AzureConfigKey::ContainerName => self.container_name.clone(),
             AzureConfigKey::DisableTagging => Some(self.disable_tagging.to_string()),
+            AzureConfigKey::FabricTokenServiceUrl => self.fabric_token_service_url.clone(),
+            AzureConfigKey::FabricWorkloadHost => self.fabric_workload_host.clone(),
+            AzureConfigKey::FabricSessionToken => self.fabric_session_token.clone(),
+            AzureConfigKey::FabricClusterIdentifier => self.fabric_cluster_identifier.clone(),
         }
     }
 
@@ -895,6 +955,28 @@ impl MicrosoftAzureBuilder {
                 static_creds(AzureCredential::SASToken(split_sas(&sas)?))
             } else if self.use_azure_cli.get()? {
                 Arc::new(AzureCliCredential::new()) as _
+            } else if let (
+                Some(fabric_token_service_url),
+                Some(fabric_workload_host),
+                Some(fabric_session_token),
+                Some(fabric_cluster_identifier),
+            ) = (
+                &self.fabric_token_service_url,
+                &self.fabric_workload_host,
+                &self.fabric_session_token,
+                &self.fabric_cluster_identifier,
+            ) {
+                let fabric_credential = FabricTokenOAuthProvider::new(
+                    fabric_token_service_url,
+                    fabric_workload_host,
+                    fabric_session_token,
+                    fabric_cluster_identifier,
+                );
+                Arc::new(TokenCredentialProvider::new(
+                    fabric_credential,
+                    self.client_options.client()?,
+                    self.retry_config.clone(),
+                )) as _
             } else {
                 let msi_credential = ImdsManagedIdentityProvider::new(
                     self.client_id,

--- a/object_store/src/azure/credential.rs
+++ b/object_store/src/azure/credential.rs
@@ -1018,15 +1018,10 @@ impl TokenProvider for FabricTokenOAuthProvider {
                         token: Arc::new(AzureCredential::BearerToken(storage_access_token.clone())),
                         expiry: Some(Instant::now() + Duration::from_secs(exp_in)),
                     });
-                } else {
-                    println!("access token is expired");
                 }
-            } else {
-                println!("access token is invalid");
             }
         }
 
-        println!("requesting new token");
         let query_items = vec![("resource", AZURE_STORAGE_RESOURCE)];
         let access_token: String = client
             .request(Method::GET, &self.fabric_token_service_url)
@@ -1043,11 +1038,8 @@ impl TokenProvider for FabricTokenOAuthProvider {
             .text()
             .await
             .context(TokenResponseBodySnafu)?;
-
         let exp_in = Self::validate_and_get_expiry(&access_token)
             .map_or(3600, |expiry| expiry - get_current_timestamp());
-        println!("exp_in: {}", exp_in);
-
         Ok(TemporaryToken {
             token: Arc::new(AzureCredential::BearerToken(access_token)),
             expiry: Some(Instant::now() + Duration::from_secs(exp_in)),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In Azure Fabric, we use token service to get user access token, for supporting long reading and writing operation and auto refresh access token, we implement this.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


This pull request introduces significant enhancements to the Azure integration within the `object_store` module, including the implementation of a new `FabricTokenOAuthProvider`. These changes aim to improve the authentication mechanism and add support for fabric token services.

### Azure Builder Enhancements:
* Added new fields to `MicrosoftAzureBuilder` to support fabric token services, including `fabric_token_service_url`, `fabric_workload_host`, `fabric_session_token`, and `fabric_cluster_identifier`. (`object_store/src/azure/builder.rs` [object_store/src/azure/builder.rsR175-R182](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R175-R182))
* Updated `AzureConfigKey` to include new configuration keys related to fabric token services. (`object_store/src/azure/builder.rs` [object_store/src/azure/builder.rsR347-R374](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R347-R374))
* Modified `impl AsRef<str>` and `impl FromStr` for `AzureConfigKey` to handle new fabric token service keys. (`object_store/src/azure/builder.rs` [[1]](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R400-R403) [[2]](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R449-R456)
* Enhanced `MicrosoftAzureBuilder` to set and get the new fabric token service-related fields. (`object_store/src/azure/builder.rs` [[1]](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R576-R583) [[2]](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R620-R623)
* Added logic to `MicrosoftAzureBuilder` to create a `FabricTokenOAuthProvider` if fabric token service fields are provided. (`object_store/src/azure/builder.rs` [object_store/src/azure/builder.rsR919-R942](diffhunk://#diff-8a210e33eba6ee7a3f8413616b7737e5f50658e481e1707024ab91b97e106363R919-R942))

### Credential Enhancements:
* Introduced `FabricTokenOAuthProvider` to handle OAuth token challenges for fabric token services, including methods for token validation and fetching. (`object_store/src/azure/credential.rs` [object_store/src/azure/credential.rsR943-R1049](diffhunk://#diff-53498fbed9bb6cfcf50c4c9335b23cd5add9d77be3a150dca7235a05716718b4R943-R1049))
* Added new headers and constants related to fabric token services. (`object_store/src/azure/credential.rs` [object_store/src/azure/credential.rsR55-R63](diffhunk://#diff-53498fbed9bb6cfcf50c4c9335b23cd5add9d77be3a150dca7235a05716718b4R55-R63))

These changes collectively enhance the Azure integration by supporting more complex authentication mechanisms, particularly for environments utilizing fabric token services.

# Are there any user-facing changes?

After that, we can set some environment variables to make it auto refresh access token in Fabric Notebook.
```
# For Fabric Spark Notebook
import os
import urllib.parse
workload_endpoint = urllib.parse.urlparse(f"{spark.conf.get('trident.lakehouse.tokenservice.endpoint')}/access")
os.environ['azure_fabric_token_service_url'.upper()] = f"https://{spark.conf.get('spark.tokenServiceEndpoint')}/api/v1/proxy{workload_endpoint.path}"
os.environ['azure_fabric_workload_host'.upper()] = f"{workload_endpoint.scheme}://{workload_endpoint.hostname}"
os.environ['azure_fabric_session_token'.upper()] = spark.conf.get("trident.session.token")
os.environ['azure_fabric_cluster_identifier'.upper()] = spark.conf.get("spark.synapse.clusteridentifier")
os.environ['azure_storage_token'.upper()] = notebookutils.credentials.getToken("storage")

# For Fabric Python Notebook
import os
from notebookutils.common import configs
import urllib.parse
workload_endpoint = urllib.parse.urlparse(f"{configs.workload_endpoint()}/access")
os.environ['azure_fabric_token_service_url'.upper()] = f"{configs.ts_endpoint()}/api/v1/proxy{workload_endpoint.path}"
os.environ['azure_fabric_workload_host'.upper()] = f"{workload_endpoint.scheme}://{workload_endpoint.hostname}"
os.environ['azure_fabric_session_token'.upper()] = configs.session_token()
os.environ['azure_fabric_cluster_identifier'.upper()] = configs.cluster_identifier()
os.environ['azure_storage_token'.upper()] = notebookutils.credentials.getToken("storage")
```

Then, user can read/write delta table without storage_option.
```
from deltalake import DeltaTable
dt = DeltaTable('abfss://xxxx@onelake.dfs.fabric.microsoft.com/LH.Lakehouse/Tables/dbo/test')
df = dt.to_pyarrow_dataset().head(10).to_pandas()
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
