### PR TITLE
Added PartialOrd for FixedSizeListArray (and struct members)

### DIFF
--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -115,7 +115,7 @@ use std::sync::Arc;
 ///
 /// [`StringArray`]: crate::array::StringArray
 /// [fixed size arrays](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-list-layout)
-#[derive(Clone)]
+#[derive(Clone, PartialEq, PartialOrd)]
 pub struct FixedSizeListArray {
     data_type: DataType, // Must be DataType::FixedSizeList(value_length)
     values: ArrayRef,

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -24,6 +24,7 @@ use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_data::ArrayData;
 use arrow_schema::{DataType, IntervalUnit, TimeUnit};
 use std::any::Any;
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 pub use binary_array::*;
@@ -533,6 +534,12 @@ pub trait ArrayAccessor: Array {
 impl PartialEq for dyn Array + '_ {
     fn eq(&self, other: &Self) -> bool {
         self.to_data().eq(&other.to_data())
+    }
+}
+
+impl PartialOrd for dyn Array + '_ {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.to_data().partial_cmp(&other.to_data())
     }
 }
 

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -25,7 +25,7 @@ use crate::{
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 /// A slice-able [`Buffer`] containing bit-packed booleans
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, PartialOrd)]
 pub struct BooleanBuffer {
     buffer: Buffer,
     offset: usize,

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::alloc::Layout;
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -54,6 +55,12 @@ impl PartialEq for Buffer {
 }
 
 impl Eq for Buffer {}
+
+impl PartialOrd for Buffer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
+    }
+}
 
 unsafe impl Send for Buffer where Bytes: Send {}
 unsafe impl Sync for Buffer where Bytes: Sync {}

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -26,7 +26,7 @@ use crate::{Buffer, MutableBuffer};
 /// that it is null.
 ///
 /// [Arrow specification]: https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
 pub struct NullBuffer {
     buffer: BooleanBuffer,
     null_count: usize,

--- a/arrow-data/src/ord/mod.rs
+++ b/arrow-data/src/ord/mod.rs
@@ -15,22 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Low-level array data abstractions for [Apache Arrow Rust](https://docs.rs/arrow)
-//!
-//! For a higher-level, strongly-typed interface see [arrow_array](https://docs.rs/arrow_array)
+//! Module containing functionality to compute array order.
+//! This module uses [ArrayData] and does not
+//! depend on dynamic casting of `Array`.
 
-mod data;
-pub use data::*;
+use crate::ArrayData;
+use std::cmp::Ordering;
 
-mod equal;
-mod ord;
-pub mod transform;
+mod utils;
 
-pub use arrow_buffer::{bit_iterator, bit_mask};
-pub mod decimal;
-
-#[cfg(feature = "ffi")]
-pub mod ffi;
-
-mod byte_view;
-pub use byte_view::*;
+/// Orders two [ArrayData].
+///
+/// If the [ArrayData]'s [DataType] fields are both [DataType::Map], orders by the [FieldRef]'s
+/// partial_cmp.
+///
+/// Otherwise, ordering is determined by the partial_cmp result of the [DataType] fields.
+pub fn ord(lhs: &ArrayData, rhs: &ArrayData) -> Option<Ordering> {
+    utils::partial_ord(lhs, rhs)
+}

--- a/arrow-data/src/ord/utils.rs
+++ b/arrow-data/src/ord/utils.rs
@@ -15,22 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Low-level array data abstractions for [Apache Arrow Rust](https://docs.rs/arrow)
-//!
-//! For a higher-level, strongly-typed interface see [arrow_array](https://docs.rs/arrow_array)
+use crate::data::ArrayData;
+use arrow_schema::DataType;
+use std::cmp::Ordering;
 
-mod data;
-pub use data::*;
-
-mod equal;
-mod ord;
-pub mod transform;
-
-pub use arrow_buffer::{bit_iterator, bit_mask};
-pub mod decimal;
-
-#[cfg(feature = "ffi")]
-pub mod ffi;
-
-mod byte_view;
-pub use byte_view::*;
+#[inline]
+pub(super) fn partial_ord(lhs: &ArrayData, rhs: &ArrayData) -> Option<Ordering> {
+    match (lhs.data_type(), rhs.data_type()) {
+        (DataType::Map(l_field, _), DataType::Map(r_field, _)) => {
+            match (l_field.data_type(), r_field.data_type()) {
+                (DataType::Struct(l_fields), DataType::Struct(r_fields))
+                    if l_fields.len() == 2 && r_fields.len() == 2 =>
+                {
+                    l_fields.partial_cmp(r_fields)
+                }
+                _ => None,
+            }
+        }
+        (l_data_type, r_data_type) => l_data_type.partial_cmp(r_data_type),
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related https://github.com/apache/datafusion/issues/8932.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Allows upstream users of FixedSizeListArray, such as DataFusion, to use derived PartialOrd.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added PartialOrd implementation for Array, ArrayData and Buffer. 
Added derived PartialOrd for BooleanBuffer, NullBuffer, and FixedSizeListArray.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->

FixedSizeListArray and its subtypes will have PartialOrd available.
