### PR TITLE
use `BooleanBuffer::collect_bool` in the make_comparator documentation example

### DIFF
--- a/arrow-ord/src/ord.rs
+++ b/arrow-ord/src/ord.rs
@@ -324,7 +324,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
 ///
 /// ```
 /// # use arrow_array::{Array, BooleanArray};
-/// # use arrow_buffer::NullBuffer;
+/// # use arrow_buffer::{NullBuffer, BooleanBuffer};
 /// # use arrow_ord::cmp;
 /// # use arrow_ord::ord::make_comparator;
 /// # use arrow_schema::{ArrowError, SortOptions};
@@ -335,7 +335,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
 ///
 ///     let cmp = make_comparator(a, b, SortOptions::default())?;
 ///     let len = a.len().min(b.len());
-///     let values = (0..len).map(|i| cmp(i, i).is_eq()).collect();
+///     let values = BooleanBuffer::collect_bool(len, |i| cmp(i, i).is_eq());
 ///     let nulls = NullBuffer::union(a.nulls(), b.nulls());
 ///     Ok(BooleanArray::new(values, nulls))
 /// }


### PR DESCRIPTION
# Which issue does this PR close?

No issue as there were no bug or feature requests behind it

# Rationale for this change
 
using `BooleanBuffer::collect_bool` is supposed to be faster as it eliminates the conditional `Iterator::next`

# What changes are included in this PR?

update docs example from:

```rust
let values = (0..len).map(|i| cmp(i, i).is_eq()).collect();
```

to :
```rust
let values = BooleanBuffer::collect_bool(len, |i| cmp(i, i).is_eq());
```

# Are there any user-facing changes?

Nope
