### PR TITLE
fix: binary_mut should work if only one input array has null buffer

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -640,6 +640,7 @@ mod tests {
             Some(vec![true, true, true, true, true].into()),
         );
 
+        // unwrap here means that no copying occured
         let r2 = try_binary_mut(a, &b, |a, b| Ok(a + b)).unwrap();
         assert_eq!(r1.unwrap(), r2.unwrap());
     }

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -591,6 +591,7 @@ mod tests {
             Some(vec![true, true, true, true, true].into()),
         );
 
+        // unwrap here means that no copying occured
         let r2 = binary_mut(a, &b, |a, b| a + b).unwrap();
         assert_eq!(r1.unwrap(), r2.unwrap());
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6374.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
