### PR TITLE
Derive `Clone` for `object_store::aws::AmazonS3`

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -77,7 +77,7 @@ use crate::client::parts::Parts;
 pub use credential::{AwsAuthorizer, AwsCredential};
 
 /// Interface for [Amazon S3](https://aws.amazon.com/s3/).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AmazonS3 {
     client: Arc<S3Client>,
 }


### PR DESCRIPTION
Because the inner of `AmazonS3` is an `Arc<...>`, it could be cloned in cheap overhead, please consider this change.