### PR TITLE
fix: don't panic in IPC reader if struct child arrays have different …

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -31,7 +31,9 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use arrow_array::*;
-use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, ScalarBuffer};
+use arrow_buffer::{
+    ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, ScalarBuffer,
+};
 use arrow_data::ArrayData;
 use arrow_schema::*;
 


### PR DESCRIPTION
…lengths

# Which issue does this PR close?

Closes #6416 

# Rationale for this change
 
While we don't expect to receive invalid IPC data via flight. We would like to avoid panics if possible.

# What changes are included in this PR?

Use StructArray::try_new vs StructArray::from in ipc reader. StructArray::from impls use StructArray::new. new calls try_new but unwraps.

# Are there any user-facing changes?

No
