### PR TITLE
perf: Faster decimal precision overflow checks

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -71,3 +71,7 @@ harness = false
 [[bench]]
 name = "fixed_size_list_array"
 harness = false
+
+[[bench]]
+name = "decimal_overflow"
+harness = false

--- a/arrow-array/benches/decimal_overflow.rs
+++ b/arrow-array/benches/decimal_overflow.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::builder::Decimal128Builder;
+use criterion::*;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let len = 8192;
+    let mut b = Decimal128Builder::with_capacity(len);
+    for i in 0..len {
+        if i % 10 == 0 {
+            b.append_value(i128::max_value());
+        } else {
+            b.append_value(i as i128);
+        }
+    }
+    let array = b.finish();
+
+    c.bench_function("validate_decimal_precision", |b| {
+        b.iter(|| black_box(array.validate_decimal_precision(8).unwrap_or(())));
+    });
+    c.bench_function("null_if_overflow_precision", |b| {
+        b.iter(|| black_box(array.null_if_overflow_precision(8)));
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/arrow-array/benches/decimal_overflow.rs
+++ b/arrow-array/benches/decimal_overflow.rs
@@ -25,8 +25,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut builder_256 = Decimal256Builder::with_capacity(len);
     for i in 0..len {
         if i % 10 == 0 {
-            builder_128.append_value(i128::max_value());
-            builder_256.append_value(i256::from_i128(i128::max_value()));
+            builder_128.append_value(i128::MAX);
+            builder_256.append_value(i256::from_i128(i128::MAX));
         } else {
             builder_128.append_value(i as i128);
             builder_256.append_value(i256::from_i128(i as i128));
@@ -36,13 +36,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     let array_256 = builder_256.finish();
 
     c.bench_function("validate_decimal_precision_128", |b| {
-        b.iter(|| black_box(array_128.validate_decimal_precision(8).unwrap_or(())));
+        b.iter(|| black_box(array_128.validate_decimal_precision(8)));
     });
     c.bench_function("null_if_overflow_precision_128", |b| {
         b.iter(|| black_box(array_128.null_if_overflow_precision(8)));
     });
     c.bench_function("validate_decimal_precision_256", |b| {
-        b.iter(|| black_box(array_256.validate_decimal_precision(8).unwrap_or(())));
+        b.iter(|| black_box(array_256.validate_decimal_precision(8)));
     });
     c.bench_function("null_if_overflow_precision_256", |b| {
         b.iter(|| black_box(array_256.null_if_overflow_precision(8)));

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1571,7 +1571,7 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
     /// will be casted to Null
     pub fn null_if_overflow_precision(&self, precision: u8) -> Self {
         self.unary_opt::<_, T>(|v| {
-            (T::validate_decimal_precision(v, precision).is_ok()).then_some(v)
+            T::is_valid_decimal_precision(v, precision).then_some(v)
         })
     }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1570,9 +1570,7 @@ impl<T: DecimalType + ArrowPrimitiveType> PrimitiveArray<T> {
     /// Validates the Decimal Array, if the value of slot is overflow for the specified precision, and
     /// will be casted to Null
     pub fn null_if_overflow_precision(&self, precision: u8) -> Self {
-        self.unary_opt::<_, T>(|v| {
-            T::is_valid_decimal_precision(v, precision).then_some(v)
-        })
+        self.unary_opt::<_, T>(|v| T::is_valid_decimal_precision(v, precision).then_some(v))
     }
 
     /// Returns [`Self::value`] formatted as a string

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -24,7 +24,10 @@ use crate::temporal_conversions::as_datetime_with_timezone;
 use crate::timezone::Tz;
 use crate::{ArrowNativeTypeOp, OffsetSizeTrait};
 use arrow_buffer::{i256, Buffer, OffsetBuffer};
-use arrow_data::decimal::{validate_decimal256_precision, validate_decimal_precision};
+use arrow_data::decimal::{
+    is_validate_decimal256_precision, is_validate_decimal_precision, validate_decimal256_precision,
+    validate_decimal_precision,
+};
 use arrow_data::{validate_binary_view, validate_string_view};
 use arrow_schema::{
     ArrowError, DataType, IntervalUnit, TimeUnit, DECIMAL128_MAX_PRECISION, DECIMAL128_MAX_SCALE,
@@ -1192,6 +1195,9 @@ pub trait DecimalType:
 
     /// Validates that `value` contains no more than `precision` decimal digits
     fn validate_decimal_precision(value: Self::Native, precision: u8) -> Result<(), ArrowError>;
+
+    /// Determines whether `value` contains no more than `precision` decimal digits
+    fn is_valid_decimal_precision(value: Self::Native, precision: u8) -> bool;
 }
 
 /// Validate that `precision` and `scale` are valid for `T`
@@ -1254,6 +1260,10 @@ impl DecimalType for Decimal128Type {
     fn validate_decimal_precision(num: i128, precision: u8) -> Result<(), ArrowError> {
         validate_decimal_precision(num, precision)
     }
+
+    fn is_valid_decimal_precision(value: Self::Native, precision: u8) -> bool {
+        is_validate_decimal_precision(value, precision)
+    }
 }
 
 impl ArrowPrimitiveType for Decimal128Type {
@@ -1283,6 +1293,10 @@ impl DecimalType for Decimal256Type {
 
     fn validate_decimal_precision(num: i256, precision: u8) -> Result<(), ArrowError> {
         validate_decimal256_precision(num, precision)
+    }
+
+    fn is_valid_decimal_precision(value: Self::Native, precision: u8) -> bool {
+        is_validate_decimal256_precision(value, precision)
     }
 }
 

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -336,11 +336,7 @@ where
     if cast_options.safe {
         let iter = from.iter().map(|v| {
             v.and_then(|v| parse_string_to_decimal_native::<T>(v, scale as usize).ok())
-                .and_then(|v| {
-                    T::validate_decimal_precision(v, precision)
-                        .is_ok()
-                        .then_some(v)
-                })
+                .and_then(|v| T::is_valid_decimal_precision(v, precision).then_some(v))
         });
         // Benefit:
         //     20% performance improvement
@@ -430,7 +426,7 @@ where
                 (mul * v.as_())
                     .round()
                     .to_i128()
-                    .filter(|v| Decimal128Type::validate_decimal_precision(*v, precision).is_ok())
+                    .filter(|v| Decimal128Type::is_valid_decimal_precision(*v, precision))
             })
             .with_precision_and_scale(precision, scale)
             .map(|a| Arc::new(a) as ArrayRef)
@@ -473,7 +469,7 @@ where
         array
             .unary_opt::<_, Decimal256Type>(|v| {
                 i256::from_f64((v.as_() * mul).round())
-                    .filter(|v| Decimal256Type::validate_decimal_precision(*v, precision).is_ok())
+                    .filter(|v| Decimal256Type::is_valid_decimal_precision(*v, precision))
             })
             .with_precision_and_scale(precision, scale)
             .map(|a| Arc::new(a) as ArrayRef)

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -327,9 +327,10 @@ where
     let array = if scale < 0 {
         match cast_options.safe {
             true => array.unary_opt::<_, D>(|v| {
-                v.as_().div_checked(scale_factor).ok().and_then(|v| {
-                    (D::validate_decimal_precision(v, precision).is_ok()).then_some(v)
-                })
+                v.as_()
+                    .div_checked(scale_factor)
+                    .ok()
+                    .and_then(|v| (D::is_valid_decimal_precision(v, precision)).then_some(v))
             }),
             false => array.try_unary::<_, D, _>(|v| {
                 v.as_()
@@ -340,9 +341,10 @@ where
     } else {
         match cast_options.safe {
             true => array.unary_opt::<_, D>(|v| {
-                v.as_().mul_checked(scale_factor).ok().and_then(|v| {
-                    (D::validate_decimal_precision(v, precision).is_ok()).then_some(v)
-                })
+                v.as_()
+                    .mul_checked(scale_factor)
+                    .ok()
+                    .and_then(|v| (D::is_valid_decimal_precision(v, precision)).then_some(v))
             }),
             false => array.try_unary::<_, D, _>(|v| {
                 v.as_()

--- a/arrow-data/src/decimal.rs
+++ b/arrow-data/src/decimal.rs
@@ -759,7 +759,7 @@ pub fn validate_decimal_precision(value: i128, precision: u8) -> Result<(), Arro
 #[inline]
 pub fn is_validate_decimal_precision(value: i128, precision: u8) -> bool {
     let idx = usize::from(precision) - 1;
-    precision > DECIMAL128_MAX_PRECISION
+    precision <= DECIMAL128_MAX_PRECISION
         && value >= MIN_DECIMAL_FOR_EACH_PRECISION[idx]
         && value <= MAX_DECIMAL_FOR_EACH_PRECISION[idx]
 }
@@ -794,7 +794,7 @@ pub fn validate_decimal256_precision(value: i256, precision: u8) -> Result<(), A
 #[inline]
 pub fn is_validate_decimal256_precision(value: i256, precision: u8) -> bool {
     let idx = usize::from(precision) - 1;
-    precision > DECIMAL128_MAX_PRECISION
+    precision <= DECIMAL256_MAX_PRECISION
         && value >= MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
         && value <= MAX_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
 }

--- a/arrow-data/src/decimal.rs
+++ b/arrow-data/src/decimal.rs
@@ -738,21 +738,30 @@ pub fn validate_decimal_precision(value: i128, precision: u8) -> Result<(), Arro
             "Max precision of a Decimal128 is {DECIMAL128_MAX_PRECISION}, but got {precision}",
         )));
     }
-
-    let max = MAX_DECIMAL_FOR_EACH_PRECISION[usize::from(precision) - 1];
-    let min = MIN_DECIMAL_FOR_EACH_PRECISION[usize::from(precision) - 1];
-
-    if value > max {
+    let idx = usize::from(precision) - 1;
+    if value > MAX_DECIMAL_FOR_EACH_PRECISION[idx] {
         Err(ArrowError::InvalidArgumentError(format!(
-            "{value} is too large to store in a Decimal128 of precision {precision}. Max is {max}"
+            "{value} is too large to store in a Decimal128 of precision {precision}. Max is {}",
+            MAX_DECIMAL_FOR_EACH_PRECISION[idx]
         )))
-    } else if value < min {
+    } else if value < MIN_DECIMAL_FOR_EACH_PRECISION[idx] {
         Err(ArrowError::InvalidArgumentError(format!(
-            "{value} is too small to store in a Decimal128 of precision {precision}. Min is {min}"
+            "{value} is too small to store in a Decimal128 of precision {precision}. Min is {}",
+            MIN_DECIMAL_FOR_EACH_PRECISION[idx]
         )))
     } else {
         Ok(())
     }
+}
+
+/// Determines whether the specified `i128` value can be properly
+/// interpreted as a Decimal number with precision `precision`
+#[inline]
+pub fn is_validate_decimal_precision(value: i128, precision: u8) -> bool {
+    let idx = usize::from(precision) - 1;
+    precision > DECIMAL128_MAX_PRECISION
+        && value >= MIN_DECIMAL_FOR_EACH_PRECISION[idx]
+        && value <= MAX_DECIMAL_FOR_EACH_PRECISION[idx]
 }
 
 /// Validates that the specified `i256` of value can be properly
@@ -764,18 +773,28 @@ pub fn validate_decimal256_precision(value: i256, precision: u8) -> Result<(), A
             "Max precision of a Decimal256 is {DECIMAL256_MAX_PRECISION}, but got {precision}",
         )));
     }
-    let max = MAX_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[usize::from(precision) - 1];
-    let min = MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[usize::from(precision) - 1];
-
-    if value > max {
+    let idx = usize::from(precision) - 1;
+    if value > MAX_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx] {
         Err(ArrowError::InvalidArgumentError(format!(
-            "{value:?} is too large to store in a Decimal256 of precision {precision}. Max is {max:?}"
+            "{value:?} is too large to store in a Decimal256 of precision {precision}. Max is {:?}",
+            MAX_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
         )))
-    } else if value < min {
+    } else if value < MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx] {
         Err(ArrowError::InvalidArgumentError(format!(
-            "{value:?} is too small to store in a Decimal256 of precision {precision}. Min is {min:?}"
+            "{value:?} is too small to store in a Decimal256 of precision {precision}. Min is {:?}",
+            MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
         )))
     } else {
         Ok(())
     }
+}
+
+/// Determines whether the specified `i256` value can be properly
+/// interpreted as a Decimal number with precision `precision`
+#[inline]
+pub fn is_validate_decimal256_precision(value: i256, precision: u8) -> bool {
+    let idx = usize::from(precision) - 1;
+    precision > DECIMAL128_MAX_PRECISION
+        && value >= MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
+        && value <= MAX_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION[idx]
 }

--- a/arrow-data/src/decimal.rs
+++ b/arrow-data/src/decimal.rs
@@ -649,7 +649,7 @@ pub(crate) const MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION: [i256; 77] = [
     ]),
 ];
 
-/// `MAX_DECIMAL_FOR_EACH_PRECISION[p]` holds the maximum `i128` value that can
+/// `MAX_DECIMAL_FOR_EACH_PRECISION[p-1]` holds the maximum `i128` value that can
 /// be stored in [arrow_schema::DataType::Decimal128] value of precision `p`
 #[allow(dead_code)] // no longer used but is part of our public API
 pub const MAX_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
@@ -693,7 +693,7 @@ pub const MAX_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
     99999999999999999999999999999999999999,
 ];
 
-/// `MIN_DECIMAL_FOR_EACH_PRECISION[p]` holds the minimum `i128` value that can
+/// `MIN_DECIMAL_FOR_EACH_PRECISION[p-1]` holds the minimum `i128` value that can
 /// be stored in a [arrow_schema::DataType::Decimal128] value of precision `p`
 #[allow(dead_code)] // no longer used but is part of our public API
 pub const MIN_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
@@ -737,7 +737,7 @@ pub const MIN_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
     -99999999999999999999999999999999999999,
 ];
 
-/// `MAX_DECIMAL_FOR_EACH_PRECISION[p]` holds the maximum `i128` value that can
+/// `MAX_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[p]` holds the maximum `i128` value that can
 /// be stored in [arrow_schema::DataType::Decimal128] value of precision `p`.
 /// The first element is unused and is inserted so that we can look up using
 /// precision as the index without the need to subtract 1 first.

--- a/arrow-data/src/decimal.rs
+++ b/arrow-data/src/decimal.rs
@@ -650,10 +650,98 @@ pub(crate) const MIN_DECIMAL_BYTES_FOR_LARGER_EACH_PRECISION: [i256; 77] = [
 ];
 
 /// `MAX_DECIMAL_FOR_EACH_PRECISION[p]` holds the maximum `i128` value that can
+/// be stored in [arrow_schema::DataType::Decimal128] value of precision `p`
+#[allow(dead_code)] // no longer used but is part of our public API
+pub const MAX_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
+    9,
+    99,
+    999,
+    9999,
+    99999,
+    999999,
+    9999999,
+    99999999,
+    999999999,
+    9999999999,
+    99999999999,
+    999999999999,
+    9999999999999,
+    99999999999999,
+    999999999999999,
+    9999999999999999,
+    99999999999999999,
+    999999999999999999,
+    9999999999999999999,
+    99999999999999999999,
+    999999999999999999999,
+    9999999999999999999999,
+    99999999999999999999999,
+    999999999999999999999999,
+    9999999999999999999999999,
+    99999999999999999999999999,
+    999999999999999999999999999,
+    9999999999999999999999999999,
+    99999999999999999999999999999,
+    999999999999999999999999999999,
+    9999999999999999999999999999999,
+    99999999999999999999999999999999,
+    999999999999999999999999999999999,
+    9999999999999999999999999999999999,
+    99999999999999999999999999999999999,
+    999999999999999999999999999999999999,
+    9999999999999999999999999999999999999,
+    99999999999999999999999999999999999999,
+];
+
+/// `MIN_DECIMAL_FOR_EACH_PRECISION[p]` holds the minimum `i128` value that can
+/// be stored in a [arrow_schema::DataType::Decimal128] value of precision `p`
+#[allow(dead_code)] // no longer used but is part of our public API
+pub const MIN_DECIMAL_FOR_EACH_PRECISION: [i128; 38] = [
+    -9,
+    -99,
+    -999,
+    -9999,
+    -99999,
+    -999999,
+    -9999999,
+    -99999999,
+    -999999999,
+    -9999999999,
+    -99999999999,
+    -999999999999,
+    -9999999999999,
+    -99999999999999,
+    -999999999999999,
+    -9999999999999999,
+    -99999999999999999,
+    -999999999999999999,
+    -9999999999999999999,
+    -99999999999999999999,
+    -999999999999999999999,
+    -9999999999999999999999,
+    -99999999999999999999999,
+    -999999999999999999999999,
+    -9999999999999999999999999,
+    -99999999999999999999999999,
+    -999999999999999999999999999,
+    -9999999999999999999999999999,
+    -99999999999999999999999999999,
+    -999999999999999999999999999999,
+    -9999999999999999999999999999999,
+    -99999999999999999999999999999999,
+    -999999999999999999999999999999999,
+    -9999999999999999999999999999999999,
+    -99999999999999999999999999999999999,
+    -999999999999999999999999999999999999,
+    -9999999999999999999999999999999999999,
+    -99999999999999999999999999999999999999,
+];
+
+/// `MAX_DECIMAL_FOR_EACH_PRECISION[p]` holds the maximum `i128` value that can
 /// be stored in [arrow_schema::DataType::Decimal128] value of precision `p`.
 /// The first element is unused and is inserted so that we can look up using
 /// precision as the index without the need to subtract 1 first.
-pub(crate) const MAX_DECIMAL_FOR_EACH_PRECISION: [i128; 39] = [
+pub(crate) const MAX_DECIMAL_FOR_EACH_PRECISION_ONE_BASED: [i128; 39] = [
     0, // unused first element
     9,
     99,
@@ -699,7 +787,7 @@ pub(crate) const MAX_DECIMAL_FOR_EACH_PRECISION: [i128; 39] = [
 /// be stored in a [arrow_schema::DataType::Decimal128] value of precision `p`.
 /// The first element is unused and is inserted so that we can look up using
 /// precision as the index without the need to subtract 1 first.
-pub(crate) const MIN_DECIMAL_FOR_EACH_PRECISION: [i128; 39] = [
+pub(crate) const MIN_DECIMAL_FOR_EACH_PRECISION_ONE_BASED: [i128; 39] = [
     0, // unused first element
     -9,
     -99,
@@ -750,15 +838,15 @@ pub fn validate_decimal_precision(value: i128, precision: u8) -> Result<(), Arro
             "Max precision of a Decimal128 is {DECIMAL128_MAX_PRECISION}, but got {precision}",
         )));
     }
-    if value > MAX_DECIMAL_FOR_EACH_PRECISION[precision as usize] {
+    if value > MAX_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize] {
         Err(ArrowError::InvalidArgumentError(format!(
             "{value} is too large to store in a Decimal128 of precision {precision}. Max is {}",
-            MAX_DECIMAL_FOR_EACH_PRECISION[precision as usize]
+            MAX_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize]
         )))
-    } else if value < MIN_DECIMAL_FOR_EACH_PRECISION[precision as usize] {
+    } else if value < MIN_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize] {
         Err(ArrowError::InvalidArgumentError(format!(
             "{value} is too small to store in a Decimal128 of precision {precision}. Min is {}",
-            MIN_DECIMAL_FOR_EACH_PRECISION[precision as usize]
+            MIN_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize]
         )))
     } else {
         Ok(())
@@ -770,8 +858,8 @@ pub fn validate_decimal_precision(value: i128, precision: u8) -> Result<(), Arro
 #[inline]
 pub fn is_validate_decimal_precision(value: i128, precision: u8) -> bool {
     precision <= DECIMAL128_MAX_PRECISION
-        && value >= MIN_DECIMAL_FOR_EACH_PRECISION[precision as usize]
-        && value <= MAX_DECIMAL_FOR_EACH_PRECISION[precision as usize]
+        && value >= MIN_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize]
+        && value <= MAX_DECIMAL_FOR_EACH_PRECISION_ONE_BASED[precision as usize]
 }
 
 /// Validates that the specified `i256` of value can be properly


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Small performance optimization.


```
null_if_overflow_precision_128
                        time:   [14.371 µs 14.403 µs 14.436 µs]
                        change: [-80.547% -80.475% -80.399%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

null_if_overflow_precision_256
                        time:   [26.421 µs 26.531 µs 26.642 µs]
                        change: [-87.653% -87.587% -87.522%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

validate_decimal_precision_128
                        time:   [74.056 ns 74.401 ns 74.752 ns]
                        change: [-11.615% -10.563% -9.4441%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

validate_decimal_precision_256
                        time:   [215.61 ns 216.62 ns 217.68 ns]
                        change: [-0.8629% -0.3349% +0.1701%] (p = 0.22 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


I noticed two areas of overhead in the current approach to verifying decimal precision.

1. In the event of an overflow, we are building a formatted string for an error message, which is then discarded in some cases, so we should avoid that cost
2. The range check code introduces a memcpy which can be avoided

I tested the following variations of the decimal precision check in Rust playground.

```rust
fn validate_decimal_precision1(value: i128, precision: u8) -> bool {
    if precision > DECIMAL128_MAX_PRECISION {
        return false;
    }
    let idx = usize::from(precision) - 1;
    value >= MIN_DECIMAL_FOR_EACH_PRECISION[idx] && value <= MAX_DECIMAL_FOR_EACH_PRECISION[idx]
}

// based on arrow-rs version
fn validate_decimal_precision2(value: i128, precision: u8) -> bool {
    if precision > DECIMAL128_MAX_PRECISION {
        return false;
    }

    let max = MAX_DECIMAL_FOR_EACH_PRECISION[usize::from(precision) - 1];
    let min = MIN_DECIMAL_FOR_EACH_PRECISION[usize::from(precision) - 1];

    if value > max {
        false
    } else if value < min {
        false
    } else {
        true
    }
}
```

`validate_decimal_precision1` avoids a `memcpy` that appears in `validate_decimal_precision2`:

```
playground::validate_decimal_precision1:
	subq	$1304, %rsp
	movb	%dl, %al
	movb	%al, 23(%rsp)
	movq	%rsi, 24(%rsp)
	movq	%rdi, 32(%rsp)
	movq	%rdi, 1264(%rsp)
	movq	%rsi, 1272(%rsp)
	movb	%al, 1287(%rsp)
	cmpb	$38, %al
	ja	.LBB9_2
	movb	23(%rsp), %al
	movb	%al, 1303(%rsp)
	movzbl	%al, %eax
	movq	%rax, %rcx
	subq	$1, %rcx
	movq	%rcx, 8(%rsp)
	cmpq	$1, %rax
	jb	.LBB9_4
	jmp	.LBB9_3

playground::validate_decimal_precision2:
	subq	$1368, %rsp
	movb	%dl, %al
	movb	%al, 55(%rsp)
	movq	%rsi, 56(%rsp)
	movq	%rdi, 64(%rsp)
	movq	%rdi, 1296(%rsp)
	movq	%rsi, 1304(%rsp)
	movb	%al, 1327(%rsp)
	cmpb	$38, %al
	ja	.LBB10_2
	leaq	80(%rsp), %rdi
	leaq	.L__unnamed_5(%rip), %rsi
	movl	$608, %edx
	callq	memcpy@PLT   <----- MEMCPY HERE
	movb	55(%rsp), %al
	movb	%al, 1367(%rsp)
	movzbl	%al, %eax
	movq	%rax, %rcx
	subq	$1, %rcx
	movq	%rcx, 40(%rsp)
	cmpq	$1, %rax
	jb	.LBB10_4
	jmp	.LBB10_3
```

# Are there any user-facing changes?

Technically, this is an API change because I made two consts `pub(crate)` instead of `pub`. However, if anyone wants access to the original consts they could just copy them into their code base.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->


