### PR TITLE
Use `Arc<[Buffer]>` instead of raw `Vec<Buffer>` in `GenericByteViewA…

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -114,7 +114,7 @@ use super::ByteArrayType;
 pub struct GenericByteViewArray<T: ByteViewType + ?Sized> {
     data_type: DataType,
     views: ScalarBuffer<u128>,
-    buffers: Vec<Buffer>,
+    buffers: Arc<[Buffer]>,
     phantom: PhantomData<T>,
     nulls: Option<NullBuffer>,
 }
@@ -178,7 +178,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         Ok(Self {
             data_type: T::DATA_TYPE,
             views,
-            buffers,
+            buffers: buffers.into(),
             nulls,
             phantom: Default::default(),
         })
@@ -191,14 +191,14 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     /// Safe if [`Self::try_new`] would not error
     pub unsafe fn new_unchecked(
         views: ScalarBuffer<u128>,
-        buffers: Vec<Buffer>,
+        buffers: impl Into<Arc<[Buffer]>>,
         nulls: Option<NullBuffer>,
     ) -> Self {
         Self {
             data_type: T::DATA_TYPE,
             phantom: Default::default(),
             views,
-            buffers,
+            buffers: buffers.into(),
             nulls,
         }
     }
@@ -208,7 +208,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         Self {
             data_type: T::DATA_TYPE,
             views: vec![0; len].into(),
-            buffers: vec![],
+            buffers: vec![].into(),
             nulls: Some(NullBuffer::new_null(len)),
             phantom: Default::default(),
         }
@@ -234,7 +234,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     }
 
     /// Deconstruct this array into its constituent parts
-    pub fn into_parts(self) -> (ScalarBuffer<u128>, Vec<Buffer>, Option<NullBuffer>) {
+    pub fn into_parts(self) -> (ScalarBuffer<u128>, Arc<[Buffer]>, Option<NullBuffer>) {
         (self.views, self.buffers, self.nulls)
     }
 
@@ -516,7 +516,7 @@ impl<T: ByteViewType + ?Sized> From<ArrayData> for GenericByteViewArray<T> {
         Self {
             data_type: T::DATA_TYPE,
             views,
-            buffers,
+            buffers: buffers.into(),
             nulls: value.nulls().cloned(),
             phantom: Default::default(),
         }
@@ -569,12 +569,20 @@ where
 }
 
 impl<T: ByteViewType + ?Sized> From<GenericByteViewArray<T>> for ArrayData {
-    fn from(mut array: GenericByteViewArray<T>) -> Self {
+    fn from(array: GenericByteViewArray<T>) -> Self {
         let len = array.len();
-        array.buffers.insert(0, array.views.into_inner());
+        let new_buffers = {
+            let mut buffers = Vec::with_capacity(array.buffers.len() + 1);
+            buffers.push(array.views.into_inner());
+            for buffer in array.buffers.iter() {
+                buffers.push(buffer.clone());
+            }
+            buffers
+        };
+
         let builder = ArrayDataBuilder::new(T::DATA_TYPE)
             .len(len)
-            .buffers(array.buffers)
+            .buffers(new_buffers)
             .nulls(array.nulls);
 
         unsafe { builder.build_unchecked() }


### PR DESCRIPTION
…rray` for faster `slice`

# Which issue does this PR close?
Close #6408 
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
In the `GenericByteViewArray`, the `buffers` field is a raw vector, leading to heap allocation when some methods, e.g. `clone`, `slice`. Using `Arc<[Buffer]>` instead of the raw `Vec<Buffer>` can avoid such heap allocation.

(TODO: add the benchmark results when the benchmark case is added)

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Use `Arc<[Buffer]>` instead of the raw `Vec<Buffer>` as the type of `buffers` field of `GenericByteViewArray`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
The signature of the method `GenericByteViewArray::new_unchecked` is changed from:
```
pub unsafe fn new_unchecked(
        views: ScalarBuffer<u128>,
        buffers: Vec<[Buffer]>,
        nulls: Option<NullBuffer>,
    ) -> Self;
```
to
```
pub unsafe fn new_unchecked(
        views: ScalarBuffer<u128>,
        buffers: impl Into<Arc<[Buffer]>>,
        nulls: Option<NullBuffer>,
    ) -> Self;
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
