### PR TITLE
Add RowSelection::skipped_row_count

### DIFF
--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -436,6 +436,11 @@ impl RowSelection {
     pub fn row_count(&self) -> usize {
         self.iter().filter(|s| !s.skip).map(|s| s.row_count).sum()
     }
+
+    /// Returns the number of de-selected rows
+    pub fn skipped_row_count(&self) -> usize {
+        self.iter().filter(|s| s.skip).map(|s| s.row_count).sum()
+    }
 }
 
 impl From<Vec<RowSelector>> for RowSelection {
@@ -1344,5 +1349,33 @@ mod tests {
                 &RowSelector::skip(10),
             ]
         );
+    }
+
+    #[test]
+    fn test_row_count() {
+        let selection = RowSelection::from(vec![
+            RowSelector::skip(34),
+            RowSelector::select(12),
+            RowSelector::skip(3),
+            RowSelector::select(35),
+        ]);
+
+        assert_eq!(selection.row_count(), 12 + 35);
+        assert_eq!(selection.skipped_row_count(), 34 + 3);
+
+        let selection = RowSelection::from(vec![RowSelector::select(12), RowSelector::select(35)]);
+
+        assert_eq!(selection.row_count(), 12 + 35);
+        assert_eq!(selection.skipped_row_count(), 0);
+
+        let selection = RowSelection::from(vec![RowSelector::skip(34), RowSelector::skip(3)]);
+
+        assert_eq!(selection.row_count(), 0);
+        assert_eq!(selection.skipped_row_count(), 34 + 3);
+
+        let selection = RowSelection::from(vec![]);
+
+        assert_eq!(selection.row_count(), 0);
+        assert_eq!(selection.skipped_row_count(), 0);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6428.

# Rationale for this change
 
This spares some boilerplate to users, like Datafusion did here:

https://github.com/apache/datafusion/blob/f2159e6cae658a0a3f561ec2d15ea948213fd0f8/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs#L271-L277

Suggested by @alamb here: https://github.com/apache/datafusion/pull/12545#discussion_r1768748882

# What changes are included in this PR?

Added `RowSelection::skipped_row_count`, and tests for both it and `RowSelection::row_count`

# Are there any user-facing changes?

New method