### PR TITLE
Bump arrow-flight msrv to 1.71.1

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -20,7 +20,7 @@ name = "arrow-flight"
 description = "Apache Arrow Flight"
 version = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.70.0"
+rust-version = "1.71.1"
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6436 

# Rationale for this change


# What changes are included in this PR?

Bump arrow-flight MSRV to 1.71.1

# Are there any user-facing changes?

arrow-flight now requires rust 1.71.1 or newer
