### PR TITLE
fix: overestimating memory size in buffer

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -1027,17 +1027,6 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_size_primitive_sliced() {
-        let arr = PrimitiveArray::<Int64Type>::from_iter_values(0..128);
-        let slice1 = arr.slice(0, 64);
-        let slice2 = arr.slice(64, 64);
-
-        // both slices report the full buffer memory usage, even though the buffers are shared
-        assert_eq!(slice1.get_array_memory_size(), arr.get_array_memory_size());
-        assert_eq!(slice2.get_array_memory_size(), arr.get_array_memory_size());
-    }
-
-    #[test]
     fn test_memory_size_primitive_nullable() {
         let arr: PrimitiveArray<Int64Type> = (0..128)
             .map(|i| if i % 20 == 0 { Some(i) } else { None })

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -164,7 +164,7 @@ impl Buffer {
     /// For externally owned buffers, this returns zero
     #[inline]
     pub fn capacity(&self) -> usize {
-        self.data.capacity()
+        self.length + self.data.capacity() - self.data.len()
     }
 
     /// Returns whether the buffer is empty.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6363 

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
see https://github.com/apache/arrow-rs/issues/6363#issuecomment-2366788331
# What changes are included in this PR?

change the capacity function in `Buffer`
from 
```
self.data.capacity()
```
to
```
self.length + self.data.capacity() - self.data.len()
```

# Are there any user-facing changes?

maybe no


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
