### PR TITLE
Add additional documentation and builder APIs to `SortOptions`

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1491,10 +1491,7 @@ mod tests {
 
         let converter = RowConverter::new(vec![SortField::new_with_options(
             DataType::Boolean,
-            SortOptions {
-                descending: true,
-                nulls_first: false,
-            },
+            SortOptions::default().desc().with_nulls_first(false),
         )])
         .unwrap();
 
@@ -1612,10 +1609,7 @@ mod tests {
 
         let converter = RowConverter::new(vec![SortField::new_with_options(
             DataType::Binary,
-            SortOptions {
-                descending: true,
-                nulls_first: false,
-            },
+            SortOptions::default().desc().with_nulls_first(false),
         )])
         .unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&col)]).unwrap();
@@ -1694,10 +1688,7 @@ mod tests {
 
         let converter = RowConverter::new(vec![SortField::new_with_options(
             a.data_type().clone(),
-            SortOptions {
-                descending: true,
-                nulls_first: false,
-            },
+            SortOptions::default().desc().with_nulls_first(false),
         )])
         .unwrap();
 
@@ -1712,10 +1703,7 @@ mod tests {
 
         let converter = RowConverter::new(vec![SortField::new_with_options(
             a.data_type().clone(),
-            SortOptions {
-                descending: true,
-                nulls_first: true,
-            },
+            SortOptions::default().desc().with_nulls_first(true),
         )])
         .unwrap();
 
@@ -1888,10 +1876,7 @@ mod tests {
         back[0].to_data().validate_full().unwrap();
         assert_eq!(&back[0], &list);
 
-        let options = SortOptions {
-            descending: false,
-            nulls_first: false,
-        };
+        let options = SortOptions::default().asc().with_nulls_first(false);
         let field = SortField::new_with_options(d.clone(), options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();
@@ -1908,10 +1893,7 @@ mod tests {
         back[0].to_data().validate_full().unwrap();
         assert_eq!(&back[0], &list);
 
-        let options = SortOptions {
-            descending: true,
-            nulls_first: false,
-        };
+        let options = SortOptions::default().desc().with_nulls_first(false);
         let field = SortField::new_with_options(d.clone(), options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();
@@ -1928,10 +1910,7 @@ mod tests {
         back[0].to_data().validate_full().unwrap();
         assert_eq!(&back[0], &list);
 
-        let options = SortOptions {
-            descending: true,
-            nulls_first: true,
-        };
+        let options = SortOptions::default().desc().with_nulls_first(true);
         let field = SortField::new_with_options(d, options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();
@@ -1991,10 +1970,7 @@ mod tests {
         //   null
         //   [[1, 2]]
         // ]
-        let options = SortOptions {
-            descending: false,
-            nulls_first: true,
-        };
+        let options = SortOptions::default().asc().with_nulls_first(true);
         let field = SortField::new_with_options(d.clone(), options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();
@@ -2010,10 +1986,7 @@ mod tests {
         back[0].to_data().validate_full().unwrap();
         assert_eq!(&back[0], &list);
 
-        let options = SortOptions {
-            descending: true,
-            nulls_first: true,
-        };
+        let options = SortOptions::default().desc().with_nulls_first(true);
         let field = SortField::new_with_options(d.clone(), options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();
@@ -2029,10 +2002,7 @@ mod tests {
         back[0].to_data().validate_full().unwrap();
         assert_eq!(&back[0], &list);
 
-        let options = SortOptions {
-            descending: true,
-            nulls_first: false,
-        };
+        let options = SortOptions::default().desc().with_nulls_first(false);
         let field = SortField::new_with_options(d, options);
         let converter = RowConverter::new(vec![field]).unwrap();
         let rows = converter.convert_columns(&[Arc::clone(&list)]).unwrap();

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -18,7 +18,9 @@
 //! Arrow logical types
 
 mod datatype;
+
 pub use datatype::*;
+use std::fmt::Display;
 mod datatype_parse;
 mod error;
 pub use error::*;
@@ -34,12 +36,91 @@ use std::ops;
 pub mod ffi;
 
 /// Options that define the sort order of a given column
+///
+/// The default sorts equivalently to of `ASC NULLS FIRST` in SQL (i.e.
+/// ascending order with nulls sorting before any other values).
+///
+/// # Example creation
+/// ```
+/// # use arrow_schema::SortOptions;
+/// let options = SortOptions {
+///   descending: false,
+///   nulls_first: true,
+/// };
+/// // Default is ASC NULLs First
+/// assert_eq!(options, SortOptions::default());
+/// assert_eq!(options.to_string(), "ASC");
+///
+/// // Configure using builder APIs
+/// let options = SortOptions::default()
+///  .desc()
+///  .with_nulls_first(true);
+/// assert_eq!(options.to_string(), "DESC NULLS FIRST");
+/// ```
+///
+/// # Example operations
+/// It is also possible to negate the sort options using the `!` operator.
+/// ```
+/// use arrow_schema::SortOptions;
+/// let options = !SortOptions::default();
+/// assert_eq!(options.to_string(), "DESC NULLS LAST");
+/// ```
 #[derive(Clone, Hash, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,
     /// Whether to sort nulls first
     pub nulls_first: bool,
+}
+
+impl Display for SortOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.descending {
+            write!(f, "DESC")?;
+        } else {
+            write!(f, "ASC")?;
+        }
+        if self.nulls_first {
+            // purposely don't display default NULLs value
+        } else {
+            write!(f, " NULLS LAST")?;
+        }
+        Ok(())
+    }
+}
+
+impl SortOptions {
+    /// Create a new `SortOptions` struct
+    pub fn new(descending: bool, nulls_first: bool) -> Self {
+        Self {
+            descending,
+            nulls_first,
+        }
+    }
+
+    /// Set this sort options to sort in descending order
+    pub fn desc(mut self) -> Self {
+        self.descending = true;
+        self
+    }
+
+    /// Set this sort options to sort in ascending order
+    pub fn asc(mut self) -> Self {
+        self.descending = false;
+        self
+    }
+
+    /// Set this sort options to sort descending if argument is true
+    pub fn with_descending(mut self, descending: bool) -> Self {
+        self.descending = descending;
+        self
+    }
+
+    /// Set this sort options to sort nulls first if argument is true
+    pub fn with_nulls_first(mut self, nulls_first: bool) -> Self {
+        self.nulls_first = nulls_first;
+        self
+    }
 }
 
 impl Default for SortOptions {

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -49,7 +49,7 @@ pub mod ffi;
 /// };
 /// // Default is ASC NULLs First
 /// assert_eq!(options, SortOptions::default());
-/// assert_eq!(options.to_string(), "ASC");
+/// assert_eq!(options.to_string(), "ASC NULLS FIRST");
 ///
 /// // Configure using builder APIs
 /// let options = SortOptions::default()
@@ -81,7 +81,7 @@ impl Display for SortOptions {
             write!(f, "ASC")?;
         }
         if self.nulls_first {
-            // purposely don't display default NULLs value
+            write!(f, " NULLS FIRST")?;
         } else {
             write!(f, " NULLS LAST")?;
         }

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ffi;
 /// # Example creation
 /// ```
 /// # use arrow_schema::SortOptions;
+/// // configure using explicit initialization
 /// let options = SortOptions {
 ///   descending: false,
 ///   nulls_first: true,
@@ -55,8 +56,14 @@ pub mod ffi;
 /// // Configure using builder APIs
 /// let options = SortOptions::default()
 ///  .desc()
-///  .with_nulls_first(true);
+///  .nulls_first();
 /// assert_eq!(options.to_string(), "DESC NULLS FIRST");
+///
+/// // configure using explicit field values
+/// let options = SortOptions::default()
+///  .with_descending(false)
+///  .with_nulls_first(false);
+/// assert_eq!(options.to_string(), "ASC NULLS LAST");
 /// ```
 ///
 /// # Example operations
@@ -100,14 +107,34 @@ impl SortOptions {
     }
 
     /// Set this sort options to sort in descending order
+    ///
+    /// See [Self::with_descending] to explicitly set the underlying field
     pub fn desc(mut self) -> Self {
         self.descending = true;
         self
     }
 
     /// Set this sort options to sort in ascending order
+    ///
+    /// See [Self::with_descending] to explicitly set the underlying field
     pub fn asc(mut self) -> Self {
         self.descending = false;
+        self
+    }
+
+    /// Set this sort options to sort nulls first
+    ///
+    /// See [Self::with_nulls_first] to explicitly set the underlying field
+    pub fn nulls_first(mut self) -> Self {
+        self.nulls_first = true;
+        self
+    }
+
+    /// Set this sort options to sort nulls last
+    ///
+    /// See [Self::with_nulls_first] to explicitly set the underlying field
+    pub fn nulls_last(mut self) -> Self {
+        self.nulls_first = false;
         self
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Related to https://github.com/apache/datafusion/issues/12446


# Rationale for this change
 
While working on https://github.com/apache/datafusion/pull/12562 I found I kept having to do mental gymnastics to remember the default value of `SortOptions`

I also found creating them was a bit confuisng as if I want to make `ASC` the default I have to do
`descending: false` and the double negative was making my head hurt.

# What changes are included in this PR?
1. Add additional documentation
2. Add builder style APIs that permits configuring an `ASC` sort with `options.asc()` rather than `descending:false`
3. Update some uses to the new builder style to demonstrate its use

# Are there any user-facing changes?
New API and docs, no changes to existing APIs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
