### PR TITLE
feat: expose HTTP/2 max frame size in `object_store`

### DIFF
--- a/object_store/src/config.rs
+++ b/object_store/src/config.rs
@@ -103,6 +103,15 @@ impl Parse for usize {
     }
 }
 
+impl Parse for u32 {
+    fn parse(v: &str) -> Result<Self> {
+        Self::from_str(v).map_err(|_| Error::Generic {
+            store: "Config",
+            source: format!("failed to parse \"{v}\" as u32").into(),
+        })
+    }
+}
+
 impl Parse for HeaderValue {
     fn parse(v: &str) -> Result<Self> {
         Self::from_str(v).map_err(|_| Error::Generic {


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Especially when transferring large amounts of data over HTTP/2, this can massively reduce the overhead.

# What changes are included in this PR?
Add config wiring for [`http2_max_frame_size`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.http2_max_frame_size).

# Are there any user-facing changes?
New config value, existing configs do NOT change.
