### PR TITLE
Support cast between Durations + between Durations all numeric types

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -273,6 +273,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         ) => true,
         (Int64, Duration(_)) => true,
         (Duration(_), Int64) => true,
+        (Duration(_), Duration(_)) => true,
         (Interval(from_type), Int64) => {
             match from_type {
                 YearMonth => true,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -5306,18 +5306,16 @@ mod tests {
             let to_size = time_unit_multiple(&to_unit);
 
             let (v1_before, v2_before) = (8640003005, 1696002001);
-            let (v1_after, v2_after) = if from_size > to_size {
+            let (v1_after, v2_after) = if from_size >= to_size {
                 (
                     v1_before / (from_size / to_size),
                     v2_before / (from_size / to_size),
                 )
-            } else if from_size < to_size {
+            } else {
                 (
                     v1_before * (to_size / from_size),
                     v2_before * (to_size / from_size),
                 )
-            } else {
-                (v1_before, v2_before)
             };
 
             let array =

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -5287,6 +5287,23 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_between_durations() {
+        let array =
+            DurationMillisecondArray::from(vec![Some(864000003005), Some(1545696002001), None]);
+        let b = cast(&array, &DataType::Duration(TimeUnit::Second)).unwrap();
+        let c = b.as_primitive::<DurationSecondType>();
+        assert_eq!(864000003, c.value(0));
+        assert_eq!(1545696002, c.value(1));
+        assert!(c.is_null(2));
+
+        let b = cast(&array, &DataType::Duration(TimeUnit::Nanosecond)).unwrap();
+        let c = b.as_primitive::<DurationNanosecondType>();
+        assert_eq!(864000003005000000, c.value(0));
+        assert_eq!(1545696002001000000, c.value(1));
+        assert!(c.is_null(2));
+    }
+
+    #[test]
     fn test_cast_to_strings() {
         let a = Int32Array::from(vec![1, 2, 3]);
         let out = cast(&a, &DataType::Utf8).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

This resolves https://github.com/apache/arrow-rs/discussions/6425.

# Rationale for this change
 
Durations are represent by i64. They can be casted from/to each other just like Timestamps.

# What changes are included in this PR?

Support cast between Durations. And catch up support cast between Durations and all numeric type.

# Are there any user-facing changes?

Not quite. Users would found new reasonable cast supported, nothing works currently changed.
