### PR TITLE
Minor: Error rather than panic for unsupported for dictionary `cast`ing

### DIFF
--- a/arrow-cast/src/cast/dictionary.rs
+++ b/arrow-cast/src/cast/dictionary.rs
@@ -91,12 +91,17 @@ pub(crate) fn dictionary_cast<K: ArrowDictionaryKeyType>(
             let dict_array = array
                 .as_dictionary::<K>()
                 .downcast_dict::<StringArray>()
-                .unwrap();
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(
+                        "Internal Error: Cannot cast Utf8View to StringArray of expected type"
+                            .to_string(),
+                    )
+                })?;
 
             let string_view = view_from_dict_values::<K, StringViewType, GenericStringType<i32>>(
                 dict_array.values(),
                 dict_array.keys(),
-            );
+            )?;
             Ok(Arc::new(string_view))
         }
         BinaryView => {
@@ -105,12 +110,17 @@ pub(crate) fn dictionary_cast<K: ArrowDictionaryKeyType>(
             let dict_array = array
                 .as_dictionary::<K>()
                 .downcast_dict::<BinaryArray>()
-                .unwrap();
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(
+                        "Internal Error: Cannot cast BinaryView to BinaryArray of expected type"
+                            .to_string(),
+                    )
+                })?;
 
             let binary_view = view_from_dict_values::<K, BinaryViewType, BinaryType>(
                 dict_array.values(),
                 dict_array.keys(),
-            );
+            )?;
             Ok(Arc::new(binary_view))
         }
         _ => unpack_dictionary::<K>(array, to_type, cast_options),
@@ -120,7 +130,7 @@ pub(crate) fn dictionary_cast<K: ArrowDictionaryKeyType>(
 fn view_from_dict_values<K: ArrowDictionaryKeyType, T: ByteViewType, V: ByteArrayType>(
     array: &GenericByteArray<V>,
     keys: &PrimitiveArray<K>,
-) -> GenericByteViewArray<T> {
+) -> Result<GenericByteViewArray<T>, ArrowError> {
     let value_buffer = array.values();
     let value_offsets = array.value_offsets();
     let mut builder = GenericByteViewBuilder::<T>::with_capacity(keys.len());
@@ -128,7 +138,9 @@ fn view_from_dict_values<K: ArrowDictionaryKeyType, T: ByteViewType, V: ByteArra
     for i in keys.iter() {
         match i {
             Some(v) => {
-                let idx = v.to_usize().unwrap();
+                let idx = v.to_usize().ok_or_else(|| {
+                    ArrowError::ComputeError("Invalid dictionary index".to_string())
+                })?;
 
                 // Safety
                 // (1) The index is within bounds as they are offsets
@@ -145,7 +157,7 @@ fn view_from_dict_values<K: ArrowDictionaryKeyType, T: ByteViewType, V: ByteArra
             }
         }
     }
-    builder.finish()
+    Ok(builder.finish())
 }
 
 // Unpack a dictionary where the keys are of type <K> into a flattened array of type to_type
@@ -211,7 +223,11 @@ pub(crate) fn cast_to_dictionary<K: ArrowDictionaryKeyType>(
             let dict = dict
                 .as_dictionary::<K>()
                 .downcast_dict::<Decimal128Array>()
-                .unwrap();
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(
+                        "Internal Error: Cannot cast dict to Decimal128Array".to_string(),
+                    )
+                })?;
             let value = dict.values().clone();
             // Set correct precision/scale
             let value = value.with_precision_and_scale(p, s)?;
@@ -229,7 +245,11 @@ pub(crate) fn cast_to_dictionary<K: ArrowDictionaryKeyType>(
             let dict = dict
                 .as_dictionary::<K>()
                 .downcast_dict::<Decimal256Array>()
-                .unwrap();
+                .ok_or_else(|| {
+                    ArrowError::ComputeError(
+                        "Internal Error: Cannot cast dict to Decimal256Array".to_string(),
+                    )
+                })?;
             let value = dict.values().clone();
             // Set correct precision/scale
             let value = value.with_precision_and_scale(p, s)?;
@@ -350,7 +370,12 @@ where
         1024,
         1024,
     );
-    let string_view = array.as_any().downcast_ref::<StringViewArray>().unwrap();
+    let string_view = array
+        .as_any()
+        .downcast_ref::<StringViewArray>()
+        .ok_or_else(|| {
+            ArrowError::ComputeError("Internal Error: Cannot cast to StringViewArray".to_string())
+        })?;
     for v in string_view.iter() {
         match v {
             Some(v) => {
@@ -376,7 +401,12 @@ where
         1024,
         1024,
     );
-    let binary_view = array.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+    let binary_view = array
+        .as_any()
+        .downcast_ref::<BinaryViewArray>()
+        .ok_or_else(|| {
+            ArrowError::ComputeError("Internal Error: Cannot cast to BinaryViewArray".to_string())
+        })?;
     for v in binary_view.iter() {
         match v {
             Some(v) => {
@@ -405,7 +435,9 @@ where
     let values = cast_values
         .as_any()
         .downcast_ref::<GenericByteArray<T>>()
-        .unwrap();
+        .ok_or_else(|| {
+            ArrowError::ComputeError("Internal Error: Cannot cast to GenericByteArray".to_string())
+        })?;
     let mut b = GenericByteDictionaryBuilder::<K, T>::with_capacity(values.len(), 1024, 1024);
 
     // copy each element one at a time


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

no correlated issue.

# Rationale for this change
While working on https://github.com/apache/datafusion/pull/12621#issuecomment-2374141849 , I got the panic from the arrow side. Instead of panicking, we can throw the ArrowError. It would be easier to trace the error for downstream projects (e.g. DataFusion).
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Remove `unwrap()` and return `ArrowError` instead.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
