### PR TITLE
Minor: Silence compiler warnings for `parquet::file::metadata::reader`

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -638,18 +638,6 @@ impl ParquetMetaDataReader {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    #[cfg(feature = "async")]
-    use futures::future::BoxFuture;
-    #[cfg(feature = "async")]
-    use futures::FutureExt;
-    #[cfg(feature = "async")]
-    use std::fs::File;
-    #[cfg(feature = "async")]
-    use std::future::Future;
-    #[cfg(feature = "async")]
-    use std::io::{Read, Seek, SeekFrom};
-    #[cfg(feature = "async")]
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::basic::SortOrder;
     use crate::basic::Type;
@@ -827,11 +815,27 @@ mod tests {
             "EOF: Parquet file too small. Size is 1728 but need 1729"
         );
     }
+}
 
-    #[cfg(feature = "async")]
+#[cfg(feature = "async")]
+#[cfg(test)]
+mod async_tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::future::BoxFuture;
+    use futures::FutureExt;
+    use std::fs::File;
+    use std::future::Future;
+    use std::io::{Read, Seek, SeekFrom};
+    use std::ops::Range;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::arrow::async_reader::MetadataFetch;
+    use crate::file::reader::Length;
+    use crate::util::test_common::file_util::get_test_file;
+
     struct MetadataFetchFn<F>(F);
 
-    #[cfg(feature = "async")]
     impl<F, Fut> MetadataFetch for MetadataFetchFn<F>
     where
         F: FnMut(Range<usize>) -> Fut + Send,
@@ -842,7 +846,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "async")]
     fn read_range(file: &mut File, range: Range<usize>) -> Result<Bytes> {
         file.seek(SeekFrom::Start(range.start as _))?;
         let len = range.end - range.start;
@@ -851,7 +854,6 @@ mod tests {
         Ok(buf.into())
     }
 
-    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_simple() {
         let mut file = get_test_file("nulls.snappy.parquet");
@@ -937,7 +939,6 @@ mod tests {
         assert_eq!(err, "Parquet error: Invalid Parquet file. Corrupt footer");
     }
 
-    #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_page_index() {
         let mut file = get_test_file("alltypes_tiny_pages.parquet");

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -642,10 +642,13 @@ mod tests {
     use futures::future::BoxFuture;
     #[cfg(feature = "async")]
     use futures::FutureExt;
+    #[cfg(feature = "async")]
     use std::fs::File;
     #[cfg(feature = "async")]
     use std::future::Future;
+    #[cfg(feature = "async")]
     use std::io::{Read, Seek, SeekFrom};
+    #[cfg(feature = "async")]
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::basic::SortOrder;


### PR DESCRIPTION

# Rationale for this change
 
When compiling parquet tests with default features, several unused imports are flagged.
```
% cargo clippy -p parquet --all-targets -- -D warnings
    Checking parquet v53.0.0 (/Users/seidl/src/arrow-rs/parquet)
error: unused import: `std::fs::File`
   --> parquet/src/file/metadata/reader.rs:645:9
    |
645 |     use std::fs::File;
    |         ^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: unused imports: `Read`, `SeekFrom`, and `Seek`
   --> parquet/src/file/metadata/reader.rs:648:19
    |
648 |     use std::io::{Read, Seek, SeekFrom};
    |                   ^^^^  ^^^^  ^^^^^^^^

error: unused imports: `AtomicUsize` and `Ordering`
   --> parquet/src/file/metadata/reader.rs:649:29
    |
649 |     use std::sync::atomic::{AtomicUsize, Ordering};
    |                             ^^^^^^^^^^^  ^^^^^^^^
```

# What changes are included in this PR?

Only include the above if the "async" feature is enabled.

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
