### PR TITLE
Deprecate `MetadataLoader`

### DIFF
--- a/parquet/src/arrow/async_reader/metadata.rs
+++ b/parquet/src/arrow/async_reader/metadata.rs
@@ -213,16 +213,6 @@ where
     }
 }
 
-impl<'a, F, Fut> MetadataFetch for &'a mut MetadataFetchFn<F>
-where
-    F: FnMut(Range<usize>) -> Fut + Send,
-    Fut: Future<Output = Result<Bytes>> + Send,
-{
-    fn fetch(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>> {
-        async move { self.0(range).await }.boxed()
-    }
-}
-
 /// Fetches parquet metadata
 ///
 /// Parameters:
@@ -249,10 +239,10 @@ where
     F: FnMut(Range<usize>) -> Fut + Send,
     Fut: Future<Output = Result<Bytes>> + Send,
 {
-    let mut fetch = MetadataFetchFn(fetch);
+    let fetch = MetadataFetchFn(fetch);
     ParquetMetaDataReader::new()
         .with_prefetch_hint(prefetch)
-        .load_and_finish(&mut fetch, file_size)
+        .load_and_finish(fetch, file_size)
         .await
 }
 

--- a/parquet/src/arrow/async_reader/metadata.rs
+++ b/parquet/src/arrow/async_reader/metadata.rs
@@ -213,6 +213,16 @@ where
     }
 }
 
+impl<'a, F, Fut> MetadataFetch for &'a mut MetadataFetchFn<F>
+where
+    F: FnMut(Range<usize>) -> Fut + Send,
+    Fut: Future<Output = Result<Bytes>> + Send,
+{
+    fn fetch(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>> {
+        async move { self.0(range).await }.boxed()
+    }
+}
+
 /// Fetches parquet metadata
 ///
 /// Parameters:
@@ -239,10 +249,10 @@ where
     F: FnMut(Range<usize>) -> Fut + Send,
     Fut: Future<Output = Result<Bytes>> + Send,
 {
-    let fetch = MetadataFetchFn(fetch);
+    let mut fetch = MetadataFetchFn(fetch);
     ParquetMetaDataReader::new()
         .with_prefetch_hint(prefetch)
-        .load_and_finish(fetch, file_size)
+        .load_and_finish(&mut fetch, file_size)
         .await
 }
 

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -124,12 +124,11 @@ impl AsyncFileReader for ParquetObjectReader {
 
     fn get_metadata(&mut self) -> BoxFuture<'_, Result<Arc<ParquetMetaData>>> {
         Box::pin(async move {
-            let file_size = self.meta.size;
             let metadata = ParquetMetaDataReader::new()
                 .with_column_indexes(self.preload_column_index)
                 .with_offset_indexes(self.preload_offset_index)
                 .with_prefetch_hint(self.metadata_size_hint)
-                .load_and_finish(self, file_size)
+                .load_and_finish(self, self.meta.size)
                 .await?;
             Ok(Arc::new(metadata))
         })

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -124,11 +124,12 @@ impl AsyncFileReader for ParquetObjectReader {
 
     fn get_metadata(&mut self) -> BoxFuture<'_, Result<Arc<ParquetMetaData>>> {
         Box::pin(async move {
+            let file_size = self.meta.size;
             let metadata = ParquetMetaDataReader::new()
                 .with_column_indexes(self.preload_column_index)
                 .with_offset_indexes(self.preload_offset_index)
                 .with_prefetch_hint(self.metadata_size_hint)
-                .load_and_finish(self, self.meta.size)
+                .load_and_finish(self, file_size)
                 .await?;
             Ok(Arc::new(metadata))
         })

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -329,13 +329,18 @@ impl ParquetMetaDataReader {
             return Ok(());
         }
 
-        self.load_page_index(fetch, remainder).await
+        self.load_page_index_with_remainder(fetch, remainder).await
     }
 
     /// Asynchronously fetch the page index structures when a [`ParquetMetaData`] has already
     /// been obtained. See [`Self::new_with_metadata()`].
     #[cfg(feature = "async")]
-    pub async fn load_page_index<F: MetadataFetch>(
+    pub async fn load_page_index<F: MetadataFetch>(&mut self, fetch: F) -> Result<()> {
+        self.load_page_index_with_remainder(fetch, None).await
+    }
+
+    #[cfg(feature = "async")]
+    async fn load_page_index_with_remainder<F: MetadataFetch>(
         &mut self,
         mut fetch: F,
         remainder: Option<(usize, Bytes)>,

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -552,7 +552,7 @@ mod tests {
             }
         }
 
-        impl<'a> MetadataFetch for &'a mut MaskedBytes {
+        impl MetadataFetch for &mut MaskedBytes {
             fn fetch(&mut self, range: Range<usize>) -> BoxFuture<'_, ParquetResult<Bytes>> {
                 let inner_range = self.inner_range.clone();
                 println!("inner_range: {:?}", inner_range);

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -516,7 +516,7 @@ mod tests {
     /// Temporary function so we can test loading metadata with page indexes
     /// while we haven't fully figured out how to load it cleanly
     async fn load_metadata_from_bytes(file_size: usize, data: Bytes) -> ParquetMetaData {
-        use crate::arrow::async_reader::{MetadataFetch, MetadataLoader};
+        use crate::arrow::async_reader::MetadataFetch;
         use crate::errors::Result as ParquetResult;
         use futures::future::BoxFuture;
         use futures::FutureExt;
@@ -569,13 +569,11 @@ mod tests {
             Box::new(AsyncBytes::new(data)),
             file_size - metadata_length..file_size,
         );
-        let metadata = MetadataLoader::load(&mut reader, file_size, None)
+        ParquetMetaDataReader::new()
+            .with_page_indexes(true)
+            .load_and_finish(&mut reader, file_size)
             .await
-            .unwrap();
-        let loaded_metadata = metadata.finish();
-        let mut metadata = MetadataLoader::new(&mut reader, loaded_metadata);
-        metadata.load_page_index(true, true).await.unwrap();
-        metadata.finish()
+            .unwrap()
     }
 
     fn check_columns_are_equivalent(left: &ColumnChunkMetaData, right: &ColumnChunkMetaData) {

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -552,7 +552,7 @@ mod tests {
             }
         }
 
-        impl MetadataFetch for &mut MaskedBytes {
+        impl<'a> MetadataFetch for &'a mut MaskedBytes {
             fn fetch(&mut self, range: Range<usize>) -> BoxFuture<'_, ParquetResult<Bytes>> {
                 let inner_range = self.inner_range.clone();
                 println!("inner_range: {:?}", inner_range);


### PR DESCRIPTION
# Which issue does this PR close?
Part of #6447

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Deprecate public methods in `MetadataLoader`, as well as `metadata::fetch_parquet_metadata()`. 

Also changes the load API in `ParquetMetaDataReader` to use references to the `MetadataFetch` rather than taking ownership.

# Are there any user-facing changes?

Yes, but only to the as yet unreleased `ParquetMetaDataReader`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
