### PR TITLE
fix: check overflow numbers while inferring type for csv files

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -216,8 +216,8 @@ impl InferredDataType {
             1 << 8 // Utf8
         } else if let Some(m) = REGEX_SET.matches(string).into_iter().next() {
             if m == 1 && string.len() >= 19 && string.parse::<i64>().is_err() {
-                // if overflow i64, fallback to f64
-                1 << 2
+                // if overflow i64, fallback to utf8
+                1 << 8
             } else {
                 1 << m
             }
@@ -1824,6 +1824,8 @@ mod tests {
             infer_field_schema("2021-12-19T13:12:30.123456789"),
             DataType::Timestamp(TimeUnit::Nanosecond, None)
         );
+        assert_eq!(infer_field_schema("–9223372036854775809"), DataType::Utf8);
+        assert_eq!(infer_field_schema("9223372036854775808"), DataType::Utf8);
     }
 
     #[test]

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -215,7 +215,12 @@ impl InferredDataType {
         self.packed |= if string.starts_with('"') {
             1 << 8 // Utf8
         } else if let Some(m) = REGEX_SET.matches(string).into_iter().next() {
-            1 << m
+            if m == 1 && string.len() >= 19 && string.parse::<i64>().is_err() {
+                // if overflow i64, fallback to f64
+                1 << 2
+            } else {
+                1 << m
+            }
         } else {
             1 << 8 // Utf8
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #2580. Also related to https://github.com/apache/datafusion/issues/3174

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently we use regex to infer types in .csv files. The regex for `Int64` is `(^-?(\d+)$)` which accepts all numbers even overflow (this caused https://github.com/apache/datafusion/issues/3174). Initially I think we can use a regex that match the numbers in range, but the regex will be too long (more than 300 chars as I tried.

We can turn to a function trying to parse the string to `i64`, which is simple and flexible. The original regex could be kept or changed to more effective funtions if needed.

# What changes are included in this PR?

Change the regex mentioned above to funtions.

I only changed the boolean and i64 to functions since it's obvious. The regex of decimal is extended to accept overflowing numbers. Other regex is kept. I also add a TODO for further improvements. (I'd like to try to change it later if following questions are addressed)

Some questions here:
1. The regex of timestamp is `^\d{4}-\d\d-\d\d[T ]\d\d:\d\d:\d\d(?:[^\d\.].*)?$` which accept some illegal timestamps like `1000-00-00T11:11:11(adewoifas)`. I wonder if it's alright to use `chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").is_ok()` to replace it.
2. The tests are performed over the file `uk_cities.csv` which has meaningful content. I wonder if it's alright to add some meaningless strings to it for testing.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The numbers that overflow now will be inferred as decimal type instead of int64.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
