### PR TITLE
Add configuration option to `StatisticsConverter` to control interpretation of missing null counts in Parquet statistics 

### DIFF
--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -1159,7 +1159,7 @@ where
 ///
 /// # Schemas
 ///
-/// The converter ues the schema of the Parquet file and the Arrow schema to
+/// The converter uses the schema of the Parquet file and the Arrow schema to
 /// convert the underlying statistics value (stored as a parquet value) into the
 /// corresponding Arrow value. For example, Decimals are stored as binary in
 /// parquet files and this structure handles mapping them to the `i128`
@@ -1198,10 +1198,10 @@ impl<'a> StatisticsConverter<'a> {
     /// By default, the converter will treat missing null counts as though
     /// the null count is known to be `0`.
     ///
-    /// Note that due to <https://github.com/apache/arrow-rs/pull/6257>, prior
-    /// to version 53.0.0, parquet files written by parquet-rs did not store
-    /// null counts even when it was known there were zero nulls and the reader
-    /// would return 0 for the null counts.
+    /// Note that parquet files written by parquet-rs currently do not store
+    /// null counts even when it is known there are zero nulls, and the reader
+    /// will return 0 for the null counts in that instance. This behavior may
+    /// change in a future release.
     ///
     /// Both parquet-java and parquet-cpp store null counts as 0 when there are
     /// no nulls, and don't write unknown values to the null count field.

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -125,35 +125,22 @@ pub fn from_thrift(
 ) -> Result<Option<Statistics>> {
     Ok(match thrift_stats {
         Some(stats) => {
-            // transform null count to u64
-            let null_count = stats
-                .null_count
-                .map(|null_count| {
-                    if null_count < 0 {
-                        return Err(ParquetError::General(format!(
-                            "Statistics null count is negative {}",
-                            null_count
-                        )));
-                    }
-                    Ok(null_count as u64)
-                })
-                .transpose()?;
+            // Number of nulls recorded, when it is not available, we just mark it as 0.
+            // TODO this should be `None` if there is no information about NULLS.
+            // see https://github.com/apache/arrow-rs/pull/6216/files
+            let null_count = stats.null_count.unwrap_or(0);
 
+            if null_count < 0 {
+                return Err(ParquetError::General(format!(
+                    "Statistics null count is negative {}",
+                    null_count
+                )));
+            }
+
+            // Generic null count.
+            let null_count = Some(null_count as u64);
             // Generic distinct count (count of distinct values occurring)
-            let distinct_count = stats
-                .distinct_count
-                .map(|distinct_count| {
-                    if distinct_count < 0 {
-                        return Err(ParquetError::General(format!(
-                            "Statistics distinct count is negative {}",
-                            distinct_count
-                        )));
-                    }
-
-                    Ok(distinct_count as u64)
-                })
-                .transpose()?;
-
+            let distinct_count = stats.distinct_count.map(|value| value as u64);
             // Whether or not statistics use deprecated min/max fields.
             let old_format = stats.min_value.is_none() && stats.max_value.is_none();
             // Generic min value as bytes.
@@ -261,21 +248,20 @@ pub fn from_thrift(
 pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
     let stats = stats?;
 
-    // record null count if it can fit in i64
+    // record null counts if greater than zero.
+    //
+    // TODO: This should be Some(0) if there are no nulls.
+    // see https://github.com/apache/arrow-rs/pull/6216/files
     let null_count = stats
         .null_count_opt()
-        .and_then(|value| i64::try_from(value).ok());
-
-    // record distinct count if it can fit in i64
-    let distinct_count = stats
-        .distinct_count_opt()
-        .and_then(|value| i64::try_from(value).ok());
+        .map(|value| value as i64)
+        .filter(|&x| x > 0);
 
     let mut thrift_stats = TStatistics {
         max: None,
         min: None,
         null_count,
-        distinct_count,
+        distinct_count: stats.distinct_count_opt().map(|value| value as i64),
         max_value: None,
         min_value: None,
         is_max_value_exact: None,
@@ -429,20 +415,9 @@ impl Statistics {
     /// Returns number of null values for the column, if known.
     /// Note that this includes all nulls when column is part of the complex type.
     ///
-    /// Note: Versions of this library prior to `53.0.0` returned 0 if the null count was
-    /// not available. This method returns `None` in that case.
-    ///
-    /// Also, versions of this library prior to `53.0.0` did not store the null count in the
-    /// statistics if the null count was `0`.
-    ///
-    /// To preserve the prior behavior and read null counts properly from older files
-    /// you should default to zero:
-    ///
-    /// ```no_run
-    /// # use parquet::file::statistics::Statistics;
-    /// # let statistics: Statistics = todo!();
-    /// let null_count = statistics.null_count_opt().unwrap_or(0);
-    /// ```
+    /// Note this API returns Some(0) even if the null count was not present
+    /// in the statistics.
+    /// See <https://github.com/apache/arrow-rs/pull/6216/files>
     pub fn null_count_opt(&self) -> Option<u64> {
         statistics_enum_func![self, null_count_opt]
     }
@@ -1076,92 +1051,5 @@ mod tests {
             Some(7),
             true,
         ));
-    }
-
-    #[test]
-    fn test_count_encoding() {
-        statistics_count_test(None, None);
-        statistics_count_test(Some(0), Some(0));
-        statistics_count_test(Some(100), Some(2000));
-        statistics_count_test(Some(1), None);
-        statistics_count_test(None, Some(1));
-    }
-
-    #[test]
-    fn test_count_encoding_distinct_too_large() {
-        // statistics are stored using i64, so test trying to store larger values
-        let statistics = make_bool_stats(Some(u64::MAX), Some(100));
-        let thrift_stats = to_thrift(Some(&statistics)).unwrap();
-        assert_eq!(thrift_stats.distinct_count, None); // can't store u64 max --> null
-        assert_eq!(thrift_stats.null_count, Some(100));
-    }
-
-    #[test]
-    fn test_count_encoding_null_too_large() {
-        // statistics are stored using i64, so test trying to store larger values
-        let statistics = make_bool_stats(Some(100), Some(u64::MAX));
-        let thrift_stats = to_thrift(Some(&statistics)).unwrap();
-        assert_eq!(thrift_stats.distinct_count, Some(100));
-        assert_eq!(thrift_stats.null_count, None); // can' store u64 max --> null
-    }
-
-    #[test]
-    fn test_count_decoding_distinct_invalid() {
-        let tstatistics = TStatistics {
-            distinct_count: Some(-42),
-            ..Default::default()
-        };
-        let err = from_thrift(Type::BOOLEAN, Some(tstatistics)).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Parquet error: Statistics distinct count is negative -42"
-        );
-    }
-
-    #[test]
-    fn test_count_decoding_null_invalid() {
-        let tstatistics = TStatistics {
-            null_count: Some(-42),
-            ..Default::default()
-        };
-        let err = from_thrift(Type::BOOLEAN, Some(tstatistics)).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Parquet error: Statistics null count is negative -42"
-        );
-    }
-
-    /// Writes statistics to thrift and reads them back and ensures:
-    /// - The statistics are the same
-    /// - The statistics written to thrift are the same as the original statistics
-    fn statistics_count_test(distinct_count: Option<u64>, null_count: Option<u64>) {
-        let statistics = make_bool_stats(distinct_count, null_count);
-
-        let thrift_stats = to_thrift(Some(&statistics)).unwrap();
-        assert_eq!(thrift_stats.null_count.map(|c| c as u64), null_count);
-        assert_eq!(
-            thrift_stats.distinct_count.map(|c| c as u64),
-            distinct_count
-        );
-
-        let round_tripped = from_thrift(Type::BOOLEAN, Some(thrift_stats))
-            .unwrap()
-            .unwrap();
-        assert_eq!(round_tripped, statistics);
-    }
-
-    fn make_bool_stats(distinct_count: Option<u64>, null_count: Option<u64>) -> Statistics {
-        let min = Some(true);
-        let max = Some(false);
-        let is_min_max_deprecated = false;
-
-        // test is about the counts, so we aren't really testing the min/max values
-        Statistics::Boolean(ValueStatistics::new(
-            min,
-            max,
-            distinct_count,
-            null_count,
-            is_min_max_deprecated,
-        ))
     }
 }

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -189,7 +189,7 @@ fn test_primitive() {
                     pages: (0..8)
                         .map(|_| Page {
                             rows: 250,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 1000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
@@ -218,14 +218,14 @@ fn test_primitive() {
                     pages: vec![
                         Page {
                             rows: 250,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 258,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 1750,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 7000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
@@ -233,7 +233,7 @@ fn test_primitive() {
                     ],
                     dictionary_page: Some(Page {
                         rows: 250,
-                        page_header_size: 38,
+                        page_header_size: 36,
                         compressed_size: 1000,
                         encoding: Encoding::PLAIN,
                         page_type: PageType::DICTIONARY_PAGE,
@@ -260,42 +260,42 @@ fn test_primitive() {
                     pages: vec![
                         Page {
                             rows: 400,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 452,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 370,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 472,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 240,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 332,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
@@ -303,7 +303,7 @@ fn test_primitive() {
                     ],
                     dictionary_page: Some(Page {
                         rows: 2000,
-                        page_header_size: 38,
+                        page_header_size: 36,
                         compressed_size: 8000,
                         encoding: Encoding::PLAIN,
                         page_type: PageType::DICTIONARY_PAGE,
@@ -329,7 +329,7 @@ fn test_primitive() {
                     pages: (0..20)
                         .map(|_| Page {
                             rows: 100,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 400,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
@@ -364,14 +364,14 @@ fn test_string() {
                     pages: (0..15)
                         .map(|_| Page {
                             rows: 130,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 1040,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         })
                         .chain(std::iter::once(Page {
                             rows: 50,
-                            page_header_size: 37,
+                            page_header_size: 35,
                             compressed_size: 400,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
@@ -400,21 +400,21 @@ fn test_string() {
                     pages: vec![
                         Page {
                             rows: 130,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 138,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 1250,
-                            page_header_size: 40,
+                            page_header_size: 38,
                             compressed_size: 10000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 620,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 4960,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
@@ -422,7 +422,7 @@ fn test_string() {
                     ],
                     dictionary_page: Some(Page {
                         rows: 130,
-                        page_header_size: 38,
+                        page_header_size: 36,
                         compressed_size: 1040,
                         encoding: Encoding::PLAIN,
                         page_type: PageType::DICTIONARY_PAGE,
@@ -449,42 +449,42 @@ fn test_string() {
                     pages: vec![
                         Page {
                             rows: 400,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 452,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 370,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 472,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 330,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 464,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
                             rows: 240,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 332,
                             encoding: Encoding::RLE_DICTIONARY,
                             page_type: PageType::DATA_PAGE,
@@ -492,7 +492,7 @@ fn test_string() {
                     ],
                     dictionary_page: Some(Page {
                         rows: 2000,
-                        page_header_size: 38,
+                        page_header_size: 36,
                         compressed_size: 16000,
                         encoding: Encoding::PLAIN,
                         page_type: PageType::DICTIONARY_PAGE,
@@ -532,7 +532,7 @@ fn test_list() {
                     pages: (0..10)
                         .map(|_| Page {
                             rows: 20,
-                            page_header_size: 38,
+                            page_header_size: 36,
                             compressed_size: 672,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6256.

# Rationale for this change
 In #6257 @alamb changes the behavior of the parquet writer to always write `Some(0)` when the null count is known to be zero. Part of #6257 allows users of `StatisticsConverter` to choose whether or not to treat missing null counts as 0.

# What changes are included in this PR?

This PR consists of @alamb's changes to `StatisticsConverter` without the changes to writer behavior. By default no behavior is changed, but users can prepare for later changes to how the `Statistics::null_count` field is written.
See the conversation [here](https://github.com/apache/arrow-rs/pull/6257#issuecomment-2366765273) for the rationale.

# Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
