### PR TITLE
Minor: fix local clippy using anon deprecated tonic-build API

### DIFF
--- a/arrow-flight/gen/src/main.rs
+++ b/arrow-flight/gen/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // protoc in unbuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src")
-        .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
+        .compile_protos_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
     // read file contents to string
     let mut file = OpenOptions::new()
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // protoc in ubuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src/sql")
-        .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
+        .compile_protos_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
     // read file contents to string
     let mut file = OpenOptions::new()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
When I run clippy locally I seeing the following error:

```
error: use of deprecated method `tonic_build::Builder::compile_with_config`: renamed to `compile_protos_with_config()`
  --> arrow-flight/gen/src/main.rs:32:10
   |
32 |         .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
   |          ^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(deprecated)]`
```


# What changes are included in this PR?

Change the code to use the non deprecated API

# Are there any user-facing changes?

No, this is an internal build script
