### PR TITLE
Benchmark both scenarios, with records skipped and without skipping, for delta-bin-packed primitive arrays with half nulls.

### DIFF
--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -910,6 +910,23 @@ fn bench_primitive<T>(
         assert_eq!(count, EXPECTED_VALUE_COUNT);
     });
 
+    // binary packed, half NULLs
+    let data = build_encoded_primitive_page_iterator::<T>(
+        optional_column_desc.clone(),
+        0.5,
+        Encoding::DELTA_BINARY_PACKED,
+        min,
+        max,
+    );
+    group.bench_function("binary packed, optional, half NULLs", |b| {
+        b.iter(|| {
+            let array_reader =
+                create_primitive_array_reader(data.clone(), optional_column_desc.clone());
+            count = bench_array_reader(array_reader);
+        });
+        assert_eq!(count, EXPECTED_VALUE_COUNT);
+    });
+
     // binary packed skip , no NULLs
     let data = build_encoded_primitive_page_iterator::<T>(
         mandatory_column_desc.clone(),
@@ -943,7 +960,7 @@ fn bench_primitive<T>(
         assert_eq!(count, EXPECTED_VALUE_COUNT);
     });
 
-    // binary packed, half NULLs
+    // binary packed skip, half NULLs
     let data = build_encoded_primitive_page_iterator::<T>(
         optional_column_desc.clone(),
         0.5,
@@ -951,11 +968,11 @@ fn bench_primitive<T>(
         min,
         max,
     );
-    group.bench_function("binary packed, optional, half NULLs", |b| {
+    group.bench_function("binary packed skip, optional, half NULLs", |b| {
         b.iter(|| {
             let array_reader =
                 create_primitive_array_reader(data.clone(), optional_column_desc.clone());
-            count = bench_array_reader(array_reader);
+            count = bench_array_reader_skip(array_reader);
         });
         assert_eq!(count, EXPECTED_VALUE_COUNT);
     });


### PR DESCRIPTION
# Which issue does this PR close?

Follow up to [this comment](https://github.com/apache/arrow-rs/pull/6297#discussion_r1780648330), when it was noticed that a certain benchmark scenario is not covered.

# Rationale for this change
 
The delta-bin-packed primitive arrays, when half null, was not benchmarked for both skipping and no skipped record batches. This is a minor change to include both scenarios.


# What changes are included in this PR?

See above.

# Are there any user-facing changes?

No
