### PR TITLE
Update hashbrown requirement from 0.14.2 to 0.15.0

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -48,7 +48,7 @@ chrono = { workspace = true }
 chrono-tz = { version = "0.10", optional = true }
 num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-hashbrown = { version = "0.14.2", default-features = false }
+hashbrown = { version = "0.15.0", default-features = false }
 
 [features]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]

--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -48,7 +48,7 @@ chrono = { workspace = true }
 chrono-tz = { version = "0.10", optional = true }
 num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-hashbrown = { version = "0.15.0", default-features = false }
+hashbrown = { version = "0.15.0", default-features = false, features = ["inline-more", "raw-entry"] }
 
 [features]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]

--- a/arrow-flight/gen/src/main.rs
+++ b/arrow-flight/gen/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // protoc in unbuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src")
-        .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
+        .compile_protos_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
     // read file contents to string
     let mut file = OpenOptions::new()
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // protoc in ubuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir("src/sql")
-        .compile_with_config(prost_config(), &[proto_path], &[proto_dir])?;
+        .compile_protos_with_config(prost_config(), &[proto_path], &[proto_dir])?;
 
     // read file contents to string
     let mut file = OpenOptions::new()

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
-hashbrown = { version = "0.14", default-features = false }
+hashbrown = { version = "0.15", default-features = false }
 twox-hash = { version = "1.6", default-features = false }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"], op
 seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
-hashbrown = { version = "0.15", default-features = false }
+hashbrown = { version = "0.15", default-features = false, features = ["inline-more", "raw-entry"] }
 twox-hash = { version = "1.6", default-features = false }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }


### PR DESCRIPTION
# Which issue does this PR close?

Alternative PR to https://github.com/apache/arrow-rs/pull/6486.

# Rationale for this change
 
Update the ver 0.15 of hashbrown.

We are not using the deprecated `RawTable`, only raw entries.
In order to continue using raw entries, we need to use the [inline-more](https://docs.rs/hashbrown/0.15.0/src/hashbrown/raw_entry.rs.html#106) and `raw-entry` feature flags.

# What changes are included in this PR?

See above.

# Are there any user-facing changes?


No
