### PR TITLE
Minor: Fix path in format command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Note that currently the above will not check all source files in the parquet cra
 parquet files run the following from the top-level `arrow-rs` directory:
 
 ```bash
-cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
+cargo fmt -p parquet -- --check --config skip_children=true `find ./parquet -name "*.rs" \! -name format.rs`
 ```
 
 ## Breaking Changes


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
The instructions for running `cargo fmt` on the parquet crate will scan too many files.

# What changes are included in this PR?

Change instructions so only the parquet directory will be traversed.

# Are there any user-facing changes?
No, documentation change only.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
