### PR TITLE
fix: override `size_hint` for `BitIterator` to return the exact remaining size

### DIFF
--- a/arrow-buffer/src/util/bit_iterator.rs
+++ b/arrow-buffer/src/util/bit_iterator.rs
@@ -66,6 +66,11 @@ impl<'a> Iterator for BitIterator<'a> {
         self.current_offset += 1;
         Some(v)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining_bits = self.end_offset - self.current_offset;
+        (remaining_bits, Some(remaining_bits))
+    }
 }
 
 impl<'a> ExactSizeIterator for BitIterator<'a> {}
@@ -262,6 +267,30 @@ pub fn try_for_each_valid_idx<E, F: FnMut(usize) -> Result<(), E>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_bit_iterator_size_hint() {
+        let mut b = BitIterator::new(&[0b00000011], 0, 2);
+        assert_eq!(
+            b.size_hint(),
+            (2, Some(2)),
+            "Expected size_hint to be (2, Some(2))"
+        );
+
+        b.next();
+        assert_eq!(
+            b.size_hint(),
+            (1, Some(1)),
+            "Expected size_hint to be (1, Some(1)) after one bit consumed"
+        );
+
+        b.next();
+        assert_eq!(
+            b.size_hint(),
+            (0, Some(0)),
+            "Expected size_hint to be (0, Some(0)) after all bits consumed"
+        );
+    }
 
     #[test]
     fn test_bit_iterator() {


### PR DESCRIPTION
### Which issue does this PR close?

Closes #6480 

### Rationale for this change

The `BitIterator` implementation was missing a proper `size_hint` method, which caused it to panic when used in conjunction with `ExactSizeIterator`. The `ExactSizeIterator` trait requires that `size_hint()` always return a precise number of elements, and failing to do so caused a mismatch in the expected and actual sizes, leading to an assertion failure.

### What changes are included in this PR?

This PR introduces a fix by overriding the `size_hint()` method in `BitIterator` to return the correct remaining number of bits, ensuring compatibility with `ExactSizeIterator` and preventing panics.

### Are there any user-facing changes?

No breaking changes to public APIs. 
