### PR TITLE
fix arrow-json encoding with dictionary including nulls

### DIFF
--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1806,4 +1806,29 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_writer_null_dict() {
+        let keys = Int32Array::from_iter(vec![Some(0), None, Some(1)]);
+        let values = Arc::new(StringArray::from_iter(vec![Some("a"), None]));
+        let dict = DictionaryArray::new(keys, values);
+
+        let schema = SchemaRef::new(Schema::new(vec![Field::new(
+            "my_dict",
+            DataType::Dictionary(DataType::Int32.into(), DataType::Utf8.into()),
+            true,
+        )]));
+
+        let array = Arc::new(dict) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let mut json = Vec::new();
+        let write_builder = WriterBuilder::new().with_explicit_nulls(true);
+        let mut writer = write_builder.build::<_, JsonArray>(&mut json);
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let json_str = str::from_utf8(&json).unwrap();
+        assert_eq!(json_str, r#"[{"my_dict":"a"},{"my_dict":null},{"my_dict":null}]"#)
+    }
 }

--- a/arrow-json/src/writer.rs
+++ b/arrow-json/src/writer.rs
@@ -1829,6 +1829,9 @@ mod tests {
         writer.close().unwrap();
 
         let json_str = str::from_utf8(&json).unwrap();
-        assert_eq!(json_str, r#"[{"my_dict":"a"},{"my_dict":null},{"my_dict":null}]"#)
+        assert_eq!(
+            json_str,
+            r#"[{"my_dict":"a"},{"my_dict":null},{"my_dict":null}]"#
+        )
     }
 }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -409,7 +409,7 @@ impl<'a, K: ArrowDictionaryKeyType> DictionaryEncoder<'a, K> {
         array: &'a DictionaryArray<K>,
         options: &EncoderOptions,
     ) -> Result<Self, ArrowError> {
-        let encoder = make_encoder(array.values().as_ref(), options)?;
+        let (encoder, _) = make_encoder_impl(array.values().as_ref(), options)?;
 
         Ok(Self {
             keys: array.keys().values().clone(),

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -111,8 +111,7 @@ use std::{fmt::Debug, io::Write};
 use arrow_array::*;
 use arrow_schema::*;
 
-use crate::writer::encoder::EncoderOptions;
-use encoder::make_encoder;
+use encoder::{make_encoder, EncoderOptions};
 
 /// This trait defines how to format a sequence of JSON objects to a
 /// byte stream.


### PR DESCRIPTION
# Rationale for this change
 
While dictionary values are generally not null (it's more efficient to have a `null` in the keys), there's nothing to stop them from being nulls, and currently `datafusion-functions-json` generates dictionaries with null values.

Until now they caused `arrow-json` to panic, that is now fixed.

# What changes are included in this PR?

Use `make_encoder_impl`, not `make_encoder` in `DictionaryEncoder` to avoid unnecessary and incorrect `nulls.is_none()` assertion.

Add a test.

# Are there any user-facing changes?

no.

---

Related: we've copied arrow-json and customised it to support the unions generated by `datafusion-functions-json`, and also to inline JSON data within JSON based no field metadata, would you be inerested in accepting logic to allow customising of JSON encoding?
