### PR TITLE
Detect missing page indexes while reading Parquet metadata

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -288,7 +288,7 @@ impl ParquetMetaDataReader {
         // overlap.
         if let Some(metadata_size) = self.metadata_size {
             let metadata_range = file_size.saturating_sub(metadata_size)..file_size;
-            if metadata_range.contains(&range.end) {
+            if range.end > metadata_range.start {
                 return Err(eof_err!(
                     "Parquet file too small. Page index range {:?} overlaps with file metadata {:?}",
                     range,

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -670,7 +670,9 @@ mod tests {
     #[test]
     fn test_parse_metadata_size_smaller_than_footer() {
         let test_file = tempfile::tempfile().unwrap();
-        let err = ParquetMetaDataReader::new().parse_metadata(&test_file).unwrap_err();
+        let err = ParquetMetaDataReader::new()
+            .parse_metadata(&test_file)
+            .unwrap_err();
         assert!(matches!(err, ParquetError::IndexOutOfBound(8, _)));
     }
 
@@ -687,7 +689,9 @@ mod tests {
     #[test]
     fn test_parse_metadata_invalid_start() {
         let test_file = Bytes::from(vec![255, 0, 0, 0, b'P', b'A', b'R', b'1']);
-        let err = ParquetMetaDataReader::new().parse_metadata(&test_file).unwrap_err();
+        let err = ParquetMetaDataReader::new()
+            .parse_metadata(&test_file)
+            .unwrap_err();
         assert!(matches!(err, ParquetError::IndexOutOfBound(263, _)));
     }
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -58,7 +58,8 @@ pub struct ParquetMetaDataReader {
     column_index: bool,
     offset_index: bool,
     prefetch_hint: Option<usize>,
-    // size of the serialized thrift metadata plus the 8 byte footer
+    // Size of the serialized thrift metadata plus the 8 byte footer. Only set if
+    // `self.parse_metadata` is called.
     metadata_size: Option<usize>,
 }
 
@@ -470,7 +471,8 @@ impl ParquetMetaDataReader {
         range
     }
 
-    // one-shot parse of footer
+    // One-shot parse of footer.
+    // Side effect: this will set `self.metadata_size`
     fn parse_metadata<R: ChunkReader>(&mut self, chunk_reader: &R) -> Result<ParquetMetaData> {
         // check file is large enough to hold footer
         let file_size = chunk_reader.len();


### PR DESCRIPTION
# Which issue does this PR close?
Addresses part of #6464.

# Rationale for this change
 
If reading metadata from an external cache that lacks the page indexes, but the footer metadata contains page index offsets valid for the original source, attempting to read the page indexes can cause a variety of errors.

# What changes are included in this PR?

Modifies `ParqetMetaDataReader` to keep track of the size of the footer metadata, and when reading the page indexes detects if the ranges for the two structures overlap. Returns an EOF error if they do.

# Are there any user-facing changes?
No, changes are to internal APIs only.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
