### PR TITLE
[object_store] Retry S3 requests with 200 response with "Error" in body

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -33,7 +33,6 @@ all-features = true
 async-trait = "0.1.53"
 bytes = "1.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
-encoding_rs = "0.8"
 futures = "0.3"
 humantime = "2.1"
 itertools = "0.13.0"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -33,6 +33,7 @@ all-features = true
 async-trait = "0.1.53"
 bytes = "1.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
+encoding_rs = "0.8"
 futures = "0.3"
 humantime = "2.1"
 itertools = "0.13.0"

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -186,6 +186,10 @@ impl Default for RetryConfig {
     }
 }
 
+fn body_contains_error(response_body: &str) -> bool {
+    response_body.contains("InternalError") || response_body.contains("SlowDown")
+}
+
 pub(crate) struct RetryableRequest {
     client: Client,
     request: Request,
@@ -262,7 +266,9 @@ impl RetryableRequest {
             match self.client.execute(request).await {
                 Ok(r) => match r.error_for_status_ref() {
                     Ok(_) if r.status().is_success() => {
-                        // Response body might contain an Error despite the status saying 200 for some PUT and POST requests.
+                        // For certain S3 requests, 200 response may contain `InternalError` or
+                        // `SlowDown` in the message. These responses should be handled similarly
+                        // to r5xx errors.
                         // More info here: https://repost.aws/knowledge-center/s3-resolve-200-internalerror
                         if !self.retry_error_body {
                             return Ok(r);
@@ -282,14 +288,15 @@ impl RetryableRequest {
                         let response_body = String::from_utf8_lossy(&bytes);
                         info!("Checking for error in response_body: {}", response_body);
 
-                        if !response_body.contains("Error") {
-                            // Clone response
+                        if !body_contains_error(&response_body) {
+                            // Success response and no error, clone and return response
                             let mut success_response = hyper::Response::new(bytes);
                             *success_response.status_mut() = status;
                             *success_response.headers_mut() = headers;
 
                             return Ok(reqwest::Response::from(success_response));
                         } else {
+                            // Retry as if this was a 5xx response
                             if retries == max_retries || now.elapsed() > retry_timeout {
                                 return Err(Error::Server {
                                     body: Some(response_body.into_owned()),
@@ -472,12 +479,26 @@ impl RetryExt for reqwest::RequestBuilder {
 #[cfg(test)]
 mod tests {
     use crate::client::mock_server::MockServer;
-    use crate::client::retry::{Error, RetryExt};
+    use crate::client::retry::{body_contains_error, Error, RetryExt};
     use crate::RetryConfig;
     use hyper::header::LOCATION;
     use hyper::Response;
     use reqwest::{Client, Method, StatusCode};
     use std::time::Duration;
+
+    #[test]
+    fn test_body_contains_error() {
+        // Example error message provided by https://repost.aws/knowledge-center/s3-resolve-200-internalerror
+        let error_response = "AmazonS3Exception: We encountered an internal error. Please try again. (Service: Amazon S3; Status Code: 200; Error Code: InternalError; Request ID: 0EXAMPLE9AAEB265)";
+        assert!(body_contains_error(error_response));
+
+        let error_response_2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message><RequestId>123</RequestId><HostId>456</HostId></Error>";
+        assert!(body_contains_error(error_response_2));
+
+        // Example success response from https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+        let success_response = "<CopyObjectResult><LastModified>2009-10-12T17:50:30.000Z</LastModified><ETag>\"9b2cf535f27731c974343645a3985328\"</ETag></CopyObjectResult>";
+        assert!(!body_contains_error(success_response));
+    }
 
     #[tokio::test]
     async fn test_retry() {
@@ -701,6 +722,39 @@ mod tests {
             .sensitive(true);
         let err = req.send().await.unwrap_err().to_string();
         assert!(!err.contains("SENSITIVE"), "{err}");
+
+        // Success response with error in body is retried
+        mock.push(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body("InternalError".to_string())
+                .unwrap(),
+        );
+        let req = client
+            .request(Method::PUT, &url)
+            .retryable(&retry)
+            .idempotent(true)
+            .retry_error_body(true);
+        let r = req.send().await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        // Response with InternalError should have been retried
+        assert!(!r.text().await.unwrap().contains("InternalError"));
+
+        // Should not retry success response with no error in body
+        mock.push(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body("success".to_string())
+                .unwrap(),
+        );
+        let req = client
+            .request(Method::PUT, &url)
+            .retryable(&retry)
+            .idempotent(true)
+            .retry_error_body(true);
+        let r = req.send().await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        assert!(r.text().await.unwrap().contains("success"));
 
         // Shutdown
         mock.shutdown().await

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -19,9 +19,10 @@
 
 use crate::client::backoff::{Backoff, BackoffConfig};
 use crate::PutPayload;
+use encoding_rs::{Encoding, UTF_8};
 use futures::future::BoxFuture;
 use reqwest::header::LOCATION;
-use reqwest::{Client, Request, Response, StatusCode};
+use reqwest::{Client, Method, Request, Response, StatusCode};
 use snafu::Error as SnafuError;
 use snafu::Snafu;
 use std::time::{Duration, Instant};
@@ -32,6 +33,12 @@ use tracing::info;
 pub enum Error {
     #[snafu(display("Received redirect without LOCATION, this normally indicates an incorrectly configured region"))]
     BareRedirect,
+
+    #[snafu(display("Server error, body contains Error, with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
+    Server {
+        status: StatusCode,
+        body: Option<String>,
+    },
 
     #[snafu(display("Client error with status {status}: {}", body.as_deref().unwrap_or("No Body")))]
     Client {
@@ -54,6 +61,7 @@ impl Error {
     pub fn status(&self) -> Option<StatusCode> {
         match self {
             Self::BareRedirect => None,
+            Self::Server { status, .. } => Some(*status),
             Self::Client { status, .. } => Some(*status),
             Self::Reqwest { source, .. } => source.status(),
         }
@@ -63,6 +71,7 @@ impl Error {
     pub fn body(&self) -> Option<&str> {
         match self {
             Self::Client { body, .. } => body.as_deref(),
+            Self::Server { body, .. } => body.as_deref(),
             Self::BareRedirect => None,
             Self::Reqwest { .. } => None,
         }
@@ -242,9 +251,63 @@ impl RetryableRequest {
                 *request.body_mut() = Some(payload.body());
             }
 
+            let is_put_or_post =
+                request.method() != Method::PUT && request.method() != Method::POST;
+
             match self.client.execute(request).await {
                 Ok(r) => match r.error_for_status_ref() {
-                    Ok(_) if r.status().is_success() => return Ok(r),
+                    Ok(_) if r.status().is_success() => {
+                        // Response body might contain an Error despite the status saying 200 for some PUT and POST requests.
+                        // More info here: https://repost.aws/knowledge-center/s3-resolve-200-internalerror
+                        if is_put_or_post {
+                            return Ok(r);
+                        }
+
+                        let status = r.status();
+                        let headers = r.headers().clone();
+
+                        let encoding = Encoding::for_label(b"utf-8").unwrap_or(UTF_8);
+                        let full_bytes = r.bytes().await.unwrap();
+
+                        let (text, _, _) = encoding.decode(&full_bytes);
+                        let response_body = text.into_owned();
+
+                        match response_body.contains("Error") {
+                            false => {
+                                // Clone response
+                                let mut success_response = hyper::Response::new(full_bytes);
+                                *success_response.status_mut() = status;
+
+                                let mut hyper_headers = hyper::HeaderMap::new();
+                                for (header_name, header_value) in headers {
+                                    hyper_headers.insert(header_name.unwrap(), header_value);
+                                }
+
+                                *success_response.headers_mut() = hyper_headers;
+
+                                return Ok(reqwest::Response::from(success_response));
+                            }
+                            true => {
+                                if retries == max_retries || now.elapsed() > retry_timeout {
+                                    return Err(Error::Server {
+                                        body: Some(response_body),
+                                        status,
+                                    });
+                                }
+
+                                let sleep = backoff.next();
+                                retries += 1;
+                                info!(
+                                    "Encountered a response status of {} but body contains Error, backing off for {} seconds, retry {} of {}",
+                                    status,
+                                    sleep.as_secs_f32(),
+                                    retries,
+                                    max_retries,
+                                );
+                                tokio::time::sleep(sleep).await;
+                            }
+                        }
+                    }
                     Ok(r) if r.status() == StatusCode::NOT_MODIFIED => {
                         return Err(Error::Client {
                             body: None,

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -230,6 +230,7 @@ impl RetryableRequest {
         Self { payload, ..self }
     }
 
+    #[allow(unused)]
     pub(crate) fn retry_error_body(self, retry_error_body: bool) -> Self {
         Self {
             retry_error_body,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/5938

# Rationale for this change

Some S3 requests like CopyObject and CompleteMultipartUpload may return a 200 response but have "InternalError" or "SlowDown" in the response body. These should be retried as if they were a 5xx error.

[Relevant AWS documentation](https://repost.aws/knowledge-center/s3-resolve-200-internalerror)

e.g. we received this as a body of a 200 response
`<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>SlowDown</Code><Message>Please reduce your request rate.</Message><RequestId>123</RequestId><HostId>456</HostId></Error>`
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

This PR adds the `retry_body_error` attribute for `Request`/`RetryableRequest`, which is `false` by default. It is set to true for S3 `copy` and `complete_multipart` requests.

If `retry_body_error` is `true`, and if the body contains an error, we will retry it as if we got a 5xx resopnse.

Unfortunately AWS doesn't seem to provide us with the exact format of the error message, so we can only look for `InternalError` or `SlowDown` in the response body and not much else.

# Are there any user-facing changes?

No
