### PR TITLE
Update Tonic to 0.12.3

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -48,7 +48,7 @@ prost = { version = "0.13.1", default-features = false, features = ["prost-deriv
 # For Timestamp type
 prost-types = { version = "0.13.1", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
-tonic = { version = "0.12.1", default-features = false, features = ["transport", "codegen", "prost"] }
+tonic = { version = "0.12.3", default-features = false, features = ["transport", "codegen", "prost"] }
 
 # CLI-related dependencies
 anyhow = { version = "1.0", optional = true }


### PR DESCRIPTION
# Which issue does this PR close?

Issue #6515

Closes #6515.

The current master does not compile due to the error described in #6515.

Upgraded `Cargo.toml` to use the latest `tonic` version: "0.12.3"

This should not cause any user changes, but someone more familiar than me should review. There are no breaking API changes, but now it will have support for `GRPC_STATUS` so it can build.
