### PR TITLE
object_store: retry on response decoding errors

### DIFF
--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -312,6 +312,7 @@ impl RetryableRequest {
                     let mut do_retry = false;
                     if e.is_connect()
                         || e.is_body()
+                        || e.is_decode()
                         || (e.is_request() && !e.is_timeout())
                         || (is_idempotent && e.is_timeout())
                     {


### PR DESCRIPTION
Closes https://github.com/apache/arrow-rs-object-store/issues/53

This PR includes `reqwest::Error::Decode` as an error case to retry on, which can occur when a server drops a connection in the middle of sending the response body.

