### PR TITLE
object_store: Clarify what is a prefix in list() documentation

### DIFF
--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -715,7 +715,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
 
     /// List all the objects with the given prefix.
     ///
-    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar` is a prefix of `foo/bar/x` but not of
     /// `foo/bar_baz/x`. List is recursive, i.e. `foo/bar/more/x` will be included.
     ///
     /// Note: the order of returned [`ObjectMeta`] is not guaranteed
@@ -742,7 +742,7 @@ pub trait ObjectStore: std::fmt::Display + Send + Sync + Debug + 'static {
     /// delimiter. Returns common prefixes (directories) in addition to object
     /// metadata.
     ///
-    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar` is a prefix of `foo/bar/x` but not of
     /// `foo/bar_baz/x`. List is not recursive, i.e. `foo/bar/more/x` will not be included.
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult>;
 


### PR DESCRIPTION
# Which issue does this PR close?

none, this is a very small change

# Rationale for this change
 
It should be obvious to reader that `foo/bar/` is not a prefix of `foo/bar_baz`, because it is true whether they think in term of strings, S3-like API paths, or POSIX-like paths.

What is less clear is that `foo/bar` is also not a prefix of `foo/bar_baz`, because this is not true with strings or S3-like API paths, only of POSIX-like paths.

Additionally, the definition of paths
(https://docs.rs/object_store/0.11.0/object_store/path/struct.Path.html) says that paths cannot have a trailing `/`.

# What changes are included in this PR?

Replace the `foo/bar/` example prefix with `foo/bar`

# Are there any user-facing changes?

only the documentation