### PR TITLE
Allow to read parquet binary column as UTF8 type

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -3130,9 +3130,7 @@ mod tests {
         assert_eq!(
             batch
                 .column(0)
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("downcast to string")
+                .as_string::<i32>()
                 .iter()
                 .collect::<Vec<_>>(),
             vec![Some("one"), Some("two"), Some("three")]
@@ -3141,22 +3139,14 @@ mod tests {
         assert_eq!(
             batch
                 .column(1)
-                .as_any()
-                .downcast_ref::<LargeStringArray>()
-                .expect("downcast to large string")
+                .as_string::<i64>()
                 .iter()
                 .collect::<Vec<_>>(),
             vec![Some("one"), Some("two"), Some("three")]
         );
 
         assert_eq!(
-            batch
-                .column(2)
-                .as_any()
-                .downcast_ref::<StringViewArray>()
-                .expect("downcast to string view")
-                .iter()
-                .collect::<Vec<_>>(),
+            batch.column(2).as_string_view().iter().collect::<Vec<_>>(),
             vec![Some("one"), Some("two"), Some("three")]
         );
     }
@@ -3186,8 +3176,7 @@ mod tests {
         .expect("reader builder with schema")
         .build()
         .expect("reader with schema");
-
-        arrow_reader.next();
+        arrow_reader.next().unwrap().unwrap_err();
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -3078,6 +3078,119 @@ mod tests {
     }
 
     #[test]
+    fn test_read_binary_as_utf8() {
+        let file = write_parquet_from_iter(vec![
+            (
+                "binary_to_utf8",
+                Arc::new(BinaryArray::from(vec![
+                    b"one".as_ref(),
+                    b"two".as_ref(),
+                    b"three".as_ref(),
+                ])) as ArrayRef,
+            ),
+            (
+                "large_binary_to_large_utf8",
+                Arc::new(LargeBinaryArray::from(vec![
+                    b"one".as_ref(),
+                    b"two".as_ref(),
+                    b"three".as_ref(),
+                ])) as ArrayRef,
+            ),
+            (
+                "binary_view_to_utf8_view",
+                Arc::new(BinaryViewArray::from(vec![
+                    b"one".as_ref(),
+                    b"two".as_ref(),
+                    b"three".as_ref(),
+                ])) as ArrayRef,
+            ),
+        ]);
+        let supplied_fields = Fields::from(vec![
+            Field::new("binary_to_utf8", ArrowDataType::Utf8, false),
+            Field::new(
+                "large_binary_to_large_utf8",
+                ArrowDataType::LargeUtf8,
+                false,
+            ),
+            Field::new("binary_view_to_utf8_view", ArrowDataType::Utf8View, false),
+        ]);
+
+        let options = ArrowReaderOptions::new().with_schema(Arc::new(Schema::new(supplied_fields)));
+        let mut arrow_reader = ParquetRecordBatchReaderBuilder::try_new_with_options(
+            file.try_clone().unwrap(),
+            options,
+        )
+        .expect("reader builder with schema")
+        .build()
+        .expect("reader with schema");
+
+        let batch = arrow_reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("downcast to string")
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some("one"), Some("two"), Some("three")]
+        );
+
+        assert_eq!(
+            batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("downcast to large string")
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some("one"), Some("two"), Some("three")]
+        );
+
+        assert_eq!(
+            batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .expect("downcast to string view")
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some("one"), Some("two"), Some("three")]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid UTF8 sequence at")]
+    fn test_read_non_utf8_binary_as_utf8() {
+        let file = write_parquet_from_iter(vec![(
+            "non_utf8_binary",
+            Arc::new(BinaryArray::from(vec![
+                b"\xDE\x00\xFF".as_ref(),
+                b"\xDE\x01\xAA".as_ref(),
+                b"\xDE\x02\xFF".as_ref(),
+            ])) as ArrayRef,
+        )]);
+        let supplied_fields = Fields::from(vec![Field::new(
+            "non_utf8_binary",
+            ArrowDataType::Utf8,
+            false,
+        )]);
+
+        let options = ArrowReaderOptions::new().with_schema(Arc::new(Schema::new(supplied_fields)));
+        let mut arrow_reader = ParquetRecordBatchReaderBuilder::try_new_with_options(
+            file.try_clone().unwrap(),
+            options,
+        )
+        .expect("reader builder with schema")
+        .build()
+        .expect("reader with schema");
+
+        arrow_reader.next();
+    }
+
+    #[test]
     fn test_with_schema() {
         let nested_fields = Fields::from(vec![
             Field::new("utf8_to_dict", ArrowDataType::Utf8, false),

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -57,6 +57,11 @@ fn apply_hint(parquet: DataType, hint: DataType) -> DataType {
         (DataType::Utf8, DataType::LargeUtf8) => hint,
         (DataType::Binary, DataType::LargeBinary) => hint,
 
+        // Read as Utf8
+        (DataType::Binary, DataType::Utf8) => hint,
+        (DataType::Binary, DataType::LargeUtf8) => hint,
+        (DataType::Binary, DataType::Utf8View) => hint,
+
         // Determine view type
         (DataType::Utf8, DataType::Utf8View) => hint,
         (DataType::Binary, DataType::BinaryView) => hint,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

No related issue.
# Rationale for this change
While working on https://github.com/apache/datafusion/issues/12788#issuecomment-2402885802 in DataFusion, I found we can't read the parquet binary column as string types (Utf8, LargeUtf8, or Utf8View) through `ArrowReaderOptions::with_schema`. I think it makes sense to read them as strings if the user ensures it's a string binary value.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
I added some matching rules in `apply_hint` in `parquet/src/arrow/schema/primitive.rs` to handle the binary-to-string cases.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
cc @alamb 