### PR TITLE
`unsafe` improvements

### DIFF
--- a/arrow-buffer/src/builder/offset.rs
+++ b/arrow-buffer/src/builder/offset.rs
@@ -70,8 +70,11 @@ impl<O: ArrowNativeType> OffsetBufferBuilder<O> {
     ///
     /// Panics if offsets overflow `O`
     pub fn finish_cloned(&self) -> OffsetBuffer<O> {
-        O::from_usize(self.last_offset).expect("overflow");
-        unsafe { OffsetBuffer::new_unchecked(self.offsets.clone().into()) }
+        let cloned = Self {
+            offsets: self.offsets.clone(),
+            last_offset: self.last_offset,
+        };
+        cloned.finish()
     }
 }
 

--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -127,7 +127,7 @@ unsafe fn set_upto_64bits(
 }
 
 /// # Safety
-/// The caller must ensure `data` has `offset..(offset + 8)` range
+/// The caller must ensure `data` has `offset..(offset + 8)` range, and `count <= 8`.
 #[inline]
 unsafe fn read_bytes_to_u64(data: &[u8], offset: usize, count: usize) -> u64 {
     debug_assert!(count <= 8);

--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -131,12 +131,12 @@ unsafe fn set_upto_64bits(
 #[inline]
 unsafe fn read_bytes_to_u64(data: &[u8], offset: usize, count: usize) -> u64 {
     debug_assert!(count <= 8);
-    let mut tmp = std::mem::MaybeUninit::<u64>::new(0);
+    let mut tmp : u64 = 0;
     let src = data.as_ptr().add(offset);
     unsafe {
-        std::ptr::copy_nonoverlapping(src, tmp.as_mut_ptr() as *mut u8, count);
-        tmp.assume_init()
+        std::ptr::copy_nonoverlapping(src, &mut tmp as *mut _ as *mut u8, count);
     }
+    tmp
 }
 
 /// # Safety

--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -131,7 +131,7 @@ unsafe fn set_upto_64bits(
 #[inline]
 unsafe fn read_bytes_to_u64(data: &[u8], offset: usize, count: usize) -> u64 {
     debug_assert!(count <= 8);
-    let mut tmp : u64 = 0;
+    let mut tmp: u64 = 0;
     let src = data.as_ptr().add(offset);
     unsafe {
         std::ptr::copy_nonoverlapping(src, &mut tmp as *mut _ as *mut u8, count);

--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -127,7 +127,7 @@ unsafe fn set_upto_64bits(
 }
 
 /// # Safety
-/// The caller must ensure all arguments are within the valid range.
+/// The caller must ensure `data` has `offset..(offset + 8)` range
 #[inline]
 unsafe fn read_bytes_to_u64(data: &[u8], offset: usize, count: usize) -> u64 {
     debug_assert!(count <= 8);


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
I discovered these while reviewing the unsafe code of arrow-rs -- this mostly just removes some instances of potentially-unsafe code, replacing them with safe equivalents. That makes it easier to review, at (so far as I know) no performance cost.

# What changes are included in this PR?

* Reuse `unsafe` code in the `OffsetBufferBuilder`.
* Use a `u64` instead of an always-initialized `MaybeUninit<u64>`.
* More precisely specify safety for `read_bytes_to_u64`.

# Are there any user-facing changes?

No.