### PR TITLE
POC Memory Tracking of Potentially Shared Buffer

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -28,10 +28,16 @@ include = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[package.metadata.docs.rs]
+features = ["pool"]
+
 [lib]
 name = "arrow_buffer"
 path = "src/lib.rs"
 bench = false
+
+[features]
+pool = []
 
 [dependencies]
 bytes = { version = "1.4" }

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -357,6 +357,12 @@ impl Buffer {
     pub fn ptr_eq(&self, other: &Self) -> bool {
         self.ptr == other.ptr && self.length == other.length
     }
+
+    /// Register this [`Buffer`] with the provided [`MemoryPool`]
+    #[cfg(feature = "pool")]
+    pub fn claim(&self, pool: &dyn crate::MemoryPool) {
+        self.data.claim(pool)
+    }
 }
 
 /// Note that here we deliberately do not implement

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -358,7 +358,7 @@ impl Buffer {
         self.ptr == other.ptr && self.length == other.length
     }
 
-    /// Register this [`Buffer`] with the provided [`MemoryPool`]
+    /// Register this [`Buffer`] with the provided [`MemoryPool`], replacing any prior assignment
     #[cfg(feature = "pool")]
     pub fn claim(&self, pool: &dyn crate::MemoryPool) {
         self.data.claim(pool)

--- a/arrow-buffer/src/bytes.rs
+++ b/arrow-buffer/src/bytes.rs
@@ -101,7 +101,7 @@ impl Bytes {
         }
     }
 
-    /// Register this [`Bytes`] with the provided [`MemoryPool`]
+    /// Register this [`Bytes`] with the provided [`MemoryPool`], replacing any prior assignment
     #[cfg(feature = "pool")]
     pub fn claim(&self, pool: &dyn crate::MemoryPool) {
         *self.reservation.lock().unwrap() = Some(pool.register(self.capacity()));

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -43,3 +43,8 @@ mod interval;
 pub use interval::*;
 
 mod arith;
+
+#[cfg(feature = "pool")]
+mod pool;
+#[cfg(feature = "pool")]
+pub use pool::*;

--- a/arrow-buffer/src/pool.rs
+++ b/arrow-buffer/src/pool.rs
@@ -1,0 +1,79 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// A [`MemoryPool`] can be used to track memory usage by [`Buffer`](crate::Buffer)
+pub trait MemoryPool {
+    fn register(&self, size: usize) -> Box<dyn MemoryReservation>;
+}
+
+/// A memory reservation within a [`MemoryPool`] that is freed on drop
+pub trait MemoryReservation {
+    fn resize(&mut self, new: usize);
+}
+
+/// A simple [`MemoryPool`] that tracks memory usage
+#[derive(Debug, Default)]
+pub struct TrackingMemoryPool(Arc<AtomicUsize>);
+
+impl TrackingMemoryPool {
+    /// Returns the total allocated size
+    pub fn allocated(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl MemoryPool for TrackingMemoryPool {
+    fn register(&self, size: usize) -> Box<dyn MemoryReservation> {
+        self.0.fetch_add(size, Ordering::Relaxed);
+        Box::new(Tracker {
+            size,
+            shared: Arc::clone(&self.0),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Tracker {
+    size: usize,
+    shared: Arc<AtomicUsize>,
+}
+
+impl Drop for Tracker {
+    fn drop(&mut self) {
+        self.shared.fetch_sub(self.size, Ordering::Relaxed);
+    }
+}
+
+impl MemoryReservation for Tracker {
+    fn resize(&mut self, new: usize) {
+        match self.size < new {
+            true => self.shared.fetch_add(new - self.size, Ordering::Relaxed),
+            false => self.shared.fetch_sub(self.size - new, Ordering::Relaxed),
+        };
+        self.size = new;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Buffer;
+
+    #[test]
+    fn test_memory_pool() {
+        let pool = TrackingMemoryPool::default();
+        let b1 = Buffer::from(vec![0_i64, 1, 2]);
+        let b2 = Buffer::from(vec![3_u16, 4, 5]);
+
+        let buffers = [b1.clone(), b1.slice(12), b1.clone(), b2.clone()];
+        buffers.iter().for_each(|x| x.claim(&pool));
+
+        assert_eq!(pool.allocated(), b1.capacity() + b2.capacity());
+        drop(buffers);
+        assert_eq!(pool.allocated(), b1.capacity() + b2.capacity());
+        drop(b2);
+        assert_eq!(pool.allocated(), b1.capacity());
+        drop(b1);
+        assert_eq!(pool.allocated(), 0);
+    }
+}

--- a/arrow-buffer/src/pool.rs
+++ b/arrow-buffer/src/pool.rs
@@ -3,15 +3,17 @@ use std::sync::Arc;
 
 /// A [`MemoryPool`] can be used to track memory usage by [`Buffer`](crate::Buffer)
 pub trait MemoryPool {
+    /// Return a memory reservation of `size` bytes
     fn register(&self, size: usize) -> Box<dyn MemoryReservation>;
 }
 
 /// A memory reservation within a [`MemoryPool`] that is freed on drop
 pub trait MemoryReservation {
+    /// Resize this reservation to `new` bytes
     fn resize(&mut self, new: usize);
 }
 
-/// A simple [`MemoryPool`] that tracks memory usage
+/// A simple [`MemoryPool`] that reports the total memory usage
 #[derive(Debug, Default)]
 pub struct TrackingMemoryPool(Arc<AtomicUsize>);
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Relates to #6439.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

A POC showing how we could add more accurate memory tracking to arrays without a huge amount of churn

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This adds two traits `MemoryPool` and `MemoryReservation` that work together to allow accurate instrumentation of `Buffer` memory usage.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
