### PR TITLE
Temporarily disable C# Arrow Integration Test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,8 @@ jobs:
       ARROW_RUST_EXE_PATH: /build/rust/debug
       BUILD_DOCS_CPP: OFF
       ARROW_INTEGRATION_CPP: ON
-      ARROW_INTEGRATION_CSHARP: ON
+      # Sisable C# integration tests due to https://github.com/apache/arrow-rs/issues/6577
+      ARROW_INTEGRATION_CSHARP: OFF
       ARROW_INTEGRATION_GO: ON
       ARROW_INTEGRATION_JAVA: ON
       ARROW_INTEGRATION_JS: ON


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-rs/issues/6577

# Rationale for this change
 
Disable newly added CI test to get CI on arrow green while we work out the underlying issue (with the test harness)

# What changes are included in this PR?

Disable c# test

# Are there any user-facing changes?
No