### PR TITLE
Remove `test_private_bucket` object_store test

### DIFF
--- a/object_store/src/aws/resolve.rs
+++ b/object_store/src/aws/resolve.rs
@@ -80,13 +80,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_private_bucket() {
-        let bucket = "bloxbender";
+        let bucket = "public-datasets";
 
         let region = resolve_bucket_region(bucket, &ClientOptions::new())
             .await
             .unwrap();
 
-        let expected = "us-west-2".to_string();
+        let expected = "eu-west-1".to_string();
 
         assert_eq!(region, expected);
     }

--- a/object_store/src/aws/resolve.rs
+++ b/object_store/src/aws/resolve.rs
@@ -79,19 +79,6 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_private_bucket() {
-        let bucket = "public-datasets";
-
-        let region = resolve_bucket_region(bucket, &ClientOptions::new())
-            .await
-            .unwrap();
-
-        let expected = "eu-west-1".to_string();
-
-        assert_eq!(region, expected);
-    }
-
-    #[tokio::test]
     async fn test_bucket_does_not_exist() {
         let bucket = "please-dont-exist";
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6600

# Rationale for this change
The test is failing on main

I think it is due to whatever the `bloxblender` s3 bucket being moved 

# What changes are included in this PR?

Remove the test as it is testing some behavior of S3 (see @tustvold 's comment below)

# Are there any user-facing changes?

No this is a test only