### PR TITLE
Implement arrow_json encoder for Decimal128 & Decimal256

### DIFF
--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -67,6 +67,7 @@ fn make_encoder_impl<'a>(
         DataType::Float16 => primitive_helper!(Float16Type),
         DataType::Float32 => primitive_helper!(Float32Type),
         DataType::Float64 => primitive_helper!(Float64Type),
+        DataType::Decimal128(_, _) => primitive_helper!(Decimal128Type),
         DataType::Boolean => {
             let array = array.as_boolean();
             (Box::new(BooleanEncoder(array)), array.nulls().cloned())
@@ -133,11 +134,6 @@ fn make_encoder_impl<'a>(
                 explicit_nulls: options.explicit_nulls,
             };
             (Box::new(encoder) as _, array.nulls().cloned())
-        }
-        DataType::Decimal128(_, _) => {
-            let array = array.as_any().downcast_ref::<Decimal128Array>()
-                .ok_or_else(|| ArrowError::InvalidArgumentError("Expected Decimal128Array".to_string()))?;
-            (Box::new(Decimal128Encoder::new(array)) as _, array.nulls().cloned())
         }
         DataType::Decimal256(_, _) => {
             let array = array.as_any().downcast_ref::<Decimal256Array>()
@@ -240,7 +236,7 @@ macro_rules! integer_encode {
         )*
     };
 }
-integer_encode!(i8, i16, i32, i64, u8, u16, u32, u64);
+integer_encode!(i8, i16, i32, i64, i128, u8, u16, u32, u64);
 
 macro_rules! float_encode {
     ($($t:ty),*) => {
@@ -553,23 +549,6 @@ where
             write!(out, "{byte:02x}").unwrap();
         }
         out.push(b'"');
-    }
-}
-
-struct Decimal128Encoder<'a> {
-    array: &'a Decimal128Array,
-}
-
-impl<'a> Decimal128Encoder<'a> {
-    fn new(array: &'a Decimal128Array) -> Self {
-        Self { array }
-    }
-}
-
-impl<'a> Encoder for Decimal128Encoder<'a> {
-    fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
-        let formatted = self.array.value_as_string(idx);
-        out.extend_from_slice(formatted.as_bytes());
     }
 }
 

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -17,8 +17,6 @@
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
-use arrow_array::Decimal128Array;
-use arrow_array::Decimal256Array;
 use arrow_array::*;
 use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_cast::display::{ArrayFormatter, FormatOptions};


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6605

# Rationale for this change
 
Makes the arrow_json crate able to serialize more record batches.

# What changes are included in this PR?

Implements a Decimal128Encoder and Decimal256Encoder and uses that within the `make_encoder_impl` function for the Decimal128 & Decimal256 types.

# Are there any user-facing changes?

More record batches will be able to be serialized to JSON, and this is backwards compatible.
