### PR TITLE
Minor: more comments for `RecordBatch.get_array_memory_size()`

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -469,7 +469,8 @@ impl RecordBatch {
     }
 
     /// Returns the total number of bytes of memory occupied physically by this batch.
-    /// Note that this does not always correspond to the exact memory usage of an
+    ///
+    /// Note that this does not always correspond to the exact memory usage of a
     /// `RecordBatch` (might overestimate), since multiple columns can share the same
     /// buffers or slices thereof, the memory used by the shared buffers might be
     /// counted multiple times.

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -469,6 +469,10 @@ impl RecordBatch {
     }
 
     /// Returns the total number of bytes of memory occupied physically by this batch.
+    /// Note that this does not always correspond to the exact memory usage of an
+    /// `RecordBatch` (might overestimate), since multiple columns can share the same
+    /// buffers or slices thereof, the memory used by the shared buffers might be
+    /// counted multiple times.
     pub fn get_array_memory_size(&self) -> usize {
         self.columns()
             .iter()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
If multiple columns within one `RecordBatch` are sharing the same buffer to store array data, `get_array_memory_size()` will overcount the memory usage.
I found a bug caused by misusing this function (likely the same root cause as https://github.com/apache/arrow-rs/issues/6363)
So add more comments for the semantics
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
