### PR TITLE
Remove APIs deprecated since v 2.0.0

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -32,15 +32,6 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch, ArrowError>> {
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have the same schema as returned from this method.
     fn schema(&self) -> SchemaRef;
-
-    /// Reads the next `RecordBatch`.
-    #[deprecated(
-        since = "2.0.0",
-        note = "This method is deprecated in favour of `next` from the trait Iterator."
-    )]
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
-        self.next().transpose()
-    }
 }
 
 impl<R: RecordBatchReader + ?Sized> RecordBatchReader for Box<R> {

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -331,15 +331,6 @@ impl MutableBuffer {
         self.data.as_ptr()
     }
 
-    #[deprecated(
-        since = "2.0.0",
-        note = "This method is deprecated in favour of `into` from the trait `Into`."
-    )]
-    /// Freezes this buffer and return an immutable version of it.
-    pub fn freeze(self) -> Buffer {
-        self.into_buffer()
-    }
-
     #[inline]
     pub(super) fn into_buffer(self) -> Buffer {
         let bytes = unsafe { Bytes::new(self.data, self.len, Deallocation::Standard(self.layout)) };


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
The deprecated APIs are not supposed to stay around for ever. The purpose of deprecation is to eventually remove.

# What changes are included in this PR?

Remove `freeze` and `next_batch`.

# Are there any user-facing changes?


yes
