### PR TITLE
Re-enable `C#` arrow flight integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,8 +60,7 @@ jobs:
       ARROW_RUST_EXE_PATH: /build/rust/debug
       BUILD_DOCS_CPP: OFF
       ARROW_INTEGRATION_CPP: ON
-      # Disable C# integration tests due to https://github.com/apache/arrow-rs/issues/6577
-      ARROW_INTEGRATION_CSHARP: OFF
+      ARROW_INTEGRATION_CSHARP: ON
       ARROW_INTEGRATION_GO: ON
       ARROW_INTEGRATION_JAVA: ON
       ARROW_INTEGRATION_JS: ON

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -48,9 +48,13 @@ type Result<T = (), E = Error> = std::result::Result<T, E>;
 /// Run a scenario that tests integration testing.
 pub async fn scenario_setup(port: u16) -> Result {
     let addr = super::listen_on(port).await?;
+    let resolved_port = addr.port();
 
     let service = FlightServiceImpl {
-        server_location: format!("grpc+tcp://{addr}"),
+        // See https://github.com/apache/arrow-rs/issues/6577
+        // C# had trouble resolving addressed like 0.0.0.0:port
+        // server_location: format!("grpc+tcp://{addr}"),
+        server_location: format!("grpc+tcp://localhost:{resolved_port}"),
         ..Default::default()
     };
     let svc = FlightServiceServer::new(service);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes https://github.com/apache/arrow-rs/issues/6577

# Rationale for this change
 
This test was turned off in  https://github.com/apache/arrow-rs/pull/6598 as it was failing

# What changes are included in this PR?
Implement @adamreeve 's suggestion (❤️ )  from https://github.com/apache/arrow/pull/44377#issuecomment-2425385883
1. Change address sent in `FlightInfo` to be `localhost` rather than `0.0.0.0`
2. Re-enable the integration test


Note that @adamreeve says this might be something the C# client should handle, so maybe we should take a different approach 🤔 

> But I'm not 100% sure this isn't something the C# client should handle, given the other clients seem OK with it.


# Are there any user-facing changes?
No this is testing only

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
