### PR TITLE
Add `ParquetObjectReader::with_runtime`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-# The tokio_unstable flag is needed for the parquet::arrow::async_reader::test_runtime_is_used
-# test, as it relies on checking the amount of tasks that have run on a runtime
-[test]
-rustflags = ["--cfg", "tokio_unstable"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# The tokio_unstable flag is needed for the parquet::arrow::async_reader::test_runtime_is_used
+# test, as it relies on checking the amount of tasks that have run on a runtime
+[test]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -442,7 +442,7 @@ impl Encoder for ArrayFormatter<'_> {
 /// A newtype wrapper around [`ArrayFormatter`] that skips surrounding the value with `"`
 struct RawArrayFormatter<'a>(ArrayFormatter<'a>);
 
-impl<'a> Encoder for RawArrayFormatter<'a> {
+impl Encoder for RawArrayFormatter<'_> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         let _ = write!(out, "{}", self.0.value(idx));
     }

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -239,7 +239,7 @@ fn equals_kernel((n, h): (&u8, &u8)) -> bool {
 }
 
 fn equals_ignore_ascii_case_kernel((n, h): (&u8, &u8)) -> bool {
-    n.to_ascii_lowercase() == h.to_ascii_lowercase()
+    n.eq_ignore_ascii_case(h)
 }
 
 /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -28,6 +28,10 @@ readme = "README.md"
 edition = { workspace = true }
 rust-version = "1.70.0"
 
+# we need this for the arrow::async_reader::test_runtime_is_used test
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tokio_unstable)"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -28,10 +28,6 @@ readme = "README.md"
 edition = { workspace = true }
 rust-version = "1.70.0"
 
-# we need this for the arrow::async_reader::test_runtime_is_used test
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tokio_unstable)"] }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
 
@@ -85,7 +81,7 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "io-util", "fs"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 object_store = { version = "0.11.0", default-features = false, features = ["azure"] }
 

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -274,6 +274,7 @@ mod tests {
         tokio::runtime::Handle::current().spawn_blocking(move || drop(rt));
     }
 
+    /// Unit test that `ParquetObjectReader::spawn`spawns on the provided runtime
     #[tokio::test]
     async fn test_runtime_thread_id_different() {
         let rt = tokio::runtime::Builder::new_multi_thread()

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -21,12 +21,13 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{FutureExt, TryFutureExt};
-
+use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
+use tokio::runtime::Handle;
 
 use crate::arrow::async_reader::AsyncFileReader;
-use crate::errors::Result;
-use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
+use crate::errors::{ParquetError, Result};
+use crate::file::metadata::{ParquetMetaDataReader, ParquetMetaData};
 
 /// Reads Parquet files in object storage using [`ObjectStore`].
 ///
@@ -59,6 +60,7 @@ pub struct ParquetObjectReader {
     metadata_size_hint: Option<usize>,
     preload_column_index: bool,
     preload_offset_index: bool,
+    runtime: Option<Handle>,
 }
 
 impl ParquetObjectReader {
@@ -72,6 +74,7 @@ impl ParquetObjectReader {
             metadata_size_hint: None,
             preload_column_index: false,
             preload_offset_index: false,
+            runtime: None,
         }
     }
 
@@ -99,27 +102,57 @@ impl ParquetObjectReader {
             ..self
         }
     }
+
+    /// Perform IO on the provided tokio runtime
+    ///
+    /// Tokio is a cooperative scheduler, and relies on tasks yielding in a timely manner
+    /// to service IO. Therefore, running IO and CPU-bound tasks, such as parquet decoding,
+    /// on the same tokio runtime can lead to degraded throughput, dropped connections and
+    /// other issues. For more information see [here].
+    ///
+    /// [here]: https://www.influxdata.com/blog/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/
+    pub fn with_runtime(self, handle: Handle) -> Self {
+        Self {
+            runtime: Some(handle),
+            ..self
+        }
+    }
+
+    fn spawn<F, O>(&self, f: F) -> BoxFuture<'_, Result<O>>
+    where
+        F: for<'a> FnOnce(&'a Arc<dyn ObjectStore>, &'a Path) -> BoxFuture<'a, Result<O>>
+            + Send
+            + 'static,
+        O: Send + 'static,
+    {
+        match &self.runtime {
+            Some(handle) => {
+                let path = self.meta.location.clone();
+                let store = Arc::clone(&self.store);
+                let fut = handle.spawn(async move { f(&store, &path).await });
+                fut.unwrap_or_else(|e| match e.try_into_panic() {
+                    Ok(p) => std::panic::resume_unwind(p),
+                    Err(e) => Err(ParquetError::External(Box::new(e))),
+                })
+                .boxed()
+            }
+            None => f(&self.store, &self.meta.location),
+        }
+    }
 }
 
 impl AsyncFileReader for ParquetObjectReader {
     fn get_bytes(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>> {
-        self.store
-            .get_range(&self.meta.location, range)
-            .map_err(|e| e.into())
-            .boxed()
+        self.spawn(|store, path| store.get_range(path, range).map_err(|e| e.into()).boxed())
     }
 
     fn get_byte_ranges(&mut self, ranges: Vec<Range<usize>>) -> BoxFuture<'_, Result<Vec<Bytes>>>
     where
         Self: Send,
     {
-        async move {
-            self.store
-                .get_ranges(&self.meta.location, &ranges)
-                .await
-                .map_err(|e| e.into())
-        }
-        .boxed()
+        self.spawn(move |store, path| {
+            async move { store.get_ranges(path, &ranges).await.map_err(|e| e.into()) }.boxed()
+        })
     }
 
     fn get_metadata(&mut self) -> BoxFuture<'_, Result<Arc<ParquetMetaData>>> {

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -179,12 +179,9 @@ impl AsyncFileReader for ParquetObjectReader {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        convert::Infallible,
-        sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        },
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
     };
 
     use futures::TryStreamExt;
@@ -197,6 +194,7 @@ mod tests {
 
     use crate::arrow::async_reader::{AsyncFileReader, ParquetObjectReader};
     use crate::arrow::ParquetRecordBatchStreamBuilder;
+    use crate::errors::ParquetError;
 
     async fn get_meta_store() -> (ObjectMeta, Arc<dyn ObjectStore>) {
         let res = parquet_test_data();
@@ -293,7 +291,7 @@ mod tests {
         let current_id = std::thread::current().id();
 
         let other_id = reader
-            .spawn(|_, _| async move { Ok::<_, Infallible>(std::thread::current().id()) }.boxed())
+            .spawn(|_, _| async move { Ok::<_, ParquetError>(std::thread::current().id()) }.boxed())
             .await
             .unwrap();
 

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -107,6 +107,13 @@ impl From<str::Utf8Error> for ParquetError {
     }
 }
 
+#[cfg(test)]
+impl From<std::convert::Infallible> for ParquetError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}
+
 #[cfg(feature = "arrow")]
 impl From<ArrowError> for ParquetError {
     fn from(e: ArrowError) -> ParquetError {

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -106,14 +106,6 @@ impl From<str::Utf8Error> for ParquetError {
         ParquetError::External(Box::new(e))
     }
 }
-
-#[cfg(test)]
-impl From<std::convert::Infallible> for ParquetError {
-    fn from(value: std::convert::Infallible) -> Self {
-        match value {}
-    }
-}
-
 #[cfg(feature = "arrow")]
 impl From<ArrowError> for ParquetError {
     fn from(e: ArrowError) -> ParquetError {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6248

# What changes are included in this PR?

This PR works on top of #6249 to add a test for the new `with_runtime` fn, as well as changing the signature of the `spawn` function slightly to avoid an extra re-boxing when a runtime is set.

This also fixes a few things that `clippy` was complaining about.

# Rationale for this change

See #6248 for the API addition.

With regard to the test, I felt like this is really the only test we'd want for this feature - we just want to make sure that the runtime is actually being used by `ParquetObjectReader`. We can't make any guarantees about how it actually performs or would work if there's another runtime being used for CPU-bound operations, so all we really want to test is if it is used.

# Are there any user-facing changes?

No
