### PR TITLE
Add Parquet RowSelection benchmark

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -222,5 +222,9 @@ harness = false
 name = "metadata"
 harness = false
 
+[[bench]]
+name = "row_selector"
+harness = false
+
 [lib]
 bench = false

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -225,6 +225,7 @@ harness = false
 [[bench]]
 name = "row_selector"
 harness = false
+required-features = ["arrow"]
 
 [lib]
 bench = false

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::BooleanArray;
+use criterion::*;
+use parquet::arrow::arrow_reader::RowSelection;
+use rand::Rng;
+
+/// Generates a random RowSelection with a specified selection ratio.
+///
+/// # Arguments
+///
+/// * `total_rows` - The total number of rows in the selection.
+/// * `selection_ratio` - The ratio of rows to select (e.g., 1/3 for ~33% selection).
+///
+/// # Returns
+///
+/// * A `RowSelection` instance with randomly selected rows based on the provided ratio.
+fn generate_random_row_selection(total_rows: usize, selection_ratio: f64) -> RowSelection {
+    let mut rng = rand::thread_rng();
+    let bools: Vec<bool> = (0..total_rows)
+        .map(|_| rng.gen_bool(selection_ratio))
+        .collect();
+    let boolean_array = BooleanArray::from(bools);
+    RowSelection::from_filters(&[boolean_array])
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let total_rows = 300_000;
+    let selection_ratio = 1.0 / 3.0;
+
+    // Generate two random RowSelections with approximately 1/3 of the rows selected.
+    let row_selection_a = generate_random_row_selection(total_rows, selection_ratio);
+    let row_selection_b = generate_random_row_selection(total_rows, selection_ratio);
+
+    // Benchmark the intersection of the two RowSelections.
+    c.bench_function("intersection", |b| {
+        b.iter(|| {
+            let intersection = row_selection_a.intersection(&row_selection_b);
+            criterion::black_box(intersection);
+        })
+    });
+
+    c.bench_function("union", |b| {
+        b.iter(|| {
+            let union = row_selection_a.union(&row_selection_b);
+            criterion::black_box(union);
+        })
+    });
+
+    c.bench_function("from_filters", |b| {
+        let mut rng = rand::thread_rng();
+        let bools: Vec<bool> = (0..total_rows)
+            .map(|_| rng.gen_bool(selection_ratio))
+            .collect();
+        let boolean_array = BooleanArray::from(bools);
+        b.iter(|| {
+            let array = boolean_array.clone();
+            let selection = RowSelection::from_filters(&[array]);
+            criterion::black_box(selection);
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -74,6 +74,15 @@ fn criterion_benchmark(c: &mut Criterion) {
             criterion::black_box(selection);
         })
     });
+
+    c.bench_function("and_then", |b| {
+        let selected = row_selection_a.row_count();
+        let sub_selection = generate_random_row_selection(selected, selection_ratio);
+        b.iter(|| {
+            let result = row_selection_a.and_then(&sub_selection);
+            criterion::black_box(result);
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of  #5523

# Rationale for this change

As the first step of measure-then-build, we add some benchmarks.

The benchmark has 300_000 rows, and the selector will select 1/3 of the rows, this roughly matches with the `SearchPhase <> ''` predicate in many ClickBench queries.

I added `intersection`, `union`, `from_filters` and `and_then` because they are the most pronounced ones in the flamegraph.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
