### PR TITLE
Fix test feature selection so all feature combinations work as expected

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -31,7 +31,7 @@ use crate::schema::types;
 use crate::schema::types::SchemaDescriptor;
 use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", feature = "arrow"))]
 use crate::arrow::async_reader::MetadataFetch;
 
 /// Reads the [`ParquetMetaData`] from a byte stream.
@@ -321,7 +321,7 @@ impl ParquetMetaDataReader {
     ///
     /// See [`Self::with_prefetch_hint`] for a discussion of how to reduce the number of fetches
     /// performed by this function.
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     pub async fn load_and_finish<F: MetadataFetch>(
         mut self,
         fetch: F,
@@ -336,7 +336,7 @@ impl ParquetMetaDataReader {
     ///
     /// See [`Self::with_prefetch_hint`] for a discussion of how to reduce the number of fetches
     /// performed by this function.
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     pub async fn try_load<F: MetadataFetch>(
         &mut self,
         mut fetch: F,
@@ -357,12 +357,12 @@ impl ParquetMetaDataReader {
 
     /// Asynchronously fetch the page index structures when a [`ParquetMetaData`] has already
     /// been obtained. See [`Self::new_with_metadata()`].
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     pub async fn load_page_index<F: MetadataFetch>(&mut self, fetch: F) -> Result<()> {
         self.load_page_index_with_remainder(fetch, None).await
     }
 
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     async fn load_page_index_with_remainder<F: MetadataFetch>(
         &mut self,
         mut fetch: F,
@@ -513,7 +513,7 @@ impl ParquetMetaDataReader {
     /// Return the number of bytes to read in the initial pass. If `prefetch_size` has
     /// been provided, then return that value if it is larger than the size of the Parquet
     /// file footer (8 bytes). Otherwise returns `8`.
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     fn get_prefetch_size(&self) -> usize {
         if let Some(prefetch) = self.prefetch_hint {
             if prefetch > FOOTER_SIZE {
@@ -523,7 +523,7 @@ impl ParquetMetaDataReader {
         FOOTER_SIZE
     }
 
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", feature = "arrow"))]
     async fn load_metadata<F: MetadataFetch>(
         fetch: &mut F,
         file_size: usize,
@@ -851,7 +851,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", feature = "arrow"))]
 #[cfg(test)]
 mod async_tests {
     use super::*;

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -851,8 +851,7 @@ mod tests {
     }
 }
 
-#[cfg(all(feature = "async", feature = "arrow"))]
-#[cfg(test)]
+#[cfg(all(feature = "async", feature = "arrow", test))]
 mod async_tests {
     use super::*;
     use bytes::Bytes;

--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -111,6 +111,7 @@ fn test_arrow_rs_gh_6229_dict_header() {
 }
 
 #[test]
+#[cfg(feature = "snap")]
 fn test_arrow_rs_gh_6229_dict_levels() {
     let err = read_file("ARROW-RS-GH-6229-LEVELS.parquet").unwrap_err();
     assert_eq!(

--- a/parquet/tests/arrow_reader/checksum.rs
+++ b/parquet/tests/arrow_reader/checksum.rs
@@ -26,10 +26,10 @@ use parquet::arrow::arrow_reader::ArrowReaderBuilder;
 fn test_datapage_v1_corrupt_checksum() {
     let errors = read_file_batch_errors("datapage_v1-corrupt-checksum.parquet");
     assert_eq!(errors, [
-        Err("Parquet argument error: Parquet error: Page CRC checksum mismatch".to_string()), 
+        Err("Parquet argument error: Parquet error: Page CRC checksum mismatch".to_string()),
         Ok(()),
         Ok(()),
-        Err("Parquet argument error: Parquet error: Page CRC checksum mismatch".to_string()), 
+        Err("Parquet argument error: Parquet error: Page CRC checksum mismatch".to_string()),
         Err("Parquet argument error: Parquet error: Not all children array length are the same!".to_string())
     ]);
 }
@@ -41,6 +41,7 @@ fn test_datapage_v1_uncompressed_checksum() {
 }
 
 #[test]
+#[cfg(feature = "snap")]
 fn test_datapage_v1_snappy_compressed_checksum() {
     let errors = read_file_batch_errors("datapage_v1-snappy-compressed-checksum.parquet");
     assert_eq!(errors, [Ok(()), Ok(()), Ok(()), Ok(()), Ok(())]);
@@ -52,6 +53,7 @@ fn test_plain_dict_uncompressed_checksum() {
     assert_eq!(errors, [Ok(())]);
 }
 #[test]
+#[cfg(feature = "snap")]
 fn test_rle_dict_snappy_checksum() {
     let errors = read_file_batch_errors("rle-dict-snappy-checksum.parquet");
     assert_eq!(errors, [Ok(())]);


### PR DESCRIPTION
# Which issue does this PR close?

Some combinations of features cause compilation failures or test failures where not necessary. For example, in the `parquet/src/file/metadata/reader.rs` file, the `MetadataFetch` trait is only imported when `feature = "async"`, but that trait exists under a module that's marked `feature = "arrow"`, so we need to enable both those features to get it to work.

# Rationale for this change
 
There's nothing stopping people from using any combination of features from this crate, so we should make sure they're all supported

# What changes are included in this PR?

This just adds extra `#[cfg()]` attributes where necessary to fix compilation and test failures.

# Are there any user-facing changes?

No. It looks, on the surface, like we could be breaking the parquet crate for people who have the `async` flag enabled with the `arrow` flag disabled, but this crate doesn't compile in its current form for that combination, so this won't actually adversely affect anyone.
