### PR TITLE
Return error rather than panic when too many row groups are written

### DIFF
--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1900,10 +1900,10 @@ mod tests {
     #[test]
     fn test_too_many_rowgroups() {
         let message_type = "
-        message test_schema {
-            REQUIRED BYTE_ARRAY a (UTF8);
-        }
-    ";
+            message test_schema {
+                REQUIRED BYTE_ARRAY a (UTF8);
+            }
+        ";
         let schema = Arc::new(parse_message_type(message_type).unwrap());
         let file: File = tempfile::tempfile().unwrap();
         let props = Arc::new(
@@ -1914,10 +1914,11 @@ mod tests {
         );
         let mut writer = SerializedFileWriter::new(&file, schema, props).unwrap();
 
-        // create 32k empty rowgroups
+        // Create 32k empty rowgroups. Should error when i == 32768.
         for i in 0..0x8001 {
             match writer.next_row_group() {
                 Ok(mut row_group_writer) => {
+                    assert_ne!(i, 0x8000);
                     let col_writer = row_group_writer.next_column().unwrap().unwrap();
                     col_writer.close().unwrap();
                     row_group_writer.close().unwrap();

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -378,7 +378,12 @@ fn write_bloom_filters<W: Write + Send>(
         .ordinal()
         .expect("Missing row group ordinal")
         .try_into()
-        .expect("Negative row group ordinal");
+        .map_err(|_| {
+            ParquetError::General(format!(
+                "Negative row group ordinal: {})",
+                row_group.ordinal().unwrap()
+            ))
+        })?;
     let row_group_idx = row_group_idx as usize;
     for (column_idx, column_chunk) in row_group.columns_mut().iter_mut().enumerate() {
         if let Some(bloom_filter) = bloom_filters[row_group_idx][column_idx].take() {
@@ -1890,6 +1895,43 @@ mod tests {
             .unwrap();
         assert_eq!(page_sizes.len(), 1);
         assert_eq!(page_sizes[0], unenc_size);
+    }
+
+    #[test]
+    fn test_too_many_rowgroups() {
+        let message_type = "
+        message test_schema {
+            REQUIRED BYTE_ARRAY a (UTF8);
+        }
+    ";
+        let schema = Arc::new(parse_message_type(message_type).unwrap());
+        let file: File = tempfile::tempfile().unwrap();
+        let props = Arc::new(
+            WriterProperties::builder()
+                .set_statistics_enabled(EnabledStatistics::None)
+                .set_max_row_group_size(1)
+                .build(),
+        );
+        let mut writer = SerializedFileWriter::new(&file, schema, props).unwrap();
+
+        // create 32k empty rowgroups
+        for i in 0..0x8001 {
+            match writer.next_row_group() {
+                Ok(mut row_group_writer) => {
+                    let col_writer = row_group_writer.next_column().unwrap().unwrap();
+                    col_writer.close().unwrap();
+                    row_group_writer.close().unwrap();
+                }
+                Err(e) => {
+                    assert_eq!(i, 0x8000);
+                    assert_eq!(
+                        e.to_string(),
+                        "Parquet error: Parquet does not support more than 32767 row groups per file (currently: 32768)"
+                    );
+                }
+            }
+        }
+        writer.close().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6591.

# Rationale for this change
 
Does not panic in the unlikely event that the row group ordinal is negative when writing bloom filters.

# What changes are included in this PR?

Replace `expect` with `map_err`, also adds test for changes from #6378.

# Are there any user-facing changes?

No, since the panic should no longer be possible to trigger.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
