### PR TITLE
Add `ParquetError::NeedMoreData` mark `ParquetError` as `non_exhaustive`

### DIFF
--- a/parquet/src/arrow/async_reader/metadata.rs
+++ b/parquet/src/arrow/async_reader/metadata.rs
@@ -119,7 +119,7 @@ impl<F: MetadataFetch> MetadataLoader<F> {
             return Err(ParquetError::EOF(format!(
                 "file size of {} is less than footer + metadata {}",
                 file_size,
-                length + 8
+                length + FOOTER_SIZE
             )));
         }
 

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -47,6 +47,8 @@ pub enum ParquetError {
     IndexOutOfBound(usize, usize),
     /// An external error variant
     External(Box<dyn Error + Send + Sync>),
+    /// Returned when a function needs more data to complete properly.
+    NeedMoreData(usize),
 }
 
 impl std::fmt::Display for ParquetError {
@@ -63,6 +65,7 @@ impl std::fmt::Display for ParquetError {
                 write!(fmt, "Index {index} out of bound: {bound}")
             }
             ParquetError::External(e) => write!(fmt, "External: {e}"),
+            ParquetError::NeedMoreData(needed) => write!(fmt, "NeedMoreData: {needed}"),
         }
     }
 }

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -27,6 +27,7 @@ use arrow_schema::ArrowError;
 // Note: we don't implement PartialEq as the semantics for the
 // external variant are not well defined (#4469)
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ParquetError {
     /// General Parquet error.
     /// Returned when code violates normal workflow of working with Parquet files.

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -48,7 +48,8 @@ pub enum ParquetError {
     IndexOutOfBound(usize, usize),
     /// An external error variant
     External(Box<dyn Error + Send + Sync>),
-    /// Returned when a function needs more data to complete properly.
+    /// Returned when a function needs more data to complete properly. The `usize` field indicates
+    /// the total number of bytes required, not the number of additional bytes.
     NeedMoreData(usize),
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #6447.

# Rationale for this change
 
`ParquetMetaDataReader` currently uses `ParquetError::IndexOutOfBound` to indicate the need for more data. This is not the intended use for `IndexOutOfBound`.

# What changes are included in this PR?
Adds a  new enum value `NeedMoreData`.

# Are there any user-facing changes?
Yes, this changes the `ParquetError` API as well as `ParquetMetaDataReader`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
