### PR TITLE
object_store: Add enabled-by-default "fs" feature

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -54,6 +54,10 @@ jobs:
       # targets.
       - name: Run clippy with default features
         run: cargo clippy -- -D warnings
+      - name: Run clippy without default features
+        run: cargo clippy --no-default-features -- -D warnings
+      - name: Run clippy with fs features
+        run: cargo clippy --no-default-features --features fs -- -D warnings
       - name: Run clippy with aws feature
         run: cargo clippy --features aws -- -D warnings
       - name: Run clippy with gcp feature

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -41,7 +41,7 @@ percent-encoding = "2.1"
 snafu = { version = "0.8", default-features = false, features = ["std", "rust_1_61"] }
 tracing = { version = "0.1" }
 url = "2.2"
-walkdir = "2"
+walkdir = { version = "2", optional = true }
 
 # Cloud storage support
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
@@ -61,8 +61,10 @@ httparse = { version = "1.8.0", default-features = false, features = ["std"], op
 nix = { version = "0.29.0", features = ["fs"] }
 
 [features]
+default = ["fs"]
 cloud = ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/json", "reqwest/stream", "chrono/serde", "base64", "rand", "ring"]
 azure = ["cloud", "httparse"]
+fs = ["walkdir"]
 gcp = ["cloud", "rustls-pemfile"]
 aws = ["cloud", "md-5"]
 http = ["cloud"]

--- a/object_store/src/chunked.rs
+++ b/object_store/src/chunked.rs
@@ -86,6 +86,7 @@ impl ObjectStore for ChunkedStore {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let r = self.inner.get_opts(location, options).await?;
         let stream = match r.payload {
+            #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
             GetResultPayload::File(file, path) => {
                 crate::local::chunked_stream(file, path, r.range.clone(), self.chunk_size)
             }
@@ -178,7 +179,9 @@ impl ObjectStore for ChunkedStore {
 mod tests {
     use futures::StreamExt;
 
+    #[cfg(feature = "fs")]
     use crate::integration::*;
+    #[cfg(feature = "fs")]
     use crate::local::LocalFileSystem;
     use crate::memory::InMemory;
     use crate::path::Path;
@@ -209,6 +212,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "fs")]
     #[tokio::test]
     async fn test_chunked() {
         let temporary = tempfile::tempdir().unwrap();

--- a/object_store/src/limit.rs
+++ b/object_store/src/limit.rs
@@ -199,6 +199,7 @@ impl<T: ObjectStore> ObjectStore for LimitStore<T> {
 
 fn permit_get_result(r: GetResult, permit: OwnedSemaphorePermit) -> GetResult {
     let payload = match r.payload {
+        #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
         v @ GetResultPayload::File(_, _) => v,
         GetResultPayload::Stream(s) => {
             GetResultPayload::Stream(PermitWrapper::new(s, permit).boxed())

--- a/object_store/src/parse.rs
+++ b/object_store/src/parse.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 use crate::local::LocalFileSystem;
 use crate::memory::InMemory;
 use crate::path::Path;
@@ -179,7 +179,7 @@ where
     let path = Path::parse(path)?;
 
     let store = match scheme {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
         ObjectStoreScheme::Local => Box::new(LocalFileSystem::new()) as _,
         ObjectStoreScheme::Memory => Box::new(InMemory::new()) as _,
         #[cfg(feature = "aws")]

--- a/object_store/src/throttle.rs
+++ b/object_store/src/throttle.rs
@@ -307,8 +307,10 @@ fn usize_to_u32_saturate(x: usize) -> u32 {
 }
 
 fn throttle_get(result: GetResult, wait_get_per_byte: Duration) -> GetResult {
+    #[allow(clippy::infallible_destructuring_match)]
     let s = match result.payload {
         GetResultPayload::Stream(s) => s,
+        #[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
         GetResultPayload::File(_, _) => unimplemented!(),
     };
 

--- a/object_store/src/util.rs
+++ b/object_store/src/util.rs
@@ -75,7 +75,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "fs", not(target_arch = "wasm32")))]
 /// Takes a function and spawns it to a tokio blocking pool if available
 pub(crate) async fn maybe_spawn_blocking<F, T>(f: F) -> Result<T>
 where


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6055.

# Rationale for this change
 
see https://github.com/apache/arrow-rs/issues/6055 😉 

# What changes are included in this PR?

This PR introduces a new `fs` feature for the `object_store` crate, which is enabled by default. If disabled, the `local` module is excluded from the crate and the `walkdir` dependency is skipped.

# Are there any user-facing changes?

Only for users of `default-features = false`, but since this crate did not have any default features before there probably won't be many `object_store` users that specify `default-features = false`.
