### PR TITLE
fix: enable TLS roots for flight CLI client

### DIFF
--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -357,7 +357,7 @@ async fn setup_client(args: ClientArgs) -> Result<FlightSqlServiceClient<Channel
         .keep_alive_while_idle(true);
 
     if args.tls {
-        let tls_config = ClientTlsConfig::new();
+        let tls_config = ClientTlsConfig::new().with_enabled_roots();
         endpoint = endpoint
             .tls_config(tls_config)
             .context("create TLS endpoint")?;


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Otherwise you get:

```text
Error: setup client

Caused by:
    0: connect to endpoint
    1: transport error
    2: invalid peer certificate: UnknownIssuer
    3: invalid peer certificate: UnknownIssuer
```

Also see https://github.com/hyperium/tonic/issues/1904 .

# What changes are included in this PR?
Just call the method that registers the roots that we include via feature flags anyways.

# Are there any user-facing changes?
TLS works again.