### PR TITLE
Add support for deserializing list-encoded JSON structs [#6558]

### DIFF
--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -17,6 +17,7 @@
 
 use crate::reader::tape::{Tape, TapeElement};
 use crate::reader::{make_decoder, ArrayDecoder};
+use crate::StructMode;
 use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::buffer::NullBuffer;
@@ -37,6 +38,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
         coerce_primitive: bool,
         strict_mode: bool,
         is_nullable: bool,
+        struct_mode: StructMode,
     ) -> Result<Self, ArrowError> {
         let field = match &data_type {
             DataType::List(f) if !O::IS_LARGE => f,
@@ -48,6 +50,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
             coerce_primitive,
             strict_mode,
             field.is_nullable(),
+            struct_mode,
         )?;
 
         Ok(Self {

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -17,6 +17,7 @@
 
 use crate::reader::tape::{Tape, TapeElement};
 use crate::reader::{make_decoder, ArrayDecoder};
+use crate::StructMode;
 use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder};
 use arrow_buffer::buffer::NullBuffer;
 use arrow_buffer::ArrowNativeType;
@@ -36,6 +37,7 @@ impl MapArrayDecoder {
         coerce_primitive: bool,
         strict_mode: bool,
         is_nullable: bool,
+        struct_mode: StructMode,
     ) -> Result<Self, ArrowError> {
         let fields = match &data_type {
             DataType::Map(_, true) => {
@@ -59,12 +61,14 @@ impl MapArrayDecoder {
             coerce_primitive,
             strict_mode,
             fields[0].is_nullable(),
+            struct_mode,
         )?;
         let values = make_decoder(
             fields[1].data_type().clone(),
             coerce_primitive,
             strict_mode,
             fields[1].is_nullable(),
+            struct_mode,
         )?;
 
         Ok(Self {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6558.

# Rationale for this change
 
Currently, a StructArray can only be deserialized from a JSON object (e.g. `{a: 1, b: "c"}`), but some services (e.g. Presto and Trino) encode ROW types as JSON lists (e.g. `[1, "c"]`) because this is more compact, and the schema is known.
Arrow-json cannot currently deserialize these.


# What changes are included in this PR?

This PR adds the ability to parse JSON lists into StructArrays, if the StructParseMode is set to ListOnly.  In ListOnly mode, object-encoded structs raise an error.  Setting to ObjectOnly (the default) has the original parsing behavior.

# Are there any user-facing changes?

Users may set the `StructParsingMode` enum to `ListOnly` to parse list-style structs.  The associated enum,
variants, and method have been documented.  I'm happy to update any other documentation.

# Discussion topics

1. I've made a JsonParseMode struct instead of a bool flag for two reasons.  One is that it's self-descriptive (what would `true` be?), and the other is that it allows a future Mixed mode that could deserialize either.  The latter isn't currently requested by anyone.
2. I kept the error messages as similar to the old messages as possible. I considered having more specific error messages (like "Encountered a '[' when parsing a Struct, but the StructParseMode is ObjectOnly" or similar), but wanted to hear opinions before I went that route.
3. I'm not attached to any name/code-style/etc, so happy to modify to fit local conventions.
4. One requirement was that benchmarks do not regress.  My running of benchmarks have been inconclusive (see https://gist.github.com/jagill/6749248171a1f12fb7c653ff70c5ed42).  There are often small regressions or improvements in the single-digit % range whenever I switch between master and this PR.  I suspect they are statistical but I wanted to note these.
