### PR TITLE
fix: include chrono-tz in flight sql cli

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -65,7 +65,7 @@ flight-sql-experimental = ["arrow-arith", "arrow-data", "arrow-ord", "arrow-row"
 tls = ["tonic/tls"]
 
 # Enable CLI tools
-cli = ["anyhow", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
+cli = ["anyhow", "arrow-array/chrono-tz", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Otherwise you get an error like:

```text
Error: format results

Caused by:
    Parser error: Invalid timezone \"Europe/Berlin\": only offset based timezones supported without chrono-tz feature
```

# What changes are included in this PR?
- enable required feature
- add test

# Are there any user-facing changes?
Printing results w/ time zones now works.