### PR TITLE
Let std::fmt::Debug for StructArray output Null/Validity info

### DIFF
--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::array::print_long_array;
 use crate::{make_array, new_null_array, Array, ArrayRef, RecordBatch};
 use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
@@ -407,21 +408,7 @@ impl std::fmt::Debug for StructArray {
         writeln!(f, "StructArray")?;
         writeln!(f, "-- validity: ")?;
         writeln!(f, "[")?;
-        let head = std::cmp::min(10, self.len());
-        for i in 0..head {
-            writeln!(f, "  {},", if self.is_valid(i) { "valid" } else { "null" })?;
-        }
-        if self.len() > 10 {
-            if self.len() > 20 {
-                writeln!(f, "  ...{} elements...,", self.len() - 20)?;
-            }
-
-            let tail = std::cmp::max(head, self.len() - 10);
-
-            for i in tail..self.len() {
-                writeln!(f, "  {},", if self.is_valid(i) { "valid" } else { "null" })?;
-            }
-        }
+        print_long_array(self, f, |_array, _index, f| write!(f, "valid"))?;
         writeln!(f, "]\n[")?;
         for (child_index, name) in self.column_names().iter().enumerate() {
             let column = self.column(child_index);

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -408,7 +408,7 @@ impl std::fmt::Debug for StructArray {
         writeln!(f, "-- validity: ")?;
         writeln!(f, "[")?;
         for i in 0..self.len() {
-            write!(f, "  {},\n", self.is_valid(i))?;
+            writeln!(f, "  {},", if self.is_valid(i) { "valid" } else { "null" })?;
         }
         writeln!(f, "]\n[")?;
         for (child_index, name) in self.column_names().iter().enumerate() {

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -404,7 +404,13 @@ impl From<Vec<(FieldRef, ArrayRef)>> for StructArray {
 
 impl std::fmt::Debug for StructArray {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "StructArray\n[\n")?;
+        writeln!(f, "StructArray")?;
+        writeln!(f, "-- validity: ")?;
+        writeln!(f, "[")?;
+        for i in 0..self.len() {
+            write!(f, "  {},\n", self.is_valid(i))?;
+        }
+        writeln!(f, "]\n[")?;
         for (child_index, name) in self.column_names().iter().enumerate() {
             let column = self.column(child_index);
             writeln!(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

When we are comparing whether two Arrays/RecordBatches are equal (e.g., `assert_eq!(array1, array2)`, we also compare `NullBuffer` in `ArrayData`). Right now it is possible that two `StructArray`s are different because of the struct-level nulls but their debug format strings are the same, which brings confusion for debugging.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
