### PR TITLE
Fix string view LIKE checks with NULL values

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -1708,7 +1708,93 @@ mod tests {
     }
 
     #[test]
-    fn like_scalar_null() {
+    fn string_null_like_pattern() {
+        // Different patterns have different execution code paths
+        for pattern in &[
+            "",           // can execute as equality check
+            "_",          // can execute as length check
+            "%",          // can execute as starts_with("") or non-null check
+            "a%",         // can execute as starts_with("a")
+            "%a",         // can execute as ends_with("")
+            "a%b",        // can execute as starts_with("a") && ends_with("b")
+            "%a%",        // can_execute as contains("a")
+            "%a%b_c_d%e", // can_execute as regular expression
+        ] {
+            let a = Scalar::new(StringArray::new_null(1));
+            let b = StringArray::new_scalar(pattern);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = Scalar::new(StringArray::new_null(1));
+            let b = StringArray::from_iter_values([pattern]);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = StringArray::new_null(1);
+            let b = StringArray::from_iter_values([pattern]);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = StringArray::new_null(1);
+            let b = StringArray::new_scalar(pattern);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+        }
+    }
+
+    #[test]
+    fn string_view_null_like_pattern() {
+        // Different patterns have different execution code paths
+        for pattern in &[
+            "",           // can execute as equality check
+            "_",          // can execute as length check
+            "%",          // can execute as starts_with("") or non-null check
+            "a%",         // can execute as starts_with("a")
+            "%a",         // can execute as ends_with("")
+            "a%b",        // can execute as starts_with("a") && ends_with("b")
+            "%a%",        // can_execute as contains("a")
+            "%a%b_c_d%e", // can_execute as regular expression
+        ] {
+            let a = Scalar::new(StringViewArray::new_null(1));
+            let b = StringViewArray::new_scalar(pattern);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = Scalar::new(StringViewArray::new_null(1));
+            let b = StringViewArray::from_iter_values([pattern]);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = StringViewArray::new_null(1);
+            let b = StringViewArray::from_iter_values([pattern]);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+
+            let a = StringViewArray::new_null(1);
+            let b = StringViewArray::new_scalar(pattern);
+            let r = like(&a, &b).unwrap();
+            assert_eq!(r.len(), 1, "With pattern {pattern}");
+            assert_eq!(r.null_count(), 1, "With pattern {pattern}");
+            assert!(r.is_null(0), "With pattern {pattern}");
+        }
+    }
+
+    #[test]
+    fn string_like_scalar_null() {
         let a = StringArray::new_scalar("a");
         let b = Scalar::new(StringArray::new_null(1));
         let r = like(&a, &b).unwrap();
@@ -1732,6 +1818,37 @@ mod tests {
 
         let a = StringArray::new_scalar("a");
         let b = StringArray::new_null(1);
+        let r = like(&a, &b).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.null_count(), 1);
+        assert!(r.is_null(0));
+    }
+
+    #[test]
+    fn string_view_like_scalar_null() {
+        let a = StringViewArray::new_scalar("a");
+        let b = Scalar::new(StringViewArray::new_null(1));
+        let r = like(&a, &b).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.null_count(), 1);
+        assert!(r.is_null(0));
+
+        let a = StringViewArray::from_iter_values(["a"]);
+        let b = Scalar::new(StringViewArray::new_null(1));
+        let r = like(&a, &b).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.null_count(), 1);
+        assert!(r.is_null(0));
+
+        let a = StringViewArray::from_iter_values(["a"]);
+        let b = StringViewArray::new_null(1);
+        let r = like(&a, &b).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.null_count(), 1);
+        assert!(r.is_null(0));
+
+        let a = StringViewArray::new_scalar("a");
+        let b = StringViewArray::new_null(1);
         let r = like(&a, &b).unwrap();
         assert_eq!(r.len(), 1);
         assert_eq!(r.null_count(), 1);

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -114,27 +114,9 @@ impl<'a> Predicate<'a> {
             Predicate::IEqAscii(v) => BooleanArray::from_unary(array, |haystack| {
                 haystack.eq_ignore_ascii_case(v) != negate
             }),
-            Predicate::Contains(finder) => {
-                if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
-                    let nulls = string_view_array.logical_nulls();
-                    BooleanArray::from(
-                        string_view_array
-                            .bytes_iter()
-                            .enumerate()
-                            .map(|(idx, haystack)| {
-                                if nulls.as_ref().map(|n| n.is_null(idx)).unwrap_or_default() {
-                                    return None;
-                                }
-                                Some(finder.find(haystack).is_some() != negate)
-                            })
-                            .collect::<Vec<_>>(),
-                    )
-                } else {
-                    BooleanArray::from_unary(array, |haystack| {
-                        finder.find(haystack.as_bytes()).is_some() != negate
-                    })
-                }
-            }
+            Predicate::Contains(finder) => BooleanArray::from_unary(array, |haystack| {
+                finder.find(haystack.as_bytes()).is_some() != negate
+            }),
             Predicate::StartsWith(v) => {
                 if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
                     let nulls = string_view_array.logical_nulls();

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -158,6 +158,7 @@ impl<'a> Predicate<'a> {
             }
             Predicate::IStartsWithAscii(v) => {
                 if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
+                    // TODO respect null buffer
                     BooleanArray::from(
                         string_view_array
                             .prefix_bytes_iter(v.len())
@@ -199,6 +200,7 @@ impl<'a> Predicate<'a> {
             }
             Predicate::IEndsWithAscii(v) => {
                 if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
+                    // TODO respect null buffer
                     BooleanArray::from(
                         string_view_array
                             .suffix_bytes_iter(v.len())


### PR DESCRIPTION
# Which issue does this PR close?

- for https://github.com/apache/datafusion/issues/12637#issuecomment-2449571495

# Rationale for this change
 
Fix correctness

# What changes are included in this PR?

Fix `StringView LIKE ..` result when tested values include nulls.

# Are there any user-facing changes?

Yes