### PR TITLE
Support `Utf8View` for `bit_length` kernel

### DIFF
--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -138,15 +138,10 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
             let list = array.as_string::<i64>();
             Ok(bit_length_impl::<Int64Type>(list.offsets(), list.nulls()))
         }
-        DataType::Utf8View => {
-            let list = array.as_string_view();
-            let values = list
-                .views()
-                .iter()
-                .map(|view| (*view as i32).wrapping_mul(8))
-                .collect();
-            Ok(Arc::new(Int32Array::new(values, array.nulls().cloned())))
-        }
+        DataType::Utf8View => Ok(Arc::new(Int32Array::from_unary(
+            array.as_string_view(),
+            |x| i32::mul_wrapping(x.bytes().len() as i32, 8),
+        ))),
         DataType::Binary => {
             let list = array.as_binary::<i32>();
             Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -138,10 +138,15 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
             let list = array.as_string::<i64>();
             Ok(bit_length_impl::<Int64Type>(list.offsets(), list.nulls()))
         }
-        DataType::Utf8View => Ok(Arc::new(Int32Array::from_unary(
-            array.as_string_view(),
-            |x| i32::mul_wrapping(x.bytes().len() as i32, 8),
-        ))),
+        DataType::Utf8View => {
+            let list = array.as_string_view();
+            let values = list
+                .views()
+                .iter()
+                .map(|view| (*view as i32).wrapping_mul(8))
+                .collect();
+            Ok(Arc::new(Int32Array::new(values, array.nulls().cloned())))
+        }
         DataType::Binary => {
             let list = array.as_binary::<i32>();
             Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -137,6 +137,10 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
             let list = array.as_string::<i64>();
             Ok(bit_length_impl::<Int64Type>(list.offsets(), list.nulls()))
         }
+        DataType::Utf8View => {
+            let list = array.as_string::<i32>();
+            Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))
+        }
         DataType::Binary => {
             let list = array.as_binary::<i32>();
             Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -116,8 +116,6 @@ pub fn length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
 /// * bit_length of null is null.
 /// * bit_length is in number of bits
 pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    println!("In Array bit_length()");
-
     if let Some(d) = array.as_any_dictionary_opt() {
         let lengths = bit_length(d.values().as_ref())?;
         return Ok(d.with_values(lengths));
@@ -142,11 +140,8 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
         }
         DataType::Utf8View => {
             let list = array.as_string_view();
-            let values = list
-                .views()
-                .iter()
-                .enumerate()
-                .map(|(i, _)| {
+            let values = (0..list.len())
+                .map(|i| {
                     if list.is_valid(i) {
                         list.views()[i] as u32 * 8
                     } else {
@@ -154,7 +149,6 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
                     }
                 })
                 .collect::<Vec<u32>>();
-
             Ok(Arc::new(UInt32Array::new(
                 values.into(),
                 array.nulls().cloned(),
@@ -180,8 +174,6 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
 
 #[cfg(test)]
 mod tests {
-    use std::ptr::null;
-
     use super::*;
     use arrow_buffer::Buffer;
     use arrow_data::ArrayData;

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -19,9 +19,8 @@
 
 use arrow_array::*;
 use arrow_array::{cast::AsArray, types::*};
-use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer};
 use arrow_schema::{ArrowError, DataType};
-use cast::as_string_array;
 use std::sync::Arc;
 
 fn length_impl<P: ArrowPrimitiveType>(


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/13195

# Rationale for this change
 
Thanks to @jayzhan211 , he noticed following issue, array compute kernel `bit_length()` doesn't support `Utf8View` type:
```rust
create table test_source as values
  ('Andrew', 'X'),
  ('Xiangpeng', 'Xiangpeng'),
  ('Raphael', 'R'),
  (NULL, 'R');
create table test as
SELECT
  arrow_cast(column1, 'Utf8View') as column1_utf8view
FROM test_source;

select bit_length(column1_utf8view) from test;
```
caused the error:
```rust
query error DataFusion error: Arrow error: Compute error: bit_length not supported for Utf8View
```

# What changes are included in this PR?

Update `bit_length()` array function to support `Utf8View`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
