### PR TITLE
[ffi] Fix arrow-array null_count error during conversion from C to Rust

### DIFF
--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -271,6 +271,18 @@ impl FFI_ArrowArray {
         self.null_count as usize
     }
 
+    /// whether the null count value is valid
+    #[inline]
+    pub fn null_count_checked(&self) -> bool {
+        self.null_count >= 0
+    }
+
+    /// set the null count of the array
+    #[inline]
+    pub fn set_null_count(&mut self, null_count: i64) {
+        self.null_count = null_count;
+    }
+
     /// Returns the buffer at the provided index
     ///
     /// # Panic

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -277,9 +277,10 @@ impl FFI_ArrowArray {
         usize::try_from(self.null_count).ok()
     }
 
-    /// # Safety
-    ///
     /// Set the null count of the array
+    ///
+    /// # Safety
+    /// Null count must match that of null buffer
     #[inline]
     pub unsafe fn set_null_count(&mut self, null_count: i64) {
         self.null_count = null_count;

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -271,15 +271,15 @@ impl FFI_ArrowArray {
         self.null_count as usize
     }
 
-    /// whether the null count value is valid
+    /// Returns the null count, checking for validity
     #[inline]
-    pub fn null_count_checked(&self) -> bool {
-        self.null_count >= 0
+    pub fn null_count_opt(&self) -> Option<usize> {
+        usize::try_from(self.null_count).ok()
     }
 
     /// set the null count of the array
     #[inline]
-    pub fn set_null_count(&mut self, null_count: i64) {
+    pub unsafe fn set_null_count(&mut self, null_count: i64) {
         self.null_count = null_count;
     }
 

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -277,7 +277,9 @@ impl FFI_ArrowArray {
         usize::try_from(self.null_count).ok()
     }
 
-    /// set the null count of the array
+    /// # Safety
+    ///
+    /// Set the null count of the array
     #[inline]
     pub unsafe fn set_null_count(&mut self, null_count: i64) {
         self.null_count = null_count;


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6497
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
1. Let FFI_ArrowArray null_count() function return `Option<usize>`, and return None if the value of null_count  < 0.
2. Pass FFI_ArrowArray null_count() to ArrayData 's null_count, which is also `Option<usize>`, ArrayData will initialize if value is None. 
3. Add UT to verify it.



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
