### PR TITLE
Check predicate and values are the same length for run end array filter safety

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -1288,10 +1288,19 @@ mod tests {
         let run_ends = Int64Array::from(vec![2, 3, 8, 10]);
         let values = Int64Array::from(vec![7, -2, 9, -8]);
         let a = RunArray::try_new(&run_ends, &values).expect("Failed to create RunArray");
-        let b = BooleanArray::from(vec![false, true, false]);
+        let b = BooleanArray::from(vec![false, true, true]);
         let c = filter(&a, &b).unwrap();
         let actual: &RunArray<Int64Type> = as_run_array(&c);
-        assert_eq!(1, actual.len());
+        assert_eq!(2, actual.len());
+
+        let expected = RunArray::try_new(
+            &Int64Array::from(vec![1, 2]),
+            &Int64Array::from(vec![7, -2]),
+        )
+        .expect("Failed to make expected RunArray test is broken");
+
+        assert_eq!(&actual.run_ends().values(), &expected.run_ends().values());
+        assert_eq!(actual.values(), expected.values())
     }
 
     #[test]

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -380,7 +380,7 @@ fn filter_array(values: &dyn Array, predicate: &FilterPredicate) -> Result<Array
             DataType::RunEndEncoded(_, _) => {
                 if predicate.filter.len() != values.len() {
                     return Err(ArrowError::InvalidArgumentError(format!(
-                        "Filter predicate of length {} is not equal than target array of length {}",
+                        "Filter predicate of length {} is not equal to the target array of length {}",
                         predicate.filter.len(),
                         values.len()
                     )));


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6569

# Rationale for this change

It's possible for a filter predicate with less values than the target array to be passed into `filter_run_end_array` which will result in an out of bounds index on the filter values, as described in the issue.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

<s> 
* Mark `filter_run_end_array` as unsafe
* Check the predicate and values have the same length before calling `filter_run_end_array`
* Add a test for an error if the predicate and values do not have the same length
</s>

I thought that it would be inconsistent with the other filters to have this one return an error if the lengths do not match. Eg for an int or string array filter if there are less filter values than array values then those extra values are filtered out. I replaced the unchecked filter value with a skip/take iterator.

# Are there any user-facing changes?

<s>An error is returned if the predicate and values do not have the same length</s>
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
