### PR TITLE
Don't attempt to run 64-bit tests on 32-bit platforms

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -665,9 +665,18 @@ mod tests {
         );
 
         let err = v.try_append_view(0, u32::MAX, 1).unwrap_err();
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(err.to_string(), "Invalid argument error: Range 4294967295..4294967295 out of bounds for block of length 17");
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(err.to_string(), "Invalid argument error: Range 4294967295..4294967296 out of bounds for block of length 17");
 
         let err = v.try_append_view(0, 1, u32::MAX).unwrap_err();
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument error: Range 1..4294967295 out of bounds for block of length 17"
+        );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             err.to_string(),
             "Invalid argument error: Range 1..4294967296 out of bounds for block of length 17"

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -678,6 +678,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn byte_size_should_not_regress() {
         let schema = Schema::new(vec![
             Field::new("a", DataType::Int32, false),

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -345,10 +345,16 @@ mod tests {
         assert_eq!(IntervalDayTime::new(1, 0).as_usize(), 1);
         assert_eq!(IntervalMonthDayNano::new(1, 0, 0).as_usize(), 1);
 
+        #[cfg(target_pointer_width = "32")]
+        let a = IntervalDayTime::new(23, 0);
+        #[cfg(target_pointer_width = "64")]
         let a = IntervalDayTime::new(23, 53);
         let b = IntervalDayTime::usize_as(a.as_usize());
         assert_eq!(a, b);
 
+        #[cfg(target_pointer_width = "32")]
+        let a = IntervalMonthDayNano::new(23, 0, 0);
+        #[cfg(target_pointer_width = "64")]
         let a = IntervalMonthDayNano::new(23, 53, 0);
         let b = IntervalMonthDayNano::usize_as(a.as_usize());
         assert_eq!(a, b);

--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ceil() {
+    fn test_ceil_with_32_bits() {
         assert_eq!(ceil(0, 1), 0);
         assert_eq!(ceil(1, 1), 1);
         assert_eq!(ceil(1, 2), 1);
@@ -266,8 +266,16 @@ mod tests {
         assert_eq!(ceil(8, 8), 1);
         assert_eq!(ceil(9, 8), 2);
         assert_eq!(ceil(9, 9), 1);
-        assert_eq!(ceil(10000000000, 10), 1000000000);
-        assert_eq!(ceil(10, 10000000000), 1);
-        assert_eq!(ceil(10000000000, 1000000000), 10);
+        assert_eq!(ceil(1_000_000_000, 10), 100_000_000);
+        assert_eq!(ceil(10, 1_000_000_000), 1);
+        assert_eq!(ceil(1_000_000_000, 100_000_000), 10);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_ceil_with_64_bits() {
+        assert_eq!(ceil(10_000_000_000_000, 10), 1_000_000_000_000);
+        assert_eq!(ceil(10, 10_000_000_000_000), 1);
+        assert_eq!(ceil(10_000_000_000_000, 1_000_000_000_000), 10);
     }
 }

--- a/arrow-integration-testing/tests/ipc_writer.rs
+++ b/arrow-integration-testing/tests/ipc_writer.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::ipc;
 use arrow::ipc::reader::{FileReader, StreamReader};
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions, StreamWriter};
 use arrow::util::test_util::arrow_test_data;
@@ -91,7 +90,9 @@ fn write_1_0_0_littleendian() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn write_2_0_0_compression() {
+    use arrow::ipc;
     let testdata = arrow_test_data();
     let version = "2.0.0-compression";
     let paths = ["generated_lz4", "generated_zstd"];

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -2678,6 +2678,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_decimal128_alignment8_is_unaligned() {
         const IPC_ALIGNMENT: usize = 8;
 

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1250,7 +1250,8 @@ mod tests {
         test_timestamp::<TimestampNanosecondType>();
     }
 
-    fn test_time<T: ArrowTemporalType>() {
+    #[cfg(target_pointer_width = "64")]
+    fn test_time_with_64_bits<T: ArrowTemporalType>() {
         let buf = r#"
         {"a": 1, "b": "09:26:56.123 AM", "c": 38.30}
         {"a": 2, "b": "23:59:59", "c": 123.456}
@@ -1323,11 +1324,12 @@ mod tests {
     }
 
     #[test]
-    fn test_times() {
-        test_time::<Time32MillisecondType>();
-        test_time::<Time32SecondType>();
-        test_time::<Time64MicrosecondType>();
-        test_time::<Time64NanosecondType>();
+    #[cfg(target_pointer_width = "64")]
+    fn test_times_with_64_bits() {
+        test_time_with_64_bits::<Time32MillisecondType>();
+        test_time_with_64_bits::<Time32SecondType>();
+        test_time_with_64_bits::<Time64MicrosecondType>();
+        test_time_with_64_bits::<Time64NanosecondType>();
     }
 
     #[test]

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -1058,6 +1058,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn size_should_not_regress() {
         assert_eq!(std::mem::size_of::<DataType>(), 24);
     }

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -54,6 +54,7 @@ fn test_bad_number_of_buffers() {
 #[should_panic(
     expected = "Need at least 18446744073709551615 bytes in buffers[0] in array of type Int64, but got 8"
 )]
+#[cfg(target_pointer_width = "64")]
 fn test_fixed_width_overflow() {
     let buffer = Buffer::from_slice_ref([0i32, 2i32]);
     ArrayData::try_new(DataType::Int64, usize::MAX, None, 0, vec![buffer], vec![]).unwrap();

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -925,18 +925,23 @@ mod tests {
 
     use bytes::Bytes;
     use half::f16;
+    #[cfg(target_pointer_width = "64")]
     use num::PrimInt;
     use rand::{thread_rng, Rng, RngCore};
     use tempfile::tempfile;
 
     use arrow_array::builder::*;
     use arrow_array::cast::AsArray;
+    #[cfg(target_pointer_width = "64")]
+    use arrow_array::types::DecimalType;
     use arrow_array::types::{
-        Decimal128Type, Decimal256Type, DecimalType, Float16Type, Float32Type, Float64Type,
-        Time32MillisecondType, Time64MicrosecondType,
+        Decimal128Type, Float16Type, Float32Type, Float64Type, Time32MillisecondType,
+        Time64MicrosecondType,
     };
     use arrow_array::*;
-    use arrow_buffer::{i256, ArrowNativeType, Buffer, IntervalDayTime};
+    #[cfg(target_pointer_width = "64")]
+    use arrow_buffer::ArrowNativeType;
+    use arrow_buffer::{i256, Buffer, IntervalDayTime};
     use arrow_data::ArrayDataBuilder;
     use arrow_schema::{
         ArrowError, DataType as ArrowDataType, Field, Fields, Schema, SchemaRef, TimeUnit,
@@ -3848,6 +3853,7 @@ mod tests {
         assert_eq!(out, batch.slice(2, 1));
     }
 
+    #[cfg(target_pointer_width = "64")]
     fn test_decimal_roundtrip<T: DecimalType>() {
         // Precision <= 9 -> INT32
         // Precision <= 18 -> INT64
@@ -3896,7 +3902,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_decimal() {
+        use arrow_array::types::Decimal256Type;
         test_decimal_roundtrip::<Decimal128Type>();
         test_decimal_roundtrip::<Decimal256Type>();
     }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -517,6 +517,7 @@ mod tests {
             (0.1, 1000000, 5772541),
             (0.01, 1000000, 9681526),
             (0.001, 1000000, 14607697),
+            #[cfg(target_pointer_width = "64")]
             (1e-50, 1_000_000_000_000, 14226231280773240832),
         ] {
             assert_eq!(*num_bits, num_of_bits_from_ndv_fpp(*ndv, *fpp) as u64);

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1861,6 +1861,9 @@ mod tests {
         let parquet_meta = ParquetMetaDataBuilder::new(file_metadata.clone())
             .set_row_groups(row_group_meta_with_stats)
             .build();
+        #[cfg(target_pointer_width = "32")]
+        let base_expected_size = 1632;
+        #[cfg(target_pointer_width = "64")]
         let base_expected_size = 2312;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
@@ -1888,6 +1891,9 @@ mod tests {
             ]]))
             .build();
 
+        #[cfg(target_pointer_width = "32")]
+        let bigger_expected_size = 1972;
+        #[cfg(target_pointer_width = "64")]
         let bigger_expected_size = 2816;
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -102,6 +102,7 @@ fn test_arrow_gh_41317() {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn test_arrow_rs_gh_6229_dict_header() {
     let err = read_file("ARROW-RS-GH-6229-DICTHEADER.parquet").unwrap_err();
     assert_eq!(

--- a/parquet_derive/src/parquet_field.rs
+++ b/parquet_derive/src/parquet_field.rs
@@ -841,6 +841,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_generating_a_simple_writer_snippet() {
         let snippet: proc_macro2::TokenStream = quote! {
           struct ABoringStruct {
@@ -868,6 +869,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_generating_a_simple_reader_snippet() {
         let snippet: proc_macro2::TokenStream = quote! {
           struct ABoringStruct {

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -106,16 +106,18 @@ mod tests {
     use super::*;
 
     use chrono::SubsecRound;
-    use std::{env, fs, io::Write, sync::Arc};
+    use std::{env, fs, io::Write};
 
     use parquet::{
         file::writer::SerializedFileWriter,
         record::{RecordReader, RecordWriter},
-        schema::parser::parse_message_type,
     };
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_parquet_derive_hello() {
+        use parquet::schema::parser::parse_message_type;
+        use std::sync::Arc;
         let file = get_temp_file("test_parquet_derive_hello", &[]);
 
         // The schema is not required, but this tests that the generated


### PR DESCRIPTION
# Which issue does this PR close?

Closes #109.

I'm not qualified to enable arm32v7 in the CI environment, but this PR performs periodic maintenance to get all the tests to pass.

# Rationale for this change
 
Tests should pass on the world's top 3 best-selling computers of all time. Also Arrow is great for edge computing, where hardware refresh cycles are considerably longer than in the datacenter.

# What changes are included in this PR?

Tests that are specifically for 64-bit platforms are no longer attempted on 32-bit platforms.

# Are there any user-facing changes?

Hopefully not. If so, I made a mistake.