### PR TITLE
Update twox-hash requirement from 1.6 to 2.0

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -64,7 +64,7 @@ seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.15", default-features = false }
-twox-hash = { version = "1.6", default-features = false }
+twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"]}
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 sysinfo = { version = "0.32.0", optional = true, default-features = false, features = ["system"] }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -82,7 +82,6 @@ use crate::format::{
 };
 use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 use bytes::Bytes;
-use std::hash::Hasher;
 use std::io::Write;
 use std::sync::Arc;
 use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol};
@@ -397,9 +396,7 @@ const SEED: u64 = 0;
 
 #[inline]
 fn hash_as_bytes<A: AsBytes + ?Sized>(value: &A) -> u64 {
-    let mut hasher = XxHash64::with_seed(SEED);
-    hasher.write(value.as_bytes());
-    hasher.finish()
+    XxHash64::oneshot(SEED, value.as_bytes())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replaces #6677.