### PR TITLE
Reimplement `PartialEq` of `GenericByteViewArray` compares by logical value

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -54,19 +54,6 @@ use super::ByteArrayType;
 ///
 /// [`ByteView`]: arrow_data::ByteView
 ///
-/// # Use the [`eq`] kernel to compare the logical content.
-///
-/// Comparing two `GenericByteViewArray` using PartialEq compares by structure
-/// (the `u128`s) and contents of the buffers, not by logical content. As there
-/// are many different buffer layouts to represent the same data (e.g. different
-/// offsets, different buffer sizes, etc) two arrays with the same data may not
-/// compare equal.
-///
-/// To compare the logical content of two `GenericByteViewArray`s, use the [`eq`]
-/// kernel.
-///
-/// [`eq`]: https://docs.rs/arrow/latest/arrow/compute/kernels/cmp/fn.eq.html
-///
 /// # Layout: "views" and buffers
 ///
 /// A `GenericByteViewArray` stores variable length byte strings. An array of
@@ -189,16 +176,6 @@ impl<T: ByteViewType + ?Sized> Clone for GenericByteViewArray<T> {
             nulls: self.nulls.clone(),
             phantom: Default::default(),
         }
-    }
-}
-
-// PartialEq
-impl<T: ByteViewType + ?Sized> PartialEq for GenericByteViewArray<T> {
-    fn eq(&self, other: &Self) -> bool {
-        other.data_type.eq(&self.data_type)
-            && other.views.eq(&self.views)
-            && other.buffers.eq(&self.buffers)
-            && other.nulls.eq(&self.nulls)
     }
 }
 
@@ -1065,6 +1042,6 @@ mod tests {
         };
         assert_eq!(array1, array1.clone());
         assert_eq!(array2, array2.clone());
-        assert_ne!(array1, array2);
+        assert_eq!(array1, array2);
     }
 }

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -654,6 +654,12 @@ impl PartialEq for StructArray {
     }
 }
 
+impl<T: ByteViewType + ?Sized> PartialEq for GenericByteViewArray<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_data().eq(&other.to_data())
+    }
+}
+
 /// Constructs an array using the input `data`.
 /// Returns a reference-counted `Array` instance.
 pub fn make_array(data: ArrayData) -> ArrayRef {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6679.

# Rationale for this change
Implement `PartialEq` for `GenericByteViewArray` that compares two arrays on logical value rather than physical representation.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
