### PR TITLE
Prevent FlightData overflowing max size limit whenever possible.

### DIFF
--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -521,7 +521,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: (offset + length) <= self.len()")]
+    #[should_panic(
+        expected = "Attempting to slice an array with offset 0, len 9 when self.len is 8"
+    )]
     // Different error messages, so skip for now
     // https://github.com/apache/arrow-rs/issues/1545
     #[cfg(not(feature = "force_validate"))]

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -159,8 +159,7 @@ impl FixedSizeListArray {
                 if let Some(n) = nulls.as_ref() {
                     if n.len() != len {
                         return Err(ArrowError::InvalidArgumentError(format!(
-                            "Incorrect length of null buffer for FixedSizeListArray, expected {} got {}",
-                            len,
+                            "Incorrect length of null buffer for FixedSizeListArray, expected {len} got {}",
                             n.len(),
                         )));
                     }

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -254,14 +254,19 @@ impl<R: RunEndIndexType> RunArray<R> {
 }
 
 impl<R: RunEndIndexType> From<ArrayData> for RunArray<R> {
-    // The method assumes the caller already validated the data using `ArrayData::validate_data()`
     fn from(data: ArrayData) -> Self {
-        match data.data_type() {
-            DataType::RunEndEncoded(_, _) => {}
-            _ => {
-                panic!("Invalid data type for RunArray. The data type should be DataType::RunEndEncoded");
-            }
-        }
+        Self::from(&data)
+    }
+}
+
+impl<R: RunEndIndexType> From<&ArrayData> for RunArray<R> {
+    // The method assumes the caller already validated the data using `ArrayData::validate_data()`
+    fn from(data: &ArrayData) -> Self {
+        let DataType::RunEndEncoded(_, _) = data.data_type() else {
+            panic!(
+                "Invalid data type for RunArray. The data type should be DataType::RunEndEncoded"
+            );
+        };
 
         // Safety
         // ArrayData is valid

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -261,11 +261,11 @@ impl Buffer {
     }
 
     /// Returns a slice of this buffer starting at a certain bit offset.
-    /// If the offset is byte-aligned the returned buffer is a shallow clone,
+    /// If the offset and length are byte-aligned the returned buffer is a shallow clone,
     /// otherwise a new buffer is allocated and filled with a copy of the bits in the range.
     pub fn bit_slice(&self, offset: usize, len: usize) -> Self {
-        if offset % 8 == 0 {
-            return self.slice(offset / 8);
+        if offset % 8 == 0 && len % 8 == 0 {
+            return self.slice_with_length(offset / 8, len / 8);
         }
 
         bitwise_unary_op_helper(self, offset, len, |a| a)

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -899,7 +899,6 @@ impl ArrayData {
         let required_len = (len + self.offset) * mem::size_of::<T>();
 
         if buffer.len() < required_len {
-            // panic!("just get it over with");
             return Err(ArrowError::InvalidArgumentError(format!(
                 "Buffer {} of {} isn't large enough. Expected {} bytes got {}",
                 idx,

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -559,7 +559,7 @@ impl ArrayData {
                 child_data: self
                     .child_data()
                     .iter()
-                    .map(|data| data.slice(offset, length.min(data.len())))
+                    .map(|data| data.slice(offset, length))
                     .collect(),
                 nulls: self.nulls.as_ref().map(|x| x.slice(offset, length)),
             }

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -440,6 +440,10 @@ impl ArrayData {
         &self,
         alignment: Option<u8>,
     ) -> Result<usize, ArrowError> {
+        // Note: This accounts for data used by the Dictionary DataType that isn't actually encoded
+        // as a part of `write_array_data` in arrow-ipc - specifically, the `values` part of
+        // each Dictionary are encoded in the `child_data` of the `ArrayData` it produces, but (for
+        // some reason that I don't fully understand) it doesn't encode those values. hmm.
         let layout = layout(&self.data_type);
 
         // Just pulled from arrow-ipc

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -681,10 +681,6 @@ mod tests {
 
     use super::*;
 
-    // TESTS TO ADD:
-    // - Ensure ArrayData::get_slice_memory_size_with_alignment returns the same data size as IPC
-    //   encoding it
-
     #[test]
     // flight_data_from_arrow_batch is deprecated but does exactly what we need. Would probably be
     // good to just move it to this test mod when it's due to be removed.
@@ -1684,17 +1680,11 @@ mod tests {
 
     /// Coverage for <https://github.com/apache/arrow-rs/issues/3478>
     ///
-    /// Encodes the specified batch using several values of
-    /// `max_flight_data_size` between 1K to 5K and ensures that the
-    /// resulting size of the flight data stays within the limit
-    /// + `allowed_overage`
-    ///
-    /// `allowed_overage` is how far off the actual data encoding is
-    /// from the target limit that was set. It is an improvement when
-    /// the allowed_overage decreses.
-    ///
-    /// Note this overhead will likely always be greater than zero to
-    /// account for encoding overhead such as IPC headers and padding.
+    /// Encodes the specified batch using several values of `max_flight_data_size` between 1K to 5K
+    /// and ensures that the resulting size of the flight data stays within the limit, except for
+    /// in cases where only 1 row is sent - if only 1 row is sent, then we know that there was no
+    /// way to keep the data within the limit (since the minimum possible amount of data was sent),
+    /// so we allow it to go over.
     ///
     async fn verify_encoded_split_no_overage(batch: RecordBatch) {
         let num_rows = batch.num_rows();

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -681,6 +681,10 @@ mod tests {
 
     use super::*;
 
+    // TESTS TO ADD:
+    // - Ensure ArrayData::get_slice_memory_size_with_alignment returns the same data size as IPC
+    //   encoding it
+
     #[test]
     // flight_data_from_arrow_batch is deprecated but does exactly what we need. Would probably be
     // good to just move it to this test mod when it's due to be removed.

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     // flight_data_from_arrow_batch is deprecated but does exactly what we need. Would probably be
     // good to just move it to this test mod when it's due to be removed.
-    #[expect(deprecated)]
+    #[allow(deprecated)]
     /// ensure only the batch's used data (not the allocated data) is sent
     /// <https://github.com/apache/arrow-rs/issues/208>
     fn test_encode_flight_data() {

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -983,12 +983,16 @@ mod tests {
             ))],
         );
 
-        struct_builder.field_builder::<ListBuilder<GenericByteDictionaryBuilder<UInt16Type,GenericStringType<i32>>>>(0).unwrap().append_value(vec![Some("a"), None, Some("b")]);
+        struct_builder.field_builder::<ListBuilder<GenericByteDictionaryBuilder<UInt16Type, GenericStringType<i32>>>>(0)
+            .unwrap()
+            .append_value(vec![Some("a"), None, Some("b")]);
         struct_builder.append(true);
 
         let arr1 = struct_builder.finish();
 
-        struct_builder.field_builder::<ListBuilder<GenericByteDictionaryBuilder<UInt16Type,GenericStringType<i32>>>>(0).unwrap().append_value(vec![Some("c"), None, Some("d")]);
+        struct_builder.field_builder::<ListBuilder<GenericByteDictionaryBuilder<UInt16Type, GenericStringType<i32>>>>(0)
+            .unwrap()
+            .append_value(vec![Some("c"), None, Some("d")]);
         struct_builder.append(true);
 
         let arr2 = struct_builder.finish();
@@ -1497,7 +1501,7 @@ mod tests {
             .encoded_batch_with_size(&batch, &mut dict_tracker, &write_opts, max_flight_data_size)
             .unwrap()
             .1;
-        assert_eq!(split.len(), 3);
+        assert_eq!(split.len(), 2);
         /*assert_eq!(
             split.iter().map(|batch| batch.num_rows()).sum::<usize>(),
             n_rows

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1555,7 +1555,7 @@ mod tests {
         ])
         .unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1564,7 +1564,7 @@ mod tests {
         let array = StringArray::from_iter_values((0..1024).map(|i| "*".repeat(i)));
         let batch = RecordBatch::try_from_iter([("data", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1597,7 +1597,7 @@ mod tests {
         ])
         .unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1613,7 +1613,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1625,7 +1625,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1637,7 +1637,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     #[tokio::test]
@@ -1660,7 +1660,7 @@ mod tests {
         ])
         .unwrap();
 
-        verify_encoded_split_no_overhead(batch).await;
+        verify_encoded_split_no_overage(batch).await;
     }
 
     /// Return size, in memory of flight data
@@ -1692,7 +1692,7 @@ mod tests {
     /// Note this overhead will likely always be greater than zero to
     /// account for encoding overhead such as IPC headers and padding.
     ///
-    async fn verify_encoded_split_no_overhead(batch: RecordBatch) {
+    async fn verify_encoded_split_no_overage(batch: RecordBatch) {
         let num_rows = batch.num_rows();
 
         for max_flight_data_size in [1024, 2021, 5000] {

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -43,7 +43,7 @@ pub fn flight_data_from_arrow_batch(
     assert_eq!(
         flight_batches.len(),
         1,
-        "encoded_batch with a max size of usize::MAX should never return more than 1 batch"
+        "encoded_batch with a max size of usize::MAX should not be able to return more or less than 1 batch"
     );
     let flight_batch = flight_batches.pop().unwrap();
 

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -125,16 +125,9 @@ async fn send_batch(
     batch: &RecordBatch,
     options: &writer::IpcWriteOptions,
 ) -> Result {
-    let data_gen = writer::IpcDataGenerator::default();
-    let mut dictionary_tracker = writer::DictionaryTracker::new_with_preserve_dict_id(false, true);
-
-    let (encoded_dictionaries, encoded_batch) = data_gen
-        .encoded_batch(batch, &mut dictionary_tracker, options)
-        .expect("DictionaryTracker configured above to not error on replacement");
-
-    let dictionary_flight_data: Vec<FlightData> =
-        encoded_dictionaries.into_iter().map(Into::into).collect();
-    let mut batch_flight_data: FlightData = encoded_batch.into();
+    #[expect(deprecated)]
+    let (dictionary_flight_data, mut batch_flight_data) =
+        arrow_flight::utils::flight_data_from_arrow_batch(batch, options);
 
     upload_tx
         .send_all(&mut stream::iter(dictionary_flight_data).map(Ok))

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -125,7 +125,7 @@ async fn send_batch(
     batch: &RecordBatch,
     options: &writer::IpcWriteOptions,
 ) -> Result {
-    #[expect(deprecated)]
+    #[allow(deprecated)]
     let (dictionary_flight_data, mut batch_flight_data) =
         arrow_flight::utils::flight_data_from_arrow_batch(batch, options);
 

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -27,7 +27,7 @@ use arrow::{
     buffer::Buffer,
     datatypes::Schema,
     datatypes::SchemaRef,
-    ipc::{self, reader, writer},
+    ipc::{self, reader},
     record_batch::RecordBatch,
 };
 use arrow_flight::{
@@ -127,22 +127,16 @@ impl FlightService for FlightServiceImpl {
             .iter()
             .enumerate()
             .flat_map(|(counter, batch)| {
-                let data_gen = writer::IpcDataGenerator::default();
-                let mut dictionary_tracker =
-                    writer::DictionaryTracker::new_with_preserve_dict_id(false, true);
-
-                let (encoded_dictionaries, encoded_batch) = data_gen
-                    .encoded_batch(batch, &mut dictionary_tracker, &options)
-                    .expect("DictionaryTracker configured above to not error on replacement");
-
-                let dictionary_flight_data = encoded_dictionaries.into_iter().map(Into::into);
-                let mut batch_flight_data: FlightData = encoded_batch.into();
+                #[expect(deprecated)]
+                let (dictionary_flight_data, mut batch_flight_data) =
+                    arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
 
                 // Only the record batch's FlightData gets app_metadata
                 let metadata = counter.to_string().into();
                 batch_flight_data.app_metadata = metadata;
 
                 dictionary_flight_data
+                    .into_iter()
                     .chain(std::iter::once(batch_flight_data))
                     .map(Ok)
             });

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -127,7 +127,7 @@ impl FlightService for FlightServiceImpl {
             .iter()
             .enumerate()
             .flat_map(|(counter, batch)| {
-                #[expect(deprecated)]
+                #[allow(deprecated)]
                 let (dictionary_flight_data, mut batch_flight_data) =
                     arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1058,7 +1058,7 @@ impl<R: Read + Seek> FileReader<R> {
     /// Try to create a new file reader.
     ///
     /// There is no internal buffering. If buffered reads are needed you likely want to use
-    /// [`FileReader::try_new_buffered`] instead.    
+    /// [`FileReader::try_new_buffered`] instead.
     ///
     /// # Errors
     ///

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1785,7 +1785,7 @@ mod tests {
         // can be compared as such.
         assert_eq!(input_batch.column(1), output_batch.column(1));
 
-        let run_array_1_unsliced = unslice_run_array(run_array_1_sliced.into_data()).unwrap();
+        let run_array_1_unsliced = unslice_run_array(&run_array_1_sliced.into_data()).unwrap();
         assert_eq!(run_array_1_unsliced, output_batch.column(0).into_data());
     }
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -454,6 +454,10 @@ impl IpcDataGenerator {
         Ok(())
     }
 
+    /// Calls [`Self::encoded_batch_with_size`] with no limit, returning the first (and only)
+    /// [`EncodedData`] that is produced. This method should be used over
+    /// [`Self::encoded_batch_with_size`] if the consumer has no concerns about encoded message
+    /// size limits
     pub fn encoded_batch(
         &self,
         batch: &RecordBatch,

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1863,8 +1863,6 @@ impl<'fbb> FlatBufferSizeTracker<'fbb> {
         compression_codec: Option<CompressionCodec>,
         alignment: u8,
     ) -> Result<(), ArrowError> {
-        let start_len = self.arrow_data.len();
-
         let len: i64 = if self.dry_run {
             // Flatbuffers will essentially optimize this away if we say the len is 0 for all of
             // these, so to make sure the header size is the same in the dry run and in the real

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1488,6 +1488,10 @@ fn encode_array_datas(
         };
 
         let rows_left = n_rows - offset;
+        // TODO? maybe this could be more efficient by continually approximating the maximum number
+        // of rows based on (size / n_rows) of the current ArrayData slice until we've found the
+        // maximum that can fit? e.g. 'oh, it's 200 bytes and 10 rows, so each row is probably 20
+        // bytes - let's do (max_size / 20) rows and see if that fits'
         let length = (1..=rows_left)
             .find(|len| {
                 // If we've exhausted the available length of the array datas, then just return -


### PR DESCRIPTION
# Which issue does this PR close?

Closes #3478 

# What changes are included in this PR?

This reworks the encoding/writing step of flight data messages to ensure it never overflows the given limit whenever possible (specifically, it's impossible when we can't even fit a single row + header within the limit - there are still no mechanisms for splitting a single row of data between multiple messages).

It does this by first constructing a fake IPC header, then getting that header's encoded length, and then subtracting that length from the provided max size. Because the header's size stays the same with the same schema (the only thing that changes is the value within the 'length of data' fields), we don't need to continually recalculate it.

There are more tests I'd like to add before merging this, I was just hoping to get this filed first so that I could get feedback in case any behavior seemed seriously off.

# Rationale for these changes

Since we are dynamically checking array data sizes to see if they can fit within the alloted size, this ensures that they will never go over if possible. Of course, as I said before, they will still go over if necessary, but I've rewritten the tests to check this behavior (if the tests sense an overage, but decode it to see that only one row was written, they allow it as there is no other way to get the data across).

# Are there any user-facing changes?

Yes, there are API additions. They are documented. As far as I can tell, this shouldn't require a breaking release, but I haven't run anything like cargo-semver-checks on it to actually verify.