### PR TITLE
check sign_payload instead of skip_signature before computing checksum

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -350,7 +350,9 @@ impl<'a> Request<'a> {
     }
 
     pub(crate) fn with_payload(mut self, payload: PutPayload) -> Self {
-        if (!self.config.skip_signature && self.config.sign_payload) || self.config.checksum.is_some() {
+        if (!self.config.skip_signature && self.config.sign_payload)
+            || self.config.checksum.is_some()
+        {
             let mut sha256 = Context::new(&digest::SHA256);
             payload.iter().for_each(|x| sha256.update(x));
             let payload_sha256 = sha256.finish();

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -350,7 +350,7 @@ impl<'a> Request<'a> {
     }
 
     pub(crate) fn with_payload(mut self, payload: PutPayload) -> Self {
-        if self.config.sign_payload || self.config.checksum.is_some() {
+        if (!self.config.skip_signature && self.config.sign_payload) || self.config.checksum.is_some() {
             let mut sha256 = Context::new(&digest::SHA256);
             payload.iter().for_each(|x| sha256.update(x));
             let payload_sha256 = sha256.finish();

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -350,7 +350,7 @@ impl<'a> Request<'a> {
     }
 
     pub(crate) fn with_payload(mut self, payload: PutPayload) -> Self {
-        if !self.config.skip_signature || self.config.checksum.is_some() {
+        if self.config.sign_payload || self.config.checksum.is_some() {
             let mut sha256 = Context::new(&digest::SHA256);
             payload.iter().for_each(|x| sha256.update(x));
             let payload_sha256 = sha256.finish();


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6697

# What changes are included in this PR?
Checks for `sign_payload` instead of `!skip_signature` before generating the payload checksum

# Are there any user-facing changes?
Yes
