### PR TITLE
Add filter_kernel benchmark for run array

### DIFF
--- a/arrow/benches/filter_kernels.rs
+++ b/arrow/benches/filter_kernels.rs
@@ -23,7 +23,7 @@ use arrow::util::bench_util::*;
 
 use arrow::array::*;
 use arrow::compute::filter;
-use arrow::datatypes::{Field, Float32Type, Int32Type, Schema, UInt8Type};
+use arrow::datatypes::{Field, Float32Type, Int32Type, Int64Type, Schema, UInt8Type};
 
 use arrow_array::types::Decimal128Type;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -283,6 +283,17 @@ fn add_benchmark(c: &mut Criterion) {
         "filter context mixed string view low selectivity (kept 1/1024)",
         |b| b.iter(|| bench_built_filter(&sparse_filter, &data_array)),
     );
+
+    let data_array = create_primitive_run_array::<Int32Type, Int64Type>(size, size);
+    c.bench_function("filter run array (kept 1/2)", |b| {
+        b.iter(|| bench_built_filter(&filter, &data_array))
+    });
+    c.bench_function("filter run array high selectivity (kept 1023/1024)", |b| {
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
+    });
+    c.bench_function("filter run array low selectivity (kept 1/1024)", |b| {
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
+    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/arrow-rs/pull/6691 and https://github.com/apache/arrow-rs/pull/6675

# Rationale for this change
 
There currently aren't any filter kernel benchmarks for the run array.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

I've added in some benchmarks for `RunArray` following the examples of the others inside the `filter_kernel` benchmark.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
