### PR TITLE
Support for casting `StringViewArray` to `DecimalArray`

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -447,10 +447,12 @@ where
             scale,
             cast_options,
         )?,
-        other => return Err(ArrowError::ComputeError(format!(
-            "Cannot cast {:?} to decimal",
-            other
-        ))),
+        other => {
+            return Err(ArrowError::ComputeError(format!(
+                "Cannot cast {:?} to decimal",
+                other
+            )))
+        }
     };
 
     Ok(Arc::new(result))

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -323,7 +323,7 @@ where
     })
 }
 
-pub(crate) fn generic_string_to_decimal_cast<'a, T, S, Offset>(
+pub(crate) fn generic_string_to_decimal_cast<'a, T, S>(
     from: &'a S,
     precision: u8,
     scale: i8,
@@ -333,7 +333,6 @@ where
     T: DecimalType,
     T::Native: DecimalCast + ArrowNativeTypeOp,
     &'a S: StringArrayType<'a>,
-    Offset: OffsetSizeTrait,
 {
     if cast_options.safe {
         let iter = from.iter().map(|v| {
@@ -387,7 +386,7 @@ where
     T: DecimalType,
     T::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    generic_string_to_decimal_cast::<T, GenericStringArray<Offset>, Offset>(
+    generic_string_to_decimal_cast::<T, GenericStringArray<Offset>>(
         from,
         precision,
         scale,
@@ -405,7 +404,7 @@ where
     T: DecimalType,
     T::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    generic_string_to_decimal_cast::<T, StringViewArray, i32>(from, precision, scale, cast_options)
+    generic_string_to_decimal_cast::<T, StringViewArray>(from, precision, scale, cast_options)
 }
 
 /// Cast Utf8 to decimal

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -59,7 +59,6 @@ use crate::parse::{
     parse_interval_day_time, parse_interval_month_day_nano, parse_interval_year_month,
     string_to_datetime, Parser,
 };
-use arrow_array::iterator::ArrayIter;
 use arrow_array::{builder::*, cast::*, temporal_conversions::*, timezone::Tz, types::*, *};
 use arrow_buffer::{i256, ArrowNativeType, OffsetBuffer};
 use arrow_data::transform::MutableArrayData;
@@ -2482,21 +2481,6 @@ where
     }
 
     Ok(Arc::new(byte_array_builder.finish()))
-}
-
-trait StringArrayType<'a>: ArrayAccessor<Item = &'a str> + Sized {
-    /// Constructs a new iterator
-    fn iter(&self) -> ArrayIter<Self>;
-}
-impl<'a, O: OffsetSizeTrait> StringArrayType<'a> for &'a GenericStringArray<O> {
-    fn iter(&self) -> ArrayIter<Self> {
-        GenericStringArray::<O>::iter(self)
-    }
-}
-impl<'a> StringArrayType<'a> for &'a StringViewArray {
-    fn iter(&self) -> ArrayIter<Self> {
-        StringViewArray::iter(self)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6715.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add support cast string view (`Utf8View`) to numeric(`Int`/`Float`/`Decimal`).
- Unit tests.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
