### PR TITLE
Improve default implementation of Array::is_nullable

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -317,8 +317,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// even if the nulls present in [`DictionaryArray::values`] are not referenced by any key,
     /// and therefore would not appear in [`Array::logical_nulls`].
     fn is_nullable(&self) -> bool {
-        // TODO this is not necessarily perfect default implementation, since null_count() and logical_null_count() are not always equivalent
-        self.null_count() != 0
+        self.logical_null_count() != 0
     }
 
     /// Returns the total number of bytes of memory pointed to by this array.


### PR DESCRIPTION
# Description

Improve default implementation of Array::is_nullable

Since is_nullable returns `false` if the array is guaranteed to not contain any logical nulls, the correct default implementation could leverage `self.logical_null_count` more appropriately than `self.null_count`.

To reduce chance of negative surprises in downstream projects, we could introduce the new behavior under `is_logically_nullable` name and deprecate `is_nullable` without changing it.

# Which issue does this PR close?

None

# Rationale for this change
 
Fix technically incorrect default implementation of `Array::is_nullable`

# What changes are included in this PR?

Change default implementation of `Array::is_nullable`.

# Are there any user-facing changes?

No