### PR TITLE
Update PR template section about API breaking changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@ If there are user-facing changes then we may require documentation to be updated
 -->
 
 <!---
-If there are any breaking changes to public APIs, please add the `breaking change` label.
+If there are any breaking changes to public APIs, please call them out.
 -->


### PR DESCRIPTION

# Which issue does this PR close?

None

# Rationale for this change

The pull request template  section about API breaking changes does not seem possible to follow. The `breaking change` label doesn't seem to exist. Also, a contributor without triage GitHub permission level cannot set labels. 


# What changes are included in this PR?

Update the instructions what to do on breaking API changes.

# Are there any user-facing changes?


No
