### PR TITLE
Fix signed decimal e-notation parsing

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -841,19 +841,20 @@ pub fn parse_decimal<T: DecimalType>(
     let base = T::Native::usize_as(10);
 
     let bs = s.as_bytes();
-    let (bs, negative) = match bs.first() {
-        Some(b'-') => (&bs[1..], true),
-        Some(b'+') => (&bs[1..], false),
-        _ => (bs, false),
+    let (signed, negative) = match bs.first() {
+        Some(b'-') => (true, true),
+        Some(b'+') => (true, false),
+        _ => (false, false),
     };
 
-    if bs.is_empty() {
+    if bs.is_empty() || signed && bs.len() == 1 {
         return Err(ArrowError::ParseError(format!(
             "can't parse the string value {s} to decimal"
         )));
     }
 
-    let mut bs = bs.iter().enumerate();
+    // Iterate over the raw input bytes, skipping the sign if any
+    let mut bs = bs.iter().enumerate().skip(signed as usize);
 
     let mut is_e_notation = false;
 
@@ -2678,6 +2679,21 @@ mod tests {
                 "1.016744e-320",
                 0i128,
                 15,
+            ),
+            (
+                "-1e3",
+                -1000000000i128,
+                6,
+            ),
+            (
+                "+1e3",
+                1000000000i128,
+                6,
+            ),
+            (
+                "-1e31",
+                -10000000000000000000000000000000000000i128,
+                6,
             ),
         ];
         for (s, i, scale) in edge_tests_128 {

--- a/arrow-select/src/zip.rs
+++ b/arrow-select/src/zip.rs
@@ -53,7 +53,7 @@ pub fn zip(
             "all arrays should have the same length".into(),
         ));
     }
-    if truthy_is_scalar && truthy.len() != 1 {
+    if falsy_is_scalar && falsy.len() != 1 {
         return Err(ArrowError::InvalidArgumentError(
             "scalar arrays must have 1 element".into(),
         ));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6728.

# Rationale for this change
When parsing signed decimal numbers the leading sign is stripped from the raw value bytes, and the `e` index is passed relative to the stripped slice.

However, the full value is passed into `parse_e_notation`, leading to a off-by-one error of the index for the signed numbers.

# What changes are included in this PR?
Do not strip the sign when parsing, and make the `e` index relative to the full value, thus aligning `parse_e_notation` and `parse_decimal`.

# Are there any user-facing changes?
None
