### PR TITLE
Allow reading Parquet maps that lack a `values` field

### DIFF
--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -271,8 +271,13 @@ impl Visitor {
             return Err(arrow_err!("Child of map field must be repeated"));
         }
 
+        // According to the specification the values are optional (#1642).
+        // In this case, return the keys as a list.
+        if map_key_value.get_fields().len() == 1 {
+            return self.visit_list(map_type, context);
+        }
+
         if map_key_value.get_fields().len() != 2 {
-            // According to the specification the values are optional (#1642)
             return Err(arrow_err!(
                 "Child of map field must have two children, found {}",
                 map_key_value.get_fields().len()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1642.

# Rationale for this change
 
The Parquet spec does not require the `values` field of a map to be present, but current readers will error out if this field is missing.

# What changes are included in this PR?

Changes both the record reader and arrow reader to read a `MAP` lacking `values` as a list of keys. This matches the behavior of arrow-cpp.

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
