### PR TITLE
Remove redundant implementation of `StringArrayType`

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -18,12 +18,15 @@
 //! Provide SQL's LIKE operators for Arrow's string arrays
 
 use crate::predicate::Predicate;
+
 use arrow_array::cast::AsArray;
 use arrow_array::*;
 use arrow_schema::*;
 use arrow_select::take::take;
-use iterator::ArrayIter;
+
 use std::sync::Arc;
+
+pub use arrow_array::StringArrayType;
 
 #[derive(Debug)]
 enum Op {
@@ -147,39 +150,6 @@ fn like_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, Arr
         (l_t, r_t) => Err(ArrowError::InvalidArgumentError(format!(
             "Invalid string operation: {l_t} {op} {r_t}"
         ))),
-    }
-}
-
-/// A trait for Arrow String Arrays, currently three types are supported:
-/// - `StringArray`
-/// - `LargeStringArray`
-/// - `StringViewArray`
-///
-/// This trait helps to abstract over the different types of string arrays
-/// so that we don't need to duplicate the implementation for each type.
-pub trait StringArrayType<'a>: ArrayAccessor<Item = &'a str> + Sized {
-    /// Returns true if all data within this string array is ASCII
-    fn is_ascii(&self) -> bool;
-    /// Constructs a new iterator
-    fn iter(&self) -> ArrayIter<Self>;
-}
-
-impl<'a, O: OffsetSizeTrait> StringArrayType<'a> for &'a GenericStringArray<O> {
-    fn is_ascii(&self) -> bool {
-        GenericStringArray::<O>::is_ascii(self)
-    }
-
-    fn iter(&self) -> ArrayIter<Self> {
-        GenericStringArray::<O>::iter(self)
-    }
-}
-impl<'a> StringArrayType<'a> for &'a StringViewArray {
-    fn is_ascii(&self) -> bool {
-        StringViewArray::is_ascii(self)
-    }
-
-    fn iter(&self) -> ArrayIter<Self> {
-        StringViewArray::iter(self)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
`StringArrayType` now moved from [`arrow-string`] to [`arrow-array`] for general usage (since #6720). This PR cleans up the previous implementation.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
I'm not sure but maybe this could potentially be marked as API breaking change. Due to we have public the old implementation since #6376, it's possible that downstream users have used it.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
