### PR TITLE
Update cache action to v4

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # these represent dependencies downloaded by cargo
         # and thus do not depend on the OS, arch nor rust version.


### PR DESCRIPTION


# Which issue does this PR close?

none

# Rationale for this change
 
- consistent with other usages of `actions/cache` in workflows
- addresses a warning raised by GitHub:
  ```
  Verify MSRV
  The following actions use a deprecated Node.js version and will be forced
  to run on node20: actions/cache@v3. 
  ```

apparently dependabot can  update actions in workflows (https://github.com/apache/arrow-rs/pull/5308), but not in composite actions

# What changes are included in this PR?

actions/cache version update

# Are there any user-facing changes?

none