### PR TITLE
Wilder implementor of Box<dyn AsyncArrowWriter> and Box<dyn AsyncArrowReader> in parquet

### DIFF
--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -158,7 +158,7 @@ pub trait AsyncFileReader: Send {
     fn get_metadata(&mut self) -> BoxFuture<'_, Result<Arc<ParquetMetaData>>>;
 }
 
-impl AsyncFileReader for Box<dyn AsyncFileReader> {
+impl<'reader> AsyncFileReader for Box<dyn AsyncFileReader + 'reader> {
     fn get_bytes(&mut self, range: Range<usize>) -> BoxFuture<'_, Result<Bytes>> {
         self.as_mut().get_bytes(range)
     }

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -89,7 +89,7 @@ pub trait AsyncFileWriter: Send {
     fn complete(&mut self) -> BoxFuture<'_, Result<()>>;
 }
 
-impl AsyncFileWriter for Box<dyn AsyncFileWriter> {
+impl<'writer> AsyncFileWriter for Box<dyn AsyncFileWriter + 'writer> {
     fn write(&mut self, bs: Bytes) -> BoxFuture<'_, Result<()>> {
         self.as_mut().write(bs)
     }


### PR DESCRIPTION
In the current,
```rust
impl AsyncFileReader for Box<dyn AsyncFileReader> {
    ...
}
```
equals to
```rust
impl AsyncFileReader for Box<dyn AsyncFileReader + 'static> {
    ...
}
```

which `'static` bound is not necessary, I removed this requirement to make it more trivial