### PR TITLE
Expose 'parquet::record::make_row' function call to users

### DIFF
--- a/parquet/src/record/mod.rs
+++ b/parquet/src/record/mod.rs
@@ -25,7 +25,8 @@ mod triplet;
 
 pub use self::{
     api::{
-        Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowColumnIter, RowFormatter,
+        make_row, Field, List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowColumnIter,
+        RowFormatter,
     },
     record_reader::RecordReader,
     record_writer::RecordWriter,


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6761

# Rationale for this change
 
`parquet::record::make_row` was not exposed to users, leaving them no option to create `parquet::record::Row` objects themselfes.

# What changes are included in this PR?

`parquet::record::make_row` is exposed publicy.
