### PR TITLE
Include license and notice files in published crates

### DIFF
--- a/arrow-arith/LICENSE.txt
+++ b/arrow-arith/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-arith/NOTICE.txt
+++ b/arrow-arith/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-array/LICENSE.txt
+++ b/arrow-array/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-array/NOTICE.txt
+++ b/arrow-array/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-avro/LICENSE.txt
+++ b/arrow-avro/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-avro/NOTICE.txt
+++ b/arrow-avro/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-buffer/LICENSE.txt
+++ b/arrow-buffer/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-buffer/NOTICE.txt
+++ b/arrow-buffer/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-cast/LICENSE.txt
+++ b/arrow-cast/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-cast/NOTICE.txt
+++ b/arrow-cast/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-csv/LICENSE.txt
+++ b/arrow-csv/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-csv/NOTICE.txt
+++ b/arrow-csv/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-data/LICENSE.txt
+++ b/arrow-data/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-data/NOTICE.txt
+++ b/arrow-data/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-flight/LICENSE.txt
+++ b/arrow-flight/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-flight/NOTICE.txt
+++ b/arrow-flight/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-integration-test/LICENSE.txt
+++ b/arrow-integration-test/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-integration-test/NOTICE.txt
+++ b/arrow-integration-test/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-ipc/LICENSE.txt
+++ b/arrow-ipc/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-ipc/NOTICE.txt
+++ b/arrow-ipc/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-json/LICENSE.txt
+++ b/arrow-json/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-json/NOTICE.txt
+++ b/arrow-json/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-ord/LICENSE.txt
+++ b/arrow-ord/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-ord/NOTICE.txt
+++ b/arrow-ord/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-row/LICENSE.txt
+++ b/arrow-row/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-row/NOTICE.txt
+++ b/arrow-row/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-schema/LICENSE.txt
+++ b/arrow-schema/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-schema/NOTICE.txt
+++ b/arrow-schema/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-select/LICENSE.txt
+++ b/arrow-select/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-select/NOTICE.txt
+++ b/arrow-select/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow-string/LICENSE.txt
+++ b/arrow-string/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow-string/NOTICE.txt
+++ b/arrow-string/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/arrow/LICENSE.txt
+++ b/arrow/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/arrow/NOTICE.txt
+++ b/arrow/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/parquet/LICENSE.txt
+++ b/parquet/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/parquet/NOTICE.txt
+++ b/parquet/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt

--- a/parquet_derive/LICENSE.txt
+++ b/parquet_derive/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/parquet_derive/NOTICE.txt
+++ b/parquet_derive/NOTICE.txt
@@ -1,0 +1,1 @@
+../NOTICE.txt


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change
 
This is nice for `cargo vendor` and other tools (https://github.com/microsoft/windows-rs/issues/1587#issuecomment-1063010186).

# What changes are included in this PR?

This symlinks `LICENSE.txt` and `NOTICE.txt` so they're included in the published crates.

# Are there any user-facing changes?

N/A