### PR TITLE
Allow NullBuffer construction directly from array 

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -358,7 +358,7 @@ mod tests {
         let values = b"helloparquet";
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(12)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
         let offsets = [0, 5, 5, 12].map(|n| O::from_usize(n).unwrap());
@@ -415,7 +415,7 @@ mod tests {
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(15)
             .offset(5)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
 
@@ -460,7 +460,7 @@ mod tests {
         let values = b"HelloArrow";
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(10)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .null_bit_buffer(Some(Buffer::from_slice_ref([0b1010101010])))
             .build()
             .unwrap();

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -662,7 +662,7 @@ mod tests {
 
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(3)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(&values))
             .build()
             .unwrap();
         let fixed_size_binary_array = FixedSizeBinaryArray::from(array_data);
@@ -691,7 +691,7 @@ mod tests {
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(&values))
             .build()
             .unwrap();
         let fixed_size_binary_array = FixedSizeBinaryArray::from(array_data);
@@ -798,7 +798,7 @@ mod tests {
 
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(3)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(&values))
             .build()
             .unwrap();
         let arr = FixedSizeBinaryArray::from(array_data);

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -2296,7 +2296,7 @@ mod tests {
         ];
         let array_data = ArrayData::builder(DataType::Decimal128(38, 6))
             .len(2)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(&values))
             .build()
             .unwrap();
         let decimal_array = Decimal128Array::from(array_data);

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -382,7 +382,7 @@ mod tests {
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(15)
             .offset(5)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
 
@@ -427,7 +427,7 @@ mod tests {
         let values = b"HelloArrow";
         let child_data = ArrayData::builder(DataType::UInt8)
             .len(10)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .null_bit_buffer(Some(Buffer::from_slice_ref([0b1010101010])))
             .build()
             .unwrap();
@@ -469,7 +469,7 @@ mod tests {
         let values = b"HelloArrow";
         let child_data = ArrayData::builder(DataType::UInt16)
             .len(5)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
 

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -235,6 +235,12 @@ impl From<&[bool]> for NullBuffer {
     }
 }
 
+impl<const N: usize> From<&[bool; N]> for NullBuffer {
+    fn from(value: &[bool; N]) -> Self {
+        value[..].into()
+    }
+}
+
 impl From<Vec<bool>> for NullBuffer {
     fn from(value: Vec<bool>) -> Self {
         BooleanBuffer::from(value).into()

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1778,7 +1778,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_struct_empty_fields() {
-        let nulls = NullBuffer::from(&[true, true, false][..]);
+        let nulls = NullBuffer::from(&[true, true, false]);
         let rb = RecordBatch::try_from_iter([(
             "",
             Arc::new(StructArray::new_empty_fields(nulls.len(), Some(nulls))) as _,

--- a/arrow-string/src/substring.rs
+++ b/arrow-string/src/substring.rs
@@ -636,7 +636,7 @@ mod tests {
 
         let data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(2)
-            .add_buffer(Buffer::from(&values[..]))
+            .add_buffer(Buffer::from(&values))
             .offset(1)
             .null_bit_buffer(Some(Buffer::from(bits_v)))
             .build()

--- a/arrow/examples/builders.rs
+++ b/arrow/examples/builders.rs
@@ -76,7 +76,7 @@ fn main() {
     let array_data = ArrayData::builder(DataType::Utf8)
         .len(3)
         .add_buffer(Buffer::from(offsets.to_byte_slice()))
-        .add_buffer(Buffer::from(&values[..]))
+        .add_buffer(Buffer::from(&values))
         .null_bit_buffer(Some(Buffer::from([0b00000101])))
         .build()
         .unwrap();

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -325,11 +325,11 @@ fn make_fixed_size_list_array() -> FixedSizeListArray {
 }
 
 fn make_fixed_size_binary_array() -> FixedSizeBinaryArray {
-    let values: [u8; 15] = *b"hellotherearrow";
+    let values: &[u8; 15] = b"hellotherearrow";
 
     let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
         .len(3)
-        .add_buffer(Buffer::from(&values[..]))
+        .add_buffer(Buffer::from(values))
         .build()
         .unwrap();
     FixedSizeBinaryArray::from(array_data)

--- a/parquet/src/arrow/buffer/view_buffer.rs
+++ b/parquet/src/arrow/buffer/view_buffer.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_view_buffer_append_view() {
         let mut buffer = ViewBuffer::default();
-        let string_buffer = Buffer::from(&b"0123456789long string to test string view"[..]);
+        let string_buffer = Buffer::from(b"0123456789long string to test string view");
         let block_id = buffer.append_block(string_buffer);
 
         unsafe {
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_view_buffer_pad_null() {
         let mut buffer = ViewBuffer::default();
-        let string_buffer = Buffer::from(&b"0123456789long string to test string view"[..]);
+        let string_buffer = Buffer::from(b"0123456789long string to test string view");
         let block_id = buffer.append_block(string_buffer);
 
         unsafe {


### PR DESCRIPTION
# Which issue does this PR close?

none

# Rationale for this change
 
For convenience and API compatibility with Buffer.


# What changes are included in this PR?

- Allow `NullBuffer::from(array)`
- Migrate code to use `Buffer::from(array)` where it results in shorter code

# Are there any user-facing changes?

yes, new `NullBuffer::from` variant