### PR TITLE
Improve list builder usage example in docs

### DIFF
--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -49,7 +49,6 @@ use std::sync::Arc;
 /// builder.append(true);
 ///
 /// // Null
-/// builder.values().append_value("?"); // irrelevant
 /// builder.append(false);
 ///
 /// // [D]
@@ -70,15 +69,14 @@ use std::sync::Arc;
 ///   array.values().as_ref(),
 ///   &StringArray::from(vec![
 ///     Some("A"), Some("B"), Some("C"),
-///     Some("?"), Some("D"), None,
-///     Some("F")
+///     Some("D"), None, Some("F")
 ///   ])
 /// );
 ///
 /// // Offsets are indexes into the values array
 /// assert_eq!(
 ///   array.value_offsets(),
-///   &[0, 3, 3, 4, 5, 7]
+///   &[0, 3, 3, 3, 4, 6]
 /// );
 /// ```
 ///


### PR DESCRIPTION


# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
The example could leave the impression that it is important to append some dummy element (which value is irrelevant) to values builder when constructing null list entry.


# What changes are included in this PR?

doc change for GenericListBuilder

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


no