### PR TITLE
impl std::fmt::Write for StringViewBuilder / BinaryViewBuilder

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -296,7 +296,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// - String length exceeds `u32::MAX`
     #[inline]
     pub fn append_str(&mut self, value: &str) {
-        // SAFETY: UTF8 bytes are valid for both string and binaary
+        // SAFETY: UTF8 bytes are valid for both string and binary
         unsafe { self.append_bytes(value.as_bytes()) }
     }
 
@@ -430,7 +430,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         buffer_size + in_progress + tracker + views + null
     }
 
-    /// Return a structure that implements `std::fmt::Write` to write stirngs
+    /// Return a structure that implements `std::fmt::Write` to write strings
     /// directly to the builder. See example on [`StringViewBuilder`]
     pub fn formatter(&mut self) -> ByteViewFormatter<'_, T> {
         ByteViewFormatter::new(self)
@@ -677,7 +677,7 @@ where
     }
 }
 
-/// When a StringViewWriter is dropped, it writes the the value to the StringViewBuilder
+/// When a StringViewWriter is dropped, it writes the value to the StringViewBuilder
 impl<'a, T> Drop for ByteViewFormatter<'a, T>
 where
     T: ByteViewType + ?Sized,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/6373

# Rationale for this change
 
@tlm365 is trying to implement cast from various types to StringView efficiently in
- https://github.com/apache/arrow-rs/pull/6719

Also, DataFusion had several places where it would like to write to a StringViewBuilder using standard rust formatting such as  `write!`



# What changes are included in this PR?
1. impl std::fmt::Write for StringViewBuilder / BinaryViewBuilder
2. Tests + documentation


Open questions / follow on PRs:
1. Should I implement the same sort of "finish the row on drop" style API for StringBuilder

# Are there any user-facing changes?
Yes, new APIs + docs
