### PR TITLE
Add support `StringView` / `BinaryView` in `interleave` kernel

### DIFF
--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -22,14 +22,10 @@ use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder, PrimitiveBuilder
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
-use arrow_buffer::{
-    ArrowNativeType, Buffer, MutableBuffer, NullBuffer, NullBufferBuilder, OffsetBuffer,
-    ScalarBuffer,
-};
+use arrow_buffer::{ArrowNativeType, MutableBuffer, NullBuffer, NullBufferBuilder, OffsetBuffer};
 use arrow_data::transform::MutableArrayData;
 use arrow_data::ByteView;
 use arrow_schema::{ArrowError, DataType};
-use builder::{ArrayBuilder, GenericByteViewBuilder};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -502,10 +502,10 @@ mod tests {
     #[test]
     fn test_interleave_views() {
         let values = StringArray::from_iter_values(["hello", "world", "foo", "bar", "baz"]);
-        let view_a = StringViewArray::try_from(&values).unwrap();
+        let view_a = StringViewArray::from(&values);
 
         let values = StringArray::from_iter_values(["test", "data", "more", "views", "here"]);
-        let view_b = StringViewArray::try_from(&values).unwrap();
+        let view_b = StringViewArray::from(&values);
 
         let indices = &[
             (0, 2), // "foo"
@@ -548,10 +548,10 @@ mod tests {
     #[test]
     fn test_interleave_views_with_nulls() {
         let values = StringArray::from_iter([Some("hello"), None, Some("foo"), Some("bar"), None]);
-        let view_a = StringViewArray::try_from(&values).unwrap();
+        let view_a = StringViewArray::from(&values);
 
         let values = StringArray::from_iter([Some("test"), Some("data"), None, None, Some("here")]);
-        let view_b = StringViewArray::try_from(&values).unwrap();
+        let view_b = StringViewArray::from(&values);
 
         let indices = &[
             (0, 1), // null


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/arrow-rs/issues/6780

# Rationale for this change
 
Currently interleaving `ByteViewArray`s are done with the fallback implementation, which uses a `MutableArrayBuilder`. The `extend` method on this builder is copying over all variadic buffers because it doesn't know if there are buffers not referenced by any views in the array. Especially on datafusion's TopK implementation, which uses an heap that interleaves arrow arrays to produce the top k rows, current interleave implementation results in an explosion of variadic buffer count for byte view arrays, adding the same set of buffers over and over again. Where this becomes really problematic is when sending such arrays over flight, current encoder materialises all variadic buffers.

# What changes are included in this PR?

Add a `ByteViewArray` specific interleave implementation that does not add a previously referenced variadic buffer when building the interleaved array

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
