### PR TITLE
Remove APIs deprecated on or before 49.0.0

### DIFF
--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
 use cast::as_primitive_array;
-use chrono::{Datelike, NaiveDateTime, Offset, TimeZone, Timelike, Utc};
+use chrono::{Datelike, TimeZone, Timelike, Utc};
 
 use arrow_array::temporal_conversions::{
     date32_to_datetime, date64_to_datetime, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
@@ -82,6 +82,7 @@ impl std::fmt::Display for DatePart {
 /// Returns function to extract relevant [`DatePart`] from types like a
 /// [`NaiveDateTime`] or [`DateTime`].
 ///
+/// [`NaiveDateTime`]: chrono::NaiveDateTime
 /// [`DateTime`]: chrono::DateTime
 fn get_date_time_part_extract_fn<T>(part: DatePart) -> fn(T) -> i32
 where
@@ -662,20 +663,6 @@ impl<T: Datelike> ChronoDateExt for T {
     fn num_days_from_sunday(&self) -> i32 {
         self.weekday().num_days_from_sunday() as i32
     }
-}
-
-/// Parse the given string into a string representing fixed-offset that is correct as of the given
-/// UTC NaiveDateTime.
-///
-/// Note that the offset is function of time and can vary depending on whether daylight savings is
-/// in effect or not. e.g. Australia/Sydney is +10:00 or +11:00 depending on DST.
-#[deprecated(since = "26.0.0", note = "Use arrow_array::timezone::Tz instead")]
-pub fn using_chrono_tz_and_utc_naive_date_time(
-    tz: &str,
-    utc: NaiveDateTime,
-) -> Option<chrono::offset::FixedOffset> {
-    let tz: Tz = tz.parse().ok()?;
-    Some(tz.offset_from_utc_datetime(&utc).fix())
 }
 
 /// Extracts the hours of a given array as an array of integers within

--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -24,12 +24,6 @@ use arrow_schema::DataType;
 pub type GenericBinaryArray<OffsetSize> = GenericByteArray<GenericBinaryType<OffsetSize>>;
 
 impl<OffsetSize: OffsetSizeTrait> GenericBinaryArray<OffsetSize> {
-    /// Get the data type of the array.
-    #[deprecated(since = "20.0.0", note = "please use `Self::DATA_TYPE` instead")]
-    pub const fn get_data_type() -> DataType {
-        Self::DATA_TYPE
-    }
-
     /// Creates a [GenericBinaryArray] from a vector of byte slices
     ///
     /// See also [`Self::from_iter_values`]

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1480,24 +1480,6 @@ def_numeric_from_vec!(TimestampMicrosecondType);
 def_numeric_from_vec!(TimestampNanosecondType);
 
 impl<T: ArrowTimestampType> PrimitiveArray<T> {
-    /// Construct a timestamp array from a vec of i64 values and an optional timezone
-    #[deprecated(since = "26.0.0", note = "Use with_timezone_opt instead")]
-    pub fn from_vec(data: Vec<i64>, timezone: Option<String>) -> Self
-    where
-        Self: From<Vec<i64>>,
-    {
-        Self::from(data).with_timezone_opt(timezone)
-    }
-
-    /// Construct a timestamp array from a vec of `Option<i64>` values and an optional timezone
-    #[deprecated(since = "26.0.0", note = "Use with_timezone_opt instead")]
-    pub fn from_opt_vec(data: Vec<Option<i64>>, timezone: Option<String>) -> Self
-    where
-        Self: From<Vec<Option<i64>>>,
-    {
-        Self::from(data).with_timezone_opt(timezone)
-    }
-
     /// Returns the timezone of this array if any
     pub fn timezone(&self) -> Option<&str> {
         match self.data_type() {

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -17,18 +17,12 @@
 
 use crate::types::GenericStringType;
 use crate::{GenericBinaryArray, GenericByteArray, GenericListArray, OffsetSizeTrait};
-use arrow_schema::{ArrowError, DataType};
+use arrow_schema::ArrowError;
 
 /// A [`GenericByteArray`] for storing `str`
 pub type GenericStringArray<OffsetSize> = GenericByteArray<GenericStringType<OffsetSize>>;
 
 impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
-    /// Get the data type of the array.
-    #[deprecated(since = "20.0.0", note = "please use `Self::DATA_TYPE` instead")]
-    pub const fn get_data_type() -> DataType {
-        Self::DATA_TYPE
-    }
-
     /// Returns the number of `Unicode Scalar Value` in the string at index `i`.
     /// # Performance
     /// This function has `O(n)` time complexity where `n` is the string length.
@@ -167,7 +161,7 @@ mod tests {
     use crate::Array;
     use arrow_buffer::Buffer;
     use arrow_data::ArrayData;
-    use arrow_schema::Field;
+    use arrow_schema::{DataType, Field};
     use std::sync::Arc;
 
     #[test]

--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -689,15 +689,6 @@ array_downcast_fn!(as_struct_array, StructArray);
 array_downcast_fn!(as_union_array, UnionArray);
 array_downcast_fn!(as_map_array, MapArray);
 
-/// Force downcast of an Array, such as an ArrayRef to Decimal128Array, panic’ing on failure.
-#[deprecated(
-    since = "42.0.0",
-    note = "please use `as_primitive_array::<Decimal128Type>` instead"
-)]
-pub fn as_decimal_array(arr: &dyn Array) -> &PrimitiveArray<Decimal128Type> {
-    as_primitive_array::<Decimal128Type>(arr)
-}
-
 /// Downcasts a `dyn Array` to a concrete type
 ///
 /// ```

--- a/arrow-array/src/types.rs
+++ b/arrow-array/src/types.rs
@@ -324,12 +324,6 @@ pub trait ArrowTimestampType: ArrowTemporalType<Native = i64> {
     /// The [`TimeUnit`] of this timestamp.
     const UNIT: TimeUnit;
 
-    /// Returns the `TimeUnit` of this timestamp.
-    #[deprecated(since = "36.0.0", note = "Use Self::UNIT")]
-    fn get_time_unit() -> TimeUnit {
-        Self::UNIT
-    }
-
     /// Creates a ArrowTimestampType::Native from the provided [`NaiveDateTime`]
     ///
     /// See [`DataType::Timestamp`] for more information on timezone handling

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -96,17 +96,6 @@ impl BooleanBuffer {
         BitChunks::new(self.values(), self.offset, self.len)
     }
 
-    /// Returns `true` if the bit at index `i` is set
-    ///
-    /// # Panics
-    ///
-    /// Panics if `i >= self.len()`
-    #[inline]
-    #[deprecated(since = "36.0.0", note = "use BooleanBuffer::value")]
-    pub fn is_set(&self, i: usize) -> bool {
-        self.value(i)
-    }
-
     /// Returns the offset of this [`BooleanBuffer`] in bits
     #[inline]
     pub fn offset(&self) -> usize {

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -278,14 +278,6 @@ impl Buffer {
         BitChunks::new(self.as_slice(), offset, len)
     }
 
-    /// Returns the number of 1-bits in this buffer.
-    #[deprecated(since = "27.0.0", note = "use count_set_bits_offset instead")]
-    pub fn count_set_bits(&self) -> usize {
-        let len_in_bits = self.len() * 8;
-        // self.offset is already taken into consideration by the bit_chunks implementation
-        self.count_set_bits_offset(0, len_in_bits)
-    }
-
     /// Returns the number of 1-bits in this buffer, starting from `offset` with `length` bits
     /// inspected. Note that both `offset` and `length` are measured in bits.
     pub fn count_set_bits_offset(&self, offset: usize, len: usize) -> usize {

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -118,13 +118,6 @@ impl MutableBuffer {
         Self { data, len, layout }
     }
 
-    /// Create a [`MutableBuffer`] from the provided [`Vec`] without copying
-    #[inline]
-    #[deprecated(since = "46.0.0", note = "Use From<Vec<T>>")]
-    pub fn from_vec<T: ArrowNativeType>(vec: Vec<T>) -> Self {
-        Self::from(vec)
-    }
-
     /// Allocates a new [MutableBuffer] from given `Bytes`.
     pub(crate) fn from_bytes(bytes: Bytes) -> Result<Self, Bytes> {
         let layout = match bytes.deallocation() {

--- a/arrow-buffer/src/native.rs
+++ b/arrow-buffer/src/native.rs
@@ -88,30 +88,6 @@ pub trait ArrowNativeType:
     /// Returns `None` if [`Self`] is not an integer or conversion would result
     /// in truncation/overflow
     fn to_i64(self) -> Option<i64>;
-
-    /// Convert native type from i32.
-    ///
-    /// Returns `None` if [`Self`] is not `i32`
-    #[deprecated(since = "24.0.0", note = "please use `Option::Some` instead")]
-    fn from_i32(_: i32) -> Option<Self> {
-        None
-    }
-
-    /// Convert native type from i64.
-    ///
-    /// Returns `None` if [`Self`] is not `i64`
-    #[deprecated(since = "24.0.0", note = "please use `Option::Some` instead")]
-    fn from_i64(_: i64) -> Option<Self> {
-        None
-    }
-
-    /// Convert native type from i128.
-    ///
-    /// Returns `None` if [`Self`] is not `i128`
-    #[deprecated(since = "24.0.0", note = "please use `Option::Some` instead")]
-    fn from_i128(_: i128) -> Option<Self> {
-        None
-    }
 }
 
 macro_rules! native_integer {
@@ -147,23 +123,15 @@ macro_rules! native_integer {
             fn usize_as(i: usize) -> Self {
                 i as _
             }
-
-
-            $(
-                #[inline]
-                fn $from(v: $t) -> Option<Self> {
-                    Some(v)
-                }
-            )*
         }
     };
 }
 
 native_integer!(i8);
 native_integer!(i16);
-native_integer!(i32, from_i32);
-native_integer!(i64, from_i64);
-native_integer!(i128, from_i128);
+native_integer!(i32);
+native_integer!(i64);
+native_integer!(i128);
 native_integer!(u8);
 native_integer!(u16);
 native_integer!(u32);

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -256,14 +256,6 @@ impl WriterBuilder {
         Self::default()
     }
 
-    /// Set whether to write headers
-    #[deprecated(since = "39.0.0", note = "Use Self::with_header")]
-    #[doc(hidden)]
-    pub fn has_headers(mut self, has_headers: bool) -> Self {
-        self.has_header = has_headers;
-        self
-    }
-
     /// Set whether to write the CSV file with a header
     pub fn with_header(mut self, header: bool) -> Self {
         self.has_header = header;
@@ -395,17 +387,6 @@ impl WriterBuilder {
     /// Get the value to represent null in output
     pub fn null(&self) -> &str {
         self.null_value.as_deref().unwrap_or(DEFAULT_NULL_VALUE)
-    }
-
-    /// Use RFC3339 format for date/time/timestamps (default)
-    #[deprecated(since = "39.0.0", note = "Use WriterBuilder::default()")]
-    pub fn with_rfc3339(mut self) -> Self {
-        self.date_format = None;
-        self.datetime_format = None;
-        self.time_format = None;
-        self.timestamp_format = None;
-        self.timestamp_tz_format = None;
-        self
     }
 
     /// Create a new `Writer`

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -30,11 +30,6 @@ use std::sync::Arc;
 
 use crate::{equal, validate_binary_view, validate_string_view};
 
-/// A collection of [`Buffer`]
-#[doc(hidden)]
-#[deprecated(since = "46.0.0", note = "Use [Buffer]")]
-pub type Buffers<'a> = &'a [Buffer];
-
 #[inline]
 pub(crate) fn contains_nulls(
     null_bit_buffer: Option<&NullBuffer>,

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -246,13 +246,6 @@ impl ReaderBuilder {
 
     /// Sets if the decoder should coerce primitive values (bool and number) into string
     /// when the Schema's column is Utf8 or LargeUtf8.
-    #[deprecated(since = "39.0.0", note = "Use with_coerce_primitive")]
-    pub fn coerce_primitive(self, coerce_primitive: bool) -> Self {
-        self.with_coerce_primitive(coerce_primitive)
-    }
-
-    /// Sets if the decoder should coerce primitive values (bool and number) into string
-    /// when the Schema's column is Utf8 or LargeUtf8.
     pub fn with_coerce_primitive(self, coerce_primitive: bool) -> Self {
         Self {
             coerce_primitive,

--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -24,7 +24,6 @@ use arrow_buffer::BooleanBuffer;
 use arrow_schema::ArrowError;
 
 use crate::cmp::distinct;
-use crate::sort::SortColumn;
 
 /// A computed set of partitions, see [`partition`]
 #[derive(Debug, Clone)]
@@ -158,21 +157,6 @@ fn find_boundaries(v: &dyn Array) -> Result<BooleanBuffer, ArrowError> {
     let v1 = v.slice(0, slice_len);
     let v2 = v.slice(1, slice_len);
     Ok(distinct(&v1, &v2)?.values().clone())
-}
-
-/// Use [`partition`] instead. Given a list of already sorted columns, find
-/// partition ranges that would partition lexicographically equal values across
-/// columns.
-///
-/// The returned vec would be of size k where k is cardinality of the sorted values; Consecutive
-/// values will be connected: (a, b) and (b, c), where start = 0 and end = n for the first and last
-/// range.
-#[deprecated(since = "46.0.0", note = "Use partition")]
-pub fn lexicographical_partition_ranges(
-    columns: &[SortColumn],
-) -> Result<impl Iterator<Item = Range<usize>> + '_, ArrowError> {
-    let cols: Vec<_> = columns.iter().map(|x| x.values.clone()).collect();
-    Ok(partition(&cols)?.ranges().into_iter())
 }
 
 #[cfg(test)]

--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -468,12 +468,6 @@ impl InMemory {
         Self { storage }
     }
 
-    /// Creates a clone of the store
-    #[deprecated(since = "44.0.0", note = "Use fork() instead")]
-    pub async fn clone(&self) -> Self {
-        self.fork()
-    }
-
     async fn entry(&self, location: &Path) -> Result<Entry> {
         let storage = self.storage.read();
         let value = storage

--- a/object_store/src/prefix.rs
+++ b/object_store/src/prefix.rs
@@ -26,10 +26,6 @@ use crate::{
     PutOptions, PutPayload, PutResult, Result,
 };
 
-#[doc(hidden)]
-#[deprecated(since = "36.0.0", note = "Use PrefixStore")]
-pub type PrefixObjectStore<T> = PrefixStore<T>;
-
 /// Store wrapper that applies a constant prefix to all paths handled by the store.
 #[derive(Debug, Clone)]
 pub struct PrefixStore<T: ObjectStore> {

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -185,31 +185,6 @@ where
         }
     }
 
-    /// Reads a batch of values of at most `batch_size`, returning a tuple containing the
-    /// actual number of non-null values read, followed by the corresponding number of levels,
-    /// i.e, the total number of values including nulls, empty lists, etc...
-    ///
-    /// If the max definition level is 0, `def_levels` will be ignored, otherwise it will be
-    /// populated with the number of levels read, with an error returned if it is `None`.
-    ///
-    /// If the max repetition level is 0, `rep_levels` will be ignored, otherwise it will be
-    /// populated with the number of levels read, with an error returned if it is `None`.
-    ///
-    /// `values` will be contiguously populated with the non-null values. Note that if the column
-    /// is not required, this may be less than either `batch_size` or the number of levels read
-    #[deprecated(since = "42.0.0", note = "Use read_records")]
-    pub fn read_batch(
-        &mut self,
-        batch_size: usize,
-        def_levels: Option<&mut D::Buffer>,
-        rep_levels: Option<&mut R::Buffer>,
-        values: &mut V::Buffer,
-    ) -> Result<(usize, usize)> {
-        let (_, values, levels) = self.read_records(batch_size, def_levels, rep_levels, values)?;
-
-        Ok((values, levels))
-    }
-
     /// Read up to `max_records` whole records, returning the number of complete
     /// records, non-null values and levels decoded. All levels for a given record
     /// will be read, i.e. the next repetition level, if any, will be 0

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -230,12 +230,6 @@ impl ParquetMetaData {
         &self.row_groups
     }
 
-    /// Returns page indexes in this file.
-    #[deprecated(since = "39.0.0", note = "Use Self::column_index")]
-    pub fn page_indexes(&self) -> Option<&ParquetColumnIndex> {
-        self.column_index.as_ref()
-    }
-
     /// Returns the column index for this file if loaded
     ///
     /// Returns `None` if the parquet file does not have a `ColumnIndex` or
@@ -244,12 +238,6 @@ impl ParquetMetaData {
     /// [ArrowReaderOptions::with_page_index]: https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ArrowReaderOptions.html#method.with_page_index
     pub fn column_index(&self) -> Option<&ParquetColumnIndex> {
         self.column_index.as_ref()
-    }
-
-    /// Returns the offset index for this file if loaded
-    #[deprecated(since = "39.0.0", note = "Use Self::offset_index")]
-    pub fn offset_indexes(&self) -> Option<&ParquetOffsetIndex> {
-        self.offset_index.as_ref()
     }
 
     /// Returns offset indexes in this file, if loaded


### PR DESCRIPTION

# Which issue does this PR close?

none

# Rationale for this change
 
The purpose of deprecation is to eventually remove and 49.0.0 release was Nov 9, 2023. 



# What changes are included in this PR?

Remove the APIs that are deprecated since then, or earlier than that.
Few such deprecated APIs remain in the code, they are still in use so the code needs update.


# Are there any user-facing changes?


yes


cc @alamb 