### PR TITLE
Add `Array::shrink_to_fit(&self) -> ArrayRef`

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -308,6 +308,13 @@ impl Array for BooleanArray {
         self.values.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            values: self.values.clone().shrink_to_fit(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+        })
+    }
+
     fn offset(&self) -> usize {
         self.values.offset()
     }

--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -453,6 +453,15 @@ impl<T: ByteArrayType> Array for GenericByteArray<T> {
         self.value_offsets.len() <= 1
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            value_offsets: self.value_offsets.clone().shrink_to_fit(),
+            value_data: self.value_data.clone().shrink_to_fit(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -720,6 +720,21 @@ impl<T: ArrowDictionaryKeyType> Array for DictionaryArray<T> {
         self.keys.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            keys: self
+                .keys
+                .shrink_to_fit()
+                .as_any()
+                .downcast_ref::<PrimitiveArray<T>>()
+                .unwrap()
+                .clone(),
+            values: self.values.shrink_to_fit(),
+            is_ordered: self.is_ordered,
+        })
+    }
+
     fn offset(&self) -> usize {
         self.keys.offset()
     }
@@ -872,6 +887,10 @@ impl<K: ArrowDictionaryKeyType, V: Sync> Array for TypedDictionaryArray<'_, K, V
 
     fn is_empty(&self) -> bool {
         self.dictionary.is_empty()
+    }
+
+    fn shrink_to_fit(&self) -> ArrayRef {
+        unimplemented!("shrink_to_fit cannot be implemented for TypedDictionaryArray")
     }
 
     fn offset(&self) -> usize {

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -603,6 +603,16 @@ impl Array for FixedSizeBinaryArray {
         self.len == 0
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            value_data: self.value_data.clone().shrink_to_fit(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            len: self.len,
+            value_length: self.value_length,
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -401,6 +401,16 @@ impl Array for FixedSizeListArray {
         self.len == 0
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            values: self.values.shrink_to_fit(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            value_length: self.value_length,
+            len: self.len,
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -485,6 +485,15 @@ impl<OffsetSize: OffsetSizeTrait> Array for GenericListArray<OffsetSize> {
         self.value_offsets.len() <= 1
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            values: self.values.shrink_to_fit(),
+            value_offsets: self.value_offsets.clone().shrink_to_fit(),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/list_view_array.rs
+++ b/arrow-array/src/array/list_view_array.rs
@@ -326,6 +326,16 @@ impl<OffsetSize: OffsetSizeTrait> Array for GenericListViewArray<OffsetSize> {
         self.value_sizes.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            values: self.values.shrink_to_fit(),
+            value_offsets: self.value_offsets.clone().shrink_to_fit(),
+            value_sizes: self.value_sizes.clone().shrink_to_fit(),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -372,6 +372,22 @@ impl Array for MapArray {
         self.value_offsets.len() <= 1
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            entries: self
+                .entries
+                .clone()
+                .shrink_to_fit()
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .unwrap()
+                .clone(),
+            value_offsets: self.value_offsets.clone().shrink_to_fit(),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -167,6 +167,10 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// ```
     fn is_empty(&self) -> bool;
 
+    /// Frees up unused memory.
+    #[must_use]
+    fn shrink_to_fit(&self) -> ArrayRef;
+
     /// Returns the offset into the underlying data used by this array(-slice).
     /// Note that the underlying data can be shared by many arrays.
     /// This defaults to `0`.
@@ -365,6 +369,10 @@ impl Array for ArrayRef {
         self.as_ref().is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        self.as_ref().shrink_to_fit()
+    }
+
     fn offset(&self) -> usize {
         self.as_ref().offset()
     }
@@ -433,6 +441,9 @@ impl<T: Array> Array for &T {
 
     fn is_empty(&self) -> bool {
         T::is_empty(self)
+    }
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(T::shrink_to_fit(self))
     }
 
     fn offset(&self) -> usize {

--- a/arrow-array/src/array/null_array.rs
+++ b/arrow-array/src/array/null_array.rs
@@ -105,6 +105,10 @@ impl Array for NullArray {
         self.len == 0
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self { len: self.len })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1152,6 +1152,14 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
         self.values.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            values: self.values.clone().shrink_to_fit(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -330,6 +330,14 @@ impl<T: RunEndIndexType> Array for RunArray<T> {
         self.run_ends.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            run_ends: self.run_ends.clone().shrink_to_fit(),
+            values: self.values.shrink_to_fit(),
+        })
+    }
+
     fn offset(&self) -> usize {
         self.run_ends.offset()
     }
@@ -582,6 +590,10 @@ impl<R: RunEndIndexType, V: Sync> Array for TypedRunArray<'_, R, V> {
 
     fn is_empty(&self) -> bool {
         self.run_array.is_empty()
+    }
+
+    fn shrink_to_fit(&self) -> ArrayRef {
+        unimplemented!("shrink_to_fit cannot be implemented for TypedRunArray")
     }
 
     fn offset(&self) -> usize {

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -364,6 +364,15 @@ impl Array for StructArray {
         self.len == 0
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            len: self.len,
+            data_type: self.data_type.clone(),
+            nulls: self.nulls.clone().map(|n| n.shrink_to_fit()),
+            fields: self.fields.iter().map(|n| n.shrink_to_fit()).collect(),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -744,6 +744,19 @@ impl Array for UnionArray {
         self.type_ids.is_empty()
     }
 
+    fn shrink_to_fit(&self) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            type_ids: self.type_ids.clone().shrink_to_fit(),
+            offsets: self.offsets.clone().map(|o| o.shrink_to_fit()),
+            fields: self
+                .fields
+                .iter()
+                .map(|option| option.as_ref().map(|n| n.shrink_to_fit()))
+                .collect(),
+        })
+    }
+
     fn offset(&self) -> usize {
         0
     }

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -125,6 +125,18 @@ impl BooleanBuffer {
         self.len == 0
     }
 
+    /// Free up unused memory.
+    #[inline]
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        Self {
+            // TODO: we could shrink even more in the case where we are a small sub-slice of the full buffer
+            buffer: self.buffer.shrink_to_fit(),
+            offset: self.offset,
+            len: self.len,
+        }
+    }
+
     /// Returns the boolean value at index `i`.
     ///
     /// # Panics

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -167,6 +167,20 @@ impl Buffer {
         self.data.capacity()
     }
 
+    /// Shrinks the capacity of the buffer as much as possible, freeing unused memory.
+    ///
+    /// The capacity of the returned buffer will be the same as [`Self::len`].
+    ///
+    /// If the capacity is already less than or equal to the desired capacity, this is a no-op.
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        if self.capacity() == self.len() {
+            self
+        } else {
+            Self::from_vec(self.as_slice().to_vec())
+        }
+    }
+
     /// Returns whether the buffer is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -560,6 +574,21 @@ mod tests {
         assert_eq!(0, buf4.len());
         assert!(buf4.is_empty());
         assert_eq!(buf2.slice_with_length(2, 1).as_slice(), &[10]);
+    }
+
+    #[test]
+    fn test_shrink_to_fit() {
+        let original = Buffer::from(&[1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(original.len(), 7);
+        assert_eq!(original.capacity(), 64);
+
+        let slice = original.slice(3);
+        assert_eq!(slice.len(), 4);
+        assert_eq!(slice.capacity(), 64);
+
+        let shurnk = slice.shrink_to_fit();
+        assert_eq!(shurnk.len(), 4);
+        assert_eq!(shurnk.capacity(), 4);
     }
 
     #[test]

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -130,6 +130,16 @@ impl NullBuffer {
         self.buffer.is_empty()
     }
 
+    /// Free up unused memory.
+    #[inline]
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        Self {
+            buffer: self.buffer.shrink_to_fit(),
+            null_count: self.null_count,
+        }
+    }
+
     /// Returns the null count for this [`NullBuffer`]
     #[inline]
     pub fn null_count(&self) -> usize {

--- a/arrow-buffer/src/buffer/offset.rs
+++ b/arrow-buffer/src/buffer/offset.rs
@@ -133,6 +133,13 @@ impl<O: ArrowNativeType> OffsetBuffer<O> {
         Self(out.into())
     }
 
+    /// Free up unused memory.
+    #[inline]
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        Self(self.0.shrink_to_fit())
+    }
+
     /// Returns the inner [`ScalarBuffer`]
     pub fn inner(&self) -> &ScalarBuffer<O> {
         &self.0

--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -136,6 +136,18 @@ where
         self.len == 0
     }
 
+    /// Free up unused memory.
+    #[inline]
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        Self {
+            // TODO: we could shrink even more in the case where we are a small sub-slice of the full buffer
+            run_ends: self.run_ends.shrink_to_fit(),
+            len: self.len,
+            offset: self.offset,
+        }
+    }
+
     /// Returns the values of this [`RunEndBuffer`] not including any offset
     #[inline]
     pub fn values(&self) -> &[E] {

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -72,6 +72,16 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
         buffer.slice_with_length(byte_offset, byte_len).into()
     }
 
+    /// Free up unused memory.
+    #[inline]
+    #[must_use]
+    pub fn shrink_to_fit(self) -> Self {
+        Self {
+            buffer: self.buffer.shrink_to_fit(),
+            phantom: self.phantom,
+        }
+    }
+
     /// Returns a zero-copy slice of this buffer with length `len` and starting at `offset`
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         Self::new(self.buffer.clone(), offset, len)


### PR DESCRIPTION
# Which issue does this PR close?
* Closes #6360

# Rationale for this change
Concatenating many arrow buffers incrementally can lead to situations where the buffers are using much more memory than they need (their capacity is larger than their lengths).

Example:

```rs
use arrow::{
    array::{Array, ArrayRef, ListArray, PrimitiveArray},
    buffer::OffsetBuffer,
    datatypes::{Field, UInt8Type},
};

fn main() {
    let array0: PrimitiveArray<UInt8Type> = (0..200 * 300)
        .map(|v| (v % 255) as u8)
        .collect::<Vec<_>>()
        .into();
    let array0: ArrayRef = Arc::new(array0);

    let (global, local) = memory_use(|| {
        let concatenated = concatenate(array0.clone());
        dbg!(concatenated.data_type());
        eprintln!("expected: ~{}", how_many_bytes(concatenated.clone()));
        concatenated
    });
    eprintln!("global: {global} bytes");
    eprintln!("local: {local} bytes");

    eprintln!("---");

    let array1 = ListArray::new(
        Field::new_list_field(array0.data_type().clone(), false).into(),
        OffsetBuffer::from_lengths(std::iter::once(array0.len())),
        array0.clone(),
        None,
    );
    let array1: ArrayRef = Arc::new(array1);

    let (global, local) = memory_use(|| {
        let concatenated = concatenate(array1.clone()).shrink_to_fit();
        dbg!(concatenated.data_type());
        eprintln!("expected: ~{}", how_many_bytes(concatenated.clone()));
        concatenated
    });
    eprintln!("global: {global} bytes");
    eprintln!("local: {local} bytes");
}

fn concatenate(array: ArrayRef) -> ArrayRef {
    let mut concatenated = array.clone();

    for _ in 0..1000 {
        concatenated = arrow::compute::kernels::concat::concat(&[&*concatenated, &*array]).unwrap();
    }

    concatenated
}

fn how_many_bytes(array: ArrayRef) -> u64 {
    let mut array = array;
    loop {
        match array.data_type() {
            arrow::datatypes::DataType::UInt8 => break,
            arrow::datatypes::DataType::List(_) => {
                let list = array.as_any().downcast_ref::<ListArray>().unwrap();
                array = list.values().clone();
            }
            _ => unreachable!(),
        }
    }

    array.len() as _
}

// --- Memory tracking ---

use std::sync::{
    atomic::{AtomicUsize, Ordering::Relaxed},
    Arc,
};

static LIVE_BYTES_GLOBAL: AtomicUsize = AtomicUsize::new(0);

thread_local! {
    static LIVE_BYTES_IN_THREAD: AtomicUsize = const { AtomicUsize::new(0)  } ;
}

pub struct TrackingAllocator {
    allocator: std::alloc::System,
}

#[global_allocator]
pub static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator {
    allocator: std::alloc::System,
};

#[allow(unsafe_code)]
// SAFETY:
// We just do book-keeping and then let another allocator do all the actual work.
unsafe impl std::alloc::GlobalAlloc for TrackingAllocator {
    #[allow(clippy::let_and_return)]
    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
        LIVE_BYTES_IN_THREAD.with(|bytes| bytes.fetch_add(layout.size(), Relaxed));
        LIVE_BYTES_GLOBAL.fetch_add(layout.size(), Relaxed);

        // SAFETY:
        // Just deferring
        unsafe { self.allocator.alloc(layout) }
    }

    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
        LIVE_BYTES_IN_THREAD.with(|bytes| bytes.fetch_sub(layout.size(), Relaxed));
        LIVE_BYTES_GLOBAL.fetch_sub(layout.size(), Relaxed);

        // SAFETY:
        // Just deferring
        unsafe { self.allocator.dealloc(ptr, layout) };
    }
}

fn live_bytes_local() -> usize {
    LIVE_BYTES_IN_THREAD.with(|bytes| bytes.load(Relaxed))
}

fn live_bytes_global() -> usize {
    LIVE_BYTES_GLOBAL.load(Relaxed)
}

/// Returns `(num_bytes_allocated, num_bytes_allocated_by_this_thread)`.
fn memory_use<R>(run: impl Fn() -> R) -> (usize, usize) {
    let used_bytes_start_local = live_bytes_local();
    let used_bytes_start_global = live_bytes_global();
    let ret = run();
    let bytes_used_local = live_bytes_local() - used_bytes_start_local;
    let bytes_used_global = live_bytes_global() - used_bytes_start_global;
    drop(ret);
    (bytes_used_global, bytes_used_local)
}
```

If you run this you will see 12 MB is used for 6 MB of data.

# What changes are included in this PR?

This PR adds `shrink_to_fit` to `Array` and all buffers.

# Are there any user-facing changes?

`trait Array` now has a `fn shrink_to_fit(&self) -> ArrayRef`.

# Problems
I could not implement `Array::shrink_to_fit` for `TypedDictionaryArray` nor `TypedRunArray`, since they are types wrapping references. Calling `shrink_to_fit` on these will result in an `unimplemented!` panic. Perhaps we should return an error instead.

Due to the above problem, perhaps we should consider an alternative approach?