### PR TITLE
Add option to disable writing of Parquet offset index

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -396,7 +396,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
         // Disable offset_index_builder if requested by user.
         let mut offset_index_builder = OffsetIndexBuilder::new();
-        if props.offset_index_disabled(descr.path()) {
+        if props.offset_index_disabled() {
             offset_index_builder.disable()
         }
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1535,6 +1535,7 @@ pub struct OffsetIndexBuilder {
     first_row_index_array: Vec<i64>,
     unencoded_byte_array_data_bytes_array: Option<Vec<i64>>,
     current_first_row_index: i64,
+    enabled: bool,
 }
 
 impl Default for OffsetIndexBuilder {
@@ -1552,7 +1553,18 @@ impl OffsetIndexBuilder {
             first_row_index_array: Vec::new(),
             unencoded_byte_array_data_bytes_array: None,
             current_first_row_index: 0,
+            enabled: true,
         }
+    }
+
+    /// Disable writing of offset indexes.
+    pub fn disable(&mut self) {
+        self.enabled = false;
+    }
+
+    /// Indicate if writing of the offset indexes is enabled.
+    pub fn enabled(&self) -> bool {
+        self.enabled
     }
 
     /// Append the row count of the next page.

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1742,6 +1742,7 @@ mod tests {
         let props = WriterProperties::builder()
             .set_statistics_enabled(EnabledStatistics::None)
             .set_column_statistics_enabled("a".into(), EnabledStatistics::Page)
+            .set_offset_index_disabled(true) // this should be ignored because of the line above
             .build();
         let mut file = Vec::with_capacity(1024);
         let mut file_writer =


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6778.

# Rationale for this change
 
Allow disabling offset indexes.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Adds a global `offset_index_disabled` writer property. This was made global rather than per-column because the index is not very useful if not defined for all columns.

# Are there any user-facing changes?
Yes, adds a new property.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
