### PR TITLE
fix: Encoding of List offsets was incorrect when slice offsets begin with zero

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -23,6 +23,7 @@
 use std::cmp::min;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
+use std::mem::size_of;
 use std::sync::Arc;
 
 use flatbuffers::FlatBufferBuilder;

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1429,8 +1429,14 @@ fn reencode_offsets<O: OffsetSizeTrait>(
     let start_offset = offset_slice.first().unwrap();
     let end_offset = offset_slice.last().unwrap();
 
-    let offsets: Buffer = match start_offset.as_usize() {
-        0 => Buffer::from_slice_ref(offset_slice),
+    let offsets = match start_offset.as_usize() {
+        0 => {
+            let size = size_of::<O>();
+            offsets.slice_with_length(
+                data.offset() * size,
+                (data.offset() + data.len() + 1) * size,
+            )
+        }
         _ => offset_slice.iter().map(|x| *x - *start_offset).collect(),
     };
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1430,7 +1430,7 @@ fn reencode_offsets<O: OffsetSizeTrait>(
     let end_offset = offset_slice.last().unwrap();
 
     let offsets: Buffer = match start_offset.as_usize() {
-        0 => offset_slice.iter().copied().collect(),
+        0 => Buffer::from_slice_ref(offset_slice),
         _ => offset_slice.iter().map(|x| *x - *start_offset).collect(),
     };
 


### PR DESCRIPTION
When encoding offsets the code had an optimization to reuse the offsets if the first offset was zero assuming the slice already pointed to first element. But the offset can also be zero if all previous lists were empty. When this occured it mold make all lists in the slice as empty, even if they shouldn't be.

# Which issue does this PR close?

Closes #6803 .

# Rationale for this change
 
Fixing a bug that can lead to loss of information when encoding record batches.

# What changes are included in this PR?

- Change the encoding and a test to demonstrate the fix.

# Are there any user-facing changes?

No, though some clients will experience smaller encoded messages since only the relevant slice will be sent.
