### PR TITLE
Hide implicit optional dependency features in arrow-flight

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -61,11 +61,11 @@ all-features = true
 
 [features]
 default = []
-flight-sql-experimental = ["arrow-arith", "arrow-data", "arrow-ord", "arrow-row", "arrow-select", "arrow-string", "once_cell"]
+flight-sql-experimental = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell"]
 tls = ["tonic/tls"]
 
 # Enable CLI tools
-cli = ["anyhow", "arrow-array/chrono-tz", "arrow-cast/prettyprint", "clap", "tracing-log", "tracing-subscriber", "tonic/tls-webpki-roots"]
+cli = ["dep:anyhow", "arrow-array/chrono-tz", "arrow-cast/prettyprint", "dep:clap", "dep:tracing-log", "dep:tracing-subscriber", "tonic/tls-webpki-roots"]
 
 [dev-dependencies]
 arrow-cast = { workspace = true, features = ["prettyprint"] }


### PR DESCRIPTION


# Which issue does this PR close?

None but was found when working on https://github.com/apache/arrow-rs/issues/6796 / https://github.com/apache/arrow-rs/pull/6804

# Rationale for this change
 
A dependency X marked `optional = true` implicitly defines a feature X. Docs: https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies This can be seen at https://docs.rs/crate/arrow-flight/53.3.0/features

The optional dependencies were not meant to be standalone features though. Using `dep:` in the `[features]` section is supposed to disable this. It is enough to use `dep:` once. It's used for every optional dependency for consistency.

# What changes are included in this PR?

- remove unintentional implicit features from arrow-flight

# Are there any user-facing changes?

yes

cc @alamb 