### PR TITLE
deduplicate variadic buffers in MutableArrayData::extend for ByteView arrays

### DIFF
--- a/arrow/benches/interleave_kernels.rs
+++ b/arrow/benches/interleave_kernels.rs
@@ -78,12 +78,12 @@ fn add_benchmark(c: &mut Criterion) {
     let sparse_dict = create_sparse_dict_from_values::<Int32Type>(1024, 0.0, &values, 10..20);
 
     let cases: &[(&str, &dyn Array)] = &[
-        // ("i32(0.0)", &i32),
-        // ("i32(0.5)", &i32_opt),
-        // ("str(20, 0.0)", &string),
-        // ("str(20, 0.5)", &string_opt),
-        // ("dict(20, 0.0)", &dict),
-        // ("dict_sparse(20, 0.0)", &sparse_dict),
+        ("i32(0.0)", &i32),
+        ("i32(0.5)", &i32_opt),
+        ("str(20, 0.0)", &string),
+        ("str(20, 0.5)", &string_opt),
+        ("dict(20, 0.0)", &dict),
+        ("dict_sparse(20, 0.0)", &sparse_dict),
         ("string_view(0.5, 50, true)", &string_view),
     ];
 
@@ -100,14 +100,14 @@ fn add_benchmark(c: &mut Criterion) {
         }
     }
 
-    // for len in [100, 1024, 2048] {
-    //     bench_values(
-    //         c,
-    //         &format!("interleave dict_distinct {len}"),
-    //         100,
-    //         &[&dict, &sparse_dict],
-    //     );
-    // }
+    for len in [100, 1024, 2048] {
+        bench_values(
+            c,
+            &format!("interleave dict_distinct {len}"),
+            100,
+            &[&dict, &sparse_dict],
+        );
+    }
 }
 
 criterion_group!(benches, add_benchmark);

--- a/arrow/benches/interleave_kernels.rs
+++ b/arrow/benches/interleave_kernels.rs
@@ -72,17 +72,19 @@ fn add_benchmark(c: &mut Criterion) {
     let string_opt = create_string_array_with_len::<i32>(1024, 0.5, 20);
     let values = create_string_array_with_len::<i32>(10, 0.0, 20);
     let dict = create_dict_from_values::<Int32Type>(1024, 0.0, &values);
+    let string_view = create_string_view_array_with_len(1024, 0.5, 50, true);
 
     let values = create_string_array_with_len::<i32>(1024, 0.0, 20);
     let sparse_dict = create_sparse_dict_from_values::<Int32Type>(1024, 0.0, &values, 10..20);
 
     let cases: &[(&str, &dyn Array)] = &[
-        ("i32(0.0)", &i32),
-        ("i32(0.5)", &i32_opt),
-        ("str(20, 0.0)", &string),
-        ("str(20, 0.5)", &string_opt),
-        ("dict(20, 0.0)", &dict),
-        ("dict_sparse(20, 0.0)", &sparse_dict),
+        // ("i32(0.0)", &i32),
+        // ("i32(0.5)", &i32_opt),
+        // ("str(20, 0.0)", &string),
+        // ("str(20, 0.5)", &string_opt),
+        // ("dict(20, 0.0)", &dict),
+        // ("dict_sparse(20, 0.0)", &sparse_dict),
+        ("string_view(0.5, 50, true)", &string_view),
     ];
 
     for (prefix, base) in cases {
@@ -98,14 +100,14 @@ fn add_benchmark(c: &mut Criterion) {
         }
     }
 
-    for len in [100, 1024, 2048] {
-        bench_values(
-            c,
-            &format!("interleave dict_distinct {len}"),
-            100,
-            &[&dict, &sparse_dict],
-        );
-    }
+    // for len in [100, 1024, 2048] {
+    //     bench_values(
+    //         c,
+    //         &format!("interleave dict_distinct {len}"),
+    //         100,
+    //         &[&dict, &sparse_dict],
+    //     );
+    // }
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 MutableArrayData adds all variadic buffers from input arrays together,  potentially duplicating the same buffers in the output array. 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

`extend` now checks if the same buffer is added from some other input array and changes the views to be appended to point to the new deduplicated buffer indices
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
