### PR TITLE
chore: enrich panic context when BooleanBuffer fails to create

### DIFF
--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -100,17 +100,6 @@ impl BooleanBuffer {
         BitChunks::new(self.values(), self.offset, self.len)
     }
 
-    /// Returns `true` if the bit at index `i` is set
-    ///
-    /// # Panics
-    ///
-    /// Panics if `i >= self.len()`
-    #[inline]
-    #[deprecated(note = "use BooleanBuffer::value")]
-    pub fn is_set(&self, i: usize) -> bool {
-        self.value(i)
-    }
-
     /// Returns the offset of this [`BooleanBuffer`] in bits
     #[inline]
     pub fn offset(&self) -> usize {

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -52,8 +52,12 @@ impl BooleanBuffer {
     /// This method will panic if `buffer` is not large enough
     pub fn new(buffer: Buffer, offset: usize, len: usize) -> Self {
         let total_len = offset.saturating_add(len);
-        let bit_len = buffer.len().saturating_mul(8);
-        assert!(total_len <= bit_len);
+        let buffer_len = buffer.len();
+        let bit_len = buffer_len.saturating_mul(8);
+        assert!(
+            total_len <= bit_len,
+            "buffer not large enough (offset: {offset}, len: {len}, buffer_len: {buffer_len})"
+        );
         Self {
             buffer,
             offset,
@@ -94,6 +98,17 @@ impl BooleanBuffer {
     #[inline]
     pub fn bit_chunks(&self) -> BitChunks {
         BitChunks::new(self.values(), self.offset, self.len)
+    }
+
+    /// Returns `true` if the bit at index `i` is set
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`
+    #[inline]
+    #[deprecated(note = "use BooleanBuffer::value")]
+    pub fn is_set(&self, i: usize) -> bool {
+        self.value(i)
     }
 
     /// Returns the offset of this [`BooleanBuffer`] in bits


### PR DESCRIPTION
TRIVIAL AS IS

Today I encounter this panic while I have no idea whether my data set is too large or there is other logical errors.