### PR TITLE
improve `zip` performance

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -733,15 +733,13 @@ impl<'a> MutableArrayData<'a> {
     /// or `start` + `count`  > the length of the `index`th array
     /// 
     pub fn extend_scalar(&mut self, index: usize, scalar_index: usize, count: usize) {
-        let f = &self.extend_null_bits[index];
+        let extend_null_fn = &self.extend_null_bits[index];
+        let extend_value_fn = &self.extend_values[index];
         for _ in 0..count {
-            f(&mut self.data, scalar_index, 1);
+            extend_null_fn(&mut self.data, scalar_index, 1);
+            extend_value_fn(&mut self.data, index, scalar_index, 1);
+            self.data.len += 1;
         }
-        let f = &self.extend_values[index];
-        for _ in 0..count {
-            f(&mut self.data, index, scalar_index, 1);
-        }
-        self.data.len += count;
     }
 
     /// Extends the in progress array with null elements, ignoring the input arrays.

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -702,7 +702,7 @@ impl<'a> MutableArrayData<'a> {
 
     /// Extends the in progress array with a region of the input arrays
     ///
-    /// For extending scalar value, use [MutableArrayData::extend_scalar].
+    /// For extending scalar value, use [MutableArrayData::extend_n].
     ///
     /// # Arguments
     /// * `index` - the index of array that you what to copy values from
@@ -732,7 +732,7 @@ impl<'a> MutableArrayData<'a> {
     /// i.e. `index` >= the number of source arrays
     /// or `start` + `count`  > the length of the `index`th array
     ///
-    pub fn extend_scalar(&mut self, index: usize, scalar_index: usize, count: usize) {
+    pub fn extend_n(&mut self, index: usize, scalar_index: usize, count: usize) {
         let extend_null_fn = &self.extend_null_bits[index];
         let extend_value_fn = &self.extend_values[index];
         for _ in 0..count {

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -701,6 +701,8 @@ impl<'a> MutableArrayData<'a> {
     }
 
     /// Extends the in progress array with a region of the input arrays
+    /// 
+    /// For extending scalar value, use [MutableArrayData::extend_scalar].
     ///
     /// # Arguments
     /// * `index` - the index of array that you what to copy values from
@@ -716,6 +718,30 @@ impl<'a> MutableArrayData<'a> {
         (self.extend_null_bits[index])(&mut self.data, start, len);
         (self.extend_values[index])(&mut self.data, index, start, len);
         self.data.len += len;
+    }
+
+    /// Extends the in progress array with the same value from the input arrays
+    ///
+    /// # Arguments
+    /// * `index` - the index of array that you what to copy values from
+    /// * `scalar_index` - the index of the scalar value to copy
+    /// * `count` - the number of times to repeat the value
+    ///
+    /// # Panic
+    /// This function panics if there is an invalid index,
+    /// i.e. `index` >= the number of source arrays
+    /// or `start` + `count`  > the length of the `index`th array
+    /// 
+    pub fn extend_scalar(&mut self, index: usize, scalar_index: usize, count: usize) {
+        let f = &self.extend_null_bits[index];
+        for _ in 0..count {
+            f(&mut self.data, scalar_index, 1);
+        }
+        let f = &self.extend_values[index];
+        for _ in 0..count {
+            f(&mut self.data, index, scalar_index, 1);
+        }
+        self.data.len += count;
     }
 
     /// Extends the in progress array with null elements, ignoring the input arrays.

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -701,7 +701,7 @@ impl<'a> MutableArrayData<'a> {
     }
 
     /// Extends the in progress array with a region of the input arrays
-    /// 
+    ///
     /// For extending scalar value, use [MutableArrayData::extend_scalar].
     ///
     /// # Arguments
@@ -731,7 +731,7 @@ impl<'a> MutableArrayData<'a> {
     /// This function panics if there is an invalid index,
     /// i.e. `index` >= the number of source arrays
     /// or `start` + `count`  > the length of the `index`th array
-    /// 
+    ///
     pub fn extend_scalar(&mut self, index: usize, scalar_index: usize, count: usize) {
         let extend_null_fn = &self.extend_null_bits[index];
         let extend_value_fn = &self.extend_values[index];

--- a/arrow-select/src/zip.rs
+++ b/arrow-select/src/zip.rs
@@ -155,7 +155,7 @@ fn zip_both_array(mask: &BooleanArray, mutable: &mut MutableArrayData) {
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
-            mutable.extend(1, start, end);
+            mutable.extend(1, filled, start);
         }
 
         // fill with truthy values

--- a/arrow-select/src/zip.rs
+++ b/arrow-select/src/zip.rs
@@ -89,10 +89,10 @@ fn zip_both_scalar(mask: &BooleanArray, mutable: &mut MutableArrayData) {
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
-            mutable.extend_scalar(1, 0, start - filled);
+            mutable.extend_n(1, 0, start - filled);
         }
         // fill with truthy values
-        mutable.extend_scalar(0, 0, end - start);
+        mutable.extend_n(0, 0, end - start);
 
         filled = end;
     });
@@ -100,7 +100,7 @@ fn zip_both_scalar(mask: &BooleanArray, mutable: &mut MutableArrayData) {
     // the remaining part is falsy
     if filled < mask.len() {
         // Copy the first item from the 'falsy' array into the output buffer.
-        mutable.extend_scalar(1, 0, mask.len() - filled);
+        mutable.extend_n(1, 0, mask.len() - filled);
     }
 }
 
@@ -115,7 +115,7 @@ fn zip_truthy_scalar_falsy_array(mask: &BooleanArray, mutable: &mut MutableArray
         }
 
         // fill with truthy values
-        mutable.extend_scalar(0, 0, end - start);
+        mutable.extend_n(0, 0, end - start);
 
         filled = end;
     });
@@ -133,7 +133,7 @@ fn zip_truthy_array_falsy_scalar(mask: &BooleanArray, mutable: &mut MutableArray
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
-            mutable.extend_scalar(1, 0, start - filled);
+            mutable.extend_n(1, 0, start - filled);
         }
 
         // fill with truthy values
@@ -145,7 +145,7 @@ fn zip_truthy_array_falsy_scalar(mask: &BooleanArray, mutable: &mut MutableArray
     // the remaining part is falsy
     if filled < mask.len() {
         // Copy the first item from the 'falsy' array into the output buffer.
-        mutable.extend_scalar(1, 0, mask.len() - filled);
+        mutable.extend_n(1, 0, mask.len() - filled);
     }
 }
 

--- a/arrow-select/src/zip.rs
+++ b/arrow-select/src/zip.rs
@@ -75,7 +75,7 @@ pub fn zip(
         (true, true) => zip_both_scalar(mask, &mut mutable),
         (true, false) => zip_truthy_scalar_falsy_array(mask, &mut mutable),
         (false, true) => zip_truthy_array_falsy_scalar(mask, &mut mutable),
-        (false, false) => zip_both_array(mask, &mut mutable)
+        (false, false) => zip_both_array(mask, &mut mutable),
     };
 
     let data = mutable.freeze();
@@ -89,35 +89,24 @@ fn zip_both_scalar(mask: &BooleanArray, mutable: &mut MutableArrayData) {
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
-            for _ in filled..start {
-                // Copy the first item from the 'falsy' array into the output buffer.
-                mutable.extend(1, 0, 1);
-            }
+            mutable.extend_scalar(1, 0, start - filled);
         }
         // fill with truthy values
-        for _ in start..end {
-            // Copy the first item from the 'truthy' array into the output buffer.
-            mutable.extend(0, 0, 1);
-        }
+        mutable.extend_scalar(0, 0, end - start);
 
         filled = end;
     });
 
-
-
     // the remaining part is falsy
     if filled < mask.len() {
-        for _ in filled..mask.len() {
-            // Copy the first item from the 'falsy' array into the output buffer.
-            mutable.extend(1, 0, 1);
-        }
+        // Copy the first item from the 'falsy' array into the output buffer.
+        mutable.extend_scalar(1, 0, mask.len() - filled);
     }
 }
 
 fn zip_truthy_scalar_falsy_array(mask: &BooleanArray, mutable: &mut MutableArrayData) {
     // keep track of how much is filled
     let mut filled = 0;
-
 
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
@@ -126,10 +115,7 @@ fn zip_truthy_scalar_falsy_array(mask: &BooleanArray, mutable: &mut MutableArray
         }
 
         // fill with truthy values
-        for _ in start..end {
-            // Copy the first item from the 'truthy' array into the output buffer.
-            mutable.extend(0, 0, 1);
-        }
+        mutable.extend_scalar(0, 0, end - start);
 
         filled = end;
     });
@@ -147,10 +133,7 @@ fn zip_truthy_array_falsy_scalar(mask: &BooleanArray, mutable: &mut MutableArray
     SlicesIterator::new(mask).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
-            for _ in filled..start {
-                // Copy the first item from the 'falsy' array into the output buffer.
-                mutable.extend(1, 0, 1);
-            }
+            mutable.extend_scalar(1, 0, start - filled);
         }
 
         // fill with truthy values
@@ -159,13 +142,10 @@ fn zip_truthy_array_falsy_scalar(mask: &BooleanArray, mutable: &mut MutableArray
         filled = end;
     });
 
-
     // the remaining part is falsy
     if filled < mask.len() {
-        for _ in filled..mask.len() {
-            // Copy the first item from the 'falsy' array into the output buffer.
-            mutable.extend(1, 0, 1);
-        }
+        // Copy the first item from the 'falsy' array into the output buffer.
+        mutable.extend_scalar(1, 0, mask.len() - filled);
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

No issue

# Rationale for this change
 
I saw that we do for every range of true check if the truthy values and falsy are scalar, which can be checked once

# What changes are included in this PR?

1. Specialize cases for scalars in `zip` function
2. Add `extend_scalar` function to `MutableArrayData` to be optimized for single value that is being copy over and over again


# Are there any user-facing changes?

No (I think)



----

there are no `benchmarks` to `zip` unfortunately 