### PR TITLE
change map field default names to follow the parquet format spec

### DIFF
--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -78,9 +78,9 @@ pub struct MapFieldNames {
 impl Default for MapFieldNames {
     fn default() -> Self {
         Self {
-            entry: "entries".to_string(),
-            key: "keys".to_string(),
-            value: "values".to_string(),
+            entry: "key_value".to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
         }
     }
 }

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -370,7 +370,7 @@ pub enum DataType {
     ///
     /// In a field with Map type, the field has a child Struct field, which then
     /// has two children: key type and the second the value type. The names of the
-    /// child fields may be respectively "entries", "key", and "value", but this is
+    /// child fields may be respectively "key_value", "key", and "value", but this is
     /// not enforced.
     Map(FieldRef, bool),
     /// A run-end encoding (REE) is a variation of run-length encoding (RLE). These


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes [#6213 ](https://github.com/apache/arrow-rs/issues/6213) .

# Rationale for this change
The MapBuilder uses the nonstandardized default names, which results in [#6213 ](https://github.com/apache/arrow-rs/issues/6213). Changing to parquet spec helps reduce confusion and provides users with a more standardized naming guide.

[According to the parquet-format spec](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules-1), the outer-most level should be a group that contains a single field named **key_value** for Map type:
> The outer-most level must be a group annotated with MAP that contains a single field named **key_value**. The repetition of this level must be either optional or required and determines whether the map is nullable.
The middle level, named key_value, must be a repeated group with a **key** field for map keys and, optionally, a **value** field for map values. It must not contain any other values.


Changing the default map field names to match it not only complies with the parquet spec, but also aligns with pyarrow.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Default value of the MapFieldNames

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No(I think)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
