### PR TITLE
Fix arrow-avro compilation without default features

### DIFF
--- a/arrow-avro/src/compression.rs
+++ b/arrow-avro/src/compression.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use arrow_schema::ArrowError;
-use flate2::read;
 use std::io;
 use std::io::Read;
 
@@ -35,7 +34,7 @@ impl CompressionCodec {
         match self {
             #[cfg(feature = "deflate")]
             CompressionCodec::Deflate => {
-                let mut decoder = read::DeflateDecoder::new(block);
+                let mut decoder = flate2::read::DeflateDecoder::new(block);
                 let mut out = Vec::new();
                 decoder.read_to_end(&mut out)?;
                 Ok(out)


### PR DESCRIPTION

# Which issue does this PR close?

none

# Rationale for this change
 
Before the change, using arrow-avro without default features would fail to compile. This can be seen with

    cargo check -p arrow-avro --no-default-features

# What changes are included in this PR?

make code compile with default features disabled

# Are there any user-facing changes?

no