### PR TITLE
Always explicitly disable `gzip` automatic decompression on reqwest client used by object_store

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -77,6 +77,7 @@ http-body-util = "0.1"
 rand = "0.8"
 tempfile = "3.1.0"
 regex = "1.11.1"
+# The "gzip" feature for reqwest is enabled for an integration test.
 reqwest = { version = "0.12", features = ["gzip"] }
 http = "1.1.0"
 

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -77,6 +77,7 @@ http-body-util = "0.1"
 rand = "0.8"
 tempfile = "3.1.0"
 regex = "1.11.1"
+reqwest = { version = "0.12", features = ["gzip"] }
 http = "1.1.0"
 
 [[test]]

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -671,6 +671,8 @@ impl ClientOptions {
             builder = builder.danger_accept_invalid_certs(true)
         }
 
+        builder = builder.no_gzip();
+
         builder
             .https_only(!self.allow_http.get()?)
             .build()

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -671,6 +671,8 @@ impl ClientOptions {
             builder = builder.danger_accept_invalid_certs(true)
         }
 
+        // Reqwest will remove the `Content-Length` header if it is configured to
+        // transparently decompress the body via the non-default `gzip` feature.
         builder = builder.no_gzip();
 
         builder

--- a/object_store/tests/http.rs
+++ b/object_store/tests/http.rs
@@ -30,7 +30,7 @@ async fn test_http_store_gzip() {
         .build()
         .unwrap();
 
-    let object = http_store
+    let _ = http_store
         .get_opts(
             &Path::parse("LICENSE.txt").unwrap(),
             GetOptions {

--- a/object_store/tests/http.rs
+++ b/object_store/tests/http.rs
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests the HTTP store implementation
+
+#[cfg(feature = "http")]
+use object_store::{http::HttpBuilder, path::Path, GetOptions, GetRange, ObjectStore};
+
+/// Tests that even when reqwest has the `gzip` feature enabled, the HTTP store
+/// does not error on a missing `Content-Length` header.
+#[tokio::test]
+#[cfg(feature = "http")]
+async fn test_http_store_gzip() {
+    let http_store = HttpBuilder::new()
+        .with_url("https://raw.githubusercontent.com/apache/arrow-rs/refs/heads/main")
+        .build()
+        .unwrap();
+
+    let object = http_store
+        .get_opts(
+            &Path::parse("LICENSE.txt").unwrap(),
+            GetOptions {
+                range: Some(GetRange::Bounded(0..100)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6842

# Rationale for this change
 
Fixes an issue where enabling a non-default feature (`gzip`) for `reqwest` would cause `object_store` to stop working if using the HTTP store against an HTTP server that supports gzip response compression.

# What changes are included in this PR?

Call the [`no_gzip`] method on the reqest ClientBuilder to ensure that even if the `gzip` feature is enabled, the `object_store` client will not use the transparent decompression logic.

[`no_gzip`]: https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.no_gzip

I considered making this an option instead of always setting it, but since this is such a frustrating footgun to encounter and debug, I think its better to always set it unless there is a compelling reason not to.

# Are there any user-facing changes?

My understanding is that most/all users interacting with object stores do not want the `gzip` compression logic (since none of the major cloud object store providers support it), so this change should not be breaking.