### PR TITLE
Add deprecation / API removal policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,16 @@ Rust programs to still compile, but will generate compiler warnings. This gives
 downstream crates time to migrate to non deprecated APIs prior to their removal.
 
 All deprecated APIs are marked using the `#[deprecated]` attribute with both the
-first version they were deprecated in, as well as what new API to use instead.
+first version they were deprecated in, and what new API to use instead.
 
 ```rust
 #[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
 ```
 
-Deprecated APIs will be kept for at least one major release after they were
+Deprecated APIs will be kept for at least two major releases after they were
 deprecated. For example, an API deprecated in `51.3.0` will not be removed until
-at least `53.0.0`. Given the planned release schedule, this is typically between
-3 and 6 months.
+at least `54.0.0`. Given the planned release schedule, this is typically between
+6 and 9 months.
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ deprecated in `51.3.0` can be removed in `54.0.0` (or later). Deprecated APIs
 may be removed earlier or later than these guidelines at the discretion of the
 maintainers.
 
-
 ## Related Projects
 
 There are several related crates in different repositories

--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ versions approximately every 2 months.
 
 [`object_store`]: https://crates.io/crates/object_store
 
+### Deprecation Policy
+
+Minor releases may deprecate, but not remove APIs. Deprecating APIs allows the
+Rust programs to still compile, but will generate compiler warnings. This gives
+downstream crates time to migrate to non deprecated APIs prior to their removal.
+
+All deprecated APIs are marked using the `#[deprecated]` attribute with both the
+first version they were deprecated in, as well as what new API to use instead.
+
+```rust
+#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
+```
+
+Deprecated APIs will be kept for at least one major release after they were
+deprecated. For example, an API deprecated in `51.3.0` will not be removed until
+at least `53.0.0`. Given the planned release schedule, this is typically between
+3 and 6 months.
+
 ## Related Projects
 
 There are several related crates in different repositories

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ versions approximately every 2 months.
 
 [`object_store`]: https://crates.io/crates/object_store
 
-### Deprecation Policy
+### Deprecation Guidelines
 
-Minor releases may deprecate, but not remove APIs. Deprecating APIs allows the
-Rust programs to still compile, but will generate compiler warnings. This gives
-downstream crates time to migrate to non deprecated APIs prior to their removal.
+Minor releases may deprecate, but not remove APIs. Deprecating APIs allows
+downstream Rust programs to still compile, but generate compiler warnings. This
+gives downstream crates time to migrate prior to API removal.
 
 All deprecated APIs are marked using the `#[deprecated]` attribute with both the
 first version they were deprecated in, and what new API to use instead.
@@ -95,10 +95,12 @@ first version they were deprecated in, and what new API to use instead.
 #[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
 ```
 
-Deprecated APIs will be kept for at least two major releases after they were
-deprecated. For example, an API deprecated in `51.3.0` will not be removed until
-at least `54.0.0`. Given the planned release schedule, this is typically between
-6 and 9 months.
+In general, deprecated APIs will be kept for at least two major releases after
+they were deprecated (typically between 6 - 9 months later). For example, an API
+deprecated in `51.3.0` can be removed in `54.0.0` (or later). Deprecated APIs
+may be removed earlier or later than these guidelines at the discretion of the
+maintainers.
+
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,22 @@ Minor releases may deprecate, but not remove APIs. Deprecating APIs allows
 downstream Rust programs to still compile, but generate compiler warnings. This
 gives downstream crates time to migrate prior to API removal.
 
-All deprecated APIs are marked using the `#[deprecated]` attribute with both the
-first version they were deprecated in, and what new API to use instead.
+To deprecate an API:
+
+- Mark the API as deprecated using `#[deprecated]` and specify the exact arrow-rs version in which it was deprecated
+- Concisely describe the preferred API to help the user transition
+
+The deprecated version is the next version which will be released (please
+consult the list above). To mark the API as deprecated, use the
+`#[deprecated(since = "...", note = "...")]` attribute.
+
+Foe example
 
 ```rust
 #[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
 ```
 
-In general, deprecated APIs will be kept for at least two major releases after
+In general, deprecated APIs will remain in the codebase for at least two major releases after
 they were deprecated (typically between 6 - 9 months later). For example, an API
 deprecated in `51.3.0` can be removed in `54.0.0` (or later). Deprecated APIs
 may be removed earlier or later than these guidelines at the discretion of the

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -37,7 +37,7 @@ This crate is tested with the latest stable version of Rust. We do not currently
 
 The `arrow` crate follows the [SemVer standard] defined by Cargo and works well
 within the Rust crate ecosystem. See the [repository README] for more details on
-the release schedule and version.
+the release schedule, version and deprecation policy.
 
 [SemVer standard]: https://doc.rust-lang.org/cargo/reference/semver.html
 [repository README]: https://github.com/apache/arrow-rs

--- a/parquet/README.md
+++ b/parquet/README.md
@@ -36,7 +36,7 @@ This crate is tested with the latest stable version of Rust. We do not currently
 
 The `parquet` crate follows the [SemVer standard] defined by Cargo and works well
 within the Rust crate ecosystem. See the [repository README] for more details on
-the release schedule and version.
+the release schedule, version and deprecation policy.
 
 [semver standard]: https://doc.rust-lang.org/cargo/reference/semver.html
 [repository readme]: https://github.com/apache/arrow-rs


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/6851

# Rationale for this change
 
As this crate matures, more predictability is good

# What changes are included in this PR?

Add a proposed deprecation policy to the README 

Options considered:
* at least one major release ==> 3-6 months
* 2 major releases ==> 6 - 9 months. 

I am currently proposing 2 major releases, but would love to hear more input

# Are there any user-facing changes?
Just docs, but new policy

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
