### PR TITLE
Improve MSRV failure CI JOB output display

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,13 +126,13 @@ jobs:
         run: cargo update -p ahash --precise 0.8.7
       - name: Check arrow
         working-directory: arrow
-        run: cargo msrv --log-target stdout verify
+        run: cargo msrv verify
       - name: Check parquet
         working-directory: parquet
-        run: cargo msrv --log-target stdout verify
+        run: cargo msrv verify
       - name: Check arrow-flight
         working-directory: arrow-flight
-        run: cargo msrv --log-target stdout verify
+        run: cargo msrv verify
       - name: Downgrade object_store dependencies
         working-directory: object_store
         # Necessary because tokio 1.30.0 updates MSRV to 1.63
@@ -142,4 +142,4 @@ jobs:
           cargo update -p url --precise 2.5.0
       - name: Check object_store
         working-directory: object_store
-        run: cargo msrv --log-target stdout verify
+        run: cargo msrv verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,13 +126,13 @@ jobs:
         run: cargo update -p ahash --precise 0.8.7
       - name: Check arrow
         working-directory: arrow
-        run: cargo msrv verify
+        run: cargo msrv verify --output-format json
       - name: Check parquet
         working-directory: parquet
-        run: cargo msrv verify
+        run: cargo msrv verify --output-format json
       - name: Check arrow-flight
         working-directory: arrow-flight
-        run: cargo msrv verify
+        run: cargo msrv verify --output-format json
       - name: Downgrade object_store dependencies
         working-directory: object_store
         # Necessary because tokio 1.30.0 updates MSRV to 1.63
@@ -142,4 +142,4 @@ jobs:
           cargo update -p url --precise 2.5.0
       - name: Check object_store
         working-directory: object_store
-        run: cargo msrv verify
+        run: cargo msrv verify --output-format json

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -36,6 +36,7 @@ bench = false
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "std", "rc"], optional = true }
 bitflags = { version = "2.0.0", default-features = false, optional = true }
+criterion = { version = "0.5", default-features = false }
 
 [features]
 # Enable ffi support


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 

While debugging https://github.com/apache/arrow-rs/pull/6852 with @andygrove and @viirya , the CI output display for MSRV failures look 🤮 and doesn't tell you what the problem is

https://github.com/apache/arrow-rs/actions/runs/12207850027/job/34060002164?pr=6853

![Screenshot 2024-12-07 at 7 42 10 AM](https://github.com/user-attachments/assets/1e753219-2b45-4215-a982-58a2d82f2c08)

# What changes are included in this PR?


It seems msrv has improved thier display since we list made this better

```shell
andrewlamb@Andrews-MacBook-Pro-2:~/Software/arrow-rs/arrow$ cargo msrv verify
  [Meta]   cargo-msrv 0.17.1

Compatibility Check #1: Rust 1.70.0
  [FAIL]   Is incompatible

  ╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: package `clap v4.5.23` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0 │
  │ Either upgrade to rustc 1.74 or newer, or use                                                                                             │
  │ cargo update -p clap@4.5.23 --precise ver                                                                                                 │
  │ where `ver` is the latest version of `clap` supporting rustc 1.70.0                                                                       │
  │                                                                                                                                           │
  ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```





# Are there any user-facing changes?

Example of new MSRV failure
XXX

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
