### PR TITLE
feat: Add RecordBatchOptions::skip_schema_check option

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -640,8 +640,8 @@ pub struct RecordBatchOptions {
     /// Option to skip schema checking when creating new record batches. This is intended for
     /// cases where the schema has already been checked or where more flexibility is required
     /// in downstream projects, such as allowing either Utf8 or Dictionary<_, Utf8> for a
-    /// schema with type Utf8. This option should not be used within DataFusion since it is
-    /// an invariant that all batches must have the same physical schema during execution.
+    /// schema with type Utf8. Using this option is likely to break compatibility with arrow-rs
+    /// kernels that operate on RecordBatch so should be used with caution.
     pub skip_schema_check: bool,
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In Comet, I would like the freedom to specify a logical type of Utf8 in a schema and then allow some batches to use Dictionary<_, Utf8> instead. In other words, I still want to enforce the logical type of columns in a batch but do not want to enforce that they all have the same physical type.

I understand that I will need to cast the batches to all have the same physical types before passing them on to any DataFusion operators.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New option in `RecordBatchOptions`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, if users are creating the `RecordBatchOptions` struct without using the builder API then they will need so specify this new option.

<!---
If there are any breaking changes to public APIs, please call them out.
-->

Yup, this is a breaking change.