### PR TITLE
Fix docstring for `Format::with_header` in `arrow-csv`

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -241,7 +241,7 @@ pub struct Format {
 }
 
 impl Format {
-    /// Specify whether the CSV file has a header, defaults to `true`
+    /// Specify whether the CSV file has a header, defaults to `false`
     ///
     /// When `true`, the first row of the CSV file is treated as a header row
     pub fn with_header(mut self, has_header: bool) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
Fix documentation

# What changes are included in this PR?

`Format::header` defaults to `false` but is documented as defaulting to `true`

```rs
/// The format specification for the CSV file
#[derive(Debug, Clone, Default)]
pub struct Format {
    header: bool,
```

# Are there any user-facing changes?

No
