### PR TITLE
Minor: add comments explaining bad MSRV, output in json

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   msrv:
-    name: Verify MSRV
+    name: Verify MSRV (Minimum Supported Rust Version)
     runs-on: ubuntu-latest
     container:
       image: amd64/rust
@@ -126,13 +126,19 @@ jobs:
         run: cargo update -p ahash --precise 0.8.7
       - name: Check arrow
         working-directory: arrow
-        run: cargo msrv --log-target stdout verify
+        run: |
+          # run `cd arrow; cargo msrv verify` to see problematic dependencies
+          cargo msrv --log-target stdout verify
       - name: Check parquet
         working-directory: parquet
-        run: cargo msrv --log-target stdout verify
+        run: |
+          # run `cd parquet; cargo msrv verify` to see problematic dependencies
+          cargo msrv --log-target stdout verify
       - name: Check arrow-flight
         working-directory: arrow-flight
-        run: cargo msrv --log-target stdout verify
+        run: |
+          # run `cd arrow-flight; cargo msrv verify` to see problematic dependencies
+          cargo msrv --log-target stdout verify
       - name: Downgrade object_store dependencies
         working-directory: object_store
         # Necessary because tokio 1.30.0 updates MSRV to 1.63
@@ -142,4 +148,6 @@ jobs:
           cargo update -p url --precise 2.5.0
       - name: Check object_store
         working-directory: object_store
-        run: cargo msrv --log-target stdout verify
+        run: |
+          # run `cd object_store; cargo msrv verify` to see problematic dependencies
+          cargo msrv --log-target stdout verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,17 +128,17 @@ jobs:
         working-directory: arrow
         run: |
           # run `cd arrow; cargo msrv verify` to see problematic dependencies
-          cargo msrv --log-target stdout verify
+          cargo msrv verify --output-format=json
       - name: Check parquet
         working-directory: parquet
         run: |
           # run `cd parquet; cargo msrv verify` to see problematic dependencies
-          cargo msrv --log-target stdout verify
+          cargo msrv verify --output-format=json
       - name: Check arrow-flight
         working-directory: arrow-flight
         run: |
           # run `cd arrow-flight; cargo msrv verify` to see problematic dependencies
-          cargo msrv --log-target stdout verify
+          cargo msrv verify --output-format=json
       - name: Downgrade object_store dependencies
         working-directory: object_store
         # Necessary because tokio 1.30.0 updates MSRV to 1.63
@@ -150,4 +150,4 @@ jobs:
         working-directory: object_store
         run: |
           # run `cd object_store; cargo msrv verify` to see problematic dependencies
-          cargo msrv --log-target stdout verify
+          cargo msrv verify --output-format=json

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -36,6 +36,7 @@ bench = false
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "std", "rc"], optional = true }
 bitflags = { version = "2.0.0", default-features = false, optional = true }
+criterion = { version = "0.5", default-features = false }
 
 [features]
 # Enable ffi support

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -36,7 +36,6 @@ bench = false
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "std", "rc"], optional = true }
 bitflags = { version = "2.0.0", default-features = false, optional = true }
-criterion = { version = "0.5", default-features = false }
 
 [features]
 # Enable ffi support


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 

While debugging https://github.com/apache/arrow-rs/pull/6853 with @andygrove and @viirya , the CI output display for MSRV failures look 🤮 and doesn't tell you what the problem is

https://github.com/apache/arrow-rs/actions/runs/12207850027/job/34060002164?pr=6853

![Screenshot 2024-12-07 at 7 42 10 AM](https://github.com/user-attachments/assets/1e753219-2b45-4215-a982-58a2d82f2c08)

I also tried improving the output display here but it doesn't seem to display the error to logs
-  https://github.com/apache/arrow-rs/pull/6854

# What changes are included in this PR?

1. Add comments explaining what to do on failure
2. Change the output to JSON which at least has the actual error in the string, even if it is somewhat hard to see

Here is an example failure message from https://github.com/apache/arrow-rs/actions/runs/12215692321/job/34077953686?pr=6857
```
{"type":"subcommand_result","subcommand_id":"verify","result":{"toolchain":{"version":"1.70.0","target":"x86_64-unknown-linux-gnu","components":[]},"is_compatible":false,"error":"error: package `clap_lex v0.7.4` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0\nEither upgrade to rustc 1.74 or newer, or use\ncargo update -p clap_lex@0.7.4 --precise ver\nwhere `ver` is the latest version of `clap_lex` supporting rustc 1.70.0\n"}}

```

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
