### PR TITLE
Use randomized content ID for Azure multipart uploads

### DIFF
--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -570,6 +570,7 @@ mod tests {
         rename_and_copy(&integration).await;
         stream_get(&integration).await;
         multipart(&integration, &integration).await;
+        multipart_race_condition(&integration, true).await;
         signing(&integration).await;
         s3_encryption(&integration).await;
         put_get_attributes(&integration).await;

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -36,6 +36,7 @@ use base64::Engine;
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, Utc};
 use hyper::http::HeaderName;
+use rand::Rng as _;
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, IF_MATCH, IF_NONE_MATCH},
     Client as ReqwestClient, Method, RequestBuilder, Response,
@@ -556,10 +557,11 @@ impl AzureClient {
     pub(crate) async fn put_block(
         &self,
         path: &Path,
-        part_idx: usize,
+        _part_idx: usize,
         payload: PutPayload,
     ) -> Result<PartId> {
-        let content_id = format!("{part_idx:20}");
+        let part_idx = u128::from_be_bytes(rand::thread_rng().gen());
+        let content_id = format!("{part_idx:40}");
         let block_id = BASE64_STANDARD.encode(&content_id);
 
         self.put_request(path, payload)

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -561,7 +561,7 @@ impl AzureClient {
         payload: PutPayload,
     ) -> Result<PartId> {
         let part_idx = u128::from_be_bytes(rand::thread_rng().gen());
-        let content_id = format!("{part_idx:40}");
+        let content_id = format!("{part_idx:032x}");
         let block_id = BASE64_STANDARD.encode(&content_id);
 
         self.put_request(path, payload)

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -414,16 +414,50 @@ mod tests {
         let mut multipart_upload_1 = integration.put_multipart(&path).await.unwrap();
         let mut multipart_upload_2 = integration.put_multipart(&path).await.unwrap();
 
-        for i in 0..5 {
-            multipart_upload_1
-                .put_part(Bytes::from(format!("1:{},", i)).into())
-                .await
-                .unwrap();
-            multipart_upload_2
-                .put_part(Bytes::from(format!("2:{},", i)).into())
-                .await
-                .unwrap();
-        }
+        multipart_upload_1
+            .put_part(Bytes::from("1:0,").into())
+            .await
+            .unwrap();
+        multipart_upload_2
+            .put_part(Bytes::from("2:0,").into())
+            .await
+            .unwrap();
+
+        multipart_upload_2
+            .put_part(Bytes::from("2:1,").into())
+            .await
+            .unwrap();
+        multipart_upload_1
+            .put_part(Bytes::from("1:1,").into())
+            .await
+            .unwrap();
+
+        multipart_upload_1
+            .put_part(Bytes::from("1:2,").into())
+            .await
+            .unwrap();
+        multipart_upload_2
+            .put_part(Bytes::from("2:2,").into())
+            .await
+            .unwrap();
+
+        multipart_upload_2
+            .put_part(Bytes::from("2:3,").into())
+            .await
+            .unwrap();
+        multipart_upload_1
+            .put_part(Bytes::from("1:3,").into())
+            .await
+            .unwrap();
+
+        multipart_upload_1
+            .put_part(Bytes::from("1:4,").into())
+            .await
+            .unwrap();
+        multipart_upload_2
+            .put_part(Bytes::from("2:4,").into())
+            .await
+            .unwrap();
 
         multipart_upload_1.complete().await.unwrap();
         let err = multipart_upload_2.complete().await.unwrap_err();

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -295,10 +295,14 @@ impl MultipartStore for MicrosoftAzure {
 
 #[cfg(test)]
 mod tests {
+    use core::str;
+
     use super::*;
     use crate::integration::*;
     use crate::tests::*;
     use bytes::Bytes;
+    use rand::thread_rng;
+    use rand::Rng;
 
     #[tokio::test]
     async fn azure_blob_test() {
@@ -391,5 +395,66 @@ mod tests {
             builder.get_config_value(&AzureConfigKey::Token).unwrap(),
             azure_storage_token
         );
+    }
+
+    #[tokio::test]
+    async fn azure_parallel_put_multipart_test() {
+        maybe_skip_integration!();
+        let integration = MicrosoftAzureBuilder::from_env().build().unwrap();
+
+        let rng = thread_rng();
+        let suffix = String::from_utf8(
+            rng.sample_iter(rand::distributions::Alphanumeric)
+                .take(32)
+                .collect(),
+        )
+        .unwrap();
+        let path = Path::from(format!("put_multipart_{suffix}"));
+
+        let mut multipart_upload_1 = integration.put_multipart(&path).await.unwrap();
+        let mut multipart_upload_2 = integration.put_multipart(&path).await.unwrap();
+
+        for i in 0..5 {
+            multipart_upload_1
+                .put_part(Bytes::from(format!("1:{},", i)).into())
+                .await
+                .unwrap();
+            multipart_upload_2
+                .put_part(Bytes::from(format!("2:{},", i)).into())
+                .await
+                .unwrap();
+        }
+
+        multipart_upload_1.complete().await.unwrap();
+        let err = multipart_upload_2.complete().await.unwrap_err();
+
+        assert!(matches!(err, crate::Error::Generic { .. }), "{err}");
+
+        if let crate::Error::Generic { source, store } = err as crate::Error {
+            assert_eq!(store, STORE);
+
+            if let Some(crate::client::retry::Error::Client { status, body, .. }) =
+                source.downcast_ref::<crate::client::retry::Error>()
+            {
+                assert_eq!(status.clone(), http::StatusCode::BAD_REQUEST);
+
+                let body = body.clone().unwrap();
+                if !body.contains("<Error><Code>InvalidBlockList</Code><Message>The specified block list is invalid.") {
+                    panic!(
+                        "assertion failed: `{body:?}` is not an InvalidBlockList response",
+                    );
+                }
+            } else {
+                panic!("Not a Client error")
+            }
+        } else {
+            panic!("Not a Generic error")
+        }
+
+        let get_result = integration.get(&path).await.unwrap();
+        let bytes = get_result.bytes().await.unwrap();
+        let string_contents = str::from_utf8(&bytes).unwrap();
+
+        assert_eq!("1:0,1:1,1:2,1:3,1:4,", string_contents);
     }
 }

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -314,7 +314,7 @@ mod tests {
         stream_get(&integration).await;
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
-        multipart_race_condition(&integration).await;
+        multipart_race_condition(&integration, false).await;
         signing(&integration).await;
 
         let validate = !integration.client.config().disable_tagging;

--- a/object_store/src/azure/mod.rs
+++ b/object_store/src/azure/mod.rs
@@ -318,6 +318,7 @@ mod tests {
         stream_get(&integration).await;
         put_opts(&integration, true).await;
         multipart(&integration, &integration).await;
+        multipart_race_condition(&integration).await;
         signing(&integration).await;
 
         let validate = !integration.client.config().disable_tagging;

--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -297,6 +297,7 @@ mod test {
             // https://github.com/fsouza/fake-gcs-server/issues/852
             stream_get(&integration).await;
             multipart(&integration, &integration).await;
+            multipart_race_condition(&integration, true).await;
             // Fake GCS server doesn't currently honor preconditions
             get_opts(&integration).await;
             put_opts(&integration, true).await;

--- a/object_store/src/integration.rs
+++ b/object_store/src/integration.rs
@@ -1178,5 +1178,9 @@ pub async fn multipart_race_condition(storage: &dyn ObjectStore, last_writer_win
     let bytes = get_result.bytes().await.unwrap();
     let string_contents = str::from_utf8(&bytes).unwrap();
 
-    assert_eq!("1:0,1:1,1:2,1:3,1:4,", string_contents);
+    if last_writer_wins {
+        assert_eq!("2:0,2:1,2:2,2:3,2:4,", string_contents);
+    } else {
+        assert_eq!("1:0,1:1,1:2,1:3,1:4,", string_contents);
+    }
 }

--- a/object_store/src/integration.rs
+++ b/object_store/src/integration.rs
@@ -1120,60 +1120,47 @@ pub async fn multipart_race_condition(storage: &dyn ObjectStore, last_writer_win
     let mut multipart_upload_2 = storage.put_multipart(&path).await.unwrap();
 
     multipart_upload_1
-        .put_part(Bytes::from("1:0,").into())
+        .put_part(Bytes::from(format!("1:{:05300000},", 0)).into())
         .await
         .unwrap();
     multipart_upload_2
-        .put_part(Bytes::from("2:0,").into())
+        .put_part(Bytes::from(format!("2:{:05300000},", 0)).into())
         .await
         .unwrap();
 
     multipart_upload_2
-        .put_part(Bytes::from("2:1,").into())
+        .put_part(Bytes::from(format!("2:{:05300000},", 1)).into())
         .await
         .unwrap();
     multipart_upload_1
-        .put_part(Bytes::from("1:1,").into())
-        .await
-        .unwrap();
-
-    multipart_upload_1
-        .put_part(Bytes::from("1:2,").into())
-        .await
-        .unwrap();
-    multipart_upload_2
-        .put_part(Bytes::from("2:2,").into())
-        .await
-        .unwrap();
-
-    multipart_upload_2
-        .put_part(Bytes::from("2:3,").into())
-        .await
-        .unwrap();
-    multipart_upload_1
-        .put_part(Bytes::from("1:3,").into())
+        .put_part(Bytes::from(format!("1:{:05300000},", 1)).into())
         .await
         .unwrap();
 
     multipart_upload_1
-        .put_part(Bytes::from("1:4,").into())
+        .put_part(Bytes::from(format!("1:{:05300000},", 2)).into())
         .await
         .unwrap();
     multipart_upload_2
-        .put_part(Bytes::from("2:4,").into())
+        .put_part(Bytes::from(format!("2:{:05300000},", 2)).into())
         .await
         .unwrap();
 
-    // This is to satisy AWS S3's minimum allowed upload size of 5242880
-    let last_chunk_size = 5 * 1024 * 1024;
-    let last_chunk = get_chunk(last_chunk_size);
+    multipart_upload_2
+        .put_part(Bytes::from(format!("2:{:05300000},", 3)).into())
+        .await
+        .unwrap();
+    multipart_upload_1
+        .put_part(Bytes::from(format!("1:{:05300000},", 3)).into())
+        .await
+        .unwrap();
 
     multipart_upload_1
-        .put_part(last_chunk.clone().into())
+        .put_part(Bytes::from(format!("1:{:05300000},", 4)).into())
         .await
         .unwrap();
     multipart_upload_2
-        .put_part(last_chunk.into())
+        .put_part(Bytes::from(format!("2:{:05300000},", 4)).into())
         .await
         .unwrap();
 
@@ -1192,8 +1179,20 @@ pub async fn multipart_race_condition(storage: &dyn ObjectStore, last_writer_win
     let string_contents = str::from_utf8(&bytes).unwrap();
 
     if last_writer_wins {
-        assert!(string_contents.starts_with("2:0,2:1,2:2,2:3,2:4,"));
+        assert!(string_contents.starts_with(
+            format!(
+                "2:{:05300000},2:{:05300000},2:{:05300000},2:{:05300000},2:{:05300000},",
+                0, 1, 2, 3, 4
+            )
+            .as_str()
+        ));
     } else {
-        assert!(string_contents.starts_with("1:0,1:1,1:2,1:3,1:4,"));
+        assert!(string_contents.starts_with(
+            format!(
+                "1:{:05300000},1:{:05300000},1:{:05300000},1:{:05300000},1:{:05300000},",
+                0, 1, 2, 3, 4
+            )
+            .as_str()
+        ));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6868.

# Rationale for this change
 
Explained in the issue

# What changes are included in this PR?

In `object_store`'s `AzureClient.put_block()`, use a random, u128 for `part_idx` instead of the counter based `part_idx` parameter.

# Are there any user-facing changes?

No
