### PR TITLE
Improvements to UTF-8 statistics truncation

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -3198,7 +3198,8 @@ mod tests {
         // Max 2-byte should not truncate as it would need 3-byte code points
         assert!(increment_utf8("\u{7ff}\u{7ff}".as_bytes().to_vec()).is_none());
 
-        // 3-byte without overflow
+        // 3-byte without overflow [U+800, U+800] -> [U+800, U+801] (note that these
+        // characters should render right to left).
         test_inc("ࠀࠀ", "ࠀࠁ");
 
         // 3-byte ending in max 3-byte

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -3268,8 +3268,8 @@ mod tests {
         assert_eq!(&r, "yyyyyyyz".as_bytes());
 
         // 2-byte without overflow
-        let r = truncate_and_increment_utf8("ééééé", 8).unwrap();
-        assert_eq!(&r, "éééê".as_bytes());
+        let r = truncate_and_increment_utf8("ééééé", 7).unwrap();
+        assert_eq!(&r, "ééê".as_bytes());
 
         // 2-byte that overflows lowest byte
         let r = truncate_and_increment_utf8("\u{ff}\u{ff}\u{ff}\u{ff}\u{ff}", 8).unwrap();
@@ -3281,7 +3281,7 @@ mod tests {
 
         // 3-byte without overflow [U+800, U+800, U+800] -> [U+800, U+801] (note that these
         // characters should render right to left).
-        let r = truncate_and_increment_utf8("ࠀࠀࠀ", 8).unwrap();
+        let r = truncate_and_increment_utf8("ࠀࠀࠀࠀ", 8).unwrap();
         assert_eq!(&r, "ࠀࠁ".as_bytes());
 
         // max 3-byte should not truncate as it would need 4-byte code points
@@ -3289,7 +3289,7 @@ mod tests {
         assert!(r.is_none());
 
         // 4-byte without overflow
-        let r = truncate_and_increment_utf8("𐀀𐀀𐀀", 8).unwrap();
+        let r = truncate_and_increment_utf8("𐀀𐀀𐀀𐀀", 9).unwrap();
         assert_eq!(&r, "𐀀𐀁".as_bytes());
 
         // max 4-byte should not truncate

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1467,13 +1467,12 @@ fn truncate_and_increment_utf8(data: &str, length: usize) -> Option<Vec<u8>> {
 ///
 /// Note that this implementation will not promote an N-byte code point to (N+1) bytes.
 fn increment_utf8(data: &str) -> Option<Vec<u8>> {
-    for (idx, code_point) in data.char_indices().rev() {
-        let curr_len = code_point.len_utf8();
-        let original = code_point as u32;
-        if let Some(next_char) = char::from_u32(original + 1) {
+    for (idx, original_char) in data.char_indices().rev() {
+        let original_len = original_char.len_utf8();
+        if let Some(next_char) = char::from_u32(original_char as u32 + 1) {
             // do not allow increasing byte width of incremented char
-            if next_char.len_utf8() == curr_len {
-                let mut result = data.as_bytes()[..idx + curr_len].to_vec();
+            if next_char.len_utf8() == original_len {
+                let mut result = data.as_bytes()[..idx + original_len].to_vec();
                 next_char.encode_utf8(&mut result[idx..]);
                 return Some(result);
             }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -3211,6 +3211,9 @@ mod tests {
 
         // Max 4-byte should not truncate
         assert!(increment_utf8("\u{10ffff}\u{10ffff}".as_bytes().to_vec()).is_none());
+
+        // Skip over surrogate pair range (0xD800..=0xDFFF)
+        test_inc("a\u{D7FF}", "a\u{e000}");
     }
 
     #[test]

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -884,6 +884,16 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             || self.get_descriptor().converted_type() == ConvertedType::UTF8
     }
 
+    /// Truncates a binary statistic to at most `truncation_length` bytes.
+    ///
+    /// If truncation is not possible, returns `data`.
+    ///
+    /// The `bool` in the returned tuple indicates whether truncation occurred or not.
+    ///
+    /// UTF-8 Note:
+    /// If the column type indicates UTF-8, and `data` contains valid UTF-8, then the result will
+    /// also remain valid UTF-8, but may be less tnan `truncation_length` bytes to avoid splitting
+    /// on non-character boundaries.
     fn truncate_min_value(&self, truncation_length: Option<usize>, data: &[u8]) -> (Vec<u8>, bool) {
         truncation_length
             .filter(|l| data.len() > *l)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6867.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
See issue.

# What changes are included in this PR?
For max statistics replaces `truncate_utf8().and_then(increment_utf8)` with a new function `truncate_and_increment_utf8()`. This defers the creation of a new `Vec<u8>` until all processing is complete. This also changes `increment_utf8` to operate on entire unicode code points rather than doing arithmetic on the individual UTF-8 encoded bytes. Finally, this modifies the truncation logic so that UTF-8 handling is only done for columns whose logical type is `String` (or converted type `UTF8`).

The new increment logic is up to 30X faster for pathological cases of strings that cannot be truncated, and is no slower than the current code for simple cases where only the last byte of a string needs to be incremented.

# Are there any user-facing changes?
No API changes, but will potentially produce different truncated max statistics.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
