### PR TITLE
add `extend_dictionary` in dictionary builder for improved performance

### DIFF
--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -305,9 +305,10 @@ where
         };
     }
 
-    /// Extends builder with dictionary
+    /// Extends builder with an existing dictionary array.
     ///
-    /// This is the same as `extends` but avoid lookup for each item in the iterator
+    /// This is the same as [`Self::extend`] but is faster as it translates
+    /// the dictionary values once rather than doing a lookup for each item in the iterator
     ///
     /// when dictionary values are null (the actual mapped values) the keys are null
     ///

--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -307,7 +307,9 @@ where
 
     /// Extends builder with dictionary
     ///
-    /// This is the same as `extends` but avoid lookup for each item in the iterator 
+    /// This is the same as `extends` but avoid lookup for each item in the iterator
+    ///
+    /// when dictionary values are null (the actual mapped values) the keys are null
     ///
     pub fn extend_dictionary(&mut self, dictionary: &TypedDictionaryArray<K, GenericByteArray<T>>) -> Result<(), ArrowError> {
         let values = dictionary.values();

--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -727,7 +727,7 @@ mod tests {
         let some_dict = {
             let mut builder = GenericByteDictionaryBuilder::<Int32Type, Utf8Type>::new();
             builder.extend(["a", "b", "c", "a", "b", "c"].into_iter().map(Some));
-            builder.extend([None::<&str>].into_iter());
+            builder.extend([None::<&str>]);
             builder.extend(["c", "d", "a"].into_iter().map(Some));
             builder.append_null();
             builder.finish()

--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -307,7 +307,8 @@ where
 
     /// Extends builder with dictionary
     ///
-    /// This is the same as `extends` but avoid lookup for each item in the iterator
+    /// This is the same as [`Self::extend`] but is faster as it translates
+    /// the dictionary values once rather than doing a lookup for each item in the iterator
     ///
     /// when dictionary values are null (the actual mapped values) the keys are null
     ///

--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -46,7 +46,7 @@ impl<T: ToByteSlice> PartialEq for Value<T> {
 
 impl<T: ToByteSlice> Eq for Value<T> {}
 
-/// Builder for [`DictionaryArray`] of [`PrimitiveArray`](crate::array::PrimitiveArray)
+/// Builder for [`DictionaryArray`] of [`PrimitiveArray`]
 ///
 /// # Example:
 ///
@@ -507,7 +507,7 @@ mod tests {
         let some_dict = {
             let mut builder = PrimitiveDictionaryBuilder::<Int32Type, Int32Type>::new();
             builder.extend([1, 2, 3, 1, 2, 3, 1, 2, 3].into_iter().map(Some));
-            builder.extend([None::<i32>].into_iter());
+            builder.extend([None::<i32>]);
             builder.extend([4, 5, 1, 3, 1].into_iter().map(Some));
             builder.append_null();
             builder.finish()


### PR DESCRIPTION
# Which issue does this PR close?

No issue

# Rationale for this change
 
This is done to improve the performance when wanting to add already build dictionary to existing builder by taking advantage of the fact that we don't need to check the values for each key

# What changes are included in this PR?

added `extend_dictionary` for `PrimitiveDictionaryBuilder` and for `GenericByteDictionaryBuilder`

# Are there any user-facing changes?

yes, these are public methods
