### PR TITLE
chore: Upgrade to twoxhash 2.1 and use oneshot API for improved performance

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -64,7 +64,7 @@ seq-macro = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.15", default-features = false }
-twox-hash = { version = "1.6", default-features = false }
+twox-hash = { version = "2.1", default-features = false, features = ["xxhash64"] }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 sysinfo = { version = "0.32.0", optional = true, default-features = false, features = ["system"] }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -82,7 +82,6 @@ use crate::format::{
 };
 use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 use bytes::Bytes;
-use std::hash::Hasher;
 use std::io::Write;
 use std::sync::Arc;
 use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol};
@@ -397,9 +396,7 @@ const SEED: u64 = 0;
 
 #[inline]
 fn hash_as_bytes<A: AsBytes + ?Sized>(value: &A) -> u64 {
-    let mut hasher = XxHash64::with_seed(SEED);
-    hasher.write(value.as_bytes());
-    hasher.finish()
+    XxHash64::oneshot(SEED, value.as_bytes())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There is a new version of `twoxhash` that has a new `oneshot` API for use cases where all data is available at once. This is more performant than the streaming API.

Arrow uses this crate for hashing related to bloom filters.

We saw significant performance improvements in Comet with this approach, so hopefully it helps with arrow as well.

I tried benchmarking with `write_batch` benchmarks but am seeing highly variable results on my desktop, so I am not sure how to prove that this helps with performance.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
