### PR TITLE
Minor: make it easier to find fix instructions when `cargo fmt` on parquet fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: parquet
         run: |
           # if this fails, run this from the parquet directory:
-          # cargo fmt -p parquet -- --config skip_children=true `find ./parquet -name "*.rs" \! -name format.rs`
+          # cargo fmt -p parquet -- --config skip_children=true `find . -name "*.rs" \! -name format.rs`
           cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
       - name: Format object_store
         working-directory: object_store

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,12 +101,13 @@ jobs:
       - name: Format arrow
         run: cargo fmt --all -- --check
       - name: Format parquet
-        # Many modules in parquet are skipped, so check parquet separately. If this check fails, run:
-        #   cargo fmt -p parquet -- --config skip_children=true `find ./parquet -name "*.rs" \! -name format.rs`
-        # from the top level arrow-rs directory and check in the result.
+        # Many modules in parquet are skipped, so check parquet separately
         # https://github.com/apache/arrow-rs/issues/6179
         working-directory: parquet
-        run: cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
+        run: |
+          # if this fails, run this from the parquet directory:
+          # cargo fmt -p parquet -- --config skip_children=true `find ./parquet -name "*.rs" \! -name format.rs`
+          cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
       - name: Format object_store
         working-directory: object_store
         run: cargo fmt --all -- --check

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -249,7 +249,9 @@ pub fn arrow_to_parquet_schema_with_root(
     Ok(SchemaDescriptor::new(Arc::new(group)))
 }
 
-fn parse_key_value_metadata(key_value_metadata: Option<&Vec<KeyValue>>) -> Option<HashMap<String, String>> {
+fn parse_key_value_metadata(
+    key_value_metadata: Option<&Vec<KeyValue>>,
+) -> Option<HashMap<String, String>> {
     match key_value_metadata {
         Some(key_values) => {
             let map: HashMap<String, String> = key_values

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -249,9 +249,7 @@ pub fn arrow_to_parquet_schema_with_root(
     Ok(SchemaDescriptor::new(Arc::new(group)))
 }
 
-fn parse_key_value_metadata(
-    key_value_metadata: Option<&Vec<KeyValue>>,
-) -> Option<HashMap<String, String>> {
+fn parse_key_value_metadata(key_value_metadata: Option<&Vec<KeyValue>>) -> Option<HashMap<String, String>> {
     match key_value_metadata {
         Some(key_values) => {
             let map: HashMap<String, String> = key_values


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
While working on https://github.com/apache/arrow-rs/pull/6840 the `fmt` ci check failed on parquet. For example: https://github.com/apache/arrow-rs/actions/runs/12361198145/job/34497838320

```
Run cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
Diff in /__w/arrow-rs/arrow-rs/parquet/src/arrow/schema/mod.rs:1[7](https://github.com/apache/arrow-rs/actions/runs/12361198145/job/34497838320#step:7:8)75:
             Field::new("decimal256", DataType::Decimal256(39, 2), false),
         ];
         let arrow_schema = Schema::new(arrow_fields);
-        let converted_arrow_schema = ArrowSchemaConverter::new()
-            .convert(&arrow_schema)
-            .unwrap();
+        let converted_arrow_schema = ArrowSchemaConverter::new().convert(&arrow_schema).unwrap();
 
         assert_eq!(
             parquet_schema.columns().len(),
Error: Process completed with exit code 1.
```

However, the exact recipe to fix this was not clear (you have to run a certain command within the arquet directory)

# What changes are included in this PR?

1. Add the commands needed to fix CI as comments in the script so they are visible in the failure

Example https://github.com/apache/arrow-rs/actions/runs/12361621609/job/34499177568?pr=6886

![Screenshot 2024-12-16 at 4 30 04 PM](https://github.com/user-attachments/assets/22b2e6fa-042f-45ad-a5e5-8dbf7b031623)


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
