### PR TITLE
chore(arrow-ord): move `can_rank` to the `rank` file

### DIFF
--- a/arrow-ord/src/rank.rs
+++ b/arrow-ord/src/rank.rs
@@ -24,6 +24,15 @@ use arrow_buffer::NullBuffer;
 use arrow_schema::{ArrowError, DataType, SortOptions};
 use std::cmp::Ordering;
 
+/// Whether `arrow_ord::rank` can rank an array of given data type.
+pub(crate) fn can_rank(data_type: &DataType) -> bool {
+    data_type.is_primitive()
+        || matches!(
+            data_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
+        )
+}
+
 /// Assigns a rank to each value in `array` based on its position in the sorted order
 ///
 /// Where values are equal, they will be assigned the highest of their ranks,

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -30,7 +30,7 @@ use arrow_select::take::take;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use crate::rank::rank;
+use crate::rank::{can_rank, rank};
 pub use arrow_schema::SortOptions;
 
 /// Sort the `ArrayRef` using `SortOptions`.
@@ -188,15 +188,6 @@ fn partition_validity(array: &dyn Array) -> (Vec<u32>, Vec<u32>) {
             indices.partition(|index| array.is_valid(*index as usize))
         }
     }
-}
-
-/// Whether `arrow_ord::rank` can rank an array of given data type.
-fn can_rank(data_type: &DataType) -> bool {
-    data_type.is_primitive()
-        || matches!(
-            data_type,
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
-        )
 }
 
 /// Whether `sort_to_indices` can sort an array of given data type.


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
`can_rank` should be next to the actual implementation.
I'm in a middle of adding support for ranking booleans and was not aware of this function

# Are there any user-facing changes?

No, as this function was not public