### PR TITLE
[object_store] Support MD5 checksum in attributes

### DIFF
--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -47,6 +47,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
+use crate::checksum::ChecksumAlgorithm;
 
 const VERSION_HEADER: &str = "x-ms-version-id";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-ms-meta-";
@@ -58,6 +59,7 @@ static MS_CONTENT_ENCODING: HeaderName = HeaderName::from_static("x-ms-blob-cont
 static MS_CONTENT_LANGUAGE: HeaderName = HeaderName::from_static("x-ms-blob-content-language");
 
 static TAGS_HEADER: HeaderName = HeaderName::from_static("x-ms-tags");
+static CHECKSUM_MD5_HEADER: HeaderName = HeaderName::from_static("Content-MD5");
 
 /// A specialized `Error` for object store-related errors
 #[derive(Debug, Snafu)]
@@ -228,6 +230,9 @@ impl<'a> PutRequest<'a> {
         for (k, v) in &attributes {
             builder = match k {
                 Attribute::CacheControl => builder.header(&MS_CACHE_CONTROL, v.as_ref()),
+                Attribute::Checksum(algorithm) => match algorithm {
+                    ChecksumAlgorithm::MD5 => builder.header(&CHECKSUM_MD5_HEADER, v.as_ref()),
+                }
                 Attribute::ContentDisposition => {
                     builder.header(&MS_CONTENT_DISPOSITION, v.as_ref())
                 }

--- a/object_store/src/checksum.rs
+++ b/object_store/src/checksum.rs
@@ -1,0 +1,7 @@
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Enum representing checksum algorithms that may be used to verify object integrity.
+pub enum ChecksumAlgorithm {
+    /// MD5 algorithm.
+    MD5,
+}

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -46,10 +46,12 @@ use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::sync::Arc;
+use crate::checksum::ChecksumAlgorithm;
 
 const VERSION_HEADER: &str = "x-goog-generation";
 const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
 const USER_DEFINED_METADATA_HEADER_PREFIX: &str = "x-goog-meta-";
+const CHECKSUM_MD5_HEADER: &str = "Content-MD5";
 
 static VERSION_MATCH: HeaderName = HeaderName::from_static("x-goog-if-generation-match");
 
@@ -196,6 +198,9 @@ impl<'a> Request<'a> {
         for (k, v) in &attributes {
             builder = match k {
                 Attribute::CacheControl => builder.header(CACHE_CONTROL, v.as_ref()),
+                Attribute::Checksum(algorithm) => match algorithm{
+                    ChecksumAlgorithm::MD5 => builder.header(CHECKSUM_MD5_HEADER, v.as_ref()),
+                }
                 Attribute::ContentDisposition => builder.header(CONTENT_DISPOSITION, v.as_ref()),
                 Attribute::ContentEncoding => builder.header(CONTENT_ENCODING, v.as_ref()),
                 Attribute::ContentLanguage => builder.header(CONTENT_LANGUAGE, v.as_ref()),

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -545,11 +545,13 @@ mod upload;
 mod util;
 
 mod attributes;
+mod checksum;
 
 #[cfg(any(feature = "integration", test))]
 pub mod integration;
 
 pub use attributes::*;
+pub use checksum::*;
 
 pub use parse::{parse_url, parse_url_opts, ObjectStoreScheme};
 pub use payload::*;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6914

# Rationale for this change
 
I would like AWS, Azure, and GCP to validate the data integrity of my uploaded objects. All three providers allow doing so by providing a `Content-MD5` header with a 128-bit base64-encoded digest.

# What changes are included in this PR?

See #6914

# Are there any user-facing changes?

There's an additional `Checksum` attribute that can be set on requests.