### PR TITLE
Expose arrow-schema methods, for use when writing parquet outside of ArrowWriter

### DIFF
--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -123,8 +123,8 @@ use arrow_schema::{FieldRef, Schema};
 pub use self::schema::arrow_to_parquet_schema;
 
 pub use self::schema::{
-    parquet_to_arrow_field_levels, parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns,
-    ArrowSchemaConverter, FieldLevels,
+    add_encoded_arrow_schema_to_metadata, encode_arrow_schema, parquet_to_arrow_field_levels,
+    parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns, ArrowSchemaConverter, FieldLevels,
 };
 
 /// Schema metadata key used to store serialized Arrow IPC schema

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -170,7 +170,7 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
 }
 
 /// Encodes the Arrow schema into the IPC format, and base64 encodes it
-fn encode_arrow_schema(schema: &Schema) -> String {
+pub fn encode_arrow_schema(schema: &Schema) -> String {
     let options = writer::IpcWriteOptions::default();
     #[allow(deprecated)]
     let mut dictionary_tracker =
@@ -192,7 +192,7 @@ fn encode_arrow_schema(schema: &Schema) -> String {
 
 /// Mutates writer metadata by storing the encoded Arrow schema.
 /// If there is an existing Arrow schema metadata, it is replaced.
-pub(crate) fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterProperties) {
+pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterProperties) {
     let encoded = encode_arrow_schema(schema);
 
     let schema_kv = KeyValue {


### PR DESCRIPTION

# Which issue does this PR close?

Addresses need [noted here in Datafusion](https://github.com/apache/datafusion/pull/13866#discussion_r1894526006), by making two methods public.

# Rationale for this change
 
When writing parquet with the [ArrowWriter](https://docs.rs/parquet/53.3.0/parquet/arrow/arrow_writer/struct.ArrowWriter.html), the default behavior will [encode the arrow schema in the parquet kv_metadata](https://github.com/apache/arrow-rs/blob/2905ce6796cad396241fc50164970dbf1237440a/parquet/src/arrow/arrow_writer/mod.rs#L188-L190).

Other libraries may have their own parquet writers, such as Datafusion's ParquetSink, which will need to do the same operation in order to produce equivalent parquet (see [DF issue](https://github.com/apache/datafusion/issues/11770)).

# What changes are included in this PR?

Make two existing methods public.

# Are there any user-facing changes?

Exposes 2 existing methods.
