### PR TITLE
Fix error message typos with Parquet compression

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -426,14 +426,19 @@ fn split_compression_string(str_setting: &str) -> Result<(&str, Option<u32>), Pa
 
 fn check_level_is_none(level: &Option<u32>) -> Result<(), ParquetError> {
     if level.is_some() {
-        return Err(ParquetError::General("level is not support".to_string()));
+        return Err(ParquetError::General(
+            "compression level is not supported".to_string(),
+        ));
     }
 
     Ok(())
 }
 
 fn require_level(codec: &str, level: Option<u32>) -> Result<u32, ParquetError> {
-    level.ok_or(ParquetError::General(format!("{} require level", codec)))
+    level.ok_or(ParquetError::General(format!(
+        "{} requires a compression level",
+        codec
+    )))
 }
 
 impl FromStr for Compression {


### PR DESCRIPTION
# Rationale for this change
 
The current error messages do not have great grammar, and are not very helpful.

I'm exposing the compression type via a Python library, and the error messages are being bubbled up.

This MR makes them slightly more useful, and fixes some grammar errors.

