### PR TITLE
Add doctest example for `Buffer::from_bytes`

### DIFF
--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -61,7 +61,7 @@ unsafe impl Sync for Buffer where Bytes: Sync {}
 impl Buffer {
     /// Auxiliary method to create a new Buffer
     ///
-    /// This can be used with a `bytes::Bytes` via `into()`:
+    /// This can be used with a [`bytes::Bytes`] via `into()`:
     ///
     /// ```
     /// # use arrow_buffer::Buffer;

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -60,6 +60,15 @@ unsafe impl Sync for Buffer where Bytes: Sync {}
 
 impl Buffer {
     /// Auxiliary method to create a new Buffer
+    ///
+    /// This can be used with a `bytes::Bytes` via `into()`:
+    ///
+    /// ```
+    /// # use arrow_buffer::Buffer;
+    /// let bytes = bytes::Bytes::from_static(b"foo");
+    /// let buffer = Buffer::from_bytes(bytes.into());
+    /// ```
+    /// Though the Arrow bytes type is not public,
     #[inline]
     pub fn from_bytes(bytes: Bytes) -> Self {
         let length = bytes.len();

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -68,7 +68,6 @@ impl Buffer {
     /// let bytes = bytes::Bytes::from_static(b"foo");
     /// let buffer = Buffer::from_bytes(bytes.into());
     /// ```
-    /// Though the Arrow bytes type is not public,
     #[inline]
     pub fn from_bytes(bytes: Bytes) -> Self {
         let length = bytes.len();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

It was unclear how to use `arrow_buffer::Buffer::from_bytes` because `arrow_buffer::Bytes` is private, so it's hard to see the `From` impl.

# What changes are included in this PR?

Documentation update.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
