### PR TITLE
[POC] Experimental parquet decoder with first-class filter pushdown support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "53.2.0"
+version = "53.3.0"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -205,6 +205,51 @@ impl BooleanBuffer {
     pub fn set_slices(&self) -> BitSliceIterator<'_> {
         BitSliceIterator::new(self.values(), self.offset, self.len)
     }
+
+    /// Combines this [`BooleanBuffer`] with another using logical AND on the selected bits.
+    ///
+    /// Unlike intersection, the `other` [`BooleanBuffer`] must have exactly as many **set bits** as `self`,
+    /// i.e., self.count_set_bits() == other.len().
+    ///
+    /// This method will keep only the bits in `self` that are also set in `other`
+    /// at the positions corresponding to `self`'s set bits.
+    /// For example:
+    /// self:   NNYYYNNYYNYN
+    /// other:    YNY  NY N
+    /// result: NNYNYNNNYNNN
+    pub fn and_then(&self, other: &Self) -> Self {
+        // Ensure that 'other' has exactly as many set bits as 'self'
+        debug_assert_eq!(
+            self.count_set_bits(),
+            other.len(),
+            "The 'other' selection must have exactly as many set bits as 'self'."
+        );
+
+        if self.len() == other.len() {
+            // fast path if the two bool masks are the same length
+            // this happens when self selects all rows
+            debug_assert_eq!(self.count_set_bits(), self.len());
+            return other.clone();
+        }
+
+        let mut buffer = MutableBuffer::from_len_zeroed(self.values().len());
+        buffer.copy_from_slice(self.values());
+        let mut builder = BooleanBufferBuilder::new_from_buffer(buffer, self.len());
+
+        // Create iterators for 'self' and 'other' bits
+        let mut other_bits = other.iter();
+
+        for bit_idx in self.set_indices() {
+            let predicate = other_bits
+                .next()
+                .expect("Mismatch in set bits between self and other");
+            if !predicate {
+                builder.set_bit(bit_idx, false);
+            }
+        }
+
+        builder.finish()
+    }
 }
 
 impl Not for &BooleanBuffer {

--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -245,6 +245,7 @@ fn build_primitive_reader(
             page_iterator,
             column_desc,
             arrow_type,
+            col_idx,
         )?) as _,
         PhysicalType::INT32 => {
             if let Some(DataType::Null) = arrow_type {
@@ -257,6 +258,7 @@ fn build_primitive_reader(
                     page_iterator,
                     column_desc,
                     arrow_type,
+                    col_idx,
                 )?) as _
             }
         }
@@ -264,21 +266,25 @@ fn build_primitive_reader(
             page_iterator,
             column_desc,
             arrow_type,
+            col_idx,
         )?) as _,
         PhysicalType::INT96 => Box::new(PrimitiveArrayReader::<Int96Type>::new(
             page_iterator,
             column_desc,
             arrow_type,
+            col_idx,
         )?) as _,
         PhysicalType::FLOAT => Box::new(PrimitiveArrayReader::<FloatType>::new(
             page_iterator,
             column_desc,
             arrow_type,
+            col_idx,
         )?) as _,
         PhysicalType::DOUBLE => Box::new(PrimitiveArrayReader::<DoubleType>::new(
             page_iterator,
             column_desc,
             arrow_type,
+            col_idx,
         )?) as _,
         PhysicalType::BYTE_ARRAY => match arrow_type {
             Some(DataType::Dictionary(_, _)) => {

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -80,6 +80,7 @@ where
     def_levels_buffer: Option<Vec<i16>>,
     rep_levels_buffer: Option<Vec<i16>>,
     record_reader: RecordReader<T>,
+    #[allow(unused)]
     column_idx: usize,
 }
 
@@ -417,9 +418,13 @@ mod tests {
             );
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
-            let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
-                    .unwrap();
+            let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
+                Box::new(page_iterator),
+                column_desc,
+                None,
+                0,
+            )
+            .unwrap();
 
             // Read first 50 values, which are all from the first column chunk
             let array = array_reader.next_batch(50).unwrap();
@@ -624,9 +629,13 @@ mod tests {
 
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
-            let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
-                    .unwrap();
+            let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
+                Box::new(page_iterator),
+                column_desc,
+                None,
+                0,
+            )
+            .unwrap();
 
             let mut accu_len: usize = 0;
 
@@ -700,9 +709,13 @@ mod tests {
             );
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
-            let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
-                    .unwrap();
+            let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
+                Box::new(page_iterator),
+                column_desc,
+                None,
+                0,
+            )
+            .unwrap();
 
             // read data from the reader
             // the data type is decimal(8,2)
@@ -759,9 +772,13 @@ mod tests {
             );
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
-            let mut array_reader =
-                PrimitiveArrayReader::<Int64Type>::new(Box::new(page_iterator), column_desc, None, 0)
-                    .unwrap();
+            let mut array_reader = PrimitiveArrayReader::<Int64Type>::new(
+                Box::new(page_iterator),
+                column_desc,
+                None,
+                0,
+            )
+            .unwrap();
 
             // read data from the reader
             // the data type is decimal(18,4)

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -80,6 +80,7 @@ where
     def_levels_buffer: Option<Vec<i16>>,
     rep_levels_buffer: Option<Vec<i16>>,
     record_reader: RecordReader<T>,
+    column_idx: usize,
 }
 
 impl<T> PrimitiveArrayReader<T>
@@ -93,6 +94,7 @@ where
         pages: Box<dyn PageIterator>,
         column_desc: ColumnDescPtr,
         arrow_type: Option<ArrowType>,
+        column_idx: usize,
     ) -> Result<Self> {
         // Check if Arrow type is specified, else create it from Parquet type
         let data_type = match arrow_type {
@@ -110,6 +112,7 @@ where
             def_levels_buffer: None,
             rep_levels_buffer: None,
             record_reader,
+            column_idx,
         })
     }
 }
@@ -371,6 +374,7 @@ mod tests {
             Box::<EmptyPageIterator>::default(),
             schema.column(0),
             None,
+            0,
         )
         .unwrap();
 
@@ -414,7 +418,7 @@ mod tests {
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
             let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None)
+                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
                     .unwrap();
 
             // Read first 50 values, which are all from the first column chunk
@@ -484,6 +488,7 @@ mod tests {
                     Box::new(page_iterator),
                     column_desc.clone(),
                     None,
+                    0,
                 )
                 .expect("Unable to get array reader");
 
@@ -620,7 +625,7 @@ mod tests {
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
             let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None)
+                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
                     .unwrap();
 
             let mut accu_len: usize = 0;
@@ -696,7 +701,7 @@ mod tests {
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
             let mut array_reader =
-                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None)
+                PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc, None, 0)
                     .unwrap();
 
             // read data from the reader
@@ -755,7 +760,7 @@ mod tests {
             let page_iterator = InMemoryPageIterator::new(page_lists);
 
             let mut array_reader =
-                PrimitiveArrayReader::<Int64Type>::new(Box::new(page_iterator), column_desc, None)
+                PrimitiveArrayReader::<Int64Type>::new(Box::new(page_iterator), column_desc, None, 0)
                     .unwrap();
 
             // read data from the reader

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 /// Implementation of struct array reader.
 pub struct StructArrayReader {
-    children: Vec<Box<dyn ArrayReader>>,
+    pub children: Vec<Box<dyn ArrayReader>>,
     data_type: ArrowType,
     struct_def_level: i16,
     struct_rep_level: i16,

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -110,7 +110,7 @@ where
 /// [`RowSelection`]: crate::arrow::arrow_reader::RowSelection
 pub struct RowFilter {
     /// A list of [`ArrowPredicate`]
-    pub(crate) predicates: Vec<Box<dyn ArrowPredicate>>,
+    pub predicates: Vec<Box<dyn ArrowPredicate>>,
 }
 
 impl RowFilter {

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -366,6 +366,12 @@ impl RowSelection {
         self
     }
 
+    /// Returns the internal selectors of this [`RowSelection`], testing only
+    #[cfg(test)]
+    pub(crate) fn selectors(&self) -> &[RowSelector] {
+        &self.selectors
+    }
+
     /// Applies an offset to this [`RowSelection`], skipping the first `offset` selected rows
     pub(crate) fn offset(mut self, offset: usize) -> Self {
         if offset == 0 {

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -441,10 +441,6 @@ impl RowSelection {
     pub fn skipped_row_count(&self) -> usize {
         self.iter().filter(|s| s.skip).map(|s| s.row_count).sum()
     }
-
-    pub(crate) fn extend(&mut self, other: Self) {
-        self.selectors.extend(other.selectors);
-    }
 }
 
 impl From<Vec<RowSelector>> for RowSelection {

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -366,12 +366,6 @@ impl RowSelection {
         self
     }
 
-    /// Returns the internal selectors of this [`RowSelection`], testing only
-    #[cfg(test)]
-    pub(crate) fn selectors(&self) -> &[RowSelector] {
-        &self.selectors
-    }
-
     /// Applies an offset to this [`RowSelection`], skipping the first `offset` selected rows
     pub(crate) fn offset(mut self, offset: usize) -> Self {
         if offset == 0 {
@@ -446,6 +440,10 @@ impl RowSelection {
     /// Returns the number of de-selected rows
     pub fn skipped_row_count(&self) -> usize {
         self.iter().filter(|s| s.skip).map(|s| s.row_count).sum()
+    }
+
+    pub(crate) fn extend(&mut self, other: Self) {
+        self.selectors.extend(other.selectors);
     }
 }
 

--- a/parquet/src/arrow/async_reader/arrow_reader.rs
+++ b/parquet/src/arrow/async_reader/arrow_reader.rs
@@ -1,0 +1,244 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use arrow_array::{cast::AsArray, Array, RecordBatch, RecordBatchReader, StructArray};
+use arrow_schema::{ArrowError, SchemaRef};
+use arrow_select::filter::prep_null_mask_filter;
+
+use crate::arrow::{
+    array_reader::{build_array_reader, ArrayReader, RowGroups, StructArrayReader},
+    arrow_reader::{ArrowPredicate, RowFilter, RowSelection, RowSelector},
+};
+use crate::errors::ParquetError;
+
+use super::ParquetField;
+
+pub struct FilteredParquetRecordBatchReader {
+    batch_size: usize,
+    array_reader: StructArrayReader,
+    predicate_readers: Vec<Box<dyn ArrayReader>>,
+    schema: SchemaRef,
+    selection: VecDeque<RowSelector>,
+    row_filter: Option<RowFilter>,
+}
+
+fn read_selection(
+    reader: &mut dyn ArrayReader,
+    selection: &RowSelection,
+) -> Result<StructArray, ParquetError> {
+    for selector in selection.iter() {
+        if selector.skip {
+            let skipped = reader.skip_records(selector.row_count)?;
+            debug_assert_eq!(skipped, selector.row_count, "failed to skip rows");
+        } else {
+            let read_records = reader.read_records(selector.row_count)?;
+            debug_assert_eq!(read_records, selector.row_count, "failed to read rows");
+        }
+    }
+    let array = reader.consume_batch()?;
+    let struct_array = array
+        .as_struct_opt()
+        .ok_or_else(|| general_err!("Struct array reader should return struct array"))?;
+    Ok(struct_array.clone())
+}
+
+/// Take the next selection from the selection queue, and return the selection
+/// whose selected row count is to_select or less (if input selection is exhausted).
+fn take_next_selection(
+    selection: &mut VecDeque<RowSelector>,
+    to_select: usize,
+) -> Option<RowSelection> {
+    let mut current_selected = 0;
+    let mut rt = Vec::new();
+    while let Some(front) = selection.pop_front() {
+        if front.skip {
+            rt.push(front);
+            continue;
+        }
+
+        if current_selected + front.row_count <= to_select {
+            rt.push(front);
+            current_selected += front.row_count;
+        } else {
+            let select = to_select - current_selected;
+            let remaining = front.row_count - select;
+            rt.push(RowSelector::select(select));
+            selection.push_front(RowSelector::select(remaining));
+
+            return Some(rt.into());
+        }
+    }
+    if !rt.is_empty() {
+        return Some(rt.into());
+    }
+    None
+}
+
+fn build_array_reader_for_filters(
+    filters: &RowFilter,
+    fields: &Option<Arc<ParquetField>>,
+    row_group: &dyn RowGroups,
+) -> Result<Vec<Box<dyn ArrayReader>>, ArrowError> {
+    let mut array_readers = Vec::new();
+    for predicate in filters.predicates.iter() {
+        let predicate_projection = predicate.projection();
+        let array_reader = build_array_reader(fields.as_deref(), predicate_projection, row_group)?;
+        array_readers.push(array_reader);
+    }
+    Ok(array_readers)
+}
+
+impl FilteredParquetRecordBatchReader {
+    fn new(batch_size: usize, array_reader: StructArrayReader, selection: RowSelection) -> Self {
+        todo!()
+    }
+
+    fn build_predicate_filter(
+        &mut self,
+        selection: &RowSelection,
+    ) -> Result<RowSelection, ArrowError> {
+        match &mut self.row_filter {
+            None => Ok(selection.clone()),
+            Some(filter) => {
+                debug_assert_eq!(
+                    self.predicate_readers.len(),
+                    filter.predicates.len(),
+                    "predicate readers and predicates should have the same length"
+                );
+                let mut selection = selection.clone();
+
+                for (predicate, reader) in filter
+                    .predicates
+                    .iter_mut()
+                    .zip(self.predicate_readers.iter_mut())
+                {
+                    let array = read_selection(reader.as_mut(), &selection)?;
+                    let batch = RecordBatch::from(array);
+                    let input_rows = batch.num_rows();
+                    let predicate_filter = predicate.evaluate(batch)?;
+                    if predicate_filter.len() != input_rows {
+                        return Err(ArrowError::ParquetError(format!(
+                            "ArrowPredicate predicate returned {} rows, expected {input_rows}",
+                            predicate_filter.len()
+                        )));
+                    }
+                    let predicate_filter = match predicate_filter.null_count() {
+                        0 => predicate_filter,
+                        _ => prep_null_mask_filter(&predicate_filter),
+                    };
+                    let raw = RowSelection::from_filters(&[predicate_filter]);
+                    selection = selection.and_then(&raw);
+                }
+                Ok(selection)
+            }
+        }
+    }
+}
+
+impl Iterator for FilteredParquetRecordBatchReader {
+    type Item = Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let selection = take_next_selection(&mut self.selection, self.batch_size)?;
+        let filtered_selection = match self.build_predicate_filter(&selection) {
+            Ok(selection) => selection,
+            Err(e) => return Some(Err(e)),
+        };
+
+        let rt = read_selection(&mut self.array_reader, &filtered_selection);
+        match rt {
+            Ok(array) => Some(Ok(RecordBatch::from(array))),
+            Err(e) => Some(Err(e.into())),
+        }
+    }
+}
+
+impl RecordBatchReader for FilteredParquetRecordBatchReader {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_take_next_selection_exact_match() {
+        let mut queue = VecDeque::from(vec![
+            RowSelector::skip(5),
+            RowSelector::select(3),
+            RowSelector::skip(2),
+            RowSelector::select(7),
+        ]);
+
+        // Request exactly 10 rows (5 skip + 3 select + 2 skip)
+        let selection = take_next_selection(&mut queue, 3).unwrap();
+        assert_eq!(
+            selection,
+            vec![
+                RowSelector::skip(5),
+                RowSelector::select(3),
+                RowSelector::skip(2)
+            ]
+            .into()
+        );
+
+        // Check remaining queue
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].row_count, 7);
+        assert_eq!(queue[0].skip, false);
+    }
+
+    #[test]
+    fn test_take_next_selection_split_required() {
+        let mut queue = VecDeque::from(vec![RowSelector::select(10), RowSelector::select(10)]);
+
+        // Request 15 rows, which should split the first selector
+        let selection = take_next_selection(&mut queue, 15).unwrap();
+
+        assert_eq!(
+            selection,
+            vec![RowSelector::select(10), RowSelector::select(5)].into()
+        );
+
+        // Check remaining queue - should have 5 rows from split and original 10
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].skip, false);
+        assert_eq!(queue[0].row_count, 5);
+    }
+
+    #[test]
+    fn test_take_next_selection_empty_queue() {
+        let mut queue = VecDeque::new();
+
+        // Should return None for empty queue
+        let selection = take_next_selection(&mut queue, 10);
+        assert!(selection.is_none());
+
+        // Test with queue that becomes empty
+        queue.push_back(RowSelector::select(5));
+        let selection = take_next_selection(&mut queue, 10).unwrap();
+        assert_eq!(selection, vec![RowSelector::select(5)].into());
+
+        // Queue should now be empty
+        let selection = take_next_selection(&mut queue, 10);
+        assert!(selection.is_none());
+    }
+}

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -843,22 +843,28 @@ impl RowGroups for InMemoryRowGroup<'_> {
                     .filter(|index| !index.is_empty())
                     .map(|index| index[i].page_locations.clone());
 
-                // let page_reader: Box<dyn PageReader> = Box::new(SerializedPageReader::new(
-                //     data.clone(),
-                //     self.metadata.column(i),
-                //     self.row_count,
-                //     page_locations,
-                // )?);
-
-                let page_reader: Box<dyn PageReader> = Box::new(CachedPageReader::new(
-                    SerializedPageReader::new(
+                let page_reader: Box<dyn PageReader> = if std::env::var("CACHE_PAGES")
+                    .map(|v| v == "1")
+                    .unwrap_or(false)
+                {
+                    Box::new(CachedPageReader::new(
+                        SerializedPageReader::new(
+                            data.clone(),
+                            self.metadata.column(i),
+                            self.row_count,
+                            page_locations,
+                        )?,
+                        self.cache.clone(),
+                        i,
+                    ))
+                } else {
+                    Box::new(SerializedPageReader::new(
                         data.clone(),
                         self.metadata.column(i),
                         self.row_count,
                         page_locations,
-                    )?,
-                    self.cache.clone(),
-                ));
+                    )?)
+                };
 
                 Ok(Box::new(ColumnChunkIterator {
                     reader: Some(Ok(page_reader)),

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -110,6 +110,7 @@ use crate::file::reader::{ChunkReader, Length, SerializedPageReader};
 use crate::file::FOOTER_SIZE;
 use crate::format::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 
+mod arrow_reader;
 mod metadata;
 pub use metadata::*;
 

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -83,6 +83,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use arrow_reader::{CachedPageReader, FilteredParquetRecordBatchReader, PageCache};
 use bytes::{Buf, Bytes};
 use futures::future::{BoxFuture, FutureExt};
 use futures::ready;
@@ -94,8 +95,7 @@ use arrow_schema::{DataType, Fields, Schema, SchemaRef};
 
 use crate::arrow::array_reader::{build_array_reader, RowGroups};
 use crate::arrow::arrow_reader::{
-    apply_range, evaluate_predicate, selects_any, ArrowReaderBuilder, ArrowReaderMetadata,
-    ArrowReaderOptions, ParquetRecordBatchReader, RowFilter, RowSelection,
+    ArrowReaderBuilder, ArrowReaderMetadata, ArrowReaderOptions, RowFilter, RowSelection,
 };
 use crate::arrow::ProjectionMask;
 
@@ -120,6 +120,8 @@ mod store;
 use crate::arrow::schema::ParquetField;
 #[cfg(feature = "object_store")]
 pub use store::*;
+
+use super::arrow_reader::RowSelector;
 
 /// The asynchronous interface used by [`ParquetRecordBatchStream`] to read parquet files
 ///
@@ -469,7 +471,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
     }
 }
 
-type ReadResult<T> = Result<(ReaderFactory<T>, Option<ParquetRecordBatchReader>)>;
+type ReadResult<T> = Result<(ReaderFactory<T>, Option<FilteredParquetRecordBatchReader>)>;
 
 /// [`ReaderFactory`] is used by [`ParquetRecordBatchStream`] to create
 /// [`ParquetRecordBatchReader`]
@@ -497,18 +499,16 @@ where
     async fn read_row_group(
         mut self,
         row_group_idx: usize,
-        mut selection: Option<RowSelection>,
+        selection: Option<RowSelection>,
         projection: ProjectionMask,
         batch_size: usize,
     ) -> ReadResult<T> {
-        // TODO: calling build_array multiple times is wasteful
-
         let meta = self.metadata.row_group(row_group_idx);
         let offset_index = self
             .metadata
             .offset_index()
             // filter out empty offset indexes (old versions specified Some(vec![]) when no present)
-            .filter(|index| !index.is_empty())
+            .filter(|index| index.first().map(|v| !v.is_empty()).unwrap_or(false))
             .map(|x| x[row_group_idx].as_slice());
 
         let mut row_group = InMemoryRowGroup {
@@ -517,48 +517,47 @@ where
             row_count: meta.num_rows() as usize,
             column_chunks: vec![None; meta.columns().len()],
             offset_index,
+            cache: Arc::new(PageCache::new()),
         };
 
+        let mut selection =
+            selection.unwrap_or_else(|| vec![RowSelector::select(row_group.row_count)].into());
+
+        let mut filter_readers = Vec::new();
         if let Some(filter) = self.filter.as_mut() {
             for predicate in filter.predicates.iter_mut() {
-                if !selects_any(selection.as_ref()) {
+                if !selection.selects_any() {
                     return Ok((self, None));
                 }
 
                 let predicate_projection = predicate.projection();
                 row_group
-                    .fetch(&mut self.input, predicate_projection, selection.as_ref())
+                    .fetch(&mut self.input, predicate_projection, Some(&selection))
                     .await?;
 
                 let array_reader =
                     build_array_reader(self.fields.as_deref(), predicate_projection, &row_group)?;
-
-                selection = Some(evaluate_predicate(
-                    batch_size,
-                    array_reader,
-                    selection,
-                    predicate.as_mut(),
-                )?);
+                filter_readers.push(array_reader);
             }
         }
 
         // Compute the number of rows in the selection before applying limit and offset
-        let rows_before = selection
-            .as_ref()
-            .map(|s| s.row_count())
-            .unwrap_or(row_group.row_count);
+        let rows_before = selection.row_count();
 
         if rows_before == 0 {
             return Ok((self, None));
         }
 
-        selection = apply_range(selection, row_group.row_count, self.offset, self.limit);
+        if let Some(offset) = self.offset {
+            selection = selection.offset(offset);
+        }
+
+        if let Some(limit) = self.limit {
+            selection = selection.limit(limit);
+        }
 
         // Compute the number of rows in the selection after applying limit and offset
-        let rows_after = selection
-            .as_ref()
-            .map(|s| s.row_count())
-            .unwrap_or(row_group.row_count);
+        let rows_after = selection.row_count();
 
         // Update offset if necessary
         if let Some(offset) = &mut self.offset {
@@ -576,13 +575,16 @@ where
         }
 
         row_group
-            .fetch(&mut self.input, &projection, selection.as_ref())
+            .fetch(&mut self.input, &projection, Some(&selection))
             .await?;
 
-        let reader = ParquetRecordBatchReader::new(
+        let array_reader = build_array_reader(self.fields.as_deref(), &projection, &row_group)?;
+        let reader = FilteredParquetRecordBatchReader::new(
             batch_size,
-            build_array_reader(self.fields.as_deref(), &projection, &row_group)?,
+            array_reader,
             selection,
+            filter_readers,
+            self.filter.take(),
         );
 
         Ok((self, Some(reader)))
@@ -593,7 +595,7 @@ enum StreamState<T> {
     /// At the start of a new row group, or the end of the parquet stream
     Init,
     /// Decoding a batch
-    Decoding(ParquetRecordBatchReader),
+    Decoding(FilteredParquetRecordBatchReader),
     /// Reading data from input
     Reading(BoxFuture<'static, ReadResult<T>>),
     /// Error
@@ -671,7 +673,12 @@ where
                         self.state = StreamState::Error;
                         return Poll::Ready(Some(Err(ParquetError::ArrowError(e.to_string()))));
                     }
-                    None => self.state = StreamState::Init,
+                    None => {
+                        // this is ugly, but works for now.
+                        let filter = batch_reader.take_filter();
+                        self.reader.as_mut().unwrap().filter = filter;
+                        self.state = StreamState::Init
+                    }
                 },
                 StreamState::Init => {
                     let row_group_idx = match self.row_groups.pop_front() {
@@ -723,6 +730,7 @@ struct InMemoryRowGroup<'a> {
     offset_index: Option<&'a [OffsetIndexMetaData]>,
     column_chunks: Vec<Option<Arc<ColumnChunkData>>>,
     row_count: usize,
+    cache: Arc<PageCache>,
 }
 
 impl<'a> InMemoryRowGroup<'a> {
@@ -834,12 +842,23 @@ impl RowGroups for InMemoryRowGroup<'_> {
                     // filter out empty offset indexes (old versions specified Some(vec![]) when no present)
                     .filter(|index| !index.is_empty())
                     .map(|index| index[i].page_locations.clone());
-                let page_reader: Box<dyn PageReader> = Box::new(SerializedPageReader::new(
-                    data.clone(),
-                    self.metadata.column(i),
-                    self.row_count,
-                    page_locations,
-                )?);
+
+                // let page_reader: Box<dyn PageReader> = Box::new(SerializedPageReader::new(
+                //     data.clone(),
+                //     self.metadata.column(i),
+                //     self.row_count,
+                //     page_locations,
+                // )?);
+
+                let page_reader: Box<dyn PageReader> = Box::new(CachedPageReader::new(
+                    SerializedPageReader::new(
+                        data.clone(),
+                        self.metadata.column(i),
+                        self.row_count,
+                        page_locations,
+                    )?,
+                    self.cache.clone(),
+                ));
 
                 Ok(Box::new(ColumnChunkIterator {
                     reader: Some(Ok(page_reader)),

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -210,6 +210,32 @@ impl ProjectionMask {
     pub fn leaf_included(&self, leaf_idx: usize) -> bool {
         self.mask.as_ref().map(|m| m[leaf_idx]).unwrap_or(true)
     }
+
+    /// Union two projection masks
+    pub fn union(&mut self, other: &Self) {
+        match (self.mask.as_ref(), other.mask.as_ref()) {
+            (None, _) | (_, None) => self.mask = None,
+            (Some(a), Some(b)) => {
+                assert_eq!(a.len(), b.len());
+                let mask = a.iter().zip(b.iter()).map(|(&a, &b)| a || b).collect();
+                self.mask = Some(mask);
+            }
+        }
+    }
+
+    /// Returns true if the mask contains the other mask
+    pub fn contains(&self, other: &Self) -> bool {
+        match (self.mask.as_ref(), other.mask.as_ref()) {
+            (None, _) => true,
+            (Some(a), Some(b)) => {
+                assert_eq!(a.len(), b.len());
+                a.iter()
+                    .zip(b.iter())
+                    .all(|(&a, &b)| if b { a } else { true })
+            }
+            (Some(_), None) => false,
+        }
+    }
 }
 
 /// Lookups up the parquet column by name


### PR DESCRIPTION
DO NOT MERGE.

I'll send breakdown PRs once I nailed down the designs.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


Many long lasting issues in DataFusion and parquet-rs, todo: find some

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Filter pushdown is great in concept, but current straightforward implementation actually slow down queries. The goal of a super fast filter pushdown parquet reader is described by @alamb  in https://github.com/apache/arrow-rs/issues/5523#issuecomment-2429364040:
> is that evaluating predicates in ArrowFilter (aka pushed down predicates) is never worse than decoding the columns first and then filtering them with the filter kernel

I initially thought we can find simple/smart tricks to workaround some of the issues https://github.com/apache/arrow-rs/issues/5523#issuecomment-2429470872 of the current implementation. After thinking more carefully about the design spaces and the implications, I believe the only way to reach that goal is to re-structure the parquet reading pipline, and also reuse as much existing implementation as possible.

### Problems of current implementation
We follow a [two phase decoding](https://github.com/apache/arrow-rs/blob/2c84f243b882eff69806cd7294d38bf422fdb24a/parquet/src/arrow/async_reader/mod.rs#L497): 
Phase 1: Build selectors on each predicate
```
Empty selector -> decode column 1 -> selection 1
Selection 1 -> decode column 2 -> selection 2
…
Selection K
```
Phase 2: Decode parquet data using the selector
```
Selection K -> decode column 1
Selection K -> decode column 2
…
Selection K -> decode column N
```

The first problem is that we have to decode the predicate column twice, for example, if column 1 is being filtered, we need to first decode column 1 while evaluating the predicate, then decode it again to build the array.

The second problem is that, we need to decode and evaluate all the predicates before we can emit the first record batch. This not only cause high first-record-batch latency, but also making caching decoded value challenging -- we need to cache the entire column to avoid double-decoding.

I have described other issues in https://github.com/apache/arrow-rs/issues/5523#issuecomment-2429470872, but they are relatively straghtforward to fix.

### Proposed decoding pipeline
We can't pre-build the filter once and use it to decode data, instead, we need to build filter batch-by-batch along with decoding. The pipeline looks like this:
```
Load predicate columns for batch 1 -> evaluate predicates -> filter 1 -> load & emit batch 1
Load predicate columns for batch 2 -> evaluate predicates -> filter 2 -> load & emit batch 2
...
Load predicate columns for batch N -> evaluate predicates -> filter N -> load & emit batch N
```

Once we have this pipeline, we can cache the `predicate columns for batch N`  and reuse it when `load & emit batch N`, this avoids double decoding.
However, the key challenge is to handle nesting types. The `predicate columns` is not an array, but a tree; same to the result columns. So the problem is not just to intersect two column lists, but also to reconstruct the predicate columns tree to the result column tree.

A workaround is to cache the decompressed pages, rather than decoded arrow arrays. As some research suggests (todo: cite myself) decompressing pages costs up to twice as much as decoding arrow, if we can cache the decompressed pages, then we only need to decode arrow twice, which might be good enough. Caching decompressed pages is much simpler to implement, as we can reuse the current array_readers and just implement a new [PageReader](https://github.com/apache/arrow-rs/blob/5249f99e0e6671fc06996365dd4cf22a8427348c/parquet/src/column/page.rs#L340).

This PR implements caching decompressed pages, however, testing on my local machine shows that it still cause slow down to some queries, particularly for string columns.

# What changes are included in this PR?
This draft PR implements some of the ideas described above, and already see many performance improvements. But here are some todos:

- [ ] Push down InMemoryRowGroup fetch to decoding time as well. Currently we fetch columns too early 
- [ ] Try to cache arrow array again
- [ ] other straightforward todos...

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
