### PR TITLE
add binary support in arrow-string

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -754,6 +754,21 @@ where
 pub type BinaryViewArray = GenericByteViewArray<BinaryViewType>;
 
 impl BinaryViewArray {
+
+    /// Returns true if all data within this array is ASCII
+    pub fn is_ascii(&self) -> bool {
+        // Alternative (but incorrect): directly check the underlying buffers
+        // (1) Our binary view might be sparse, i.e., a subset of the buffers,
+        //      so even if the buffer is not ascii, we can still be ascii.
+        // (2) It is quite difficult to know the range of each buffer (unlike BinaryArray)
+        // This means that this operation is quite expensive, shall we cache the result?
+        //  i.e. track `is_ascii` in the builder.
+        self.iter().all(|v| match v {
+            Some(v) => v.is_ascii(),
+            None => true,
+        })
+    }
+
     /// Convert the [`BinaryViewArray`] to [`StringViewArray`]
     /// If items not utf8 data, validate will fail and error returned.
     pub fn to_string_view(self) -> Result<StringViewArray, ArrowError> {

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -59,6 +59,17 @@ pub struct FixedSizeBinaryArray {
 }
 
 impl FixedSizeBinaryArray {
+
+    /// Returns true if all data within this array is ASCII
+    pub fn is_ascii(&self) -> bool {
+        // TODO - check if we can do similar to BinaryArray
+        //        as this is expensive
+        self.iter().all(|v| match v {
+            Some(v) => v.is_ascii(),
+            None => true,
+        })
+    }
+
     /// Create a new [`FixedSizeBinaryArray`] with `size` element size, panicking on failure
     ///
     /// # Panics

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -620,6 +620,52 @@ impl<'a> StringArrayType<'a> for &'a StringViewArray {
     }
 }
 
+/// A trait for Arrow Binary Arrays, currently the following types are supported:
+/// - `BinaryArray`
+/// - `LargeBinaryArray`
+/// - `BinaryViewArray`
+/// - `FixedSizeBinaryArray`
+///
+/// This trait helps to abstract over the different types of binary arrays
+/// so that we don't need to duplicate the implementation for each type.
+pub trait BinaryArrayType<'a>: ArrayAccessor<Item = &'a [u8]> + Sized {
+    /// Returns true if all data within this binary array is ASCII
+    fn is_ascii(&self) -> bool;
+
+    /// Constructs a new iterator
+    fn iter(&self) -> ArrayIter<Self>;
+}
+
+impl<'a, O: OffsetSizeTrait> BinaryArrayType<'a> for &'a GenericBinaryArray<O> {
+    fn is_ascii(&self) -> bool {
+        GenericBinaryArray::<O>::is_ascii(self)
+    }
+
+    fn iter(&self) -> ArrayIter<Self> {
+        GenericBinaryArray::<O>::iter(self)
+    }
+}
+
+impl<'a> BinaryArrayType<'a> for &'a BinaryViewArray {
+    fn is_ascii(&self) -> bool {
+        BinaryViewArray::is_ascii(self)
+    }
+
+    fn iter(&self) -> ArrayIter<Self> {
+        BinaryViewArray::iter(self)
+    }
+}
+
+impl<'a> BinaryArrayType<'a> for &'a FixedSizeBinaryArray {
+    fn is_ascii(&self) -> bool {
+        FixedSizeBinaryArray::is_ascii(self)
+    }
+
+    fn iter(&self) -> ArrayIter<Self> {
+        FixedSizeBinaryArray::iter(self)
+    }
+}
+
 impl PartialEq for dyn Array + '_ {
     fn eq(&self, other: &Self) -> bool {
         self.to_data().eq(&other.to_data())

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_array::{Array, ArrayAccessor, BooleanArray, StringViewArray};
+
+use arrow_array::{Array, ArrayAccessor, BinaryViewArray, BooleanArray, StringViewArray};
 use arrow_buffer::BooleanBuffer;
 use arrow_schema::ArrowError;
 use memchr::memchr3;
 use memchr::memmem::Finder;
-use regex::{Regex, RegexBuilder};
+use regex::{Regex, RegexBuilder, bytes::Regex as BinaryRegex, bytes::RegexBuilder as BinaryRegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
@@ -40,59 +41,127 @@ pub enum Predicate<'a> {
     Regex(Regex),
 }
 
-impl<'a> Predicate<'a> {
+/// A string based predicate
+pub enum BinaryPredicate<'a> {
+    Eq(&'a [u8]),
+    Contains(Finder<'a>),
+    StartsWith(&'a [u8]),
+    EndsWith(&'a [u8]),
+
+    /// Equality ignoring ASCII case
+    IEqAscii(&'a [u8]),
+    /// Starts with ignoring ASCII case
+    IStartsWithAscii(&'a [u8]),
+    /// Ends with ignoring ASCII case
+    IEndsWithAscii(&'a [u8]),
+
+    Regex(BinaryRegex),
+}
+
+pub trait PredicateImpl<'a>: Sized {
+
+    type UnsizedItem: ?Sized + PartialEq;
+    type RegexType;
+
     /// Create a predicate for the given like pattern
-    pub fn like(pattern: &'a str) -> Result<Self, ArrowError> {
-        if !contains_like_pattern(pattern) {
+    fn like(pattern: &'a Self::UnsizedItem) -> Result<Self, ArrowError>;
+
+    fn contains(needle: &'a Self::UnsizedItem) -> Self;
+
+    /// Create a predicate for the given ilike pattern
+    fn ilike(pattern: &'a Self::UnsizedItem, is_ascii: bool) -> Result<Self, ArrowError>;
+
+    /// Create a predicate for the given starts_with pattern
+    fn starts_with(pattern: &'a Self::UnsizedItem) -> Self;
+
+    /// Create a predicate for the given ends_with pattern
+    fn ends_with(pattern: &'a Self::UnsizedItem) -> Self;
+
+    /// Evaluate this predicate against the given haystack
+    fn evaluate(&self, haystack: &'a Self::UnsizedItem) -> bool;
+
+    /// Evaluate this predicate against the elements of `array`
+    ///
+    /// If `negate` is true the result of the predicate will be negated
+    #[inline(never)]
+    fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
+    where
+        T: ArrayAccessor<Item = &'i Self::UnsizedItem>, Self::UnsizedItem: 'i;
+
+    /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
+    ///
+    /// 1. Replace `LIKE` multi-character wildcards `%` => `.*` (unless they're at the start or end of the pattern,
+    ///    where the regex is just truncated - e.g. `%foo%` => `foo` rather than `^.*foo.*$`)
+    /// 2. Replace `LIKE` single-character wildcards `_` => `.`
+    /// 3. Escape regex meta characters to match them and not be evaluated as regex special chars. e.g. `.` => `\\.`
+    /// 4. Replace escaped `LIKE` wildcards removing the escape characters to be able to match it as a regex. e.g. `\\%` => `%`
+    fn regex_like(pattern: &'a Self::UnsizedItem, case_insensitive: bool) -> Result<Self::RegexType, ArrowError>;
+}
+
+impl<'a> PredicateImpl<'a> for Predicate<'a> {
+    type UnsizedItem = str;
+    type RegexType = Regex;
+
+    /// Create a predicate for the given like pattern
+    fn like(pattern: &'a str) -> Result<Self, ArrowError> {
+        if !contains_like_pattern(pattern.as_bytes()) {
             Ok(Self::Eq(pattern))
-        } else if pattern.ends_with('%') && !contains_like_pattern(&pattern[..pattern.len() - 1]) {
+        } else if pattern.ends_with('%') && !contains_like_pattern(&pattern[..pattern.len() - 1].as_bytes()) {
             Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
-        } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
+        } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..].as_bytes()) {
             Ok(Self::EndsWith(&pattern[1..]))
         } else if pattern.starts_with('%')
             && pattern.ends_with('%')
-            && !contains_like_pattern(&pattern[1..pattern.len() - 1])
+            && !contains_like_pattern(&pattern[1..pattern.len() - 1].as_bytes())
         {
             Ok(Self::contains(&pattern[1..pattern.len() - 1]))
         } else {
-            Ok(Self::Regex(regex_like(pattern, false)?))
+            Ok(Self::Regex(Self::regex_like(pattern, false)?))
         }
     }
 
-    pub fn contains(needle: &'a str) -> Self {
+    fn contains(needle: &'a str) -> Self {
         Self::Contains(Finder::new(needle.as_bytes()))
     }
 
     /// Create a predicate for the given ilike pattern
-    pub fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
+    fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
         if is_ascii && pattern.is_ascii() {
-            if !contains_like_pattern(pattern) {
+            if !contains_like_pattern(pattern.as_bytes()) {
                 return Ok(Self::IEqAscii(pattern));
             } else if pattern.ends_with('%')
                 && !pattern.ends_with("\\%")
-                && !contains_like_pattern(&pattern[..pattern.len() - 1])
+                && !contains_like_pattern(&pattern[..pattern.len() - 1].as_bytes())
             {
                 return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
-            } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..]) {
+            } else if pattern.starts_with('%') && !contains_like_pattern(&pattern[1..].as_bytes()) {
                 return Ok(Self::IEndsWithAscii(&pattern[1..]));
             }
         }
-        Ok(Self::Regex(regex_like(pattern, true)?))
+        Ok(Self::Regex(Self::regex_like(pattern, true)?))
+    }
+
+    fn starts_with(pattern: &'a str) -> Self {
+        Self::StartsWith(pattern)
+    }
+
+    fn ends_with(pattern: &'a str) -> Self {
+        Self::EndsWith(pattern)
     }
 
     /// Evaluate this predicate against the given haystack
-    pub fn evaluate(&self, haystack: &str) -> bool {
+    fn evaluate(&self, haystack: &'a str) -> bool {
         match self {
-            Predicate::Eq(v) => *v == haystack,
-            Predicate::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
-            Predicate::Contains(finder) => finder.find(haystack.as_bytes()).is_some(),
-            Predicate::StartsWith(v) => starts_with(haystack, v, equals_kernel),
-            Predicate::IStartsWithAscii(v) => {
-                starts_with(haystack, v, equals_ignore_ascii_case_kernel)
+            Self::Eq(v) => *v == haystack,
+            Self::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
+            Self::Contains(finder) => finder.find(haystack.as_bytes()).is_some(),
+            Self::StartsWith(v) => starts_with(haystack.as_bytes(), v.as_bytes(), equals_kernel),
+            Self::IStartsWithAscii(v) => {
+                starts_with(haystack.as_bytes(), v.as_bytes(), equals_ignore_ascii_case_kernel)
             }
-            Predicate::EndsWith(v) => ends_with(haystack, v, equals_kernel),
-            Predicate::IEndsWithAscii(v) => ends_with(haystack, v, equals_ignore_ascii_case_kernel),
-            Predicate::Regex(v) => v.is_match(haystack),
+            Self::EndsWith(v) => ends_with(haystack.as_bytes(), v.as_bytes(), equals_kernel),
+            Self::IEndsWithAscii(v) => ends_with(haystack.as_bytes(), v.as_bytes(), equals_ignore_ascii_case_kernel),
+            Self::Regex(v) => v.is_match(haystack),
         }
     }
 
@@ -100,21 +169,21 @@ impl<'a> Predicate<'a> {
     ///
     /// If `negate` is true the result of the predicate will be negated
     #[inline(never)]
-    pub fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
+    fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
     where
         T: ArrayAccessor<Item = &'i str>,
     {
         match self {
-            Predicate::Eq(v) => BooleanArray::from_unary(array, |haystack| {
+            Self::Eq(v) => BooleanArray::from_unary(array, |haystack| {
                 (haystack.len() == v.len() && haystack == *v) != negate
             }),
-            Predicate::IEqAscii(v) => BooleanArray::from_unary(array, |haystack| {
+            Self::IEqAscii(v) => BooleanArray::from_unary(array, |haystack| {
                 haystack.eq_ignore_ascii_case(v) != negate
             }),
-            Predicate::Contains(finder) => BooleanArray::from_unary(array, |haystack| {
+            Self::Contains(finder) => BooleanArray::from_unary(array, |haystack| {
                 finder.find(haystack.as_bytes()).is_some() != negate
             }),
-            Predicate::StartsWith(v) => {
+            Self::StartsWith(v) => {
                 if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
                     let nulls = string_view_array.logical_nulls();
                     let values = BooleanBuffer::from(
@@ -128,11 +197,11 @@ impl<'a> Predicate<'a> {
                     BooleanArray::new(values, nulls)
                 } else {
                     BooleanArray::from_unary(array, |haystack| {
-                        starts_with(haystack, v, equals_kernel) != negate
+                        starts_with(haystack.as_bytes(), v.as_bytes(), equals_kernel) != negate
                     })
                 }
             }
-            Predicate::IStartsWithAscii(v) => {
+            Self::IStartsWithAscii(v) => {
                 if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
                     let nulls = string_view_array.logical_nulls();
                     let values = BooleanBuffer::from(
@@ -142,6 +211,243 @@ impl<'a> Predicate<'a> {
                                 equals_bytes(
                                     haystack,
                                     v.as_bytes(),
+                                    equals_ignore_ascii_case_kernel,
+                                ) != negate
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                    BooleanArray::new(values, nulls)
+                } else {
+                    BooleanArray::from_unary(array, |haystack| {
+                        starts_with(haystack.as_bytes(), v.as_bytes(), equals_ignore_ascii_case_kernel) != negate
+                    })
+                }
+            }
+            Self::EndsWith(v) => {
+                if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
+                    let nulls = string_view_array.logical_nulls();
+                    let values = BooleanBuffer::from(
+                        string_view_array
+                            .suffix_bytes_iter(v.len())
+                            .map(|haystack| {
+                                equals_bytes(haystack, v.as_bytes(), equals_kernel) != negate
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                    BooleanArray::new(values, nulls)
+                } else {
+                    BooleanArray::from_unary(array, |haystack| {
+                        ends_with(haystack.as_bytes(), v.as_bytes(), equals_kernel) != negate
+                    })
+                }
+            }
+            Self::IEndsWithAscii(v) => {
+                if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
+                    let nulls = string_view_array.logical_nulls();
+                    let values = BooleanBuffer::from(
+                        string_view_array
+                            .suffix_bytes_iter(v.len())
+                            .map(|haystack| {
+                                equals_bytes(
+                                    haystack,
+                                    v.as_bytes(),
+                                    equals_ignore_ascii_case_kernel,
+                                ) != negate
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                    BooleanArray::new(values, nulls)
+                } else {
+                    BooleanArray::from_unary(array, |haystack| {
+                        ends_with(haystack.as_bytes(), v.as_bytes(), equals_ignore_ascii_case_kernel) != negate
+                    })
+                }
+            }
+            Self::Regex(v) => {
+                BooleanArray::from_unary(array, |haystack| v.is_match(haystack) != negate)
+            }
+        }
+    }
+
+    /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
+    ///
+    /// 1. Replace `LIKE` multi-character wildcards `%` => `.*` (unless they're at the start or end of the pattern,
+    ///    where the regex is just truncated - e.g. `%foo%` => `foo` rather than `^.*foo.*$`)
+    /// 2. Replace `LIKE` single-character wildcards `_` => `.`
+    /// 3. Escape regex meta characters to match them and not be evaluated as regex special chars. e.g. `.` => `\\.`
+    /// 4. Replace escaped `LIKE` wildcards removing the escape characters to be able to match it as a regex. e.g. `\\%` => `%`
+    fn regex_like(pattern: &str, case_insensitive: bool) -> Result<Regex, ArrowError> {
+        let mut result = String::with_capacity(pattern.len() * 2);
+        let mut chars_iter = pattern.chars().peekable();
+        match chars_iter.peek() {
+            // if the pattern starts with `%`, we avoid starting the regex with a slow but meaningless `^.*`
+            Some('%') => {
+                chars_iter.next();
+            }
+            _ => result.push('^'),
+        };
+
+        while let Some(c) = chars_iter.next() {
+            match c {
+                '\\' => {
+                    match chars_iter.peek() {
+                        Some(&next) => {
+                            if regex_syntax::is_meta_character(next) {
+                                result.push('\\');
+                            }
+                            result.push(next);
+                            // Skipping the next char as it is already appended
+                            chars_iter.next();
+                        }
+                        None => {
+                            // Trailing backslash in the pattern. E.g. PostgreSQL and Trino treat it as an error, but e.g. Snowflake treats it as a literal backslash
+                            result.push('\\');
+                            result.push('\\');
+                        }
+                    }
+                }
+                '%' => result.push_str(".*"),
+                '_' => result.push('.'),
+                c => {
+                    if regex_syntax::is_meta_character(c) {
+                        result.push('\\');
+                    }
+                    result.push(c);
+                }
+            }
+        }
+        // instead of ending the regex with `.*$` and making it needlessly slow, we just end the regex
+        if result.ends_with(".*") {
+            result.pop();
+            result.pop();
+        } else {
+            result.push('$');
+        }
+        RegexBuilder::new(&result)
+            .case_insensitive(case_insensitive)
+            .dot_matches_new_line(true)
+            .build()
+            .map_err(|e| {
+                ArrowError::InvalidArgumentError(format!(
+                    "Unable to build regex from LIKE pattern: {e}"
+                ))
+            })
+    }
+}
+
+impl<'a> PredicateImpl<'a> for BinaryPredicate<'a> {
+    type UnsizedItem = [u8];
+    type RegexType = BinaryRegex;
+
+    /// Create a predicate for the given like pattern
+    fn like(pattern: &'a [u8]) -> Result<Self, ArrowError> {
+        if !contains_like_pattern(pattern) {
+            Ok(Self::Eq(pattern))
+        } else if pattern.ends_with(b"%") && !contains_like_pattern(&pattern[..pattern.len() - 1]) {
+            Ok(Self::StartsWith(&pattern[..pattern.len() - 1]))
+        } else if pattern.starts_with(b"%") && !contains_like_pattern(&pattern[1..]) {
+            Ok(Self::EndsWith(&pattern[1..]))
+        } else if pattern.starts_with(b"%")
+            && pattern.ends_with(b"%")
+            && !contains_like_pattern(&pattern[1..pattern.len() - 1])
+        {
+            Ok(Self::contains(&pattern[1..pattern.len() - 1]))
+        } else {
+            Ok(Self::Regex(Self::regex_like(pattern, false)?))
+        }
+    }
+
+    fn contains(needle: &'a [u8]) -> Self {
+        Self::Contains(Finder::new(needle))
+    }
+
+    /// Create a predicate for the given ilike pattern
+    fn ilike(pattern: &'a [u8], is_ascii: bool) -> Result<Self, ArrowError> {
+        if is_ascii && pattern.is_ascii() {
+            if !contains_like_pattern(pattern) {
+                return Ok(Self::IEqAscii(pattern));
+            } else if pattern.ends_with(b"%")
+                && !pattern.ends_with(b"\\%")
+                && !contains_like_pattern(&pattern[..pattern.len() - 1])
+            {
+                return Ok(Self::IStartsWithAscii(&pattern[..pattern.len() - 1]));
+            } else if pattern.starts_with(b"%") && !contains_like_pattern(&pattern[1..]) {
+                return Ok(Self::IEndsWithAscii(&pattern[1..]));
+            }
+        }
+        Ok(Self::Regex(Self::regex_like(pattern, true)?))
+    }
+
+    fn starts_with(pattern: &'a [u8]) -> Self {
+        Self::StartsWith(pattern)
+    }
+
+    fn ends_with(pattern: &'a [u8]) -> Self {
+        Self::EndsWith(pattern)
+    }
+
+    /// Evaluate this predicate against the given haystack
+    fn evaluate(&self, haystack: &[u8]) -> bool {
+        match self {
+            Self::Eq(v) => *v == haystack,
+            Self::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
+            Self::Contains(finder) => finder.find(haystack).is_some(),
+            Self::StartsWith(v) => starts_with(haystack, v, equals_kernel),
+            Self::IStartsWithAscii(v) => {
+                starts_with(haystack, v, equals_ignore_ascii_case_kernel)
+            }
+            Self::EndsWith(v) => ends_with(haystack, v, equals_kernel),
+            Self::IEndsWithAscii(v) => ends_with(haystack, v, equals_ignore_ascii_case_kernel),
+            Self::Regex(v) => v.is_match(haystack),
+        }
+    }
+
+    /// Evaluate this predicate against the elements of `array`
+    ///
+    /// If `negate` is true the result of the predicate will be negated
+    #[inline(never)]
+    fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
+    where
+        T: ArrayAccessor<Item = &'i [u8]>,
+    {
+        match self {
+            Self::Eq(v) => BooleanArray::from_unary(array, |haystack| {
+                (haystack.len() == v.len() && haystack == *v) != negate
+            }),
+            Self::IEqAscii(v) => BooleanArray::from_unary(array, |haystack| {
+                haystack.eq_ignore_ascii_case(v) != negate
+            }),
+            Self::Contains(finder) => BooleanArray::from_unary(array, |haystack| {
+                finder.find(haystack).is_some() != negate
+            }),
+            Self::StartsWith(v) => {
+                if let Some(binary_view_array) = array.as_any().downcast_ref::<BinaryViewArray>() {
+                    let nulls = binary_view_array.logical_nulls();
+                    let values = BooleanBuffer::from(
+                        binary_view_array
+                            .prefix_bytes_iter(v.len())
+                            .map(|haystack| {
+                                equals_bytes(haystack, v, equals_kernel) != negate
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                    BooleanArray::new(values, nulls)
+                } else {
+                    BooleanArray::from_unary(array, |haystack| {
+                        starts_with(haystack, v, equals_kernel) != negate
+                    })
+                }
+            }
+            Self::IStartsWithAscii(v) => {
+                if let Some(binary_view_array) = array.as_any().downcast_ref::<BinaryViewArray>() {
+                    let nulls = binary_view_array.logical_nulls();
+                    let values = BooleanBuffer::from(
+                        binary_view_array
+                            .prefix_bytes_iter(v.len())
+                            .map(|haystack| {
+                                equals_bytes(
+                                    haystack,
+                                    v,
                                     equals_ignore_ascii_case_kernel,
                                 ) != negate
                             })
@@ -154,14 +460,14 @@ impl<'a> Predicate<'a> {
                     })
                 }
             }
-            Predicate::EndsWith(v) => {
-                if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
-                    let nulls = string_view_array.logical_nulls();
+            Self::EndsWith(v) => {
+                if let Some(binary_view_array) = array.as_any().downcast_ref::<BinaryViewArray>() {
+                    let nulls = binary_view_array.logical_nulls();
                     let values = BooleanBuffer::from(
-                        string_view_array
+                        binary_view_array
                             .suffix_bytes_iter(v.len())
                             .map(|haystack| {
-                                equals_bytes(haystack, v.as_bytes(), equals_kernel) != negate
+                                equals_bytes(haystack, v, equals_kernel) != negate
                             })
                             .collect::<Vec<_>>(),
                     );
@@ -172,16 +478,16 @@ impl<'a> Predicate<'a> {
                     })
                 }
             }
-            Predicate::IEndsWithAscii(v) => {
-                if let Some(string_view_array) = array.as_any().downcast_ref::<StringViewArray>() {
-                    let nulls = string_view_array.logical_nulls();
+            Self::IEndsWithAscii(v) => {
+                if let Some(binary_view_array) = array.as_any().downcast_ref::<BinaryViewArray>() {
+                    let nulls = binary_view_array.logical_nulls();
                     let values = BooleanBuffer::from(
-                        string_view_array
+                        binary_view_array
                             .suffix_bytes_iter(v.len())
                             .map(|haystack| {
                                 equals_bytes(
                                     haystack,
-                                    v.as_bytes(),
+                                    v,
                                     equals_ignore_ascii_case_kernel,
                                 ) != negate
                             })
@@ -194,10 +500,75 @@ impl<'a> Predicate<'a> {
                     })
                 }
             }
-            Predicate::Regex(v) => {
+            Self::Regex(v) => {
                 BooleanArray::from_unary(array, |haystack| v.is_match(haystack) != negate)
             }
         }
+    }
+
+    /// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
+    ///
+    /// 1. Replace `LIKE` multi-character wildcards `%` => `.*` (unless they're at the start or end of the pattern,
+    ///    where the regex is just truncated - e.g. `%foo%` => `foo` rather than `^.*foo.*$`)
+    /// 2. Replace `LIKE` single-character wildcards `_` => `.`
+    /// 3. Escape regex meta characters to match them and not be evaluated as regex special chars. e.g. `.` => `\\.`
+    /// 4. Replace escaped `LIKE` wildcards removing the escape characters to be able to match it as a regex. e.g. `\\%` => `%`
+    fn regex_like(pattern: &[u8], case_insensitive: bool) -> Result<BinaryRegex, ArrowError> {
+        let mut result = String::with_capacity(pattern.len() * 2);
+        let mut chars_iter = pattern.iter().peekable();
+        match chars_iter.peek() {
+            // if the pattern starts with `%`, we avoid starting the regex with a slow but meaningless `^.*`
+            Some(b'%') => {
+                chars_iter.next();
+            }
+            _ => result.push('^'),
+        };
+
+        while let Some(b) = chars_iter.next() {
+            match b {
+                b'\\' => {
+                    match chars_iter.peek() {
+                        Some(&next) => {
+                            if regex_syntax::is_meta_character(*next as char) {
+                                result.push('\\');
+                            }
+                            result.push(*next as char);
+                            // Skipping the next char as it is already appended
+                            chars_iter.next();
+                        }
+                        None => {
+                            // Trailing backslash in the pattern. E.g. PostgreSQL and Trino treat it as an error, but e.g. Snowflake treats it as a literal backslash
+                            result.push('\\');
+                            result.push('\\');
+                        }
+                    }
+                }
+                b'%' => result.push_str(".*"),
+                b'_' => result.push('.'),
+                b => {
+                    if regex_syntax::is_meta_character(*b as char) {
+                        result.push('\\');
+                    }
+                    result.push(*b as char);
+                }
+            }
+        }
+        // instead of ending the regex with `.*$` and making it needlessly slow, we just end the regex
+        if result.ends_with(".*") {
+            result.pop();
+            result.pop();
+        } else {
+            result.push('$');
+        }
+        BinaryRegexBuilder::new(&result)
+            .case_insensitive(case_insensitive)
+            .dot_matches_new_line(true)
+            .build()
+            .map_err(|e| {
+                ArrowError::InvalidArgumentError(format!(
+                    "Unable to build regex from LIKE pattern: {e}"
+                ))
+            })
     }
 }
 
@@ -207,22 +578,22 @@ fn equals_bytes(lhs: &[u8], rhs: &[u8], byte_eq_kernel: impl Fn((&u8, &u8)) -> b
 
 /// This is faster than `str::starts_with` for small strings.
 /// See <https://github.com/apache/arrow-rs/issues/6107> for more details.
-fn starts_with(haystack: &str, needle: &str, byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
+fn starts_with(haystack: &[u8], needle: &[u8], byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
     if needle.len() > haystack.len() {
         false
     } else {
-        zip(haystack.as_bytes(), needle.as_bytes()).all(byte_eq_kernel)
+        zip(haystack, needle).all(byte_eq_kernel)
     }
 }
 /// This is faster than `str::ends_with` for small strings.
 /// See <https://github.com/apache/arrow-rs/issues/6107> for more details.
-fn ends_with(haystack: &str, needle: &str, byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
+fn ends_with(haystack: &[u8], needle: &[u8], byte_eq_kernel: impl Fn((&u8, &u8)) -> bool) -> bool {
     if needle.len() > haystack.len() {
         false
     } else {
         zip(
-            haystack.as_bytes().iter().rev(),
-            needle.as_bytes().iter().rev(),
+            haystack.iter().rev(),
+            needle.iter().rev(),
         )
         .all(byte_eq_kernel)
     }
@@ -236,73 +607,8 @@ fn equals_ignore_ascii_case_kernel((n, h): (&u8, &u8)) -> bool {
     n.eq_ignore_ascii_case(h)
 }
 
-/// Transforms a like `pattern` to a regex compatible pattern. To achieve that, it does:
-///
-/// 1. Replace `LIKE` multi-character wildcards `%` => `.*` (unless they're at the start or end of the pattern,
-///    where the regex is just truncated - e.g. `%foo%` => `foo` rather than `^.*foo.*$`)
-/// 2. Replace `LIKE` single-character wildcards `_` => `.`
-/// 3. Escape regex meta characters to match them and not be evaluated as regex special chars. e.g. `.` => `\\.`
-/// 4. Replace escaped `LIKE` wildcards removing the escape characters to be able to match it as a regex. e.g. `\\%` => `%`
-fn regex_like(pattern: &str, case_insensitive: bool) -> Result<Regex, ArrowError> {
-    let mut result = String::with_capacity(pattern.len() * 2);
-    let mut chars_iter = pattern.chars().peekable();
-    match chars_iter.peek() {
-        // if the pattern starts with `%`, we avoid starting the regex with a slow but meaningless `^.*`
-        Some('%') => {
-            chars_iter.next();
-        }
-        _ => result.push('^'),
-    };
-
-    while let Some(c) = chars_iter.next() {
-        match c {
-            '\\' => {
-                match chars_iter.peek() {
-                    Some(&next) => {
-                        if regex_syntax::is_meta_character(next) {
-                            result.push('\\');
-                        }
-                        result.push(next);
-                        // Skipping the next char as it is already appended
-                        chars_iter.next();
-                    }
-                    None => {
-                        // Trailing backslash in the pattern. E.g. PostgreSQL and Trino treat it as an error, but e.g. Snowflake treats it as a literal backslash
-                        result.push('\\');
-                        result.push('\\');
-                    }
-                }
-            }
-            '%' => result.push_str(".*"),
-            '_' => result.push('.'),
-            c => {
-                if regex_syntax::is_meta_character(c) {
-                    result.push('\\');
-                }
-                result.push(c);
-            }
-        }
-    }
-    // instead of ending the regex with `.*$` and making it needlessly slow, we just end the regex
-    if result.ends_with(".*") {
-        result.pop();
-        result.pop();
-    } else {
-        result.push('$');
-    }
-    RegexBuilder::new(&result)
-        .case_insensitive(case_insensitive)
-        .dot_matches_new_line(true)
-        .build()
-        .map_err(|e| {
-            ArrowError::InvalidArgumentError(format!(
-                "Unable to build regex from LIKE pattern: {e}"
-            ))
-        })
-}
-
-fn contains_like_pattern(pattern: &str) -> bool {
-    memchr3(b'%', b'_', b'\\', pattern.as_bytes()).is_some()
+fn contains_like_pattern(pattern: &[u8]) -> bool {
+    memchr3(b'%', b'_', b'\\', pattern).is_some()
 }
 
 #[cfg(test)]
@@ -333,7 +639,7 @@ mod tests {
         ];
 
         for (like_pattern, expected_regexp) in test_cases {
-            let r = regex_like(like_pattern, false).unwrap();
+            let r = Predicate::regex_like(like_pattern, false).unwrap();
             assert_eq!(r.to_string(), expected_regexp);
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6923

# What changes are included in this PR?

Copied 

# Are there any user-facing changes?
Yes, allow users to pass binary arrays to like/starts with/contains and more