### PR TITLE
Provide additional common builder interfaces with ValuesBuilder, a subtrait of ArrayBuilder.

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -69,7 +69,7 @@ use std::sync::Arc;
 ///
 /// ```
 /// # use arrow_array::Array;
-/// # use arrow_array::builder::GenericByteBuilder;
+/// # use arrow_array::builder::{GenericByteBuilder, ValuesBuilder};
 /// # use arrow_array::types::Utf8Type;
 /// let mut builder = GenericByteBuilder::<Utf8Type>::new();
 /// builder.append_value("hello");

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::array::print_long_array;
-use crate::builder::{ArrayBuilder, GenericByteViewBuilder};
+use crate::builder::{ArrayBuilder, GenericByteViewBuilder, ValuesBuilder};
 use crate::iterator::ArrayIter;
 use crate::types::bytes::ByteArrayNativeType;
 use crate::types::{BinaryViewType, ByteViewType, StringViewType};
@@ -841,7 +841,7 @@ impl From<Vec<Option<String>>> for StringViewArray {
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::{BinaryViewBuilder, StringViewBuilder};
+    use crate::builder::{BinaryViewBuilder, StringViewBuilder, ValuesBuilder};
     use crate::{Array, BinaryViewArray, StringViewArray};
     use arrow_buffer::{Buffer, ScalarBuffer};
     use arrow_data::ByteView;

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -23,7 +23,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, Field};
 
 use crate::{
-    builder::StringRunBuilder,
+    builder::{StringRunBuilder, ValuesBuilder},
     make_array,
     run_iterator::RunArrayIter,
     types::{Int16Type, Int32Type, Int64Type, RunEndIndexType},

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -156,7 +156,7 @@ pub type LargeStringArray = GenericStringArray<i64>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builder::{ListBuilder, PrimitiveBuilder, StringBuilder};
+    use crate::builder::{ListBuilder, PrimitiveBuilder, StringBuilder, ValuesBuilder};
     use crate::types::UInt8Type;
     use crate::Array;
     use arrow_buffer::Buffer;

--- a/arrow-array/src/builder/generic_byte_run_builder.rs
+++ b/arrow-array/src/builder/generic_byte_run_builder.rs
@@ -33,7 +33,7 @@ use arrow_buffer::ArrowNativeType;
 ///
 /// ```
 ///
-/// # use arrow_array::builder::GenericByteRunBuilder;
+/// # use arrow_array::builder::{GenericByteRunBuilder, ValuesBuilder};
 /// # use arrow_array::{GenericByteArray, BinaryArray};
 /// # use arrow_array::types::{BinaryType, Int16Type};
 /// # use arrow_array::{Array, Int16Array};
@@ -309,7 +309,7 @@ where
 /// // Create a run-end encoded array with run-end indexes data type as `i16`.
 /// // The encoded values are Strings.
 ///
-/// # use arrow_array::builder::StringRunBuilder;
+/// # use arrow_array::builder::{StringRunBuilder, ValuesBuilder};
 /// # use arrow_array::{Int16Array, StringArray};
 /// # use arrow_array::types::Int16Type;
 /// # use arrow_array::cast::AsArray;
@@ -345,7 +345,7 @@ pub type LargeStringRunBuilder<K> = GenericByteRunBuilder<K, LargeUtf8Type>;
 /// // Create a run-end encoded array with run-end indexes data type as `i16`.
 /// // The encoded data is binary values.
 ///
-/// # use arrow_array::builder::BinaryRunBuilder;
+/// # use arrow_array::builder::{BinaryRunBuilder, ValuesBuilder};
 /// # use arrow_array::{BinaryArray, Int16Array};
 /// # use arrow_array::cast::AsArray;
 /// # use arrow_array::types::Int16Type;

--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -255,7 +255,7 @@ impl<T: ByteArrayType, V: AsRef<T::Native>> Extend<Option<V>> for GenericByteBui
 ///
 /// # Example writing strings with `append_value`
 /// ```
-/// # use arrow_array::builder::GenericStringBuilder;
+/// # use arrow_array::builder::{GenericStringBuilder, ValuesBuilder};
 /// let mut builder = GenericStringBuilder::<i32>::new();
 ///
 /// // Write one string value
@@ -273,7 +273,7 @@ impl<T: ByteArrayType, V: AsRef<T::Native>> Extend<Option<V>> for GenericByteBui
 ///
 /// ```
 /// # use std::fmt::Write;
-/// # use arrow_array::builder::GenericStringBuilder;
+/// # use arrow_array::builder::{GenericStringBuilder, ValuesBuilder};
 /// let mut builder = GenericStringBuilder::<i32>::new();
 ///
 /// // Write data in multiple `write!` calls
@@ -308,7 +308,7 @@ impl<O: OffsetSizeTrait> std::fmt::Write for GenericStringBuilder<O> {
 ///
 /// # Example
 /// ```
-/// # use arrow_array::builder::GenericBinaryBuilder;
+/// # use arrow_array::builder::{GenericBinaryBuilder, ValuesBuilder};
 /// let mut builder = GenericBinaryBuilder::<i32>::new();
 ///
 /// // Write data
@@ -327,7 +327,7 @@ impl<O: OffsetSizeTrait> std::fmt::Write for GenericStringBuilder<O> {
 ///
 /// ```
 /// # use std::io::Write;
-/// # use arrow_array::builder::GenericBinaryBuilder;
+/// # use arrow_array::builder::{GenericBinaryBuilder, ValuesBuilder};
 /// let mut builder = GenericBinaryBuilder::<i32>::new();
 ///
 /// // Write data in multiple `write_bytes` calls

--- a/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_dictionary_builder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::builder::{ArrayBuilder, GenericByteBuilder, PrimitiveBuilder};
+use crate::builder::{ArrayBuilder, GenericByteBuilder, PrimitiveBuilder, ValuesBuilder};
 use crate::types::{ArrowDictionaryKeyType, ByteArrayType, GenericBinaryType, GenericStringType};
 use crate::{Array, ArrayRef, DictionaryArray, GenericByteArray, TypedDictionaryArray};
 use arrow_buffer::ArrowNativeType;

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -474,7 +474,7 @@ impl<T: ByteViewType + ?Sized, V: AsRef<T::Native>> Extend<Option<V>>
 ///
 /// # Example
 /// ```
-/// # use arrow_array::builder::StringViewBuilder;
+/// # use arrow_array::builder::{StringViewBuilder, ValuesBuilder};
 /// # use arrow_array::StringViewArray;
 /// let mut builder = StringViewBuilder::new();
 /// builder.append_value("hello");
@@ -495,7 +495,7 @@ pub type StringViewBuilder = GenericByteViewBuilder<StringViewType>;
 ///
 /// # Example
 /// ```
-/// # use arrow_array::builder::BinaryViewBuilder;
+/// # use arrow_array::builder::{BinaryViewBuilder, ValuesBuilder};
 /// use arrow_array::BinaryViewArray;
 /// let mut builder = BinaryViewBuilder::new();
 /// builder.append_value("hello");

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 ///
 /// ```
 /// # use std::sync::Arc;
-/// # use arrow_array::{builder::ListBuilder, builder::StringBuilder, ArrayRef, StringArray, Array};
+/// # use arrow_array::{builder::{ListBuilder, StringBuilder, ValuesBuilder}, ArrayRef, StringArray, Array};
 /// #
 /// let values_builder = StringBuilder::new();
 /// let mut builder = ListBuilder::new(values_builder);

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -262,7 +262,7 @@ impl<K: ArrayBuilder, V: ArrayBuilder> ArrayBuilder for MapBuilder<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::{make_builder, Int32Builder, StringBuilder};
+    use crate::builder::{make_builder, Int32Builder, StringBuilder, ValuesBuilder};
     use crate::{Int32Array, StringArray};
 
     use super::*;

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 /// Builder for [`MapArray`]
 ///
 /// ```
-/// # use arrow_array::builder::{Int32Builder, MapBuilder, StringBuilder};
+/// # use arrow_array::builder::{Int32Builder, MapBuilder, StringBuilder, ValuesBuilder};
 /// # use arrow_array::{Int32Array, StringArray};
 ///
 /// let string_builder = StringBuilder::new();

--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -22,7 +22,7 @@
 //! Builders can be used to build simple, non-nested arrays
 //!
 //! ```
-//! # use arrow_array::builder::Int32Builder;
+//! # use arrow_array::builder::{Int32Builder, ValuesBuilder};
 //! # use arrow_array::PrimitiveArray;
 //! let mut a = Int32Builder::new();
 //! a.append_value(1);
@@ -34,7 +34,7 @@
 //! ```
 //!
 //! ```
-//! # use arrow_array::builder::StringBuilder;
+//! # use arrow_array::builder::{StringBuilder, ValuesBuilder};
 //! # use arrow_array::{Array, StringArray};
 //! let mut a = StringBuilder::new();
 //! a.append_value("foo");
@@ -50,7 +50,7 @@
 //! Builders can also be used to build more complex nested arrays, such as lists
 //!
 //! ```
-//! # use arrow_array::builder::{Int32Builder, ListBuilder};
+//! # use arrow_array::builder::{Int32Builder, ListBuilder, ValuesBuilder};
 //! # use arrow_array::ListArray;
 //! # use arrow_array::types::Int32Type;
 //! let mut a = ListBuilder::new(Int32Builder::new());
@@ -87,7 +87,7 @@
 //!
 //! ```
 //! # use std::any::Any;
-//! # use arrow_array::builder::{ArrayBuilder, Int32Builder, ListBuilder, StringBuilder};
+//! # use arrow_array::builder::{ArrayBuilder, Int32Builder, ListBuilder, StringBuilder, ValuesBuilder};
 //! # use arrow_array::{ArrayRef, RecordBatch, StructArray};
 //! # use arrow_schema::{DataType, Field};
 //! # use std::sync::Arc;
@@ -194,7 +194,7 @@ use std::any::Any;
 /// ```
 /// // Create
 /// # use arrow_array::{ArrayRef, StringArray};
-/// # use arrow_array::builder::{ArrayBuilder, Float64Builder, Int64Builder, StringBuilder};
+/// # use arrow_array::builder::{ArrayBuilder, Float64Builder, Int64Builder, StringBuilder, ValuesBuilder};
 ///
 /// let mut data_builders: Vec<Box<dyn ArrayBuilder>> = vec![
 ///     Box::new(Float64Builder::new()),

--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -298,6 +298,22 @@ impl ArrayBuilder for Box<dyn ArrayBuilder> {
     }
 }
 
+/// Trait for common interfaces used by [`ArrayBuilder`]s
+/// when building a list of values.
+pub trait ValuesBuilder<T: ?Sized>: ArrayBuilder + Send + Sync {
+    /// Type of value.
+    type Value: ?Sized;
+
+    /// Append a null value.
+    fn append_null(&mut self);
+
+    /// Append a non-null value.
+    fn append_value(&mut self, value: impl AsRef<Self::Value>);
+
+    /// Append a value, which may be null.
+    fn append_option(&mut self, value: Option<impl AsRef<Self::Value>>);
+}
+
 /// Builder for [`ListArray`](crate::array::ListArray)
 pub type ListBuilder<T> = GenericListBuilder<i32, T>;
 

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// For a practical example see the code below:
 ///
 /// ```rust
-///    use arrow_array::builder::{ArrayBuilder, ListBuilder, StringBuilder, StructBuilder};
+///    use arrow_array::builder::{ArrayBuilder, ListBuilder, StringBuilder, StructBuilder, ValuesBuilder};
 ///    use arrow_schema::{DataType, Field, Fields};
 ///    use std::sync::Arc;
 ///

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1304,7 +1304,7 @@ mod tests_from_ffi {
     use arrow_schema::{DataType, Field};
 
     use super::{ImportedArrowArray, Result};
-    use crate::builder::GenericByteViewBuilder;
+    use crate::builder::{GenericByteViewBuilder, ValuesBuilder};
     use crate::types::{BinaryViewType, ByteViewType, Int32Type, StringViewType};
     use crate::{
         array::{

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -1056,7 +1056,7 @@ pub fn lexical_to_string<N: lexical_core::ToLexical>(n: N) -> String {
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::builder::StringRunBuilder;
+    use arrow_array::builder::{StringRunBuilder, ValuesBuilder};
 
     use super::*;
 

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -419,7 +419,7 @@ mod tests {
     use crate::ReaderBuilder;
     use arrow_array::builder::{
         BinaryBuilder, Decimal128Builder, Decimal256Builder, FixedSizeBinaryBuilder,
-        LargeBinaryBuilder,
+        LargeBinaryBuilder, ValuesBuilder,
     };
     use arrow_array::types::*;
     use arrow_buffer::i256;

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -32,7 +32,7 @@ use tonic::transport::Server;
 use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
 
-use arrow_array::builder::StringBuilder;
+use arrow_array::builder::{StringBuilder, ValuesBuilder};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::sql::metadata::{

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -734,6 +734,7 @@ mod tests {
     use crate::decode::{DecodedPayload, FlightDataDecoder};
     use arrow_array::builder::{
         GenericByteDictionaryBuilder, ListBuilder, StringDictionaryBuilder, StructBuilder,
+        ValuesBuilder,
     };
     use arrow_array::*;
     use arrow_array::{cast::downcast_array, types::*};

--- a/arrow-flight/src/sql/metadata/db_schemas.rs
+++ b/arrow-flight/src/sql/metadata/db_schemas.rs
@@ -22,7 +22,10 @@
 use std::sync::Arc;
 
 use arrow_arith::boolean::and;
-use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch, StringArray};
+use arrow_array::{
+    builder::{StringBuilder, ValuesBuilder},
+    ArrayRef, RecordBatch, StringArray,
+};
 use arrow_ord::cmp::eq;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::{filter::filter_record_batch, take::take};

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -31,7 +31,7 @@ use arrow_arith::boolean::or;
 use arrow_array::array::{Array, UInt32Array, UnionArray};
 use arrow_array::builder::{
     ArrayBuilder, BooleanBuilder, Int32Builder, Int64Builder, Int8Builder, ListBuilder, MapBuilder,
-    StringBuilder, UInt32Builder,
+    StringBuilder, UInt32Builder, ValuesBuilder,
 };
 use arrow_array::{RecordBatch, Scalar};
 use arrow_data::ArrayData;

--- a/arrow-flight/src/sql/metadata/table_types.rs
+++ b/arrow-flight/src/sql/metadata/table_types.rs
@@ -21,7 +21,10 @@
 
 use std::sync::Arc;
 
-use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch};
+use arrow_array::{
+    builder::{StringBuilder, ValuesBuilder},
+    ArrayRef, RecordBatch,
+};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::take::take;
 use once_cell::sync::Lazy;

--- a/arrow-flight/src/sql/metadata/tables.rs
+++ b/arrow-flight/src/sql/metadata/tables.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use arrow_arith::boolean::{and, or};
-use arrow_array::builder::{BinaryBuilder, StringBuilder};
+use arrow_array::builder::{BinaryBuilder, StringBuilder, ValuesBuilder};
 use arrow_array::{ArrayRef, RecordBatch, StringArray};
 use arrow_ord::cmp::eq;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};

--- a/arrow-flight/src/sql/metadata/xdbc_info.rs
+++ b/arrow-flight/src/sql/metadata/xdbc_info.rs
@@ -26,7 +26,9 @@
 //!
 use std::sync::Arc;
 
-use arrow_array::builder::{BooleanBuilder, Int32Builder, ListBuilder, StringBuilder};
+use arrow_array::builder::{
+    BooleanBuilder, Int32Builder, ListBuilder, StringBuilder, ValuesBuilder,
+};
 use arrow_array::{ArrayRef, Int32Array, ListArray, RecordBatch, Scalar};
 use arrow_ord::cmp::eq;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_array::builder::GenericStringBuilder;
+use arrow_array::builder::{GenericStringBuilder, ValuesBuilder};
 use arrow_array::{Array, GenericStringArray, OffsetSizeTrait};
 use arrow_data::ArrayData;
 use arrow_schema::ArrowError;

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -117,6 +117,7 @@ mod tests {
 
     use arrow_array::builder::{
         ListBuilder, PrimitiveDictionaryBuilder, StringBuilder, StringDictionaryBuilder,
+        ValuesBuilder,
     };
     use arrow_array::types::*;
     use arrow_buffer::{i256, ArrowNativeType, Buffer, IntervalDayTime, IntervalMonthDayNano};

--- a/arrow-string/src/regexp.rs
+++ b/arrow-string/src/regexp.rs
@@ -21,7 +21,7 @@
 use crate::like::StringArrayType;
 
 use arrow_array::builder::{
-    BooleanBufferBuilder, GenericStringBuilder, ListBuilder, StringViewBuilder,
+    BooleanBufferBuilder, GenericStringBuilder, ListBuilder, StringViewBuilder, ValuesBuilder,
 };
 use arrow_array::cast::AsArray;
 use arrow_array::*;

--- a/arrow/benches/string_run_builder.rs
+++ b/arrow/benches/string_run_builder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::StringRunBuilder;
+use arrow::array::{StringRunBuilder, ValuesBuilder};
 use arrow::datatypes::Int32Type;
 use arrow::util::bench_util::create_string_array_for_runs;
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -19,7 +19,7 @@ use arrow::array::{
     make_array, Array, ArrayRef, BooleanArray, Decimal128Array, FixedSizeBinaryArray,
     FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray, GenericStringArray,
     Int32Array, Int32Builder, Int64Builder, ListArray, ListBuilder, NullArray, OffsetSizeTrait,
-    StringArray, StringDictionaryBuilder, StructArray, UnionBuilder,
+    StringArray, StringDictionaryBuilder, StructArray, UnionBuilder, ValuesBuilder,
 };
 use arrow::datatypes::{Int16Type, Int32Type};
 use arrow_array::builder::{StringBuilder, StringViewBuilder, StructBuilder};

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -19,7 +19,7 @@ use arrow::array::{
     Array, ArrayRef, BooleanArray, Decimal128Array, DictionaryArray, FixedSizeBinaryArray,
     FixedSizeListBuilder, Int16Array, Int32Array, Int64Array, Int64Builder, ListArray, ListBuilder,
     MapBuilder, NullArray, StringArray, StringBuilder, StringDictionaryBuilder, StructArray,
-    UInt16Array, UInt16Builder, UInt8Array, UnionArray,
+    UInt16Array, UInt16Builder, UInt8Array, UnionArray, ValuesBuilder,
 };
 use arrow::datatypes::Int16Type;
 use arrow_array::StringViewArray;

--- a/arrow/tests/pyarrow.rs
+++ b/arrow/tests/pyarrow.rs
@@ -18,7 +18,7 @@
 use arrow::array::{ArrayRef, Int32Array, StringArray};
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow::record_batch::RecordBatch;
-use arrow_array::builder::{BinaryViewBuilder, StringViewBuilder};
+use arrow_array::builder::{BinaryViewBuilder, StringViewBuilder, ValuesBuilder};
 use arrow_array::{Array, BinaryViewArray, StringViewArray};
 use pyo3::Python;
 use std::sync::Arc;

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -126,7 +126,7 @@ mod tests {
     use crate::arrow::arrow_reader::ParquetRecordBatchReader;
     use crate::arrow::ArrowWriter;
     use arrow::datatypes::{Field, Int32Type, Schema};
-    use arrow_array::builder::{MapBuilder, PrimitiveBuilder, StringBuilder};
+    use arrow_array::builder::{MapBuilder, PrimitiveBuilder, StringBuilder, ValuesBuilder};
     use arrow_array::cast::*;
     use arrow_array::RecordBatch;
     use arrow_schema::Fields;

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -30,7 +30,7 @@ use crate::file::statistics::Statistics as ParquetStatistics;
 use crate::schema::types::SchemaDescriptor;
 use arrow_array::builder::{
     BinaryViewBuilder, BooleanBuilder, FixedSizeBinaryBuilder, LargeStringBuilder, StringBuilder,
-    StringViewBuilder,
+    StringViewBuilder, ValuesBuilder,
 };
 use arrow_array::{
     new_empty_array, new_null_array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Date64Array,


### PR DESCRIPTION
# Which issue does this PR close?

There is no github issue. It was a gap noticed during a [code review](https://github.com/apache/arrow-rs/pull/6849#discussion_r1896417566), resulting in the use of declarative macros in place of generic functions. The problem was that we lacked defined interfaces for common builder functionality.

# Rationale for this change
 
The [ArrayBuilder](https://docs.rs/arrow/54.0.0/arrow/array/trait.ArrayBuilder.html) defines the minimum set of builder interfaces for runtime. Some common interfaces are not included, such as building lists of values or lists-of-lists. These interfaces are not included since the ArrayBuilder includes the minimum common set for generics, and handle very different bytes layouts (and runtime builder patterns) such as [MapBuilder](https://docs.rs/arrow/54.0.0/arrow/array/struct.MapBuilder.html). 

However, it may be worthwhile to define ArrayBuilder subtraits when its worthwhile for common runtime interactions -- such as building a list of values (the example done in this PR).

# What changes are included in this PR?

* commit 1 = define `trait ValuesBuilder: ArrayBuilder`, and implement for only those byte array builders
   * note: other builder could use this trait, I was doing a minimum starting change
* commit 2 = bring trait into scope when used
* commit 3 = replace macro `process_regexp_match` with generic function
* commit 4 =  replace macro `process_regexp_array_match` with generic function
* commit 5 = add trait into doc rust code examples

# Are there any user-facing changes?

A new subtrait is defined.
