### PR TITLE
Document the `ParquetRecordBatchStream` buffering

### DIFF
--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -622,8 +622,9 @@ impl<T> std::fmt::Debug for StreamState<T> {
 /// (projection + filtering, etc) and decodes the rows from those buffered pages.
 ///
 /// For example, if all rows and columns are selected, the entire row group is
-/// buffered in memory during decode. This minimized the number of IO operations
-/// required.
+/// buffered in memory during decode. This minimizes the number of IO operations
+/// required, which is especially important for object stores, where IO operations
+/// have latencies in the hundreds of milliseconds
 ///
 ///
 /// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -611,11 +611,22 @@ impl<T> std::fmt::Debug for StreamState<T> {
     }
 }
 
-/// An asynchronous [`Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) of [`RecordBatch`]
-/// for a parquet file that can be constructed using [`ParquetRecordBatchStreamBuilder`].
+/// An asynchronous [`Stream`]of [`RecordBatch`] constructed using [`ParquetRecordBatchStreamBuilder`] to read parquet files.
 ///
 /// `ParquetRecordBatchStream` also provides [`ParquetRecordBatchStream::next_row_group`] for fetching row groups,
 /// allowing users to decode record batches separately from I/O.
+///
+/// # I/O Buffering
+///
+/// `ParquetRecordBatchStream` buffers *all* data pages selected after predicates
+/// (projection + filtering, etc) and decodes the rows from those buffered pages.
+///
+/// For example, if all rows and columns are selected, the entire row group is
+/// buffered in memory during decode. This minimized the number of IO operations
+/// required.
+///
+///
+/// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 pub struct ParquetRecordBatchStream<T> {
     metadata: Arc<ParquetMetaData>,
 


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/6946

# Rationale for this change
There was some surprise that the `ParquetRecordBatchStream` buffered entire row groups during decode, so let's documet this better.

- Here is a proposal /  discussion on changing the strategy: https://github.com/apache/arrow-rs/issues/6946


# What changes are included in this PR?
1. Document buffering in `ParquetRecordBatchStream`

# Are there any user-facing changes?
Docs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
