### PR TITLE
Ensure necessary lexical-core features are used in arrow-json.

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -45,7 +45,7 @@ num = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 chrono = { workspace = true }
-lexical-core = { version = "1.0", default-features = false}
+lexical-core = { version = "1.0", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
 
 [dev-dependencies]
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
@@ -59,4 +59,3 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 [[bench]]
 name = "serde"
 harness = false
-


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6959 

# Rationale for this change

This ensures that disabling features in arrow-cast would not cause compilation errors arrow-json which independently relies but does not enable those features.

# What changes are included in this PR?

Enables the required features in arrow-json for a dependency.

# Are there any user-facing changes?

N/A