### PR TITLE
[53.0.0_maintenance] Fix CI 

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -146,11 +146,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          target: wasm32-unknown-unknown,wasm32-wasi
+          target: wasm32-unknown-unknown,wasm32-wasip1
       - name: Build wasm32-unknown-unknown
         run: cargo build -p arrow --no-default-features --features=json,csv,ipc,ffi --target wasm32-unknown-unknown
-      - name: Build wasm32-wasi
-        run: cargo build -p arrow --no-default-features --features=json,csv,ipc,ffi --target wasm32-wasi
+      - name: Build wasm32-wasip1
+        run: cargo build -p arrow --no-default-features --features=json,csv,ipc,ffi --target wasm32-wasip1
 
   clippy:
     name: Clippy

--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -199,11 +199,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          target: wasm32-unknown-unknown,wasm32-wasi
+          target: wasm32-unknown-unknown,wasm32-wasip1
       - name: Build wasm32-unknown-unknown
         run: cargo build --target wasm32-unknown-unknown
-      - name: Build wasm32-wasi
-        run: cargo build --target wasm32-wasi
+      - name: Build wasm32-wasip1
+        run: cargo build --target wasm32-wasip1
 
   windows:
     name: cargo test LocalFileSystem (win64)

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -123,13 +123,13 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
         with:
-          target: wasm32-unknown-unknown,wasm32-wasi
+          target: wasm32-unknown-unknown,wasm32-wasip1
       - name: Install clang # Needed for zlib compilation
         run: apt-get update && apt-get install -y clang gcc-multilib
       - name: Build wasm32-unknown-unknown
         run: cargo build -p parquet --target wasm32-unknown-unknown
-      - name: Build wasm32-wasi
-        run: cargo build -p parquet --target wasm32-wasi
+      - name: Build wasm32-wasip1
+        run: cargo build -p parquet --target wasm32-wasip1
 
   pyspark-integration-test:
     name: PySpark Integration Test

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -864,6 +864,7 @@ pub fn parse_decimal<T: DecimalType>(
 
     // Overflow checks are not required if 10^(precision - 1) <= T::MAX holds.
     // Thus, if we validate the precision correctly, we can skip overflow checks.
+    #[allow(clippy::question_mark)]
     while let Some((index, b)) = bs.next() {
         match b {
             b'0'..=b'9' => {

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1798,6 +1798,7 @@ mod tests {
     }
 
     /// Return size, in memory of flight data
+    #[allow(clippy::needless_as_bytes)]
     fn flight_data_size(d: &FlightData) -> usize {
         let flight_descriptor_size = d
             .flight_descriptor

--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -291,6 +291,7 @@ pub(crate) struct Request<'a> {
     retry_error_body: bool,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> Request<'a> {
     pub(crate) fn query<T: Serialize + ?Sized + Sync>(self, query: &T) -> Self {
         let builder = self.builder.query(query);

--- a/object_store/src/azure/client.rs
+++ b/object_store/src/azure/client.rs
@@ -170,6 +170,7 @@ struct PutRequest<'a> {
     idempotent: bool,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> PutRequest<'a> {
     fn header(self, k: &HeaderName, v: &str) -> Self {
         let builder = self.builder.header(k, v);

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -174,6 +174,7 @@ pub(crate) struct Request<'a> {
     idempotent: bool,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> Request<'a> {
     fn header(self, k: &HeaderName, v: &str) -> Self {
         let builder = self.builder.header(k, v);

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -724,6 +724,7 @@ struct InMemoryRowGroup<'a> {
     row_count: usize,
 }
 
+#[allow(clippy::needless_lifetimes)]
 impl<'a> InMemoryRowGroup<'a> {
     /// Fetches the necessary column data into memory
     async fn fetch<T: AsyncFileReader + Send>(

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -3163,6 +3163,7 @@ mod tests {
         assert_eq!(&v.unwrap(), "b\u{10ffff}".as_bytes());
     }
 
+    #[allow(clippy::needless_as_bytes)]
     #[test]
     fn test_truncate_utf8() {
         // No-op


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/6887#issuecomment-2583310674

# Rationale for this change
 
Rust 1.84 was released yesterday: https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html

It
1.  introduced some new clippy lints that fail on the 53 maintenance branch. 
2. Renamed the wasm target (see https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html)

# What changes are included in this PR?
1. Ignore the clippy lints (they are fixed for real on `main` but there is no reason to potentially destabilize 53 with code changes)
2. Update the CI to use the new wasm names
 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
