### PR TITLE
Simplify Validation/Alignment APIs of `ArrayDataBuilder`: validate and align

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1894,7 +1894,7 @@ impl ArrayDataBuilder {
     /// The same caveats as [`ArrayData::new_unchecked`]
     /// apply.
     pub unsafe fn build_unchecked(self) -> ArrayData {
-        self.with_skip_validation(true).build().unwrap()
+        self.skip_validation(true).build().unwrap()
     }
 
     /// Creates an `ArrayData`, consuming `self`
@@ -1952,7 +1952,7 @@ impl ArrayDataBuilder {
     /// Creates an array data, validating all inputs, and aligning any buffers
     #[deprecated(since = "54.1.0", note = "Use ArrayData::with_align_buffers instead")]
     pub fn build_aligned(self) -> Result<ArrayData, ArrowError> {
-        self.with_align_buffers(true).build()
+        self.align_buffers(true).build()
     }
 
     /// Ensure that all buffers are aligned, copying data if necessary
@@ -1970,7 +1970,7 @@ impl ArrayDataBuilder {
     ///
     /// If this flag is not enabled, `[Self::build`] return an error on encountering
     /// insufficiently aligned buffers.
-    pub fn with_align_buffers(mut self, align_buffers: bool) -> Self {
+    pub fn align_buffers(mut self, align_buffers: bool) -> Self {
         self.align_buffers = align_buffers;
         self
     }
@@ -1985,9 +1985,10 @@ impl ArrayDataBuilder {
     /// Validation can be expensive.
     ///
     /// # Safety
-    /// If validation is skipped, the buffers must form a valid Array array,
+    ///
+    /// If validation is skipped, the buffers must form a valid Arrow array,
     /// otherwise undefined behavior will result
-    pub unsafe fn with_skip_validation(mut self, skip_validation: bool) -> Self {
+    pub unsafe fn skip_validation(mut self, skip_validation: bool) -> Self {
         self.skip_validation = skip_validation;
         self
     }

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1939,10 +1939,7 @@ impl ArrayDataBuilder {
             data.align_buffers();
         }
 
-        #[cfg(feature = "force_validate")]
-        let force_validation = true;
-        #[cfg(not(feature = "force_validate"))]
-        let force_validation = false;
+        let force_validation = cfg!(feature = "force_validate");
         // force validation in testing mode
         let skip_validation = skip_validation && !force_validation;
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -182,7 +182,7 @@ fn create_array(
                 .offset(0)
                 .add_child_data(run_ends.into_data())
                 .add_child_data(values.into_data())
-                .with_align_buffers(!require_alignment)
+                .align_buffers(!require_alignment)
                 .build()?;
 
             Ok(make_array(array_data))
@@ -256,7 +256,7 @@ fn create_array(
             let array_data = ArrayData::builder(data_type.clone())
                 .len(length as usize)
                 .offset(0)
-                .with_align_buffers(!require_alignment)
+                .align_buffers(!require_alignment)
                 .build()?;
 
             // no buffer increases
@@ -303,7 +303,7 @@ fn create_primitive_array(
         t => unreachable!("Data type {:?} either unsupported or not primitive", t),
     };
 
-    let array_data = builder.with_align_buffers(!require_alignment).build()?;
+    let array_data = builder.align_buffers(!require_alignment).build()?;
 
     Ok(make_array(array_data))
 }
@@ -335,7 +335,7 @@ fn create_list_array(
         _ => unreachable!("Cannot create list or map array from {:?}", data_type),
     };
 
-    let array_data = builder.with_align_buffers(!require_alignment).build()?;
+    let array_data = builder.align_buffers(!require_alignment).build()?;
 
     Ok(make_array(array_data))
 }
@@ -356,7 +356,7 @@ fn create_dictionary_array(
             .add_buffer(buffers[1].clone())
             .add_child_data(value_array.into_data())
             .null_bit_buffer(null_buffer)
-            .with_align_buffers(!require_alignment)
+            .align_buffers(!require_alignment)
             .build()?;
 
         Ok(make_array(array_data))

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -177,17 +177,13 @@ fn create_array(
             let values = create_array(reader, values_field, variadic_counts, require_alignment)?;
 
             let run_array_length = run_node.length() as usize;
-            let builder = ArrayData::builder(data_type.clone())
+            let array_data = ArrayData::builder(data_type.clone())
                 .len(run_array_length)
                 .offset(0)
                 .add_child_data(run_ends.into_data())
-                .add_child_data(values.into_data());
-
-            let array_data = if require_alignment {
-                builder.build()?
-            } else {
-                builder.build_aligned()?
-            };
+                .add_child_data(values.into_data())
+                .with_align_buffers(!require_alignment)
+                .build()?;
 
             Ok(make_array(array_data))
         }
@@ -257,15 +253,11 @@ fn create_array(
                 )));
             }
 
-            let builder = ArrayData::builder(data_type.clone())
+            let array_data = ArrayData::builder(data_type.clone())
                 .len(length as usize)
-                .offset(0);
-
-            let array_data = if require_alignment {
-                builder.build()?
-            } else {
-                builder.build_aligned()?
-            };
+                .offset(0)
+                .with_align_buffers(!require_alignment)
+                .build()?;
 
             // no buffer increases
             Ok(Arc::new(NullArray::from(array_data)))
@@ -311,11 +303,7 @@ fn create_primitive_array(
         t => unreachable!("Data type {:?} either unsupported or not primitive", t),
     };
 
-    let array_data = if require_alignment {
-        builder.build()?
-    } else {
-        builder.build_aligned()?
-    };
+    let array_data = builder.with_align_buffers(!require_alignment).build()?;
 
     Ok(make_array(array_data))
 }
@@ -347,11 +335,7 @@ fn create_list_array(
         _ => unreachable!("Cannot create list or map array from {:?}", data_type),
     };
 
-    let array_data = if require_alignment {
-        builder.build()?
-    } else {
-        builder.build_aligned()?
-    };
+    let array_data = builder.with_align_buffers(!require_alignment).build()?;
 
     Ok(make_array(array_data))
 }
@@ -367,17 +351,13 @@ fn create_dictionary_array(
 ) -> Result<ArrayRef, ArrowError> {
     if let Dictionary(_, _) = *data_type {
         let null_buffer = (field_node.null_count() > 0).then_some(buffers[0].clone());
-        let builder = ArrayData::builder(data_type.clone())
+        let array_data = ArrayData::builder(data_type.clone())
             .len(field_node.length() as usize)
             .add_buffer(buffers[1].clone())
             .add_child_data(value_array.into_data())
-            .null_bit_buffer(null_buffer);
-
-        let array_data = if require_alignment {
-            builder.build()?
-        } else {
-            builder.build_aligned()?
-        };
+            .null_bit_buffer(null_buffer)
+            .with_align_buffers(!require_alignment)
+            .build()?;
 
         Ok(make_array(array_data))
     } else {


### PR DESCRIPTION
# Which issue does this PR close?

- Part of  https://github.com/apache/arrow-rs/issues/3287


# Rationale for this change

ArrayDataBuilder has two options today:
1. Validate the data
2. Ensure buffer alignment

There are three methods today:
1. [`build()`](https://docs.rs/arrow/latest/arrow/array/struct.ArrayDataBuilder.html#method.build) that does validates but does not ensure alignment
1. [`build_unchecked()`](https://docs.rs/arrow/latest/arrow/array/struct.ArrayDataBuilder.html#method.build) that neither validates nor ensures alignment
2. [`build_aligned()`](https://docs.rs/arrow/latest/arrow/array/struct.ArrayDataBuilder.html#method.build_aligned) that validates and ensures alignment

@totoroyyb proposed to add the other combination (no validation but aligned) in  https://github.com/apache/arrow-rs/pull/6938 as a fourth function `build_aligned_unchecked`

Instead of a fourth function I think we can use builder flags for a better API

# What changes are included in this PR?
1. Add `validate` and `align` fields to ArrayBuilder
2. Add getters/setters for those fields
3. Deprecate `build_aligned` in favor of those flags

Note I chose not to deprecate `build_unchecked` as that is used in more places in the code so deprecating it would be more API churn


# Are there any user-facing changes?

New APIs and deprecated APIs in ArrayDataBuilder

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
