### PR TITLE
Improve docs for `AmazonS3Builder::from_env`

### DIFF
--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -427,7 +427,11 @@ impl AmazonS3Builder {
 
     /// Fill the [`AmazonS3Builder`] with regular AWS environment variables
     ///
-    /// Variables extracted from environment:
+    /// All environment variables starting with `AWS_` will be evaluated. Names must
+    /// match items from [`AmazonS3ConfigKey`][]. Only upper-case environment variables are
+    /// accepted.
+    ///
+    /// Some examples of variables extracted from environment:
     /// * `AWS_ACCESS_KEY_ID` -> access_key_id
     /// * `AWS_SECRET_ACCESS_KEY` -> secret_access_key
     /// * `AWS_DEFAULT_REGION` -> region
@@ -435,6 +439,7 @@ impl AmazonS3Builder {
     /// * `AWS_SESSION_TOKEN` -> token
     /// * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` -> <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>
     /// * `AWS_ALLOW_HTTP` -> set to "true" to permit HTTP connections without TLS
+    /// * `AWS_REQUEST_PAYER` -> set to "true" to permit operations on requester-pays buckets.
     /// # Example
     /// ```
     /// use object_store::aws::AmazonS3Builder;

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -428,8 +428,8 @@ impl AmazonS3Builder {
     /// Fill the [`AmazonS3Builder`] with regular AWS environment variables
     ///
     /// All environment variables starting with `AWS_` will be evaluated. Names must
-    /// match items from [`AmazonS3ConfigKey`][]. Only upper-case environment variables are
-    /// accepted.
+    /// match acceptable input to [`AmazonS3ConfigKey::from_str`][]. Only upper-case environment
+    /// variables are accepted.
     ///
     /// Some examples of variables extracted from environment:
     /// * `AWS_ACCESS_KEY_ID` -> access_key_id

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -428,7 +428,7 @@ impl AmazonS3Builder {
     /// Fill the [`AmazonS3Builder`] with regular AWS environment variables
     ///
     /// All environment variables starting with `AWS_` will be evaluated. Names must
-    /// match acceptable input to [`AmazonS3ConfigKey::from_str`][]. Only upper-case environment
+    /// match acceptable input to [`AmazonS3ConfigKey::from_str`]. Only upper-case environment
     /// variables are accepted.
     ///
     /// Some examples of variables extracted from environment:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The documentation for [`AmazonS3Builder::from_env`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env) makes it seem like only _specific_ AWS environment variables are looked for in the current environment. However **any** env vars starting with `AWS_` are checked. 

# What changes are included in this PR?

Document that all env vars starting with `AWS_` are checked, so any value in `AmazonS3ConfigKey` can be used.

# Are there any user-facing changes?

No, documentation only.
