### PR TITLE
Update `parquet-testing` pin, add tests for new invalid data

### DIFF
--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -30,6 +30,7 @@ static KNOWN_FILES: &[&str] = &[
     "ARROW-GH-43605.parquet",
     "ARROW-RS-GH-6229-DICTHEADER.parquet",
     "ARROW-RS-GH-6229-LEVELS.parquet",
+    "ARROW-GH-45185.parquet",
     "README.md",
 ];
 
@@ -117,6 +118,16 @@ fn test_arrow_rs_gh_6229_dict_levels() {
     assert_eq!(
         err.to_string(),
         "External: Parquet argument error: Parquet error: Insufficient repetition levels read from column"
+    );
+}
+
+#[test]
+#[cfg(feature = "snap")]
+fn test_arrow_rs_gh_45185_dict_levels() {
+    let err = read_file("ARROW-GH-45185.parquet").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "External: Parquet argument error: Parquet error: first repetition level of batch must be 0"
     );
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/6887


# Rationale for this change
 
As described in https://github.com/apache/arrow-rs/issues/6887#issuecomment-2591283697 new invalid parquet files have been added to parquet testing so we need to update the tests.

# What changes are included in this PR?

1. Update `parquet-testing` pin
2. Add test for newly added file

# Are there any user-facing changes?
No, this is just tests

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
