### PR TITLE
Add check for empty schema in `parquet::schema::types::from_thrift_helper`

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3414,10 +3414,8 @@ mod tests {
     // https://github.com/apache/arrow-rs/issues/6988
     fn test_roundtrip_empty_schema() {
         // create empty record batch with empty schema
-        let empty_fields: Vec<Field> = vec![];
-        let empty_schema = Arc::new(Schema::new(empty_fields));
         let empty_batch = RecordBatch::try_new_with_options(
-            empty_schema,
+            Arc::new(Schema::empty()),
             vec![],
             &RecordBatchOptions::default().with_row_count(Some(0)),
         )

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3430,7 +3430,13 @@ mod tests {
 
         // read from parquet
         let bytes = Bytes::from(parquet_bytes);
-        let result = ParquetRecordBatchReaderBuilder::try_new(bytes);
-        result.unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+        assert_eq!(reader.schema(), &empty_batch.schema());
+        let batches: Vec<_> = reader
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(batches.len(), 0);
     }
 }

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -1211,6 +1211,13 @@ fn from_thrift_helper(elements: &[SchemaElement], index: usize) -> Result<(usize
         ));
     }
     let element = &elements[index];
+
+    // Check for empty schema
+    if let (true, None | Some(0)) = (is_root_node, element.num_children) {
+        let builder = Type::group_type_builder(&element.name);
+        return Ok((index + 1, Arc::new(builder.build().unwrap())));
+    }
+
     let converted_type = ConvertedType::try_from(element.converted_type)?;
     // LogicalType is only present in v2 Parquet files. ConvertedType is always
     // populated, regardless of the version of the file (v1 or v2).


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6988.

# Rationale for this change
Reading a file with an empty schema will fail in `parquet::schema::types::from_thrift_helper` because the root node in the schema is mistaken for a leaf node.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Adds a check in `from_thrift_helper` for a root node with no children, and exits early if one is detected.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
