### PR TITLE
Make `ParquetField` public

### DIFF
--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -35,8 +35,8 @@ use crate::schema::types::{ColumnDescriptor, SchemaDescriptor, Type};
 mod complex;
 mod primitive;
 
-use crate::arrow::ProjectionMask;
-pub(crate) use complex::{ParquetField, ParquetFieldType};
+pub use crate::arrow::ProjectionMask;
+pub use complex::{ParquetField, ParquetFieldType};
 
 use super::PARQUET_FIELD_ID_META_KEY;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
`ParquetField` (and its friends) are foundation types in the crate, without this being public, many of the functions can't be called, e.g., `build_array_reader`. If this is public, downstream users can easily hooking their own parquet reading logic while still reusing much of the existing code.



<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
