### PR TITLE
fix: Panic on reencoding offsets in arrow-ipc with sliced nested arrays

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1473,10 +1473,7 @@ fn reencode_offsets<O: OffsetSizeTrait>(
     let offsets = match start_offset.as_usize() {
         0 => {
             let size = size_of::<O>();
-            offsets.slice_with_length(
-                data.offset() * size,
-                (data.len() + 1) * size,
-            )
+            offsets.slice_with_length(data.offset() * size, (data.len() + 1) * size)
         }
         _ => offset_slice.iter().map(|x| *x - *start_offset).collect(),
     };
@@ -2620,8 +2617,12 @@ mod tests {
         let original_list = generate_list_data::<i32>();
         let original_data = original_list.into_data();
         let slice_data = original_data.slice(75, 7);
-        let (new_offsets, original_start, length) = reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
-        assert_eq!(vec![0, 3, 6, 9, 12, 15, 18, 21], new_offsets.typed_data::<i32>());
+        let (new_offsets, original_start, length) =
+            reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
+        assert_eq!(
+            vec![0, 3, 6, 9, 12, 15, 18, 21],
+            new_offsets.typed_data::<i32>()
+        );
         assert_eq!(225, original_start);
         assert_eq!(21, length);
     }
@@ -2638,7 +2639,8 @@ mod tests {
         let original_data = original_list.into_data();
 
         let slice_data = original_data.slice(1, 1);
-        let (new_offsets, original_start, length) = reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
+        let (new_offsets, original_start, length) =
+            reencode_offsets::<i32>(&slice_data.buffers()[0], &slice_data);
         assert_eq!(vec![0, 2], new_offsets.typed_data::<i32>());
         assert_eq!(0, original_start);
         assert_eq!(2, length);


### PR DESCRIPTION
Code was incorrectly defining the end of the offset slice to be the start + slice_length * 2 because slice_with_length adds the start to the end. This caused the encoded batches to be larger than they needed to be and would result in a panic for certain slices.

# Which issue does this PR close?

- Closes #6997 .
- closes https://github.com/apache/arrow-rs/pull/7004

# Rationale for this change
 
Prevent code panic during IPC write for legitimate input.

# What changes are included in this PR?

Corrects the slice length and adds unit tests that previously would cause a panic.

# Are there any user-facing changes?

No