### PR TITLE
fix prefetch of page index

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -396,7 +396,7 @@ impl ParquetMetaDataReader {
     async fn load_page_index_with_remainder<F: MetadataFetch>(
         &mut self,
         mut fetch: F,
-        remaineder: Option<(usize, Bytes)>,
+        remainder: Option<(usize, Bytes)>,
     ) -> Result<()> {
         if self.metadata.is_none() {
             return Err(general_err!("Footer metadata is not present"));
@@ -409,12 +409,12 @@ impl ParquetMetaDataReader {
             None => return Ok(()),
         };
 
-        let bytes = match &remaineder {
-            Some((remainder_start, remaineder)) if *remainder_start <= range.start => {
+        let bytes = match &remainder {
+            Some((remainder_start, remainder)) if *remainder_start <= range.start => {
                 let offset = range.start - *remainder_start;  
                 let end = offset + range.end - range.start;  
-                assert!(end <= remaineder.len());  
-                remaineder.slice(offset..end)  
+                assert!(end <= remainder.len());  
+                remainder.slice(offset..end)  
             }
             // Note: this will potentially fetch data already in remainder, this keeps things simple
             _ => fetch.fetch(range.start..range.end).await?,

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -418,7 +418,11 @@ impl ParquetMetaDataReader {
                 let range = range.start - fetched_start..range.end - fetched_start;
                 // santity check: `fetched` should always go until the end of the file
                 // so if our range is beyond that, something is wrong!
-                assert!(range.end <= fetched_start + fetched.len(), "range: {range:?}, fetched: {}, fetched_start: {fetched_start}", fetched.len());
+                assert!(
+                    range.end <= fetched_start + fetched.len(),
+                    "range: {range:?}, fetched: {}, fetched_start: {fetched_start}",
+                    fetched.len()
+                );
                 fetched.slice(range)
             }
             // Note: this will potentially fetch data already in remainder, this keeps things simple
@@ -587,10 +591,7 @@ impl ParquetMetaDataReader {
         } else {
             let metadata_start = file_size - length - FOOTER_SIZE - footer_start;
             let slice = &suffix[metadata_start..suffix_len - FOOTER_SIZE];
-            Ok((
-                Self::decode_metadata(slice)?,
-                Some((footer_start, suffix)),
-            ))
+            Ok((Self::decode_metadata(slice)?, Some((footer_start, suffix))))
         }
     }
 
@@ -1065,7 +1066,7 @@ mod async_tests {
         let f = MetadataFetchFn(&mut fetch);
         let metadata = ParquetMetaDataReader::new()
             .with_page_indexes(true)
-            .with_prefetch_hint(Some(len))  // prefetch entire file
+            .with_prefetch_hint(Some(len)) // prefetch entire file
             .load_and_finish(f, len)
             .await
             .unwrap();

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -411,10 +411,10 @@ impl ParquetMetaDataReader {
 
         let bytes = match &remainder {
             Some((remainder_start, remainder)) if *remainder_start <= range.start => {
-                let offset = range.start - *remainder_start;  
-                let end = offset + range.end - range.start;  
-                assert!(end <= remainder.len());  
-                remainder.slice(offset..end)  
+                let offset = range.start - *remainder_start;
+                let end = offset + range.end - range.start;
+                assert!(end <= remainder.len());
+                remainder.slice(offset..end)
             }
             // Note: this will potentially fetch data already in remainder, this keeps things simple
             _ => fetch.fetch(range.start..range.end).await?,

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -410,12 +410,15 @@ impl ParquetMetaDataReader {
         };
 
         let bytes = match &fetched {
-            Some((fetched_start, fetched)) if *fetched_start <= range.start && (range.end <= fetched_start + fetched.len()) => {
+            Some((fetched_start, fetched)) if *fetched_start <= range.start => {
                 // `fetched`` is an amount of data spanning from fetched_start to the end of the file
                 // We want to slice out the range we need from that data, but need to adjust the
                 // range we are looking for to be relative to fetched_start.
                 let fetched_start = *fetched_start;
                 let range = range.start - fetched_start..range.end - fetched_start;
+                // santity check: `fetched` should always go until the end of the file
+                // so if our range is beyond that, something is wrong!
+                assert!(range.end <= fetched_start + fetched.len(), "range: {range:?}, fetched: {}, fetched_start: {fetched_start}", fetched.len());
                 fetched.slice(range)
             }
             // Note: this will potentially fetch data already in remainder, this keeps things simple


### PR DESCRIPTION
Fixes the case where a metadata prefetch on a Parquet file includes the page index e.g. if you prefetch the entire file.