### PR TITLE
Minor: make it clear Predicate is crate private

### DIFF
--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,7 +24,7 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
-pub enum Predicate<'a> {
+pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),
     StartsWith(&'a str),
@@ -42,7 +42,7 @@ pub enum Predicate<'a> {
 
 impl<'a> Predicate<'a> {
     /// Create a predicate for the given like pattern
-    pub fn like(pattern: &'a str) -> Result<Self, ArrowError> {
+    pub(crate) fn like(pattern: &'a str) -> Result<Self, ArrowError> {
         if !contains_like_pattern(pattern) {
             Ok(Self::Eq(pattern))
         } else if pattern.ends_with('%') && !contains_like_pattern(&pattern[..pattern.len() - 1]) {
@@ -59,12 +59,12 @@ impl<'a> Predicate<'a> {
         }
     }
 
-    pub fn contains(needle: &'a str) -> Self {
+    pub(crate) fn contains(needle: &'a str) -> Self {
         Self::Contains(Finder::new(needle.as_bytes()))
     }
 
     /// Create a predicate for the given ilike pattern
-    pub fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
+    pub(crate) fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
         if is_ascii && pattern.is_ascii() {
             if !contains_like_pattern(pattern) {
                 return Ok(Self::IEqAscii(pattern));
@@ -81,7 +81,7 @@ impl<'a> Predicate<'a> {
     }
 
     /// Evaluate this predicate against the given haystack
-    pub fn evaluate(&self, haystack: &str) -> bool {
+    pub(crate) fn evaluate(&self, haystack: &str) -> bool {
         match self {
             Predicate::Eq(v) => *v == haystack,
             Predicate::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
@@ -100,7 +100,7 @@ impl<'a> Predicate<'a> {
     ///
     /// If `negate` is true the result of the predicate will be negated
     #[inline(never)]
-    pub fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
+    pub(crate) fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
     where
         T: ArrayAccessor<Item = &'i str>,
     {


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to https://github.com/apache/arrow-rs/pull/6926

# Rationale for this change
 
`Predicate` is marked `pub` but it is in a non public module

https://github.com/apache/arrow-rs/blob/595a83561e6512c757bca2786f974abb3b711f1d/arrow-string/src/lib.rs#L24

This gives it a false impression that it is part of the public API, which it is not: 
* https://docs.rs/arrow/latest/arrow/index.html?search=Predicate
* https://docs.rs/arrow-string/latest/arrow_string/?search=Predicate


# What changes are included in this PR?

Mark `pub(crate)` to make it explicit that this structure is not public outside the crate

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
