### PR TITLE
fix: use the values builder capacity for the hash map in `PrimitiveDictionaryBuilder::new_from_builders`

### DIFF
--- a/arrow-array/src/builder/primitive_dictionary_builder.rs
+++ b/arrow-array/src/builder/primitive_dictionary_builder.rs
@@ -126,10 +126,11 @@ where
             keys_builder.is_empty() && values_builder.is_empty(),
             "keys and values builders must be empty"
         );
+        let values_capacity = values_builder.capacity();
         Self {
             keys_builder,
             values_builder,
-            map: HashMap::new(),
+            map: HashMap::with_capacity(values_capacity),
         }
     }
 
@@ -144,7 +145,7 @@ where
     ) -> Self {
         let keys = keys_builder.values_slice();
         let values = values_builder.values_slice();
-        let mut map = HashMap::with_capacity(values_builder.capacity());
+        let mut map = HashMap::with_capacity(values.len());
 
         keys.iter().zip(values.iter()).for_each(|(key, value)| {
             map.insert(Value(*value), K::Native::to_usize(*key).unwrap());
@@ -636,12 +637,10 @@ mod tests {
 
     #[test]
     fn creating_dictionary_from_builders_should_use_values_capacity_for_the_map() {
-        let builder = unsafe {
-            PrimitiveDictionaryBuilder::<Int32Type, crate::types::TimestampMicrosecondType>::new_from_builders(
+        let builder = PrimitiveDictionaryBuilder::<Int32Type, crate::types::TimestampMicrosecondType>::new_from_empty_builders(
                   PrimitiveBuilder::with_capacity(1).with_data_type(DataType::Int32),
                   PrimitiveBuilder::with_capacity(2).with_data_type(DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, Some("+08:00".into()))),
-              )
-        };
+              );
 
         assert!(
             builder.map.capacity() >= builder.values_builder.capacity(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7011

# Rationale for this change
 
See issue

# Are there any user-facing changes?

Not really