### PR TITLE
Add `is_valid` and `truncate` methods to `NullBufferBuilder`

### DIFF
--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -136,7 +136,7 @@ impl NullBufferBuilder {
     /// Returns the capacity of the buffer
     #[inline]
     pub fn capacity(&self) -> usize {
-        if let Some(buf) = self.bitmap_builder.as_ref() {
+        if let Some(ref buf) = self.bitmap_builder {
             buf.capacity()
         } else {
             0
@@ -145,8 +145,8 @@ impl NullBufferBuilder {
 
     /// Gets a bit in the buffer at `index`
     #[inline]
-    pub fn is_valid(&mut self, index: usize) -> bool {
-        if let Some(buf) = self.bitmap_builder.as_mut() {
+    pub fn is_valid(&self, index: usize) -> bool {
+        if let Some(ref buf) = self.bitmap_builder {
             buf.get_bit(index)
         } else {
             true

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -136,7 +136,6 @@ impl NullBufferBuilder {
         } else {
             self.append_null();
         }
-
         self.capacity = self.bitmap_builder.as_ref().unwrap().capacity()
     }
 

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -90,7 +90,7 @@ impl NullBufferBuilder {
     #[inline]
     pub fn append_n_non_nulls(&mut self, n: usize) {
         if let Some(buf) = self.bitmap_builder.as_mut() {
-            buf.append_n(n, true);
+            buf.append_n(n, true)
         } else {
             self.len += n;
         }
@@ -101,7 +101,7 @@ impl NullBufferBuilder {
     #[inline]
     pub fn append_non_null(&mut self) {
         if let Some(buf) = self.bitmap_builder.as_mut() {
-            buf.append(true);
+            buf.append(true)
         } else {
             self.len += 1;
         }
@@ -127,9 +127,9 @@ impl NullBufferBuilder {
     #[inline]
     pub fn append(&mut self, not_null: bool) {
         if not_null {
-            self.append_non_null();
+            self.append_non_null()
         } else {
-            self.append_null();
+            self.append_null()
         }
     }
 

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -327,11 +327,13 @@ mod tests {
         builder.truncate(20);
         assert_eq!(builder.as_slice(), None);
         assert_eq!(builder.len(), 16);
+        assert_eq!(builder.capacity(), 10);
         builder.truncate(14);
         assert_eq!(builder.as_slice(), None);
         assert_eq!(builder.len(), 14);
         builder.append_null();
         builder.append_non_null();
         assert_eq!(builder.as_slice().unwrap(), &[0xFF, 0b10111111]);
+        assert_eq!(builder.capacity(), 512);
     }
 }

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -332,4 +332,14 @@ mod tests {
         assert_eq!(builder.as_slice().unwrap(), &[0xFF, 0b10111111]);
         assert_eq!(builder.capacity(), 512);
     }
+
+    #[test]
+    fn test_null_buffer_builder_truncate_after_push() {
+        let mut builder = NullBufferBuilder::new(0);
+        assert_eq!(builder.len(), 0);
+        builder.append_n_nulls(2);
+        assert_eq!(builder.len(), 2);
+        builder.truncate(1);
+        assert_eq!(builder.len(), 1);
+    }
 }

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,7 +24,7 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
-pub enum Predicate<'a> {
+pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),
     StartsWith(&'a str),
@@ -42,7 +42,7 @@ pub enum Predicate<'a> {
 
 impl<'a> Predicate<'a> {
     /// Create a predicate for the given like pattern
-    pub fn like(pattern: &'a str) -> Result<Self, ArrowError> {
+    pub(crate) fn like(pattern: &'a str) -> Result<Self, ArrowError> {
         if !contains_like_pattern(pattern) {
             Ok(Self::Eq(pattern))
         } else if pattern.ends_with('%') && !contains_like_pattern(&pattern[..pattern.len() - 1]) {
@@ -59,12 +59,12 @@ impl<'a> Predicate<'a> {
         }
     }
 
-    pub fn contains(needle: &'a str) -> Self {
+    pub(crate) fn contains(needle: &'a str) -> Self {
         Self::Contains(Finder::new(needle.as_bytes()))
     }
 
     /// Create a predicate for the given ilike pattern
-    pub fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
+    pub(crate) fn ilike(pattern: &'a str, is_ascii: bool) -> Result<Self, ArrowError> {
         if is_ascii && pattern.is_ascii() {
             if !contains_like_pattern(pattern) {
                 return Ok(Self::IEqAscii(pattern));
@@ -81,7 +81,7 @@ impl<'a> Predicate<'a> {
     }
 
     /// Evaluate this predicate against the given haystack
-    pub fn evaluate(&self, haystack: &str) -> bool {
+    pub(crate) fn evaluate(&self, haystack: &str) -> bool {
         match self {
             Predicate::Eq(v) => *v == haystack,
             Predicate::IEqAscii(v) => haystack.eq_ignore_ascii_case(v),
@@ -100,7 +100,7 @@ impl<'a> Predicate<'a> {
     ///
     /// If `negate` is true the result of the predicate will be negated
     #[inline(never)]
-    pub fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
+    pub(crate) fn evaluate_array<'i, T>(&self, array: T, negate: bool) -> BooleanArray
     where
         T: ArrayAccessor<Item = &'i str>,
     {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7002 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
As #7002 says, some required methods are implemented due to the need to replace `BooleanBufferBuilder` with `NullBufferBuilder` in DataFsusion.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Implemented methods below:
    * ~`capacity()`~
    * `is_valid()` (as same as `get_bit()` in `BooleanBufferBuilder`)
    * `truncate()`
* Add related unit tests

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
