### PR TITLE
Minor: Clarify NullBufferBuilder::new capacity parameter

### DIFF
--- a/arrow-buffer/src/builder/boolean.rs
+++ b/arrow-buffer/src/builder/boolean.rs
@@ -32,7 +32,11 @@ pub struct BooleanBufferBuilder {
 }
 
 impl BooleanBufferBuilder {
-    /// Creates a new `BooleanBufferBuilder`
+    /// Creates a new `BooleanBufferBuilder` with sufficient space for
+    /// `capacity` bits (not bytes).
+    ///
+    /// The capacity is rounded up to the nearest multiple of 8 for the
+    /// allocation.
     #[inline]
     pub fn new(capacity: usize) -> Self {
         let byte_capacity = bit_util::ceil(capacity, 8);

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -57,7 +57,7 @@ impl NullBufferBuilder {
     ///
     /// Note that this method does not allocate any memory, regardless of the
     /// `capacity` parameter. If an allocation is required, `capacity` is the
-    /// size in bits (not bytes) that will be allocated.
+    /// size in bits (not bytes) that will be allocated at minimum.
     pub fn new(capacity: usize) -> Self {
         Self {
             bitmap_builder: None,

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -54,7 +54,10 @@ pub struct NullBufferBuilder {
 
 impl NullBufferBuilder {
     /// Creates a new empty builder.
-    /// `capacity` is the number of bits in the null buffer.
+    ///
+    /// Note that this method does not allocate any memory, regardless of the
+    /// `capacity` parameter. If an allocation is required, `capacity` is the
+    /// size in bits (not bytes) that will be allocated.
     pub fn new(capacity: usize) -> Self {
         Self {
             bitmap_builder: None,


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/pull/7013 

# Rationale for this change
 
I was confused about how `capacity` worked for the `NullBufferBuilder` in https://github.com/apache/arrow-rs/pull/7013#discussion_r1928312784 while discussing with @Jefffrey  and @ Chen-Yuan-Lai and spent some time reading the code.

I would like to document my findings in docstrings for the next time

# What changes are included in this PR?

Add doc comments about `capacity`


# Are there any user-facing changes?
Docs only. There are no functional changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
