### PR TITLE
Fix duplicate link references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ as the [`parquet`] and [`parquet-derive`] crates.
 
 This crate releases every month. We release new major versions (with potentially
 breaking API changes) at most once a quarter, and release incremental minor
-versions in the intervening months. See [this ticket] for more details.
+versions in the intervening months. See [ticket #5368] for more details.
 
 To keep our maintenance burden down, we do regularly scheduled releases (major
 and minor) from the `main` branch. How we handle PRs with breaking API changes
@@ -72,7 +72,7 @@ Planned Release Schedule
 | Feb 2025         | `54.2.0` | Minor, NO breaking API changes             |
 | Mar 2025         | `55.0.0` | Major, potentially breaking API changes    |
 
-[this ticket]: https://github.com/apache/arrow-rs/issues/5368
+[ticket #5368]: https://github.com/apache/arrow-rs/issues/5368
 [semantic versioning]: https://semver.org/
 
 ### `object_store` crate
@@ -96,9 +96,9 @@ In general, use panics for bad states that are unreachable, unrecoverable or har
 For those caused by invalid user input, however, we prefer to report that invalidity
 gracefully as an error result instead of panicking. In general, invalid input should result
 in an `Error` as soon as possible. It _is_ ok for code paths after validation to assume
-validation has already occurred and panic if not. See [this ticket] for more nuances.
+validation has already occurred and panic if not. See [ticket #6737] for more nuances.
 
-[this ticket]: https://github.com/apache/arrow-rs/issues/6737
+[ticket #6737]: https://github.com/apache/arrow-rs/issues/6737
 
 ### Deprecation Guidelines
 


### PR DESCRIPTION
Markdown can't handle multiple reference links with same name. i.e.

```markdown
Check out [this link].

[this link]: https://github.com/apache/arrow-rs

Now how about [this link].

[this link]: https://github.com/apache/datafusion
```

The link on `Now how about this link` will point to arrow-rs instead of datafusion.

Example of how that's affecting current README:

![image](https://github.com/user-attachments/assets/6acc9408-4baf-4e35-a894-8fd85b5be843)

For now I've decided to include the issue number as part of the text so the reference links have unique names.

Alternatives were either slightly change the text, like making the second one:

```markdown
See [this issue] for more nuances.
```

Which I didn't like as I feel we may fall into this issue again.

Another alternative would be to inline both:

```markdown
Check out [this link](https://github.com/apache/arrow-rs).

Now how about [this link](https://github.com/apache/datafusion)
```

Don't have a particular preference for that or current approach.