### PR TITLE
Optimise decimal casting for infallible conversions

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -88,33 +88,18 @@ where
     T: DecimalType,
     T::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    let error = cast_decimal_to_decimal_error::<T, T>(output_precision, output_scale);
     let delta_scale = input_scale - output_scale;
-    let div = T::Native::from_decimal(10_i128)
-        .unwrap()
-        .pow_checked((input_scale - output_scale) as u32)?;
-
-    let half = div.div_wrapping(T::Native::from_usize(2).unwrap());
-    let half_neg = half.neg_wrapping();
-
-    let f = |x: T::Native| {
-        // div is >= 10 and so this cannot overflow
-        let d = x.div_wrapping(div);
-        let r = x.mod_wrapping(div);
-
-        // Round result
-        let adjusted = match x >= T::Native::ZERO {
-            true if r >= half => d.add_wrapping(T::Native::ONE),
-            false if r <= half_neg => d.sub_wrapping(T::Native::ONE),
-            _ => d,
-        };
-        T::Native::from_decimal(adjusted)
-    };
     // if the reudction of the input number through scaling (dividing) is greater
     // than a possible precision loss (plus potential increase via rounding) every input number will fit into the output type
     let is_infallible_cast = (input_precision as i8) - delta_scale < (output_precision as i8);
 
-    Ok(if is_infallible_cast {
+    if is_infallible_cast {
+        let div = T::Native::from_decimal(10_i128)
+            .unwrap()
+            .pow_checked(delta_scale as u32)?;
+
+        let half = div.div_wrapping(T::Native::from_usize(2).unwrap());
+        let half_neg = half.neg_wrapping();
         let f = |x: T::Native| {
             // div is >= 10 and so this cannot overflow
             let d = x.div_wrapping(div);
@@ -127,15 +112,16 @@ where
                 _ => d,
             }
         };
-        array.unary(f)
-    } else if cast_options.safe {
-        array.unary_opt(|x| f(x).filter(|v| T::is_valid_decimal_precision(*v, output_precision)))
+        Ok(array.unary(f))
     } else {
-        array.try_unary(|x| {
-            f(x).ok_or_else(|| error(x))
-                .and_then(|v| T::validate_decimal_precision(v, output_precision).map(|_| v))
-        })?
-    })
+        convert_to_smaller_scale_decimal::<T, T>(
+            array,
+            input_scale,
+            output_precision,
+            output_scale,
+            cast_options,
+        )
+    }
 }
 
 pub(crate) fn convert_to_smaller_scale_decimal<I, O>(
@@ -195,29 +181,26 @@ where
     T: DecimalType,
     T::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    let error = cast_decimal_to_decimal_error::<T, T>(output_precision, output_scale);
-
     let delta_scale = output_scale - input_scale;
-    let mul = T::Native::from_decimal(10_i128)
-        .unwrap()
-        .pow_checked((output_scale - input_scale) as u32)?;
-
-    let f = |x| T::Native::from_decimal(x).and_then(|x| x.mul_checked(mul).ok());
     // if the gain in precision (digits) is greater than the multiplication due to scaling
     // every number will fit into the output type
     let is_infallible_cast = (input_precision as i8) + delta_scale <= (output_precision as i8);
 
-    Ok(if is_infallible_cast {
+    if is_infallible_cast {
+        let mul = T::Native::from_decimal(10_i128)
+            .unwrap()
+            .pow_checked(delta_scale as u32)?;
         let f = |x: T::Native| x.mul_wrapping(mul);
-        array.unary(f)
-    } else if cast_options.safe {
-        array.unary_opt(|x| f(x).filter(|v| T::is_valid_decimal_precision(*v, output_precision)))
+        Ok(array.unary(f))
     } else {
-        array.try_unary(|x| {
-            f(x).ok_or_else(|| error(x))
-                .and_then(|v| T::validate_decimal_precision(v, output_precision).map(|_| v))
-        })?
-    })
+        convert_to_bigger_or_equal_scale_decimal::<T, T>(
+            array,
+            input_scale,
+            output_precision,
+            output_scale,
+            cast_options,
+        )
+    }
 }
 
 pub(crate) fn convert_to_bigger_or_equal_scale_decimal<I, O>(

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -76,6 +76,68 @@ where
     }
 }
 
+pub(crate) fn convert_to_smaller_scale_decimal_same_type<T>(
+    array: &PrimitiveArray<T>,
+    input_precision: u8,
+    input_scale: i8,
+    output_precision: u8,
+    output_scale: i8,
+    cast_options: &CastOptions,
+) -> Result<PrimitiveArray<T>, ArrowError>
+where
+    T: DecimalType,
+    T::Native: DecimalCast + ArrowNativeTypeOp,
+{
+    let error = cast_decimal_to_decimal_error::<T, T>(output_precision, output_scale);
+    let delta_scale = input_scale - output_scale;
+    let div = T::Native::from_decimal(10_i128)
+        .unwrap()
+        .pow_checked((input_scale - output_scale) as u32)?;
+
+    let half = div.div_wrapping(T::Native::from_usize(2).unwrap());
+    let half_neg = half.neg_wrapping();
+
+    let f = |x: T::Native| {
+        // div is >= 10 and so this cannot overflow
+        let d = x.div_wrapping(div);
+        let r = x.mod_wrapping(div);
+
+        // Round result
+        let adjusted = match x >= T::Native::ZERO {
+            true if r >= half => d.add_wrapping(T::Native::ONE),
+            false if r <= half_neg => d.sub_wrapping(T::Native::ONE),
+            _ => d,
+        };
+        T::Native::from_decimal(adjusted)
+    };
+    // if the reudction of the input number through scaling (dividing) is greater
+    // than a possible precision loss (plus potential increase via rounding) every input number will fit into the output type
+    let is_infallible_cast = (input_precision as i8) - delta_scale < (output_precision as i8);
+
+    Ok(if is_infallible_cast {
+        let f = |x: T::Native| {
+            // div is >= 10 and so this cannot overflow
+            let d = x.div_wrapping(div);
+            let r = x.mod_wrapping(div);
+
+            // Round result
+            match x >= T::Native::ZERO {
+                true if r >= half => d.add_wrapping(T::Native::ONE),
+                false if r <= half_neg => d.sub_wrapping(T::Native::ONE),
+                _ => d,
+            }
+        };
+        array.unary(f)
+    } else if cast_options.safe {
+        array.unary_opt(|x| f(x).filter(|v| T::is_valid_decimal_precision(*v, output_precision)))
+    } else {
+        array.try_unary(|x| {
+            f(x).ok_or_else(|| error(x))
+                .and_then(|v| T::validate_decimal_precision(v, output_precision).map(|_| v))
+        })?
+    })
+}
+
 pub(crate) fn convert_to_smaller_scale_decimal<I, O>(
     array: &PrimitiveArray<I>,
     input_scale: i8,
@@ -117,6 +179,43 @@ where
         array.try_unary(|x| {
             f(x).ok_or_else(|| error(x))
                 .and_then(|v| O::validate_decimal_precision(v, output_precision).map(|_| v))
+        })?
+    })
+}
+
+pub(crate) fn convert_to_bigger_or_equal_scale_decimal_same_type<T>(
+    array: &PrimitiveArray<T>,
+    input_precision: u8,
+    input_scale: i8,
+    output_precision: u8,
+    output_scale: i8,
+    cast_options: &CastOptions,
+) -> Result<PrimitiveArray<T>, ArrowError>
+where
+    T: DecimalType,
+    T::Native: DecimalCast + ArrowNativeTypeOp,
+{
+    let error = cast_decimal_to_decimal_error::<T, T>(output_precision, output_scale);
+
+    let delta_scale = output_scale - input_scale;
+    let mul = T::Native::from_decimal(10_i128)
+        .unwrap()
+        .pow_checked((output_scale - input_scale) as u32)?;
+
+    let f = |x| T::Native::from_decimal(x).and_then(|x| x.mul_checked(mul).ok());
+    // if the gain in precision (digits) is greater than the multiplication due to scaling
+    // every number will fit into the output type
+    let is_infallible_cast = (input_precision as i8) + delta_scale <= (output_precision as i8);
+
+    Ok(if is_infallible_cast {
+        let f = |x: T::Native| x.mul_wrapping(mul);
+        array.unary(f)
+    } else if cast_options.safe {
+        array.unary_opt(|x| f(x).filter(|v| T::is_valid_decimal_precision(*v, output_precision)))
+    } else {
+        array.try_unary(|x| {
+            f(x).ok_or_else(|| error(x))
+                .and_then(|v| T::validate_decimal_precision(v, output_precision).map(|_| v))
         })?
     })
 }
@@ -169,16 +268,19 @@ where
             array.clone()
         } else if input_scale < output_scale {
             // the scale doesn't change, but precision may change and cause overflow
-            convert_to_bigger_or_equal_scale_decimal::<T, T>(
+            convert_to_bigger_or_equal_scale_decimal_same_type::<T>(
                 array,
+                input_precision,
                 input_scale,
                 output_precision,
                 output_scale,
                 cast_options,
             )?
         } else {
-            convert_to_smaller_scale_decimal::<T, T>(
+            // input_scale > output_scale
+            convert_to_smaller_scale_decimal_same_type::<T>(
                 array,
+                input_precision,
                 input_scale,
                 output_precision,
                 output_scale,

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -100,6 +100,7 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
+    validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
     let error = cast_decimal_to_decimal_error::<I, O>(output_precision, output_scale);
     let delta_scale = input_scale - output_scale;
     // if the reduction of the input number through scaling (dividing) is greater
@@ -163,6 +164,7 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
+    validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
     let error = cast_decimal_to_decimal_error::<I, O>(output_precision, output_scale);
     let delta_scale = output_scale - input_scale;
     let mul = O::Native::from_decimal(10_i128)

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -183,6 +183,7 @@ where
     Ok(if is_infallible_cast {
         // make sure we don't perform calculations that don't make sense w/o validation
         validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
+        // unwrapping is safe since the result is guaranteed to fit into the target type
         let f = |x| O::Native::from_decimal(x).unwrap().mul_wrapping(mul);
         array.unary(f)
     } else if cast_options.safe {

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -100,7 +100,6 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
     let error = cast_decimal_to_decimal_error::<I, O>(output_precision, output_scale);
     let delta_scale = input_scale - output_scale;
     // if the reduction of the input number through scaling (dividing) is greater
@@ -137,6 +136,8 @@ where
     };
 
     Ok(if is_infallible_cast {
+        // make sure we don't perform calculations that don't make sense w/o validation
+        validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
         let g = |x: I::Native| f(x).unwrap(); // unwrapping is safe since the result is guaranteed
                                               // to fit into the target type
         array.unary(g)
@@ -164,7 +165,6 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
     let error = cast_decimal_to_decimal_error::<I, O>(output_precision, output_scale);
     let delta_scale = output_scale - input_scale;
     let mul = O::Native::from_decimal(10_i128)
@@ -181,6 +181,8 @@ where
     let f = |x| O::Native::from_decimal(x).and_then(|x| x.mul_checked(mul).ok());
 
     Ok(if is_infallible_cast {
+        // make sure we don't perform calculations that don't make sense w/o validation
+        validate_decimal_precision_and_scale::<O>(output_precision, output_scale)?;
         let f = |x| O::Native::from_decimal(x).unwrap().mul_wrapping(mul);
         array.unary(f)
     } else if cast_options.safe {

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2439,7 +2439,7 @@ mod tests {
             .unwrap();
         let input_type = array.data_type();
         let output_type = O::TYPE_CONSTRUCTOR(t.output_prec, t.output_scale);
-        assert!(can_cast_types(&input_type, &output_type));
+        assert!(can_cast_types(input_type, &output_type));
 
         let options = CastOptions {
             safe: false,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2509,9 +2509,9 @@ mod tests {
     struct DecimalCastTestConfig<T: DecimalCast> {
         input_scale: i8,
         input_prec: u8,
+        input_repr: T,
         output_scale: i8,
         output_prec: u8,
-        input_repr: T,
         expected_output_repr: Result<T, String>,
     }
 
@@ -10017,6 +10017,174 @@ mod tests {
             r#"Cast error: Casting from Utf8 to Struct([Field { name: "a", data_type: Boolean, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }]) not supported"#,
             result.unwrap_err().to_string()
         );
+    }
+
+    #[test]
+    fn test_decimal128_to_decimal128_coverage() {
+        let test_cases = [
+            // increase precision, increase scale, infallible
+            DecimalCastTestConfig {
+                input_scale: 1,
+                input_prec: 5,
+                input_repr: 99999, // 9999.9
+                output_scale: 6,
+                output_prec: 10,
+                expected_output_repr: Ok(9999900000), // 9999.900000
+            },
+            // increase precision, increase scale, fallible, safe
+            DecimalCastTestConfig {
+                input_scale: 1,
+                input_prec: 5,
+                input_repr: 99, // 9999.9
+                output_scale: 6,
+                output_prec: 7,
+                expected_output_repr: Ok(9900000), // 9.900000
+            },
+            // increase precision, increase scale, fallible, unsafe
+            DecimalCastTestConfig {
+                input_scale: 1,
+                input_prec: 5,
+                input_repr: 99999, // 9999.9
+                output_scale: 6,
+                output_prec: 7,
+                expected_output_repr: Err("Invalid argument error: 9999900000 is too large to store in a Decimal128 of precision 7. Max is 9999999".to_string()) // max is 9.999999
+            },
+            // increase precision, decrease scale, always infallible
+            DecimalCastTestConfig {
+                input_scale: 3,
+                input_prec: 5,
+                input_repr: 99999, // 99.999
+                output_scale: 2,
+                output_prec: 10,
+                expected_output_repr: Ok(10000), // 100.00
+            },
+            // increase precision, decrease scale, no rouding
+            DecimalCastTestConfig {
+                input_scale: 3,
+                input_prec: 5,
+                input_repr: 99994, // 99.994
+                output_scale: 2,
+                output_prec: 10,
+                expected_output_repr: Ok(9999), // 99.99
+            },
+            // increase precision, don't change scale, always infallible
+            DecimalCastTestConfig {
+                input_scale: 3,
+                input_prec: 5,
+                input_repr: 99999, // 99.999
+                output_scale: 3,
+                output_prec: 10,
+                expected_output_repr: Ok(99999), // 99.999
+            },
+            // decrease precision, increase scale, safe
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 999999, // 9.99999
+                output_scale: 7,
+                output_prec: 8,
+                expected_output_repr: Ok(99999900), // 9.9999900
+            },
+            // decrease precision, increase scale, unsafe
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 9999999, // 99.99999
+                output_scale: 7,
+                output_prec: 8,
+                expected_output_repr: Err("Invalid argument error: 999999900 is too large to store in a Decimal128 of precision 8. Max is 99999999".to_string()) // max is 9.9999999
+            },
+            // decrease precision, decrease scale, safe, infallible
+            DecimalCastTestConfig {
+                input_scale: 4,
+                input_prec: 7,
+                input_repr: 9999999, // 999.9999
+                output_scale: 2,
+                output_prec: 6,
+                expected_output_repr: Ok(100000),
+            },
+            // decrease precision, decrease scale, safe, fallible
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 12345678, // 123.45678
+                output_scale: 3,
+                output_prec: 8,
+                expected_output_repr: Ok(123457), // 123.457
+            },
+            // decrease precision, decrease scale, unsafe
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 9999999, // 99.99999
+                output_scale: 3,
+                output_prec: 4,
+                expected_output_repr: Err("Invalid argument error: 100000 is too large to store in a Decimal128 of precision 4. Max is 9999".to_string()) // max is 9.999
+            },
+            // decrease precision, same scale, safe
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 999999, // 9.99999
+                output_scale: 5,
+                output_prec: 6,
+                expected_output_repr: Ok(999999), // 9.99999
+            },
+            // decrease precision, same scale, unsafe
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 10,
+                input_repr: 9999999, // 99.99999
+                output_scale: 5,
+                output_prec: 6,
+                expected_output_repr: Err("Invalid argument error: 9999999 is too large to store in a Decimal128 of precision 6. Max is 999999".to_string()) // max is 9.99999
+            },
+            // same precision, increase scale, safe
+            DecimalCastTestConfig {
+                input_scale: 4,
+                input_prec: 7,
+                input_repr: 12345, // 1.2345
+                output_scale: 6,
+                output_prec: 7,
+                expected_output_repr: Ok(1234500), // 1.234500
+            },
+            // same precision, increase scale, unsafe
+            DecimalCastTestConfig {
+                input_scale: 4,
+                input_prec: 7,
+                input_repr: 123456, // 12.3456
+                output_scale: 6,
+                output_prec: 7,
+                expected_output_repr: Err("Invalid argument error: 12345600 is too large to store in a Decimal128 of precision 7. Max is 9999999".to_string()) // max is 9.99999
+            },
+            // same precision, decrease scale, infallible
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 7,
+                input_repr: 1234567, // 12.34567
+                output_scale: 4,
+                output_prec: 7,
+                expected_output_repr: Ok(123457), // 12.3457
+            },
+            // same precision, same scale, infallible
+            DecimalCastTestConfig {
+                input_scale: 5,
+                input_prec: 7,
+                input_repr: 9999999, // 99.99999
+                output_scale: 5,
+                output_prec: 7,
+                expected_output_repr: Ok(9999999), // 99.99999
+            },
+        ];
+
+        for t in test_cases {
+            generate_decimal_cast_test_case!(
+                Decimal128,
+                Decimal128Array,
+                is_validate_decimal_precision,
+                t
+            );
+        }
     }
 
     #[test]

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2397,7 +2397,7 @@ mod tests {
         output_prec: u8,
         output_scale: i8,
         expected_output_repr: Result<i128, String>, // the error variant can contain a string
-                                                    // template where the "{}" will be replaced
+                                                    // template where the "{}" will be
                                                     // replaced with the decimal type name
                                                     // (e.g. Decimal128)
     }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2391,11 +2391,11 @@ mod tests {
     use half::f16;
 
     struct DecimalCastTestConfig<T: DecimalCast> {
-        input_scale: i8,
         input_prec: u8,
+        input_scale: i8,
         input_repr: T,
-        output_scale: i8,
         output_prec: u8,
+        output_scale: i8,
         expected_output_repr: Result<T, String>,
     }
 
@@ -9916,155 +9916,155 @@ mod tests {
         let test_cases = [
             // increase precision, increase scale, infallible
             DecimalCastTestConfig {
-                input_scale: 1,
                 input_prec: 5,
+                input_scale: 1,
                 input_repr: 99999, // 9999.9
-                output_scale: 6,
                 output_prec: 10,
+                output_scale: 6,
                 expected_output_repr: Ok(9999900000), // 9999.900000
             },
             // increase precision, increase scale, fallible, safe
             DecimalCastTestConfig {
-                input_scale: 1,
                 input_prec: 5,
+                input_scale: 1,
                 input_repr: 99, // 9999.9
-                output_scale: 6,
                 output_prec: 7,
+                output_scale: 6,
                 expected_output_repr: Ok(9900000), // 9.900000
             },
             // increase precision, increase scale, fallible, unsafe
             DecimalCastTestConfig {
-                input_scale: 1,
                 input_prec: 5,
+                input_scale: 1,
                 input_repr: 99999, // 9999.9
-                output_scale: 6,
                 output_prec: 7,
+                output_scale: 6,
                 expected_output_repr: Err("Invalid argument error: 9999900000 is too large to store in a Decimal128 of precision 7. Max is 9999999".to_string()) // max is 9.999999
             },
             // increase precision, decrease scale, always infallible
             DecimalCastTestConfig {
-                input_scale: 3,
                 input_prec: 5,
+                input_scale: 3,
                 input_repr: 99999, // 99.999
-                output_scale: 2,
                 output_prec: 10,
+                output_scale: 2,
                 expected_output_repr: Ok(10000), // 100.00
             },
             // increase precision, decrease scale, no rouding
             DecimalCastTestConfig {
-                input_scale: 3,
                 input_prec: 5,
+                input_scale: 3,
                 input_repr: 99994, // 99.994
-                output_scale: 2,
                 output_prec: 10,
+                output_scale: 2,
                 expected_output_repr: Ok(9999), // 99.99
             },
             // increase precision, don't change scale, always infallible
             DecimalCastTestConfig {
-                input_scale: 3,
                 input_prec: 5,
+                input_scale: 3,
                 input_repr: 99999, // 99.999
-                output_scale: 3,
                 output_prec: 10,
+                output_scale: 3,
                 expected_output_repr: Ok(99999), // 99.999
             },
             // decrease precision, increase scale, safe
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 999999, // 9.99999
-                output_scale: 7,
                 output_prec: 8,
+                output_scale: 7,
                 expected_output_repr: Ok(99999900), // 9.9999900
             },
             // decrease precision, increase scale, unsafe
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 9999999, // 99.99999
-                output_scale: 7,
                 output_prec: 8,
+                output_scale: 7,
                 expected_output_repr: Err("Invalid argument error: 999999900 is too large to store in a Decimal128 of precision 8. Max is 99999999".to_string()) // max is 9.9999999
             },
             // decrease precision, decrease scale, safe, infallible
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
+                input_scale: 4,
                 input_repr: 9999999, // 999.9999
-                output_scale: 2,
                 output_prec: 6,
+                output_scale: 2,
                 expected_output_repr: Ok(100000),
             },
             // decrease precision, decrease scale, safe, fallible
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 12345678, // 123.45678
-                output_scale: 3,
                 output_prec: 8,
+                output_scale: 3,
                 expected_output_repr: Ok(123457), // 123.457
             },
             // decrease precision, decrease scale, unsafe
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 9999999, // 99.99999
-                output_scale: 3,
                 output_prec: 4,
+                output_scale: 3,
                 expected_output_repr: Err("Invalid argument error: 100000 is too large to store in a Decimal128 of precision 4. Max is 9999".to_string()) // max is 9.999
             },
             // decrease precision, same scale, safe
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 999999, // 9.99999
-                output_scale: 5,
                 output_prec: 6,
+                output_scale: 5,
                 expected_output_repr: Ok(999999), // 9.99999
             },
             // decrease precision, same scale, unsafe
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 10,
+                input_scale: 5,
                 input_repr: 9999999, // 99.99999
-                output_scale: 5,
                 output_prec: 6,
+                output_scale: 5,
                 expected_output_repr: Err("Invalid argument error: 9999999 is too large to store in a Decimal128 of precision 6. Max is 999999".to_string()) // max is 9.99999
             },
             // same precision, increase scale, safe
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
+                input_scale: 4,
                 input_repr: 12345, // 1.2345
-                output_scale: 6,
                 output_prec: 7,
+                output_scale: 6,
                 expected_output_repr: Ok(1234500), // 1.234500
             },
             // same precision, increase scale, unsafe
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
+                input_scale: 4,
                 input_repr: 123456, // 12.3456
-                output_scale: 6,
                 output_prec: 7,
+                output_scale: 6,
                 expected_output_repr: Err("Invalid argument error: 12345600 is too large to store in a Decimal128 of precision 7. Max is 9999999".to_string()) // max is 9.99999
             },
             // same precision, decrease scale, infallible
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 7,
+                input_scale: 5,
                 input_repr: 1234567, // 12.34567
-                output_scale: 4,
                 output_prec: 7,
+                output_scale: 4,
                 expected_output_repr: Ok(123457), // 12.3457
             },
             // same precision, same scale, infallible
             DecimalCastTestConfig {
-                input_scale: 5,
                 input_prec: 7,
+                input_scale: 5,
                 input_repr: 9999999, // 99.99999
-                output_scale: 5,
                 output_prec: 7,
+                output_scale: 5,
                 expected_output_repr: Ok(9999999), // 99.99999
             },
         ];
@@ -10083,43 +10083,43 @@ mod tests {
     fn test_decimal128_to_decimal128_increase_scale_and_precision_unchecked() {
         let test_cases = [
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 0,
                 input_repr: 99999,
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(9999900000),
             },
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 0,
                 input_repr: -99999,
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(-9999900000),
             },
             DecimalCastTestConfig {
-                input_scale: 2,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 2,
                 input_repr: 99999,
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(99999000),
             },
             DecimalCastTestConfig {
-                input_scale: -2,
                 input_prec: 5,
-                output_scale: 3,
-                output_prec: 10,
+                input_scale: -2,
                 input_repr: -99999,
+                output_prec: 10,
+                output_scale: 3,
                 expected_output_repr: Ok(-9999900000),
             },
             DecimalCastTestConfig {
-                input_scale: 3,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 6,
+                input_scale: 3,
                 input_repr: -12345,
+                output_prec: 6,
+                output_scale: 5,
                 expected_output_repr: Err("Invalid argument error: -1234500 is too small to store in a Decimal128 of precision 6. Min is -999999".to_string())
             },
         ];
@@ -10138,43 +10138,43 @@ mod tests {
     fn test_decimal128_to_decimal128_decrease_scale_and_precision_unchecked() {
         let test_cases = [
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
+                input_scale: 0,
+                input_repr: 99999,
                 output_scale: -3,
                 output_prec: 3,
-                input_repr: 99999,
                 expected_output_repr: Ok(100),
             },
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: -5,
-                output_prec: 1,
+                input_scale: 0,
                 input_repr: -99999,
+                output_prec: 1,
+                output_scale: -5,
                 expected_output_repr: Ok(-1),
             },
             DecimalCastTestConfig {
-                input_scale: 2,
                 input_prec: 10,
-                output_scale: -2,
-                output_prec: 5,
+                input_scale: 2,
                 input_repr: 123456789,
+                output_prec: 5,
+                output_scale: -2,
                 expected_output_repr: Ok(12346),
             },
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 10,
-                output_scale: 0,
-                output_prec: 7,
+                input_scale: 4,
                 input_repr: -9876543210,
+                output_prec: 7,
+                output_scale: 0,
                 expected_output_repr: Ok(-987654),
             },
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
-                output_scale: 3,
-                output_prec: 6,
+                input_scale: 4,
                 input_repr: 9999999,
+                output_prec: 6,
+                output_scale: 3,
                 expected_output_repr:
                     Err("Invalid argument error: 1000000 is too large to store in a Decimal128 of precision 6. Max is 999999".to_string()),
             },
@@ -10193,43 +10193,43 @@ mod tests {
     fn test_decimal256_to_decimal256_increase_scale_and_precision_unchecked() {
         let test_cases = [
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 0,
                 input_repr: i256::from_i128(99999),
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(i256::from_i128(9999900000)),
             },
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 0,
                 input_repr: i256::from_i128(-99999),
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(i256::from_i128(-9999900000)),
             },
             DecimalCastTestConfig {
-                input_scale: 2,
                 input_prec: 5,
-                output_scale: 5,
-                output_prec: 10,
+                input_scale: 2,
                 input_repr: i256::from_i128(99999),
+                output_prec: 10,
+                output_scale: 5,
                 expected_output_repr: Ok(i256::from_i128(99999000)),
             },
             DecimalCastTestConfig {
-                input_scale: -2,
                 input_prec: 5,
-                output_scale: 3,
-                output_prec: 10,
+                input_scale: -2,
                 input_repr: i256::from_i128(-99999),
+                output_prec: 10,
+                output_scale: 3,
                 expected_output_repr: Ok(i256::from_i128(-9999900000)),
             },
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
-                output_scale: 3,
-                output_prec: 6,
+                input_scale: 4,
                 input_repr: i256::from_i128(9999999),
+                output_prec: 6,
+                output_scale: 3,
                 expected_output_repr:
                     Err("Invalid argument error: 1000000 is too large to store in a Decimal256 of precision 6. Max is 999999".to_string()),
             },
@@ -10249,43 +10249,43 @@ mod tests {
     fn test_decimal256_to_decimal256_decrease_scale_and_precision_unchecked() {
         let test_cases = [
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: -3,
-                output_prec: 3,
+                input_scale: 0,
                 input_repr: i256::from_i128(99999),
+                output_prec: 3,
+                output_scale: -3,
                 expected_output_repr: Ok(i256::from_i128(100)),
             },
             DecimalCastTestConfig {
-                input_scale: 0,
                 input_prec: 5,
-                output_scale: -5,
-                output_prec: 1,
+                input_scale: 0,
                 input_repr: i256::from_i128(-99999),
+                output_prec: 1,
+                output_scale: -5,
                 expected_output_repr: Ok(i256::from_i128(-1)),
             },
             DecimalCastTestConfig {
-                input_scale: 2,
                 input_prec: 10,
-                output_scale: -2,
-                output_prec: 5,
+                input_scale: 2,
                 input_repr: i256::from_i128(123456789),
+                output_prec: 5,
+                output_scale: -2,
                 expected_output_repr: Ok(i256::from_i128(12346)),
             },
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 10,
-                output_scale: 0,
-                output_prec: 7,
+                input_scale: 4,
                 input_repr: i256::from_i128(-9876543210),
+                output_prec: 7,
+                output_scale: 0,
                 expected_output_repr: Ok(i256::from_i128(-987654)),
             },
             DecimalCastTestConfig {
-                input_scale: 4,
                 input_prec: 7,
-                output_scale: 3,
-                output_prec: 6,
+                input_scale: 4,
                 input_repr: i256::from_i128(9999999),
+                output_prec: 6,
+                output_scale: 3,
                 expected_output_repr:
                     Err("Invalid argument error: 1000000 is too large to store in a Decimal256 of precision 6. Max is 999999".to_string()),
             },

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10054,6 +10054,14 @@ mod tests {
                 input_repr: -99999,
                 expected_output_repr: Ok(-9999900000),
             },
+            DecimalCastTestConfig {
+                input_scale: 3,
+                input_prec: 5,
+                output_scale: 5,
+                output_prec: 6,
+                input_repr: -12345,
+                expected_output_repr: Err("Invalid argument error: -1234500 is too small to store in a Decimal128 of precision 6. Min is -999999".to_string())
+            },
         ];
 
         for t in test_cases {
@@ -10155,6 +10163,15 @@ mod tests {
                 output_prec: 10,
                 input_repr: i256::from_i128(-99999),
                 expected_output_repr: Ok(i256::from_i128(-9999900000)),
+            },
+            DecimalCastTestConfig {
+                input_scale: 4,
+                input_prec: 7,
+                output_scale: 3,
+                output_prec: 6,
+                input_repr: i256::from_i128(9999999),
+                expected_output_repr:
+                    Err("Invalid argument error: 1000000 is too large to store in a Decimal256 of precision 6. Max is 999999".to_string()),
             },
         ];
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -9948,7 +9948,7 @@ mod tests {
                 input_repr: 99999, // 9999.9
                 output_prec: 7,
                 output_scale: 6,
-                expected_output_repr: Err(r"Invalid argument error: 9999900000 is too large to store in a {} of precision 7. Max is 9999999".to_string()) // max is 9.999999
+                expected_output_repr: Err("Invalid argument error: 9999900000 is too large to store in a {} of precision 7. Max is 9999999".to_string()) // max is 9.999999
             },
             // increase precision, decrease scale, always infallible
             DecimalCastTestConfig {
@@ -9993,7 +9993,7 @@ mod tests {
                 input_repr: 9999999, // 99.99999
                 output_prec: 8,
                 output_scale: 7,
-                expected_output_repr: Err(r"Invalid argument error: 999999900 is too large to store in a {} of precision 8. Max is 99999999".to_string()) // max is 9.9999999
+                expected_output_repr: Err("Invalid argument error: 999999900 is too large to store in a {} of precision 8. Max is 99999999".to_string()) // max is 9.9999999
             },
             // decrease precision, decrease scale, safe, infallible
             DecimalCastTestConfig {
@@ -10020,7 +10020,7 @@ mod tests {
                 input_repr: 9999999, // 99.99999
                 output_prec: 4,
                 output_scale: 3,
-                expected_output_repr: Err(r"Invalid argument error: 100000 is too large to store in a {} of precision 4. Max is 9999".to_string()) // max is 9.999
+                expected_output_repr: Err("Invalid argument error: 100000 is too large to store in a {} of precision 4. Max is 9999".to_string()) // max is 9.999
             },
             // decrease precision, same scale, safe
             DecimalCastTestConfig {
@@ -10038,7 +10038,7 @@ mod tests {
                 input_repr: 9999999, // 99.99999
                 output_prec: 6,
                 output_scale: 5,
-                expected_output_repr: Err(r"Invalid argument error: 9999999 is too large to store in a {} of precision 6. Max is 999999".to_string()) // max is 9.99999
+                expected_output_repr: Err("Invalid argument error: 9999999 is too large to store in a {} of precision 6. Max is 999999".to_string()) // max is 9.99999
             },
             // same precision, increase scale, safe
             DecimalCastTestConfig {
@@ -10056,7 +10056,7 @@ mod tests {
                 input_repr: 123456, // 12.3456
                 output_prec: 7,
                 output_scale: 6,
-                expected_output_repr: Err(r"Invalid argument error: 12345600 is too large to store in a {} of precision 7. Max is 9999999".to_string()) // max is 9.99999
+                expected_output_repr: Err("Invalid argument error: 12345600 is too large to store in a {} of precision 7. Max is 9999999".to_string()) // max is 9.99999
             },
             // same precision, decrease scale, infallible
             DecimalCastTestConfig {
@@ -10075,6 +10075,33 @@ mod tests {
                 output_prec: 7,
                 output_scale: 5,
                 expected_output_repr: Ok(9999999), // 99.99999
+            },
+            // precision increase, input scale & output scale = 0, infallible
+            DecimalCastTestConfig {
+                input_prec: 7,
+                input_scale: 0,
+                input_repr: 1234567, // 1234567
+                output_prec: 8,
+                output_scale: 0,
+                expected_output_repr: Ok(1234567), // 1234567
+            },
+            // precision decrease, input scale & output scale = 0, failure
+            DecimalCastTestConfig {
+                input_prec: 7,
+                input_scale: 0,
+                input_repr: 1234567, // 1234567
+                output_prec: 6,
+                output_scale: 0,
+                expected_output_repr: Err("Invalid argument error: 1234567 is too large to store in a {} of precision 6. Max is 999999".to_string())
+            },
+            // precision decrease, input scale & output scale = 0, success
+            DecimalCastTestConfig {
+                input_prec: 7,
+                input_scale: 0,
+                input_repr: 123456, // 123456
+                output_prec: 6,
+                output_scale: 0,
+                expected_output_repr: Ok(123456), // 123456
             },
         ];
 
@@ -10124,7 +10151,7 @@ mod tests {
                 input_repr: -12345,
                 output_prec: 6,
                 output_scale: 5,
-                expected_output_repr: Err(r"Invalid argument error: -1234500 is too small to store in a {} of precision 6. Min is -999999".to_string())
+                expected_output_repr: Err("Invalid argument error: -1234500 is too small to store in a {} of precision 6. Min is -999999".to_string())
             },
         ];
 
@@ -10175,7 +10202,7 @@ mod tests {
                 output_prec: 6,
                 output_scale: 3,
                 expected_output_repr:
-                    Err(r"Invalid argument error: 1000000 is too large to store in a {} of precision 6. Max is 999999".to_string()),
+                    Err("Invalid argument error: 1000000 is too large to store in a {} of precision 6. Max is 999999".to_string()),
             },
         ];
         for t in test_cases {

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -850,18 +850,20 @@ pub fn cast_with_options(
                 cast_options,
             )
         }
-        (Decimal128(_, s1), Decimal256(p2, s2)) => {
+        (Decimal128(p1, s1), Decimal256(p2, s2)) => {
             cast_decimal_to_decimal::<Decimal128Type, Decimal256Type>(
                 array.as_primitive(),
+                *p1,
                 *s1,
                 *p2,
                 *s2,
                 cast_options,
             )
         }
-        (Decimal256(_, s1), Decimal128(p2, s2)) => {
+        (Decimal256(p1, s1), Decimal128(p2, s2)) => {
             cast_decimal_to_decimal::<Decimal256Type, Decimal128Type>(
                 array.as_primitive(),
+                *p1,
                 *s1,
                 *p2,
                 *s2,

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -267,9 +267,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(30, 3)))
     });
 
-    c.bench_function("cast decimal128 to decimal128 512 with lower scale (infallible)", |b| {
-        b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(7, -1)))
-    });
+    c.bench_function(
+        "cast decimal128 to decimal128 512 with lower scale (infallible)",
+        |b| b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(7, -1))),
+    );
 
     c.bench_function("cast decimal256 to decimal256 512 with same scale", |b| {
         b.iter(|| cast_array(&decimal256_array, DataType::Decimal256(60, 3)))

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -266,6 +266,11 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast decimal128 to decimal128 512 with same scale", |b| {
         b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(30, 3)))
     });
+
+    c.bench_function("cast decimal128 to decimal128 512 with lower scale (infallible)", |b| {
+        b.iter(|| cast_array(&decimal128_array, DataType::Decimal128(7, -1)))
+    });
+
     c.bench_function("cast decimal256 to decimal256 512 with same scale", |b| {
         b.iter(|| cast_array(&decimal256_array, DataType::Decimal256(60, 3)))
     });


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #6877.

# Rationale for this change
 
As mentioned in the issue there are certain conversions for which we don't need to check precision / overflow and can thus improve performance by using the infallible unary kernel.

## Explanation of the optimisation:
### Case 1, increasing scale:
Increasing the scale will result in multiplication with powers of 10, thus being equivalent to a "shift left" of the digits.
Every number will thus "gain" additional digits. The operation is safe when the output type gives enough precision (i.e. digits) to contain the original digits, as well as the digits gained.
This can be boiled down to the condition `input_prec + (output_scale - input_scale) <= output_prec`

#### Example:
consider a conversion from `Decimal(5, 0)` to `Decimal(8, 3)`  with the number `12345 * 10^0 = 12345000 * 10^(-3)`
If we are starting with any number `xxxxx`, then an increase of scale by 3 will have the following effect on the representation: `[xxxxx] -> [xxxxx000]`.
So for this to work, every output type needs to have at least 8 digits of precision.

### Case 2, decreasing scale:
Decreasing the scale will result in division with powers of 10, thus "shifting right" of the digits __and adding a rounding term__. We usually need less precision to represent the result. By shifting right we lose `input_scale - output_scale` digits, but adding a rounding term can result in one additional digit being required, therefore we can boil this down to
`input_prec - (input_scale - output_scale) < output_prec`

#### Example:
consider a conversion from `Decimal(5, 0)` to `Decimal(3, -3)` with the number `99900 * 10^0 = 99.9 * 10^(3)` which is then rounded to `100 * 10^3 = 100000`
If we are starting with any number `xxxxx`, then and decrease the scale by 3 will have the following effect on the representation: `[xxxxx] -> [xx] (+ 1 possibly)`. In the example plus one adds an additional digit, so the conversion to work, every output type needs to have at least 3 digits of precision.
A conversion to `Decimal(2, -3)` would not be possible.

### Performance impact
The only cases affected are between decimal128 types, for increasing scale there is a considerable improvements that I measured of around 80%.
For decreasing the scale there was an improvement of around 25%.
```
cast decimal128 to decimal128 512                                  6.98      2.8±0.00µs        ? ?/sec    1.00    402.4±0.35ns        ? ?/sec
cast decimal128 to decimal128 512 lower precision                  1.01      3.0±0.00µs        ? ?/sec    1.00      2.9±0.01µs        ? ?/sec
cast decimal128 to decimal128 512 with lower scale (infallible)    1.31      3.3±0.00µs        ? ?/sec    1.00      2.5±0.00µs        ? ?/sec
cast decimal128 to decimal128 512 with same scale                  1.07     54.2±1.47ns        ? ?/sec    1.00     50.5±1.41ns        ? ?/sec
cast decimal128 to decimal256 512                                  1.00      6.1±0.01µs        ? ?/sec    1.00      6.1±0.01µs        ? ?/sec
cast decimal256 to decimal128 512                                  1.02     13.2±0.67µs        ? ?/sec    1.00     12.9±0.12µs        ? ?/sec
cast decimal256 to decimal256 512                                  1.01      6.1±0.02µs        ? ?/sec    1.00      6.1±0.03µs        ? ?/sec
cast decimal256 to decimal256 512 with same scale                  1.05     54.1±1.98ns        ? ?/sec    1.00     51.6±1.15ns        ? ?/sec
```

# What changes are included in this PR?

I've added a new specialization for dealing with "safe" casts between the same decimal type both when reducing and increasing scale
A new benchmark for reducing scale

# Are there any user-facing changes?

No, the behavior of the casts should stay the same. 