### PR TITLE
docs: add to bit slice iterator docs that the start value is inclusive and end value is exclusive

### DIFF
--- a/arrow-buffer/src/util/bit_iterator.rs
+++ b/arrow-buffer/src/util/bit_iterator.rs
@@ -93,6 +93,8 @@ impl DoubleEndedIterator for BitIterator<'_> {
 /// Returns `(usize, usize)` each representing an interval where the corresponding
 /// bits in the provides mask are set
 ///
+/// the first value is the start of the range (inclusive) and the second value is the end of the range (exclusive)
+///
 #[derive(Debug)]
 pub struct BitSliceIterator<'a> {
     iter: UnalignedBitChunkIterator<'a>,


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

When working on https://github.com/apache/datafusion/pull/14299 I had to look through the code to understand if the end is exclusive or not

# Are there any user-facing changes?
only docs