### PR TITLE
Introduce `UnsafeFlag` to manage disabling `ArrayData` validation

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -28,6 +28,7 @@ use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::data::private::UnsafeFlag;
 use crate::{equal, validate_binary_view, validate_string_view};
 
 #[inline]
@@ -255,6 +256,10 @@ impl ArrayData {
         buffers: Vec<Buffer>,
         child_data: Vec<ArrayData>,
     ) -> Self {
+        let mut skip_validation = UnsafeFlag::new();
+        // SAFETY: caller responsible for ensuring data is valid
+        skip_validation.set(true);
+
         ArrayDataBuilder {
             data_type,
             len,
@@ -265,8 +270,7 @@ impl ArrayData {
             buffers,
             child_data,
             align_buffers: false,
-            // SAFETY: caller responsible for ensuring data is valid
-            skip_validation: true,
+            skip_validation,
         }
         .build()
         .unwrap()
@@ -1779,6 +1783,34 @@ impl PartialEq for ArrayData {
     }
 }
 
+mod private {
+    /// A boolean flag that cannot be mutated outside of unsafe code.
+    ///
+    /// Defaults to a value of false.
+    ///
+    /// This structure is used to enforce safety in the [`ArrayDataBuilder`]
+    #[derive(Debug)]
+    pub struct UnsafeFlag(bool);
+
+    impl UnsafeFlag {
+        /// Creates a new `UnsafeFlag` with the value set to `false`
+        #[inline]
+        pub const fn new() -> Self {
+            Self(false)
+        }
+
+        #[inline]
+        pub unsafe fn set(&mut self, val: bool) {
+            self.0 = val;
+        }
+
+        #[inline]
+        pub fn get(&self) -> bool {
+            self.0
+        }
+    }
+}
+
 /// Builder for [`ArrayData`] type
 #[derive(Debug)]
 pub struct ArrayDataBuilder {
@@ -1803,7 +1835,7 @@ pub struct ArrayDataBuilder {
     /// This flag can only be set to true using `unsafe` APIs. However, once true
     /// subsequent calls to `build()` may result in undefined behavior if the data
     /// is not valid.
-    skip_validation: bool,
+    skip_validation: UnsafeFlag,
 }
 
 impl ArrayDataBuilder {
@@ -1820,7 +1852,7 @@ impl ArrayDataBuilder {
             buffers: vec![],
             child_data: vec![],
             align_buffers: false,
-            skip_validation: false,
+            skip_validation: UnsafeFlag::new(),
         }
     }
 
@@ -1957,7 +1989,7 @@ impl ArrayDataBuilder {
         }
 
         // SAFETY: `skip_validation` is only set to true using `unsafe` APIs
-        if !skip_validation || cfg!(feature = "force_validate") {
+        if !skip_validation.get() || cfg!(feature = "force_validate") {
             data.validate_data()?;
         }
         Ok(data)
@@ -2003,7 +2035,7 @@ impl ArrayDataBuilder {
     /// If validation is skipped, the buffers must form a valid Arrow array,
     /// otherwise undefined behavior will result
     pub unsafe fn skip_validation(mut self, skip_validation: bool) -> Self {
-        self.skip_validation = skip_validation;
+        self.skip_validation.set(skip_validation);
         self
     }
 }
@@ -2020,7 +2052,7 @@ impl From<ArrayData> for ArrayDataBuilder {
             null_bit_buffer: None,
             null_count: None,
             align_buffers: false,
-            skip_validation: false,
+            skip_validation: UnsafeFlag::new(),
         }
     }
 }

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1789,6 +1789,8 @@ mod private {
     /// Defaults to a value of false.
     ///
     /// This structure is used to enforce safety in the [`ArrayDataBuilder`]
+    ///
+    /// [`ArrayDataBuilder`]: super::ArrayDataBuilder
     #[derive(Debug)]
     pub struct UnsafeFlag(bool);
 


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to refactor for unsafe flag: #6966



# Rationale for this change
 
As mentioned previously, the management of disabling validation must be handled very carefully to ensure the overall API remains `safe`.

@tustvold suggested an approach that adds additional compile time checking in https://github.com/apache/arrow-rs/pull/7006#pullrequestreview-2574041835, in the form of an an extra layer of protection when modifying the flags. I thought it was a great idea so figured I would start with it here


# What changes are included in this PR?
1. Introduce the `UnsafeFlag` type
2. Update `ArrayDataBuilder` to use it


# Are there any user-facing changes?
No, this is entirely internal

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
