### PR TITLE
Create GitHub releases automatically on tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+      - '!*-rc*'
+permissions:
+  contents: write
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Releases
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            object_store_*)
+              version=${GITHUB_REF_NAME#object_store_}
+              title="object_store ${version}"
+              notes_file=object_store/CHANGELOG.md
+              ;;
+            *)
+              version=${GITHUB_REF_NAME}
+              title="arrow ${version}"
+              notes_file=CHANGELOG.md
+              ;;
+          esac
+          gh release create ${GITHUB_REF_NAME} \
+            --title "${title}" \
+            --notes-file ${notes_file} \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Creates a github release on https://github.com/apache/arrow-rs/releases
+# when a tag is pushed to the repository
 name: Release
 on:
   push:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7041.

# Rationale for this change

In general, a release process should be automated as much as possible. It reduces maintenance costs and avoid human mistakes.

# What changes are included in this PR?

Add a GitHub Actions workflow that is executed on tagging. It creates GitHub releases from existing information.

Example results on my fork:
* For `55.0.0` tag: https://github.com/kou/arrow-rs/releases/tag/55.0.0
* For `object_store_0.12.0` tag: https://github.com/kou/arrow-rs/releases/tag/object_store_0.12.0

# Are there any user-facing changes?

No.
