### PR TITLE
Support both 0x01 and 0x02 as type for list of booleans in thrift metadata

### DIFF
--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -302,7 +302,7 @@ mod tests {
         // Boolean collection type encoded as 0x01, as used by this crate when writing.
         // Values encoded as 1 (true) or 2 (false) as in the current version of the thrift
         // documentation.
-        let bytes = vec![25, 33, 2, 1, 25, 8, 25, 8, 21, 0, 0];
+        let bytes = vec![0x19, 0x21, 2, 1, 0x19, 8, 0x19, 8, 0x15, 0, 0];
 
         let mut protocol = TCompactSliceInputProtocol::new(bytes.as_slice());
         let index = ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
@@ -310,7 +310,7 @@ mod tests {
             null_pages: vec![false, true],
             min_values: vec![],
             max_values: vec![],
-            boundary_order: BoundaryOrder(0),
+            boundary_order: BoundaryOrder::UNORDERED,
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,
@@ -323,7 +323,7 @@ mod tests {
     pub fn read_boolean_list_alternative_encoding() {
         // Boolean collection type encoded as 0x02, as allowed by the spec.
         // Values encoded as 1 (true) or 0 (false) as before the thrift documentation change on 2024-12-13.
-        let bytes = vec![25, 34, 0, 1, 25, 8, 25, 8, 21, 0, 0];
+        let bytes = vec![0x19, 0x22, 0, 1, 0x19, 8, 0x19, 8, 0x15, 0, 0];
 
         let mut protocol = TCompactSliceInputProtocol::new(bytes.as_slice());
         let index = ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
@@ -331,7 +331,7 @@ mod tests {
             null_pages: vec![false, true],
             min_values: vec![],
             max_values: vec![],
-            boundary_order: BoundaryOrder(0),
+            boundary_order: BoundaryOrder::UNORDERED,
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes apache/datafusion#14281.

# Rationale for this change

The [thrift documentation for lists of booleans](https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set) was recently updated to clarify encoding of booleans:

> For historical and compatibility reasons, a reader should be capable to deal with both cases. The only valid value in the original spec was 2, but due to an widespread implementation bug the defacto standard across large parts of the library became 1 instead. As a result, both values are now allowed.

At least the go implementation seems to encode the type as 0x02

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Be a bit more lenient and accept both types.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No, this should be a compatible change. Might even be worth backparting to a bugfix release.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
