### PR TITLE
perf: inline `from_iter` for `ScalarBuffer`

### DIFF
--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -182,6 +182,7 @@ impl<T: ArrowNativeType> From<BufferBuilder<T>> for ScalarBuffer<T> {
 }
 
 impl<T: ArrowNativeType> FromIterator<T> for ScalarBuffer<T> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         iter.into_iter().collect::<Vec<_>>().into()
     }


### PR DESCRIPTION
When benchmarking `ScalarBuffer::from_iter` as part of https://github.com/spiraldb/vortex/blob/develop/vortex-buffer/benches/vortex_buffer.rs, the performance increases significantly if the function gets annotated with `#[inline]`.

On a MacBook Air M2:

Without annotating `from_iter` with `#[inline]`:

```
vortex_buffer                                                 fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ from_iter                                                                │               │               │               │         │
│  ├─ Arrow<arrow_buffer::buffer::scalar::ScalarBuffer<i32>>                │               │               │               │         │
│  │  ├─ 1                                                    28.67 ns      │ 29.8 ns       │ 29.15 ns      │ 29.14 ns      │ 100     │ 25600
│  │  ├─ 100                                                  116.8 ns      │ 163.7 ns      │ 121.4 ns      │ 124.2 ns      │ 100     │ 3200
│  │  ├─ 1000                                                 614.3 ns      │ 895.5 ns      │ 632.5 ns      │ 670.1 ns      │ 100     │ 800
│  │  ├─ 100000                                               57.79 µs      │ 112.3 µs      │ 58.35 µs      │ 60.02 µs      │ 100     │ 100
│  │  ╰─ 10000000                                             7.425 ms      │ 9.524 ms      │ 7.844 ms      │ 8.113 ms      │ 100     │ 100
│  ╰─ Buffer<i32>                                                           │               │               │               │         │
```

After annotating `from_iter` with `#[inline]`:

```
vortex_buffer                                                 fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ from_iter                                                                │               │               │               │         │
│  ├─ Arrow<arrow_buffer::buffer::scalar::ScalarBuffer<i32>>                │               │               │               │         │
│  │  ├─ 1                                                    26.87 ns      │ 27.19 ns      │ 27.03 ns      │ 27.03 ns      │ 100     │ 25600
│  │  ├─ 100                                                  64.14 ns      │ 91.48 ns      │ 64.8 ns       │ 67.08 ns      │ 100     │ 6400
│  │  ├─ 1000                                                 79.77 ns      │ 115.5 ns      │ 81.08 ns      │ 88.88 ns      │ 100     │ 6400
│  │  ├─ 100000                                               5.165 µs      │ 53.83 µs      │ 5.541 µs      │ 6.642 µs      │ 100     │ 100
│  │  ╰─ 10000000                                             2.42 ms       │ 3.895 ms      │ 2.743 ms      │ 2.742 ms      │ 100     │ 100
```