### PR TITLE
Support converting large dates (i.e. +10999-12-31) from string to Date32

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -4217,6 +4217,23 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_string_with_large_date_to_date32() {
+        let array = Arc::new(StringArray::from(vec![
+            Some("+10999-12-31"),
+            Some("-0010-02-28")
+        ])) as ArrayRef;
+        let to_type = DataType::Date32;
+        let options = CastOptions {
+            safe: false,
+            format_options: FormatOptions::default(),
+        };
+        let b = cast_with_options(&array, &to_type, &options).unwrap();
+        let c = b.as_primitive::<Date32Type>();
+        assert_eq!(3298139, c.value(0));
+        assert_eq!(-723122, c.value(1));
+    }
+
+    #[test]
     fn test_cast_string_format_yyyymmdd_to_date32() {
         let a0 = Arc::new(StringViewArray::from(vec![
             Some("2020-12-25"),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -4220,7 +4220,7 @@ mod tests {
     fn test_cast_string_with_large_date_to_date32() {
         let array = Arc::new(StringArray::from(vec![
             Some("+10999-12-31"),
-            Some("-0010-02-28")
+            Some("-0010-02-28"),
         ])) as ArrayRef;
         let to_type = DataType::Date32;
         let options = CastOptions {

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -591,6 +591,26 @@ const EPOCH_DAYS_FROM_CE: i32 = 719_163;
 const ERR_NANOSECONDS_NOT_SUPPORTED: &str = "The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804";
 
 fn parse_date(string: &str) -> Option<NaiveDate> {
+    // If the date has an extended (signed) year such as "+10999-12-31" or "-0012-05-06"
+    if string.starts_with('+') || string.starts_with('-') {
+        // Skip the sign and look for the hyphen that terminates the year digits.
+        // According to ISO 8601 the unsigned part must be at least 4 digits.
+        let rest = &string[1..];
+        let hyphen = rest.find('-')?;
+        if hyphen < 4 {
+            return None;
+        }
+        // The year substring is the sign and the digits (but not the separator)
+        // e.g. for "+10999-12-31", hyphen is 5 and s[..6] is "+10999"
+        let year: i32 = string[..hyphen + 1].parse().ok()?;
+        // The remainder should begin with a '-' which we strip off, leaving the month-day part.
+        let remainder = string[hyphen + 1..].strip_prefix('-')?;
+        let mut parts = remainder.splitn(2, '-');
+        let month: u32 = parts.next()?.parse().ok()?;
+        let day: u32 = parts.next()?.parse().ok()?;
+        return NaiveDate::from_ymd_opt(year, month, day);
+    }
+
     if string.len() > 10 {
         // Try to parse as datetime and return just the date part
         return string_to_datetime(&Utc, string)

--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -34,11 +34,11 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-arrow-array = { workspace = true }
-arrow-buffer = { workspace = true }
-arrow-cast = { workspace = true }
-arrow-data = { workspace = true }
-arrow-schema = { workspace = true }
+arrow-array = { version = "53" }
+arrow-buffer = { version = "53" }
+arrow-cast = { version = "53" }
+arrow-data = { version = "53" }
+arrow-schema = { version = "53" }
 half = { version = "2.1", default-features = false }
 indexmap = { version = "2.0", default-features = false, features = ["std"] }
 num = { version = "0.4", default-features = false, features = ["std"] }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -80,6 +80,10 @@ fn make_encoder_impl<'a>(
             let array = array.as_string::<i64>();
             (Box::new(StringEncoder(array)) as _, array.nulls().cloned())
         }
+        DataType::Utf8View => {
+            let array = array.as_string_view();
+            (Box::new(StringViewEncoder(array)) as _, array.nulls().cloned())
+        }
         DataType::List(_) => {
             let array = array.as_list::<i32>();
             (Box::new(ListEncoder::try_new(array, options)?) as _, array.nulls().cloned())
@@ -311,6 +315,14 @@ impl<'a> Encoder for BooleanEncoder<'a> {
 struct StringEncoder<'a, O: OffsetSizeTrait>(&'a GenericStringArray<O>);
 
 impl<'a, O: OffsetSizeTrait> Encoder for StringEncoder<'a, O> {
+    fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
+        encode_string(self.0.value(idx), out);
+    }
+}
+
+struct StringViewEncoder<'a>(&'a StringViewArray);
+
+impl Encoder for StringViewEncoder<'_> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         encode_string(self.0.value(idx), out);
     }

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -67,6 +67,7 @@ fn make_encoder_impl<'a>(
         DataType::Float16 => primitive_helper!(Float16Type),
         DataType::Float32 => primitive_helper!(Float32Type),
         DataType::Float64 => primitive_helper!(Float64Type),
+        DataType::Decimal128(_, _) => primitive_helper!(Decimal128Type),
         DataType::Boolean => {
             let array = array.as_boolean();
             (Box::new(BooleanEncoder(array)), array.nulls().cloned())
@@ -133,11 +134,6 @@ fn make_encoder_impl<'a>(
                 explicit_nulls: options.explicit_nulls,
             };
             (Box::new(encoder) as _, array.nulls().cloned())
-        }
-        DataType::Decimal128(_, _) => {
-            let array = array.as_any().downcast_ref::<Decimal128Array>()
-                .ok_or_else(|| ArrowError::InvalidArgumentError("Expected Decimal128Array".to_string()))?;
-            (Box::new(Decimal128Encoder::new(array)) as _, array.nulls().cloned())
         }
         DataType::Decimal256(_, _) => {
             let array = array.as_any().downcast_ref::<Decimal256Array>()
@@ -240,7 +236,7 @@ macro_rules! integer_encode {
         )*
     };
 }
-integer_encode!(i8, i16, i32, i64, u8, u16, u32, u64);
+integer_encode!(i8, i16, i32, i64, i128, u8, u16, u32, u64);
 
 macro_rules! float_encode {
     ($($t:ty),*) => {
@@ -553,23 +549,6 @@ where
             write!(out, "{byte:02x}").unwrap();
         }
         out.push(b'"');
-    }
-}
-
-struct Decimal128Encoder<'a> {
-    array: &'a Decimal128Array,
-}
-
-impl<'a> Decimal128Encoder<'a> {
-    fn new(array: &'a Decimal128Array) -> Self {
-        Self { array }
-    }
-}
-
-impl<'a> Encoder for Decimal128Encoder<'a> {
-    fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
-        let formatted = self.array.value_as_string(idx);
-        out.extend_from_slice(formatted.as_bytes());
     }
 }
 

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -17,8 +17,6 @@
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
-use arrow_array::Decimal128Array;
-use arrow_array::Decimal256Array;
 use arrow_array::*;
 use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_cast::display::{ArrayFormatter, FormatOptions};

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -457,16 +457,22 @@ mod tests {
     }
 
     #[test]
-    fn write_large_utf8() {
+    fn write_large_utf8_and_utf8_view() {
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Utf8, true),
             Field::new("c2", DataType::LargeUtf8, true),
+            Field::new("c3", DataType::Utf8View, true),
         ]);
 
         let a = StringArray::from(vec![Some("a"), None, Some("c"), Some("d"), None]);
         let b = LargeStringArray::from(vec![Some("a"), Some("b"), None, Some("d"), None]);
+        let c = StringViewArray::from(vec![Some("a"), Some("b"), None, Some("d"), None]);
 
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(a), Arc::new(b), Arc::new(c)],
+        )
+        .unwrap();
 
         let mut buf = Vec::new();
         {
@@ -476,10 +482,10 @@ mod tests {
 
         assert_json_eq(
             &buf,
-            r#"{"c1":"a","c2":"a"}
-{"c2":"b"}
+            r#"{"c1":"a","c2":"a","c3":"a"}
+{"c2":"b","c3":"b"}
 {"c1":"c"}
-{"c1":"d","c2":"d"}
+{"c1":"d","c2":"d","c3":"d"}
 {}
 "#,
         );

--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -143,9 +143,7 @@ enum GetResultError {
         actual: Range<usize>,
     },
 
-    #[snafu(display(
-        "Timed out getting data, please increase timeout parameter for {store} client"
-    ))]
+    #[snafu(display("Request timed out, please increase timeout parameter for {store} client"))]
     DataStreamTimeout { store: String },
 }
 

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -671,6 +671,8 @@ impl ClientOptions {
             builder = builder.danger_accept_invalid_certs(true)
         }
 
+        builder = builder.no_gzip();
+
         builder
             .https_only(!self.allow_http.get()?)
             .build()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7073

# Rationale for this change
 
Support for casting large dates from string to Date32.

# What changes are included in this PR?

Extend the `parse_date` method, which is used in the `impl Parser for Date32Type`, to handle dates which are prefixed with `+` or `-`. If the date is not prefixed with `+` or `-`, the existing logic is used unmodified.

This code isn't as optimized as the code for processing more common date formats - but given that these extended dates are relatively rare in practice, I don't think it matters all that much.

# Are there any user-facing changes?

Aside from the desired fix, no.
