### PR TITLE
minor: re-export `OffsetBufferBuilder` in `arrow` crate

### DIFF
--- a/arrow-array/src/builder/buffer_builder.rs
+++ b/arrow-array/src/builder/buffer_builder.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 pub use arrow_buffer::BufferBuilder;
+pub use arrow_buffer::OffsetBufferBuilder;
+
 use half::f16;
 
 use crate::types::*;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
As you can see from the arrow docs, `OffsetBufferBuilder` is not in the arrow crate (it is in arrow_buffe)

https://docs.rs/arrow/latest/arrow/index.html?search=OffsetBufferBuilder

<img width="852" alt="Screenshot 2025-02-05 at 5 41 24 AM" src="https://github.com/user-attachments/assets/9b67ca21-5737-443d-b341-06eeed7a7aca" />


This is a papercut as it means a user needs to add `arrow_buffer` to their project if they want to use this structure (as we do in DataFusion) such as https://github.com/apache/datafusion/blob/5e46314c49a0a65785101269c438a26077a7bdb7/datafusion/substrait/Cargo.toml#L34

# What changes are included in this PR?

RE-export `OffsetBufferBuilder` in `arrow::array::OffsetBufferBuilder`, similarly to `BufferBuilder

https://docs.rs/arrow/latest/arrow/array/struct.BufferBuilder.html

# Are there any user-facing changes?

New export
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
