### PR TITLE
Add another decimal cast edge test case

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10001,7 +10001,7 @@ mod tests {
             520
         );
 
-        // Cast 0 of dcimal(3,0) type to decimal(2,0)
+        // Cast 0 of decimal(3, 0) type to decimal(2, 0)
         assert_eq!(
             &cast(
                 &create_decimal_array(vec![Some(0)], 3, 0).unwrap(),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10000,6 +10000,16 @@ mod tests {
             result.unwrap().as_primitive::<Decimal128Type>().value(0),
             520
         );
+
+        // Cast 0 of dcimal(3,0) type to decimal(2,0)
+        assert_eq!(
+            &cast(
+                &create_decimal_array(vec![Some(0)], 3, 0).unwrap(),
+                &DataType::Decimal128(2, 0)
+            )
+            .unwrap(),
+            &(Arc::new(create_decimal_array(vec![Some(0)], 2, 0).unwrap()) as ArrayRef)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Before 1019f5b27d3596077bcdd7e10b67e2c6d4cfbf02 this test would fail, as the cast produced 1. 0 is an edge case worth explicitly testing for.
