### PR TITLE
Refactor `NullBufferBuilder` to use an internal state machine

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -397,7 +397,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// Return the allocated size of this builder in bytes, useful for memory accounting.
     pub fn allocated_size(&self) -> usize {
         let views = self.views_builder.capacity() * std::mem::size_of::<u128>();
-        let null = self.null_buffer_builder.allocated_size();
+        let null = self.null_buffer_builder.allocated_size() / 8;
         let buffer_size = self.completed.iter().map(|b| b.capacity()).sum::<usize>();
         let in_progress = self.in_progress.capacity();
         let tracker = match &self.string_tracker {

--- a/arrow-buffer/src/builder/boolean.rs
+++ b/arrow-buffer/src/builder/boolean.rs
@@ -83,7 +83,7 @@ impl BooleanBufferBuilder {
         self.len == 0
     }
 
-    /// Returns the capacity of the buffer
+    /// Returns the capacity of the buffer (in bits)
     #[inline]
     pub fn capacity(&self) -> usize {
         self.buffer.capacity() * 8

--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -199,12 +199,15 @@ impl NullBufferBuilder {
                 None
             }
             NullBufferBuilderState::Materialized { bitmap_builder } => {
-                let a = bitmap_builder.finish();
+                let boolean_buffer = bitmap_builder.finish();
                 self.state = NullBufferBuilderState::Unmaterialized {
                     len: 0,
+                    // TODO: Only usage of self.initial_capacity here. Should we be using it,
+                    //       or instead should use bitmap_builder.capacity()? Considering
+                    //       self.initial_capacity <= bitmap_builder.capacity()
                     capacity: self.initial_capacity,
                 };
-                Some(NullBuffer::new(a))
+                Some(NullBuffer::new(boolean_buffer))
             }
         }
     }
@@ -255,7 +258,7 @@ impl NullBufferBuilder {
         }
     }
 
-    /// Return the allocated size of this builder, in bytes, useful for memory accounting.
+    /// Return the allocated size of this builder, in bits, useful for memory accounting.
     pub fn allocated_size(&self) -> usize {
         match &self.state {
             NullBufferBuilderState::Unmaterialized { .. } => 0,


### PR DESCRIPTION
During the course of #7013 I  realized how confusing the internals of `NullBufferBuilder` are, how some private fields are applicable only when the builder is in a certain state; this isn't enforced in the code, rather via comments (and knowledge of the struct).

Experimenting with refactoring it to use an internal state machine to explicitly delineate the different states it can have and therefore enforce at compile time the rules which were previously implicit before.