### PR TITLE
New SerializedPageReader when dictionary page is provided

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -526,7 +526,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
         SerializedPageReader::new_with_properties(reader, meta, total_rows, page_locations, props)
     }
 
-    /// Creates a new serialized page with custom options.
+    /// Creates a new serialized page reader with custom options.
     /// Note: The first page in `page_locations` (if available) 
     /// must be the first data page to infer the dictionary page's location.
     pub fn new_with_properties(
@@ -575,7 +575,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
         }
     }
 
-    /// Creates a new serialized page with custom options and dictionary page (if available).
+    /// Creates a new serialized page reader with custom options and dictionary page (if available).
     /// This method does not require the first page in `page_locations` to be the first data page since 
     /// `dictionary_page` is provided.
     pub fn new_with_properties_and_dictionary(

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -527,7 +527,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
     }
 
     /// Creates a new serialized page reader with custom options.
-    /// Note: The first page in `page_locations` (if available) 
+    /// Note: The first page in `page_locations` (if available)
     /// must be the first data page to infer the dictionary page's location.
     pub fn new_with_properties(
         reader: Arc<R>,
@@ -576,7 +576,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
     }
 
     /// Creates a new serialized page reader with custom options and dictionary page (if available).
-    /// This method does not require the first page in `page_locations` to be the first data page since 
+    /// This method does not require the first page in `page_locations` to be the first data page since
     /// `dictionary_page` is provided.
     pub fn new_with_properties_and_dictionary(
         reader: Arc<R>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/arrow-rs/issues/5940.

# Rationale for this change

Our use case is that we have already iterate through all the page headers of the parquet file at the beginning so we know the location of the dictionary page so we don't want to have to pass the first data page in the `page_location` argument anymore.



<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Adds a new constructor to `SerializedPageReader` to make sure we don't break existing callers of `SerializedPageReader`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Yes in a way that there is a new constructor but existing callers should still be able to function. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
