### PR TITLE
Expose record boundary information in JSON decoder

### DIFF
--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -615,11 +615,27 @@ impl Decoder {
         self.tape_decoder.serialize(rows)
     }
 
+    /// True if the decoder is currently part way through decoding a record.
+    pub fn has_partial_record(&self) -> bool {
+        self.tape_decoder.has_partial_row()
+    }
+
+    /// The number of unflushed records, including the partially decoded record (if any).
+    pub fn len(&self) -> usize {
+        self.tape_decoder.num_buffered_rows()
+    }
+
+    /// True if there are no records to flush, i.e. [`len`] is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Flushes the currently buffered data to a [`RecordBatch`]
     ///
-    /// Returns `Ok(None)` if no buffered data
+    /// Returns `Ok(None)` if no buffered data, i.e. [`is_empty`] is true.
     ///
-    /// Note: if called part way through decoding a record, this will return an error
+    /// Note: This will return an error if called part way through decoding a record,
+    /// i.e. [`has_partial_record`] is true.
     pub fn flush(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
         let tape = self.tape_decoder.finish()?;
 
@@ -802,6 +818,20 @@ mod tests {
             Field::new("d", DataType::Date32, true),
             Field::new("e", DataType::Date64, true),
         ]));
+
+        let mut decoder = ReaderBuilder::new(schema.clone()).build_decoder().unwrap();
+        assert!(decoder.is_empty());
+        assert_eq!(decoder.len(), 0);
+        assert!(!decoder.has_partial_record());
+        assert_eq!(decoder.decode(buf.as_bytes()).unwrap(), 221);
+        assert!(!decoder.is_empty());
+        assert_eq!(decoder.len(), 6);
+        assert!(!decoder.has_partial_record());
+        let batch = decoder.flush().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 6);
+        assert!(decoder.is_empty());
+        assert_eq!(decoder.len(), 0);
+        assert!(!decoder.has_partial_record());
 
         let batches = do_read(buf, 1024, false, false, schema);
         assert_eq!(batches.len(), 1);
@@ -2157,6 +2187,14 @@ mod tests {
             vec![Field::new("child", DataType::Int32, false)],
             true,
         )]));
+
+        let mut decoder = ReaderBuilder::new(schema.clone()).build_decoder().unwrap();
+        let _ = decoder.decode(r#"{"a": { "child":"#.as_bytes()).unwrap();
+        assert!(decoder.tape_decoder.has_partial_row());
+        assert_eq!(decoder.tape_decoder.num_buffered_rows(), 1);
+        let _ = decoder.flush().unwrap_err();
+        assert!(decoder.tape_decoder.has_partial_row());
+        assert_eq!(decoder.tape_decoder.num_buffered_rows(), 1);
 
         let parse_err = |s: &str| {
             ReaderBuilder::new(schema.clone())

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -625,17 +625,17 @@ impl Decoder {
         self.tape_decoder.num_buffered_rows()
     }
 
-    /// True if there are no records to flush, i.e. [`len`] is zero.
+    /// True if there are no records to flush, i.e. [`Self::len`] is zero.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Flushes the currently buffered data to a [`RecordBatch`]
     ///
-    /// Returns `Ok(None)` if no buffered data, i.e. [`is_empty`] is true.
+    /// Returns `Ok(None)` if no buffered data, i.e. [`Self::is_empty`] is true.
     ///
     /// Note: This will return an error if called part way through decoding a record,
-    /// i.e. [`has_partial_record`] is true.
+    /// i.e. [`Self::has_partial_record`] is true.
     pub fn flush(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
         let tape = self.tape_decoder.finish()?;
 

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -550,7 +550,8 @@ impl TapeDecoder {
         self.cur_row
     }
 
-    /// True if the decoder is part way through decoding a row. If so, calling [`finish`] would return an error.
+    /// True if the decoder is part way through decoding a row. If so, calling [`Self::finish`]
+    /// would return an error.
     pub fn has_partial_row(&self) -> bool {
         !self.stack.is_empty()
     }

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -545,6 +545,16 @@ impl TapeDecoder {
         Ok(())
     }
 
+    /// The number of buffered rows, including the partially decoded row (if any).
+    pub fn num_buffered_rows(&self) -> usize {
+        self.cur_row
+    }
+
+    /// True if the decoder is part way through decoding a row. If so, calling [`finish`] would return an error.
+    pub fn has_partial_row(&self) -> bool {
+        !self.stack.is_empty()
+    }
+
     /// Finishes the current [`Tape`]
     pub fn finish(&self) -> Result<Tape<'_>, ArrowError> {
         if let Some(b) = self.stack.last() {
@@ -726,8 +736,12 @@ mod tests {
         "#;
         let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(a.as_bytes()).unwrap();
+        assert!(!decoder.has_partial_row());
+        assert_eq!(decoder.num_buffered_rows(), 7);
 
         let finished = decoder.finish().unwrap();
+        assert!(!decoder.has_partial_row());
+        assert_eq!(decoder.num_buffered_rows(), 7); // didn't call clear() yet
         assert_eq!(
             finished.elements,
             &[
@@ -820,7 +834,11 @@ mod tests {
                 0, 5, 10, 13, 14, 17, 19, 22, 25, 28, 29, 30, 31, 32, 32, 32, 33, 34, 35, 41, 47,
                 52, 55, 57, 58, 59, 62, 63, 63, 66, 69, 70, 71, 72, 73, 74, 75, 76, 77
             ]
-        )
+        );
+
+        decoder.clear();
+        assert!(!decoder.has_partial_row());
+        assert_eq!(decoder.num_buffered_rows(), 0);
     }
 
     #[test]
@@ -874,6 +892,8 @@ mod tests {
         // Test truncation
         let mut decoder = TapeDecoder::new(16, 2);
         decoder.decode(b"{\"he").unwrap();
+        assert!(decoder.has_partial_row());
+        assert_eq!(decoder.num_buffered_rows(), 1);
         let err = decoder.finish().unwrap_err().to_string();
         assert_eq!(err, "Json error: Truncated record whilst reading string");
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/6522

# Rationale for this change

The current JSON decoder gives no way to reliably identify record boundaries in the input (as different from mere whitespace or buffer boundaries), which makes it very difficult to correctly and efficiently parse a series of unrelated JSON values (such as from a `StringArray` column). 

Examples of adversarial inputs include: blank strings (no rows produced), a single string containing multiple records (multiple rows produced), or multiple invalid strings whose concatenation looks like a single record (one row produced). 

Such cases can be detected easily by checking the number of records parsed, and whether the last record was incomplete -- but that state is not publicly accessible (buried in the `TapeDecoder` struct).

# What changes are included in this PR?

Expose two new methods on the `TapeDecoder` struct, which support three new pub methods on `Decoder`, which exposes the number of records the decoder has buffered up so far, and whether the last record is partial (incomplete).

This allows e.g.
```rust
fn parse_one_record(decoder: &mut Decoder, bytes: &[u8]) -> Result<(), ArrowError> {
    let existing_len = decoder.len();
    let decoded_bytes = decoder.decode(bytes)?;
    assert_eq!(decoded_bytes, bytes.len()); // all bytes consumed
    assert_eq!(decoder.len(), existing_len + 1); // exactly one record produced
    assert!(!decoder.has_partial_record()); // the record was complete
    Ok(())
}
```

Also update documentation and add unit tests.

# Are there any user-facing changes?

Three new public methods on `Decoder`: `has_partial_record`, `len`, and `is_empty`.