### PR TITLE
bugfix: adjust allocated_size() in GenericByteViewBuilder

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -404,10 +404,6 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
             Some((ht, _)) => ht.capacity() * std::mem::size_of::<usize>(),
             None => 0,
         };
-        println!(
-            "views: {}, null: {}, buffer: {}, in_progress: {}, tracker: {}",
-            views, null, buffer_size, in_progress, tracker
-        );
         buffer_size + in_progress + tracker + views + null
     }
 }

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -397,7 +397,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// Return the allocated size of this builder in bytes, useful for memory accounting.
     pub fn allocated_size(&self) -> usize {
         let views = self.views_builder.capacity() * std::mem::size_of::<u128>();
-        let null = self.null_buffer_builder.allocated_size();
+        let null = self.null_buffer_builder.allocated_size() / 8;
         let buffer_size = self.completed.iter().map(|b| b.capacity()).sum::<usize>();
         let in_progress = self.in_progress.capacity();
         let tracker = match &self.string_tracker {

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -404,6 +404,10 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
             Some((ht, _)) => ht.capacity() * std::mem::size_of::<usize>(),
             None => 0,
         };
+        println!(
+            "views: {}, null: {}, buffer: {}, in_progress: {}, tracker: {}",
+            views, null, buffer_size, in_progress, tracker
+        );
         buffer_size + in_progress + tracker + views + null
     }
 }
@@ -729,5 +733,17 @@ mod tests {
             exp_builder.completed.last().unwrap().capacity(),
             MAX_BLOCK_SIZE as usize
         );
+    }
+
+    #[test]
+    fn test_string_view_size() {
+        let mut builder = StringViewBuilder::new();
+        assert_eq!(builder.allocated_size(), 16384);
+
+        builder.append_value("hello");
+        assert_eq!(builder.allocated_size(), 16384);
+
+        builder.append_null();
+        assert_eq!(builder.allocated_size(), 16384 + 128);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7099 .

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

As #7099 says, `allocated_size()` in `GenericByteViewBuilder` needs to be adjusted since allocated_size() in `NullBufferBuilder` returns bits, not bytes. 
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

1. Divide the `allocated_size` by 8.
2. Add related test

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
