### PR TITLE
object_store/gcp: derive Clone for GoogleCloudStorage

### DIFF
--- a/object_store/src/gcp/mod.rs
+++ b/object_store/src/gcp/mod.rs
@@ -72,7 +72,7 @@ pub type GcpSigningCredentialProvider =
     Arc<dyn CredentialProvider<Credential = GcpSigningCredential>>;
 
 /// Interface for [Google Cloud Storage](https://cloud.google.com/storage/).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GoogleCloudStorage {
     client: Arc<GoogleCloudStorageClient>,
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7113.

# Rationale for this change
 
Deriving Clone will be useful for callers who wish to take advantage of the Arc and and share ownership across threads or callsites.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->


# Are there any user-facing changes?

Users will see the new derive in docs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
