### PR TITLE
fix: NullBufferBuilder::allocated_size should return Size in Bytes

### DIFF
--- a/arrow-buffer/src/builder/null.rs
+++ b/arrow-buffer/src/builder/null.rs
@@ -217,11 +217,11 @@ impl NullBufferBuilder {
         self.bitmap_builder.as_mut().map(|b| b.as_slice_mut())
     }
 
-    /// Return the allocated size of this builder, in bits, useful for memory accounting.
+    /// Return the allocated size of this builder, in bytes, useful for memory accounting.
     pub fn allocated_size(&self) -> usize {
         self.bitmap_builder
             .as_ref()
-            .map(|b| b.capacity())
+            .map(|b| b.capacity() / 8)
             .unwrap_or(0)
     }
 }
@@ -250,7 +250,7 @@ mod tests {
         builder.append_n_nulls(2);
         builder.append_n_non_nulls(2);
         assert_eq!(6, builder.len());
-        assert_eq!(512, builder.allocated_size());
+        assert_eq!(64, builder.allocated_size());
 
         let buf = builder.finish().unwrap();
         assert_eq!(&[0b110010_u8], buf.validity());
@@ -263,7 +263,7 @@ mod tests {
         builder.append_n_nulls(2);
         builder.append_slice(&[false, false, false]);
         assert_eq!(6, builder.len());
-        assert_eq!(512, builder.allocated_size());
+        assert_eq!(64, builder.allocated_size());
 
         let buf = builder.finish().unwrap();
         assert_eq!(&[0b0_u8], buf.validity());
@@ -327,7 +327,7 @@ mod tests {
         builder.append_null();
         builder.append_non_null();
         assert_eq!(builder.as_slice().unwrap(), &[0xFF, 0b10111111]);
-        assert_eq!(builder.allocated_size(), 512);
+        assert_eq!(builder.allocated_size(), 64);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7121.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Refer to the comment from @tustvold in [issue#7121](https://github.com/apache/arrow-rs/pull/7121)

"Given no reasonable allocator allocates memory in bits, it is somewhat expected that the quantity returned is in bytes, and returning in bits is a bug."

# What changes are included in this PR?
Updates the `NullBufferBuilder::allocated_size` function to return the size in bytes.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

This change will break public API usage of `NullBufferBuilder::allocated_size`:
- the returned size after this change will be different from the size returned before  (1/8 of the original value).
