### PR TITLE
refactor: remove unused `async` from `InMemory::entry`

### DIFF
--- a/object_store/src/memory.rs
+++ b/object_store/src/memory.rs
@@ -235,7 +235,7 @@ impl ObjectStore for InMemory {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        let entry = self.entry(location).await?;
+        let entry = self.entry(location)?;
         let e_tag = entry.e_tag.to_string();
 
         let meta = ObjectMeta {
@@ -270,7 +270,7 @@ impl ObjectStore for InMemory {
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
-        let entry = self.entry(location).await?;
+        let entry = self.entry(location)?;
         ranges
             .iter()
             .map(|range| {
@@ -295,7 +295,7 @@ impl ObjectStore for InMemory {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let entry = self.entry(location).await?;
+        let entry = self.entry(location)?;
 
         Ok(ObjectMeta {
             location: location.clone(),
@@ -390,7 +390,7 @@ impl ObjectStore for InMemory {
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-        let entry = self.entry(from).await?;
+        let entry = self.entry(from)?;
         self.storage
             .write()
             .insert(to, entry.data, entry.attributes);
@@ -398,7 +398,7 @@ impl ObjectStore for InMemory {
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-        let entry = self.entry(from).await?;
+        let entry = self.entry(from)?;
         let mut storage = self.storage.write();
         if storage.map.contains_key(to) {
             return Err(Error::AlreadyExists {
@@ -483,7 +483,7 @@ impl InMemory {
         Self { storage }
     }
 
-    async fn entry(&self, location: &Path) -> Result<Entry> {
+    fn entry(&self, location: &Path) -> Result<Entry> {
         let storage = self.storage.read();
         let value = storage
             .map


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Keep the code readable and clean.

# What changes are included in this PR?
Removes an `async` from a method that is effectively sync.

# Are there any user-facing changes?
None. It's a private method.
