### PR TITLE
Minor: Add doctest to ArrayDataBuilder::build_unchecked 

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1929,7 +1929,13 @@ impl ArrayDataBuilder {
 
     /// Creates an array data, without any validation
     ///
-    /// Note: This is shorthand for `self.skip_validation(true).build().unwrap()`
+    /// Note: This is shorthand for
+    /// ```rust
+    /// # let mut builder = arrow_data::ArrayDataBuilder::new(arrow_schema::DataType::Null);
+    /// # let _ = unsafe {
+    /// builder.skip_validation(true).build().unwrap()
+    /// # };
+    /// ```
     ///
     /// # Safety
     ///


### PR DESCRIPTION
# Which issue does this PR close?

Follow on to #7103 

# Rationale for this change
 
As suggested by @Jefffrey in https://github.com/apache/arrow-rs/pull/7103#discussion_r1948665705, making the code block into a doctest would catch any future error in tests

# What changes are included in this PR?

Transform the code block into a doctest

# Are there any user-facing changes?

Docs only
