### PR TITLE
object_store: Disable all compression formats in HTTP reqwest client

### DIFF
--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -671,9 +671,11 @@ impl ClientOptions {
             builder = builder.danger_accept_invalid_certs(true)
         }
 
-        // Reqwest will remove the `Content-Length` header if it is configured to
-        // transparently decompress the body via the non-default `gzip` feature.
-        builder = builder.no_gzip();
+        // Explicitly disable compression, since it may be automatically enabled
+        // when certain reqwest features are enabled. Compression interferes
+        // with the `Content-Length` header, which is used to determine the
+        // size of objects.
+        builder = builder.no_gzip().no_brotli().no_zstd().no_deflate();
 
         builder
             .https_only(!self.allow_http.get()?)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7142.

# Rationale for this change

Resolves an issue where enabling extra compression features in reqwest (`zstd`, `brotli`, `deflate`) would cause the client to automatically include the `Accept-Encoding` header in the request, which-- in turn-- may cause an HTTP server to respond with compression. Reqwest would then filter out `Content-Length` from the response, resulting in an error.

# What changes are included in this PR?

This PR expands on the work from #6843 to disable all the compression formats that reqwest (currently) supports. Now, in addition to disabling `gzip`, the compression formats `zstd`, `brotli`, and `deflate` are also disabled.

# Are there any user-facing changes?

Behind the scenes, the `Accept-Encoding` header on outbound HTTP requests may have changed if the reqwest features `zstd`, `brotli`, or `deflate` were enabled. The only effect users should notice is that HTTP requests that were once failing due to a missing `Content-Length` header may now succeed.