### PR TITLE
Use `doc_auto_cfg`, logo and favicon for docs.rs

### DIFF
--- a/arrow-arith/Cargo.toml
+++ b/arrow-arith/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_arith"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -40,5 +42,3 @@ arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
-
-[dev-dependencies]

--- a/arrow-arith/src/lib.rs
+++ b/arrow-arith/src/lib.rs
@@ -17,6 +17,12 @@
 
 //! Arrow arithmetic and aggregation kernels
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 pub mod aggregate;
 #[doc(hidden)] // Kernels to be removed in a future release

--- a/arrow-arith/src/lib.rs
+++ b/arrow-arith/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 pub mod aggregate;
 #[doc(hidden)] // Kernels to be removed in a future release

--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -30,9 +30,7 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_array"
-path = "src/lib.rs"
 bench = false
-
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
@@ -50,6 +48,9 @@ num = { version = "0.4.1", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.15.1", default-features = false }
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi"]
 force_validate = []
@@ -57,8 +58,6 @@ force_validate = []
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 criterion = { version = "0.5", default-features = false }
-
-[build-dependencies]
 
 [[bench]]
 name = "occupancy"

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -226,7 +226,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -221,6 +221,12 @@
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [RecordBatchStream]: https://docs.rs/datafusion/latest/datafusion/execution/trait.RecordBatchStream.html
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-avro/Cargo.toml
+++ b/arrow-avro/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_avro"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 default = ["deflate", "snappy", "zstd"]
@@ -49,7 +51,5 @@ snap = { version = "1.0", default-features = false, optional = true }
 zstd = { version = "0.13", default-features = false, optional = true }
 crc = { version = "3.0", optional = true }
 
-
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-

--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -25,7 +25,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 #![allow(unused)] // Temporary
 

--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -20,6 +20,12 @@
 //! [Apache Arrow]: https://arrow.apache.org
 //! [Apache Avro]: https://avro.apache.org/
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 #![allow(unused)] // Temporary
 

--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_buffer"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 bytes = { version = "1.4" }
@@ -41,8 +43,6 @@ half = { version = "2.1", default-features = false }
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-
-[build-dependencies]
 
 [[bench]]
 name = "bit_mask"

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -17,6 +17,12 @@
 
 //! Low-level buffer abstractions for [Apache Arrow Rust](https://docs.rs/arrow)
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 // used by [`buffer::mutable::dangling_ptr`]
 #![cfg_attr(miri, feature(strict_provenance))]
 #![warn(missing_docs)]

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 // used by [`buffer::mutable::dangling_ptr`]
 #![cfg_attr(miri, feature(strict_provenance))]
 #![warn(missing_docs)]

--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -30,11 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_cast"
-path = "src/lib.rs"
 bench = false
 
 [package.metadata.docs.rs]
-features = ["prettyprint"]
+all-features = true
 
 [features]
 prettyprint = ["comfy-table"]
@@ -59,8 +58,6 @@ ryu = "1.0.16"
 criterion = { version = "0.5", default-features = false }
 half = { version = "2.1", default-features = false }
 rand = "0.8"
-
-[build-dependencies]
 
 [[bench]]
 name = "parse_timestamp"

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 pub mod cast;
 pub use cast::*;

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -17,6 +17,12 @@
 
 //! Functions for converting from one data type to another in [Apache Arrow](https://docs.rs/arrow)
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 pub mod cast;
 pub use cast::*;

--- a/arrow-csv/Cargo.toml
+++ b/arrow-csv/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_csv"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 
 pub mod reader;

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -17,6 +17,12 @@
 
 //! Transfer data between the Arrow memory format and CSV (comma-separated values).
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 
 pub mod reader;

--- a/arrow-data/Cargo.toml
+++ b/arrow-data/Cargo.toml
@@ -30,7 +30,6 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_data"
-path = "src/lib.rs"
 bench = false
 
 [features]
@@ -42,7 +41,7 @@ force_validate = []
 ffi = ["arrow-schema/ffi"]
 
 [package.metadata.docs.rs]
-features = ["ffi"]
+all-features = true
 
 [dependencies]
 

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -24,7 +24,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 mod data;
 pub use data::*;

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -19,6 +19,12 @@
 //!
 //! For a higher-level, strongly-typed interface see [arrow_array](https://docs.rs/arrow_array)
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 mod data;
 pub use data::*;

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -42,7 +42,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![allow(rustdoc::invalid_html_tags)]
 #![warn(missing_docs)]
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -36,6 +36,13 @@
 //!    `flight-sql-experimental` feature of this crate to be activated.
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
+
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![allow(rustdoc::invalid_html_tags)]
 #![warn(missing_docs)]
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets

--- a/arrow-integration-test/Cargo.toml
+++ b/arrow-integration-test/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_integration_test"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow = { workspace = true }
@@ -40,5 +42,3 @@ hex = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["rc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 num = { version = "0.4", default-features = false, features = ["std"] }
-
-[build-dependencies]

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -26,7 +26,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -21,6 +21,12 @@
 //!
 //! This is not a canonical format, but provides a human-readable way of verifying language implementations
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;

--- a/arrow-ipc/Cargo.toml
+++ b/arrow-ipc/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_ipc"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -38,6 +38,12 @@
 //! [FileReader]: reader::FileReader
 //! [FileWriter]: writer::FileWriter
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 pub mod convert;
 pub mod reader;

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -43,7 +43,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 pub mod convert;
 pub mod reader;

--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_json"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -59,4 +61,3 @@ rand = { version = "0.8", default-features = false, features = ["std", "std_rng"
 [[bench]]
 name = "serde"
 harness = false
-

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -63,6 +63,12 @@
 //! [binary-to-text encoding]: https://en.wikipedia.org/wiki/Binary-to-text_encoding
 //!
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -68,7 +68,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-ord/Cargo.toml
+++ b/arrow-ord/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_ord"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -48,7 +48,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 pub mod cmp;
 #[doc(hidden)]

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -43,6 +43,12 @@
 //! ```
 //!
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 pub mod cmp;
 #[doc(hidden)]

--- a/arrow-row/Cargo.toml
+++ b/arrow-row/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_row"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -45,6 +47,3 @@ half = { version = "2.1", default-features = false }
 arrow-cast = { workspace = true }
 arrow-ord = { workspace = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-
-[features]
-

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -130,7 +130,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -125,6 +125,12 @@
 //! [compared]: PartialOrd
 //! [compare]: PartialOrd
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -30,7 +30,6 @@ rust-version = "1.64"
 
 [lib]
 name = "arrow_schema"
-path = "src/lib.rs"
 bench = false
 
 [dependencies]
@@ -49,7 +48,7 @@ ffi = ["bitflags"]
 serde = ["dep:serde"]
 
 [package.metadata.docs.rs]
-features = ["ffi"]
+all-features = true
 
 [dev-dependencies]
 bincode = { version = "1.3.3", default-features = false }

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -15,8 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![warn(missing_docs)]
 //! Arrow logical types
+
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![warn(missing_docs)]
 
 mod datatype;
 

--- a/arrow-select/Cargo.toml
+++ b/arrow-select/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_select"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-buffer = { workspace = true }
@@ -40,9 +42,6 @@ arrow-schema = { workspace = true }
 arrow-array = { workspace = true }
 num = { version = "0.4", default-features = false, features = ["std"] }
 ahash = { version = "0.8", default-features = false}
-
-[features]
-default = []
 
 [dev-dependencies]
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/arrow-select/src/lib.rs
+++ b/arrow-select/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 
 pub mod concat;

--- a/arrow-select/src/lib.rs
+++ b/arrow-select/src/lib.rs
@@ -15,8 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![warn(missing_docs)]
 //! Arrow selection kernels
+
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+#![warn(missing_docs)]
 
 pub mod concat;
 mod dictionary;

--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -30,8 +30,10 @@ rust-version = { workspace = true }
 
 [lib]
 name = "arrow_string"
-path = "src/lib.rs"
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow-buffer = { workspace = true }

--- a/arrow-string/src/lib.rs
+++ b/arrow-string/src/lib.rs
@@ -15,8 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![warn(missing_docs)]
 //! Arrow string kernels
+
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+#![warn(missing_docs)]
 
 mod binary_like;
 mod binary_predicate;

--- a/arrow-string/src/lib.rs
+++ b/arrow-string/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 
 mod binary_like;

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -34,8 +34,6 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [lib]
-name = "arrow"
-path = "src/lib.rs"
 bench = false
 
 [dependencies]
@@ -58,7 +56,7 @@ pyo3 = { version = "0.23", default-features = false, optional = true }
 half = { version = "2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
-features = ["prettyprint", "ipc_compression", "ffi", "pyarrow"]
+all-features = true
 
 [features]
 default = ["csv", "ipc", "json"]

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -367,7 +367,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -362,6 +362,12 @@
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [issue tracker]: https://github.com/apache/arrow-rs/issues
 
+#![doc(
+    html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",
+    html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_copy_implementations,

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -87,7 +87,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 /// Defines a an item with an experimental public API
 ///

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -82,6 +82,12 @@
 //! [Logical Types]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 //! [object_store]: https://docs.rs/object_store/latest/object_store/
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 /// Defines a an item with an experimental public API
 ///

--- a/parquet_derive/Cargo.toml
+++ b/parquet_derive/Cargo.toml
@@ -36,3 +36,6 @@ proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
 syn = { version = "2.0", features = ["extra-traits"] }
 parquet = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -23,7 +23,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![warn(missing_docs)]
 #![recursion_limit = "128"]
 

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -18,6 +18,12 @@
 //! This crate provides a procedural macro to derive
 //! implementations of a RecordWriter and RecordReader
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![warn(missing_docs)]
 #![recursion_limit = "128"]
 

--- a/parquet_derive_test/Cargo.toml
+++ b/parquet_derive_test/Cargo.toml
@@ -33,3 +33,6 @@ parquet = { workspace = true }
 parquet_derive = { path = "../parquet_derive", default-features = false }
 chrono = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -15,6 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
+)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 #![allow(clippy::approx_constant)]
 
 use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -20,7 +20,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-
 #![allow(clippy::approx_constant)]
 
 use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
1. Make it easier to discover required features for items in the arrow, parquet and object_store crates on docs.rs.
2. Add logos and favicon for arrow and parquet crates on docs.rs.

# What changes are included in this PR?

- `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` for all published crates (also the ones without features, to make this work when features are added in the feature).
- Set `all-features = true` in `[package.metadata.docs.rs]` for those crates to get docs for all items.
- Add logos for arrow ([logo](https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg) and [favicon](https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg)) and parquet ([logo/favicon](
https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg)) on docs.rs.
- Removed `src/lib.rs` from `[lib]` sections (this is the default value), and removed some empty `[*-dependencies]` sections in `Cargo.toml` files.

To test this locally (requires nightly rust + cargo-docs-rs):
```
rustup toolchain install nightly
cargo install --locked cargo-docs-rs
cargo +nightly docs-rs -p <crate>
```

# Are there any user-facing changes?

Users will now see required features on docs.rs.
