### PR TITLE
object_store/gcp: do not double-percent-encode object paths

### DIFF
--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -40,7 +40,7 @@ use hyper::header::{
     CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LENGTH,
     CONTENT_TYPE,
 };
-use percent_encoding::{percent_encode, utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use reqwest::header::HeaderName;
 use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -353,10 +353,9 @@ impl GoogleCloudStorageClient {
     }
 
     pub(crate) fn object_url(&self, path: &Path) -> String {
-        let encoded = utf8_percent_encode(path.as_ref(), NON_ALPHANUMERIC);
         format!(
             "{}/{}/{}",
-            self.config.base_url, self.bucket_name_encoded, encoded
+            self.config.base_url, self.bucket_name_encoded, path,
         )
     }
 
@@ -556,8 +555,7 @@ impl GoogleCloudStorageClient {
         let credential = self.get_credential().await?;
         let url = self.object_url(to);
 
-        let from = utf8_percent_encode(from.as_ref(), NON_ALPHANUMERIC);
-        let source = format!("{}/{}", self.bucket_name_encoded, from);
+        let source = format!("{}/{}", self.bucket_name_encoded, from.as_ref());
 
         let mut builder = self
             .client


### PR DESCRIPTION
Closes #7148.


# Rationale for this change
 
Right now the `object_store` crate can't read an object in GCS with name `[foo]`.

`GoogleCloudStorage::get(&Path::from("[foo]")` will see the object name percent encoded once in `PathPart::from`, then again in `GoogleCloudStorageClient::object_url`, and the resulting request URL will be double-encoded `%255Bfoo%255D` instead of `%5Bfoo%5D`.

This double-encoding seems like a bug to me. It probably doesn't affect clients who exclusively use the `object_store` crate (since the double encoding happens on read and write) but for those operating across multiple clients, this is a serious issue.

Fixing this bug will introduce a backwards-compatibility issue for users who have written double-encoded object paths into GCS using `object_store`. If this is not acceptable, I can add an option into the client and client builder to enable or disable this behavior.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
