### PR TITLE
fix: Data type inference for NaN, inf and -inf in csv files

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1661,7 +1661,7 @@ mod tests {
         let mut csv = builder.build(file).unwrap();
         let batch = csv.next().unwrap().unwrap();
 
-        assert_eq!(7, batch.num_rows());
+        assert_eq!(10, batch.num_rows());
         assert_eq!(6, batch.num_columns());
 
         let schema = batch.schema();
@@ -1805,6 +1805,9 @@ mod tests {
         assert_eq!(infer_field_schema("10.2"), DataType::Float64);
         assert_eq!(infer_field_schema(".2"), DataType::Float64);
         assert_eq!(infer_field_schema("2."), DataType::Float64);
+        assert_eq!(infer_field_schema("NaN"), DataType::Float64);
+        assert_eq!(infer_field_schema("inf"), DataType::Float64);
+        assert_eq!(infer_field_schema("-inf"), DataType::Float64);
         assert_eq!(infer_field_schema("true"), DataType::Boolean);
         assert_eq!(infer_field_schema("trUe"), DataType::Boolean);
         assert_eq!(infer_field_schema("false"), DataType::Boolean);
@@ -2374,7 +2377,7 @@ mod tests {
     fn test_buffered() {
         let tests = [
             ("test/data/uk_cities.csv", false, 37),
-            ("test/data/various_types.csv", true, 7),
+            ("test/data/various_types.csv", true, 10),
             ("test/data/decimal_test.csv", false, 10),
         ];
 

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -221,7 +221,7 @@ impl InferredDataType {
             } else {
                 1 << m
             }
-        } else if string == "NaN" || string == "inf" || string == "-inf" {
+        } else if string == "NaN" || string == "nan" || string == "inf" || string == "-inf" {
             1 << 2 // Float64
         } else {
             1 << 8 // Utf8
@@ -1806,6 +1806,7 @@ mod tests {
         assert_eq!(infer_field_schema(".2"), DataType::Float64);
         assert_eq!(infer_field_schema("2."), DataType::Float64);
         assert_eq!(infer_field_schema("NaN"), DataType::Float64);
+        assert_eq!(infer_field_schema("nan"), DataType::Float64);
         assert_eq!(infer_field_schema("inf"), DataType::Float64);
         assert_eq!(infer_field_schema("-inf"), DataType::Float64);
         assert_eq!(infer_field_schema("true"), DataType::Boolean);

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -221,6 +221,8 @@ impl InferredDataType {
             } else {
                 1 << m
             }
+        } else if string == "NaN" || string == "inf" || string == "-inf" {
+            1 << 2 // Float64
         } else {
             1 << 8 // Utf8
         }

--- a/arrow-csv/test/data/various_types.csv
+++ b/arrow-csv/test/data/various_types.csv
@@ -6,3 +6,6 @@ c_int|c_float|c_string|c_bool|c_date|c_datetime
 5|6.6|""|false|1990-01-01|1990-01-01T03:00:00
 4|4e6||false||
 4|4.0e-6||false||
+6|NaN||false||
+7|inf||false||
+8|-inf||false||


### PR DESCRIPTION
# Which issue does this PR close?
Closes #7149

# Rationale for this change
`NaN`, `inf` and `-inf` will be inferred as `Float64`, not `Utf8` as of now

