### PR TITLE
Avoid overflow of remainder

### DIFF
--- a/arrow-arith/src/numeric.rs
+++ b/arrow-arith/src/numeric.rs
@@ -1148,7 +1148,6 @@ mod tests {
         assert_eq!(&r.values()[..5], &[0., 0., 6., -1., -1.]);
         assert!(r.value(5).is_nan());
 
-
         let result = rem_wrapping(&a, &b).unwrap();
         let r = result.as_primitive::<Float32Type>();
         assert_eq!(&r.values()[..5], &[0., 0., 6., -1., -1.]);

--- a/arrow-arith/src/numeric.rs
+++ b/arrow-arith/src/numeric.rs
@@ -1135,7 +1135,21 @@ mod tests {
         assert_eq!(r.value(3), -4. / -3.);
         assert!(r.value(5).is_nan());
 
+        let result = div_wrapping(&a, &b).unwrap();
+        let r = result.as_primitive::<Float32Type>();
+        assert_eq!(r.value(0), 1.);
+        assert_eq!(r.value(1), 1.);
+        assert!(r.value(2) < f32::EPSILON);
+        assert_eq!(r.value(3), -4. / -3.);
+        assert!(r.value(5).is_nan());
+
         let result = rem(&a, &b).unwrap();
+        let r = result.as_primitive::<Float32Type>();
+        assert_eq!(&r.values()[..5], &[0., 0., 6., -1., -1.]);
+        assert!(r.value(5).is_nan());
+
+
+        let result = rem_wrapping(&a, &b).unwrap();
         let r = result.as_primitive::<Float32Type>();
         assert_eq!(&r.values()[..5], &[0., 0., 6., -1., -1.]);
         assert!(r.value(5).is_nan());
@@ -1217,7 +1231,11 @@ mod tests {
             .unwrap();
         let err = div(&a, &b).unwrap_err().to_string();
         assert_eq!(err, "Divide by zero error");
+        let err = div_wrapping(&a, &b).unwrap_err().to_string();
+        assert_eq!(err, "Divide by zero error");
         let err = rem(&a, &b).unwrap_err().to_string();
+        assert_eq!(err, "Divide by zero error");
+        let err = rem_wrapping(&a, &b).unwrap_err().to_string();
         assert_eq!(err, "Divide by zero error");
     }
 

--- a/arrow/benches/arithmetic_kernels.rs
+++ b/arrow/benches/arithmetic_kernels.rs
@@ -60,18 +60,12 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| criterion::black_box(mul_wrapping(&arr_a, &scalar).unwrap()))
         });
         c.bench_function(&format!("divide({null_density})"), |b| {
-            b.iter(|| criterion::black_box(div_wrapping(&arr_a, &arr_b).unwrap()))
-        });
-        c.bench_function(&format!("divide_checked({null_density})"), |b| {
             b.iter(|| criterion::black_box(div(&arr_a, &arr_b).unwrap()))
         });
         c.bench_function(&format!("divide_scalar({null_density})"), |b| {
             b.iter(|| criterion::black_box(div(&arr_a, &scalar).unwrap()))
         });
         c.bench_function(&format!("modulo({null_density})"), |b| {
-            b.iter(|| criterion::black_box(rem_wrapping(&arr_a, &arr_b).unwrap()))
-        });
-        c.bench_function(&format!("modulo_checked({null_density})"), |b| {
             b.iter(|| criterion::black_box(rem(&arr_a, &arr_b).unwrap()))
         });
         c.bench_function(&format!("modulo_scalar({null_density})"), |b| {

--- a/arrow/benches/arithmetic_kernels.rs
+++ b/arrow/benches/arithmetic_kernels.rs
@@ -60,12 +60,18 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| criterion::black_box(mul_wrapping(&arr_a, &scalar).unwrap()))
         });
         c.bench_function(&format!("divide({null_density})"), |b| {
+            b.iter(|| criterion::black_box(div_wrapping(&arr_a, &arr_b).unwrap()))
+        });
+        c.bench_function(&format!("divide_checked({null_density})"), |b| {
             b.iter(|| criterion::black_box(div(&arr_a, &arr_b).unwrap()))
         });
         c.bench_function(&format!("divide_scalar({null_density})"), |b| {
             b.iter(|| criterion::black_box(div(&arr_a, &scalar).unwrap()))
         });
         c.bench_function(&format!("modulo({null_density})"), |b| {
+            b.iter(|| criterion::black_box(rem_wrapping(&arr_a, &arr_b).unwrap()))
+        });
+        c.bench_function(&format!("modulo_checked({null_density})"), |b| {
             b.iter(|| criterion::black_box(rem(&arr_a, &arr_b).unwrap()))
         });
         c.bench_function(&format!("modulo_scalar({null_density})"), |b| {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7158.

# Rationale for this change

~~The `div/rem` operations may also overflow, so I want to add `div_wrapping/rem_wrapping` operations to wrapping on overflow. Make it consistent with the logic of `add/sub/mul` so that we can implement `fail_on_overflow` feature for `div/rem` in downstream `datafusion`.~~

make `signed_integer::MIN % -1` return 0

# What changes are included in this PR?

~~add `div_wrapping/rem_wrapping` functions~~

use `mod_wrapping` for `Op::Rem`

# Are there any user-facing changes?

~~yes, newly added `div_wrapping/rem_wrapping` functions~~

yes, `signed_integer::MIN % -1` will not result in an error but return 0