### PR TITLE
feat: implement GetOptions extensions

### DIFF
--- a/object_store/src/extensions.rs
+++ b/object_store/src/extensions.rs
@@ -1,0 +1,191 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::Arc,
+};
+
+/// Trait that must be implemented by extensions.
+pub trait Extension: std::fmt::Debug + Send + Sync {
+    /// Return a &Any for this type.
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Ensure that [`Extensions`] can implement [`std::cmp::PartialEq`] by requiring [`ExtTrait`]
+    /// implementors to implement a dyn-compatible partial equality operation.
+    ///
+    /// This is necessary because [`std::cmp::PartialEq`] uses a `Self` type parameter, which
+    /// violates dyn-compatibility rules: https://doc.rust-lang.org/error_codes/E0038.html#trait-uses-self-as-a-type-parameter-in-the-supertrait-listing
+    fn partial_eq(&self, other: &dyn std::any::Any) -> bool;
+}
+
+type ExtensionMap = HashMap<TypeId, Arc<dyn Extension>>;
+type Ext = Arc<dyn Any + Send + Sync + 'static>;
+
+/// Type that holds opaque instances of types referenced by their [`std::any::TypeId`].
+///
+/// Types are stored as instances of the [`Extension`] trait in order to enable implementation of
+/// [`std::fmt::Debug`] and [`std::cmp::PartialEq`].
+#[derive(Debug, Default, Clone)]
+pub struct Extensions {
+    inner: ExtensionMap,
+}
+
+impl PartialEq for Extensions {
+    fn eq(&self, other: &Self) -> bool {
+        for (k, v) in &self.inner {
+            if let Some(ov) = other.inner.get(&k) {
+                if !v.partial_eq(ov.as_any()) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl Extensions {
+    pub(crate) fn set_ext<T: Extension + 'static>(&mut self, t: T) {
+        let id = t.type_id();
+        let a = Arc::new(t);
+        self.inner.insert(id, a);
+    }
+
+    pub(crate) fn get_ext<T: Extension + 'static>(&self) -> Option<&T> {
+        let id = TypeId::of::<T>();
+        self.inner
+            .get(&id)
+            .map(|e| e.as_any().downcast_ref())
+            .flatten()
+    }
+}
+
+impl From<HashMap<TypeId, Ext>> for Extensions {
+    fn from(other: HashMap<TypeId, Ext>) -> Self {
+        let mut s = Self::default();
+        for (k, v) in other {
+            let v = Arc::new(ExtWrapper::new(v));
+            s.inner.insert(k, v);
+        }
+        s
+    }
+}
+
+/// Type that implements [`Extension`] for the sake of converting to [`Extensions`] from external
+/// instances of `HashMap<TypeId, Ext>'.
+#[derive(Debug)]
+struct ExtWrapper<T: std::fmt::Debug> {
+    inner: Arc<T>,
+}
+
+impl<T: std::fmt::Debug> ExtWrapper<T> {
+    fn new(v: T) -> Self {
+        Self { inner: Arc::new(v) }
+    }
+}
+
+impl<T: Any + Send + Sync + std::fmt::Debug + 'static> Extension for ExtWrapper<T> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_ref()
+    }
+
+    fn partial_eq(&self, other: &dyn std::any::Any) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct MyExt {
+        x: u8,
+    }
+
+    impl Extension for MyExt {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn partial_eq(&self, other: &dyn std::any::Any) -> bool {
+            let self_id = self.type_id();
+            let other_id = other.type_id();
+            println!("MyExt.partial_eq");
+            println!(
+                "  self  : {self_id:?}, {}",
+                std::any::type_name_of_val(self)
+            );
+            println!(
+                "  other : {other_id:?}, {}",
+                std::any::type_name_of_val(other)
+            );
+            other
+                .downcast_ref::<Self>()
+                .inspect(|v| println!("{v:?}"))
+                .map(|other| self.x == other.x)
+                .unwrap_or_default()
+        }
+    }
+
+    #[test]
+    fn custom_ext_trait_impl() {
+        let mut exts1 = Extensions::default();
+        let myext1 = MyExt { x: 0 };
+        exts1.set_ext(myext1);
+        let t1 = TypeId::of::<MyExt>();
+        println!("type id of MyExt: {t1:?}");
+
+        let mut exts2 = Extensions::default();
+        let myext2 = MyExt { x: 1 };
+        exts2.set_ext(myext2);
+
+        assert_ne!(
+            exts1, exts2,
+            "extensions of the same type with different values should not be equal"
+        );
+
+        let mut exts3 = Extensions::default();
+        let myext3 = MyExt { x: 0 };
+        exts3.set_ext(myext3);
+
+        assert_eq!(
+            exts1, exts3,
+            "extensions of the same type with the same values should be equal"
+        );
+    }
+
+    #[test]
+    fn ext_wrapper() {
+        let v1 = 0;
+        let v2 = 1;
+        let v3 = 0;
+
+        let wrapped1 = ExtWrapper::new(v1);
+        let wrapped2 = ExtWrapper::new(v2);
+        let wrapped3 = ExtWrapper::new(v3);
+
+        let t1 = wrapped1.type_id();
+        println!("type id of ExtWrapper<i32>: {t1:?}");
+
+        let t2 = wrapped2.type_id();
+        println!("type id of ExtWrapper<i32>: {t2:?}");
+
+        let mut exts1 = Extensions::default();
+        exts1.set_ext(wrapped1);
+
+        let mut exts2 = Extensions::default();
+        exts2.set_ext(wrapped2);
+
+        assert_eq!(
+            exts1, exts2,
+            "extentions of type ExtWrapper are always equal even if their values aren't"
+        );
+
+        let mut exts3 = Extensions::default();
+        exts3.set_ext(wrapped3);
+
+        assert_eq!(exts1, exts3, "extentions of type ExtWrapper are equal");
+    }
+}

--- a/object_store/src/extensions.rs
+++ b/object_store/src/extensions.rs
@@ -32,17 +32,15 @@ pub struct Extensions {
 
 impl PartialEq for Extensions {
     fn eq(&self, other: &Self) -> bool {
-        for (k, v) in &self.inner {
-            if let Some(ov) = other.inner.get(&k) {
-                if !v.clone().partial_eq(ov.clone().as_any()) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
+        if self.inner.len() != other.inner.len() {
+            return false;
         }
 
-        true
+        self.inner.iter().all(|(key, value)| {
+            other.inner.get(key).map_or(false, |other| {
+                value.clone().partial_eq(other.clone().as_any())
+            })
+        })
     }
 }
 
@@ -166,13 +164,20 @@ mod test {
         exts1.set_ext_wrapped(String::from("meow"));
 
         let mut exts2 = Extensions::default();
-        exts2.set_ext_wrapped(1);
+        exts2.set_ext_wrapped(0);
 
         assert_ne!(
             exts1, exts2,
             "two different Extensions cannot be equal if they don't carry the same types"
         );
+
+        // validate the PartialEq impl is commutative
+        assert_ne!(
+            exts2, exts1,
+            "two different Extensions cannot be equal if they don't carry the same types"
+        );
     }
+
     #[test]
     fn equality_ext_wrapper() {
         let mut exts1 = Extensions::default();

--- a/object_store/src/extensions.rs
+++ b/object_store/src/extensions.rs
@@ -53,13 +53,10 @@ impl Extensions {
         self.inner.insert(id, a);
     }
 
-    fn set_ext_wrapper<T: Any + Send + Sync + std::fmt::Debug + 'static>(
-        &mut self,
-        t: ExtWrapper<T>,
-    ) {
+    fn set_ext_wrapped<T: Any + Send + Sync + std::fmt::Debug + 'static>(&mut self, t: T) {
         let id = TypeId::of::<T>();
-        // println!("inserting: {id:?}: {}", std::any::type_name::<T>());
-        let a = Arc::new(t);
+        //println!("inserting: {id:?}: {}", std::any::type_name::<T>());
+        let a = Arc::new(ExtWrapper::new(t));
         self.inner.insert(id, a);
     }
 
@@ -211,17 +208,10 @@ mod test {
     #[test]
     fn equality_ext_wrapper() {
         let mut exts1 = Extensions::default();
-        let wrapped1 = ExtWrapper::new(0);
-        let t1 = wrapped1.type_id();
-        println!("type id of ExtWrapper<i32>: {t1:?}");
-        exts1.set_ext_wrapper(wrapped1);
+        exts1.set_ext_wrapped(0);
 
         let mut exts2 = Extensions::default();
-        let wrapped2 = ExtWrapper::new(1);
-        let t2 = wrapped2.type_id();
-        println!("type id of ExtWrapper<i32>: {t2:?}");
-
-        exts2.set_ext_wrapper(wrapped2);
+        exts2.set_ext_wrapped(1);
 
         assert_eq!(
             exts1, exts2,
@@ -232,8 +222,7 @@ mod test {
         );
 
         let mut exts3 = Extensions::default();
-        let wrapped3 = ExtWrapper::new(0);
-        exts3.set_ext_wrapper(wrapped3);
+        exts3.set_ext_wrapped(0);
 
         assert_eq!(exts1, exts3, "extensions of type ExtWrapper are equal");
     }
@@ -260,14 +249,12 @@ mod test {
         let mut exts = Extensions::default();
 
         println!("validate ExtWrapper<i32> with value 0");
-        let wrapped = ExtWrapper::new(0i32);
-        exts.set_ext_wrapper(wrapped);
+        exts.set_ext_wrapped(0i32);
         let expected = exts.get_ext::<i32>().expect("must get a value");
         assert_eq!(0, *expected, "return the same instance we just added");
 
         println!("validate replacing previous ExtWrapper<i32> with value 1");
-        let wrapped = ExtWrapper::new(1i32);
-        exts.set_ext_wrapper(wrapped);
+        exts.set_ext_wrapped(1i32);
         let expected = exts.get_ext::<i32>().expect("must get a value");
         assert_eq!(1, *expected, "return the same instance we just added");
     }

--- a/object_store/src/extensions.rs
+++ b/object_store/src/extensions.rs
@@ -7,14 +7,15 @@ use std::{
 /// Trait that must be implemented by extensions.
 pub trait Extension: std::fmt::Debug + Send + Sync {
     /// Return a &Any for this type.
-    fn as_any(&self) -> &dyn std::any::Any;
+    fn as_any(self: Arc<Self>) -> Ext;
 
-    /// Ensure that [`Extensions`] can implement [`std::cmp::PartialEq`] by requiring [`ExtTrait`]
+    /// Ensure that [`Extensions`] can implement [`std::cmp::PartialEq`] by requiring [`Extension`]
     /// implementors to implement a dyn-compatible partial equality operation.
     ///
     /// This is necessary because [`std::cmp::PartialEq`] uses a `Self` type parameter, which
-    /// violates dyn-compatibility rules: https://doc.rust-lang.org/error_codes/E0038.html#trait-uses-self-as-a-type-parameter-in-the-supertrait-listing
-    fn partial_eq(&self, other: &dyn std::any::Any) -> bool;
+    /// violates dyn-compatibility rules:
+    /// https://doc.rust-lang.org/error_codes/E0038.html#trait-uses-self-as-a-type-parameter-in-the-supertrait-listing
+    fn partial_eq(self: Arc<Self>, other: Ext) -> bool;
 }
 
 type ExtensionMap = HashMap<TypeId, Arc<dyn Extension>>;
@@ -33,7 +34,7 @@ impl PartialEq for Extensions {
     fn eq(&self, other: &Self) -> bool {
         for (k, v) in &self.inner {
             if let Some(ov) = other.inner.get(&k) {
-                if !v.partial_eq(ov.as_any()) {
+                if !v.clone().partial_eq(ov.clone().as_any()) {
                     return false;
                 }
             } else {
@@ -52,12 +53,54 @@ impl Extensions {
         self.inner.insert(id, a);
     }
 
-    pub(crate) fn get_ext<T: Extension + 'static>(&self) -> Option<&T> {
+    fn set_ext_wrapper<T: Any + Send + Sync + std::fmt::Debug + 'static>(
+        &mut self,
+        t: ExtWrapper<T>,
+    ) {
         let id = TypeId::of::<T>();
-        self.inner
-            .get(&id)
-            .map(|e| e.as_any().downcast_ref())
-            .flatten()
+        // println!("inserting: {id:?}: {}", std::any::type_name::<T>());
+        let a = Arc::new(t);
+        self.inner.insert(id, a);
+    }
+
+    pub(crate) fn get_ext<T: Any + Send + Sync + 'static>(&self) -> Option<Arc<T>> {
+        let id = TypeId::of::<T>();
+        // println!(
+        //     "looking for        : {id:?}: {}",
+        //     std::any::type_name::<T>()
+        // );
+        self.inner.get(&id).map(|e| {
+            // let id = e.type_id();
+            // println!(
+            //     "found value        : {id:?}: {}",
+            //     std::any::type_name_of_val(e)
+            // );
+            let v = Arc::clone(&e);
+            // let id = v.type_id();
+            // println!(
+            //     "cloned value       : {id:?}: {}",
+            //     std::any::type_name_of_val(&v)
+            // );
+            let v = v.as_any();
+            // let id = v.type_id();
+            // println!(
+            //     "as_any value       : {id:?}: {}",
+            //     std::any::type_name_of_val(&v)
+            // );
+            let v: Arc<T> =
+                Arc::downcast::<T>(v).expect("must be able to downcast to type if found in map");
+            // let id = v.type_id();
+            // println!(
+            //     "found value        : {id:?}: {}",
+            //     std::any::type_name_of_val(&v)
+            // );
+            // let id = v.as_ref().type_id();
+            // println!(
+            //     "found value (inner): {id:?}: {}",
+            //     std::any::type_name_of_val(v.as_ref())
+            // );
+            v
+        })
     }
 }
 
@@ -74,23 +117,32 @@ impl From<HashMap<TypeId, Ext>> for Extensions {
 
 /// Type that implements [`Extension`] for the sake of converting to [`Extensions`] from external
 /// instances of `HashMap<TypeId, Ext>'.
+///
+/// NOTE: Different instances of the same type held by ExtWrapper are considered equal for the sake
+/// of the `Extensions.partial_eq` trait since its intended use case is for wrapping dyn-compatible
+/// trait objects; because [`std::cmp::PartialEq`] has `Self` as a generic type parameter, the type
+/// system won't let us set it as a trait bound on incoming trait objects when constructing
+/// ExtWrapper.
 #[derive(Debug)]
-struct ExtWrapper<T: std::fmt::Debug> {
+struct ExtWrapper<T> {
     inner: Arc<T>,
 }
 
-impl<T: std::fmt::Debug> ExtWrapper<T> {
+impl<T: std::fmt::Debug + Send + Sync> ExtWrapper<T> {
     fn new(v: T) -> Self {
         Self { inner: Arc::new(v) }
     }
 }
 
-impl<T: Any + Send + Sync + std::fmt::Debug + 'static> Extension for ExtWrapper<T> {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self.inner.as_ref()
+impl<T: std::fmt::Debug + Send + Sync + 'static> Extension for ExtWrapper<T> {
+    fn as_any(self: Arc<Self>) -> Ext {
+        self.inner.clone()
     }
 
-    fn partial_eq(&self, other: &dyn std::any::Any) -> bool {
+    fn partial_eq(self: Arc<Self>, _: Ext) -> bool {
+        // this is necessary because ExtWrapper is a generic impl of Extensions necessary for
+        // converting from external Arc<dyn Any ...> types where none of the trait bounts can
+        // implement PartialEq due to dyn-compatibility requirements.
         true
     }
 }
@@ -105,21 +157,21 @@ mod test {
     }
 
     impl Extension for MyExt {
-        fn as_any(&self) -> &dyn std::any::Any {
+        fn as_any(self: Arc<Self>) -> Ext {
             self
         }
 
-        fn partial_eq(&self, other: &dyn std::any::Any) -> bool {
+        fn partial_eq(self: Arc<Self>, other: Ext) -> bool {
             let self_id = self.type_id();
             let other_id = other.type_id();
             println!("MyExt.partial_eq");
             println!(
                 "  self  : {self_id:?}, {}",
-                std::any::type_name_of_val(self)
+                std::any::type_name_of_val(self.as_ref())
             );
             println!(
                 "  other : {other_id:?}, {}",
-                std::any::type_name_of_val(other)
+                std::any::type_name_of_val(other.as_ref())
             );
             other
                 .downcast_ref::<Self>()
@@ -130,7 +182,7 @@ mod test {
     }
 
     #[test]
-    fn custom_ext_trait_impl() {
+    fn equality_custom_ext_trait_impl() {
         let mut exts1 = Extensions::default();
         let myext1 = MyExt { x: 0 };
         exts1.set_ext(myext1);
@@ -157,35 +209,66 @@ mod test {
     }
 
     #[test]
-    fn ext_wrapper() {
-        let v1 = 0;
-        let v2 = 1;
-        let v3 = 0;
-
-        let wrapped1 = ExtWrapper::new(v1);
-        let wrapped2 = ExtWrapper::new(v2);
-        let wrapped3 = ExtWrapper::new(v3);
-
+    fn equality_ext_wrapper() {
+        let mut exts1 = Extensions::default();
+        let wrapped1 = ExtWrapper::new(0);
         let t1 = wrapped1.type_id();
         println!("type id of ExtWrapper<i32>: {t1:?}");
+        exts1.set_ext_wrapper(wrapped1);
 
+        let mut exts2 = Extensions::default();
+        let wrapped2 = ExtWrapper::new(1);
         let t2 = wrapped2.type_id();
         println!("type id of ExtWrapper<i32>: {t2:?}");
 
-        let mut exts1 = Extensions::default();
-        exts1.set_ext(wrapped1);
-
-        let mut exts2 = Extensions::default();
-        exts2.set_ext(wrapped2);
+        exts2.set_ext_wrapper(wrapped2);
 
         assert_eq!(
             exts1, exts2,
-            "extentions of type ExtWrapper are always equal even if their values aren't"
+            // this behavior is necessary because ExtWrapper is a generic impl of Extensions
+            // necessary for converting from external Arc<dyn Any ...> types where none of the
+            // trait bounts can implement PartialEq due to dyn-compatibility requirements.
+            "extensions of type ExtWrapper are always equal even if their values aren't"
         );
 
         let mut exts3 = Extensions::default();
-        exts3.set_ext(wrapped3);
+        let wrapped3 = ExtWrapper::new(0);
+        exts3.set_ext_wrapper(wrapped3);
 
-        assert_eq!(exts1, exts3, "extentions of type ExtWrapper are equal");
+        assert_eq!(exts1, exts3, "extensions of type ExtWrapper are equal");
+    }
+
+    #[test]
+    fn one_instance_of_same_type_custom_impl() {
+        let mut exts = Extensions::default();
+
+        println!("validate MyExt");
+        let myext = MyExt { x: 0 };
+        exts.set_ext(myext);
+        let expected = exts.get_ext::<MyExt>().expect("must get a value");
+        assert_eq!(0, expected.x, "return the same instance we just added");
+
+        println!("validate replacing previous MyExt");
+        let myext = MyExt { x: 1 };
+        exts.set_ext(myext);
+        let expected = exts.get_ext::<MyExt>().expect("must get a value");
+        assert_eq!(1, expected.x, "return the same instance we just added");
+    }
+
+    #[test]
+    fn one_instance_of_same_type_ext_wrapper() {
+        let mut exts = Extensions::default();
+
+        println!("validate ExtWrapper<i32> with value 0");
+        let wrapped = ExtWrapper::new(0i32);
+        exts.set_ext_wrapper(wrapped);
+        let expected = exts.get_ext::<i32>().expect("must get a value");
+        assert_eq!(0, *expected, "return the same instance we just added");
+
+        println!("validate replacing previous ExtWrapper<i32> with value 1");
+        let wrapped = ExtWrapper::new(1i32);
+        exts.set_ext_wrapper(wrapped);
+        let expected = exts.get_ext::<i32>().expect("must get a value");
+        assert_eq!(1, *expected, "return the same instance we just added");
     }
 }

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -536,6 +536,7 @@ mod config;
 
 mod tags;
 
+pub use extensions::{Extensions, Extension};
 pub use tags::TagSet;
 
 pub mod multipart;
@@ -545,6 +546,7 @@ mod upload;
 mod util;
 
 mod attributes;
+mod extensions;
 
 #[cfg(any(feature = "integration", test))]
 pub mod integration;
@@ -910,7 +912,6 @@ pub struct ObjectMeta {
     /// A version indicator for this object
     pub version: Option<String>,
 }
-
 /// Options for a get request, such as range
 #[derive(Debug, Default, Clone)]
 pub struct GetOptions {
@@ -963,6 +964,13 @@ pub struct GetOptions {
     ///
     /// <https://datatracker.ietf.org/doc/html/rfc9110#name-head>
     pub head: bool,
+
+    /// Implementation-specific extensions.  but
+    /// intended for use by [`ObjectStore`] implementations that need to pass context-specific
+    /// information (like tracing spans) via trait methods.
+    ///
+    /// These extensions are ignored entirely by backends offered through this crate.
+    pub extensions: Extensions,
 }
 
 impl GetOptions {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -965,9 +965,8 @@ pub struct GetOptions {
     /// <https://datatracker.ietf.org/doc/html/rfc9110#name-head>
     pub head: bool,
 
-    /// Implementation-specific extensions.  but
-    /// intended for use by [`ObjectStore`] implementations that need to pass context-specific
-    /// information (like tracing spans) via trait methods.
+    /// Implementation-specific extensions. Intended for use by [`ObjectStore`] implementations
+    /// that need to pass context-specific information (like tracing spans) via trait methods.
     ///
     /// These extensions are ignored entirely by backends offered through this crate.
     pub extensions: Extensions,


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/7155

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

This is laid out in the associated issue.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Introduces a new type, `object_store::Extensions`
  * Uses a `HashMap<TypeId, Arc<dyn Any + Send + Sync + 'static>>` 
  * This is modeled after (ie copied from) and meant to be compatible with the [extension mechanism in datafusion::execution::config::SessionConfig](https://github.com/apache/datafusion/blob/main/datafusion/execution/src/config.rs#L466-L591)
  * It's probably worth considering using the same [double hash avoidance optimization](https://github.com/apache/datafusion/blob/2f40f6c2ef352904d6661653ffe18ba4c3144b92/datafusion/execution/src/config.rs#L595-L596) used there, but for simplicity I've left it out of this PR while it's in draft form -- I just wanted to end up with something I could test out and get early feedback on.
  * This is a public type for now because I am not sure what the preference of maintainers will be and it's simpler in my mind for now to make use of this at the datafusion level (draft PR for that coming shortly after this) if we can construct an `Extensions` instance once rather than on every `ObjectStore` method call where one is needed.
* Adds a new `extensions: Extensions` field to `GetOptions`
  * Could easily be implemented for `PutOptions` as well, but I'm personally less interested in that so I'm leaving it out for now.

# Are there any user-facing changes?

Yes, the new field in `GetOptions` and a new publicly-exposed type, `object_store::Extensions`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
