### PR TITLE
Add Week ISO, Year ISO computation

### DIFF
--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -142,6 +142,7 @@ where
 /// assert_eq!(week_iso.as_ref(), &expected);
 /// let year_iso = date_part(&input, DatePart::YearISO).unwrap();
 /// let expected: Int32Array = vec![Some(2021), None, Some(2024)].into();
+/// assert_eq!(year_iso.as_ref(), &expected);
 /// ```
 pub fn date_part(array: &dyn Array, part: DatePart) -> Result<ArrayRef, ArrowError> {
     downcast_temporal_array!(
@@ -2096,5 +2097,86 @@ mod tests {
         ensure_returns_error(&DurationMillisecondArray::from(vec![0]));
         ensure_returns_error(&DurationMicrosecondArray::from(vec![0]));
         ensure_returns_error(&DurationNanosecondArray::from(vec![0]));
+    }
+    #[test]
+    fn test_temporal_array_date64_week_iso() {
+        let a: PrimitiveArray<Date64Type> = vec![Some(1514764800000), Some(1550636625000)].into();
+
+        let b = date_part(&a, DatePart::WeekISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(1, actual.value(0));
+        assert_eq!(8, actual.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_date64_year_iso() {
+        let a: PrimitiveArray<Date64Type> = vec![Some(1514764800000), Some(1550636625000)].into();
+
+        let b = date_part(&a, DatePart::YearISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(2018, actual.value(0));
+        assert_eq!(2019, actual.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_week_iso() {
+        let a = TimestampSecondArray::from(vec![0, 86400 * 4, 86400 * 4 - 1]);
+        let b = date_part(&a, DatePart::WeekISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(1, actual.value(0));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_year_iso() {
+        let a = TimestampSecondArray::from(vec![0, 86400 * 4, 86400 * 4 - 1]);
+        let b = date_part(&a, DatePart::YearISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(1970, actual.value(0));
+    }
+
+    #[test]
+    fn test_temporal_array_date64_week_iso_edge_cases() {
+        // 2015-12-28 is the first day of the first ISO week of 2016
+        // 2016-01-03 is the last day of the first ISO week of 2016
+        let a: PrimitiveArray<Date64Type> = vec![Some(1451260800000), Some(1451779200000)].into();
+
+        let b = date_part(&a, DatePart::WeekISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(53, actual.value(0));
+        assert_eq!(53, actual.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_date64_year_iso_edge_cases() {
+        // 2015-12-28 is the first day of the first ISO week of 2016
+        // 2016-01-03 is the last day of the first ISO week of 2016
+        let a: PrimitiveArray<Date64Type> = vec![Some(1451260800000), Some(1451779200000)].into();
+
+        let b = date_part(&a, DatePart::YearISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(2016, actual.value(0));
+        assert_eq!(2016, actual.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_week_iso_edge_cases() {
+        // 2015-12-28 is the first day of the first ISO week of 2016
+        // 2016-01-03 is the last day of the first ISO week of 2016
+        let a = TimestampSecondArray::from(vec![1451260800, 1451779200]);
+        let b = date_part(&a, DatePart::WeekISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(53, actual.value(0));
+        assert_eq!(53, actual.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_year_iso_edge_cases() {
+        // 2015-12-28 is the first day of the first ISO week of 2016
+        // 2016-01-03 is the last day of the first ISO week of 2016
+        let a = TimestampSecondArray::from(vec![1451260800, 1451779200]);
+        let b = date_part(&a, DatePart::YearISO).unwrap();
+        let actual = b.as_primitive::<Int32Type>();
+        assert_eq!(2016, actual.value(0));
+        assert_eq!(2016, actual.value(1));
     }
 }

--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -94,8 +94,17 @@ where
 {
     match part {
         DatePart::Quarter => |d| d.quarter() as i32,
-        DatePart::Year => |d| d.year(),
-        DatePart::YearISO => |d| d.iso_week().year(),
+        DatePart::Year => |d| {
+            let y = d.year();
+            println!("==> Year: input  computed = {}", y);
+            y
+        },
+        DatePart::YearISO => |d| {
+            let week_iso = d.iso_week();
+            let y_iso = week_iso.year();
+            println!("==> WeekIso {:?}, YearISO:  computed = {}", week_iso, y_iso);
+            y_iso
+        },
         DatePart::Month => |d| d.month() as i32,
         DatePart::Week | DatePart::WeekISO => |d| d.iso_week().week() as i32,
         DatePart::Day => |d| d.day() as i32,
@@ -107,7 +116,7 @@ where
         DatePart::Second => |d| d.second() as i32,
         DatePart::Millisecond => |d| (d.nanosecond() / 1_000_000) as i32,
         DatePart::Microsecond => |d| (d.nanosecond() / 1_000) as i32,
-        DatePart::Nanosecond => |d| (d.nanosecond()) as i32,
+        DatePart::Nanosecond => |d| d.nanosecond() as i32,
     }
 }
 

--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -47,12 +47,13 @@ pub enum DatePart {
     Quarter,
     /// Calendar year
     Year,
-    /// ISO year
+    /// ISO year, computed as per ISO 8601
     YearISO,
     /// Month in the year, in range `1..=12`
     Month,
-    /// ISO week of the year, in range `1..=53`
+    /// week of the year, in range `1..=53`, computed as per ISO 8601
     Week,
+    /// ISO week of the year, in range `1..=53`
     WeekISO,
     /// Day of the month, in range `1..=31`
     Day,
@@ -460,7 +461,7 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalYearMonthType> {
 impl ExtractDatePartExt for PrimitiveArray<IntervalDayTimeType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week | DatePart::WeekISO => Ok(self.unary_opt(|d| Some(d.days / 7))),
+            DatePart::Week => Ok(self.unary_opt(|d| Some(d.days / 7))),
             DatePart::Day => Ok(self.unary_opt(|d| Some(d.days))),
             DatePart::Hour => Ok(self.unary_opt(|d| Some(d.milliseconds / (60 * 60 * 1_000)))),
             DatePart::Minute => Ok(self.unary_opt(|d| Some(d.milliseconds / (60 * 1_000)))),
@@ -472,6 +473,7 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalDayTimeType> {
             DatePart::Quarter
             | DatePart::Year
             | DatePart::YearISO
+            | DatePart::WeekISO
             | DatePart::Month
             | DatePart::DayOfWeekSunday0
             | DatePart::DayOfWeekMonday0
@@ -585,7 +587,7 @@ impl ExtractDatePartExt for PrimitiveArray<DurationMillisecondType> {
 impl ExtractDatePartExt for PrimitiveArray<DurationMicrosecondType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week | DatePart::WeekISO => {
+            DatePart::Week => {
                 Ok(self.unary_opt(|d| (d / (1_000_000 * 60 * 60 * 24 * 7)).try_into().ok()))
             }
             DatePart::Day => {
@@ -602,6 +604,7 @@ impl ExtractDatePartExt for PrimitiveArray<DurationMicrosecondType> {
 
             DatePart::Year
             | DatePart::YearISO
+            | DatePart::WeekISO
             | DatePart::Quarter
             | DatePart::Month
             | DatePart::DayOfWeekSunday0

--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
 use cast::as_primitive_array;
-use chrono::{Datelike, NaiveDate, TimeZone, Timelike, Utc};
+use chrono::{Datelike, TimeZone, Timelike, Utc};
 
 use arrow_array::temporal_conversions::{
     date32_to_datetime, date64_to_datetime, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
@@ -436,12 +436,10 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalYearMonthType> {
         match part {
             DatePart::Year => Ok(self.unary_opt(|d| Some(d / 12))),
             DatePart::YearISO => {
-                Ok(self.unary_opt(|d| {
-                    let date = NaiveDate::from_num_days_from_ce_opt(d)?; // Convert days to a date
-                    Some(date.iso_week().year()) // Get the correct ISO year
-                }))
+                Ok(self.unary_opt(|d| Some(d / 12 + if d % 12 >= 0 { 1 } else { 0 })))
             }
             DatePart::Month => Ok(self.unary_opt(|d| Some(d % 12))),
+
             DatePart::Quarter
             | DatePart::Week
             | DatePart::WeekISO
@@ -464,12 +462,7 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalYearMonthType> {
 impl ExtractDatePartExt for PrimitiveArray<IntervalDayTimeType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.days / 7))),
-            DatePart::WeekISO => Ok(self.unary_opt(|d: IntervalMonthDayNano| {
-                let base = chrono::Utc.timestamp(0, 0);
-                let dt = base.checked_add_signed(chrono::Duration::days(d.days as i64));
-                dt.map(|dt| dt.iso_week().week())
-            })),
+            DatePart::Week | DatePart::WeekISO => Ok(self.unary_opt(|d| Some(d.days / 7))),
             DatePart::Day => Ok(self.unary_opt(|d| Some(d.days))),
             DatePart::Hour => Ok(self.unary_opt(|d| Some(d.milliseconds / (60 * 60 * 1_000)))),
             DatePart::Minute => Ok(self.unary_opt(|d| Some(d.milliseconds / (60 * 1_000)))),
@@ -495,19 +488,13 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalMonthDayNanoType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
             DatePart::Year => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.months / 12))),
-            DatePart::YearISO => {
-                Ok(self.unary_opt(|d| {
-                    let date = NaiveDate::from_num_days_from_ce_opt(d)?; // Convert days to a date
-                    Some(date.iso_week().year()) // Get the correct ISO year
-                }))
-            }
-            DatePart::Month => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.months))),
-            DatePart::Week => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.days / 7))),
-            DatePart::WeekISO => Ok(self.unary_opt(|d: IntervalMonthDayNano| {
-                let base = chrono::Utc.timestamp(0, 0);
-                let dt = base.checked_add_signed(chrono::Duration::days(d.days as i64));
-                dt.map(|dt| dt.iso_week().week())
+            DatePart::YearISO => Ok(self.unary_opt(|d: IntervalMonthDayNano| {
+                Some((d.months / 12) + if d.days >= 0 { 1 } else { 0 })
             })),
+            DatePart::Month => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.months))),
+            DatePart::Week | DatePart::WeekISO => {
+                Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.days / 7)))
+            }
             DatePart::Day => Ok(self.unary_opt(|d: IntervalMonthDayNano| Some(d.days))),
             DatePart::Hour => {
                 Ok(self.unary_opt(|d| (d.nanoseconds / (60 * 60 * 1_000_000_000)).try_into().ok()))
@@ -539,15 +526,9 @@ impl ExtractDatePartExt for PrimitiveArray<IntervalMonthDayNanoType> {
 impl ExtractDatePartExt for PrimitiveArray<DurationSecondType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week => Ok(self.unary_opt(|d| (d / (60 * 60 * 24 * 7)).try_into().ok())),
-            DatePart::WeekISO => Ok(self.unary_opt(|d| {
-                chrono::Utc
-                    .timestamp(d, 0)
-                    .iso_week()
-                    .week()
-                    .try_into()
-                    .ok()
-            })),
+            DatePart::Week | DatePart::WeekISO => {
+                Ok(self.unary_opt(|d| (d / (60 * 60 * 24 * 7)).try_into().ok()))
+            }
             DatePart::Day => Ok(self.unary_opt(|d| (d / (60 * 60 * 24)).try_into().ok())),
             DatePart::Hour => Ok(self.unary_opt(|d| (d / (60 * 60)).try_into().ok())),
             DatePart::Minute => Ok(self.unary_opt(|d| (d / 60).try_into().ok())),
@@ -578,17 +559,9 @@ impl ExtractDatePartExt for PrimitiveArray<DurationSecondType> {
 impl ExtractDatePartExt for PrimitiveArray<DurationMillisecondType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week => {
+            DatePart::Week | DatePart::WeekISO => {
                 Ok(self.unary_opt(|d| (d / (1_000 * 60 * 60 * 24 * 7)).try_into().ok()))
             }
-            DatePart::WeekISO => Ok(self.unary_opt(|d| {
-                chrono::Utc
-                    .timestamp_millis(d)
-                    .iso_week()
-                    .week()
-                    .try_into()
-                    .ok()
-            })),
             DatePart::Day => Ok(self.unary_opt(|d| (d / (1_000 * 60 * 60 * 24)).try_into().ok())),
             DatePart::Hour => Ok(self.unary_opt(|d| (d / (1_000 * 60 * 60)).try_into().ok())),
             DatePart::Minute => Ok(self.unary_opt(|d| (d / (1_000 * 60)).try_into().ok())),
@@ -617,16 +590,9 @@ impl ExtractDatePartExt for PrimitiveArray<DurationMillisecondType> {
 impl ExtractDatePartExt for PrimitiveArray<DurationMicrosecondType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week => {
+            DatePart::Week | DatePart::WeekISO => {
                 Ok(self.unary_opt(|d| (d / (1_000_000 * 60 * 60 * 24 * 7)).try_into().ok()))
             }
-            DatePart::WeekISO => Ok(self.unary_opt(|d| {
-                if let chrono::LocalResult::Single(dt) = chrono::Utc.timestamp_micros(d) {
-                    Some(dt.iso_week().week())
-                } else {
-                    None
-                }
-            })),
             DatePart::Day => {
                 Ok(self.unary_opt(|d| (d / (1_000_000 * 60 * 60 * 24)).try_into().ok()))
             }
@@ -655,17 +621,9 @@ impl ExtractDatePartExt for PrimitiveArray<DurationMicrosecondType> {
 impl ExtractDatePartExt for PrimitiveArray<DurationNanosecondType> {
     fn date_part(&self, part: DatePart) -> Result<Int32Array, ArrowError> {
         match part {
-            DatePart::Week => {
+            DatePart::Week | DatePart::WeekISO => {
                 Ok(self.unary_opt(|d| (d / (1_000_000_000 * 60 * 60 * 24 * 7)).try_into().ok()))
             }
-            DatePart::WeekISO => Ok(self.unary_opt(|d| {
-                chrono::Utc
-                    .timestamp_nanos(d)
-                    .iso_week()
-                    .week()
-                    .try_into()
-                    .ok()
-            })),
             DatePart::Day => {
                 Ok(self.unary_opt(|d| (d / (1_000_000_000 * 60 * 60 * 24)).try_into().ok()))
             }

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1070,7 +1070,7 @@ mod tests {
     };
     use arrow_schema::{DataType, Field, Schema};
     use futures::{StreamExt, TryStreamExt};
-    use rand::{rng, Rng};
+    use rand::{thread_rng, Rng};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use tempfile::tempfile;
@@ -1400,7 +1400,7 @@ mod tests {
 
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let mut rand = rng();
+        let mut rand = thread_rng();
 
         for _ in 0..100 {
             let mut expected_rows = 0;
@@ -1409,7 +1409,7 @@ mod tests {
             let mut selectors = vec![];
 
             while total_rows < 7300 {
-                let row_count: usize = rand.random_range(1..100);
+                let row_count: usize = rand.gen_range(1..100);
 
                 let row_count = row_count.min(7300 - total_rows);
 
@@ -1436,7 +1436,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let col_idx: usize = rand.random_range(0..13);
+            let col_idx: usize = rand.gen_range(0..13);
             let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![col_idx]);
 
             let stream = builder
@@ -1467,7 +1467,7 @@ mod tests {
 
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let mut rand = rng();
+        let mut rand = thread_rng();
 
         let mut expected_rows = 0;
         let mut total_rows = 0;
@@ -1480,7 +1480,7 @@ mod tests {
         });
 
         while total_rows < 7300 {
-            let row_count: usize = rand.random_range(1..100);
+            let row_count: usize = rand.gen_range(1..100);
 
             let row_count = row_count.min(7300 - total_rows);
 
@@ -1507,7 +1507,7 @@ mod tests {
             .await
             .unwrap();
 
-        let col_idx: usize = rand.random_range(0..13);
+        let col_idx: usize = rand.gen_range(0..13);
         let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![col_idx]);
 
         let stream = builder

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1070,7 +1070,7 @@ mod tests {
     };
     use arrow_schema::{DataType, Field, Schema};
     use futures::{StreamExt, TryStreamExt};
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use tempfile::tempfile;
@@ -1400,7 +1400,7 @@ mod tests {
 
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let mut rand = thread_rng();
+        let mut rand = rng();
 
         for _ in 0..100 {
             let mut expected_rows = 0;
@@ -1409,7 +1409,7 @@ mod tests {
             let mut selectors = vec![];
 
             while total_rows < 7300 {
-                let row_count: usize = rand.gen_range(1..100);
+                let row_count: usize = rand.random_range(1..100);
 
                 let row_count = row_count.min(7300 - total_rows);
 
@@ -1436,7 +1436,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let col_idx: usize = rand.gen_range(0..13);
+            let col_idx: usize = rand.random_range(0..13);
             let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![col_idx]);
 
             let stream = builder
@@ -1467,7 +1467,7 @@ mod tests {
 
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let mut rand = thread_rng();
+        let mut rand = rng();
 
         let mut expected_rows = 0;
         let mut total_rows = 0;
@@ -1480,7 +1480,7 @@ mod tests {
         });
 
         while total_rows < 7300 {
-            let row_count: usize = rand.gen_range(1..100);
+            let row_count: usize = rand.random_range(1..100);
 
             let row_count = row_count.min(7300 - total_rows);
 
@@ -1507,7 +1507,7 @@ mod tests {
             .await
             .unwrap();
 
-        let col_idx: usize = rand.gen_range(0..13);
+        let col_idx: usize = rand.random_range(0..13);
         let mask = ProjectionMask::leaves(builder.parquet_schema(), vec![col_idx]);
 
         let stream = builder


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7115.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

PostgreSQL, Trino, Snowflake support week iso, year iso datetime extraction.
https://github.com/apache/datafusion/issues/14524



# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add support for DatePart::WeekISO, DatePart::YearISO and tests.

# Are there any user-facing changes?
Added WeekISO, YearISO to DatePart enum

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Updated the Rustdoc with extraction examples.

<!---
If there are any breaking changes to public APIs, please call them out.
-->
