### PR TITLE
Fix some Clippy 1.85 warnings

### DIFF
--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -994,7 +994,7 @@ fn selection_mask(type_ids_chunk: &[i8], type_id: i8) -> u64 {
         .copied()
         .enumerate()
         .fold(0, |packed, (bit_idx, v)| {
-            packed | ((v == type_id) as u64) << bit_idx
+            packed | (((v == type_id) as u64) << bit_idx)
         })
 }
 

--- a/arrow-buffer/src/bigint/div.rs
+++ b/arrow-buffer/src/bigint/div.rs
@@ -258,7 +258,7 @@ fn full_shl<const N: usize>(v: &[u64; N], shift: u32) -> ArrayPlusOne<u64, N> {
     let mut out = [0u64; N];
     out[0] = v[0] << shift;
     for i in 1..N {
-        out[i] = v[i - 1] >> (64 - shift) | v[i] << shift
+        out[i] = (v[i - 1] >> (64 - shift)) | (v[i] << shift)
     }
     let carry = v[N - 1] >> (64 - shift);
     ArrayPlusOne(out, carry)
@@ -272,7 +272,7 @@ fn full_shr<const N: usize>(a: &ArrayPlusOne<u64, N>, shift: u32) -> [u64; N] {
     }
     let mut out = [0; N];
     for i in 0..N - 1 {
-        out[i] = a[i] >> shift | a[i + 1] << (64 - shift)
+        out[i] = (a[i] >> shift) | (a[i + 1] << (64 - shift))
     }
     out[N - 1] = a[N - 1] >> shift;
     out

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -475,8 +475,8 @@ impl i256 {
     /// Interpret 4 `u64` digits, least significant first, as a [`i256`]
     fn from_digits(digits: [u64; 4]) -> Self {
         Self::from_parts(
-            digits[0] as u128 | (digits[1] as u128) << 64,
-            digits[2] as i128 | (digits[3] as i128) << 64,
+            digits[0] as u128 | ((digits[1] as u128) << 64),
+            digits[2] as i128 | ((digits[3] as i128) << 64),
         )
     }
 
@@ -746,7 +746,7 @@ impl Shl<u8> for i256 {
             self
         } else if rhs < 128 {
             Self {
-                high: self.high << rhs | (self.low >> (128 - rhs)) as i128,
+                high: (self.high << rhs) | (self.low >> (128 - rhs)) as i128,
                 low: self.low << rhs,
             }
         } else {
@@ -768,7 +768,7 @@ impl Shr<u8> for i256 {
         } else if rhs < 128 {
             Self {
                 high: self.high >> rhs,
-                low: self.low >> rhs | ((self.high as u128) << (128 - rhs)),
+                low: (self.low >> rhs) | ((self.high as u128) << (128 - rhs)),
             }
         } else {
             Self {

--- a/arrow-json/src/reader/decimal_array.rs
+++ b/arrow-json/src/reader/decimal_array.rs
@@ -66,7 +66,7 @@ where
                 }
                 TapeElement::I64(high) => match tape.get(*p + 1) {
                     TapeElement::I32(low) => {
-                        let val = ((high as i64) << 32 | (low as u32) as i64).to_string();
+                        let val = (((high as i64) << 32) | (low as u32) as i64).to_string();
                         let value = parse_decimal::<D>(&val, self.precision, self.scale)?;
                         builder.append_value(value)
                     }
@@ -79,7 +79,7 @@ where
                 }
                 TapeElement::F64(high) => match tape.get(*p + 1) {
                     TapeElement::F32(low) => {
-                        let val = f64::from_bits((high as u64) << 32 | low as u64).to_string();
+                        let val = f64::from_bits(((high as u64) << 32) | low as u64).to_string();
                         let value = parse_decimal::<D>(&val, self.precision, self.scale)?;
                         builder.append_value(value)
                     }

--- a/arrow-json/src/reader/primitive_array.rs
+++ b/arrow-json/src/reader/primitive_array.rs
@@ -132,7 +132,7 @@ where
                 }
                 TapeElement::F64(high) => match tape.get(p + 1) {
                     TapeElement::F32(low) => {
-                        let v = f64::from_bits((high as u64) << 32 | low as u64);
+                        let v = f64::from_bits(((high as u64) << 32) | low as u64);
                         let value = NumCast::from(v).ok_or_else(|| {
                             ArrowError::JsonError(format!("failed to parse {v} as {d}",))
                         })?;
@@ -142,7 +142,7 @@ where
                 },
                 TapeElement::I64(high) => match tape.get(p + 1) {
                     TapeElement::I32(low) => {
-                        let v = (high as i64) << 32 | (low as u32) as i64;
+                        let v = ((high as i64) << 32) | (low as u32) as i64;
                         let value = NumCast::from(v).ok_or_else(|| {
                             ArrowError::JsonError(format!("failed to parse {v} as {d}",))
                         })?;

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -102,7 +102,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
                 }
                 TapeElement::I64(high) if coerce_primitive => match tape.get(p + 1) {
                     TapeElement::I32(low) => {
-                        let val = (high as i64) << 32 | (low as u32) as i64;
+                        let val = ((high as i64) << 32) | (low as u32) as i64;
                         builder.append_value(val.to_string());
                     }
                     _ => unreachable!(),
@@ -115,7 +115,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
                 }
                 TapeElement::F64(high) if coerce_primitive => match tape.get(p + 1) {
                     TapeElement::F32(low) => {
-                        let val = f64::from_bits((high as u64) << 32 | low as u64);
+                        let val = f64::from_bits(((high as u64) << 32) | low as u64);
                         builder.append_value(val.to_string());
                     }
                     _ => unreachable!(),

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -180,7 +180,7 @@ impl<'a> Tape<'a> {
             TapeElement::Null => out.push_str("null"),
             TapeElement::I64(high) => match self.get(idx + 1) {
                 TapeElement::I32(low) => {
-                    let val = (high as i64) << 32 | (low as u32) as i64;
+                    let val = ((high as i64) << 32) | (low as u32) as i64;
                     let _ = write!(out, "{val}");
                     return idx + 2;
                 }
@@ -191,7 +191,7 @@ impl<'a> Tape<'a> {
             }
             TapeElement::F64(high) => match self.get(idx + 1) {
                 TapeElement::F32(low) => {
-                    let val = f64::from_bits((high as u64) << 32 | low as u64);
+                    let val = f64::from_bits(((high as u64) << 32) | low as u64);
                     let _ = write!(out, "{val}");
                     return idx + 2;
                 }
@@ -491,7 +491,7 @@ impl TapeDecoder {
                 // Parse a unicode escape sequence
                 DecoderState::Unicode(high, low, idx) => loop {
                     match *idx {
-                        0..=3 => *high = *high << 4 | parse_hex(next!(iter))? as u16,
+                        0..=3 => *high = (*high << 4) | parse_hex(next!(iter))? as u16,
                         4 => {
                             if let Some(c) = char::from_u32(*high as u32) {
                                 write_char(c, &mut self.bytes);
@@ -508,7 +508,7 @@ impl TapeDecoder {
                             b'u' => {}
                             b => return Err(err(b, "parsing surrogate pair unicode")),
                         },
-                        6..=9 => *low = *low << 4 | parse_hex(next!(iter))? as u16,
+                        6..=9 => *low = (*low << 4) | parse_hex(next!(iter))? as u16,
                         _ => {
                             let c = char_from_surrogate_pair(*low, *high)?;
                             write_char(c, &mut self.bytes);
@@ -683,7 +683,7 @@ fn err(b: u8, ctx: &str) -> ArrowError {
 
 /// Creates a character from an UTF-16 surrogate pair
 fn char_from_surrogate_pair(low: u16, high: u16) -> Result<char, ArrowError> {
-    let n = (((high - 0xD800) as u32) << 10 | (low - 0xDC00) as u32) + 0x1_0000;
+    let n = (((high - 0xD800) as u32) << 10) | ((low - 0xDC00) as u32 + 0x1_0000);
     char::from_u32(n)
         .ok_or_else(|| ArrowError::JsonError(format!("Invalid UTF-16 surrogate pair {n}")))
 }

--- a/arrow-json/src/reader/timestamp_array.rs
+++ b/arrow-json/src/reader/timestamp_array.rs
@@ -97,7 +97,7 @@ where
                 TapeElement::I32(v) => builder.append_value(v as i64),
                 TapeElement::I64(high) => match tape.get(p + 1) {
                     TapeElement::I32(low) => {
-                        builder.append_value((high as i64) << 32 | (low as u32) as i64)
+                        builder.append_value(((high as i64) << 32) | (low as u32) as i64)
                     }
                     _ => unreachable!(),
                 },

--- a/arrow-select/src/union_extract.rs
+++ b/arrow-select/src/union_extract.rs
@@ -341,7 +341,7 @@ fn eq_scalar_inner(chunk_size: usize, type_ids: &[i8], target: i8) -> BoolValue 
             .copied()
             .enumerate()
             .fold(0, |packed, (bit_idx, v)| {
-                packed | ((v == target) as u64) << bit_idx
+                packed | (((v == target) as u64) << bit_idx)
             })
     }));
 

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -938,7 +938,7 @@ mod tests {
 
         // bit-packed header
         let run_bytes = ceil(num_values * bit_width, 8) as u64;
-        writer.put_vlq_int(run_bytes << 1 | 1);
+        writer.put_vlq_int((run_bytes << 1) | 1);
         for _ in 0..run_bytes {
             writer.put_aligned(0xFF_u8, 1);
         }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change
 
Rust 1.85 was released today.

# What changes are included in this PR?

Following Clippy 1.85 suggestions to put shifts between parentheses (https://github.com/rust-lang/rust-clippy/pull/13743).

# Are there any user-facing changes?

No.