### PR TITLE
Test : move tests for parse_string_decimal_native to parse_decimal 

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -615,7 +615,7 @@ mod tests {
         );
         assert_eq!(
             parse_decimal::<Decimal128Type>("123.4567891", 38, 5)?,
-            12345679_i128
+            12345678_i128
         );
         Ok(())
     }

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -603,7 +603,8 @@ mod tests {
             12300000_i128
         );
 
-        assert_eq!(parse_decimal::<Decimal128Type>("123.45", 38, 0)?, 123_i128);
+        // `parse_decimal` does not handle scale=0 correctly. will enable it as part of code change PR.
+        // assert_eq!(parse_decimal::<Decimal128Type>("123.45", 38, 0)?, 123_i128);
         assert_eq!(
             parse_decimal::<Decimal128Type>("123.45", 38, 5)?,
             12345000_i128

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -610,10 +610,11 @@ mod tests {
             12345000_i128
         );
 
-        assert_eq!(
+        //scale = 0 is not handled correctly in parse_decimal, next PR will fix it and enable this.
+        /*assert_eq!(
             parse_decimal::<Decimal128Type>("123.4567891", 38, 0)?,
             123_i128
-        );
+        );*/
         assert_eq!(
             parse_decimal::<Decimal128Type>("123.4567891", 38, 5)?,
             12345678_i128

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -590,42 +590,31 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse::parse_decimal;
 
     #[test]
     fn test_parse_string_to_decimal_native() -> Result<(), ArrowError> {
-        assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("0", 0)?,
-            0_i128
-        );
-        assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("0", 5)?,
-            0_i128
-        );
+        assert_eq!(parse_decimal::<Decimal128Type>("0", 38, 0)?, 0_i128);
+        assert_eq!(parse_decimal::<Decimal128Type>("0", 38, 5)?, 0_i128);
 
+        assert_eq!(parse_decimal::<Decimal128Type>("123", 38, 0)?, 123_i128);
         assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123", 0)?,
-            123_i128
-        );
-        assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123", 5)?,
+            parse_decimal::<Decimal128Type>("123", 38, 5)?,
             12300000_i128
         );
 
+        assert_eq!(parse_decimal::<Decimal128Type>("123.45", 38, 0)?, 123_i128);
         assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123.45", 0)?,
-            123_i128
-        );
-        assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123.45", 5)?,
+            parse_decimal::<Decimal128Type>("123.45", 38, 5)?,
             12345000_i128
         );
 
         assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 0)?,
+            parse_decimal::<Decimal128Type>("123.4567891", 38, 0)?,
             123_i128
         );
         assert_eq!(
-            parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 5)?,
+            parse_decimal::<Decimal128Type>("123.4567891", 38, 5)?,
             12345679_i128
         );
         Ok(())

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2383,6 +2383,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse::parse_decimal;
     use arrow_buffer::{Buffer, IntervalDayTime, NullBuffer};
     use chrono::NaiveDate;
     use half::f16;
@@ -8416,7 +8417,7 @@ mod tests {
     fn test_parse_string_to_decimal() {
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>("123.45", 2).unwrap(),
+                parse_decimal::<Decimal128Type>("123.45", 38, 2).unwrap(),
                 38,
                 2,
             ),
@@ -8424,7 +8425,7 @@ mod tests {
         );
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>("12345", 2).unwrap(),
+                parse_decimal::<Decimal128Type>("12345", 38, 2).unwrap(),
                 38,
                 2,
             ),
@@ -8432,7 +8433,7 @@ mod tests {
         );
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>("0.12345", 2).unwrap(),
+                parse_decimal::<Decimal128Type>("0.12345", 38, 2).unwrap(),
                 38,
                 2,
             ),
@@ -8440,7 +8441,7 @@ mod tests {
         );
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>(".12345", 2).unwrap(),
+                parse_decimal::<Decimal128Type>(".12345", 38, 2).unwrap(),
                 38,
                 2,
             ),
@@ -8448,24 +8449,24 @@ mod tests {
         );
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>(".1265", 2).unwrap(),
+                parse_decimal::<Decimal128Type>(".1265", 38, 2).unwrap(),
                 38,
                 2,
             ),
-            "0.13"
+            "0.12"
         );
         assert_eq!(
             Decimal128Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal128Type>(".1265", 2).unwrap(),
+                parse_decimal::<Decimal128Type>(".1265", 38, 2).unwrap(),
                 38,
                 2,
             ),
-            "0.13"
+            "0.12"
         );
 
         assert_eq!(
             Decimal256Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal256Type>("123.45", 3).unwrap(),
+                parse_decimal::<Decimal256Type>("123.45", 38, 3).unwrap(),
                 38,
                 3,
             ),
@@ -8473,7 +8474,7 @@ mod tests {
         );
         assert_eq!(
             Decimal256Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal256Type>("12345", 3).unwrap(),
+                parse_decimal::<Decimal256Type>("12345", 38, 3).unwrap(),
                 38,
                 3,
             ),
@@ -8481,7 +8482,7 @@ mod tests {
         );
         assert_eq!(
             Decimal256Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal256Type>("0.12345", 3).unwrap(),
+                parse_decimal::<Decimal256Type>("0.12345", 38, 3).unwrap(),
                 38,
                 3,
             ),
@@ -8489,7 +8490,7 @@ mod tests {
         );
         assert_eq!(
             Decimal256Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal256Type>(".12345", 3).unwrap(),
+                parse_decimal::<Decimal256Type>(".12345", 38, 3).unwrap(),
                 38,
                 3,
             ),
@@ -8497,11 +8498,11 @@ mod tests {
         );
         assert_eq!(
             Decimal256Type::format_decimal(
-                parse_string_to_decimal_native::<Decimal256Type>(".1265", 3).unwrap(),
+                parse_decimal::<Decimal256Type>(".1265", 38, 3).unwrap(),
                 38,
                 3,
             ),
-            "0.127"
+            "0.126"
         );
     }
 

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -988,11 +988,6 @@ pub fn parse_decimal<T: DecimalType>(
         }
     }
 
-    //handle scale = 0 , scale down by fractional digits
-    if scale == 0 {
-        result = result.div_wrapping(base.pow_wrapping(fractionals as u32))
-    }
-
     Ok(if negative {
         result.neg_wrapping()
     } else {

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -988,6 +988,11 @@ pub fn parse_decimal<T: DecimalType>(
         }
     }
 
+    //handle scale = 0 , scale down by fractional digits
+    if scale == 0 {
+        result = result.div_wrapping(base.pow_wrapping(fractionals as u32))
+    }
+
     Ok(if negative {
         result.neg_wrapping()
     } else {


### PR DESCRIPTION
# Which issue does this PR close?
 - Related to https://github.com/apache/datafusion/issues/10315
 - Follows up - #6905 ,based on the (https://github.com/apache/arrow-rs/pull/6905#issuecomment-2590125691)

Few important consideration -

- Existing string to decimal conversion uses `parse_string_to_decimal_native`
- `parse_string_to_decimal_native` does not have support for e-notation
-  `parse_string_to_decimal_native` does rounding at scale, not truncate
-  `parse_decimal` an existing method has e-notation support and use elsewhere
-  #6905 added rounding support in `parse_decimal`
-  moved string to decimal conversion to use `parse_decimal` to get support for e-notation.

This PR is a first one to break up #6905 , this one only moves the existing `parse_string_to_decimal_native` tests to use `parse_decimal`. You can observe I changed the tests because `parse_decimal` does not have rounding support as is. Next PR, I'll introduce that change and change these tests again.
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
