### PR TITLE
feat: add rounding logic and scale zero fix parse_decimal to match parse_string_to_decimal_native behavior

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -590,6 +590,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parse::parse_decimal;
 
     #[test]
     fn test_parse_string_to_decimal_native() -> Result<(), ArrowError> {
@@ -598,7 +599,20 @@ mod tests {
             0_i128
         );
         assert_eq!(
+            parse_decimal::<Decimal128Type>("0", 38, 0)?,
+            parse_string_to_decimal_native::<Decimal128Type>("0", 0)?,
+            "value is {}",
+            0_i128
+        );
+
+        assert_eq!(
             parse_string_to_decimal_native::<Decimal128Type>("0", 5)?,
+            0_i128
+        );
+        assert_eq!(
+            parse_decimal::<Decimal128Type>("0", 38, 5)?,
+            parse_string_to_decimal_native::<Decimal128Type>("0", 5)?,
+            "value is {}",
             0_i128
         );
 
@@ -607,7 +621,20 @@ mod tests {
             123_i128
         );
         assert_eq!(
+            parse_decimal::<Decimal128Type>("123", 38, 0)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123", 0)?,
+            "value is {}",
+            123_i128
+        );
+
+        assert_eq!(
             parse_string_to_decimal_native::<Decimal128Type>("123", 5)?,
+            12300000_i128
+        );
+        assert_eq!(
+            parse_decimal::<Decimal128Type>("123", 38, 5)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123", 5)?,
+            "value is {}",
             12300000_i128
         );
 
@@ -616,7 +643,20 @@ mod tests {
             123_i128
         );
         assert_eq!(
+            parse_decimal::<Decimal128Type>("123.45", 38, 0)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123.45", 0)?,
+            "value is {}",
+            123_i128
+        );
+
+        assert_eq!(
             parse_string_to_decimal_native::<Decimal128Type>("123.45", 5)?,
+            12345000_i128
+        );
+        assert_eq!(
+            parse_decimal::<Decimal128Type>("123.45", 38, 5)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123.45", 5)?,
+            "value is {}",
             12345000_i128
         );
 
@@ -625,7 +665,20 @@ mod tests {
             123_i128
         );
         assert_eq!(
+            parse_decimal::<Decimal128Type>("123.4567891", 38, 0)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 0)?,
+            "value is {}",
+            123_i128
+        );
+
+        assert_eq!(
             parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 5)?,
+            12345679_i128
+        );
+        assert_eq!(
+            parse_decimal::<Decimal128Type>("123.4567891", 38, 5)?,
+            parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 5)?,
+            "value is {}",
             12345679_i128
         );
         Ok(())

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -2655,29 +2655,6 @@ mod tests {
             assert_eq!(result_256_e.unwrap(), result_256_d.unwrap());
         }
 
-        // here the 2nd column is expected result, it is also converted using parse_decimal
-        let test_rounding_for_e_notation_varying_scale = [
-            ("1.2345e4", "12345", 2),
-            ("12345e-5", "0.12", 2),
-            ("12345E-5", "0.123", 3),
-            ("12345e-5", "0.1235", 4),
-            ("1265E-4", ".127", 3),
-            ("12.345e3", "12345.000", 3),
-            ("1.2345e4", "12345", 0),
-            ("1.2345e3", "1235", 0),
-            ("1.23e-3", "0", 0),
-            ("123e-2", "1", 0),
-        ];
-
-        for (e, d, scale) in test_rounding_for_e_notation_varying_scale {
-            let result_128_e = parse_decimal::<Decimal128Type>(e, 38, scale);
-            let result_128_d = parse_decimal::<Decimal128Type>(d, 38, scale);
-            assert_eq!(result_128_e.unwrap(), result_128_d.unwrap());
-            let result_256_e = parse_decimal::<Decimal256Type>(e, 38, scale);
-            let result_256_d = parse_decimal::<Decimal256Type>(d, 38, scale);
-            assert_eq!(result_256_e.unwrap(), result_256_d.unwrap());
-        }
-
         let can_not_parse_tests = [
             "123,123",
             ".",

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -2594,6 +2594,16 @@ mod tests {
             assert_eq!(i256::from_i128(i), result_256.unwrap());
         }
 
+        let tests_with_varying_scale = [
+            ("123.4567891", 12345679_i128, 5),
+            ("123.4567891", 123_i128, 0),
+            ("123.45", 12345000_i128, 5),
+        ];
+        for (str, e, scale) in tests_with_varying_scale {
+            let result_128_a = parse_decimal::<Decimal128Type>(str, 20, scale);
+            assert_eq!(result_128_a.unwrap(), e);
+        }
+
         let e_notation_tests = [
             ("1.23e3", "1230.0", 2),
             ("5.6714e+2", "567.14", 4),
@@ -2629,6 +2639,9 @@ mod tests {
             ("000001.1034567002e0", "000001.1034567002", 3),
             ("1.234e16", "12340000000000000", 0),
             ("123.4e16", "1234000000000000000", 0),
+            ("4e+5", "400000", 4),
+            ("4e7", "40000000", 2),
+            ("1265E-4", ".1265", 3),
         ];
         for (e, d, scale) in e_notation_tests {
             let result_128_e = parse_decimal::<Decimal128Type>(e, 20, scale);
@@ -2638,6 +2651,29 @@ mod tests {
             let result_256_d = parse_decimal::<Decimal256Type>(d, 20, scale);
             assert_eq!(result_256_e.unwrap(), result_256_d.unwrap());
         }
+
+        let test_rounding_for_e_notation_varying_scale = [
+            ("1.2345e4", "12345", 2),
+            ("12345e-5", "0.12", 2),
+            ("12345E-5", "0.123", 3),
+            ("12345e-5", "0.1235", 4),
+            ("1265E-4", ".127", 3),
+            ("12.345e3", "12345.000", 3),
+            ("1.2345e4", "12345", 0),
+            ("1.2345e3", "1235", 0),
+            ("1.23e-3", "0", 0),
+            ("123e-2", "1", 0),
+        ];
+
+        for (e, d, scale) in test_rounding_for_e_notation_varying_scale {
+            let result_128_e = parse_decimal::<Decimal128Type>(e, 38, scale);
+            let result_128_d = parse_decimal::<Decimal128Type>(d, 38, scale);
+            assert_eq!(result_128_e.unwrap(), result_128_d.unwrap());
+            let result_256_e = parse_decimal::<Decimal256Type>(e, 38, scale);
+            let result_256_d = parse_decimal::<Decimal256Type>(d, 38, scale);
+            assert_eq!(result_256_e.unwrap(), result_256_d.unwrap());
+        }
+
         let can_not_parse_tests = [
             "123,123",
             ".",

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -850,7 +850,16 @@ fn parse_e_notation<T: DecimalType>(
     }
 
     if exp < 0 {
-        result = result.div_wrapping(base.pow_wrapping(-exp as _));
+        let result_with_scale = result.div_wrapping(base.pow_wrapping(-exp as _));
+        let result_with_one_scale_up =
+            result.div_wrapping(base.pow_wrapping(-exp.add_wrapping(1) as _));
+        let rounding_digit =
+            result_with_one_scale_up.sub_wrapping(result_with_scale.mul_wrapping(base));
+        if rounding_digit >= T::Native::usize_as(5) {
+            result = result_with_scale.add_wrapping(T::Native::usize_as(1));
+        } else {
+            result = result_with_scale;
+        }
     } else {
         result = result.mul_wrapping(base.pow_wrapping(exp as _));
     }
@@ -868,6 +877,7 @@ pub fn parse_decimal<T: DecimalType>(
     let mut result = T::Native::usize_as(0);
     let mut fractionals: i8 = 0;
     let mut digits: u8 = 0;
+    let mut rounding_digit = -1; // to store digit after the scale for rounding
     let base = T::Native::usize_as(10);
 
     let bs = s.as_bytes();
@@ -895,6 +905,13 @@ pub fn parse_decimal<T: DecimalType>(
             b'0'..=b'9' => {
                 if digits == 0 && *b == b'0' {
                     // Ignore leading zeros.
+                    continue;
+                }
+                if fractionals == scale && scale != 0 {
+                    // Capture the rounding digit once
+                    if rounding_digit < 0 {
+                        rounding_digit = (b - b'0') as i8;
+                    }
                     continue;
                 }
                 digits += 1;
@@ -925,11 +942,17 @@ pub fn parse_decimal<T: DecimalType>(
                             "can't parse the string value {s} to decimal"
                         )));
                     }
-                    if fractionals == scale && scale != 0 {
+                    if fractionals == scale {
+                        // Capture the rounding digit once
+                        if rounding_digit < 0 {
+                            rounding_digit = (b - b'0') as i8;
+                        }
                         // We have processed all the digits that we need. All that
                         // is left is to validate that the rest of the string contains
                         // valid digits.
-                        continue;
+                        if scale != 0 {
+                            continue;
+                        }
                     }
                     fractionals += 1;
                     digits += 1;
@@ -985,6 +1008,13 @@ pub fn parse_decimal<T: DecimalType>(
             return Err(ArrowError::ParseError(format!(
                 "parse decimal overflow ({s})"
             )));
+        }
+        if scale == 0 {
+            result = result.div_wrapping(base.pow_wrapping(fractionals as u32))
+        }
+        //add one if >=5
+        if rounding_digit >= 5 {
+            result = result.add_wrapping(T::Native::usize_as(1));
         }
     }
 

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -2601,6 +2601,8 @@ mod tests {
             ("123.4567891", 12345679_i128, 5),
             ("123.4567891", 123_i128, 0),
             ("123.45", 12345000_i128, 5),
+            ("-2.5", -3_i128, 0),
+            ("-2.49", -2_i128, 0),
         ];
         for (str, e, scale) in tests_with_varying_scale {
             let result_128_a = parse_decimal::<Decimal128Type>(str, 20, scale);

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1286,7 +1286,7 @@ mod tests {
         assert_eq!("53.002666", lat.value_as_string(1));
         assert_eq!("52.412811", lat.value_as_string(2));
         assert_eq!("51.481583", lat.value_as_string(3));
-        assert_eq!("12.123456", lat.value_as_string(4));
+        assert_eq!("12.123457", lat.value_as_string(4));
         assert_eq!("50.760000", lat.value_as_string(5));
         assert_eq!("0.123000", lat.value_as_string(6));
         assert_eq!("123.000000", lat.value_as_string(7));

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1181,7 +1181,7 @@ mod tests {
         assert!(col1.is_null(5));
         assert_eq!(
             col1.values(),
-            &[100, 200, 204, 1103420, 0, 0].map(T::Native::usize_as)
+            &[100, 200, 205, 1103420, 0, 0].map(T::Native::usize_as)
         );
 
         let col2 = batches[0].column(1).as_primitive::<T>();
@@ -1201,7 +1201,7 @@ mod tests {
         assert!(col3.is_null(5));
         assert_eq!(
             col3.values(),
-            &[3830, 12345, 0, 0, 0, 0].map(T::Native::usize_as)
+            &[3830, 12346, 0, 0, 0, 0].map(T::Native::usize_as)
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?
 - Closes #7355 
 - related to  https://github.com/apache/datafusion/issues/10315
 - Follows up - #6905 ,based on the (https://github.com/apache/arrow-rs/pull/6905#issuecomment-2590125691)

Few important consideration -

- Existing string to decimal conversion uses `parse_string_to_decimal_native`
- `parse_string_to_decimal_native` does not have support for e-notation
-  `parse_string_to_decimal_native` does rounding at scale, not truncate
-  `parse_decimal` an existing method has e-notation support and use elsewhere
-  #6905 added rounding support in `parse_decimal`
-  moved string to decimal conversion to use `parse_decimal` to get support for e-notation.

This PR is a 2nd one to break up #6905 , this one add rounding logic to parse_decimal to match the behavior in existing  `parse_string_to_decimal_native`. 

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

At present, string to decimal conversion does not support e-notation, in arrow, `parse_string_to_decimal_native` is called to get generic string to decimal. parse_decimal on the other hand is used from generic parse method and it has e-notation support. This PR is adding rounding and scale 0 handling to match the behavior or `parse_string_to_decimal_native` method. Then we can replace `parse_string_to_decimal_native` call with `parse_decimal`. This way, we will get e-notation support too.
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
