### PR TITLE
feat:use parse_decimal for generic_string_to_decimal conversion.

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::cast::*;
+use crate::parse::*;
 
 /// A utility trait that provides checked conversions between
 /// decimal types inspired by [`NumCast`]
@@ -352,7 +353,7 @@ where
 {
     if cast_options.safe {
         let iter = from.iter().map(|v| {
-            v.and_then(|v| parse_string_to_decimal_native::<T>(v, scale as usize).ok())
+            v.and_then(|v| parse_decimal::<T>(v, precision, scale).ok())
                 .and_then(|v| T::is_valid_decimal_precision(v, precision).then_some(v))
         });
         // Benefit:
@@ -368,12 +369,13 @@ where
             .iter()
             .map(|v| {
                 v.map(|v| {
-                    parse_string_to_decimal_native::<T>(v, scale as usize)
+                    parse_decimal::<T>(v, precision, scale)
                         .map_err(|_| {
                             ArrowError::CastError(format!(
-                                "Cannot cast string '{}' to value of {:?} type",
+                                "Cannot cast string '{}' to decimal type of precision {} and scale {}",
                                 v,
-                                T::DATA_TYPE,
+                                precision,
+                                scale
                             ))
                         })
                         .and_then(|v| T::validate_decimal_precision(v, precision).map(|_| v))


### PR DESCRIPTION
# Which issue does this PR close?
 - Closes https://github.com/apache/datafusion/issues/10315
 - Follows up - based on the (https://github.com/apache/arrow-rs/pull/6905#issuecomment-2590125691)
 - depends on #7179  - tests will pass when this one is merged.

Few important consideration -

- Existing string to decimal conversion uses `parse_string_to_decimal_native`
- `parse_string_to_decimal_native` does not have support for e-notation
-  `parse_string_to_decimal_native` does rounding at scale, not truncate
-  `parse_decimal` an existing method has e-notation support and use elsewhere
-   add rounding support in `parse_decimal`
-  moved string to decimal conversion to use `parse_decimal` to get support for e-notation.

This PR is a 3rd one to break up #6905 , this one add rounding logic to parse_decimal to match the behavior in existing  `parse_string_to_decimal_native`. 

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

At present, string to decimal conversion does not support e-notation, in arrow, `parse_string_to_decimal_native` is called to get generic string to decimal. parse_decimal on the other hand is used from generic parse method and it has e-notation support. This PR is adding rounding and scale 0 handling to match the behavior or `parse_string_to_decimal_native` method. Then we can replace `parse_string_to_decimal_native` call with `parse_decimal`. This way, we will get e-notation support too.
 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
