### PR TITLE
Improve RleDecoder performance

### DIFF
--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -378,9 +378,7 @@ impl RleDecoder {
                 let num_values = cmp::min(buffer.len() - values_read, self.rle_left as usize);
                 let repeated_value =
                     T::try_from_le_slice(&self.current_value.as_mut().unwrap().to_ne_bytes())?;
-                for i in 0..num_values {
-                    buffer[values_read + i] = repeated_value.clone();
-                }
+                buffer[values_read..values_read+num_values].fill(repeated_value);
                 self.rle_left -= num_values as u32;
                 values_read += num_values;
             } else if self.bit_packed_left > 0 {
@@ -455,9 +453,11 @@ impl RleDecoder {
             if self.rle_left > 0 {
                 let num_values = cmp::min(max_values - values_read, self.rle_left as usize);
                 let dict_idx = self.current_value.unwrap() as usize;
-                for i in 0..num_values {
-                    buffer[values_read + i].clone_from(&dict[dict_idx]);
-                }
+                let dict_value = dict[dict_idx].clone();
+            
+                buffer[values_read..values_read + num_values]
+                    .fill(dict_value);
+
                 self.rle_left -= num_values as u32;
                 values_read += num_values;
             } else if self.bit_packed_left > 0 {
@@ -480,9 +480,10 @@ impl RleDecoder {
                         self.bit_packed_left = 0;
                         break;
                     }
-                    for i in 0..num_values {
-                        buffer[values_read + i].clone_from(&dict[index_buf[i] as usize])
-                    }
+                    buffer[values_read..values_read + num_values]
+                        .iter_mut()
+                        .zip(index_buf[..num_values].iter())
+                        .for_each(|(b, i)|b.clone_from(&dict[*i as usize]));
                     self.bit_packed_left -= num_values as u32;
                     values_read += num_values;
                     if num_values < to_read {

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -378,7 +378,7 @@ impl RleDecoder {
                 let num_values = cmp::min(buffer.len() - values_read, self.rle_left as usize);
                 let repeated_value =
                     T::try_from_le_slice(&self.current_value.as_mut().unwrap().to_ne_bytes())?;
-                buffer[values_read..values_read+num_values].fill(repeated_value);
+                buffer[values_read..values_read + num_values].fill(repeated_value);
                 self.rle_left -= num_values as u32;
                 values_read += num_values;
             } else if self.bit_packed_left > 0 {
@@ -454,9 +454,8 @@ impl RleDecoder {
                 let num_values = cmp::min(max_values - values_read, self.rle_left as usize);
                 let dict_idx = self.current_value.unwrap() as usize;
                 let dict_value = dict[dict_idx].clone();
-            
-                buffer[values_read..values_read + num_values]
-                    .fill(dict_value);
+
+                buffer[values_read..values_read + num_values].fill(dict_value);
 
                 self.rle_left -= num_values as u32;
                 values_read += num_values;
@@ -483,7 +482,7 @@ impl RleDecoder {
                     buffer[values_read..values_read + num_values]
                         .iter_mut()
                         .zip(index_buf[..num_values].iter())
-                        .for_each(|(b, i)|b.clone_from(&dict[*i as usize]));
+                        .for_each(|(b, i)| b.clone_from(&dict[*i as usize]));
                     self.bit_packed_left -= num_values as u32;
                     values_read += num_values;
                     if num_values < to_read {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Closes #7206


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Just some  small performance improvement:

```
arrow_array_reader/Int64Array/dictionary encoded, mandatory, no NULLs
                        time:   [68.938 µs 70.463 µs 72.200 µs]
                        change: [-22.970% -21.331% -19.572%] (p = 0.00 < 0.05)
                        Performance has improved.
arrow_array_reader/Int64Array/dictionary encoded, optional, no NULLs
                        time:   [77.723 µs 79.461 µs 81.282 µs]
                        change: [-22.811% -20.776% -18.535%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->



# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
