### PR TITLE
Remove zstd pin

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -86,14 +86,6 @@ tokio = { version = "1.0", default-features = false, features = ["macros", "rt-m
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 object_store = { version = "0.11.0", default-features = false, features = ["azure"] }
 
-# TODO: temporary to fix parquet wasm build
-# upstream issue: https://github.com/gyscos/zstd-rs/issues/269
-[target.'cfg(target_family = "wasm")'.dependencies]
-zstd-sys = { version = ">=2.0.0, <2.0.14", optional = true, default-features = false }
-
-[target.'cfg(target_family = "wasm")'.dev-dependencies]
-zstd-sys = { version = ">=2.0.0, <2.0.14", default-features = false }
-
 [package.metadata.docs.rs]
 all-features = true
 
@@ -118,7 +110,7 @@ async = ["futures", "tokio"]
 # Enable object_store integration
 object_store = ["dep:object_store", "async"]
 # Group Zstd dependencies
-zstd = ["dep:zstd", "zstd-sys"]
+zstd = ["dep:zstd"]
 # Display memory in example/write_parquet.rs
 sysinfo = ["dep:sysinfo"]
 # Verify 32-bit CRC checksum when decoding parquet pages


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There was an issue in zstd-sys `<2.0.10` that caused us to pin it https://github.com/apache/arrow-rs/pull/5567

A succession of PRs have loosened this constraint to the point where it no longer actually serves any purpose, the problematic version is permitted.

Given this hasn't caused downstream issue I think we should just remove the pin entirely

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
