### PR TITLE
feat: add `Extensions` to object store `PutOptions`

### DIFF
--- a/object_store/src/aws/client.rs
+++ b/object_store/src/aws/client.rs
@@ -389,6 +389,11 @@ impl Request<'_> {
         Self { builder, ..self }
     }
 
+    pub(crate) fn with_extensions(self, extensions: ::http::Extensions) -> Self {
+        let builder = self.builder.extensions(extensions);
+        Self { builder, ..self }
+    }
+
     pub(crate) fn with_payload(mut self, payload: PutPayload) -> Self {
         if (!self.config.skip_signature && self.config.sign_payload)
             || self.config.checksum.is_some()

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -159,15 +159,23 @@ impl ObjectStore for AmazonS3 {
         payload: PutPayload,
         opts: PutOptions,
     ) -> Result<PutResult> {
+        let PutOptions {
+            mode,
+            tags,
+            attributes,
+            extensions,
+        } = opts;
+
         let request = self
             .client
             .request(Method::PUT, location)
             .with_payload(payload)
-            .with_attributes(opts.attributes)
-            .with_tags(opts.tags)
+            .with_attributes(attributes)
+            .with_tags(tags)
+            .with_extensions(extensions)
             .with_encryption_headers();
 
-        match (opts.mode, &self.client.config.conditional_put) {
+        match (mode, &self.client.config.conditional_put) {
             (PutMode::Overwrite, _) => request.idempotent(true).do_put().await,
             (PutMode::Create | PutMode::Update(_), None) => Err(Error::NotImplemented),
             (PutMode::Create, Some(S3ConditionalPut::ETagMatch)) => {

--- a/object_store/src/lib.rs
+++ b/object_store/src/lib.rs
@@ -1154,7 +1154,7 @@ impl From<PutResult> for UpdateVersion {
 }
 
 /// Options for a put request
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct PutOptions {
     /// Configure the [`PutMode`] for this operation
     pub mode: PutMode,
@@ -1166,7 +1166,34 @@ pub struct PutOptions {
     ///
     /// Implementations that don't support an attribute should return an error
     pub attributes: Attributes,
+    /// Implementation-specific extensions. Intended for use by [`ObjectStore`] implementations
+    /// that need to pass context-specific information (like tracing spans) via trait methods.
+    ///
+    /// These extensions are ignored entirely by backends offered through this crate.
+    ///
+    /// They are also eclused from [`PartialEq`] and [`Eq`].
+    pub extensions: ::http::Extensions,
 }
+
+impl PartialEq<Self> for PutOptions {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            mode,
+            tags,
+            attributes,
+            extensions: _,
+        } = self;
+        let Self {
+            mode: other_mode,
+            tags: other_tags,
+            attributes: other_attributes,
+            extensions: _,
+        } = other;
+        (mode == other_mode) && (tags == other_tags) && (attributes == other_attributes)
+    }
+}
+
+impl Eq for PutOptions {}
 
 impl From<PutMode> for PutOptions {
     fn from(mode: PutMode) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Follow-up to #7170.

See https://github.com/apache/arrow-rs/pull/7170#issuecomment-2687892737 .

# What changes are included in this PR?
`PutOptions::extensions`.

# Are there any user-facing changes?
**Breaking:** New field.
