### PR TITLE
Minor: Fix json StructMode docs links

### DIFF
--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -92,8 +92,8 @@ use serde_json::{Number, Value};
 /// lists, the entries must be the same number and in the same order as the
 /// struct fields. Map columns are not affected by this option.
 ///
-/// [Presto]: (https://prestodb.io/docs/current/develop/client-protocol.html#important-queryresults-attributes)
-/// [Trino]: (https://trino.io/docs/current/develop/client-protocol.html#important-queryresults-attributes)
+/// [Presto]: https://prestodb.io/docs/current/develop/client-protocol.html#important-queryresults-attributes
+/// [Trino]: https://trino.io/docs/current/develop/client-protocol.html#important-queryresults-attributes
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum StructMode {
     #[default]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
 Trino and PrestoDB links at [StructMode](https://docs.rs/arrow-json/54.2.1/arrow_json/enum.StructMode.html) are enclosed in parentheses, making them relative paths, pointing to:

 https://docs.rs/arrow-json/latest/arrow_json/(https://prestodb.io/docs/current/develop/client-protocol.html#important-queryresults-attributes)
 
 https://docs.rs/arrow-json/latest/arrow_json/(https://trino.io/docs/current/develop/client-protocol.html#important-queryresults-attributes)

# What changes are included in this PR?

Remove parentheses from the links

# Are there any user-facing changes?

Docs only