### PR TITLE
ObjectStore WASM32 Support

### DIFF
--- a/.github/workflows/object_store.yml
+++ b/.github/workflows/object_store.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Build wasm32-unknown-unknown
         run: cargo build --target wasm32-unknown-unknown
       - name: Build wasm32-wasip1
-        run: cargo build --target wasm32-wasip1
+        run: cargo build --all-features --target wasm32-wasip1
 
   windows:
     name: cargo test LocalFileSystem (win64)

--- a/object_store/src/aws/builder.rs
+++ b/object_store/src/aws/builder.rs
@@ -23,7 +23,7 @@ use crate::aws::{
     AmazonS3, AwsCredential, AwsCredentialProvider, Checksum, S3ConditionalPut, S3CopyIfNotExists,
     STORE,
 };
-use crate::client::{HttpConnector, ReqwestConnector, TokenCredentialProvider};
+use crate::client::{http_connector, HttpConnector, TokenCredentialProvider};
 use crate::config::ConfigValue;
 use crate::{ClientConfigKey, ClientOptions, Result, RetryConfig, StaticCredentialProvider};
 use base64::prelude::BASE64_STANDARD;
@@ -896,9 +896,7 @@ impl AmazonS3Builder {
             self.parse_url(&url)?;
         }
 
-        let http = self
-            .http_connector
-            .unwrap_or_else(|| Arc::new(ReqwestConnector::default()));
+        let http = http_connector(self.http_connector)?;
 
         let bucket = self.bucket_name.ok_or(Error::MissingBucketName)?;
         let region = self.region.unwrap_or_else(|| "us-east-1".to_string());

--- a/object_store/src/aws/mod.rs
+++ b/object_store/src/aws/mod.rs
@@ -58,12 +58,16 @@ mod client;
 mod credential;
 mod dynamo;
 mod precondition;
+
+#[cfg(not(target_arch = "wasm32"))]
 mod resolve;
 
 pub use builder::{AmazonS3Builder, AmazonS3ConfigKey};
 pub use checksum::Checksum;
 pub use dynamo::DynamoCommit;
 pub use precondition::{S3ConditionalPut, S3CopyIfNotExists};
+
+#[cfg(not(target_arch = "wasm32"))]
 pub use resolve::resolve_bucket_region;
 
 /// This struct is used to maintain the URI path encoding

--- a/object_store/src/azure/builder.rs
+++ b/object_store/src/azure/builder.rs
@@ -21,7 +21,7 @@ use crate::azure::credential::{
     ImdsManagedIdentityProvider, WorkloadIdentityOAuthProvider,
 };
 use crate::azure::{AzureCredential, AzureCredentialProvider, MicrosoftAzure, STORE};
-use crate::client::{HttpConnector, ReqwestConnector, TokenCredentialProvider};
+use crate::client::{http_connector, HttpConnector, TokenCredentialProvider};
 use crate::config::ConfigValue;
 use crate::{ClientConfigKey, ClientOptions, Result, RetryConfig, StaticCredentialProvider};
 use percent_encoding::percent_decode_str;
@@ -907,9 +907,7 @@ impl MicrosoftAzureBuilder {
             Arc::new(StaticCredentialProvider::new(credential))
         };
 
-        let http = self
-            .http_connector
-            .unwrap_or_else(|| Arc::new(ReqwestConnector::default()));
+        let http = http_connector(self.http_connector)?;
 
         let (is_emulator, storage_url, auth, account) = if self.use_emulator.get()? {
             let account_name = self

--- a/object_store/src/client/body.rs
+++ b/object_store/src/client/body.rs
@@ -39,6 +39,7 @@ impl HttpRequestBody {
         Self(Inner::Bytes(Bytes::new()))
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn into_reqwest(self) -> reqwest::Body {
         match self.0 {
             Inner::Bytes(b) => b.into(),

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -19,6 +19,7 @@
 
 pub(crate) mod backoff;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod dns;
 
 #[cfg(test)]
@@ -48,21 +49,24 @@ pub use body::{HttpRequest, HttpRequestBody, HttpResponse, HttpResponseBody};
 pub(crate) mod builder;
 
 mod connection;
-pub use connection::{
-    HttpClient, HttpConnector, HttpError, HttpErrorKind, HttpService, ReqwestConnector,
-};
+pub(crate) use connection::http_connector;
+#[cfg(not(target_arch = "wasm32"))]
+pub use connection::ReqwestConnector;
+pub use connection::{HttpClient, HttpConnector, HttpError, HttpErrorKind, HttpService};
 
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 pub(crate) mod parts;
 
 use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{Client, ClientBuilder, NoProxy, Proxy};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+use reqwest::{NoProxy, Proxy};
 
 use crate::config::{fmt_duration, ConfigValue};
 use crate::path::Path;
@@ -195,8 +199,10 @@ impl FromStr for ClientConfigKey {
 /// This is used to configure the client to trust a specific certificate. See
 /// [Self::from_pem] for an example
 #[derive(Debug, Clone)]
+#[cfg(not(target_arch = "wasm32"))]
 pub struct Certificate(reqwest::tls::Certificate);
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Certificate {
     /// Create a `Certificate` from a PEM encoded certificate.
     ///
@@ -243,6 +249,7 @@ impl Certificate {
 #[derive(Debug, Clone)]
 pub struct ClientOptions {
     user_agent: Option<ConfigValue<HeaderValue>>,
+    #[cfg(not(target_arch = "wasm32"))]
     root_certificates: Vec<Certificate>,
     content_type_map: HashMap<String, String>,
     default_content_type: Option<String>,
@@ -276,6 +283,7 @@ impl Default for ClientOptions {
         // we opt for a slightly higher default timeout of 30 seconds
         Self {
             user_agent: None,
+            #[cfg(not(target_arch = "wasm32"))]
             root_certificates: Default::default(),
             content_type_map: Default::default(),
             default_content_type: None,
@@ -402,6 +410,7 @@ impl ClientOptions {
     ///
     /// This can be used to connect to a server that has a self-signed
     /// certificate for example.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_root_certificate(mut self, certificate: Certificate) -> Self {
         self.root_certificates.push(certificate);
         self
@@ -614,8 +623,9 @@ impl ClientOptions {
             .with_connect_timeout(Duration::from_secs(1))
     }
 
-    pub(crate) fn client(&self) -> Result<Client> {
-        let mut builder = ClientBuilder::new();
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn client(&self) -> Result<reqwest::Client> {
+        let mut builder = reqwest::ClientBuilder::new();
 
         match &self.user_agent {
             Some(user_agent) => builder = builder.user_agent(user_agent.get()?),

--- a/object_store/src/gcp/builder.rs
+++ b/object_store/src/gcp/builder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::client::{HttpConnector, ReqwestConnector, TokenCredentialProvider};
+use crate::client::{http_connector, HttpConnector, TokenCredentialProvider};
 use crate::gcp::client::{GoogleCloudStorageClient, GoogleCloudStorageConfig};
 use crate::gcp::credential::{
     ApplicationDefaultCredentials, InstanceCredentialProvider, ServiceAccountCredentials,
@@ -442,9 +442,7 @@ impl GoogleCloudStorageBuilder {
 
         let bucket_name = self.bucket_name.ok_or(Error::MissingBucketName {})?;
 
-        let http = self
-            .http_connector
-            .unwrap_or_else(|| Arc::new(ReqwestConnector::default()));
+        let http = http_connector(self.http_connector)?;
 
         // First try to initialize from the service account information.
         let service_account_credentials =

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -41,7 +41,7 @@ use url::Url;
 
 use crate::client::get::GetClientExt;
 use crate::client::header::get_etag;
-use crate::client::{HttpConnector, ReqwestConnector};
+use crate::client::{http_connector, HttpConnector};
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
@@ -248,10 +248,7 @@ impl HttpBuilder {
         let url = self.url.ok_or(Error::MissingUrl)?;
         let parsed = Url::parse(&url).map_err(|source| Error::UnableToParseUrl { url, source })?;
 
-        let client = match self.http_connector {
-            None => ReqwestConnector::default().connect(&self.client_options)?,
-            Some(x) => x.connect(&self.client_options)?,
-        };
+        let client = http_connector(self.http_connector)?.connect(&self.client_options)?;
 
         Ok(HttpStore {
             client: Arc::new(Client::new(

--- a/object_store/src/parse.rs
+++ b/object_store/src/parse.rs
@@ -201,7 +201,13 @@ where
             let url = &url[..url::Position::BeforePath];
             builder_opts!(crate::http::HttpBuilder, url, _options)
         }
-        #[cfg(not(all(feature = "aws", feature = "azure", feature = "gcp", feature = "http")))]
+        #[cfg(not(all(
+            feature = "aws",
+            feature = "azure",
+            feature = "gcp",
+            feature = "http",
+            not(target_arch = "wasm32")
+        )))]
         s => {
             return Err(super::Error::Generic {
                 store: "parse_url",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6818.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This allows building object_store with all features enabled on wasm32-wasip1.

It is worth noting, providing an HttpConnector and by extension HttpClient is an exercise for the user, but I could see this changing - it just needs someone to go away and figure out how best to do this. I am also aware that wasm32-wasip2 adds proper socket support, and so there is the possibility it could use a more "normal" HTTP client eventually.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Some feature gating to make it possible to enable the cloud features on WASM platforms. 

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

FYI @kylebarron 
