### PR TITLE
Backport `chrono`-`quarter` fix 0.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,4 +93,4 @@ arrow-select = { version = "53.3.0", path = "./arrow-select" }
 arrow-string = { version = "53.3.0", path = "./arrow-string" }
 parquet = { version = "53.3.0", path = "./parquet", default-features = false }
 
-chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.40", default-features = false, features = ["clock"] }

--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -633,12 +633,6 @@ pub(crate) use return_compute_error_with;
 
 // Internal trait, which is used for mapping values from DateLike structures
 trait ChronoDateExt {
-    /// Returns a value in range `1..=4` indicating the quarter this date falls into
-    fn quarter(&self) -> u32;
-
-    /// Returns a value in range `0..=3` indicating the quarter (zero-based) this date falls into
-    fn quarter0(&self) -> u32;
-
     /// Returns the day of week; Monday is encoded as `0`, Tuesday as `1`, etc.
     fn num_days_from_monday(&self) -> i32;
 
@@ -647,14 +641,6 @@ trait ChronoDateExt {
 }
 
 impl<T: Datelike> ChronoDateExt for T {
-    fn quarter(&self) -> u32 {
-        self.quarter0() + 1
-    }
-
-    fn quarter0(&self) -> u32 {
-        self.month0() / 3
-    }
-
     fn num_days_from_monday(&self) -> i32 {
         self.weekday().num_days_from_monday() as i32
     }


### PR DESCRIPTION
* Carbon-copy of https://github.com/apache/arrow-rs/pull/7198

Target is the 0.53.0_maintanance branch. When merged, I hope this can make it to a 53.4.1 patch release.