### PR TITLE
Backport `chrono`-`quarter` fix 0.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,4 +93,4 @@ arrow-select = { version = "53.3.0", path = "./arrow-select" }
 arrow-string = { version = "53.3.0", path = "./arrow-string" }
 parquet = { version = "53.3.0", path = "./parquet", default-features = false }
 
-chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
+chrono = { version = ">= 0.4.34, < 0.4.40", default-features = false, features = ["clock"] }


### PR DESCRIPTION
* Carbon-copy of https://github.com/apache/arrow-rs/pull/7210
* The only difference this PR is target at 53 instead of 54