### PR TITLE
feat: use `force_validate` feature flag when creating an arrays

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -164,6 +164,9 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         values: Buffer,
         nulls: Option<NullBuffer>,
     ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(offsets, values, nulls);
+        }
         Self {
             data_type: T::DATA_TYPE,
             value_offsets: offsets,

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -232,6 +232,10 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         buffers: Vec<Buffer>,
         nulls: Option<NullBuffer>,
     ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(views, buffers, nulls);
+        }
+
         Self {
             data_type: T::DATA_TYPE,
             phantom: Default::default(),

--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -327,6 +327,10 @@ impl<K: ArrowDictionaryKeyType> DictionaryArray<K> {
     ///
     /// Safe provided [`Self::try_new`] would not return an error
     pub unsafe fn new_unchecked(keys: PrimitiveArray<K>, values: ArrayRef) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(keys, values);
+        }
+
         let data_type = DataType::Dictionary(
             Box::new(keys.data_type().clone()),
             Box::new(values.data_type().clone()),

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -189,6 +189,10 @@ impl StructArray {
         arrays: Vec<ArrayRef>,
         nulls: Option<NullBuffer>,
     ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(fields, arrays, nulls);
+        }
+
         let len = arrays.first().map(|x| x.len()).unwrap_or_default();
         Self {
             len,

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1298,12 +1298,12 @@ mod tests_to_then_from_ffi {
 mod tests_from_ffi {
     use std::sync::Arc;
 
-    use arrow_buffer::{bit_util, buffer::Buffer, MutableBuffer, OffsetBuffer};
+    use arrow_buffer::{bit_util, buffer::Buffer};
     use arrow_data::transform::MutableArrayData;
     use arrow_data::ArrayData;
     use arrow_schema::{DataType, Field};
 
-    use super::{ImportedArrowArray, Result};
+    use super::Result;
     use crate::builder::GenericByteViewBuilder;
     use crate::types::{BinaryViewType, ByteViewType, Int32Type, StringViewType};
     use crate::{
@@ -1507,7 +1507,11 @@ mod tests_from_ffi {
     }
 
     #[test]
+    #[cfg(not(feature = "force_validate"))]
     fn test_empty_string_with_non_zero_offset() -> Result<()> {
+        use super::ImportedArrowArray;
+        use arrow_buffer::{MutableBuffer, OffsetBuffer};
+
         // Simulate an empty string array with a non-zero offset from a producer
         let data: Buffer = MutableBuffer::new(0).into();
         let offsets = OffsetBuffer::new(vec![123].into());


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
Sometimes I use `new_unchecked` to create arrays for perfromance reasons, but for testing I would like to always assert so I'm using the `force_validate` feature flag.

# What changes are included in this PR?

Force validate for `ByteArray`, `ByteViewArray`, `DictionaryArray` and `StructArray`, also changed `test_empty_string_with_non_zero_offset` in ffi to only run when not having force validate 

# Are there any user-facing changes?

Kind of