### PR TITLE
Allow INT96 timestamps to be stores as FixedSizeBinary(12)

### DIFF
--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -20,15 +20,14 @@ use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
 use crate::basic::Type as PhysicalType;
 use crate::column::page::PageIterator;
-use crate::data_type::{DataType, Int96};
+use crate::data_type::{AsBytes, DataType, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
-use arrow_array::Decimal256Array;
 use arrow_array::{
-    builder::TimestampNanosecondBufferBuilder, ArrayRef, BooleanArray, Decimal128Array,
-    Float32Array, Float64Array, Int32Array, Int64Array, TimestampNanosecondArray, UInt32Array,
-    UInt64Array,
+    builder::TimestampNanosecondBuilder, cast::AsArray, Array, ArrayRef, BooleanArray,
+    Decimal128Array, Float32Array, Float64Array, Int32Array, Int64Array, UInt32Array, UInt64Array,
 };
+use arrow_array::{Decimal256Array, FixedSizeBinaryArray};
 use arrow_buffer::{i256, BooleanBuffer, Buffer};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType as ArrowType, TimeUnit};
@@ -59,11 +58,11 @@ impl IntoBuffer for Vec<bool> {
 
 impl IntoBuffer for Vec<Int96> {
     fn into_buffer(self) -> Buffer {
-        let mut builder = TimestampNanosecondBufferBuilder::new(self.len());
-        for v in self {
-            builder.append(v.to_nanos())
-        }
-        builder.finish()
+        let mut data = Vec::<u8>::with_capacity(self.len() * 12);
+        self.iter()
+            .for_each(|value| data.extend_from_slice(value.as_bytes()));
+        assert_eq!(data.len(), self.len() * 12);
+        data.into_buffer()
     }
 }
 
@@ -160,10 +159,7 @@ where
             }
             PhysicalType::FLOAT => ArrowType::Float32,
             PhysicalType::DOUBLE => ArrowType::Float64,
-            PhysicalType::INT96 => match target_type {
-                ArrowType::Timestamp(TimeUnit::Nanosecond, _) => target_type.clone(),
-                _ => unreachable!("INT96 must be timestamp nanosecond"),
-            },
+            PhysicalType::INT96 => ArrowType::FixedSizeBinary(12),
             PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
                 unreachable!("PrimitiveArrayReaders don't support complex physical types");
             }
@@ -194,7 +190,7 @@ where
             },
             PhysicalType::FLOAT => Arc::new(Float32Array::from(array_data)),
             PhysicalType::DOUBLE => Arc::new(Float64Array::from(array_data)),
-            PhysicalType::INT96 => Arc::new(TimestampNanosecondArray::from(array_data)),
+            PhysicalType::INT96 => Arc::new(FixedSizeBinaryArray::from(array_data)),
             PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
                 unreachable!("PrimitiveArrayReaders don't support complex physical types");
             }
@@ -210,7 +206,32 @@ where
         // These are:
         // - date64: cast int32 to date32, then date32 to date64.
         // - decimal: cast int32 to decimal, int64 to decimal
+        // - int96: convert to nanosecond precision timestamp i64. Related discussion:
+        //      - https://github.com/apache/arrow-rs/issues/982
+        //      - https://github.com/apache/arrow-rs/pull/2481
         let array = match target_type {
+            ArrowType::Timestamp(TimeUnit::Nanosecond, _)
+                if T::get_physical_type() == PhysicalType::INT96 =>
+            {
+                // Build up Timestamp Array from FixedSizeBinary Array by converting each element.
+                let mut builder = TimestampNanosecondBuilder::with_capacity(array.len());
+                let fsb_array = array.as_fixed_size_binary();
+                let mut temp_int96 = Int96::new();
+                for fsb in fsb_array {
+                    match fsb {
+                        None => {
+                            builder.append_null();
+                        }
+                        Some(bytes) => {
+                            temp_int96.set_bytes(bytes);
+                            builder.append_value(temp_int96.to_nanos());
+                        }
+                    }
+                }
+
+                let array = Arc::new(builder.finish()) as ArrayRef;
+                arrow_cast::cast(&array, target_type)?
+            }
             ArrowType::Date64 if *(array.data_type()) == ArrowType::Int32 => {
                 // this is cheap as it internally reinterprets the data
                 let a = arrow_cast::cast(&array, &ArrowType::Date32)?;

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -53,6 +53,9 @@ fn apply_hint(parquet: DataType, hint: DataType) -> DataType {
         // Determine timezone
         (DataType::Timestamp(p, _), DataType::Timestamp(h, Some(_))) if p == h => hint,
 
+        // Read Timestamp as raw bytes
+        (DataType::Timestamp(TimeUnit::Nanosecond, _), DataType::FixedSizeBinary(12)) => hint,
+
         // Determine offset size
         (DataType::Utf8, DataType::LargeUtf8) => hint,
         (DataType::Binary, DataType::LargeBinary) => hint,

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -56,6 +56,16 @@ impl Int96 {
         self.value = [elem0, elem1, elem2];
     }
 
+    /// Sets data for this INT96 type.
+    #[inline]
+    pub fn set_bytes(&mut self, bytes: &[u8]) {
+        assert_eq!(bytes.len(), 12);
+        let elem0 = u32::from_ne_bytes(bytes[..4].try_into().unwrap());
+        let elem1 = u32::from_ne_bytes(bytes[4..8].try_into().unwrap());
+        let elem2 = u32::from_ne_bytes(bytes[8..].try_into().unwrap());
+        self.value = [elem0, elem1, elem2];
+    }
+
     /// Converts this INT96 into an i64 representing the number of MILLISECONDS since Epoch
     pub fn to_i64(&self) -> i64 {
         let (seconds, nanoseconds) = self.to_seconds_and_nanos();
@@ -89,6 +99,14 @@ impl From<Vec<u32>> for Int96 {
         assert_eq!(buf.len(), 3);
         let mut result = Self::new();
         result.set_data(buf[0], buf[1], buf[2]);
+        result
+    }
+}
+
+impl From<&[u8]> for Int96 {
+    fn from(bytes: &[u8]) -> Self {
+        let mut result = Self::new();
+        result.set_bytes(bytes);
         result
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7220.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Please see #7220 for the motivation.

# What changes are included in this PR?

- `IntoBuffer` for `Vec<Int96>` now creates a byte buffer which `consume_batch` in turn uses to create a `FSB(12)` `Array`. If the requested type is `Timestamp(Timeunit::Nanoseconds,_)` only then does the conversion occur.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?



<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

`ArrowType::FixedSizeBinary(12)` is now a valid hint/provided schema data type for `Timestamp(Timeunit::Nanoseconds,_)`.