### PR TITLE
Replace humantime crate with jiff

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -35,8 +35,8 @@ bytes = "1.0"
 chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
 futures = "0.3"
 http = "1.2.0"
-humantime = "2.1"
 itertools = "0.14.0"
+jiff = { version = "0.2", default-features = false }
 parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 thiserror = "2.0.2"

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 description = "A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage, Azure Blob Storage and local files."
 keywords = ["object", "storage", "cloud"]
 repository = "https://github.com/apache/arrow-rs/tree/main/object_store"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
<!--
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.

Closes #.
-->


# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The crate [`humantime`](https://crates.io/crates/humantime) appears to be unmaintained. There's open PR in RustSec's advisory-db about this: https://github.com/rustsec/advisory-db/pull/2249

The crates [`clap`](https://crates.io/crates/clap) and [`env_logger`](https://crates.io/crates/env_logger) have already made the switch from `humantime` to [`jiff`](https://crates.io/crates/jiff):

 * https://github.com/clap-rs/clap/pull/5944
 * https://github.com/rust-cli/env_logger/pull/352

Since new version of `env_logger` is already published the `object_store` crate is now second largest user of `humantime` crate by crates.io downloads counts and the largest user after new version of `clap` is released.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Replace `humantime` crate with `jiff`. The functionality should stay the same.

# Are there any user-facing changes?

There should be none.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->


Fixes #7264
