### PR TITLE
Fix requirement of object store for http-body-util

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -47,7 +47,7 @@ walkdir = { version = "2", optional = true }
 # Cloud storage support
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
 form_urlencoded = { version = "1.2", optional = true }
-http-body-util = { version = "0.1", optional = true }
+http-body-util = { version = "0.1.2", optional = true }
 httparse = { version = "1.8.0", default-features = false, features = ["std"], optional = true }
 hyper = { version = "1.2", default-features = false, optional = true }
 md-5 = { version = "0.10.6", default-features = false, optional = true }


### PR DESCRIPTION
Fix the compilation of the `object store` due to incorrect requirement.

When updating to `object-store` 0.12.0, I ran into a crate compilation failure.

```
error[E0599]: no method named `into_data_stream` found for struct `BoxBody` in the current scope
   --> /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/object_store-0.12.0/src/client/body.rs:176:24
    |
176 |         let s = self.0.into_data_stream();
    |                        ^^^^^^^^^^^^^^^^
    |
help: there is a method `into_raw` with a similar name
    |
176 |         let s = self.0.into_raw();
    |                        ~~~~~~~~

error[E0599]: no method named `into_data_stream` found for struct `BoxBody` in the current scope
   --> /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/object_store-0.12.0/src/client/body.rs:182:16
    |
182 |         self.0.into_data_stream().boxed()
    |                ^^^^^^^^^^^^^^^^
    |
help: there is a method `into_raw` with a similar name
    |
182 |         self.0.into_raw().boxed()
    |                ~~~~~~~~
```

The method `into_data_stream` has been introduced in `http-body-util` in [0.1.2](https://github.com/hyperium/http-body/blob/master/http-body-util/CHANGELOG.md#v012).

Therefore `object store` needs to have a precise patch version requirement.
