### PR TITLE
Optimize numeric-to-string coercion in StringArrayDecoder

### DIFF
--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -109,8 +109,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
                     builder.append_value(FALSE);
                 }
                 TapeElement::Number(idx) if coerce_primitive => {
-                    let s = self.write_number(tape.get_string(idx));
-                    builder.append_value(s);
+                    builder.append_value(tape.get_string(idx));
                 }
                 TapeElement::I64(high) if coerce_primitive => match tape.get(p + 1) {
                     TapeElement::I32(low) => {

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -46,7 +46,8 @@ impl<O: OffsetSizeTrait> StringArrayDecoder<O> {
     fn write_number<T: std::fmt::Display>(&mut self, n: T) -> &str {
         self.number_buffer.clear();
         write!(&mut self.number_buffer, "{}", n).unwrap();
-        // SAFETY: We just wrote valid UTF-8 using write! macro
+        // SAFETY: We only write ASCII characters (digits, signs, decimal points,
+        // exponent symbols) into `number_buffer`, which are guaranteed valid UTF-8.
         unsafe { std::str::from_utf8_unchecked(&self.number_buffer) }
     }
 }

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -109,7 +109,8 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
                     builder.append_value(FALSE);
                 }
                 TapeElement::Number(idx) if coerce_primitive => {
-                    builder.append_value(tape.get_string(idx));
+                    let s = self.write_number(tape.get_string(idx));
+                    builder.append_value(s);
                 }
                 TapeElement::I64(high) if coerce_primitive => match tape.get(p + 1) {
                     TapeElement::I32(low) => {


### PR DESCRIPTION
# Which issue does this PR close?

I see an issue opened here: [https://github.com/apache/arrow-rs/issues/7273](https://github.com/apache/arrow-rs/issues/7273)
I realized that can be optimized and I worked on that (not in the way that was suggested in the issue).

Closes #7273

# Rationale for this change

This PR introduces performance improvements for string coercion.

Performance Metrics:

Author of the [https://github.com/apache/arrow-rs/issues/7273](https://github.com/apache/arrow-rs/issues/7273) recommends to use `cargo bench --bench json_reader`, we will go with that.

Step#1: Save Baseline Metrics
```
> git checkout main
> cargo bench --bench json_reader -- --save-baseline before        
```

Step#2: Compare the changes with Baseline Metrics

```
> git checkout ndemir/string-coerce-optimization
> cargo bench --bench json_reader --  --baseline before

small_bench_primitive   time:   [8.5790 µs 8.5890 µs 8.6029 µs]
                        change: [-3.0652% -2.4764% -1.9676%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

large_bench_primitive   time:   [3.2421 ms 3.2951 ms 3.3615 ms]
                        change: [+0.9382% +2.6439% +4.5593%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

small_bench_list        time:   [17.444 µs 17.655 µs 18.076 µs]
                        change: [-6.4619% -4.0195% -2.1687%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) high mild
  3 (3.00%) high severe
```

# What changes are included in this PR?

- Shared buffer for numeric -> string: Added a number_buffer to reuse for numeric->string conversions.
- Performance: This reduces overhead by writing numeric values to a single buffer and then converting to &str.
- Safety comment: I added a comment and explain why from_utf8_unchecked is valid.

# Are there any user-facing changes?

No.