### PR TITLE
Include license and notice files in published crates, part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ include = [
     "benches/*.rs",
     "src/**/*.rs",
     "Cargo.toml",
+    "LICENSE.txt",
+    "NOTICE.txt",
 ]
 edition = "2021"
 rust-version = "1.70"

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -29,6 +29,8 @@ include = [
     "src/**/*.rs",
     "tests/*.rs",
     "Cargo.toml",
+    "LICENSE.txt",
+    "NOTICE.txt",
 ]
 edition = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
# Rationale for this change
 
This is a follow up to #6767. The license and notice files still aren't included in published crates due to the `include` field.