### PR TITLE
Reapply Box `FlightErrror::tonic` to reduce size (fixes nightly clippy)

### DIFF
--- a/arrow-flight/src/client.rs
+++ b/arrow-flight/src/client.rs
@@ -210,7 +210,7 @@ impl FlightClient {
         let (response_stream, trailers) = extract_lazy_trailers(response_stream);
 
         Ok(FlightRecordBatchStream::new_from_flight_data(
-            response_stream.map_err(FlightError::Tonic),
+            response_stream.map_err(|status| status.into()),
         )
         .with_headers(md)
         .with_trailers(trailers))
@@ -470,7 +470,7 @@ impl FlightClient {
             .list_flights(request)
             .await?
             .into_inner()
-            .map_err(FlightError::Tonic);
+            .map_err(|status| status.into());
 
         Ok(response.boxed())
     }
@@ -537,7 +537,7 @@ impl FlightClient {
             .list_actions(request)
             .await?
             .into_inner()
-            .map_err(FlightError::Tonic);
+            .map_err(|status| status.into());
 
         Ok(action_stream.boxed())
     }
@@ -575,7 +575,7 @@ impl FlightClient {
             .do_action(request)
             .await?
             .into_inner()
-            .map_err(FlightError::Tonic)
+            .map_err(|status| status.into())
             .map(|r| {
                 r.map(|r| {
                     // unwrap inner bytes

--- a/arrow-flight/src/error.rs
+++ b/arrow-flight/src/error.rs
@@ -27,7 +27,7 @@ pub enum FlightError {
     /// Returned when functionality is not yet available.
     NotYetImplemented(String),
     /// Error from the underlying tonic library
-    Tonic(tonic::Status),
+    Tonic(Box<tonic::Status>),
     /// Some unexpected message was received
     ProtocolError(String),
     /// An error occurred during decoding
@@ -74,7 +74,7 @@ impl Error for FlightError {
 
 impl From<tonic::Status> for FlightError {
     fn from(status: tonic::Status) -> Self {
-        Self::Tonic(status)
+        Self::Tonic(Box::new(status))
     }
 }
 
@@ -91,7 +91,7 @@ impl From<FlightError> for tonic::Status {
         match value {
             FlightError::Arrow(e) => tonic::Status::internal(e.to_string()),
             FlightError::NotYetImplemented(e) => tonic::Status::internal(e),
-            FlightError::Tonic(status) => status,
+            FlightError::Tonic(status) => *status,
             FlightError::ProtocolError(e) => tonic::Status::internal(e),
             FlightError::DecodeError(e) => tonic::Status::internal(e),
             FlightError::ExternalError(e) => tonic::Status::internal(e.to_string()),
@@ -146,5 +146,11 @@ mod test {
 
         let source = root_error.downcast_ref::<FlightError>().unwrap();
         assert!(matches!(source, FlightError::DecodeError(_)));
+    }
+
+    #[test]
+    fn test_error_size() {
+        // use Box in variants to keep this size down
+        assert_eq!(std::mem::size_of::<FlightError>(), 32);
     }
 }

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -309,7 +309,7 @@ impl FlightSqlServiceClient<Channel> {
         let (response_stream, trailers) = extract_lazy_trailers(response_stream);
 
         Ok(FlightRecordBatchStream::new_from_flight_data(
-            response_stream.map_err(FlightError::Tonic),
+            response_stream.map_err(|status| status.into()),
         )
         .with_headers(md)
         .with_trailers(trailers))

--- a/arrow-flight/src/streams.rs
+++ b/arrow-flight/src/streams.rs
@@ -127,7 +127,7 @@ impl<T> Stream for FallibleTonicResponseStream<T> {
 
         match ready!(pinned.response_stream.poll_next_unpin(cx)) {
             Some(Ok(res)) => Poll::Ready(Some(Ok(res))),
-            Some(Err(status)) => Poll::Ready(Some(Err(FlightError::Tonic(status)))),
+            Some(Err(status)) => Poll::Ready(Some(Err(status.into()))),
             None => Poll::Ready(None),
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

- reverts https://github.com/apache/arrow-rs/pull/7266 /  commit f4fde769ab6e1a9b75f890b7f8b47bc22800830b.

# Rationale for this change
- This is the same code as in https://github.com/apache/arrow-rs/pull/7229 from @XiangpengHao  that contains a breaking API change
- Unfortunately we accidentally merged it and had to revert in https://github.com/apache/arrow-rs/pull/7266

# Rationale for the original change (from @XiangpengHao):

 When working on the nightly rust, I noticed that clippy warns about `FlightError` too large, more than 176 bytes.

I think it makes sense to keep the error small (32 bytes), as the Result<...> is used in a lot of places.

This PR basically makes `Tonic(tonic::Status)` into `Tonic(Box<tonic::Status>)`, which reduces the FlightError from 176 bytes down to 32 bytes.

This adds an extra allocation on error, but should probably be fine as it's not on hot path.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
