### PR TITLE
Allow retrieving Parquet decryption keys using the key metadata

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -700,13 +700,7 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
 
         #[cfg(feature = "encryption")]
         let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
-            let crypto_metadata = self
-                .metadata
-                .row_group(rg_idx)
-                .column(self.column_idx)
-                .crypto_metadata();
-
-            match crypto_metadata {
+            match meta.crypto_metadata() {
                 Some(crypto_metadata) => {
                     match CryptoContext::for_column(
                         file_decryptor,

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -706,30 +706,26 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
                 .schema_descr()
                 .column(self.column_idx);
 
-            if file_decryptor.is_column_encrypted(column_name.name()) {
-                let data_decryptor = file_decryptor.get_column_data_decryptor(column_name.name());
-                let data_decryptor = match data_decryptor {
-                    Ok(data_decryptor) => data_decryptor,
-                    Err(err) => return Some(Err(err)),
-                };
+            let crypto_metadata = self
+                .metadata
+                .row_group(rg_idx)
+                .column(self.column_idx)
+                .crypto_metadata();
 
-                let metadata_decryptor =
-                    file_decryptor.get_column_metadata_decryptor(column_name.name());
-                let metadata_decryptor = match metadata_decryptor {
-                    Ok(metadata_decryptor) => metadata_decryptor,
-                    Err(err) => return Some(Err(err)),
-                };
-
-                let crypto_context = CryptoContext::new(
-                    rg_idx,
-                    self.column_idx,
-                    data_decryptor,
-                    metadata_decryptor,
-                    file_decryptor.file_aad().clone(),
-                );
-                Some(Arc::new(crypto_context))
-            } else {
-                None
+            match crypto_metadata {
+                Some(crypto_metadata) => {
+                    match CryptoContext::for_column(
+                        file_decryptor,
+                        crypto_metadata,
+                        column_name.name(),
+                        rg_idx,
+                        self.column_idx,
+                    ) {
+                        Ok(context) => Some(Arc::new(context)),
+                        Err(err) => return Some(Err(err)),
+                    }
+                }
+                None => None,
             }
         } else {
             None

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -700,12 +700,6 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
 
         #[cfg(feature = "encryption")]
         let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
-            let column_name = self
-                .metadata
-                .file_metadata()
-                .schema_descr()
-                .column(self.column_idx);
-
             let crypto_metadata = self
                 .metadata
                 .row_group(rg_idx)
@@ -717,7 +711,6 @@ impl<T: ChunkReader + 'static> Iterator for ReaderPageIterator<T> {
                     match CryptoContext::for_column(
                         file_decryptor,
                         crypto_metadata,
-                        column_name.name(),
                         rg_idx,
                         self.column_idx,
                     ) {

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1027,27 +1027,6 @@ impl RowGroups for InMemoryRowGroup<'_> {
     }
 
     fn column_chunks(&self, i: usize) -> Result<Box<dyn PageIterator>> {
-        #[cfg(feature = "encryption")]
-        let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
-            let crypto_metadata = self
-                .metadata
-                .row_group(self.row_group_idx)
-                .column(i)
-                .crypto_metadata();
-
-            match crypto_metadata {
-                Some(crypto_metadata) => Some(Arc::new(CryptoContext::for_column(
-                    file_decryptor,
-                    crypto_metadata,
-                    self.row_group_idx,
-                    i,
-                )?)),
-                None => None,
-            }
-        } else {
-            None
-        };
-
         match &self.column_chunks[i] {
             None => Err(ParquetError::General(format!(
                 "Invalid column index {i}, column was not fetched"
@@ -1058,13 +1037,28 @@ impl RowGroups for InMemoryRowGroup<'_> {
                     // filter out empty offset indexes (old versions specified Some(vec![]) when no present)
                     .filter(|index| !index.is_empty())
                     .map(|index| index[i].page_locations.clone());
-                let metadata = self.metadata.row_group(self.row_group_idx);
+                let column_metadata = self.metadata.row_group(self.row_group_idx).column(i);
                 let page_reader = SerializedPageReader::new(
                     data.clone(),
-                    metadata.column(i),
+                    column_metadata,
                     self.row_count,
                     page_locations,
                 )?;
+
+                #[cfg(feature = "encryption")]
+                let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
+                    match column_metadata.crypto_metadata() {
+                        Some(crypto_metadata) => Some(Arc::new(CryptoContext::for_column(
+                            file_decryptor,
+                            crypto_metadata,
+                            self.row_group_idx,
+                            i,
+                        )?)),
+                        None => None,
+                    }
+                } else {
+                    None
+                };
 
                 #[cfg(feature = "encryption")]
                 let page_reader = page_reader.with_crypto_context(crypto_context);

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1029,8 +1029,6 @@ impl RowGroups for InMemoryRowGroup<'_> {
     fn column_chunks(&self, i: usize) -> Result<Box<dyn PageIterator>> {
         #[cfg(feature = "encryption")]
         let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
-            let column_name = &self.metadata.file_metadata().schema_descr().column(i);
-
             let crypto_metadata = self
                 .metadata
                 .row_group(self.row_group_idx)
@@ -1041,7 +1039,6 @@ impl RowGroups for InMemoryRowGroup<'_> {
                 Some(crypto_metadata) => Some(Arc::new(CryptoContext::for_column(
                     file_decryptor,
                     crypto_metadata,
-                    column_name.name(),
                     self.row_group_idx,
                     i,
                 )?)),

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1028,7 +1028,7 @@ impl RowGroups for InMemoryRowGroup<'_> {
 
     fn column_chunks(&self, i: usize) -> Result<Box<dyn PageIterator>> {
         #[cfg(feature = "encryption")]
-        let crypto_context = if let Some(file_decryptor) = self.metadata.clone().file_decryptor() {
+        let crypto_context = if let Some(file_decryptor) = self.metadata.file_decryptor() {
             let column_name = &self.metadata.file_metadata().schema_descr().column(i);
 
             let crypto_metadata = self

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -319,9 +319,9 @@ impl DecryptionPropertiesBuilder {
     }
 
     /// Specify the decryption key to use for a column
-    pub fn with_column_key(mut self, column_path: &str, decryption_key: Vec<u8>) -> Self {
+    pub fn with_column_key(mut self, column_name: &str, decryption_key: Vec<u8>) -> Self {
         self.column_keys
-            .insert(column_path.to_string(), decryption_key);
+            .insert(column_name.to_string(), decryption_key);
         self
     }
 }

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -180,7 +180,8 @@ pub struct FileDecryptionProperties {
 }
 
 impl FileDecryptionProperties {
-    /// Returns a new [`FileDecryptionProperties`] builder with the specified footer key.
+    /// Returns a new [`FileDecryptionProperties`] builder that will use the provided key to
+    /// decrypt footer metadata.
     pub fn builder(footer_key: Vec<u8>) -> DecryptionPropertiesBuilder {
         DecryptionPropertiesBuilder::new(footer_key)
     }
@@ -200,7 +201,7 @@ impl std::fmt::Debug for FileDecryptionProperties {
 
 impl PartialEq for FileDecryptionProperties {
     // FileDecryptionProperties needs to implement PartialEq to allow
-    // ParquetMetadata to implement PartialEq.
+    // ParquetMetaData to implement PartialEq.
     // We cannot compare a key retriever, but this isn't derived from the metadata.
     fn eq(&self, other: &Self) -> bool {
         let keys_eq = match self.keys {
@@ -226,7 +227,8 @@ pub struct DecryptionPropertiesBuilder {
 }
 
 impl DecryptionPropertiesBuilder {
-    /// Create a new [`DecryptionPropertiesBuilder`] by specifying the footer decryption key
+    /// Create a new [`DecryptionPropertiesBuilder`] builder that will use the provided key to
+    /// decrypt footer metadata.
     pub fn new(footer_key: Vec<u8>) -> DecryptionPropertiesBuilder {
         Self {
             footer_key: Some(footer_key),

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -64,7 +64,6 @@ impl CryptoContext {
     pub(crate) fn for_column(
         file_decryptor: &FileDecryptor,
         column_crypto_metadata: &ColumnCryptoMetaData,
-        column_name: &str,
         row_group_idx: usize,
         column_ordinal: usize,
     ) -> Result<Self> {
@@ -77,6 +76,13 @@ impl CryptoContext {
             }
             ColumnCryptoMetaData::EncryptionWithColumnKey(column_key_encryption) => {
                 let key_metadata = &column_key_encryption.key_metadata;
+                let full_column_name;
+                let column_name = if column_key_encryption.path_in_schema.len() == 1 {
+                    &column_key_encryption.path_in_schema[0]
+                } else {
+                    full_column_name = column_key_encryption.path_in_schema.join(".");
+                    &full_column_name
+                };
                 let data_decryptor = file_decryptor
                     .get_column_data_decryptor(column_name, key_metadata.as_deref())?;
                 let metadata_decryptor = file_decryptor

--- a/parquet/src/file/column_crypto_metadata.rs
+++ b/parquet/src/file/column_crypto_metadata.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Column chunk encryption metadata
+
+use crate::errors::Result;
+use crate::format::{
+    ColumnCryptoMetaData as TColumnCryptoMetaData,
+    EncryptionWithColumnKey as TEncryptionWithColumnKey,
+    EncryptionWithFooterKey as TEncryptionWithFooterKey,
+};
+
+/// ColumnCryptoMetadata for a column chunk
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ColumnCryptoMetaData {
+    /// The column is encrypted with the footer key
+    EncryptionWithFooterKey,
+    /// The column is encrypted with a column-specific key
+    EncryptionWithColumnKey(EncryptionWithColumnKey),
+}
+
+/// Encryption metadata for a column chunk encrypted with a column-specific key
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncryptionWithColumnKey {
+    /// Path to the column in the Parquet schema
+    pub path_in_schema: Vec<String>,
+    /// Metadata required to retrieve the column encryption key
+    pub key_metadata: Option<Vec<u8>>,
+}
+
+/// Converts Thrift definition into `ColumnCryptoMetadata`.
+pub fn try_from_thrift(
+    thrift_column_crypto_metadata: &TColumnCryptoMetaData,
+) -> Result<ColumnCryptoMetaData> {
+    let crypto_metadata = match thrift_column_crypto_metadata {
+        TColumnCryptoMetaData::ENCRYPTIONWITHFOOTERKEY(_) => {
+            ColumnCryptoMetaData::EncryptionWithFooterKey
+        }
+        TColumnCryptoMetaData::ENCRYPTIONWITHCOLUMNKEY(encryption_with_column_key) => {
+            ColumnCryptoMetaData::EncryptionWithColumnKey(EncryptionWithColumnKey {
+                path_in_schema: encryption_with_column_key.path_in_schema.clone(),
+                key_metadata: encryption_with_column_key.key_metadata.clone(),
+            })
+        }
+    };
+    Ok(crypto_metadata)
+}
+
+/// Converts `ColumnCryptoMetadata` into Thrift definition.
+pub fn to_thrift(column_crypto_metadata: &ColumnCryptoMetaData) -> TColumnCryptoMetaData {
+    match column_crypto_metadata {
+        ColumnCryptoMetaData::EncryptionWithFooterKey => {
+            TColumnCryptoMetaData::ENCRYPTIONWITHFOOTERKEY(TEncryptionWithFooterKey {})
+        }
+        ColumnCryptoMetaData::EncryptionWithColumnKey(encryption_with_column_key) => {
+            TColumnCryptoMetaData::ENCRYPTIONWITHCOLUMNKEY(TEncryptionWithColumnKey {
+                path_in_schema: encryption_with_column_key.path_in_schema.clone(),
+                key_metadata: encryption_with_column_key.key_metadata.clone(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encryption_with_footer_key_from_thrift() {
+        let metadata = ColumnCryptoMetaData::EncryptionWithFooterKey;
+
+        assert_eq!(try_from_thrift(&to_thrift(&metadata)).unwrap(), metadata);
+    }
+
+    #[test]
+    fn test_encryption_with_column_key_from_thrift() {
+        let metadata = ColumnCryptoMetaData::EncryptionWithColumnKey(EncryptionWithColumnKey {
+            path_in_schema: vec!["abc".to_owned(), "def".to_owned()],
+            key_metadata: Some(vec![0, 1, 2, 3, 4, 5]),
+        });
+
+        assert_eq!(try_from_thrift(&to_thrift(&metadata)).unwrap(), metadata);
+    }
+}

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1978,7 +1978,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let base_expected_size = 2312;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2656;
+        let base_expected_size = 2640;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2008,7 +2008,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let bigger_expected_size = 2816;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3160;
+        let bigger_expected_size = 3144;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -680,10 +680,13 @@ impl RowGroupMetaData {
                 )?;
 
                 let buf = c.encrypted_column_metadata.clone().unwrap();
-                let decrypted_cc_buf =
-                    column_decryptor.decrypt(buf.as_slice(), column_aad.as_ref()).map_err(|_| {
-                        general_err!("Unable to decrypt column '{}', perhaps the column key is wrong or missing?",
-                            d.path().string())
+                let decrypted_cc_buf = column_decryptor
+                    .decrypt(buf.as_slice(), column_aad.as_ref())
+                    .map_err(|_| {
+                        general_err!(
+                            "Unable to decrypt column '{}', perhaps the column key is wrong?",
+                            d.path().string()
+                        )
                     })?;
 
                 let mut prot = TCompactSliceInputProtocol::new(decrypted_cc_buf.as_slice());

--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -97,6 +97,8 @@
 //!     println!("{}", row.unwrap());
 //! }
 //! ```
+#[cfg(feature = "encryption")]
+pub mod column_crypto_metadata;
 pub mod footer;
 pub mod metadata;
 pub mod page_encoding_stats;

--- a/parquet/tests/arrow_reader/encryption_async.rs
+++ b/parquet/tests/arrow_reader/encryption_async.rs
@@ -115,8 +115,14 @@ async fn test_misspecified_encryption_keys() {
     .await;
 
     // Missing column key
-    check_for_error("Parquet error: Unable to decrypt column 'double_field', perhaps the column key is wrong or missing?",
-                    &path, footer_key, "".as_bytes(), column_2_key).await;
+    check_for_error(
+        "Parquet error: No column decryption key set for column 'double_field'",
+        &path,
+        footer_key,
+        "".as_bytes(),
+        column_2_key,
+    )
+    .await;
 
     // Too short column key
     check_for_error(
@@ -129,12 +135,24 @@ async fn test_misspecified_encryption_keys() {
     .await;
 
     // Wrong column key
-    check_for_error("Parquet error: Unable to decrypt column 'double_field', perhaps the column key is wrong or missing?",
-                    &path, footer_key, "1123456789012345".as_bytes(), column_2_key).await;
+    check_for_error(
+        "Parquet error: Unable to decrypt column 'double_field', perhaps the column key is wrong?",
+        &path,
+        footer_key,
+        "1123456789012345".as_bytes(),
+        column_2_key,
+    )
+    .await;
 
     // Mixed up keys
-    check_for_error("Parquet error: Unable to decrypt column 'float_field', perhaps the column key is wrong or missing?",
-                    &path, footer_key, column_2_key, column_1_key).await;
+    check_for_error(
+        "Parquet error: Unable to decrypt column 'float_field', perhaps the column key is wrong?",
+        &path,
+        footer_key,
+        column_2_key,
+        column_1_key,
+    )
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7257.

# Rationale for this change
 
This allows Parquet readers to not need to directly specify the data encryption keys required to read an encrypted Parquet file, and instead be able to retrieve them dynamically based on the key metadata.

This is a prerequisite for implementing the higher level Key Management Tools API (#7256)

# What changes are included in this PR?

* Adds a new `KeyRetriever` trait.
* Updates `FileDecryptionProperties` so that it can store a `KeyRetriever` rather than explicit decryption keys.
* Adds a new `ColumnCryptoMetaData` type corresponding to the type of the same name in the Thrift format, so that this can be parsed from the column metadata and used to retrieve the key metadata to pass to the `KeyRetriever`.
* Changes how we decide if a column is encrypted. We now read this from the file metadata rather than using the `FileDecryptionProperties` (so `FileDecryptor::is_column_encrypted` has been removed).

# Are there any user-facing changes?

Yes, this adds a new way for users to create `FileDecryptionProperties`.
