### PR TITLE
Minor: Re-enable Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,7 @@ github:
     rebase: false
   features:
     issues: true
+    discussions: true
   protected_branches:
     main:
       required_status_checks:


### PR DESCRIPTION
Due to a change in the backend of the  `.asf.yaml` features like discussions have to be enabled explicitly. No content was lost through this.