### PR TITLE
Fix MSRV CI Check (pin `half` dependency)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,6 +131,11 @@ jobs:
           cargo update -p tokio --precise 1.29.1
           cargo update -p url --precise 2.5.0
           cargo update -p once_cell --precise 1.20.3
+      - name: Downgrade arrow-pyarrow-integration-testing dependencies
+        working-directory: arrow-pyarrow-integration-testing
+        # Necessary because half 2.5 requires rust 1.81 or newer
+        run: |
+          cargo update -p half --precise 2.4.0
       - name: Downgrade workspace dependencies
         # Necessary because half 2.5 requires rust 1.81 or newer
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Downgrade workspace dependencies
         # Necessary because half 2.5 requires rust 1.81 or newer
         run: |
-          cargo update -p half --precise 2.4
+          cargo update -p half --precise 2.4.0
       - name: Check all packages
         run: |
           # run `cargo msrv verify --manifest-path "path/to/Cargo.toml"` to see problematic dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,6 +131,10 @@ jobs:
           cargo update -p tokio --precise 1.29.1
           cargo update -p url --precise 2.5.0
           cargo update -p once_cell --precise 1.20.3
+      - name: Downgrade workspace dependencies
+        # Necessary because half 2.5 requires rust 1.81 or newer
+        run: |
+          cargo update -p half --precise 2.4
       - name: Check all packages
         run: |
           # run `cargo msrv verify --manifest-path "path/to/Cargo.toml"` to see problematic dependencies


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/7289

# Rationale for this change
 
Arrow didn't change but a semver update of half has caused msrv checks to fail

# What changes are included in this PR?

Pin half to older version in CI tests 

# Are there any user-facing changes?
No code changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
