### PR TITLE
chore: require ffi feature in arrow-schema benchmark

### DIFF
--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -57,3 +57,4 @@ criterion = { version = "0.5", default-features = false }
 [[bench]]
 name = "ffi"
 harness = false
+required-features = ["ffi"]


### PR DESCRIPTION
# Rationale for this change
 
setting `required-features` in `[[bench]]` makes rust-analyzer happy,  otherwise error is linted as below:
```
error[E0432]: unresolved import `arrow_schema::ffi`
  --> arrow-schema/benches/ffi.rs:18:19
   |
18 | use arrow_schema::ffi::FFI_ArrowSchema;
   |                   ^^^ could not find `ffi` in `arrow_schema`
   |
note: found an item that was configured out
  --> /Users/gwo/Idea/arrow-rs/arrow-schema/src/lib.rs:44:9
   |
44 | pub mod ffi;
   |         ^^^
note: the item is gated behind the `ffi` feature
  --> /Users/gwo/Idea/arrow-rs/arrow-schema/src/lib.rs:43:7
   |
43 | #[cfg(feature = "ffi")]
   |       ^^^^^^^^^^^^^^^
```

# What changes are included in this PR?

modified `arrow-schema/Cargo.toml`

# Are there any user-facing changes?
no there aren't.