### PR TITLE
Add content length to GCP multipart complete

### DIFF
--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -541,7 +541,6 @@ impl GoogleCloudStorageClient {
         let response = self
             .client
             .request(Method::POST, &url)
-            .header(&CONTENT_LENGTH, data.len())
             .bearer_auth(&credential.bearer)
             .query(&[("uploadId", upload_id)])
             .body(data)

--- a/object_store/src/gcp/client.rs
+++ b/object_store/src/gcp/client.rs
@@ -517,6 +517,7 @@ impl GoogleCloudStorageClient {
             // GCS doesn't allow empty multipart uploads
             let result = self
                 .request(Method::PUT, path)
+                .header(&CONTENT_LENGTH, "0")
                 .idempotent(true)
                 .do_put()
                 .await?;
@@ -540,6 +541,7 @@ impl GoogleCloudStorageClient {
         let response = self
             .client
             .request(Method::POST, &url)
+            .header(&CONTENT_LENGTH, data.len())
             .bearer_auth(&credential.bearer)
             .query(&[("uploadId", upload_id)])
             .body(data)


### PR DESCRIPTION
# Which issue does this PR close?

- Maybe related to https://github.com/apache/arrow-rs/issues/6831.

# Rationale for this change
 
This commit fixes the GCP mulipart complete implementation by adding the Content-Length header to the XML request. According to the docs, https://cloud.google.com/storage/docs/xml-api/post-object-complete, this header is required but wasn't being set previously.

# What changes are included in this PR?

Adding Content-Length header to GCP multipart complete XML request.

# Are there any user-facing changes?

No
