### PR TITLE
memory tracking with memory pool

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -35,6 +35,9 @@ bench = false
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+pool = []
+
 [dependencies]
 bytes = { version = "1.4" }
 num = { version = "0.4", default-features = false, features = ["std"] }

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -25,6 +25,9 @@ use crate::util::bit_chunk_iterator::{BitChunks, UnalignedBitChunk};
 use crate::BufferBuilder;
 use crate::{bit_util, bytes::Bytes, native::ArrowNativeType};
 
+#[cfg(feature = "pool")]
+use crate::pool::MemoryPool;
+
 use super::ops::bitwise_unary_op_helper;
 use super::{MutableBuffer, ScalarBuffer};
 
@@ -413,6 +416,17 @@ impl Buffer {
     #[inline]
     pub fn ptr_eq(&self, other: &Self) -> bool {
         self.ptr == other.ptr && self.length == other.length
+    }
+
+    /// Register this [`Buffer`] with the provided [`MemoryPool`]
+    ///
+    /// This claims the memory used by this buffer in the pool, allowing for
+    /// accurate accounting of memory usage. Any prior reservation will be
+    /// released so this works well when the buffer is being shared among
+    /// multiple arrays.
+    #[cfg(feature = "pool")]
+    pub fn claim(&self, pool: &dyn MemoryPool) {
+        self.data.claim(pool)
     }
 }
 

--- a/arrow-buffer/src/bytes.rs
+++ b/arrow-buffer/src/bytes.rs
@@ -26,6 +26,11 @@ use std::{fmt::Debug, fmt::Formatter};
 use crate::alloc::Deallocation;
 use crate::buffer::dangling_ptr;
 
+#[cfg(feature = "pool")]
+use crate::pool::{MemoryPool, MemoryReservation};
+#[cfg(feature = "pool")]
+use std::sync::Mutex;
+
 /// A continuous, fixed-size, immutable memory region that knows how to de-allocate itself.
 ///
 /// Note that this structure is an internal implementation detail of the
@@ -49,6 +54,10 @@ pub struct Bytes {
 
     /// how to deallocate this region
     deallocation: Deallocation,
+
+    /// Memory reservation for tracking memory usage
+    #[cfg(feature = "pool")]
+    pub(super) reservation: Mutex<Option<Box<dyn MemoryReservation>>>,
 }
 
 impl Bytes {
@@ -70,6 +79,8 @@ impl Bytes {
             ptr,
             len,
             deallocation,
+            #[cfg(feature = "pool")]
+            reservation: Mutex::new(None),
         }
     }
 
@@ -98,6 +109,27 @@ impl Bytes {
             // we only know the size of the custom allocation
             // its underlying capacity might be larger
             Deallocation::Custom(_, size) => size,
+        }
+    }
+
+    /// Register this [`Bytes`] with the provided [`MemoryPool`], replacing any prior reservation.
+    #[cfg(feature = "pool")]
+    pub fn claim(&self, pool: &dyn MemoryPool) {
+        *self.reservation.lock().unwrap() = Some(pool.reserve(self.capacity()));
+    }
+
+    /// Resize the memory reservation of this buffer
+    ///
+    /// This is a no-op if this buffer doesn't have a reservation.
+    #[cfg(feature = "pool")]
+    fn resize_reservation(&self, new_size: usize) {
+        let mut guard = self.reservation.lock().unwrap();
+        if let Some(mut reservation) = guard.take() {
+            // Resize the reservation
+            reservation.resize(new_size);
+
+            // Put it back
+            *guard = Some(reservation);
         }
     }
 
@@ -135,6 +167,13 @@ impl Bytes {
                     self.ptr = ptr;
                     self.len = new_len;
                     self.deallocation = Deallocation::Standard(new_layout);
+
+                    #[cfg(feature = "pool")]
+                    {
+                        // Resize reservation
+                        self.resize_reservation(new_len);
+                    }
+
                     return Ok(());
                 }
             }
@@ -199,6 +238,8 @@ impl From<bytes::Bytes> for Bytes {
             len,
             ptr: NonNull::new(value.as_ptr() as _).unwrap(),
             deallocation: Deallocation::Custom(std::sync::Arc::new(value), len),
+            #[cfg(feature = "pool")]
+            reservation: Mutex::new(None),
         }
     }
 }
@@ -209,14 +250,85 @@ mod tests {
 
     #[test]
     fn test_from_bytes() {
-        let bytes = bytes::Bytes::from(vec![1, 2, 3, 4]);
-        let arrow_bytes: Bytes = bytes.clone().into();
+        let message = b"hello arrow";
 
-        assert_eq!(bytes.as_ptr(), arrow_bytes.as_ptr());
+        // we can create a Bytes from bytes::Bytes (created from slices)
+        let c_bytes: bytes::Bytes = message.as_ref().into();
+        let a_bytes: Bytes = c_bytes.into();
+        assert_eq!(a_bytes.as_slice(), message);
 
-        drop(bytes);
-        drop(arrow_bytes);
+        // we can create a Bytes from bytes::Bytes (created from Vec)
+        let c_bytes: bytes::Bytes = bytes::Bytes::from(message.to_vec());
+        let a_bytes: Bytes = c_bytes.into();
+        assert_eq!(a_bytes.as_slice(), message);
+    }
 
-        let _ = Bytes::from(bytes::Bytes::new());
+    #[cfg(feature = "pool")]
+    mod pool_tests {
+        use super::*;
+
+        use crate::pool::TrackingMemoryPool;
+
+        #[test]
+        fn test_bytes_with_pool() {
+            // Create a standard allocation
+            let buffer = unsafe {
+                let layout =
+                    std::alloc::Layout::from_size_align(1024, crate::alloc::ALIGNMENT).unwrap();
+                let ptr = std::alloc::alloc(layout);
+                assert!(!ptr.is_null());
+
+                Bytes::new(
+                    NonNull::new(ptr).unwrap(),
+                    1024,
+                    Deallocation::Standard(layout),
+                )
+            };
+
+            // Create a memory pool
+            let pool = TrackingMemoryPool::default();
+            assert_eq!(pool.used(), 0);
+
+            // Reserve memory and assign to buffer
+            buffer.claim(&pool);
+            assert_eq!(pool.used(), 1024);
+
+            // Claim with explicit size directly
+            buffer.claim(&pool);
+            assert_eq!(pool.used(), 512);
+
+            // Memory should be released when buffer is dropped
+            drop(buffer);
+            assert_eq!(pool.used(), 0);
+        }
+
+        #[test]
+        fn test_bytes_drop_releases_pool() {
+            let pool = TrackingMemoryPool::default();
+
+            {
+                // Create a buffer with pool
+                let _buffer = unsafe {
+                    let layout =
+                        std::alloc::Layout::from_size_align(1024, crate::alloc::ALIGNMENT).unwrap();
+                    let ptr = std::alloc::alloc(layout);
+                    assert!(!ptr.is_null());
+
+                    let bytes = Bytes::new(
+                        NonNull::new(ptr).unwrap(),
+                        1024,
+                        Deallocation::Standard(layout),
+                    );
+
+                    bytes.claim(&pool);
+                    bytes
+                };
+
+                assert_eq!(pool.used(), 1024);
+            }
+
+            // Buffer has been dropped, memory should be released
+            assert_eq!(pool.used(), 0);
+        }
     }
 }

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -48,3 +48,8 @@ mod interval;
 pub use interval::*;
 
 mod arith;
+
+#[cfg(feature = "pool")]
+mod pool;
+#[cfg(feature = "pool")]
+pub use pool::*;

--- a/arrow-buffer/src/pool.rs
+++ b/arrow-buffer/src/pool.rs
@@ -1,0 +1,189 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module contains traits for memory pool traits and an implementation
+//! for tracking memory usage.
+//!
+//! The basic traits are [`MemoryPool`] and [`MemoryReservation`]. And default
+//! implementation of [`MemoryPool`] is [`TrackingMemoryPool`]. Their relationship
+//! is as follows:
+//!
+//! ```text
+//!     (pool tracker)                        (resizable)           
+//!  ┌──────────────────┐ fn reserve() ┌─────────────────────────┐
+//!  │ trait MemoryPool │─────────────►│ trait MemoryReservation │
+//!  └──────────────────┘              └─────────────────────────┘
+//! ```
+
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// A memory reservation within a [`MemoryPool`] that is freed on drop
+pub trait MemoryReservation: Debug + Send + Sync {
+    /// Returns the size of this reservation in bytes.
+    fn size(&self) -> usize;
+
+    /// Resize this reservation to a new size in bytes.
+    fn resize(&mut self, new_size: usize);
+}
+
+/// A pool of memory that can be reserved and released.
+///
+/// This is used to accurately track memory usage when buffers are shared
+/// between multiple arrays or other data structures.
+///
+/// For example, assume we have two arrays that share underlying buffer.
+/// It's hard to tell how much memory is used by them because we can't
+/// tell if the buffer is shared or not.
+///
+/// ```text
+///       Array A           Array B    
+///    ┌────────────┐    ┌────────────┐
+///    │ slices...  │    │ slices...  │
+///    │────────────│    │────────────│
+///    │ Arc<Bytes> │    │ Arc<Bytes> │ (shared buffer)
+///    └─────▲──────┘    └───────▲────┘
+///          │                   │     
+///          │       Bytes       │     
+///          │  ┌─────────────┐  │     
+///          │  │   data...   │  │     
+///          │  │─────────────│  │     
+///          └──│   Memory    │──┘   (tracked with a memory pool)  
+///             │ Reservation │        
+///             └─────────────┘        
+/// ```
+///
+/// With a memory pool, we can count the memory usage by the shared buffer
+/// directly.
+pub trait MemoryPool: Debug + Send + Sync {
+    /// Reserves memory from the pool. Infallible.
+    ///
+    /// Returns a reservation of the requested size.
+    fn reserve(&self, size: usize) -> Box<dyn MemoryReservation>;
+
+    /// Returns the current available memory in the pool.
+    ///
+    /// The pool may be overfilled, so this method might return a negative value.
+    fn available(&self) -> isize;
+
+    /// Returns the current used memory from the pool.
+    fn used(&self) -> usize;
+
+    /// Returns the maximum memory that can be reserved from the pool.
+    fn capacity(&self) -> usize;
+}
+
+/// A simple [`MemoryPool`] that reports the total memory usage
+#[derive(Debug, Default)]
+pub struct TrackingMemoryPool(Arc<AtomicUsize>);
+
+impl TrackingMemoryPool {
+    /// Returns the total allocated size
+    pub fn allocated(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl MemoryPool for TrackingMemoryPool {
+    fn reserve(&self, size: usize) -> Box<dyn MemoryReservation> {
+        self.0.fetch_add(size, Ordering::Relaxed);
+        Box::new(Tracker {
+            size,
+            shared: Arc::clone(&self.0),
+        })
+    }
+
+    fn available(&self) -> isize {
+        isize::MAX - self.used() as isize
+    }
+
+    fn used(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    fn capacity(&self) -> usize {
+        usize::MAX
+    }
+}
+
+#[derive(Debug)]
+struct Tracker {
+    size: usize,
+    shared: Arc<AtomicUsize>,
+}
+
+impl Drop for Tracker {
+    fn drop(&mut self) {
+        self.shared.fetch_sub(self.size, Ordering::Relaxed);
+    }
+}
+
+impl MemoryReservation for Tracker {
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    fn resize(&mut self, new: usize) {
+        match self.size < new {
+            true => self.shared.fetch_add(new - self.size, Ordering::Relaxed),
+            false => self.shared.fetch_sub(self.size - new, Ordering::Relaxed),
+        };
+        self.size = new;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracking_memory_pool() {
+        let pool = TrackingMemoryPool::default();
+
+        // Reserve 512 bytes
+        let reservation = pool.reserve(512);
+        assert_eq!(reservation.size(), 512);
+        assert_eq!(pool.used(), 512);
+        assert_eq!(pool.available(), isize::MAX - 512);
+
+        // Reserve another 256 bytes
+        let reservation2 = pool.reserve(256);
+        assert_eq!(reservation2.size(), 256);
+        assert_eq!(pool.used(), 768);
+        assert_eq!(pool.available(), isize::MAX - 768);
+
+        // Test resize to increase
+        let mut reservation_mut = reservation;
+        reservation_mut.resize(600);
+        assert_eq!(reservation_mut.size(), 600);
+        assert_eq!(pool.used(), 856); // 600 + 256
+
+        // Test resize to decrease
+        reservation_mut.resize(400);
+        assert_eq!(reservation_mut.size(), 400);
+        assert_eq!(pool.used(), 656); // 400 + 256
+
+        // Drop the first reservation
+        drop(reservation_mut);
+        assert_eq!(pool.used(), 256);
+
+        // Drop the second reservation
+        drop(reservation2);
+        assert_eq!(pool.used(), 0);
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow-up of #6590.

Closes #7151.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Add `MemoryPool` under `arrow-buffer/pool` feature gate. This pool can implement precise memory tracking for Array/Bytes/MutableBuffer etc. Even in a shared buffer. Design credit to @tustvold 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New feature gate `arrow-buffer/pool`.

New traits `MemoryPool` and `MemoryReservation`.

New structs `TrackingMemoryPool` which implements `MemoryPool` for tracking memory usage.

Corresponding new API `claim` for `Buffer`/`MutableBuffer`/`Bytes`.

# Are there any user-facing changes?

Above new feature and APIs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
