### PR TITLE
Add support for file row numbers in Parquet readers

### DIFF
--- a/parquet/examples/read_with_rowgroup.rs
+++ b/parquet/examples/read_with_rowgroup.rs
@@ -129,6 +129,10 @@ impl RowGroups for InMemoryRowGroup {
             }
         }
     }
+
+    fn row_groups(&self) -> Box<dyn Iterator<Item = &RowGroupMetaData> + '_> {
+        Box::new(std::iter::once(&self.metadata))
+    }
 }
 
 impl InMemoryRowGroup {

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -563,7 +563,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut array_reader = build_array_reader(fields.as_ref(), &mask, &file_reader).unwrap();
+        let mut array_reader =
+            build_array_reader(fields.as_ref(), &mask, &file_reader, None).unwrap();
 
         let batch = array_reader.next_batch(100).unwrap();
         assert_eq!(batch.data_type(), array_reader.get_data_type());

--- a/parquet/src/arrow/array_reader/row_number.rs
+++ b/parquet/src/arrow/array_reader/row_number.rs
@@ -1,0 +1,130 @@
+use crate::arrow::array_reader::ArrayReader;
+use crate::errors::{ParquetError, Result};
+use crate::file::metadata::RowGroupMetaData;
+use arrow_array::{ArrayRef, Int64Array};
+use arrow_schema::DataType;
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+pub(crate) struct RowNumberReader {
+    row_numbers: Vec<i64>,
+    row_groups: RowGroupSizeIterator,
+}
+
+impl RowNumberReader {
+    pub(crate) fn try_new<I>(row_groups: impl IntoIterator<Item = I>) -> Result<Self>
+    where
+        I: TryInto<RowGroupSize, Error=ParquetError>,
+    {
+        let row_groups = RowGroupSizeIterator::try_new(row_groups)?;
+        Ok(Self {
+            row_numbers: Vec::new(),
+            row_groups,
+        })
+    }
+}
+
+impl ArrayReader for RowNumberReader {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_data_type(&self) -> &DataType {
+        &DataType::Int64
+    }
+
+    fn read_records(&mut self, batch_size: usize) -> Result<usize> {
+        let read = self
+            .row_groups
+            .read_records(batch_size, &mut self.row_numbers);
+        Ok(read)
+    }
+
+    fn consume_batch(&mut self) -> Result<ArrayRef> {
+        Ok(Arc::new(Int64Array::from_iter(self.row_numbers.drain(..))))
+    }
+
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        let skipped = self.row_groups.skip_records(num_records);
+        Ok(skipped)
+    }
+
+    fn get_def_levels(&self) -> Option<&[i16]> {
+        None
+    }
+
+    fn get_rep_levels(&self) -> Option<&[i16]> {
+        None
+    }
+}
+
+struct RowGroupSizeIterator {
+    row_groups: VecDeque<RowGroupSize>,
+}
+
+impl RowGroupSizeIterator {
+    fn try_new<I>(row_groups: impl IntoIterator<Item = I>) -> Result<Self>
+    where
+        I: TryInto<RowGroupSize, Error=ParquetError>,
+    {
+        Ok(Self {
+            row_groups: VecDeque::from(row_groups.into_iter().map(TryInto::try_into).collect::<Result<Vec<_>>>()?),
+        })
+    }
+}
+
+impl RowGroupSizeIterator {
+    fn read_records(&mut self, mut batch_size: usize, row_numbers: &mut Vec<i64>) -> usize {
+        let mut read = 0;
+        while batch_size > 0 {
+            let Some(front) = self.row_groups.front_mut() else {
+                return read as usize;
+            };
+            let to_read = std::cmp::min(front.num_rows, batch_size as i64);
+            row_numbers.extend(front.first_row_number..front.first_row_number + to_read);
+            front.num_rows -= to_read;
+            front.first_row_number += to_read;
+            if front.num_rows == 0 {
+                self.row_groups.pop_front();
+            }
+            batch_size -= to_read as usize;
+            read += to_read;
+        }
+        read as usize
+    }
+
+    fn skip_records(&mut self, mut num_records: usize) -> usize {
+        let mut skipped = 0;
+        while num_records > 0 {
+            let Some(front) = self.row_groups.front_mut() else {
+                return skipped as usize;
+            };
+            let to_skip = std::cmp::min(front.num_rows, num_records as i64);
+            front.num_rows -= to_skip;
+            front.first_row_number += to_skip;
+            if front.num_rows == 0 {
+                self.row_groups.pop_front();
+            }
+            skipped += to_skip;
+            num_records -= to_skip as usize;
+        }
+        skipped as usize
+    }
+}
+
+pub(crate) struct RowGroupSize {
+    first_row_number: i64,
+    num_rows: i64,
+}
+
+impl TryFrom<&RowGroupMetaData> for RowGroupSize {
+    type Error = ParquetError;
+
+    fn try_from(rg: &RowGroupMetaData) -> Result<Self, Self::Error> {
+        Ok(Self {
+            first_row_number: rg.first_row_number().ok_or(ParquetError::RowGroupMetaDataMissingRowNumber)?,
+            num_rows: rg.num_rows(),
+        })
+    }
+}

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -52,6 +52,9 @@ pub enum ParquetError {
     /// Returned when a function needs more data to complete properly. The `usize` field indicates
     /// the total number of bytes required, not the number of additional bytes.
     NeedMoreData(usize),
+    /// Returned when an operation needs to know the first row number of a row group, but the row
+    /// number is unknown.
+    RowGroupMetaDataMissingRowNumber,
 }
 
 impl std::fmt::Display for ParquetError {
@@ -69,6 +72,9 @@ impl std::fmt::Display for ParquetError {
             }
             ParquetError::External(e) => write!(fmt, "External: {e}"),
             ParquetError::NeedMoreData(needed) => write!(fmt, "NeedMoreData: {needed}"),
+            ParquetError::RowGroupMetaDataMissingRowNumber => {
+                write!(fmt, "Row group missing row number")
+            }
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7299.

# What changes are included in this PR?

In this PR we:
* Add configuration to the `ArrowReaderBuilder` to set a `row_number_column` used to extend the read `RecordBatches` with an additional column with file row numbers.
* Keep track of the first row number in each row group in the file. This is computed from the file metadata.
* Add an `ArrayReader` to the vector of `ArrayReader`s reading columns from the Parquet file, if the `row_number_column` is set in the reader configuration. This is a `RowNumberReader`, which is a special `ArrayReader`. It reads no data from the Parquet pages, but uses the first row numbers in the `RowGroupMetaData` to keep track of progress.
* Add some basic tests and fuzz tests of the functionality.

The `RowGroupMetaData::first_row_number` is `Option<i64>`, since it is possible that the row number is unknown (I encountered an instance of this when trying to integrate this PR in [delta-rs](https://github.com/delta-io/delta-rs/blob/8acfa3f1c8ec096dc06a492517d82be10cefbc67/crates/core/src/writer/stats.rs#L113)), and it's better if `None` is used instead of some special integer value.

# Are there any user-facing changes?

We add an additional public method:
* `ArrowReaderBuilder::with_row_number_column`

There are a few breaking changes as we touch a few public interfaces:
* `RowGroupMetaData::from_thrift` and `RowGroupMetaData::from_thrift_encrypted` takes an additional parameter `first_row_number: Optional<i64>`.
* The trait `RowGroups` has an additional method `RowGroups::row_groups`. Potentially this method could replace the `RowGroups::num_rows` method or provide a default implementation for it.
* An additional error variant `ParquetError::RowGroupMetaDataMissingRowNumber`.

I'm very open to suggestions on how to reduce the amount of breaking changes.