### PR TITLE
Default wasm32-unknown-unknown client

### DIFF
--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -41,7 +41,7 @@ parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 thiserror = "2.0.2"
 tracing = { version = "0.1" }
-url = "2.2"
+url = "2.5.3"
 walkdir = { version = "2", optional = true }
 
 # Cloud storage support
@@ -63,6 +63,10 @@ tokio = { version = "1.29.0", features = ["sync", "macros", "rt", "time", "io-ut
 
 [target.'cfg(target_family="unix")'.dev-dependencies]
 nix = { version = "0.29.0", features = ["fs"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-time = { version = "1.1.0" }
+wasm-bindgen-futures = "0.4.18"
 
 [features]
 default = ["fs"]

--- a/object_store/Cargo.toml
+++ b/object_store/Cargo.toml
@@ -41,7 +41,7 @@ parking_lot = { version = "0.12" }
 percent-encoding = "2.1"
 thiserror = "2.0.2"
 tracing = { version = "0.1" }
-url = "2.5.3"
+url = "2.2"
 walkdir = { version = "2", optional = true }
 
 # Cloud storage support

--- a/object_store/src/client/body.rs
+++ b/object_store/src/client/body.rs
@@ -52,7 +52,7 @@ impl HttpRequestBody {
     pub(crate) fn into_reqwest(self) -> reqwest::Body {
         match self.0 {
             Inner::Bytes(b) => b.into(),
-            Inner::PutPayload(_, payload) => Into::<Bytes>::into(payload).into()
+            Inner::PutPayload(_, payload) => Into::<Bytes>::into(payload).into(),
         }
     }
 

--- a/object_store/src/client/body.rs
+++ b/object_store/src/client/body.rs
@@ -48,6 +48,13 @@ impl HttpRequestBody {
             )),
         }
     }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub(crate) fn into_reqwest(self) -> reqwest::Body {
+        match self.0 {
+            Inner::Bytes(b) => b.into(),
+            Inner::PutPayload(_, payload) => Into::<Bytes>::into(payload).into()
+        }
+    }
 
     /// Returns true if this body is empty
     pub fn is_empty(&self) -> bool {

--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -732,8 +732,7 @@ impl ClientOptions {
             builder = builder.default_headers(headers.clone())
         }
 
-        builder
-            .build().map_err(map_client_error)
+        builder.build().map_err(map_client_error)
     }
 }
 

--- a/object_store/src/client/retry.rs
+++ b/object_store/src/client/retry.rs
@@ -26,7 +26,11 @@ use futures::future::BoxFuture;
 use http::{Method, Uri};
 use reqwest::header::LOCATION;
 use reqwest::StatusCode;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time::{Duration, Instant};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use web_time::{Duration, Instant};
+
 use tracing::info;
 
 /// Retry request error


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7227 .


# What changes are included in this PR?

Target-gated wasm32-unknown-unknown reqwest-based HttpConnector (with explicit handling surrounding non-Send, non-Sync futures).

# Are there any user-facing changes?

wasm32-unknown-unknown users will need to add the `getrandom = { version = "*", features = ["js"] }` cargo entry if they aren't already using it. The alternative would be to feature flag in a similar manner to chrono, getrandom, zstd (i.e. 'js').