### PR TITLE
fix: correct array length validation error message

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -1016,7 +1016,7 @@ impl ArrayData {
                 if values_data.len < expected_values_len {
                     return Err(ArrowError::InvalidArgumentError(format!(
                         "Values length {} is less than the length ({}) multiplied by the value size ({}) for {}",
-                        values_data.len, list_size, list_size, self.data_type
+                        values_data.len, self.len, list_size, self.data_type
                     )));
                 }
 

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -432,7 +432,7 @@ fn test_validate_large_list_view_negative_sizes() {
 
 #[test]
 #[should_panic(
-    expected = "Values length 4 is less than the length (2) multiplied by the value size (2) for FixedSizeList"
+    expected = "Values length 4 is less than the length (3) multiplied by the value size (2) for FixedSizeList"
 )]
 fn test_validate_fixed_size_list() {
     // child has 4 elements,


### PR DESCRIPTION
Prior to this commit, the validate_child_data method of the ArrayData implementation would return an incorrect error message for validation failures on FixedSizeLists.

# Which issue does this PR close?
Closes #7312