### PR TITLE
bugfix: correct offsets when serializing a list of fixed sized list and non-zero start offset

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1859,7 +1859,6 @@ mod tests {
 
     use arrow_array::builder::FixedSizeListBuilder;
     use arrow_array::builder::Float32Builder;
-    use arrow_array::builder::Int32Builder;
     use arrow_array::builder::Int64Builder;
     use arrow_array::builder::MapBuilder;
     use arrow_array::builder::UnionBuilder;
@@ -3115,13 +3114,12 @@ mod tests {
         }
         l2_builder.append(true);
 
-        for point in [[10., 11., 12.]] {
-            l2_builder.values().values().append_value(point[0]);
-            l2_builder.values().values().append_value(point[1]);
-            l2_builder.values().values().append_value(point[2]);
+        let point = [10., 11., 12.];
+        l2_builder.values().values().append_value(point[0]);
+        l2_builder.values().values().append_value(point[1]);
+        l2_builder.values().values().append_value(point[2]);
 
-            l2_builder.values().append(true);
-        }
+        l2_builder.values().append(true);
         l2_builder.append(true);
 
         let array = Arc::new(l2_builder.finish()) as ArrayRef;
@@ -3161,7 +3159,7 @@ mod tests {
         let original_batch = RecordBatch::try_new(schema.clone(), vec![subarray])?;
 
         let mut bytes = Vec::new();
-        let mut writer = StreamWriter::try_new(&mut bytes, &schema)?;
+        let mut writer = StreamWriter::try_new(&mut bytes, schema)?;
         writer.write(&original_batch)?;
         writer.finish()?;
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3101,9 +3101,18 @@ mod tests {
 
     #[test]
     fn test_roundtrip_list_of_fixed_list() -> Result<(), ArrowError> {
+        let l1_type =
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, false)), 3);
+        let l2_type = DataType::List(Arc::new(Field::new("item", l1_type.clone(), false)));
+
         let l0_builder = Float32Builder::new();
-        let l1_builder = FixedSizeListBuilder::new(l0_builder, 3);
-        let mut l2_builder = ListBuilder::new(l1_builder);
+        let l1_builder = FixedSizeListBuilder::new(l0_builder, 3).with_field(Arc::new(Field::new(
+            "item",
+            DataType::Float32,
+            false,
+        )));
+        let mut l2_builder =
+            ListBuilder::new(l1_builder).with_field(Arc::new(Field::new("item", l1_type, false)));
 
         for point in [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]] {
             l2_builder.values().values().append_value(point[0]);
@@ -3125,18 +3134,7 @@ mod tests {
         let array = Arc::new(l2_builder.finish()) as ArrayRef;
 
         let schema = Arc::new(Schema::new_with_metadata(
-            vec![Field::new(
-                "points",
-                DataType::List(Arc::new(Field::new(
-                    "item",
-                    DataType::FixedSizeList(
-                        Arc::new(Field::new("item", DataType::Float32, true)),
-                        3,
-                    ),
-                    true,
-                ))),
-                true,
-            )],
+            vec![Field::new("points", l2_type, false)],
             HashMap::default(),
         ));
 
@@ -3235,12 +3233,55 @@ mod tests {
     #[test]
     fn test_roundtrip_fixed_list() -> Result<(), ArrowError> {
         let int_builder = Int64Builder::new();
-        let mut fixed_list_builder = FixedSizeListBuilder::new(int_builder, 3);
+        let mut fixed_list_builder = FixedSizeListBuilder::new(int_builder, 3)
+            .with_field(Arc::new(Field::new("item", DataType::Int64, false)));
 
         for point in [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]] {
             fixed_list_builder.values().append_value(point[0]);
             fixed_list_builder.values().append_value(point[1]);
             fixed_list_builder.values().append_value(point[2]);
+
+            fixed_list_builder.append(true);
+        }
+
+        let array = Arc::new(fixed_list_builder.finish()) as ArrayRef;
+
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![Field::new(
+                "points",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int64, false)), 3),
+                false,
+            )],
+            HashMap::default(),
+        ));
+
+        // Test a variety of combinations that include 0 and non-zero offsets
+        // and also portions or the rest of the array
+        test_slices(&array, &schema, 0, 4)?;
+        test_slices(&array, &schema, 0, 2)?;
+        test_slices(&array, &schema, 1, 3)?;
+        test_slices(&array, &schema, 2, 1)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_roundtrip_fixed_list_w_nulls() -> Result<(), ArrowError> {
+        let int_builder = Int64Builder::new();
+        let mut fixed_list_builder = FixedSizeListBuilder::new(int_builder, 3);
+
+        for point in [
+            [Some(1), Some(2), None],
+            [Some(4), Some(5), Some(6)],
+            [None, Some(8), Some(9)],
+            [Some(10), None, None],
+        ] {
+            for p in point {
+                match p {
+                    Some(p) => fixed_list_builder.values().append_value(p),
+                    None => fixed_list_builder.values().append_null(),
+                }
+            }
 
             fixed_list_builder.append(true);
         }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7315.

# Rationale for this change
 
This bug occurs when these conditions are all met:

- We have a generic list of fixed size list
- The offset of the outer generic list is non-zero
- We writing out (serializing) the arrays

# What changes are included in this PR?

This PR checks for the case of a fixed sized list and adjusts the offsets to the child arrays during write.

Unit tests added.

# Are there any user-facing changes?

None
