### PR TITLE
feat: allow if expressions for fallbacks in downcast macro

### DIFF
--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -72,7 +72,7 @@ macro_rules! repeat_pat {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_integer {
-    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat => $fallback:expr $(,)*)*) => {
+    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         match ($($data_type),+) {
             $crate::repeat_pat!($crate::cast::__private::DataType::Int8, $($data_type),+) => {
                 $m!($crate::types::Int8Type $(, $args)*)
@@ -98,7 +98,7 @@ macro_rules! downcast_integer {
             $crate::repeat_pat!($crate::cast::__private::DataType::UInt64, $($data_type),+) => {
                 $m!($crate::types::UInt64Type $(, $args)*)
             }
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -130,19 +130,19 @@ macro_rules! downcast_integer {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_integer_array {
-    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_integer_array!($values => {$e} $($p => $fallback)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_integer_array!($values => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_integer_array!($($values),+ => {$e} $($p => $fallback)*)
+    (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_integer_array!($($values),+ => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    ($($values:ident),+ => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_integer_array!(($($values),+) => $e $($p => $fallback)*)
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_integer_array!(($($values),+) => $e $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         $crate::downcast_integer!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -179,7 +179,7 @@ macro_rules! downcast_integer_array {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_run_end_index {
-    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat => $fallback:expr $(,)*)*) => {
+    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         match ($($data_type),+) {
             $crate::repeat_pat!($crate::cast::__private::DataType::Int16, $($data_type),+) => {
                 $m!($crate::types::Int16Type $(, $args)*)
@@ -190,7 +190,7 @@ macro_rules! downcast_run_end_index {
             $crate::repeat_pat!($crate::cast::__private::DataType::Int64, $($data_type),+) => {
                 $m!($crate::types::Int64Type $(, $args)*)
             }
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -222,7 +222,7 @@ macro_rules! downcast_run_end_index {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_temporal {
-    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat => $fallback:expr $(,)*)*) => {
+    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         match ($($data_type),+) {
             $crate::repeat_pat!($crate::cast::__private::DataType::Time32($crate::cast::__private::TimeUnit::Second), $($data_type),+) => {
                 $m!($crate::types::Time32SecondType $(, $args)*)
@@ -254,7 +254,7 @@ macro_rules! downcast_temporal {
             $crate::repeat_pat!($crate::cast::__private::DataType::Timestamp($crate::cast::__private::TimeUnit::Nanosecond, _), $($data_type),+) => {
                 $m!($crate::types::TimestampNanosecondType $(, $args)*)
             }
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -286,19 +286,19 @@ macro_rules! downcast_temporal {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_temporal_array {
-    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_temporal_array!($values => {$e} $($p => $fallback)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_temporal_array!($values => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_temporal_array!($($values),+ => {$e} $($p => $fallback)*)
+    (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_temporal_array!($($values),+ => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    ($($values:ident),+ => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_temporal_array!(($($values),+) => $e $($p => $fallback)*)
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_temporal_array!(($($values),+) => $e $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         $crate::downcast_temporal!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -333,7 +333,7 @@ macro_rules! downcast_temporal_array {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_primitive {
-    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat => $fallback:expr $(,)*)*) => {
+    ($($data_type:expr),+ => ($m:path $(, $args:tt)*), $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         $crate::downcast_integer! {
             $($data_type),+ => ($m $(, $args)*),
             $crate::repeat_pat!($crate::cast::__private::DataType::Float16, $($data_type),+) => {
@@ -375,7 +375,7 @@ macro_rules! downcast_primitive {
             _ => {
                 $crate::downcast_temporal! {
                     $($data_type),+ => ($m $(, $args)*),
-                    $($p => $fallback,)*
+                    $($p $(if $pred)* => $fallback,)*
                 }
             }
         }
@@ -418,19 +418,19 @@ macro_rules! downcast_primitive_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_primitive_array {
-    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_primitive_array!($values => {$e} $($p => $fallback)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_primitive_array!($values => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_primitive_array!($($values),+ => {$e} $($p => $fallback)*)
+    (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_primitive_array!($($values),+ => {$e} $($p $(if $pred)* => $fallback)*)
     };
-    ($($values:ident),+ => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
-        $crate::downcast_primitive_array!(($($values),+) => $e $($p => $fallback)*)
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        $crate::downcast_primitive_array!(($($values),+) => $e $($p $(if $pred)* => $fallback)*)
     };
-    (($($values:ident),+) => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         $crate::downcast_primitive!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     };
 }
@@ -508,11 +508,11 @@ macro_rules! downcast_dictionary_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_dictionary_array {
-    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        downcast_dictionary_array!($values => {$e} $($p => $fallback)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        downcast_dictionary_array!($values => {$e} $($p $(if $pred)* => $fallback)*)
     };
 
-    ($values:ident => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+    ($values:ident => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         match $values.data_type() {
             $crate::cast::__private::DataType::Dictionary(k, _) => {
                 $crate::downcast_integer! {
@@ -520,7 +520,7 @@ macro_rules! downcast_dictionary_array {
                     k => unreachable!("unsupported dictionary key type: {}", k)
                 }
             }
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     }
 }
@@ -610,11 +610,11 @@ macro_rules! downcast_run_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_run_array {
-    ($values:ident => $e:expr, $($p:pat => $fallback:expr $(,)*)*) => {
-        downcast_run_array!($values => {$e} $($p => $fallback)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
+        downcast_run_array!($values => {$e} $($p $(if $pred)* => $fallback)*)
     };
 
-    ($values:ident => $e:block $($p:pat => $fallback:expr $(,)*)*) => {
+    ($values:ident => $e:block $($p:pat $(if $pred:expr)* => $fallback:expr $(,)*)*) => {
         match $values.data_type() {
             $crate::cast::__private::DataType::RunEndEncoded(k, _) => {
                 $crate::downcast_run_end_index! {
@@ -622,7 +622,7 @@ macro_rules! downcast_run_array {
                     k => unreachable!("unsupported run end index type: {}", k)
                 }
             }
-            $($p => $fallback,)*
+            $($p $(if $pred)* => $fallback,)*
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
To be able to add if expressions in the fallback pattern

# What changes are included in this PR?

added if pattern for all macro in `cast.rs` for the fallback pattern, unfortunately rust doesn't allow to add if after `expr` so I can't add if to the main pattern
 
# Are there any user-facing changes?

Yes