### PR TITLE
Bump `pyo3` to `0.24`

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -34,4 +34,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { path = "../arrow", features = ["pyarrow"] }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module"] }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -54,7 +54,7 @@ arrow-select = { workspace = true }
 arrow-string = { workspace = true }
 
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
-pyo3 = { version = "0.23", default-features = false, optional = true }
+pyo3 = { version = "0.24", default-features = false, optional = true }
 half = { version = "2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7259

# Rationale for this change
 
We also need to bump `pyo3` in `arrow-pyarrow-integration-testing/Cargo.toml`.

# What changes are included in this PR?

Bump `pyo3` to `0.24`.

# Are there any user-facing changes?

Yes.