### PR TITLE
Add missing type annotation

### DIFF
--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -129,7 +129,7 @@ fn from_parquet(parquet_type: &Type) -> Result<DataType> {
 }
 
 fn decimal_type(scale: i32, precision: i32) -> Result<DataType> {
-    if precision <= DECIMAL128_MAX_PRECISION as _ {
+    if precision <= DECIMAL128_MAX_PRECISION as i32 {
         decimal_128_type(scale, precision)
     } else {
         decimal_256_type(scale, precision)


### PR DESCRIPTION
# Which issue does this PR close?

```
error[E0282]: type annotations needed
   --> .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/parquet-54.3.0/src/arrow/schema/primitive.rs:117:49
    |
117 |     if precision <= DECIMAL128_MAX_PRECISION as _ {
    |                                                 ^ cannot infer type

For more information about this error, try `rustc --explain E0282`.
error: could not compile `parquet` (lib) due to 1 previous error
```

# Rationale for this change
 
I'm not sure why `rustc` fails to infer the type here. This showed up after updating `parquet` to `0.54.3` (as a dependency of a different crate).

# What changes are included in this PR?

Add type annotation.

# Are there any user-facing changes?

No.