### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ include = [
     "NOTICE.txt",
 ]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.81"
 
 [workspace.dependencies]
 arrow = { version = "54.3.0", path = "./arrow", default-features = false }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -463,20 +463,11 @@ impl Parser for Float64Type {
     }
 }
 
-/// This API is only stable since 1.70 so can't use it when current MSRV is lower
-#[inline(always)]
-fn is_some_and<T>(opt: Option<T>, f: impl FnOnce(T) -> bool) -> bool {
-    match opt {
-        None => false,
-        Some(x) => f(x),
-    }
-}
-
 macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                if !is_some_and(string.as_bytes().last(), |x| x.is_ascii_digit()) {
+                if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -20,7 +20,7 @@ name = "arrow-flight"
 description = "Apache Arrow Flight"
 version = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.71.1"
+rust-version = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/arrow-flight/gen/Cargo.toml
+++ b/arrow-flight/gen/Cargo.toml
@@ -20,7 +20,7 @@ name = "gen"
 description = "Code generation for arrow-flight"
 version = "0.1.0"
 edition = { workspace = true }
-rust-version = "1.71.1"
+rust-version = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 publish = false
-rust-version = "1.75.0"
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -387,15 +387,6 @@ struct StructArrayEncoder<'a> {
     struct_mode: StructMode,
 }
 
-/// This API is only stable since 1.70 so can't use it when current MSRV is lower
-#[inline(always)]
-fn is_some_and<T>(opt: Option<T>, f: impl FnOnce(T) -> bool) -> bool {
-    match opt {
-        None => false,
-        Some(x) => f(x),
-    }
-}
-
 impl Encoder for StructArrayEncoder<'_> {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         match self.struct_mode {
@@ -740,7 +731,7 @@ impl<'a> MapEncoder<'a> {
             ));
         }
 
-        if is_some_and(array.entries().nulls(), |x| x.null_count() != 0) {
+        if array.entries().nulls().is_some_and(|x| x.null_count() != 0) {
             return Err(ArrowError::InvalidArgumentError(
                 "Encountered nulls in MapArray entries".to_string(),
             ));

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow" ]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.81"
 publish = false
 
 [lib]

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -26,7 +26,7 @@ license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
 edition = { workspace = true }
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [lib]
 name = "arrow_schema"

--- a/arrow-schema/src/extension/canonical/bool8.rs
+++ b/arrow-schema/src/extension/canonical/bool8.rs
@@ -47,7 +47,7 @@ impl ExtensionType for Bool8 {
     }
 
     fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
-        if metadata.map_or(false, str::is_empty) {
+        if metadata.is_some_and(str::is_empty) {
             Ok("")
         } else {
             Err(ArrowError::InvalidArgumentError(

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -837,9 +837,8 @@ where
                             self.batch_size,
                         )
                         .await
-                        .map_err(|err| {
+                        .inspect_err(|_| {
                             self.state = StreamState::Error;
-                            err
                         })?;
                     self.reader_factory = Some(reader_factory);
 


### PR DESCRIPTION
# Which issue does this PR close?

Putting this up so we can get this in after:
- #7314

To include this with:
- #7084. 

It's also required for the following PRs that we may want to get in with that release:
- #6583
- #7200

# Rationale for this change
 
This bumps the MSRV to 1.81, following #7314. 

# What changes are included in this PR?

- Bump MSRV to 1.81
- Use this version for all crates
- Removed two copies of `is_some_and` method

# Are there any user-facing changes?

Yes, this crate now requires Rust 1.81.
