### PR TITLE
Remove `object-store` label from `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,6 @@ github:
   labels:
     - arrow
     - parquet
-    - object-store
     - rust
   enabled_merge_buttons:
     squash: true


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #7316.

# Rationale for this change
 
This repo no longer contains the `object-store` source.

# What changes are included in this PR?

Removed `object-store` repo label from `.asf.yaml`.

# Are there any user-facing changes?

No.