### PR TITLE
Remove  `AsyncFileReader::get_metadata_with_options`, add `options` to `AsyncFileReader::get_metadata`

### DIFF
--- a/parquet/examples/read_with_rowgroup.rs
+++ b/parquet/examples/read_with_rowgroup.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     let mut file = File::open(&path).await.unwrap();
 
     // The metadata could be cached in other places, this example only shows how to read
-    let metadata = file.get_metadata().await?;
+    let metadata = file.get_metadata(None).await?;
 
     for rg in metadata.row_groups() {
         let mut rowgroup = InMemoryRowGroup::create(rg.clone(), ProjectionMask::all());

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -110,14 +110,12 @@ pub trait AsyncFileReader: Send {
     /// allowing fine-grained control over how metadata is sourced, in particular allowing
     /// for caching, pre-fetching, catalog metadata, decrypting, etc...
     ///
-    /// By default calls `get_metadata()`
+    /// No default here because options under encryption are significant, and we want
+    /// the end-user to be explicit.
     fn get_metadata_with_options<'a>(
         &'a mut self,
         options: &'a ArrowReaderOptions,
-    ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
-        let _ = options;
-        self.get_metadata()
-    }
+    ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>>;
 }
 
 /// This allows Box<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -164,7 +164,7 @@ impl<T: AsyncRead + AsyncSeek + Unpin + Send> AsyncFileReader for T {
                 options.unwrap().file_decryption_properties.is_some();
 
             #[cfg(not(feature = "encryption"))]
-            let have_decryptor = options.is_some();
+            let have_decryptor = options.is_some() && cfg!(feature = "encryption"); // always false
 
             if footer.is_encrypted_footer() && !have_decryptor {
                 return Err(general_err!(

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -209,7 +209,7 @@ impl ArrowReaderMetadata {
     ) -> Result<Self> {
         // TODO: this is all rather awkward. It would be nice if AsyncFileReader::get_metadata
         // took an argument to fetch the page indexes.
-        let mut metadata = input.get_metadata_with_options(&options).await?;
+        let mut metadata = input.get_metadata(Some(&options)).await?;
 
         if options.page_index
             && metadata.column_index().is_none()

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -110,8 +110,8 @@ pub trait AsyncFileReader: Send {
     /// allowing fine-grained control over how metadata is sourced, in particular allowing
     /// for caching, pre-fetching, catalog metadata, decrypting, etc...
     ///
-    /// No default here because options under encryption are significant, and we want
-    /// the end-user to be explicit.
+    /// No default because options under encryption are significant.
+    /// We want the end-user to be explicit about what they want here.
     fn get_metadata_with_options<'a>(
         &'a mut self,
         options: &'a ArrowReaderOptions,

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -163,33 +163,22 @@ impl AsyncFileReader for ParquetObjectReader {
     // an `impl MetadataFetch` and calls those methods to get data from it. Due to `Self`'s impl of
     // `AsyncFileReader`, the calls to `MetadataFetch::fetch` are just delegated to
     // `Self::get_bytes`.
-    fn get_metadata(&mut self) -> BoxFuture<'_, Result<Arc<ParquetMetaData>>> {
-        Box::pin(async move {
-            let file_size = self.meta.size;
-            let metadata = ParquetMetaDataReader::new()
-                .with_column_indexes(self.preload_column_index)
-                .with_offset_indexes(self.preload_offset_index)
-                .with_prefetch_hint(self.metadata_size_hint)
-                .load_and_finish(self, file_size)
-                .await?;
-            Ok(Arc::new(metadata))
-        })
-    }
-
-    fn get_metadata_with_options<'a>(
+    fn get_metadata<'a>(
         &'a mut self,
-        options: &'a ArrowReaderOptions,
+        options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
         Box::pin(async move {
             let file_size = self.meta.size;
-            let metadata = ParquetMetaDataReader::new()
+            let mut metadata = ParquetMetaDataReader::new()
                 .with_column_indexes(self.preload_column_index)
                 .with_offset_indexes(self.preload_offset_index)
                 .with_prefetch_hint(self.metadata_size_hint);
 
             #[cfg(feature = "encryption")]
-            let metadata =
-                metadata.with_decryption_properties(options.file_decryption_properties.as_ref());
+            if let Some(options) = options {
+                metadata = metadata
+                    .with_decryption_properties(options.file_decryption_properties.as_ref());
+            }
 
             let metadata = metadata.load_and_finish(self, file_size).await?;
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -751,7 +751,7 @@ impl ParquetMetaDataReader {
 
                 file_decryptor = Some(decryptor);
             } else {
-                return Err(general_err!("Parquet file has an encrypted footer but no decryption properties were provided"));
+                return Err(general_err!("Parquet file has an encrypted footer but decryption properties were not provided"));
             }
         }
 

--- a/parquet/tests/arrow_reader/encryption.rs
+++ b/parquet/tests/arrow_reader/encryption.rs
@@ -154,7 +154,7 @@ fn test_decrypting_without_decryption_properties_fails() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
-        "Parquet error: Parquet file has an encrypted footer but no decryption properties were provided"
+        "Parquet error: Parquet file has an encrypted footer but decryption properties were not provided"
     );
 }
 

--- a/parquet/tests/arrow_reader/encryption_async.rs
+++ b/parquet/tests/arrow_reader/encryption_async.rs
@@ -277,7 +277,7 @@ async fn test_read_encrypted_file_from_object_store() {
     let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
 
     let mut reader = ParquetObjectReader::new(store, meta);
-    let metadata = reader.get_metadata_with_options(&options).await.unwrap();
+    let metadata = reader.get_metadata(Some(&options)).await.unwrap();
     let builder = ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
         .await
         .unwrap();

--- a/parquet/tests/arrow_reader/encryption_async.rs
+++ b/parquet/tests/arrow_reader/encryption_async.rs
@@ -277,7 +277,7 @@ async fn test_read_encrypted_file_from_object_store() {
     let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
 
     let mut reader = ParquetObjectReader::new(store, meta.location).with_file_size(meta.size);
-    let metadata = reader.get_metadata_with_options(Some(&options)).await.unwrap();
+    let metadata = reader.get_metadata(Some(&options)).await.unwrap();
     let builder = ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
         .await
         .unwrap();

--- a/parquet/tests/arrow_reader/encryption_async.rs
+++ b/parquet/tests/arrow_reader/encryption_async.rs
@@ -239,7 +239,7 @@ async fn test_decrypting_without_decryption_properties_fails() {
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
-        "Parquet error: Parquet file has an encrypted footer but no decryption properties were provided"
+        "Parquet error: Parquet file has an encrypted footer but decryption properties were not provided"
     );
 }
 


### PR DESCRIPTION
# Rationale for this change
 
In using encryption with datafusion, I found the default implementation for `get_metadata_with_options` to be more of a hindrance than a help. What happened, is that when working with encrypted parquet, my calls would mysteriously fail and I could not understand why. It took me longer than I like to admit to discover that the default implementation for `get_metadata_with_options` would quietly drop decryption information, and that was the source of my mysterious file reading failures. I propose that this default implementation should be removed so that developers get a clear compiler message that they should be explicit about what they want. If this is too much of a breaking API change, then a second best solution would be to provide a runtime error. Either way, I feel that the default implementation is simply too likely to cause unexpected and surprising errors.

# What changes are included in this PR?
Remove the default implementation for `get_metadata_with_options` for the ` AsyncFileReader: Send` trait. 

# Are there any user-facing changes?
Users will need to be explicit about what they want to do for `get_metadata_with_options ` for the ` AsyncFileReader: Send` trait. Having no default implementation is in line with other methods here. I feel that asking users to be explicit is a good change here to prevent potential errors.