### PR TITLE
refactor: apply borrowed chunk reader to Sbbf::read_from_column_chunk

### DIFF
--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -84,7 +84,6 @@ use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 use bytes::Bytes;
 use std::hash::Hasher;
 use std::io::Write;
-use std::sync::Arc;
 use thrift::protocol::{TCompactOutputProtocol, TOutputProtocol};
 use twox_hash::XxHash64;
 
@@ -308,7 +307,7 @@ impl Sbbf {
     /// Read a new bloom filter from the given offset in the given reader.
     pub(crate) fn read_from_column_chunk<R: ChunkReader>(
         column_metadata: &ColumnChunkMetaData,
-        reader: Arc<R>,
+        reader: &R,
     ) -> Result<Option<Self>, ParquetError> {
         let offset: u64 = if let Some(offset) = column_metadata.bloom_filter_offset() {
             offset

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -288,7 +288,7 @@ impl<'a, R: ChunkReader> SerializedRowGroupReader<'a, R> {
             metadata
                 .columns()
                 .iter()
-                .map(|col| Sbbf::read_from_column_chunk(col, chunk_reader.clone()))
+                .map(|col| Sbbf::read_from_column_chunk(col, &*chunk_reader))
                 .collect::<Result<Vec<_>>>()?
         } else {
             iter::repeat(None).take(metadata.columns().len()).collect()


### PR DESCRIPTION
# Rationale for this change
 
It does not need to apply owned Arc<ChunkReader> to Sbbf::read_from_column_chunk, borrowed reader is more general.

# What changes are included in this PR?

`Sbbf::read_from_column_chunk`

# Are there any user-facing changes?

No there aren't
