### PR TITLE
Add additional benchmarks for utf8view comparison kernels

### DIFF
--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -272,7 +272,6 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| lt(&left_arr_long_string_view, &right_arr_long_string_view).unwrap())
     });
 
-
     // StringArray: LIKE benchmarks
 
     c.bench_function("like_utf8 scalar equals", |b| {
@@ -311,9 +310,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_like_utf8_scalar(&arr_long_string, "%prefix_1234"))
     });
 
-    c.bench_function("long same prefix strings like_utf8 scalar starts with", |b| {
-        b.iter(|| bench_like_utf8_scalar(&arr_long_string, "prefix_1234%"))
-    });
+    c.bench_function(
+        "long same prefix strings like_utf8 scalar starts with",
+        |b| b.iter(|| bench_like_utf8_scalar(&arr_long_string, "prefix_1234%")),
+    );
 
     c.bench_function("long same prefix strings like_utf8 scalar complex", |b| {
         b.iter(|| bench_like_utf8_scalar(&arr_long_string, "%prefix_1234%xxx"))
@@ -323,26 +323,30 @@ fn add_benchmark(c: &mut Criterion) {
     // Note:
     // long strings mean strings start with same 4 bytes prefix such as "test",
     // followed by a tail, ensuring the total length is greater than 12 bytes.
-    c.bench_function("long same prefix strings like_utf8view scalar equals", |b| {
-        b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "prefix_1234"))
-    });
+    c.bench_function(
+        "long same prefix strings like_utf8view scalar equals",
+        |b| b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "prefix_1234")),
+    );
 
-    c.bench_function("long same prefix strings like_utf8view scalar contains", |b| {
-        b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234%"))
-    });
+    c.bench_function(
+        "long same prefix strings like_utf8view scalar contains",
+        |b| b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234%")),
+    );
 
-    c.bench_function("long same prefix strings like_utf8view scalar ends with", |b| {
-        b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234"))
-    });
+    c.bench_function(
+        "long same prefix strings like_utf8view scalar ends with",
+        |b| b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234")),
+    );
 
-    c.bench_function("long same prefix strings like_utf8view scalar starts with", |b| {
-        b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view,  "prefix_1234%"))
-    });
+    c.bench_function(
+        "long same prefix strings like_utf8view scalar starts with",
+        |b| b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "prefix_1234%")),
+    );
 
-    c.bench_function("long same prefix strings like_utf8view scalar complex", |b| {
-        b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234%xxx"))
-    });
-
+    c.bench_function(
+        "long same prefix strings like_utf8view scalar complex",
+        |b| b.iter(|| bench_like_utf8view_scalar(&arr_long_string_view, "%prefix_1234%xxx")),
+    );
 
     // StringViewArray: LIKE benchmarks
     // Note: since like/nlike share the same implementation, we only benchmark one

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -512,7 +512,8 @@ fn add_custom_string_benchmarks(c: &mut Criterion) {
     // Benchmark the greater-than scalar operation for utf8view (StringViewArray) with long string
     c.bench_function("gt custom utf8view scalar long string", |b| {
         // Create a scalar value to compare against.
-        let custom_scalar_view = StringViewArray::new_scalar("testXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+        let custom_scalar_view =
+            StringViewArray::new_scalar("testXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
         b.iter(|| gt(&custom_string_view, &custom_scalar_view).unwrap())
     });
 
@@ -556,7 +557,6 @@ fn add_custom_string_benchmarks(c: &mut Criterion) {
         b.iter(|| bench_nilike_utf8view_scalar(&custom_string_view, "TEST%"))
     });
 }
-
 
 criterion_group!(benches, add_benchmark, add_custom_string_benchmarks);
 criterion_main!(benches);

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -44,24 +44,12 @@ fn bench_nlike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     nlike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
 }
 
-fn bench_nlike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
-    nlike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
-}
-
 fn bench_ilike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     ilike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
 }
 
-fn bench_ilike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
-    ilike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
-}
-
 fn bench_nilike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     nilike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
-}
-
-fn bench_nilike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
-    nilike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
 }
 
 fn bench_stringview_regexp_is_match_scalar(arr_a: &StringViewArray, value_b: &str) {

--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -32,24 +32,36 @@ use rand::Rng;
 
 const SIZE: usize = 65536;
 
-fn bench_like_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
-    like(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
-}
-
 fn bench_like_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     like(arr_a, &StringArray::new_scalar(value_b)).unwrap();
+}
+
+fn bench_like_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
+    like(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
 }
 
 fn bench_nlike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     nlike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
 }
 
+fn bench_nlike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
+    nlike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
+}
+
 fn bench_ilike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     ilike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
 }
 
+fn bench_ilike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
+    ilike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
+}
+
 fn bench_nilike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     nilike(arr_a, &StringArray::new_scalar(value_b)).unwrap();
+}
+
+fn bench_nilike_utf8view_scalar(arr_a: &StringViewArray, value_b: &str) {
+    nilike(arr_a, &StringViewArray::new_scalar(value_b)).unwrap();
 }
 
 fn bench_stringview_regexp_is_match_scalar(arr_a: &StringViewArray, value_b: &str) {
@@ -424,5 +436,127 @@ fn add_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, add_benchmark);
+// Generate a string array that meets the requirements:
+// All strings start with "test", followed by a tail, ensuring the total length is greater than 12 bytes.
+fn make_custom_string_array(size: usize, tail_len: usize, rng: &mut StdRng) -> Vec<Option<String>> {
+    (0..size)
+        .map(|_| {
+            // Generate the tail: use visible ASCII characters (32 to 126) to ensure a valid UTF-8 string.
+            let tail: String = (0..tail_len)
+                .map(|_| rng.random_range(32u8..127u8) as char)
+                .collect();
+            Some(format!("test{}", tail))
+        })
+        .collect()
+}
+
+fn add_custom_string_benchmarks(c: &mut Criterion) {
+    // Assume SIZE is defined as the benchmark array size.
+    let mut rng = seedable_rng();
+    // Here, tail length is set to 12, so the total length becomes 4 + 12 = 16 bytes (> 12 bytes).
+    let custom_strings = make_custom_string_array(SIZE, 12, &mut rng);
+    let custom_string_array = StringArray::from(custom_strings);
+    let custom_string_view = StringViewArray::from_iter(custom_string_array.iter());
+
+    // Benchmark the eq operation for utf8 (StringArray)
+    c.bench_function("eq custom utf8", |b| {
+        b.iter(|| eq(&custom_string_array, &custom_string_array).unwrap())
+    });
+
+    // Benchmark the eq operation for utf8view (StringViewArray)
+    c.bench_function("eq custom utf8view", |b| {
+        b.iter(|| eq(&custom_string_view, &custom_string_view).unwrap())
+    });
+
+    // Benchmark the neq operation for utf8 (StringArray)
+    c.bench_function("neq custom utf8", |b| {
+        b.iter(|| neq(&custom_string_array, &custom_string_array).unwrap())
+    });
+
+    // Benchmark the neq operation for utf8view (StringViewArray)
+    c.bench_function("neq custom utf8view", |b| {
+        b.iter(|| neq(&custom_string_view, &custom_string_view).unwrap())
+    });
+
+    // Benchmark the greater-than (gt) operation for utf8 (StringArray)
+    c.bench_function("gt custom utf8", |b| {
+        b.iter(|| gt(&custom_string_array, &custom_string_array).unwrap())
+    });
+
+    // Benchmark the greater-than (gt) operation for utf8view (StringViewArray)
+    c.bench_function("gt custom utf8view", |b| {
+        b.iter(|| gt(&custom_string_view, &custom_string_view).unwrap())
+    });
+
+    // Benchmark the greater-than scalar operation for utf8 (StringArray)
+    c.bench_function("gt custom utf8 scalar", |b| {
+        // Create a scalar value to compare against.
+        let custom_scalar = StringArray::new_scalar("testXXXX");
+        b.iter(|| gt(&custom_string_array, &custom_scalar).unwrap())
+    });
+
+    // Benchmark the greater-than scalar operation for utf8view (StringViewArray)
+    c.bench_function("gt custom utf8view scalar", |b| {
+        // Create a scalar value to compare against.
+        let custom_scalar_view = StringViewArray::new_scalar("testXXXX");
+        b.iter(|| gt(&custom_string_view, &custom_scalar_view).unwrap())
+    });
+
+    // Benchmark the greater-than scalar operation for utf8 (StringArray) with long string
+    c.bench_function("gt custom utf8 scalar long string", |b| {
+        // Create a scalar value to compare against.
+        let custom_scalar = StringArray::new_scalar("testXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+        b.iter(|| gt(&custom_string_array, &custom_scalar).unwrap())
+    });
+
+    // Benchmark the greater-than scalar operation for utf8view (StringViewArray) with long string
+    c.bench_function("gt custom utf8view scalar long string", |b| {
+        // Create a scalar value to compare against.
+        let custom_scalar_view = StringViewArray::new_scalar("testXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+        b.iter(|| gt(&custom_string_view, &custom_scalar_view).unwrap())
+    });
+
+    // Benchmark the LIKE operation (pattern: "test%") for utf8 (StringArray)
+    c.bench_function("like custom utf8 scalar", |b| {
+        b.iter(|| bench_like_utf8_scalar(&custom_string_array, "test%"))
+    });
+
+    // Benchmark the LIKE operation for utf8view (StringViewArray)
+    c.bench_function("like custom utf8view scalar", |b| {
+        b.iter(|| bench_like_utf8view_scalar(&custom_string_view, "test%"))
+    });
+
+    // Benchmark the NOT LIKE (nlike) operation for utf8 (StringArray)
+    c.bench_function("nlike custom utf8 scalar", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&custom_string_array, "test%"))
+    });
+
+    // Benchmark the NOT LIKE (nlike) operation for utf8view (StringViewArray)
+    c.bench_function("nlike custom utf8view scalar", |b| {
+        b.iter(|| bench_nlike_utf8view_scalar(&custom_string_view, "test%"))
+    });
+
+    // Benchmark the ILIKE (case-insensitive LIKE) operation for utf8 (StringArray)
+    c.bench_function("ilike custom utf8 scalar", |b| {
+        b.iter(|| bench_ilike_utf8_scalar(&custom_string_array, "TEST%"))
+    });
+
+    // Benchmark the ILIKE (case-insensitive LIKE) operation for utf8view (StringViewArray)
+    c.bench_function("ilike custom utf8view scalar", |b| {
+        b.iter(|| bench_ilike_utf8view_scalar(&custom_string_view, "TEST%"))
+    });
+
+    // Benchmark the NOT ILIKE (nilike) operation for utf8 (StringArray)
+    c.bench_function("nilike custom utf8 scalar", |b| {
+        b.iter(|| bench_nilike_utf8_scalar(&custom_string_array, "TEST%"))
+    });
+
+    // Benchmark the NOT ILIKE (nilike) operation for utf8view (StringViewArray)
+    c.bench_function("nilike custom utf8view scalar", |b| {
+        b.iter(|| bench_nilike_utf8view_scalar(&custom_string_view, "TEST%"))
+    });
+}
+
+
+criterion_group!(benches, add_benchmark, add_custom_string_benchmarks);
 criterion_main!(benches);

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -168,10 +168,10 @@ fn create_string_array_with_len_range_and_prefix<Offset: OffsetSizeTrait>(
     let rng = &mut seedable_rng();
     (0..size)
         .map(|_| {
-            if rng.gen::<f32>() < null_density {
+            if rng.random::<f32>() < null_density {
                 None
             } else {
-                let remaining_len = rng.gen_range(
+                let remaining_len = rng.random_range(
                     min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()),
                 );
 
@@ -207,10 +207,10 @@ fn create_string_view_array_with_len_range_and_prefix(
     let rng = &mut seedable_rng();
     (0..size)
         .map(|_| {
-            if rng.gen::<f32>() < null_density {
+            if rng.random::<f32>() < null_density {
                 None
             } else {
-                let remaining_len = rng.gen_range(
+                let remaining_len = rng.random_range(
                     min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()),
                 );
 

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -156,8 +156,14 @@ fn create_string_array_with_len_range_and_prefix<Offset: OffsetSizeTrait>(
     max_str_len: usize,
     prefix: &str,
 ) -> GenericStringArray<Offset> {
-    assert!(min_str_len <= max_str_len, "min_str_len must be <= max_str_len");
-    assert!(prefix.len() <= max_str_len, "Prefix length must be <= max_str_len");
+    assert!(
+        min_str_len <= max_str_len,
+        "min_str_len must be <= max_str_len"
+    );
+    assert!(
+        prefix.len() <= max_str_len,
+        "Prefix length must be <= max_str_len"
+    );
 
     let rng = &mut seedable_rng();
     (0..size)
@@ -165,7 +171,9 @@ fn create_string_array_with_len_range_and_prefix<Offset: OffsetSizeTrait>(
             if rng.gen::<f32>() < null_density {
                 None
             } else {
-                let remaining_len = rng.gen_range(min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()));
+                let remaining_len = rng.gen_range(
+                    min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()),
+                );
 
                 let mut value = prefix.to_string();
                 value.extend(
@@ -187,8 +195,14 @@ fn create_string_view_array_with_len_range_and_prefix(
     max_str_len: usize,
     prefix: &str,
 ) -> StringViewArray {
-    assert!(min_str_len <= max_str_len, "min_str_len must be <= max_str_len");
-    assert!(prefix.len() <= max_str_len, "Prefix length must be <= max_str_len");
+    assert!(
+        min_str_len <= max_str_len,
+        "min_str_len must be <= max_str_len"
+    );
+    assert!(
+        prefix.len() <= max_str_len,
+        "Prefix length must be <= max_str_len"
+    );
 
     let rng = &mut seedable_rng();
     (0..size)
@@ -196,7 +210,9 @@ fn create_string_view_array_with_len_range_and_prefix(
             if rng.gen::<f32>() < null_density {
                 None
             } else {
-                let remaining_len = rng.gen_range(min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()));
+                let remaining_len = rng.gen_range(
+                    min_str_len.saturating_sub(prefix.len())..=(max_str_len - prefix.len()),
+                );
 
                 let mut value = prefix.to_string();
                 value.extend(
@@ -210,7 +226,6 @@ fn create_string_view_array_with_len_range_and_prefix(
         })
         .collect()
 }
-
 
 /// Creates a random (but fixed-seeded) array of rand size with a given max size, null density and length
 fn create_string_array_with_max_len<Offset: OffsetSizeTrait>(


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/7350

# Rationale for this change
 Add reproducer cases which the Utf8View will slower than Utf8

# What changes are included in this PR?

Add reproducer cases which the Utf8View will slower than Utf8

# Are there any user-facing changes?
No
