### PR TITLE
Move `sysinfo` to `dev-dependencies`

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -68,7 +68,6 @@ hashbrown = { version = "0.15", default-features = false }
 twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"] }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-sysinfo = { version = "0.34.0", optional = true, default-features = false, features = ["system"] }
 crc32fast = { version = "1.4.2", optional = true, default-features = false }
 simdutf8 = { version = "0.1.5", optional = true, default-features = false }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
@@ -87,6 +86,7 @@ arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "jso
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 object_store = { version = "0.11.0", default-features = false, features = ["azure"] }
+sysinfo = { version = "0.34.0", default-features = false, features = ["system"] }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -113,8 +113,6 @@ async = ["futures", "tokio"]
 object_store = ["dep:object_store", "async"]
 # Group Zstd dependencies
 zstd = ["dep:zstd"]
-# Display memory in example/write_parquet.rs
-sysinfo = ["dep:sysinfo"]
 # Verify 32-bit CRC checksum when decoding parquet pages
 crc = ["dep:crc32fast"]
 # Enable SIMD UTF-8 validation
@@ -135,7 +133,7 @@ path = "./examples/read_parquet.rs"
 
 [[example]]
 name = "write_parquet"
-required-features = ["cli", "sysinfo"]
+required-features = ["cli"]
 path = "./examples/write_parquet.rs"
 
 [[example]]


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up of #7352.

# Rationale for this change
 
It looks like `sysinfo` is only used in one of the `parquet` examples.

# What changes are included in this PR?

Moves the `sysinfo` dependency to `dev-dependencies` and removes the `sysinfo` feature.

# Are there any user-facing changes?

Yes, dependency moved and feature removed.