### PR TITLE
Use rust builtins

### DIFF
--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -20,7 +20,8 @@
 /// Returns the nearest number that is `>=` than `num` and is a multiple of 64
 #[inline]
 pub fn round_upto_multiple_of_64(num: usize) -> usize {
-    round_upto_power_of_2(num, 64)
+    num.checked_next_multiple_of(64)
+        .expect("failed to round upto multiple of 64")
 }
 
 /// Returns the nearest multiple of `factor` that is `>=` than `num`. Here `factor` must
@@ -86,9 +87,7 @@ pub unsafe fn unset_bit_raw(data: *mut u8, i: usize) {
 /// Returns the ceil of `value`/`divisor`
 #[inline]
 pub fn ceil(value: usize, divisor: usize) -> usize {
-    // Rewrite as `value.div_ceil(&divisor)` after
-    // https://github.com/rust-lang/rust/issues/88581 is merged.
-    value / divisor + (0 != value % divisor) as usize
+    value.div_ceil(divisor)
 }
 
 #[cfg(test)]
@@ -107,6 +106,12 @@ mod tests {
         assert_eq!(64, round_upto_multiple_of_64(64));
         assert_eq!(128, round_upto_multiple_of_64(65));
         assert_eq!(192, round_upto_multiple_of_64(129));
+    }
+
+    #[test]
+    #[should_panic(expected = "failed to round upto multiple of 64")]
+    fn test_round_upto_multiple_of_64_panic() {
+        let _ = round_upto_multiple_of_64(usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change
 
Now that we have updated msrv, we can use rust built ins for round_upto_multiple_of_64 and div_ceil

# What changes are included in this PR?



# Are there any user-facing changes?

Yes, minor edits to error message