### PR TITLE
Parquet: POC for handling struct child via StatisticsConverter

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -85,7 +85,7 @@ serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-object_store = { version = "0.11.0", default-features = false, features = ["azure"] }
+object_store = { version = "0.11.0", default-features = false, features = ["aws", "azure"] }
 sysinfo = { version = "0.34.0", default-features = false, features = ["system"] }
 
 [package.metadata.docs.rs]

--- a/parquet/benches/arrow_statistics.rs
+++ b/parquet/benches/arrow_statistics.rs
@@ -215,7 +215,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function(BenchmarkId::new("extract_statistics", dtype.clone()), |b| {
                 b.iter(|| {
                     let converter = StatisticsConverter::try_new(
-                        "col",
+                        &"col".into(),
                         reader.schema(),
                         reader.parquet_schema(),
                     )

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -20,14 +20,14 @@
 /// Notice that all the corresponding tests are in
 /// `arrow-rs/parquet/tests/arrow_reader/statistics.rs`.
 use crate::arrow::buffer::bit_util::sign_extend_be;
-use crate::arrow::parquet_column;
+use crate::arrow::{parquet_column, ProjectionMask};
 use crate::basic::Type as PhysicalType;
 use crate::data_type::{ByteArray, FixedLenByteArray};
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ParquetColumnIndex, ParquetOffsetIndex, RowGroupMetaData};
 use crate::file::page_index::index::{Index, PageIndex};
 use crate::file::statistics::Statistics as ParquetStatistics;
-use crate::schema::types::SchemaDescriptor;
+use crate::schema::types::{ColumnPath, SchemaDescriptor};
 use arrow_array::builder::{
     BinaryViewBuilder, BooleanBuilder, FixedSizeBinaryBuilder, LargeStringBuilder, StringBuilder,
     StringViewBuilder,
@@ -1290,32 +1290,60 @@ impl<'a> StatisticsConverter<'a> {
     ///
     /// * If the column is not found in the arrow schema
     pub fn try_new<'b>(
-        column_name: &'b str,
+        column: &'b ColumnPath,
         arrow_schema: &'a Schema,
         parquet_schema: &'a SchemaDescriptor,
     ) -> Result<Self> {
+        let mut fields = arrow_schema.fields();
+        dbg!(fields);
+        let mut arrow_field = None;
         // ensure the requested column is in the arrow schema
-        let Some((_idx, arrow_field)) = arrow_schema.column_with_name(column_name) else {
-            return Err(arrow_err!(format!(
-                "Column '{}' not found in schema for statistics conversion",
-                column_name
-            )));
-        };
-
-        // find the column in the parquet schema, if not, return a null array
-        let parquet_index = match parquet_column(parquet_schema, arrow_schema, column_name) {
-            Some((parquet_idx, matched_field)) => {
-                // sanity check that matching field matches the arrow field
-                if matched_field.as_ref() != arrow_field {
-                    return Err(arrow_err!(format!(
-                        "Matched column '{:?}' does not match original matched column '{:?}'",
-                        matched_field, arrow_field
-                    )));
+        for part in column.parts() {
+            if let Some((idx, inner_arrow_field)) = fields.find(&part) {
+                match inner_arrow_field.data_type() {
+                    DataType::Struct(inner_fields) => {
+                        fields = inner_fields;
+                    }
+                    _ => {
+                        arrow_field = Some(inner_arrow_field);
+                    }
                 }
-                Some(parquet_idx)
-            }
-            None => None,
-        };
+            } else {
+                return Err(arrow_err!(format!(
+                    "Column '{}' not found in schema for statistics conversion",
+                    column
+                )));
+            };
+        }
+
+        let arrow_field = arrow_field.ok_or(arrow_err!(format!(
+            "Column '{}' not found in schema for statistics conversion",
+            column
+        )))?;
+
+        let mask =
+            ProjectionMask::columns(parquet_schema, std::iter::once(column.string().as_str()));
+        let parquet_index = mask
+            .mask
+            .expect("expected mask to exist")
+            .iter()
+            .position(|x| *x);
+
+        // // find the column in the parquet schema, if not, return a null array
+        // // ProjectionMask::columns( , names)
+        // let parquet_index = match parquet_column(parquet_schema, arrow_schema, column_name) {
+        //     Some((parquet_idx, matched_field)) => {
+        //         // sanity check that matching field matches the arrow field
+        //         if matched_field.as_ref() != arrow_field {
+        //             return Err(arrow_err!(format!(
+        //                 "Matched column '{:?}' does not match original matched column '{:?}'",
+        //                 matched_field, arrow_field
+        //             )));
+        //         }
+        //         Some(parquet_idx)
+        //     }
+        //     None => None,
+        // };
 
         Ok(Self {
             parquet_column_index: parquet_index,

--- a/parquet/tests/arrow_reader/statistics.rs
+++ b/parquet/tests/arrow_reader/statistics.rs
@@ -2697,7 +2697,7 @@ mod test {
 }
 
 // To be removed before merging but a real-world use case
-#[cfg(test)]
+#[cfg(all(test, feature = "async"))]
 mod test_geoparquet {
     use std::sync::Arc;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/7364. Also related to https://github.com/apache/datafusion/issues/10609 and https://github.com/apache/datafusion/issues/8334.

# Rationale for this change

Support some way to handle struct-typed columns in `StatisticsConverter`.

# What changes are included in this PR?

I think there are two ways to handle this:

1. Support struct-type columns directly, where the user can pass the name of a struct column, and all children are automatically handled. So `row_group_mins` would return a struct-typed Arrow array.
2. Adjust `StatisticsConverter::try_new` to handle a nested column name. So the user would pass `a.b.c`, which designates a primitive type, and we reuse existing converters. So `row_group_mins` would return a **primitive-typed** Arrow array.

This PR prototypes approach 2.

In principle both approaches would be good to have, but approach 1 looked more complex, and approach 2 at least provides a valid workaround.

# Are there any user-facing changes?

Yes, a breaking change to the signature of `StatisticsConverter` to use `ColumnPath` instead of `&str` for the `column_name`. This isn't _technically_ required; we could assume that a `.` in the column name is a field delimiter, but this seems unnecessary when `ColumnPath` already exists as a type. 

(Similarly, it's weird to me that [`ProjectionMask::columns`](https://docs.rs/parquet/latest/parquet/arrow/struct.ProjectionMask.html#method.columns) takes in `&str` and not `&ColumnPath` as input)