### PR TITLE
bump pyo3 for RUSTSEC-2025-0020

### DIFF
--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -34,4 +34,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { path = "../arrow", features = ["pyarrow"] }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.24.1", features = ["extension-module"] }

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -54,7 +54,7 @@ arrow-select = { workspace = true }
 arrow-string = { workspace = true }
 
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"], optional = true }
-pyo3 = { version = "0.24", default-features = false, optional = true }
+pyo3 = { version = "0.24.1", default-features = false, optional = true }
 half = { version = "2.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
I wonder if it is possible to cut a release after this?

# Rationale for this change
 
https://rustsec.org/advisories/RUSTSEC-2025-0020.html

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
