### PR TITLE
Improve documentation on implementing Parquet predicate pushdown

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -66,20 +66,20 @@ pub mod statistics;
 ///
 /// However, most Parquet based systems will apply filters at many steps prior
 /// to decoding such as pruning files, row groups and data pages. This crate
-/// provides the low level APIs needed to implement such filtering, but not
+/// provides the low level APIs needed to implement such filtering, but does not
 /// include any logic to actually evaluate predicates. For example:
 ///
-/// *  [`Self::with_row_groups`] for Row Group pruning
+/// * [`Self::with_row_groups`] for Row Group pruning
 /// * [`Self::with_row_selection`] for data page pruning
 /// * [`StatisticsConverter`] to convert Parquet statistics to Arrow arrays
 ///
 /// The rationale for this design is that implementing predicate pushdown is a
-/// complex topic and varys significantly from system to system. For example
+/// complex topic and varies significantly from system to system. For example
 ///
 /// 1. Predicates supported (do you support predicates like prefix matching, user defined functions, etc)
 /// 2. Evaluating predicates on multiple files (with potentially different but compatible schemas)
 /// 3. Evaluating predicates using information from an external metadata catalog (e.g. Apache Iceberg or similar)
-/// 4. Interlave fetching metadata, evaluating predicates, and decoding files
+/// 4. Interleaving fetching metadata, evaluating predicates, and decoding files
 ///
 /// You can read more about this design in the [Querying Parquet with
 /// Millisecond Latency] Arrow blog post.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/arrow-rs/pull/7360
- Closes https://github.com/apache/arrow-rs/issues/7348

# Rationale for this change

It is not clear from the documentation why the parquet crate has no row group / data page predicate evaluation features as  described on https://github.com/apache/arrow-rs/issues/7348

# What changes are included in this PR?
1. Document  the rationale of why the parquet implementation does not include predicate evaluation (and instead has the building blocks to do so)


# Are there any user-facing changes?

Docs only, no functional change
