### PR TITLE
Upgrade tonic dependencies to 0.13.0 version

### DIFF
--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -54,13 +54,13 @@ jobs:
         uses: ./.github/actions/setup-builder
       - name: Test
         run: |
-          cargo test -p arrow-flight
+          cargo test -p arrow-flight --features=router
       - name: Test --all-features
         run: |
           cargo test -p arrow-flight --all-features
       - name: Test --examples
         run: |
-          cargo test -p arrow-flight  --features=flight-sql-experimental,tls --examples
+          cargo test -p arrow-flight  --features=flight-sql-experimental,tls,router --examples
 
   vendor:
     name: Verify Vendored Code

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -44,9 +44,9 @@ bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 once_cell = { version = "1", optional = true }
 paste = { version = "1.0" , optional = true }
-prost = { version = "0.13.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.5", default-features = false, features = ["prost-derive"] }
 # For Timestamp type
-prost-types = { version = "0.13.1", default-features = false }
+prost-types = { version = "0.13.5", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"], optional = true }
 tonic = { version = "0.13.0", default-features = false, features = ["transport", "codegen", "prost"] }
 
@@ -74,6 +74,7 @@ http = "1.1.0"
 http-body = "1.0.0"
 hyper-util = "0.1"
 pin-project-lite = "0.2"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tempfile = "3.3"
 tracing-log = { version = "0.2" }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["ansi", "env-filter", "fmt"] }

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -48,7 +48,7 @@ prost = { version = "0.13.1", default-features = false, features = ["prost-deriv
 # For Timestamp type
 prost-types = { version = "0.13.1", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"], optional = true }
-tonic = { version = "0.12.3", default-features = false, features = ["transport", "codegen", "prost"] }
+tonic = { version = "0.13.0", default-features = false, features = ["transport", "codegen", "prost"] }
 
 # CLI-related dependencies
 anyhow = { version = "1.0", optional = true }
@@ -62,7 +62,8 @@ all-features = true
 [features]
 default = []
 flight-sql-experimental = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
-tls = ["tonic/tls"]
+tls = ["tonic/_tls-any"]
+router = ["tonic/router"]
 # Enable CLI tools
 cli = ["arrow-array/chrono-tz", "arrow-cast/prettyprint", "tonic/tls-webpki-roots", "dep:anyhow", "dep:clap", "dep:tracing-log", "dep:tracing-subscriber"]
 
@@ -83,7 +84,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 
 [[example]]
 name = "flight_sql_server"
-required-features = ["flight-sql-experimental", "tls"]
+required-features = ["flight-sql-experimental", "tls", "router"]
 
 [[bin]]
 name = "flight_sql_client"
@@ -92,9 +93,9 @@ required-features = ["cli", "flight-sql-experimental", "tls"]
 [[test]]
 name = "flight_sql_client"
 path = "tests/flight_sql_client.rs"
-required-features = ["flight-sql-experimental", "tls"]
+required-features = ["flight-sql-experimental", "tls", "router"]
 
 [[test]]
 name = "flight_sql_client_cli"
 path = "tests/flight_sql_client_cli.rs"
-required-features = ["cli", "flight-sql-experimental", "tls"]
+required-features = ["cli", "flight-sql-experimental", "tls", "router"]

--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -46,7 +46,7 @@ that demonstrate how to build a Flight server implemented with [tonic](https://d
 - `flight-sql-experimental`: Enables experimental support for
   [Apache Arrow FlightSQL], a protocol for interacting with SQL databases.
 
-- `tls`: Enables `tls` on `tonic`
+- `tls`: Enables `_tls-any` on `tonic`
 
 ## CLI
 

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -813,7 +813,7 @@ mod tests {
     async fn bind_tcp() -> (TcpIncoming, SocketAddr) {
         let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let incoming = TcpIncoming::from_listener(listener, true, None).unwrap();
+        let incoming = TcpIncoming::from(listener);
         (incoming, addr)
     }
 
@@ -917,6 +917,9 @@ mod tests {
 
         let svc = FlightServiceServer::new(FlightSqlServiceImpl {});
 
+        // Set dafault crypto provider to use
+        // See: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider
+        rustls::crypto::ring::default_provider();
         let serve_future = Server::builder()
             .tls_config(tls_config)
             .unwrap()

--- a/arrow-flight/gen/Cargo.toml
+++ b/arrow-flight/gen/Cargo.toml
@@ -33,4 +33,4 @@ publish = false
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
 prost-build = { version = "=0.13.5", default-features = false }
-tonic-build = { version = "=0.12.3", default-features = false, features = ["transport", "prost"] }
+tonic-build = { version = "=0.13.0", default-features = false, features = ["transport", "prost"] }

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -448,7 +448,7 @@ pub mod flight_service_client {
     }
     impl<T> FlightServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -469,13 +469,13 @@ pub mod flight_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
                 Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                 >,
             >,
             <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             FlightServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -1098,7 +1098,7 @@ pub mod flight_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -1571,7 +1571,7 @@ pub mod flight_service_server {
                 }
                 _ => {
                     Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
+                        let mut response = http::Response::new(tonic::body::Body::default());
                         let headers = response.headers_mut();
                         headers
                             .insert(

--- a/arrow-flight/src/arrow.flight.protocol.rs
+++ b/arrow-flight/src/arrow.flight.protocol.rs
@@ -1571,7 +1571,9 @@ pub mod flight_service_server {
                 }
                 _ => {
                     Box::pin(async move {
-                        let mut response = http::Response::new(tonic::body::Body::default());
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
                         let headers = response.headers_mut();
                         headers
                             .insert(

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -43,7 +43,7 @@ prost = { version = "0.13", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["rc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = [ "rt-multi-thread"] }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13", default-features = false, features = ["router"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt"], optional = true }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 


### PR DESCRIPTION
# Which issue does this PR close?

Upgrade version of tonic used in dependencies from 0.12.3 to 0.13.0, which includes a batch of breaking changes.

- closes  https://github.com/apache/arrow-rs/issues/7464

# Rationale for this change
 
Using the latest version of crates will prevent any potential issues and vulnerabilities. And will allow users to use latest tonic with arrow crates without keeping different versions

# What changes are included in this PR?

Updated the new interface names.
Changed feature names used in the latest tonic.
Updated GitHub workflows to run tests correctly with the required tonic features.
