### PR TITLE
chore: apply clippy suggestions newly introduced in rust 1.86

### DIFF
--- a/arrow-buffer/src/bigint/div.rs
+++ b/arrow-buffer/src/bigint/div.rs
@@ -39,8 +39,8 @@ pub fn div_rem<const N: usize>(numerator: &[u64; N], divisor: &[u64; N]) -> ([u6
         return div_rem_small(numerator, divisor[0]);
     }
 
-    let numerator_words = (numerator_bits + 63) / 64;
-    let divisor_words = (divisor_bits + 63) / 64;
+    let numerator_words = numerator_bits.div_ceil(64);
+    let divisor_words = divisor_bits.div_ceil(64);
     let n = divisor_words;
     let m = numerator_words - divisor_words;
 

--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -53,7 +53,7 @@ impl<'a> UnalignedBitChunk<'a> {
         let byte_offset = offset / 8;
         let offset_padding = offset % 8;
 
-        let bytes_len = (len + offset_padding + 7) / 8;
+        let bytes_len = (len + offset_padding).div_ceil(8);
         let buffer = &buffer[byte_offset..byte_offset + bytes_len];
 
         let prefix_mask = compute_prefix_mask(offset_padding);

--- a/arrow/benches/buffer_create.rs
+++ b/arrow/benches/buffer_create.rs
@@ -50,7 +50,7 @@ fn mutable_buffer_iter_bitset(data: &[Vec<bool>]) -> Vec<Buffer> {
         data.iter()
             .map(|datum| {
                 let mut result =
-                    MutableBuffer::new((data.len() + 7) / 8).with_bitset(datum.len(), false);
+                    MutableBuffer::new(data.len().div_ceil(8)).with_bitset(datum.len(), false);
                 for (i, value) in datum.iter().enumerate() {
                     if *value {
                         unsafe {

--- a/parquet/src/arrow/array_reader/fixed_size_list_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_size_list_array.rs
@@ -77,7 +77,7 @@ impl ArrayReader for FixedSizeListArrayReader {
 
     fn consume_batch(&mut self) -> Result<ArrayRef> {
         let next_batch_array = self.item_reader.consume_batch()?;
-        if next_batch_array.len() == 0 {
+        if next_batch_array.is_empty() {
             return Ok(new_empty_array(&self.data_type));
         }
 

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -83,7 +83,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
 
     fn consume_batch(&mut self) -> Result<ArrayRef> {
         let next_batch_array = self.item_reader.consume_batch()?;
-        if next_batch_array.len() == 0 {
+        if next_batch_array.is_empty() {
             return Ok(new_empty_array(&self.data_type));
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7381.

# Rationale for this change

See issue 

# What changes are included in this PR?

Use `div_ceil` (available since rustc 1.73, over 1 year ago)
Use `is_empty` instead of `len() == 0`

# Are there any user-facing changes?

No