### PR TITLE
Handle compressed empty DataPage v2

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1373,7 +1373,6 @@ mod tests {
         );
 
         // Test page readers
-        // TODO: test for every column
         let page_reader_0_result = row_group_reader.get_column_page_reader(0);
         assert!(page_reader_0_result.is_ok());
         let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1195,7 +1195,7 @@ mod tests {
         assert!(page_reader_0_result.is_ok());
         let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();
         let mut page_count = 0;
-        while let Ok(Some(page)) = page_reader_0.get_next_page() {
+        while let Some(page) = page_reader_0.get_next_page().unwrap() {
             let is_expected_page = match page {
                 Page::DictionaryPage {
                     buf,
@@ -1289,7 +1289,7 @@ mod tests {
         assert!(page_reader_0_result.is_ok());
         let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();
         let mut page_count = 0;
-        while let Ok(Some(page)) = page_reader_0.get_next_page() {
+        while let Some(page) = page_reader_0.get_next_page().unwrap() {
             let is_expected_page = match page {
                 Page::DictionaryPage {
                     buf,
@@ -1391,7 +1391,7 @@ mod tests {
         assert!(page_reader_0_result.is_ok());
         let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();
         let mut page_count = 0;
-        while let Ok(Some(page)) = page_reader_0.get_next_page() {
+        while let Some(page) = page_reader_0.get_next_page().unwrap() {
             let is_expected_page = match page {
                 Page::DictionaryPage {
                     buf,
@@ -1493,7 +1493,7 @@ mod tests {
         assert!(page_reader_0_result.is_ok());
         let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();
         let mut page_count = 0;
-        while let Ok(Some(page)) = page_reader_0.get_next_page() {
+        while let Some(page) = page_reader_0.get_next_page().unwrap() {
             let is_expected_page = match page {
                 Page::DataPageV2 {
                     buf,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -448,11 +448,14 @@ pub(crate) fn decode_page(
                 > page_header.uncompressed_page_size
         {
             return Err(general_err!(
-                    "DataPage v2 header contains implausible values for definition_levels_byte_length ({}) and repetition_levels_byte_length ({}) given DataPage header provides uncompressed_page_size ({})",
-                    header_v2.definition_levels_byte_length,
-                    header_v2.repetition_levels_byte_length,
-                    page_header.uncompressed_page_size
-                ));
+                "DataPage v2 header contains implausible values \
+                    for definition_levels_byte_length ({}) \
+                    and repetition_levels_byte_length ({}) \
+                    given DataPage header provides uncompressed_page_size ({})",
+                header_v2.definition_levels_byte_length,
+                header_v2.repetition_levels_byte_length,
+                page_header.uncompressed_page_size
+            ));
         }
         offset = usize::try_from(
             header_v2.definition_levels_byte_length + header_v2.repetition_levels_byte_length,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1334,7 +1334,110 @@ mod tests {
     }
 
     #[test]
+    fn test_file_reader_empty_compressed_datapage_v2() {
+        // this file has a compressed datapage that un-compresses to 0 bytes
+        let test_file = get_test_file("page_v2_empty_compressed.parquet");
+        let reader_result = SerializedFileReader::new(test_file);
+        assert!(reader_result.is_ok());
+        let reader = reader_result.unwrap();
+
+        // Test contents in Parquet metadata
+        let metadata = reader.metadata();
+        assert_eq!(metadata.num_row_groups(), 1);
+
+        // Test contents in file metadata
+        let file_metadata = metadata.file_metadata();
+        assert!(file_metadata.created_by().is_some());
+        assert_eq!(
+            file_metadata.created_by().unwrap(),
+            "parquet-cpp-arrow version 14.0.2"
+        );
+        assert!(file_metadata.key_value_metadata().is_some());
+        assert_eq!(
+            file_metadata.key_value_metadata().to_owned().unwrap().len(),
+            1
+        );
+
+        assert_eq!(file_metadata.num_rows(), 10);
+        assert_eq!(file_metadata.version(), 2);
+        let expected_order = ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED);
+        assert_eq!(
+            file_metadata.column_orders(),
+            Some(vec![expected_order].as_ref())
+        );
+
+        let row_group_metadata = metadata.row_group(0);
+
+        // Check each column order
+        for i in 0..row_group_metadata.num_columns() {
+            assert_eq!(file_metadata.column_order(i), expected_order);
+        }
+
+        // Test row group reader
+        let row_group_reader_result = reader.get_row_group(0);
+        assert!(row_group_reader_result.is_ok());
+        let row_group_reader: Box<dyn RowGroupReader> = row_group_reader_result.unwrap();
+        assert_eq!(
+            row_group_reader.num_columns(),
+            row_group_metadata.num_columns()
+        );
+        assert_eq!(
+            row_group_reader.metadata().total_byte_size(),
+            row_group_metadata.total_byte_size()
+        );
+
+        // Test page readers
+        let page_reader_0_result = row_group_reader.get_column_page_reader(0);
+        assert!(page_reader_0_result.is_ok());
+        let mut page_reader_0: Box<dyn PageReader> = page_reader_0_result.unwrap();
+        let mut page_count = 0;
+        while let Ok(Some(page)) = page_reader_0.get_next_page() {
+            let is_expected_page = match page {
+                Page::DictionaryPage {
+                    buf,
+                    num_values,
+                    encoding,
+                    is_sorted,
+                } => {
+                    assert_eq!(buf.len(), 0);
+                    assert_eq!(num_values, 0);
+                    assert_eq!(encoding, Encoding::PLAIN);
+                    assert!(!is_sorted);
+                    true
+                }
+                Page::DataPageV2 {
+                    buf,
+                    num_values,
+                    encoding,
+                    num_nulls,
+                    num_rows,
+                    def_levels_byte_len,
+                    rep_levels_byte_len,
+                    is_compressed,
+                    statistics,
+                } => {
+                    assert_eq!(buf.len(), 3);
+                    assert_eq!(num_values, 10);
+                    assert_eq!(encoding, Encoding::RLE_DICTIONARY);
+                    assert_eq!(num_nulls, 10);
+                    assert_eq!(num_rows, 10);
+                    assert_eq!(def_levels_byte_len, 2);
+                    assert_eq!(rep_levels_byte_len, 0);
+                    assert!(is_compressed);
+                    assert!(statistics.is_some());
+                    true
+                }
+                _ => false,
+            };
+            assert!(is_expected_page);
+            page_count += 1;
+        }
+        assert_eq!(page_count, 2);
+    }
+
+    #[test]
     fn test_file_reader_empty_datapage_v2() {
+        // this file has 0 bytes compressed datapage that un-compresses to 0 bytes
         let test_file = get_test_file("datapage_v2_empty_datapage.snappy.parquet");
         let reader_result = SerializedFileReader::new(test_file);
         assert!(reader_result.is_ok());
@@ -1392,18 +1495,6 @@ mod tests {
         let mut page_count = 0;
         while let Ok(Some(page)) = page_reader_0.get_next_page() {
             let is_expected_page = match page {
-                Page::DictionaryPage {
-                    buf,
-                    num_values,
-                    encoding,
-                    is_sorted,
-                } => {
-                    assert_eq!(buf.len(), 7);
-                    assert_eq!(num_values, 1);
-                    assert_eq!(encoding, Encoding::PLAIN);
-                    assert!(!is_sorted);
-                    true
-                }
                 Page::DataPageV2 {
                     buf,
                     num_values,


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #7388.

# Rationale for this change
An empty bytes buffer cannot be decompressed. Spark's Parquet writer stores a DataPage v2 with only `null` values as an empty byte buffer, rather than compressed bytes that decompress to zero bytes.

The code currently tries to decompress a 0 bytes buffer, which is not allowed. This causes an error:

    snappy: corrupt input (empty)

The issue is identical to this Apache Arrow issue: https://github.com/apache/arrow/issues/22459
The fix is identical to Apache Arrow fix: https://github.com/apache/arrow/pull/45252

# What changes are included in this PR?
Do not attempt to decompress the empty bytes buffer.
This is tested in a unit test and a small example Parquet file.
Requires https://github.com/apache/parquet-testing/pull/74.

# Are there any user-facing changes?
No.