### PR TITLE
Experiment with Extension as a DataType

### DIFF
--- a/arrow-array/src/array/extension_array.rs
+++ b/arrow-array/src/array/extension_array.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::{any::Any, sync::Arc};
 
 use arrow_data::ArrayData;

--- a/arrow-array/src/array/extension_array.rs
+++ b/arrow-array/src/array/extension_array.rs
@@ -24,18 +24,42 @@ impl ExtensionArray {
         })
     }
 
+    /// Create a new ExtensionArray
+    pub fn new(extension: Arc<dyn DynExtensionType + Send + Sync>, storage: ArrayRef) -> Self {
+        Self::try_new(extension, storage).unwrap()
+    }
+
     /// Return the underlying storage array
     pub fn storage(&self) -> &ArrayRef {
         &self.storage
+    }
+
+    /// Return a new array with new storage of the same type
+    pub fn with_storage(&self, new_storage: ArrayRef) -> Self {
+        assert_eq!(new_storage.data_type(), new_storage.data_type());
+        Self {
+            data_type: self.data_type.clone(),
+            storage: new_storage,
+        }
     }
 }
 
 impl From<ArrayData> for ExtensionArray {
     fn from(data: ArrayData) -> Self {
-        if let DataType::Extension(_) = data.data_type() {
+        if let DataType::Extension(extension) = data.data_type() {
+            let storage_data = ArrayData::try_new(
+                extension.storage_type().clone(),
+                data.len(),
+                data.nulls().map(|b| b.buffer()).cloned(),
+                data.offset(),
+                data.buffers().to_vec(),
+                data.child_data().to_vec(),
+            )
+            .unwrap();
+
             Self {
                 data_type: data.data_type().clone(),
-                storage: Arc::new(make_array(data)) as ArrayRef,
+                storage: Arc::new(make_array(storage_data)) as ArrayRef,
             }
         } else {
             panic!("{} is not Extension", data.data_type())
@@ -49,11 +73,20 @@ impl Array for ExtensionArray {
     }
 
     fn to_data(&self) -> ArrayData {
-        self.storage.to_data()
+        let storage_data = self.storage.to_data();
+        ArrayData::try_new(
+            self.data_type.clone(),
+            storage_data.len(),
+            storage_data.nulls().map(|b| b.buffer()).cloned(),
+            storage_data.offset(),
+            storage_data.buffers().to_vec(),
+            storage_data.child_data().to_vec(),
+        )
+        .unwrap()
     }
 
     fn into_data(self) -> ArrayData {
-        self.storage.to_data()
+        self.to_data()
     }
 
     fn data_type(&self) -> &DataType {

--- a/arrow-array/src/array/extension_array.rs
+++ b/arrow-array/src/array/extension_array.rs
@@ -1,0 +1,93 @@
+use std::{any::Any, sync::Arc};
+
+use arrow_data::ArrayData;
+use arrow_schema::{extension::DynExtensionType, ArrowError, DataType};
+
+use super::{make_array, Array, ArrayRef};
+
+/// Array type for DataType::Extension
+#[derive(Debug)]
+pub struct ExtensionArray {
+    data_type: DataType,
+    storage: ArrayRef,
+}
+
+impl ExtensionArray {
+    /// Try to create a new ExtensionArray
+    pub fn try_new(
+        extension: Arc<dyn DynExtensionType + Send + Sync>,
+        storage: ArrayRef,
+    ) -> Result<Self, ArrowError> {
+        Ok(Self {
+            data_type: DataType::Extension(extension),
+            storage,
+        })
+    }
+
+    /// Return the underlying storage array
+    pub fn storage(&self) -> &ArrayRef {
+        &self.storage
+    }
+}
+
+impl From<ArrayData> for ExtensionArray {
+    fn from(data: ArrayData) -> Self {
+        if let DataType::Extension(_) = data.data_type() {
+            Self {
+                data_type: data.data_type().clone(),
+                storage: Arc::new(make_array(data)) as ArrayRef,
+            }
+        } else {
+            panic!("{} is not Extension", data.data_type())
+        }
+    }
+}
+
+impl Array for ExtensionArray {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn to_data(&self) -> ArrayData {
+        self.storage.to_data()
+    }
+
+    fn into_data(self) -> ArrayData {
+        self.storage.to_data()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> ArrayRef {
+        Arc::new(Self {
+            data_type: self.data_type.clone(),
+            storage: self.storage.slice(offset, length),
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    fn offset(&self) -> usize {
+        self.storage.offset()
+    }
+
+    fn nulls(&self) -> Option<&arrow_buffer::NullBuffer> {
+        self.storage.nulls()
+    }
+
+    fn get_buffer_memory_size(&self) -> usize {
+        self.storage.get_buffer_memory_size()
+    }
+
+    fn get_array_memory_size(&self) -> usize {
+        self.storage.get_array_memory_size()
+    }
+}

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -76,6 +76,9 @@ mod list_view_array;
 
 pub use list_view_array::*;
 
+mod extension_array;
+pub use extension_array::*;
+
 use crate::iterator::ArrayIter;
 
 /// An array in the [arrow columnar format](https://arrow.apache.org/docs/format/Columnar.html)
@@ -829,6 +832,7 @@ pub fn make_array(data: ArrayData) -> ArrayRef {
         DataType::Null => Arc::new(NullArray::from(data)) as ArrayRef,
         DataType::Decimal128(_, _) => Arc::new(Decimal128Array::from(data)) as ArrayRef,
         DataType::Decimal256(_, _) => Arc::new(Decimal256Array::from(data)) as ArrayRef,
+        DataType::Extension(_) => Arc::new(ExtensionArray::from(data)) as ArrayRef,
         dt => panic!("Unexpected data type {dt:?}"),
     }
 }

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -151,6 +151,7 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
                 }
             }
         }
+        DataType::Extension(extension) => new_buffers(extension.storage_type(), capacity),
     }
 }
 
@@ -1664,6 +1665,7 @@ pub fn layout(data_type: &DataType) -> DataTypeLayout {
             }
         }
         DataType::Dictionary(key_type, _value_type) => layout(key_type),
+        DataType::Extension(extension) => layout(extension.storage_type()),
     }
 }
 

--- a/arrow-data/src/equal/mod.rs
+++ b/arrow-data/src/equal/mod.rs
@@ -123,6 +123,7 @@ fn equal_values(
         DataType::Float16 => primitive_equal::<f16>(lhs, rhs, lhs_start, rhs_start, len),
         DataType::Map(_, _) => list_equal::<i32>(lhs, rhs, lhs_start, rhs_start, len),
         DataType::RunEndEncoded(_, _) => run_equal(lhs, rhs, lhs_start, rhs_start, len),
+        DataType::Extension(_) => unimplemented!("Extension not implemented"),
     }
 }
 

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -276,6 +276,7 @@ fn build_extend(array: &ArrayData) -> Extend {
             UnionMode::Dense => union::build_extend_dense(array),
         },
         DataType::RunEndEncoded(_, _) => todo!(),
+        DataType::Extension(_) => unimplemented!("Extension not implemented")
     }
 }
 
@@ -332,6 +333,7 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
             UnionMode::Dense => union::extend_nulls_dense,
         },
         DataType::RunEndEncoded(_, _) => todo!(),
+        DataType::Extension(_) => unimplemented!("ListView/LargeListView not implemented")
     })
 }
 
@@ -590,6 +592,7 @@ impl<'a> MutableArrayData<'a> {
                     MutableArrayData::new(child_arrays, use_nulls, array_capacity)
                 })
                 .collect::<Vec<_>>(),
+            DataType::Extension(_) => unimplemented!("Extension not implemented")
         };
 
         // Get the dictionary if any, and if it is a concatenation of multiple

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -276,7 +276,7 @@ fn build_extend(array: &ArrayData) -> Extend {
             UnionMode::Dense => union::build_extend_dense(array),
         },
         DataType::RunEndEncoded(_, _) => todo!(),
-        DataType::Extension(_) => unimplemented!("Extension not implemented")
+        DataType::Extension(_) => unimplemented!("Extension not implemented"),
     }
 }
 
@@ -333,7 +333,7 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
             UnionMode::Dense => union::extend_nulls_dense,
         },
         DataType::RunEndEncoded(_, _) => todo!(),
-        DataType::Extension(_) => unimplemented!("ListView/LargeListView not implemented")
+        DataType::Extension(_) => unimplemented!("ListView/LargeListView not implemented"),
     })
 }
 
@@ -592,7 +592,7 @@ impl<'a> MutableArrayData<'a> {
                     MutableArrayData::new(child_arrays, use_nulls, array_capacity)
                 })
                 .collect::<Vec<_>>(),
-            DataType::Extension(_) => unimplemented!("Extension not implemented")
+            DataType::Extension(_) => unimplemented!("Extension not implemented"),
         };
 
         // Get the dictionary if any, and if it is a concatenation of multiple

--- a/arrow-integration-test/src/datatype.rs
+++ b/arrow-integration-test/src/datatype.rs
@@ -345,9 +345,7 @@ pub fn data_type_to_json(data_type: &DataType) -> serde_json::Value {
             json!({"name": "map", "keysSorted": keys_sorted})
         }
         DataType::RunEndEncoded(_, _) => todo!(),
-        DataType::Extension(extension) => {
-            data_type_to_json(extension.storage_type())
-        }
+        DataType::Extension(extension) => data_type_to_json(extension.storage_type()),
     }
 }
 

--- a/arrow-integration-test/src/datatype.rs
+++ b/arrow-integration-test/src/datatype.rs
@@ -345,6 +345,9 @@ pub fn data_type_to_json(data_type: &DataType) -> serde_json::Value {
             json!({"name": "map", "keysSorted": keys_sorted})
         }
         DataType::RunEndEncoded(_, _) => todo!(),
+        DataType::Extension(extension) => {
+            data_type_to_json(extension.storage_type())
+        }
     }
 }
 

--- a/arrow-ipc/src/convert.rs
+++ b/arrow-ipc/src/convert.rs
@@ -201,7 +201,10 @@ pub fn fb_to_schema(fb: crate::Schema) -> Schema {
 }
 
 /// Deserialize an ipc [crate::Schema`] from flat buffers to an arrow [Schema] with extension support
-pub fn fb_to_schema_with_extension_factory(fb: crate::Schema, extension_factory: Option<&dyn DynExtensionTypeFactory>) -> Result<Schema, ArrowError> {
+pub fn fb_to_schema_with_extension_factory(
+    fb: crate::Schema,
+    extension_factory: Option<&dyn DynExtensionTypeFactory>,
+) -> Result<Schema, ArrowError> {
     let mut fields: Vec<Field> = vec![];
     let c_fields = fb.fields().unwrap();
     let len = c_fields.len();

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::extension::DynExtensionType;
 use crate::{ArrowError, Field, FieldRef, Fields, UnionFields};
 
 /// Datatypes supported by this implementation of Apache Arrow.
@@ -411,6 +412,8 @@ pub enum DataType {
     /// These child arrays are prescribed the standard names of "run_ends" and "values"
     /// respectively.
     RunEndEncoded(FieldRef, FieldRef),
+    /// An ExtensionType
+    Extension(Arc<dyn DynExtensionType + Send + Sync>),
 }
 
 /// An absolute length of time in seconds, milliseconds, microseconds or nanoseconds.
@@ -689,6 +692,7 @@ impl DataType {
             DataType::Union(_, _) => None,
             DataType::Dictionary(_, _) => None,
             DataType::RunEndEncoded(_, _) => None,
+            DataType::Extension(_) => None,
         }
     }
 
@@ -740,6 +744,7 @@ impl DataType {
                     run_ends.size() - std::mem::size_of_val(run_ends) + values.size()
                         - std::mem::size_of_val(values)
                 }
+                DataType::Extension(extension) => extension.size(),
             }
     }
 

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -413,6 +413,7 @@ pub enum DataType {
     /// respectively.
     RunEndEncoded(FieldRef, FieldRef),
     /// An ExtensionType
+    #[cfg_attr(feature = "serde", serde(skip))]
     Extension(Arc<dyn DynExtensionType + Send + Sync>),
 }
 

--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -408,3 +408,49 @@ impl DynExtensionTypeFactory for CanonicalExtensionTypeFactory {
         }
     }
 }
+
+/// Extension for tests
+#[derive(Debug)]
+pub struct TextExtension {
+    /// Arbitrary storage type
+    pub storage_type: DataType,
+}
+
+impl DynExtensionType for TextExtension {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn size(&self) -> usize {
+        size_of_val(self)
+    }
+
+    fn storage_type(&self) -> &DataType {
+        &self.storage_type
+    }
+
+    fn extension_name(&self) -> &'static str {
+        "arrow.rs.test"
+    }
+
+    fn serialized_metadata(&self) -> String {
+        "".to_string()
+    }
+
+    fn extension_equals(&self, other: &dyn Any) -> bool {
+        other.downcast_ref::<Self>().is_some()
+    }
+
+    fn extension_hash(&self, hasher: &mut dyn Hasher) {
+        hasher.write("arrow.rs.test".as_bytes());
+    }
+
+    fn exension_cmp(&self, other: &dyn Any) -> Ordering {
+        if self.extension_equals(other) {
+            Ordering::Equal
+        } else {
+            // Fishy...
+            Ordering::Less
+        }
+    }
+}

--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -411,12 +411,12 @@ impl DynExtensionTypeFactory for CanonicalExtensionTypeFactory {
 
 /// Extension for tests
 #[derive(Debug)]
-pub struct TextExtension {
+pub struct TestExtension {
     /// Arbitrary storage type
     pub storage_type: DataType,
 }
 
-impl DynExtensionType for TextExtension {
+impl DynExtensionType for TestExtension {
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -329,7 +329,10 @@ pub trait DynExtensionTypeFactory {
     ) -> Result<Option<Arc<dyn DynExtensionType + Send + Sync>>, ArrowError>;
 
     /// Create an extension type from a field
-    fn make_from_field(&self, field: &Field) -> Result<Option<Arc<dyn DynExtensionType + Send + Sync>>, ArrowError> {
+    fn make_from_field(
+        &self,
+        field: &Field,
+    ) -> Result<Option<Arc<dyn DynExtensionType + Send + Sync>>, ArrowError> {
         if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
             self.make_extension_type(
                 extension_name,

--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -29,6 +29,7 @@ use std::any::Any;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
+use std::panic::RefUnwindSafe;
 
 /// The metadata key for the string name identifying an [`ExtensionType`].
 pub const EXTENSION_TYPE_NAME_KEY: &str = "ARROW:extension:name";
@@ -264,7 +265,7 @@ pub trait ExtensionType: Sized {
 }
 
 /// dyn-compatible ExtensionType
-pub trait DynExtensionType: Debug {
+pub trait DynExtensionType: Debug + RefUnwindSafe {
     /// For dyn-compatible comparison methods
     fn as_any(&self) -> &dyn Any;
 

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -727,7 +727,7 @@ impl Field {
             DataType::Null => {
                 self.nullable = true;
                 self.data_type = from.data_type.clone();
-            }
+            },
             | DataType::Boolean
             | DataType::Int8
             | DataType::Int16
@@ -761,7 +761,8 @@ impl Field {
             | DataType::LargeUtf8
             | DataType::Utf8View
             | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _) => {
+            | DataType::Decimal256(_, _)
+            | DataType::Extension(_) => {
                 if from.data_type == DataType::Null {
                     self.nullable = true;
                 } else if self.data_type != from.data_type {

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -869,7 +869,7 @@ mod tests {
     use arrow_array::builder::*;
     use arrow_array::cast::as_run_array;
     use arrow_array::types::*;
-    use arrow_schema::extension::TextExtension;
+    use arrow_schema::extension::TestExtension;
     use rand::distr::uniform::{UniformSampler, UniformUsize};
     use rand::distr::{Alphanumeric, StandardUniform};
     use rand::prelude::*;
@@ -2062,7 +2062,7 @@ mod tests {
             "four",
         ]));
         let array = ExtensionArray::new(
-            Arc::new(TextExtension {
+            Arc::new(TestExtension {
                 storage_type: DataType::Utf8,
             }),
             storage.clone(),

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -2071,7 +2071,8 @@ mod tests {
         assert_eq!(result_ref.data_type(), array.data_type());
         assert_eq!(result_ref.len(), 2);
 
-        let result_array: ExtensionArray = array.to_data().into();
-        assert_eq!(result_array.storage().to_data(), storage.to_data());
+        let result_array: ExtensionArray = result_ref.to_data().into();
+        let expected = create_array!(Utf8, ["one banana", "three banana"]);
+        assert_eq!(result_array.storage().to_data(), expected.to_data());
     }
 }

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -94,13 +94,19 @@ pub fn interleave(
     }
 
     if let DataType::Extension(extension) = data_type {
-        let storage: Vec<_> = values.iter().map(|array| {
-            let extension_array: ExtensionArray = array.to_data().into();
-            extension_array.storage().clone()
-        }).collect();
+        let storage: Vec<_> = values
+            .iter()
+            .map(|array| {
+                let extension_array: ExtensionArray = array.to_data().into();
+                extension_array.storage().clone()
+            })
+            .collect();
         let storage_ref: Vec<_> = storage.iter().map(|array| array.as_ref()).collect();
         let storage_result = interleave(&storage_ref, indices)?;
-        return Ok(Arc::new(ExtensionArray::new(extension.clone(), storage_result)));
+        return Ok(Arc::new(ExtensionArray::new(
+            extension.clone(),
+            storage_result,
+        )));
     }
 
     downcast_primitive! {
@@ -379,7 +385,7 @@ pub fn interleave_record_batch(
 mod tests {
     use super::*;
     use arrow_array::builder::{Int32Builder, ListBuilder};
-    use arrow_schema::extension::TextExtension;
+    use arrow_schema::extension::TestExtension;
 
     #[test]
     fn test_primitive() {
@@ -741,7 +747,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_interleave_extension() {
         let indices = [(0, 0), (1, 3), (0, 2)];
@@ -753,7 +758,7 @@ mod tests {
         ]));
 
         let array = ExtensionArray::new(
-            Arc::new(TextExtension {
+            Arc::new(TestExtension {
                 storage_type: DataType::Utf8,
             }),
             storage.clone(),

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -123,7 +123,7 @@ mod tests {
         create_array, ExtensionArray, Int32Array, NullArray, StringArray, StructArray,
     };
     use arrow_data::ArrayData;
-    use arrow_schema::extension::TextExtension;
+    use arrow_schema::extension::TestExtension;
     use arrow_schema::{Field, Fields};
     use rand::{rng, Rng};
 
@@ -542,7 +542,7 @@ mod tests {
             "four",
         ]));
         let array = ExtensionArray::new(
-            Arc::new(TextExtension {
+            Arc::new(TestExtension {
                 storage_type: DataType::Utf8,
             }),
             storage.clone(),

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -535,7 +535,8 @@ macro_rules! get_statistics {
             DataType::LargeListView(_) |
             DataType::Struct(_) |
             DataType::Union(_, _) |
-            DataType::RunEndEncoded(_, _) => {
+            DataType::RunEndEncoded(_, _) |
+            DataType::Extension(_) => {
                 let len = $iterator.count();
                 // don't know how to extract statistics, so return a null array
                 Ok(new_null_array($data_type, len))
@@ -1056,7 +1057,8 @@ macro_rules! get_data_page_statistics {
                 DataType::Struct(_) |
                 DataType::Union(_, _) |
                 DataType::Map(_, _) |
-                DataType::RunEndEncoded(_, _) => {
+                DataType::RunEndEncoded(_, _) |
+                DataType::Extension(_) => {
                     let len = $iterator.count();
                     // don't know how to extract statistics, so return a null array
                     Ok(new_null_array($data_type, len))

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -767,6 +767,12 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
         DataType::RunEndEncoded(_, _) => Err(arrow_err!(
             "Converting RunEndEncodedType to parquet not supported",
         )),
+        DataType::Extension(extension) => arrow_to_parquet_type(
+            &field
+                .clone()
+                .with_data_type(extension.storage_type().clone()),
+            coerce_types,
+        ),
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Experiments in pursuit of #7063 and https://github.com/apache/datafusion/issues/12644 .

# Rationale for this change
 
Customizing behaviour (e.g., sorting, signatures for user defined functions, import/export from/to formats like Parquet, Arrow IPC, and FFI) is increasingly requested. arrow-rs is also increasingly the implementation of choice for compute frameworks and many APIs have been built around the `DataType` and `ArrayRef` (e.g., GeoArrow, parquet, many parts of DataFusion). To support additional types, those frameworks have to either invent a new array type and rewrite substantial wrappers (e.g., GeoArrow), or use something other than a `DataType`  (e.g., a Field or MyOwnDataType) and forego having that type automatically pass through APIs from other arrow-rs-based libraries (or arrow itself).

Incorporating an ExtensionType as a first-class data type provides a potentially less disruptive route for libraries like parquet and DataFusion to implement new Parquet types and other types other databases implement like JSON and UUID. I also have an experiment going for swapping out a `Field` for a `DataType` in DataFusion ( https://github.com/apache/datafusion/pull/15036 ).

# What changes are included in this PR?

A new `DataType::Extension()` enum member was added. I had hoped to have this be `DataType::Extension(Arc<dyn ExtensionType>)` but the current design of the ExtensionType is not dyn-compatible. The `DynExtensionType` trait is really a placeholder to collect the requirements of the rest of arrow-rs for this experiment.

This is currently just an experiment/minimum change that actually builds! I'm happy to continue the experiment if there is interest.

# Are there any user-facing changes?

Yes, a new data type enum member at least (which is a breaking change).
