### PR TITLE
Support decryption of Parquet column and offset indexes

### DIFF
--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -236,6 +236,10 @@ impl CryptoContext {
         &self.data_decryptor
     }
 
+    pub(crate) fn metadata_decryptor(&self) -> &Arc<dyn BlockDecryptor> {
+        &self.metadata_decryptor
+    }
+
     pub(crate) fn file_aad(&self) -> &Vec<u8> {
         &self.file_aad
     }

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -220,6 +220,26 @@ impl CryptoContext {
         )
     }
 
+    pub(crate) fn create_column_index_aad(&self) -> Result<Vec<u8>> {
+        create_module_aad(
+            self.file_aad(),
+            ModuleType::ColumnIndex,
+            self.row_group_idx,
+            self.column_ordinal,
+            self.page_ordinal,
+        )
+    }
+
+    pub(crate) fn create_offset_index_aad(&self) -> Result<Vec<u8>> {
+        create_module_aad(
+            self.file_aad(),
+            ModuleType::OffsetIndex,
+            self.row_group_idx,
+            self.column_ordinal,
+            self.page_ordinal,
+        )
+    }
+
     pub(crate) fn for_dictionary_page(&self) -> Self {
         Self {
             row_group_idx: self.row_group_idx,

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -383,6 +383,27 @@ async fn test_uniform_encryption_with_key_retriever() {
         .unwrap();
 }
 
+#[tokio::test]
+async fn test_decrypt_page_index() {
+    let testdata = arrow::util::test_util::parquet_test_data();
+    let path = format!("{testdata}/uniform_encryption.parquet.encrypted");
+    let mut file = File::open(&path).await.unwrap();
+
+    let key_code: &[u8] = "0123456789012345".as_bytes();
+    let decryption_properties = FileDecryptionProperties::builder(key_code.to_vec())
+        .build()
+        .unwrap();
+
+    let options = ArrowReaderOptions::new()
+        .with_file_decryption_properties(decryption_properties)
+        .with_page_index(true);
+
+    let arrow_metadata = ArrowReaderMetadata::load_async(&mut file, options).await.unwrap();
+    let _metadata = arrow_metadata.metadata();
+
+    // TODO: Verify metadata
+}
+
 async fn verify_encryption_test_file_read_async(
     file: &mut tokio::fs::File,
     decryption_properties: FileDecryptionProperties,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7390.

# Rationale for this change
 
Allows readers to read column and offset indexes when a file is encrypted with modular encryption.

# What changes are included in this PR?

Updates `ParquetMetaDataReader` so it will decrypt column and offset indexes if they are encrypted and page indexes are enabled in `ArrowReaderOptions`.

# Are there any user-facing changes?

Yes, this is a new user-facing feature.

Co-authored by @corwinjoy