### PR TITLE
Parquet: Expose accessors from `ArrowReaderOptions`

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -397,6 +397,22 @@ impl ArrowReaderOptions {
             ..self
         }
     }
+
+    /// Retrieve the currently set page index behavior.
+    ///
+    /// This can be set via [`with_page_index`][Self::with_page_index].
+    pub fn page_index(&self) -> bool {
+        self.page_index
+    }
+
+    /// Retrieve the currently set file decryption properties.
+    ///
+    /// This can be set via
+    /// [`file_decryption_properties`][Self::with_file_decryption_properties].
+    #[cfg(feature = "encryption")]
+    pub fn file_decryption_properties(&self) -> Option<&FileDecryptionProperties> {
+        self.file_decryption_properties.as_ref()
+    }
 }
 
 /// The metadata necessary to construct a [`ArrowReaderBuilder`]


### PR DESCRIPTION
# Which issue does this PR close?

Ref https://github.com/apache/arrow-rs/pull/7342#issuecomment-2791024373

We can create a standalone issue if needed.

Closes #.

# Rationale for this change

I was just updating some of my code to use the v55 release candidate, but it doesn't seem possible for third party code to use the `options` argument in `AsyncFileReader::get_metadata` because no internal data from [`ArrowReaderOptions`](https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ArrowReaderOptions.html) is publicly accessible.

The internal implementation here on `AsyncRead` and `AsyncSeek` accesses the `page_index` and `file_decryption_properties` attributes: 

https://github.com/apache/arrow-rs/blob/9322547590ab32efeff8c0486e4a3a2cb5887a26/parquet/src/arrow/async_reader/mod.rs#L175
https://github.com/apache/arrow-rs/blob/9322547590ab32efeff8c0486e4a3a2cb5887a26/parquet/src/arrow/async_reader/mod.rs#L179

But third party code can't do that.

Exposing accessors on `ArrowReaderOptions` allows third party implementations of `AsyncFileReader::get_metadata` to use the values set on `ArrowReaderOptions`.

# What changes are included in this PR?

Expose attributes from `ArrowReaderOptions`.

# Are there any user-facing changes?

New methods.