### PR TITLE
feat: Adding `with_schema_unchecked` method for `RecordBatch`

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -360,7 +360,8 @@ impl RecordBatch {
     }
 
     /// Forcibly overrides the schema of this [`RecordBatch`]
-    /// No schema checks executed so the method is faster than safe `with_schema`
+    /// without additional schema checks however bringing all the schema compatibility responsibilities
+    /// to the caller site.
     ///
     /// If provided schema is not compatible with this [`RecordBatch`] columns the runtime behavior
     /// is undefined


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 Sometimes Arrow-rs users don't require schema checks on `RecordBatch` relying on their schema checks and schema validity rules. However now it is not possible to override the schema without performance impact. 

Examples: https://github.com/apache/datafusion/issues/15162
https://github.com/apache/datafusion/pull/15603

Proposed `with_schema_unchecked` method for `RecordBatch` overrides the schema without additional schema checks however bringing all the schema compatibility responsibilities to the caller site. 


<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
