### PR TITLE
[PATHFINDING] Parse json as variant

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -50,6 +50,9 @@ memchr = "2.7.4"
 simdutf8 = "0.1.5"
 
 [dev-dependencies]
+bytebuffer = "2.3"
+num_enum = "0.7"
+static_assertions = "1.1"
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 futures = "0.3"


### PR DESCRIPTION
- Related to https://github.com/apache/arrow-rs/issues/7425

This is a pathfinding exercise, to see how easy/hard it might be to parse JSON text into parquet's new variant type, using the tape decoder. Not intended to merge, it is more of a conversation starter. 

In particular:
* It would be better to leverage a general variant library for variant bit-wrangling instead of doing it all manually here. 
* TBD Where/how to expose this functionality through a public API
* Still TBD how to assemble a bunch of variant metadata+value pairs inside an arrow array data that can eventually become a usable arrow array
* For comparison, the same exercise is repeated using serde_json instead. This would almost certainly not belong in an actual contribution to arrow-json.