### PR TITLE
Deprecate RecordBatchOptions::with_match_field_names

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -312,6 +312,7 @@ impl RecordBatch {
 
         // function for comparing column type and field type
         // return true if 2 types are not matched
+        #[allow(deprecated)]
         let type_not_match = if options.match_field_names {
             |(_, (col_type, field_type)): &(usize, (&DataType, &DataType))| col_type != field_type
         } else {
@@ -400,10 +401,7 @@ impl RecordBatch {
         RecordBatch::try_new_with_options(
             SchemaRef::new(projected_schema),
             batch_fields,
-            &RecordBatchOptions {
-                match_field_names: true,
-                row_count: Some(self.row_count),
-            },
+            &RecordBatchOptions::new().with_row_count(Some(self.row_count)),
         )
     }
 
@@ -742,6 +740,7 @@ impl RecordBatch {
 #[non_exhaustive]
 pub struct RecordBatchOptions {
     /// Match field names of structs and lists. If set to `true`, the names must match.
+    #[deprecated(note = "match_field_names is unsound")]
     pub match_field_names: bool,
 
     /// Optional row count, useful for specifying a row count for a RecordBatch with no columns
@@ -750,6 +749,7 @@ pub struct RecordBatchOptions {
 
 impl RecordBatchOptions {
     /// Creates a new `RecordBatchOptions`
+    #[allow(deprecated)]
     pub fn new() -> Self {
         Self {
             match_field_names: true,
@@ -764,6 +764,8 @@ impl RecordBatchOptions {
     }
 
     /// Sets the `match_field_names` of `RecordBatchOptions` and returns this [`RecordBatch`]
+    #[deprecated(note = "match_field_names is unsound")]
+    #[allow(deprecated)]
     pub fn with_match_field_names(mut self, match_field_names: bool) -> Self {
         self.match_field_names = match_field_names;
         self
@@ -1059,6 +1061,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn create_record_batch_field_name_mismatch() {
         let fields = vec![
             Field::new("a1", DataType::Int32, false),
@@ -1514,10 +1517,7 @@ mod tests {
         let expected = RecordBatch::try_new_with_options(
             Arc::new(Schema::empty()),
             vec![],
-            &RecordBatchOptions {
-                match_field_names: true,
-                row_count: Some(3),
-            },
+            &RecordBatchOptions::new().with_row_count(Some(3)),
         )
         .expect("valid conversion");
 
@@ -1558,6 +1558,7 @@ mod tests {
         assert_eq!("Invalid argument error: Column 'a' is declared as non-nullable but contains null values", format!("{}", maybe_batch.err().unwrap()));
     }
     #[test]
+    #[allow(deprecated)]
     fn test_record_batch_options() {
         let options = RecordBatchOptions::new()
             .with_match_field_names(false)

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -740,7 +740,7 @@ impl RecordBatch {
 #[non_exhaustive]
 pub struct RecordBatchOptions {
     /// Match field names of structs and lists. If set to `true`, the names must match.
-    #[deprecated(note = "match_field_names is unsound")]
+    #[deprecated(note = "match_field_names can lead to unpredictable behaviour")]
     pub match_field_names: bool,
 
     /// Optional row count, useful for specifying a row count for a RecordBatch with no columns
@@ -764,7 +764,7 @@ impl RecordBatchOptions {
     }
 
     /// Sets the `match_field_names` of `RecordBatchOptions` and returns this [`RecordBatch`]
-    #[deprecated(note = "match_field_names is unsound")]
+    #[deprecated(note = "match_field_names can lead to unpredictable behaviour")]
     #[allow(deprecated)]
     pub fn with_match_field_names(mut self, match_field_names: bool) -> Self {
         self.match_field_names = match_field_names;
@@ -891,7 +891,7 @@ mod tests {
     use crate::{
         BooleanArray, Int32Array, Int64Array, Int8Array, ListArray, StringArray, StringViewArray,
     };
-    use arrow_buffer::{Buffer, ToByteSlice};
+    use arrow_buffer::{Buffer, OffsetBuffer, ToByteSlice};
     use arrow_data::{ArrayData, ArrayDataBuilder};
     use arrow_schema::Fields;
     use std::collections::HashMap;

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -891,7 +891,7 @@ mod tests {
     use crate::{
         BooleanArray, Int32Array, Int64Array, Int8Array, ListArray, StringArray, StringViewArray,
     };
-    use arrow_buffer::{Buffer, OffsetBuffer, ToByteSlice};
+    use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_data::{ArrayData, ArrayDataBuilder};
     use arrow_schema::Fields;
     use std::collections::HashMap;

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -866,9 +866,7 @@ fn parse(
         RecordBatch::try_new_with_options(
             projected_schema,
             arr,
-            &RecordBatchOptions::new()
-                .with_match_field_names(true)
-                .with_row_count(Some(rows.len())),
+            &RecordBatchOptions::new().with_row_count(Some(rows.len())),
         )
     })
 }

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -2400,9 +2400,7 @@ mod tests {
     #[test]
     fn test_no_columns_batch() {
         let schema = Arc::new(Schema::empty());
-        let options = RecordBatchOptions::new()
-            .with_match_field_names(true)
-            .with_row_count(Some(10));
+        let options = RecordBatchOptions::new().with_row_count(Some(10));
         let input_batch = RecordBatch::try_new_with_options(schema, vec![], &options).unwrap();
         let output_batch = roundtrip_ipc_stream(&input_batch);
         assert_eq!(input_batch, output_batch);

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -46,7 +46,7 @@ pub fn create_random_batch(
         .map(|field| create_random_array(field, size, null_density, true_density))
         .collect::<Result<Vec<ArrayRef>>>()?;
 
-    RecordBatch::try_new_with_options(schema, columns, &RecordBatchOptions::new())
+    RecordBatch::try_new(schema, columns)
 }
 
 /// Create a random [ArrayRef] from a [DataType] with a length,

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -46,11 +46,7 @@ pub fn create_random_batch(
         .map(|field| create_random_array(field, size, null_density, true_density))
         .collect::<Result<Vec<ArrayRef>>>()?;
 
-    RecordBatch::try_new_with_options(
-        schema,
-        columns,
-        &RecordBatchOptions::new().with_match_field_names(false),
-    )
+    RecordBatch::try_new_with_options(schema, columns, &RecordBatchOptions::new())
 }
 
 /// Create a random [ArrayRef] from a [DataType] with a length,

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -198,7 +198,7 @@ fn create_float_bench_batch_with_nans(size: usize, nan_density: f32) -> Result<R
     Ok(RecordBatch::try_new_with_options(
         Arc::new(schema),
         columns,
-        &RecordBatchOptions::new().with_match_field_names(false),
+        &RecordBatchOptions::new(),
     )?)
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Noticed whilst working on https://github.com/apache/arrow-rs/pull/7405, this option is potentially unsound.

I did a quick scan of downstream projects and couldn't see any usage of this feature and so I think it is fine to just deprecate it. This will also potentially allow removing the rather cumbersome RecordBatchOptions.

The other option would be to make this method unsafe, but given the other checks within the various arrays I struggle to see how this would be usable reliably.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->

Tagging @nevi-me as I think this API was last touched by you 3 or so years ago :sweat_smile: 
