### PR TITLE
Improve performance of interleave_primitive (-15% - 45%) / interleave_bytes (-10-25%)

### DIFF
--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -153,9 +153,10 @@ fn interleave_primitive<T: ArrowPrimitiveType>(
 ) -> Result<ArrayRef, ArrowError> {
     let interleaved = Interleave::<'_, PrimitiveArray<T>>::new(values, indices);
 
-    let values = indices.iter().map(|(a,b)|
-        interleaved.arrays[*a].value(*b)
-    ).collect::<Vec<_>>();
+    let values = indices
+        .iter()
+        .map(|(a, b)| interleaved.arrays[*a].value(*b))
+        .collect::<Vec<_>>();
 
     let array = PrimitiveArray::<T>::new(values.into(), interleaved.nulls);
     Ok(Arc::new(array.with_data_type(data_type.clone())))

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -177,7 +177,7 @@ fn interleave_bytes<T: ByteArrayType>(
         T::Offset::from_usize(capacity).expect("overflow")
     }));
 
-    let mut values = MutableBuffer::new(capacity);
+    let mut values = Vec::with_capacity(capacity);
     for (a, b) in indices {
         values.extend_from_slice(interleaved.arrays[*a].value(*b).as_ref());
     }

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -22,9 +22,7 @@ use arrow_array::builder::{BooleanBufferBuilder, BufferBuilder, PrimitiveBuilder
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
-use arrow_buffer::{
-    ArrowNativeType, BooleanBuffer, MutableBuffer, NullBuffer, NullBufferBuilder, OffsetBuffer,
-};
+use arrow_buffer::{ArrowNativeType, BooleanBuffer, MutableBuffer, NullBuffer, OffsetBuffer};
 use arrow_data::transform::MutableArrayData;
 use arrow_data::ByteView;
 use arrow_schema::{ArrowError, DataType};

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -153,11 +153,9 @@ fn interleave_primitive<T: ArrowPrimitiveType>(
 ) -> Result<ArrayRef, ArrowError> {
     let interleaved = Interleave::<'_, PrimitiveArray<T>>::new(values, indices);
 
-    let mut values = Vec::with_capacity(indices.len());
-    for (a, b) in indices {
-        let v = interleaved.arrays[*a].value(*b);
-        values.push(v)
-    }
+    let values = indices.iter().map(|(a,b)|
+        interleaved.arrays[*a].value(*b)
+    ).collect::<Vec<_>>();
 
     let array = PrimitiveArray::<T>::new(values.into(), interleaved.nulls);
     Ok(Arc::new(array.with_data_type(data_type.clone())))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-rs/issues/7421

```
interleave i32(0.0) 100 [0..100, 100..230, 450..1000]
                        time:   [222.48 ns 223.18 ns 223.84 ns]
                        change: [-1.6267% -1.1263% -0.6239%] (p = 0.00 < 0.05)
                        Change within noise threshold.

interleave i32(0.0) 400 [0..100, 100..230, 450..1000]
                        time:   [450.60 ns 451.23 ns 451.74 ns]
                        change: [-12.127% -11.970% -11.794%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave i32(0.0) 1024 [0..100, 100..230, 450..1000]
                        time:   [998.30 ns 999.38 ns 1.0002 µs]
                        change: [-16.738% -15.398% -14.601%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave i32(0.0) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [986.54 ns 987.56 ns 988.80 ns]
                        change: [-15.563% -15.399% -15.254%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

interleave i32(0.5) 100 [0..100, 100..230, 450..1000]
                        time:   [465.60 ns 465.82 ns 466.07 ns]
                        change: [-26.376% -26.205% -26.041%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) low severe
  1 (1.00%) high mild

interleave i32(0.5) 400 [0..100, 100..230, 450..1000]
                        time:   [1.0934 µs 1.0938 µs 1.0942 µs]
                        change: [-39.139% -38.791% -38.459%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  7 (7.00%) low severe
  1 (1.00%) low mild
  8 (8.00%) high mild
  2 (2.00%) high severe

interleave i32(0.5) 1024 [0..100, 100..230, 450..1000]
                        time:   [2.4511 µs 2.4528 µs 2.4549 µs]
                        change: [-45.029% -44.382% -43.886%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

interleave i32(0.5) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [2.4604 µs 2.4643 µs 2.4688 µs]
                        change: [-45.677% -44.856% -44.155%] (p = 0.00 < 0.05)
                        Performance has improved.

interleave str(20, 0.0) 100 [0..100, 100..230, 450..1000]
                        time:   [820.15 ns 820.28 ns 820.42 ns]
                        change: [-9.6030% -9.4246% -9.2597%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

interleave str(20, 0.0) 400 [0..100, 100..230, 450..1000]
                        time:   [2.8129 µs 2.8159 µs 2.8204 µs]
                        change: [-9.4881% -9.4013% -9.3124%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe

interleave str(20, 0.0) 1024 [0..100, 100..230, 450..1000]
                        time:   [6.9113 µs 6.9128 µs 6.9145 µs]
                        change: [-10.418% -10.342% -10.263%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

Benchmarking interleave str(20, 0.0) 1024 [0..100, 100..230, 450..1000, 0..1000]: Collecting 100 samples in estimated 5.0081 s (722k iterationsinterleave str(20, 0.0) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [6.9336 µs 6.9345 µs 6.9354 µs]
                        change: [-10.434% -10.327% -10.231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

interleave str(20, 0.5) 100 [0..100, 100..230, 450..1000]
                        time:   [937.01 ns 938.97 ns 941.31 ns]
                        change: [-20.750% -20.527% -20.290%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

interleave str(20, 0.5) 400 [0..100, 100..230, 450..1000]
                        time:   [3.0452 µs 3.0519 µs 3.0592 µs]
                        change: [-23.362% -23.216% -23.061%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

interleave str(20, 0.5) 1024 [0..100, 100..230, 450..1000]
                        time:   [8.1354 µs 8.1484 µs 8.1620 µs]
                        change: [-23.524% -23.254% -22.982%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking interleave str(20, 0.5) 1024 [0..100, 100..230, 450..1000, 0..1000]: Collecting 100 samples in estimated 5.0272 s (611k iterationsinterleave str(20, 0.5) 1024 [0..100, 100..230, 450..1000, 0..1000]
                        time:   [8.1120 µs 8.1211 µs 8.1321 µs]
                        change: [-22.049% -21.597% -21.157%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  2 (2.00%) high mild
  17 (17.00%) high severe

```
Closes #.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
