### PR TITLE
Speedup take_bytes (-35% -69%) by precalculating capacity

### DIFF
--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1771,7 +1771,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split(batch, 56).await;
+        verify_encoded_split(batch, 0).await;
     }
 
     #[tokio::test]

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1771,7 +1771,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split(batch, 0).await;
+        verify_encoded_split(batch, 56).await;
     }
 
     #[tokio::test]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -474,11 +474,11 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
 
     let (offsets, values, nulls) = if array.null_count() == 0 && indices.null_count() == 0 {
         let mut capacity = 0;
-        for index in indices.values() {
+        offsets.extend(indices.values().iter().map(|index| {
             let index = index.as_usize();
             capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
-            offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
-        }
+            T::Offset::from_usize(capacity).expect("overflow")
+        }));
         let mut values = Vec::with_capacity(capacity);
 
         for index in indices.values() {
@@ -487,13 +487,13 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         (offsets, values, None)
     } else if indices.null_count() == 0 {
         let mut capacity = 0;
-        for index in indices.values() {
+        offsets.extend(indices.values().iter().map(|index| {
             let index = index.as_usize();
             if array.is_valid(index) {
                 capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
             }
-            offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
-        }
+            T::Offset::from_usize(capacity).expect("overflow")
+        }));
         let mut values = Vec::with_capacity(capacity);
 
         for index in indices.values() {
@@ -506,13 +506,13 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         (offsets, values, new_nulls)
     } else if array.null_count() == 0 {
         let mut capacity = 0;
-        for index in indices.values() {
+        offsets.extend(indices.values().iter().map(|index| {
             let index = index.as_usize();
             if indices.is_valid(index) {
                 capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
             }
-            offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
-        }
+            T::Offset::from_usize(capacity).expect("overflow")
+        }));
         let mut values = Vec::with_capacity(capacity);
 
         for (i, index) in indices.values().iter().enumerate() {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -27,7 +27,7 @@ use arrow_buffer::{
     bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer,
     ScalarBuffer,
 };
-use arrow_data::{ArrayData, ArrayDataBuilder};
+use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, FieldRef, UnionMode};
 
 use num::{One, Zero};

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -560,7 +560,7 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
-    let new_nulls= take_nulls(array.nulls(), indices);
+    let new_nulls = take_nulls(array.nulls(), indices);
     // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
     Ok(unsafe {
         GenericByteViewArray::new_unchecked(new_views, array.data_buffers().to_vec(), new_nulls)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -24,7 +24,8 @@ use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::{
-    bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, ScalarBuffer,
+    bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer,
+    ScalarBuffer,
 };
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, FieldRef, UnionMode};
@@ -472,10 +473,10 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
     offsets.push(T::Offset::default());
 
     let mut values = MutableBuffer::new(0);
+    let input_offsets = array.value_offsets();
 
     let nulls;
     if array.null_count() == 0 && indices.null_count() == 0 {
-        let input_offsets = array.value_offsets();
         let mut capacity = 0;
         for index in indices.values() {
             let index = index.as_usize();
@@ -487,23 +488,33 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         for index in indices.values() {
             values.extend_from_slice(array.value(index.as_usize()).as_ref());
         }
-        nulls = None
+        let array = unsafe {
+            let offsets = OffsetBuffer::new_unchecked(offsets.into());
+            GenericByteArray::<T>::new_unchecked(offsets, values.into(), None)
+        };
+        return Ok(array);
     } else if indices.null_count() == 0 {
-        let num_bytes = bit_util::ceil(data_len, 8);
-
-        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-        let null_slice = null_buf.as_slice_mut();
-        offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
+        let mut capacity = 0;
+        for index in indices.values() {
             let index = index.as_usize();
             if array.is_valid(index) {
-                let s: &[u8] = array.value(index).as_ref();
-                values.extend_from_slice(s.as_ref());
-            } else {
-                bit_util::unset_bit(null_slice, i);
+                capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
+                offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
             }
-            T::Offset::usize_as(values.len())
-        }));
-        nulls = Some(null_buf.into());
+        }
+        values = MutableBuffer::new(capacity);
+
+        for index in indices.values() {
+            let index = index.as_usize();
+            if array.is_valid(index) {
+                values.extend_from_slice(array.value(index).as_ref());
+            }
+        }
+        let array = unsafe {
+            let offsets = OffsetBuffer::new_unchecked(offsets.into());
+            GenericByteArray::<T>::new_unchecked(offsets, values.into(), None)
+        };
+        return Ok(array);
     } else if array.null_count() == 0 {
         offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
             if indices.is_valid(i) {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -472,7 +472,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
     let mut offsets = Vec::with_capacity(bytes_offset);
     offsets.push(T::Offset::default());
 
-    let mut values = MutableBuffer::new(0);
+    let mut values = vec![];
     let input_offsets = array.value_offsets();
 
     let nulls;

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -965,6 +965,7 @@ mod tests {
     use super::*;
     use arrow_array::builder::*;
     use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
+    use arrow_data::ArrayData;
     use arrow_schema::{Field, Fields, TimeUnit, UnionFields};
 
     fn test_take_decimal_arrays(

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -483,7 +483,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
             capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
             offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
         }
-        values = MutableBuffer::new(capacity);
+        let mut values = Vec::with_capacity(capacity);
 
         for index in indices.values() {
             values.extend_from_slice(array.value(index.as_usize()).as_ref());
@@ -502,7 +502,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
             }
             offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
         }
-        values = MutableBuffer::new(capacity);
+        let mut values = Vec::with_capacity(capacity);
 
         for index in indices.values() {
             let index = index.as_usize();
@@ -522,10 +522,10 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
             let index = index.as_usize();
             if indices.is_valid(index) {
                 capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
-                offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
             }
+            offsets.push(T::Offset::from_usize(capacity).expect("overflow"));
         }
-        values = MutableBuffer::new(capacity);
+        let mut values = Vec::with_capacity(capacity);
 
         for (i, index) in indices.values().iter().enumerate() {
             if indices.is_valid(i) {
@@ -535,7 +535,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         }
         let array = unsafe {
             let offsets = OffsetBuffer::new_unchecked(offsets.into());
-            GenericByteArray::<T>::new_unchecked(offsets, values.into(), None)
+            GenericByteArray::<T>::new_unchecked(offsets, values.into(), indices.nulls().cloned())
         };
         return Ok(array);
     } else {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -466,7 +466,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
     array: &GenericByteArray<T>,
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteArray<T>, ArrowError> {
-    let mut offsets = Vec::with_capacity(indices.len());
+    let mut offsets = Vec::with_capacity(indices.len() + 1);
     offsets.push(T::Offset::default());
 
     let input_offsets = array.value_offsets();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -560,7 +560,7 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
-    let new_nulls: Option<NullBuffer> = take_nulls(array.nulls(), indices);
+    let new_nulls= take_nulls(array.nulls(), indices);
     // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
     Ok(unsafe {
         GenericByteViewArray::new_unchecked(new_views, array.data_buffers().to_vec(), new_nulls)

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -466,8 +466,7 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
     array: &GenericByteArray<T>,
     indices: &PrimitiveArray<IndexType>,
 ) -> Result<GenericByteArray<T>, ArrowError> {
-    let bytes_offset = (indices.len() + 1) * std::mem::size_of::<T::Offset>();
-    let mut offsets = Vec::with_capacity(bytes_offset);
+    let mut offsets = Vec::with_capacity(indices.len());
     offsets.push(T::Offset::default());
 
     let input_offsets = array.value_offsets();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -505,9 +505,9 @@ fn take_bytes<T: ByteArrayType, IndexType: ArrowPrimitiveType>(
         (offsets, values, new_nulls)
     } else if array.null_count() == 0 {
         let mut capacity = 0;
-        offsets.extend(indices.values().iter().map(|index| {
+        offsets.extend(indices.values().iter().enumerate().map(|(i, index)| {
             let index = index.as_usize();
-            if indices.is_valid(index) {
+            if indices.is_valid(i) {
                 capacity += input_offsets[index + 1].as_usize() - input_offsets[index].as_usize();
             }
             T::Offset::from_usize(capacity).expect("overflow")


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


Closes #7432

# Rationale for this change
 
Performance improvements:

<details>


```
Benchmarking take str 512: Collecting 100 samples in estimated 5.0014 s (1.3M ittake str 512            time:   [3.9906 µs 3.9937 µs 3.9970 µs]
                        change: [-45.040% -44.844% -44.657%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking take str 1024: Collecting 100 samples in estimated 5.0285 s (556k itake str 1024           time:   [9.0347 µs 9.0435 µs 9.0519 µs]
                        change: [-69.387% -69.048% -68.716%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking take str null indices 512: Collecting 100 samples in estimated 5.00take str null indices 512
                        time:   [2.4167 µs 2.4209 µs 2.4269 µs]
                        change: [-48.977% -48.536% -48.234%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe

Benchmarking take str null indices 1024: Collecting 100 samples in estimated 5.0take str null indices 1024
                        time:   [5.9829 µs 5.9940 µs 6.0151 µs]
                        change: [-57.375% -54.878% -52.153%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe

Benchmarking take str null values 1024: Collecting 100 samples in estimated 5.00take str null values 1024
                        time:   [6.1283 µs 6.1357 µs 6.1418 µs]
                        change: [-23.035% -22.635% -22.315%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 22 outliers among 100 measurements (22.00%)
  10 (10.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  9 (9.00%) high severe

Benchmarking take str null values null indices 1024: Collecting 100 samples in etake str null values null indices 1024
                        time:   [5.2781 µs 5.2905 µs 5.3024 µs]
                        change: [-9.2518% -8.9305% -8.6089%] (p = 0.00 < 0.05)
                        Performance has improved.

```


</details>
# What changes are included in this PR?


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
