### PR TITLE
Fix validation logic in `StructArray::try_new` to account for array.logical_nulls() returning Some() and null_count == 0

### DIFF
--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -146,7 +146,9 @@ impl StructArray {
 
             if !f.is_nullable() {
                 if let Some(a) = a.logical_nulls() {
-                    if !nulls.as_ref().map(|n| n.contains(&a)).unwrap_or_default() {
+                    if a.null_count() > 0
+                        && !nulls.as_ref().map(|n| n.contains(&a)).unwrap_or_default()
+                    {
                         return Err(ArrowError::InvalidArgumentError(format!(
                             "Found unmasked nulls for non-nullable StructArray field {:?}",
                             f.name()

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -844,4 +844,22 @@ mod tests {
         );
         assert_eq!(format!("{arr:?}"), "StructArray\n-- validity:\n[\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n  ...10 elements...,\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n  valid,\n  null,\n]\n[\n-- child 0: \"c\" (Int32)\nPrimitiveArray<Int32>\n[\n  0,\n  1,\n  2,\n  3,\n  4,\n  5,\n  6,\n  7,\n  8,\n  9,\n  ...10 elements...,\n  20,\n  21,\n  22,\n  23,\n  24,\n  25,\n  26,\n  27,\n  28,\n  29,\n]\n]")
     }
+
+    #[test]
+    fn test_struct_array_logical_nulls() {
+        // Field is non-nullable
+        let field = Field::new("a", DataType::Int32, false);
+        let values = vec![1, 2, 3];
+        // Create a NullBuffer with all bits set to valid (true)
+        let nulls = NullBuffer::from(vec![true, true, true]);
+        let array = Int32Array::new(values.into(), Some(nulls));
+        let child = Arc::new(array) as ArrayRef;
+        assert!(child.logical_nulls().is_some());
+
+        let fields = Fields::from(vec![field]);
+        let arrays = vec![child];
+        let nulls = None;
+
+        drop(StructArray::try_new(fields, arrays, nulls).expect("should not error"));
+    }
 }

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -855,6 +855,7 @@ mod tests {
         let array = Int32Array::new(values.into(), Some(nulls));
         let child = Arc::new(array) as ArrayRef;
         assert!(child.logical_nulls().is_some());
+        assert_eq!(child.logical_nulls().unwrap().null_count(), 0);
 
         let fields = Fields::from(vec![field]);
         let arrays = vec![child];


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7435

# Rationale for this change
 
Fixes the validation logic in StructArray::try_new to not error if there aren't any unmasked nulls, but `a.logical_nulls()` returns Some

# What changes are included in this PR?

A single line change to check for `null_count()` on the `NullBuffer` before comparing against the parent nulls.

# Are there any user-facing changes?

No
