### PR TITLE
feat: deterministic metadata encoding

### DIFF
--- a/arrow-ipc/src/convert.rs
+++ b/arrow-ipc/src/convert.rs
@@ -138,9 +138,12 @@ pub fn metadata_to_fb<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     metadata: &HashMap<String, String>,
 ) -> WIPOffset<Vector<'a, ForwardsUOffset<KeyValue<'a>>>> {
-    let custom_metadata = metadata
-        .iter()
-        .map(|(k, v)| {
+    let mut ordered_keys = metadata.keys().collect::<Vec<_>>();
+    ordered_keys.sort();
+    let custom_metadata = ordered_keys
+        .into_iter()
+        .map(|k| {
+            let v = metadata.get(k).unwrap();
             let fb_key_name = fbb.create_string(k);
             let fb_val_name = fbb.create_string(v);
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1854,6 +1854,7 @@ fn pad_to_alignment(alignment: u8, len: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::hash::Hasher;
     use std::io::Cursor;
     use std::io::Seek;
 
@@ -3305,5 +3306,49 @@ mod tests {
         test_slices(&array, &schema, 2, 1)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_metadata_encoding_ordering() {
+        fn create_hash() -> u64 {
+            let metadata: HashMap<String, String> = [
+                ("a", "1"), //
+                ("b", "2"), //
+                ("c", "3"), //
+                ("d", "4"), //
+                ("e", "5"), //
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+
+            // Set metadata on both the schema and a field within it.
+            let schema = Arc::new(
+                Schema::new(vec![
+                    Field::new("a", DataType::Int64, true).with_metadata(metadata.clone())
+                ])
+                .with_metadata(metadata)
+                .clone(),
+            );
+            let batch = RecordBatch::new_empty(schema.clone());
+
+            let mut bytes = Vec::new();
+            let mut w = StreamWriter::try_new(&mut bytes, batch.schema_ref()).unwrap();
+            w.write(&batch).unwrap();
+            w.finish().unwrap();
+
+            let mut h = std::hash::DefaultHasher::new();
+            h.write(&bytes);
+            h.finish()
+        }
+
+        let expected = create_hash();
+
+        // Since there is randomness in the HashMap and we cannot specify our
+        // own Hasher for the implementation used for metadata, run the above
+        // code 20x and verify it does not change. This is not perfect but it
+        // should be good enough.
+        let all_passed = [0..20].into_iter().all(|_| create_hash() == expected);
+        assert!(all_passed);
     }
 }

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3348,7 +3348,7 @@ mod tests {
         // own Hasher for the implementation used for metadata, run the above
         // code 20x and verify it does not change. This is not perfect but it
         // should be good enough.
-        let all_passed = [0..20].into_iter().all(|_| create_hash() == expected);
+        let all_passed = (0..20).all(|_| create_hash() == expected);
         assert!(all_passed);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/7448

# Rationale for this change
 
The ordering of metadata is not consistent since it uses a HashMap. It can be useful in unit tests to verify an output from a known hash of it's serialized values. With metadata this is not consistent.

# What changes are included in this PR?

Adds ordering to the hashmap keys when encoding.

# Are there any user-facing changes?

No.

# Example

If you run this example multiple times, you will see the encoding changes from run to run based on the non-deterministic ordering of the hashmap iterator.

```rust
use std::{hash::Hasher, sync::Arc};

use arrow::{array::RecordBatch, datatypes::Schema};

fn main() {
    let schema = Arc::new(
        Schema::empty().with_metadata(
            [
                ("a".to_owned(), "1".to_owned()), //
                ("b".to_owned(), "2".to_owned()), //
                ("c".to_owned(), "3".to_owned()), //
                ("d".to_owned(), "4".to_owned()), //
                ("e".to_owned(), "5".to_owned()), //
            ]
            .into_iter()
            .collect(),
        ),
    );
    let batch = RecordBatch::new_empty(schema.clone());

    dbg!(&batch.schema().metadata().keys());

    let mut bytes = Vec::new();
    let mut w = arrow::ipc::writer::StreamWriter::try_new(&mut bytes, &schema).unwrap();
    w.write(&batch).unwrap();
    w.finish().unwrap();

    let mut h = std::hash::DefaultHasher::new();
    h.write(&bytes);
    let h = h.finish();

    eprintln!("{} bytes -- h = {h:x}", bytes.len());
}
```