### PR TITLE
Support writing encrypted Parquet files with plaintext footers

### DIFF
--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,7 +30,11 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_footer_tag(&self, aad: &[u8], plaintext_footer: &mut [u8]) -> Result<Vec<u8>>;
+    fn compute_plaintext_footer_tag(
+        &self,
+        aad: &[u8],
+        plaintext_footer: &mut [u8],
+    ) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -66,14 +70,21 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_footer_tag(&self, aad: &[u8], plaintext_footer: &mut [u8]) -> Result<Vec<u8>> {
+    fn compute_plaintext_footer_tag(
+        &self,
+        aad: &[u8],
+        plaintext_footer: &mut [u8],
+    ) -> Result<Vec<u8>> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let nonce = &plaintext_footer[plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
+        let nonce = &plaintext_footer
+            [plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext_footer.len() - NONCE_LEN - TAG_LEN;
-        let tag = self
-            .key
-            .seal_in_place_separate_tag(nonce, Aad::from(aad), &mut plaintext_footer[..plaintext_end])?;
+        let tag = self.key.seal_in_place_separate_tag(
+            nonce,
+            Aad::from(aad),
+            &mut plaintext_footer[..plaintext_end],
+        )?;
         Ok(tag.as_ref().to_vec())
     }
 }

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -23,12 +23,14 @@ use ring::rand::{SecureRandom, SystemRandom};
 use std::fmt::Debug;
 
 const RIGHT_TWELVE: u128 = 0x0000_0000_ffff_ffff_ffff_ffff_ffff_ffff;
-const NONCE_LEN: usize = 12;
-const TAG_LEN: usize = 16;
-const SIZE_LEN: usize = 4;
+pub(crate) const NONCE_LEN: usize = 12;
+pub(crate) const TAG_LEN: usize = 16;
+pub(crate) const SIZE_LEN: usize = 4;
 
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
+
+    fn compute_tag(&self, nonce: &[u8], aad: &[u8], ciphertext: &mut [u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +64,18 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         // Truncate result to remove the tag
         result.resize(result.len() - TAG_LEN, 0u8);
         Ok(result)
+    }
+
+    fn compute_tag(&self, nonce: &[u8], aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+        let nonce = ring::aead::Nonce::try_assume_unique_for_key(
+            &nonce,
+        )?;
+        let tag = self.key.seal_in_place_separate_tag(
+            nonce,
+            Aad::from(aad),
+            plaintext,
+        )?;
+        Ok(tag.as_ref().to_vec())
     }
 }
 

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,10 +30,10 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_footer_tag(
+    fn compute_plaintext_tag(
         &self,
         aad: &[u8],
-        plaintext_footer: &mut [u8],
+        plaintext: &mut [u8],
     ) -> Result<Vec<u8>>;
 }
 
@@ -70,20 +70,19 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_footer_tag(
+    fn compute_plaintext_tag(
         &self,
         aad: &[u8],
-        plaintext_footer: &mut [u8],
+        plaintext: &mut [u8],
     ) -> Result<Vec<u8>> {
-        // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let nonce = &plaintext_footer
-            [plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
+        let nonce = &plaintext
+            [plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
-        let plaintext_end = plaintext_footer.len() - NONCE_LEN - TAG_LEN;
+        let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;
         let tag = self.key.seal_in_place_separate_tag(
             nonce,
             Aad::from(aad),
-            &mut plaintext_footer[..plaintext_end],
+            &mut plaintext[..plaintext_end],
         )?;
         Ok(tag.as_ref().to_vec())
     }

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,11 +30,7 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_tag(
-        &self,
-        aad: &[u8],
-        plaintext: &mut [u8],
-    ) -> Result<Vec<u8>>;
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -70,13 +66,8 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_tag(
-        &self,
-        aad: &[u8],
-        plaintext: &mut [u8],
-    ) -> Result<Vec<u8>> {
-        let nonce = &plaintext
-            [plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+        let nonce = &plaintext[plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;
         let tag = self.key.seal_in_place_separate_tag(

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,7 +30,7 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>>;
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -66,7 +66,8 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+        let mut plaintext = plaintext.to_vec();
         let nonce = &plaintext[plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -67,14 +67,10 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
     }
 
     fn compute_tag(&self, nonce: &[u8], aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
-        let nonce = ring::aead::Nonce::try_assume_unique_for_key(
-            &nonce,
-        )?;
-        let tag = self.key.seal_in_place_separate_tag(
-            nonce,
-            Aad::from(aad),
-            plaintext,
-        )?;
+        let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
+        let tag = self
+            .key
+            .seal_in_place_separate_tag(nonce, Aad::from(aad), plaintext)?;
         Ok(tag.as_ref().to_vec())
     }
 }

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -17,9 +17,7 @@
 
 //! Configuration and utilities for decryption of files using Parquet Modular Encryption
 
-use crate::encryption::ciphers::{
-    BlockDecryptor, RingGcmBlockDecryptor, TAG_LEN,
-};
+use crate::encryption::ciphers::{BlockDecryptor, RingGcmBlockDecryptor, TAG_LEN};
 use crate::encryption::modules::{create_footer_aad, create_module_aad, ModuleType};
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::ColumnCryptoMetaData;
@@ -558,7 +556,10 @@ impl FileDecryptor {
     }
 
     /// Verify the signature of the footer
-    pub(crate) fn verify_plaintext_footer_signature(&self, plaintext_footer: &mut [u8]) -> Result<()> {
+    pub(crate) fn verify_plaintext_footer_signature(
+        &self,
+        plaintext_footer: &mut [u8],
+    ) -> Result<()> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
         let tag = plaintext_footer[plaintext_footer.len() - TAG_LEN..].to_vec();
         let aad = create_footer_aad(self.file_aad())?;

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -565,7 +565,7 @@ impl FileDecryptor {
         let aad = create_footer_aad(self.file_aad())?;
         let footer_decryptor = self.get_footer_decryptor()?;
 
-        let computed_tag = footer_decryptor.compute_plaintext_footer_tag(&aad, plaintext_footer)?;
+        let computed_tag = footer_decryptor.compute_plaintext_tag(&aad, plaintext_footer)?;
 
         if computed_tag != tag {
             return Err(general_err!(

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -352,7 +352,7 @@ impl FileDecryptionProperties {
         self.aad_prefix.as_ref()
     }
 
-    /// Returns true if footer signature verification is enabled.
+    /// Returns true if footer signature verification is enabled for files with plaintext footers.
     pub fn check_plaintext_footer_integrity(&self) -> bool {
         self.footer_signature_verification
     }
@@ -507,7 +507,7 @@ impl DecryptionPropertiesBuilder {
         Ok(self)
     }
 
-    /// Specify if footer signature verification should be disabled.
+    /// Disable verification of footer tags for files that use plaintext footers.
     /// Signature verification is enabled by default.
     pub fn disable_footer_signature_verification(mut self) -> Self {
         self.footer_signature_verification = false;

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -17,18 +17,20 @@
 
 //! Configuration and utilities for decryption of files using Parquet Modular Encryption
 
-use crate::encryption::ciphers::{BlockDecryptor, RingGcmBlockDecryptor, NONCE_LEN, TAG_LEN, SIZE_LEN};
+use crate::encryption::ciphers::{
+    BlockDecryptor, RingGcmBlockDecryptor, NONCE_LEN, SIZE_LEN, TAG_LEN,
+};
 use crate::encryption::modules::{create_footer_aad, create_module_aad, ModuleType};
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::ColumnCryptoMetaData;
+use crate::format::FileMetaData as TFileMetaData;
+use crate::thrift::TSerializable;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::io::Read;
 use std::sync::Arc;
 use thrift::protocol::TCompactOutputProtocol;
-use crate::thrift::TSerializable;
-use crate::format::{FileMetaData as TFileMetaData};
 
 /// Trait for retrieving an encryption key using the key's metadata
 ///
@@ -574,11 +576,7 @@ impl FileDecryptor {
         // let aad = self.file_aad();
         let footer_decryptor = self.get_footer_decryptor()?;
 
-        let computed_tag = footer_decryptor.compute_tag(
-            nonce,
-            aad.as_ref(),
-            &mut plaintext,
-        )?;
+        let computed_tag = footer_decryptor.compute_tag(nonce, aad.as_ref(), &mut plaintext)?;
 
         if computed_tag != tag {
             return Err(general_err!(

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -556,12 +556,9 @@ impl FileDecryptor {
     }
 
     /// Verify the signature of the footer
-    pub(crate) fn verify_plaintext_footer_signature(
-        &self,
-        plaintext_footer: &mut [u8],
-    ) -> Result<()> {
+    pub(crate) fn verify_plaintext_footer_signature(&self, plaintext_footer: &[u8]) -> Result<()> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let tag = plaintext_footer[plaintext_footer.len() - TAG_LEN..].to_vec();
+        let tag = &plaintext_footer[plaintext_footer.len() - TAG_LEN..];
         let aad = create_footer_aad(self.file_aad())?;
         let footer_decryptor = self.get_footer_decryptor()?;
 

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -22,7 +22,6 @@ use crate::encryption::ciphers::{
 };
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::{ColumnCryptoMetaData, EncryptionWithColumnKey};
-use crate::format::{AesGcmV1, EncryptionAlgorithm};
 use crate::schema::types::{ColumnDescPtr, SchemaDescriptor};
 use crate::thrift::TSerializable;
 use ring::rand::{SecureRandom, SystemRandom};
@@ -362,27 +361,6 @@ impl FileEncryptor {
             None => Err(general_err!("Column '{}' is not encrypted", column_path)),
             Some(column_key) => Ok(Box::new(RingGcmBlockEncryptor::new(column_key.key())?)),
         }
-    }
-
-    /// Get encryption algorithm for the plaintext footer
-    pub(crate) fn get_footer_encryptor_for_plaintext(&self) -> Result<Option<EncryptionAlgorithm>> {
-        if !self.properties.encrypt_footer() {
-            let supply_aad_prefix = self
-                .properties
-                .aad_prefix()
-                .map(|_| !self.properties.store_aad_prefix());
-            let encryption_algorithm = Some(EncryptionAlgorithm::AESGCMV1(AesGcmV1 {
-                aad_prefix: if self.properties.store_aad_prefix() {
-                    self.properties.aad_prefix().cloned()
-                } else {
-                    None
-                },
-                aad_file_unique: Some(self.aad_file_unique().clone()),
-                supply_aad_prefix,
-            }));
-            return Ok(encryption_algorithm);
-        }
-        Ok(None)
     }
 }
 

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -395,7 +395,7 @@ pub(crate) fn encrypt_object<T: TSerializable, W: Write>(
     Ok(())
 }
 
-pub(crate) fn sign_and_write_object<T: TSerializable, W: Write>(
+pub(crate) fn write_signed_plaintext_object<T: TSerializable, W: Write>(
     object: &T,
     encryptor: &mut Box<dyn BlockEncryptor>,
     sink: &mut W,
@@ -413,11 +413,11 @@ pub(crate) fn sign_and_write_object<T: TSerializable, W: Write>(
         .try_into()
         .map_err(|err| general_err!("Plaintext data too long. {:?}", err))?;
 
-    // Format is: [ciphertext size, nonce, ciphertext, authentication tag]
-    let nonce = buffer[SIZE_LEN..SIZE_LEN + NONCE_LEN].to_vec();
-    let tag = buffer[(ciphertext_length - TAG_LEN as u32) as usize..].to_vec();
-    sink.write_all(&nonce)?;
-    sink.write_all(&tag)?;
+    // Format of encrypted buffer is: [ciphertext size, nonce, ciphertext, authentication tag]
+    let nonce = &buffer[SIZE_LEN..SIZE_LEN + NONCE_LEN];
+    let tag = &buffer[(buffer.len() - TAG_LEN)..];
+    sink.write_all(nonce)?;
+    sink.write_all(tag)?;
 
     Ok(())
 }

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -409,13 +409,9 @@ pub(crate) fn write_signed_plaintext_object<T: TSerializable, W: Write>(
     sink.write_all(&buffer)?;
     buffer = encryptor.encrypt(buffer.as_ref(), module_aad)?;
 
-    let ciphertext_length : u32 = buffer.len()
-        .try_into()
-        .map_err(|err| general_err!("Plaintext data too long. {:?}", err))?;
-
     // Format of encrypted buffer is: [ciphertext size, nonce, ciphertext, authentication tag]
     let nonce = &buffer[SIZE_LEN..SIZE_LEN + NONCE_LEN];
-    let tag = &buffer[(buffer.len() - TAG_LEN)..];
+    let tag = &buffer[buffer.len() - TAG_LEN..];
     sink.write_all(nonce)?;
     sink.write_all(tag)?;
 

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -17,16 +17,18 @@
 
 //! Configuration and utilities for Parquet Modular Encryption
 
-use crate::encryption::ciphers::{BlockEncryptor, RingGcmBlockEncryptor, NONCE_LEN, SIZE_LEN, TAG_LEN};
+use crate::encryption::ciphers::{
+    BlockEncryptor, RingGcmBlockEncryptor, NONCE_LEN, SIZE_LEN, TAG_LEN,
+};
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::{ColumnCryptoMetaData, EncryptionWithColumnKey};
+use crate::format::{AesGcmV1, EncryptionAlgorithm};
 use crate::schema::types::{ColumnDescPtr, SchemaDescriptor};
 use crate::thrift::TSerializable;
 use ring::rand::{SecureRandom, SystemRandom};
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use thrift::protocol::TCompactOutputProtocol;
-use crate::format::{AesGcmV1, EncryptionAlgorithm};
 
 #[derive(Debug, Clone, PartialEq)]
 struct EncryptionKey {
@@ -361,11 +363,12 @@ impl FileEncryptor {
             Some(column_key) => Ok(Box::new(RingGcmBlockEncryptor::new(column_key.key())?)),
         }
     }
-    
+
     /// Get encryption algorithm for the plaintext footer
     pub(crate) fn get_footer_encryptor_for_plaintext(&self) -> Result<Option<EncryptionAlgorithm>> {
         if !self.properties.encrypt_footer() {
-            let supply_aad_prefix = self.properties
+            let supply_aad_prefix = self
+                .properties
                 .aad_prefix()
                 .map(|_| !self.properties.store_aad_prefix());
             let encryption_algorithm = Some(EncryptionAlgorithm::AESGCMV1(AesGcmV1 {

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -26,6 +26,7 @@ use ring::rand::{SecureRandom, SystemRandom};
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use thrift::protocol::TCompactOutputProtocol;
+use crate::format::{AesGcmV1, EncryptionAlgorithm};
 
 #[derive(Debug, Clone, PartialEq)]
 struct EncryptionKey {
@@ -359,6 +360,26 @@ impl FileEncryptor {
             None => Err(general_err!("Column '{}' is not encrypted", column_path)),
             Some(column_key) => Ok(Box::new(RingGcmBlockEncryptor::new(column_key.key())?)),
         }
+    }
+    
+    /// Get encryption algorithm for the plaintext footer
+    pub(crate) fn get_footer_encryptor_for_plaintext(&self) -> Result<Option<EncryptionAlgorithm>> {
+        if !self.properties.encrypt_footer() {
+            let supply_aad_prefix = self.properties
+                .aad_prefix()
+                .map(|_| !self.properties.store_aad_prefix());
+            let encryption_algorithm = Some(EncryptionAlgorithm::AESGCMV1(AesGcmV1 {
+                aad_prefix: if self.properties.store_aad_prefix() {
+                    self.properties.aad_prefix().cloned()
+                } else {
+                    None
+                },
+                aad_file_unique: Some(self.aad_file_unique().clone()),
+                supply_aad_prefix,
+            }));
+            return Ok(encryption_algorithm);
+        }
+        Ok(None)
     }
 }
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1999,7 +1999,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let base_expected_size = 2312;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2640;
+        let base_expected_size = 2648;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2029,7 +2029,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let bigger_expected_size = 2816;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3144;
+        let bigger_expected_size = 3152;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -17,13 +17,14 @@
 
 use std::{io::Read, ops::Range, sync::Arc};
 
+use bytes::Bytes;
+
 use crate::basic::ColumnOrder;
 #[cfg(feature = "encryption")]
 use crate::encryption::{
     decrypt::{FileDecryptionProperties, FileDecryptor},
     modules::create_footer_aad,
 };
-use bytes::Bytes;
 
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData};

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -975,10 +975,11 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?);
             if file_decryption_properties.check_plaintext_footer_integrity() {
+                let mut cpy_buf = buf.to_vec();
                 file_decryptor
                     .clone()
                     .unwrap()
-                    .verify_signature(&t_file_metadata, buf.as_ref())?;
+                    .verify_plaintext_footer_signature(cpy_buf.as_mut())?;
             }
         }
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -972,7 +972,7 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?;
             if file_decryption_properties.check_plaintext_footer_integrity() && !encrypted_footer {
-                file_decryptor_value.verify_plaintext_footer_signature(buf.to_vec().as_mut())?;
+                file_decryptor_value.verify_plaintext_footer_signature(buf)?;
             }
             file_decryptor = Some(file_decryptor_value);
         }

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -17,14 +17,13 @@
 
 use std::{io::Read, ops::Range, sync::Arc};
 
-use bytes::Bytes;
-
 use crate::basic::ColumnOrder;
 #[cfg(feature = "encryption")]
 use crate::encryption::{
     decrypt::{FileDecryptionProperties, FileDecryptor},
     modules::create_footer_aad,
 };
+use bytes::Bytes;
 
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData};

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -975,11 +975,10 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?);
             if file_decryption_properties.check_plaintext_footer_integrity() {
-                let mut cpy_buf = buf.to_vec();
                 file_decryptor
                     .clone()
                     .unwrap()
-                    .verify_plaintext_footer_signature(cpy_buf.as_mut())?;
+                    .verify_plaintext_footer_signature(buf.to_vec().as_mut())?;
             }
         }
 

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -636,13 +636,12 @@ impl MetadataObjectWriter {
     }
 
     fn get_footer_encryption_algorithm(&self) -> Option<EncryptionAlgorithm> {
-        let file_encryptor = self.file_encryptor.as_ref().unwrap();
-        if !file_encryptor.properties().encrypt_footer() {
+        if let Some(file_encryptor) = &self.file_encryptor {
             let supply_aad_prefix = file_encryptor
                 .properties()
                 .aad_prefix()
                 .map(|_| !file_encryptor.properties().store_aad_prefix());
-            let encryption_algorithm = Some(EncryptionAlgorithm::AESGCMV1(AesGcmV1 {
+            let encryption_algorithm = EncryptionAlgorithm::AESGCMV1(AesGcmV1 {
                 aad_prefix: if file_encryptor.properties().store_aad_prefix() {
                     file_encryptor.properties().aad_prefix().cloned()
                 } else {
@@ -650,8 +649,8 @@ impl MetadataObjectWriter {
                 },
                 aad_file_unique: Some(file_encryptor.aad_file_unique().clone()),
                 supply_aad_prefix,
-            }));
-            return encryption_algorithm;
+            });
+            return Some(encryption_algorithm);
         }
         None
     }

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -17,7 +17,7 @@
 
 #[cfg(feature = "encryption")]
 use crate::encryption::{
-    encrypt::{encrypt_object, encrypt_object_to_vec, sign_and_write_object, FileEncryptor},
+    encrypt::{encrypt_object, encrypt_object_to_vec, write_signed_plaintext_object, FileEncryptor},
     modules::{create_footer_aad, create_module_aad, ModuleType},
 };
 #[cfg(feature = "encryption")]
@@ -516,7 +516,7 @@ impl MetadataObjectWriter {
             Some(file_encryptor) if file_metadata.encryption_algorithm.is_some() => {
                 let aad = create_footer_aad(file_encryptor.file_aad())?;
                 let mut encryptor = file_encryptor.get_footer_encryptor()?;
-                sign_and_write_object(file_metadata, &mut encryptor, &mut sink, &aad)
+                write_signed_plaintext_object(file_metadata, &mut encryptor, &mut sink, &aad)
             }
             _ => Self::write_object(file_metadata, &mut sink),
         }

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -647,12 +647,13 @@ impl MetadataObjectWriter {
             .properties()
             .aad_prefix()
             .map(|_| !file_encryptor.properties().store_aad_prefix());
+        let aad_prefix = if file_encryptor.properties().store_aad_prefix() {
+            file_encryptor.properties().aad_prefix().cloned()
+        } else {
+            None
+        };
         EncryptionAlgorithm::AESGCMV1(AesGcmV1 {
-            aad_prefix: if file_encryptor.properties().store_aad_prefix() {
-                file_encryptor.properties().aad_prefix().cloned()
-            } else {
-                None
-            },
+            aad_prefix,
             aad_file_unique: Some(file_encryptor.aad_file_unique().clone()),
             supply_aad_prefix,
         })

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 #[cfg(feature = "encryption")]
+use crate::encryption::ciphers::{NONCE_LEN, SIZE_LEN, TAG_LEN};
+#[cfg(feature = "encryption")]
 use crate::encryption::encrypt::{encrypt_object, encrypt_object_to_vec, FileEncryptor};
 #[cfg(feature = "encryption")]
 use crate::encryption::modules::{create_footer_aad, create_module_aad, ModuleType};
@@ -502,6 +504,38 @@ impl MetadataObjectWriter {
                 let aad = create_footer_aad(file_encryptor.file_aad())?;
                 let mut encryptor = file_encryptor.get_footer_encryptor()?;
                 encrypt_object(file_metadata, &mut encryptor, &mut sink, &aad)
+            }
+            Some(file_encryptor) if !file_encryptor.properties().encrypt_footer() => {
+                // todo: should we also check for file_metadata.encryption_algorithm.is_some() ?
+                // Write unencrypted footer
+                let data_len: usize;
+                {
+                    let mut buffer: Vec<u8> = vec![];
+                    let mut unencrypted_protocol = TCompactOutputProtocol::new(&mut buffer);
+                    file_metadata.write_to_out_protocol(&mut unencrypted_protocol)?;
+                    data_len = buffer.len();
+                    sink.write_all(&buffer)?;
+                }
+
+                // Write nonce and tag
+                {
+                    let mut encrypted_buffer: Vec<u8> = vec![];
+                    let aad = create_footer_aad(file_encryptor.file_aad())?;
+                    let mut encryptor = file_encryptor.get_footer_encryptor()?;
+
+                    let mut protocol = TCompactOutputProtocol::new(&mut encrypted_buffer);
+                    file_metadata.write_to_out_protocol(&mut protocol)?;
+                    encryptor.encrypt(encrypted_buffer.as_ref(), &aad)?;
+
+                    // todo: check for overflow when calculating lengths
+                    let nonce =
+                        &encrypted_buffer[SIZE_LEN + data_len..SIZE_LEN + data_len + NONCE_LEN];
+                    sink.write_all(nonce)?;
+                    let tag = &encrypted_buffer[SIZE_LEN + data_len + NONCE_LEN
+                        ..SIZE_LEN + data_len + NONCE_LEN + TAG_LEN];
+                    sink.write_all(tag)?;
+                }
+                Ok(())
             }
             _ => Self::write_object(file_metadata, &mut sink),
         }

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -17,7 +17,9 @@
 
 #[cfg(feature = "encryption")]
 use crate::encryption::{
-    encrypt::{encrypt_object, encrypt_object_to_vec, write_signed_plaintext_object, FileEncryptor},
+    encrypt::{
+        encrypt_object, encrypt_object_to_vec, write_signed_plaintext_object, FileEncryptor,
+    },
     modules::{create_footer_aad, create_module_aad, ModuleType},
 };
 #[cfg(feature = "encryption")]

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -212,12 +212,6 @@ impl<W: Write + Send> SerializedFileWriter<W> {
         if let Some(file_encryption_properties) = &properties.file_encryption_properties {
             file_encryption_properties.validate_encrypted_column_names(schema_descriptor)?;
 
-            if !file_encryption_properties.encrypt_footer() {
-                return Err(general_err!(
-                    "Writing encrypted files with plaintext footers is not supported yet"
-                ));
-            }
-
             Ok(Some(Arc::new(FileEncryptor::new(
                 file_encryption_properties.clone(),
             )?)))

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -349,6 +349,7 @@ impl<W: Write + Send> SerializedFileWriter<W> {
         );
 
         #[cfg(feature = "encryption")]
+        // todo
         {
             encoder = encoder.with_file_encryptor(self.file_encryptor.clone());
         }

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -349,7 +349,6 @@ impl<W: Write + Send> SerializedFileWriter<W> {
         );
 
         #[cfg(feature = "encryption")]
-        // todo
         {
             encoder = encoder.with_file_encryptor(self.file_encryptor.clone());
         }

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -95,7 +95,6 @@ fn test_plaintext_footer_signature_verification() {
         .unwrap_err()
         .to_string()
         .starts_with("Parquet error: Footer signature verification failed. Computed: ["));
-    // verify_encryption_test_file_read(file, decryption_properties);
 }
 
 #[test]

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -43,13 +43,24 @@ use std::sync::Arc;
 fn test_non_uniform_encryption_plaintext_footer() {
     let test_data = arrow::util::test_util::parquet_test_data();
     let path = format!("{test_data}/encrypt_columns_plaintext_footer.parquet.encrypted");
-    let file = File::open(path).unwrap();
+    let file = File::open(path.clone()).unwrap();
 
     // There is always a footer key even with a plaintext footer,
     // but this is used for signing the footer.
     let footer_key = "0123456789012345".as_bytes(); // 128bit/16
     let column_1_key = "1234567890123450".as_bytes();
     let column_2_key = "1234567890123451".as_bytes();
+
+    let decryption_properties = FileDecryptionProperties::builder(footer_key.to_vec())
+        .disable_footer_signature_verification()
+        .with_column_key("double_field", column_1_key.to_vec())
+        .with_column_key("float_field", column_2_key.to_vec())
+        .build()
+        .unwrap();
+
+    verify_encryption_test_file_read(file, decryption_properties);
+
+    let file = File::open(path.clone()).unwrap();
 
     let decryption_properties = FileDecryptionProperties::builder(footer_key.to_vec())
         .with_column_key("double_field", column_1_key.to_vec())

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -438,7 +438,7 @@ fn test_write_non_uniform_encryption() {
 #[test]
 fn test_write_uniform_encryption_plaintext_footer() {
     let testdata = arrow::util::test_util::parquet_test_data();
-    let path = format!("{testdata}/encrypt_columns_and_footer.parquet.encrypted");
+    let path = format!("{testdata}/encrypt_columns_plaintext_footer.parquet.encrypted");
 
     let footer_key = b"0123456789012345".to_vec(); // 128bit/16
     let column_1_key = b"1234567890123450".to_vec();
@@ -455,26 +455,7 @@ fn test_write_uniform_encryption_plaintext_footer() {
         .build()
         .unwrap();
 
-    let file = File::open(path).unwrap();
-    let options = ArrowReaderOptions::default()
-        .with_file_decryption_properties(decryption_properties.clone());
-    let metadata = ArrowReaderMetadata::load(&file, options.clone()).unwrap();
-
-    let props = WriterProperties::builder()
-        .with_file_encryption_properties(file_encryption_properties)
-        .build();
-    let temp_file = tempfile::tempfile().unwrap();
-
-    let writer = ArrowWriter::try_new(
-        temp_file.try_clone().unwrap(),
-        metadata.schema().clone(),
-        Some(props),
-    );
-    assert!(writer.is_err());
-    assert_eq!(
-        writer.unwrap_err().to_string(),
-        "Parquet error: Writing encrypted files with plaintext footers is not supported yet"
-    )
+    read_and_roundtrip_to_encrypted_file(&path, decryption_properties, file_encryption_properties);
 }
 
 #[test]


### PR DESCRIPTION
Closes #7320.

# Rationale for this change
 
The Parquet format allows encrypting some or all column data while keeping footers in plaintext for compatibility with readers that don't support encryption. See [spec](https://parquet.apache.org/docs/file-format/data-pages/encryption/#55-plaintext-footer-mode).

Arrow-rs already supports reading plaintext footers and writing encrypted parquet files and should also support writing parquet files with plaintext footers.

# What changes are included in this PR?

# Are there any user-facing changes?

This now enables writing plaintext footers, while in current state attempting to write a plaintext footer would throw an error.