### PR TITLE
Add custom decoder in arrow-json

### DIFF
--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -74,7 +74,7 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::{Reader, ReaderBuilder};
+pub use self::reader::{ArrayDecoder, DecoderFactory, Reader, ReaderBuilder, Tape, TapeElement};
 pub use self::writer::{
     ArrayWriter, Encoder, EncoderFactory, EncoderOptions, LineDelimitedWriter, Writer,
     WriterBuilder,

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -24,6 +24,9 @@ use arrow_buffer::buffer::NullBuffer;
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};
 use std::marker::PhantomData;
+use std::sync::Arc;
+
+use super::DecoderFactory;
 
 pub struct ListArrayDecoder<O> {
     data_type: DataType,
@@ -39,6 +42,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
         strict_mode: bool,
         is_nullable: bool,
         struct_mode: StructMode,
+        decoder_factory: Option<Arc<dyn DecoderFactory>>,
     ) -> Result<Self, ArrowError> {
         let field = match &data_type {
             DataType::List(f) if !O::IS_LARGE => f,
@@ -51,6 +55,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
             strict_mode,
             field.is_nullable(),
             struct_mode,
+            decoder_factory,
         )?;
 
         Ok(Self {

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::reader::tape::{Tape, TapeElement};
 use crate::reader::{make_decoder, ArrayDecoder};
 use crate::StructMode;
@@ -23,6 +25,8 @@ use arrow_buffer::buffer::NullBuffer;
 use arrow_buffer::ArrowNativeType;
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};
+
+use super::DecoderFactory;
 
 pub struct MapArrayDecoder {
     data_type: DataType,
@@ -38,6 +42,7 @@ impl MapArrayDecoder {
         strict_mode: bool,
         is_nullable: bool,
         struct_mode: StructMode,
+        decoder_factory: Option<Arc<dyn DecoderFactory>>,
     ) -> Result<Self, ArrowError> {
         let fields = match &data_type {
             DataType::Map(_, true) => {
@@ -62,6 +67,7 @@ impl MapArrayDecoder {
             strict_mode,
             fields[0].is_nullable(),
             struct_mode,
+            decoder_factory.clone(),
         )?;
         let values = make_decoder(
             fields[1].data_type().clone(),
@@ -69,6 +75,7 @@ impl MapArrayDecoder {
             strict_mode,
             fields[1].is_nullable(),
             struct_mode,
+            decoder_factory,
         )?;
 
         Ok(Self {

--- a/arrow-json/src/reader/struct_array.rs
+++ b/arrow-json/src/reader/struct_array.rs
@@ -15,12 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::reader::tape::{Tape, TapeElement};
 use crate::reader::{make_decoder, ArrayDecoder, StructMode};
 use arrow_array::builder::BooleanBufferBuilder;
 use arrow_buffer::buffer::NullBuffer;
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, Fields};
+
+use super::DecoderFactory;
 
 pub struct StructArrayDecoder {
     data_type: DataType,
@@ -37,6 +41,7 @@ impl StructArrayDecoder {
         strict_mode: bool,
         is_nullable: bool,
         struct_mode: StructMode,
+        decoder_factory: Option<Arc<dyn DecoderFactory>>,
     ) -> Result<Self, ArrowError> {
         let decoders = struct_fields(&data_type)
             .iter()
@@ -51,6 +56,7 @@ impl StructArrayDecoder {
                     strict_mode,
                     nullable,
                     struct_mode,
+                    decoder_factory.clone(),
                 )
             })
             .collect::<Result<Vec<_>, ArrowError>>()?;

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -338,6 +338,7 @@ impl TapeDecoder {
         }
     }
 
+    /// Decodes JSON data from the provided buffer, returning the number of bytes consumed
     pub fn decode(&mut self, buf: &[u8]) -> Result<usize, ArrowError> {
         let mut iter = BufIter::new(buf);
 


### PR DESCRIPTION
Similar behavior as https://github.com/apache/arrow-rs/pull/7015 but on the decoder side. This would allow introducing flexibility when decoding JSON. 

For example, when trying to replicate JSON decoding in spark, spark will decode incorrect values as null or raw string. This would allow overriding the current StringDecoder to implement this functionality.