### PR TITLE
Add Map support to arrow-avro

### DIFF
--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cmp::Ordering;
 use crate::codec::{AvroDataType, Codec, Nullability};
 use crate::reader::block::{Block, BlockDecoder};
 use crate::reader::cursor::AvroCursor;
@@ -93,6 +94,13 @@ enum Decoder {
     String(OffsetBufferBuilder<i32>, Vec<u8>),
     List(FieldRef, OffsetBufferBuilder<i32>, Box<Decoder>),
     Record(Fields, Vec<Decoder>),
+    Map(
+        FieldRef,
+        OffsetBufferBuilder<i32>,
+        OffsetBufferBuilder<i32>,
+        Vec<u8>,
+        Box<Decoder>,
+    ),
     Nullable(Nullability, NullBufferBuilder, Box<Decoder>),
 }
 
@@ -144,6 +152,25 @@ impl Decoder {
                 }
                 Self::Record(arrow_fields.into(), encodings)
             }
+            Codec::Map(child) => {
+                let val_field = child.field_with_name("value").with_nullable(true);
+                let map_field = Arc::new(ArrowField::new(
+                    "entries",
+                    DataType::Struct(Fields::from(vec![
+                        ArrowField::new("key", DataType::Utf8, false),
+                        val_field,
+                    ])),
+                    false,
+                ));
+                let val_dec = Self::try_new(child)?;
+                Self::Map(
+                    map_field,
+                    OffsetBufferBuilder::new(DEFAULT_CAPACITY),
+                    OffsetBufferBuilder::new(DEFAULT_CAPACITY),
+                    Vec::with_capacity(DEFAULT_CAPACITY),
+                    Box::new(val_dec),
+                )
+            }
         };
 
         Ok(match data_type.nullability() {
@@ -174,6 +201,9 @@ impl Decoder {
                 e.append_null();
             }
             Self::Record(_, e) => e.iter_mut().for_each(|e| e.append_null()),
+            Self::Map(_, _koff, moff, _, _) => {
+                moff.push_length(0);
+            }
             Self::Nullable(_, _, _) => unreachable!("Nulls cannot be nested"),
         }
     }
@@ -206,6 +236,15 @@ impl Decoder {
                 for encoding in encodings {
                     encoding.decode(buf)?;
                 }
+            }
+            Self::Map(_, koff, moff, kdata, valdec) => {
+                let newly_added = read_map_blocks(buf, |cur| {
+                    let kb = cur.get_bytes()?;
+                    koff.push_length(kb.len());
+                    kdata.extend_from_slice(kb);
+                    valdec.decode(cur)
+                })?;
+                moff.push_length(newly_added);
             }
             Self::Nullable(nullability, nulls, e) => {
                 let is_valid = buf.get_bool()? == matches!(nullability, Nullability::NullFirst);
@@ -244,7 +283,6 @@ impl Decoder {
             ),
             Self::Float32(values) => Arc::new(flush_primitive::<Float32Type>(values, nulls)),
             Self::Float64(values) => Arc::new(flush_primitive::<Float64Type>(values, nulls)),
-
             Self::Binary(offsets, values) => {
                 let offsets = flush_offsets(offsets);
                 let values = flush_values(values).into();
@@ -267,8 +305,81 @@ impl Decoder {
                     .collect::<Result<Vec<_>, _>>()?;
                 Arc::new(StructArray::new(fields.clone(), arrays, nulls))
             }
+            Self::Map(map_field, k_off, m_off, kdata, valdec) => {
+                let moff = flush_offsets(m_off);
+                let koff = flush_offsets(k_off);
+                let kd = flush_values(kdata).into();
+                let val_arr = valdec.flush(None)?;
+                let key_arr = StringArray::new(koff, kd, None);
+                if key_arr.len() != val_arr.len() {
+                    return Err(ArrowError::InvalidArgumentError(format!(
+                        "Map keys length ({}) != map values length ({})",
+                        key_arr.len(),
+                        val_arr.len()
+                    )));
+                }
+                let final_len = moff.len() - 1;
+                if let Some(n) = &nulls {
+                    if n.len() != final_len {
+                        return Err(ArrowError::InvalidArgumentError(format!(
+                            "Map array null buffer length {} != final map length {final_len}",
+                            n.len()
+                        )));
+                    }
+                }
+                let entries_struct = StructArray::new(
+                    Fields::from(vec![
+                        Arc::new(ArrowField::new("key", DataType::Utf8, false)),
+                        Arc::new(ArrowField::new("value", val_arr.data_type().clone(), true)),
+                    ]),
+                    vec![Arc::new(key_arr), val_arr],
+                    None,
+                );
+                let map_arr = MapArray::new(map_field.clone(), moff, entries_struct, nulls, false);
+                Arc::new(map_arr)
+            }
         })
     }
+}
+
+
+fn read_map_blocks(
+    buf: &mut AvroCursor,
+    decode_entry: impl FnMut(&mut AvroCursor) -> Result<(), ArrowError>,
+) -> Result<usize, ArrowError> {
+    read_blockwise_items(buf, true, decode_entry)
+}
+
+fn read_blockwise_items(
+    buf: &mut AvroCursor,
+    read_size_after_negative: bool,
+    mut decode_fn: impl FnMut(&mut AvroCursor) -> Result<(), ArrowError>,
+) -> Result<usize, ArrowError> {
+    let mut total = 0usize;
+    loop {
+        let blk = buf.get_long()?;
+        match blk.cmp(&0) {
+            Ordering::Equal => break,
+            Ordering::Less => {
+                let cnt = (-blk) as usize;
+                if read_size_after_negative {
+                    let _size_in_bytes = buf.get_long()?;
+                }
+                for _ in 0..cnt {
+                    decode_fn(buf)?;
+                }
+                total += cnt;
+            }
+            Ordering::Greater => {
+                let cnt = blk as usize;
+                for _i in 0..cnt {
+                    decode_fn(buf)?;
+                }
+                total += cnt;
+            }
+        }
+    }
+    Ok(total)
 }
 
 #[inline]
@@ -290,3 +401,84 @@ fn flush_primitive<T: ArrowPrimitiveType>(
 }
 
 const DEFAULT_CAPACITY: usize = 1024;
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{
+        cast::AsArray, Array, Decimal128Array, DictionaryArray, FixedSizeBinaryArray,
+        IntervalMonthDayNanoArray, ListArray, MapArray, StringArray, StructArray,
+    };
+
+    fn encode_avro_long(value: i64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut v = (value << 1) ^ (value >> 63);
+        while v & !0x7F != 0 {
+            buf.push(((v & 0x7F) | 0x80) as u8);
+            v >>= 7;
+        }
+        buf.push(v as u8);
+        buf
+    }
+
+    fn encode_avro_bytes(bytes: &[u8]) -> Vec<u8> {
+        let mut buf = encode_avro_long(bytes.len() as i64);
+        buf.extend_from_slice(bytes);
+        buf
+    }
+
+    fn avro_from_codec(codec: Codec) -> AvroDataType {
+        AvroDataType::new(codec, None, Default::default())
+    }
+
+
+    #[test]
+    fn test_map_decoding_one_entry() {
+        let value_type = avro_from_codec(Codec::Utf8);
+        let map_type = avro_from_codec(Codec::Map(Arc::new(value_type)));
+        let mut decoder = Decoder::try_new(&map_type).unwrap();
+        // Encode a single map with one entry: {"hello": "world"}
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_long(1));
+        data.extend_from_slice(&encode_avro_bytes(b"hello")); // key
+        data.extend_from_slice(&encode_avro_bytes(b"world")); // value
+        data.extend_from_slice(&encode_avro_long(0));
+        let mut cursor = AvroCursor::new(&data);
+        decoder.decode(&mut cursor).unwrap();
+        let array = decoder.flush(None).unwrap();
+        let map_arr = array.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(map_arr.len(), 1); // one map
+        assert_eq!(map_arr.value_length(0), 1);
+        let entries = map_arr.value(0);
+        let struct_entries = entries.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(struct_entries.len(), 1);
+        let key_arr = struct_entries
+            .column_by_name("key")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let val_arr = struct_entries
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(key_arr.value(0), "hello");
+        assert_eq!(val_arr.value(0), "world");
+    }
+
+    #[test]
+    fn test_map_decoding_empty() {
+        let value_type = avro_from_codec(Codec::Utf8);
+        let map_type = avro_from_codec(Codec::Map(Arc::new(value_type)));
+        let mut decoder = Decoder::try_new(&map_type).unwrap();
+        let data = encode_avro_long(0);
+        decoder.decode(&mut AvroCursor::new(&data)).unwrap();
+        let array = decoder.flush(None).unwrap();
+        let map_arr = array.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(map_arr.len(), 1);
+        assert_eq!(map_arr.value_length(0), 0);
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-rs/issues/4886

Related to https://github.com/apache/arrow-rs/pull/6965

# Rationale for this change
 
Avro supports maps as a core data type, but previously arrow-avro lacked any decoding logic to handle them. As a result, any Avro file containing map fields would fail to parse correctly within the Arrow ecosystem. This PR addresses this gap by:

1. Adding explicit Map decoding: It introduces a new` Codec::Map` variant and corresponding `Decoder::Map` logic that reads map blocks in Avro format and constructs an Arrow MapArray. This preserves both the keys and values in a schema-compatible manner, enabling accurate ingestion of map-encoded data.

Overall, these changes expand Arrow’s Avro reader capabilities, allowing users to work with map-encoded data in a standardized Arrow format.

# What changes are included in this PR?

This PR adds full Map support in the arrow-avro crate. Key changes include:

**1. arrow-avro/src/codec.rs:**

* Added a `Codec::Map(Arc<AvroDataType>)` variant
* Logic to construct an Arrow MapArray, including a struct of { key, value } with typed value decoding.
* Added a new function to `AvroDataType`.

**2. arrow-avro/src/reader/record.rs:**

* Introduced the Map decoding path which leverages blockwise reads of Avro map data.
* Created helpers read_map_blocks and `read_blockwise_items` to handle block sequences of key value pairs until a terminating block count of zero.
* Implemented decoder unit tests for Map types.

# Are there any user-facing changes?

N/A
