### PR TITLE
Speedup arithmetic kernels (up to -25%) / not (-30%)

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -20,8 +20,6 @@
 use arrow_array::builder::BufferBuilder;
 use arrow_array::*;
 use arrow_buffer::buffer::NullBuffer;
-use arrow_buffer::ArrowNativeType;
-use arrow_buffer::MutableBuffer;
 use arrow_data::ArrayData;
 use arrow_schema::ArrowError;
 

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -122,7 +122,7 @@ where
 
     let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
-    let values = a.values().iter().zip(b.values()).map(|(l, r)| op(*l, *r));
+    let values = a.values().into_iter().zip(b.values()).map(|(l, r)| op(*l, *r));
 
     let buffer: Vec<_> = values.collect();
     Ok(PrimitiveArray::new(buffer.into(), nulls))

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -122,7 +122,11 @@ where
 
     let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
-    let values = a.values().into_iter().zip(b.values()).map(|(l, r)| op(*l, *r));
+    let values = a
+        .values()
+        .into_iter()
+        .zip(b.values())
+        .map(|(l, r)| op(*l, *r));
 
     let buffer: Vec<_> = values.collect();
     Ok(PrimitiveArray::new(buffer.into(), nulls))

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -825,7 +825,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         F: Fn(T::Native) -> O::Native,
     {
         let nulls = self.nulls().cloned();
-        let values = self.values().iter().map(|v| op(*v));
+        let values = self.values().into_iter().map(|v| op(*v));
         let buffer: Vec<_> = values.collect();
         PrimitiveArray::new(buffer.into(), nulls)
     }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -828,12 +828,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     {
         let nulls = self.nulls().cloned();
         let values = self.values().iter().map(|v| op(*v));
-        // JUSTIFICATION
-        //  Benefit
-        //      ~60% speedup
-        //  Soundness
-        //      `values` is an iterator with a known size because arrays are sized.
-        let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
+        let buffer: Vec<_> = values.collect();
         PrimitiveArray::new(buffer.into(), nulls)
     }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1029,7 +1029,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     {
         let nulls = left.logical_nulls();
         let buffer: Vec<_> = (0..left.len())
-            // SAFETY: i is within bounds of the array
+            // SAFETY: i in range 0..left.len()
             .map(|i| op(unsafe { left.value_unchecked(i) }))
             .collect();
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1029,6 +1029,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     {
         let nulls = left.logical_nulls();
         let buffer: Vec<_> = (0..left.len())
+            // SAFETY: i is within bounds of the array
             .map(|i| op(unsafe { left.value_unchecked(i) }))
             .collect();
 

--- a/arrow-buffer/src/buffer/ops.rs
+++ b/arrow-buffer/src/buffer/ops.rs
@@ -103,10 +103,12 @@ where
     F: FnMut(u64) -> u64,
 {
     // reserve capacity and set length so we can get a typed view of u64 chunks
-    let mut result =
-        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64 * 8, false);
+    let mut result = MutableBuffer::new(ceil(len_in_bits, 8));
 
     let left_chunks = left.bit_chunks(offset_in_bits, len_in_bits);
+
+    // SAFETY: `MutableBuffer::set_len` is sound because it is initalized right after
+    unsafe { result.set_len(left_chunks.iter().len() * 8) };
 
     let result_chunks = result.typed_data_mut::<u64>().iter_mut();
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


Closes #.

# Rationale for this change
 

<details>

```
add(0)                  time:   [8.2259 µs 8.2342 µs 8.2441 µs]
                        change: [-0.5010% -0.2757% -0.0590%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

add_checked(0)          time:   [7.0879 µs 7.3277 µs 7.6011 µs]
                        change: [-6.7853% -4.9254% -3.0503%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 25 outliers among 100 measurements (25.00%)
  20 (20.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe

add_scalar(0)           time:   [3.6041 µs 3.6297 µs 3.6584 µs]
                        change: [-38.775% -37.843% -37.013%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe

subtract(0)             time:   [6.4811 µs 6.5582 µs 6.6578 µs]
                        change: [-14.791% -12.619% -10.742%] (p = 0.00 < 0.05)
                        Performance has improved.

subtract_checked(0)     time:   [7.9566 µs 7.9676 µs 7.9805 µs]
                        change: [-4.4506% -4.1728% -3.9161%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

subtract_scalar(0)      time:   [3.8308 µs 3.9523 µs 4.1161 µs]
                        change: [-23.490% -19.635% -15.749%] (p = 0.00 < 0.05)
                        Performance has improved.

multiply(0)             time:   [6.8732 µs 6.8898 µs 6.9040 µs]
                        change: [-16.540% -16.354% -16.162%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

multiply_checked(0)     time:   [6.7054 µs 6.8740 µs 7.0836 µs]
                        change: [-10.102% -7.8101% -5.9373%] (p = 0.00 < 0.05)
                        Performance has improved.

multiply_scalar(0)      time:   [3.6219 µs 3.6418 µs 3.6607 µs]
                        change: [-37.007% -36.422% -35.888%] (p = 0.00 < 0.05)
                        Performance has improved.


not                     time:   [103.75 ns 103.80 ns 103.86 ns]
                        change: [-28.869% -28.724% -28.584%] (p = 0.00 < 0.05)
                        Performance has improved.

not_sliced              time:   [226.43 ns 226.48 ns 226.52 ns]
                        change: [-13.416% -13.278% -13.154%] (p = 0.00 < 0.05)
                        Performance has improved.

```
</details>

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
