### PR TITLE
Verify footer tags when reading encrypted Parquet files with plaintext footers

### DIFF
--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,7 +30,11 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_footer_tag(&self, aad: &[u8], plaintext_footer: &mut [u8]) -> Result<Vec<u8>>;
+    fn compute_plaintext_footer_tag(
+        &self,
+        aad: &[u8],
+        plaintext_footer: &mut [u8],
+    ) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -66,14 +70,21 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_footer_tag(&self, aad: &[u8], plaintext_footer: &mut [u8]) -> Result<Vec<u8>> {
+    fn compute_plaintext_footer_tag(
+        &self,
+        aad: &[u8],
+        plaintext_footer: &mut [u8],
+    ) -> Result<Vec<u8>> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let nonce = &plaintext_footer[plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
+        let nonce = &plaintext_footer
+            [plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext_footer.len() - NONCE_LEN - TAG_LEN;
-        let tag = self
-            .key
-            .seal_in_place_separate_tag(nonce, Aad::from(aad), &mut plaintext_footer[..plaintext_end])?;
+        let tag = self.key.seal_in_place_separate_tag(
+            nonce,
+            Aad::from(aad),
+            &mut plaintext_footer[..plaintext_end],
+        )?;
         Ok(tag.as_ref().to_vec())
     }
 }

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -23,12 +23,14 @@ use ring::rand::{SecureRandom, SystemRandom};
 use std::fmt::Debug;
 
 const RIGHT_TWELVE: u128 = 0x0000_0000_ffff_ffff_ffff_ffff_ffff_ffff;
-const NONCE_LEN: usize = 12;
-const TAG_LEN: usize = 16;
-const SIZE_LEN: usize = 4;
+pub(crate) const NONCE_LEN: usize = 12;
+pub(crate) const TAG_LEN: usize = 16;
+pub(crate) const SIZE_LEN: usize = 4;
 
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
+
+    fn compute_tag(&self, nonce: &[u8], aad: &[u8], ciphertext: &mut [u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +64,18 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         // Truncate result to remove the tag
         result.resize(result.len() - TAG_LEN, 0u8);
         Ok(result)
+    }
+
+    fn compute_tag(&self, nonce: &[u8], aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+        let nonce = ring::aead::Nonce::try_assume_unique_for_key(
+            &nonce,
+        )?;
+        let tag = self.key.seal_in_place_separate_tag(
+            nonce,
+            Aad::from(aad),
+            plaintext,
+        )?;
+        Ok(tag.as_ref().to_vec())
     }
 }
 

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,10 +30,10 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_footer_tag(
+    fn compute_plaintext_tag(
         &self,
         aad: &[u8],
-        plaintext_footer: &mut [u8],
+        plaintext: &mut [u8],
     ) -> Result<Vec<u8>>;
 }
 
@@ -70,20 +70,19 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_footer_tag(
+    fn compute_plaintext_tag(
         &self,
         aad: &[u8],
-        plaintext_footer: &mut [u8],
+        plaintext: &mut [u8],
     ) -> Result<Vec<u8>> {
-        // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let nonce = &plaintext_footer
-            [plaintext_footer.len() - NONCE_LEN - TAG_LEN..plaintext_footer.len() - TAG_LEN];
+        let nonce = &plaintext
+            [plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
-        let plaintext_end = plaintext_footer.len() - NONCE_LEN - TAG_LEN;
+        let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;
         let tag = self.key.seal_in_place_separate_tag(
             nonce,
             Aad::from(aad),
-            &mut plaintext_footer[..plaintext_end],
+            &mut plaintext[..plaintext_end],
         )?;
         Ok(tag.as_ref().to_vec())
     }

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,11 +30,7 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_tag(
-        &self,
-        aad: &[u8],
-        plaintext: &mut [u8],
-    ) -> Result<Vec<u8>>;
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -70,13 +66,8 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_tag(
-        &self,
-        aad: &[u8],
-        plaintext: &mut [u8],
-    ) -> Result<Vec<u8>> {
-        let nonce = &plaintext
-            [plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+        let nonce = &plaintext[plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;
         let tag = self.key.seal_in_place_separate_tag(

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -30,7 +30,7 @@ pub(crate) const SIZE_LEN: usize = 4;
 pub(crate) trait BlockDecryptor: Debug + Send + Sync {
     fn decrypt(&self, length_and_ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>>;
 
-    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>>;
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]
@@ -66,7 +66,8 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
         Ok(result)
     }
 
-    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
+    fn compute_plaintext_tag(&self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+        let mut plaintext = plaintext.to_vec();
         let nonce = &plaintext[plaintext.len() - NONCE_LEN - TAG_LEN..plaintext.len() - TAG_LEN];
         let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
         let plaintext_end = plaintext.len() - NONCE_LEN - TAG_LEN;

--- a/parquet/src/encryption/ciphers.rs
+++ b/parquet/src/encryption/ciphers.rs
@@ -67,14 +67,10 @@ impl BlockDecryptor for RingGcmBlockDecryptor {
     }
 
     fn compute_tag(&self, nonce: &[u8], aad: &[u8], plaintext: &mut [u8]) -> Result<Vec<u8>> {
-        let nonce = ring::aead::Nonce::try_assume_unique_for_key(
-            &nonce,
-        )?;
-        let tag = self.key.seal_in_place_separate_tag(
-            nonce,
-            Aad::from(aad),
-            plaintext,
-        )?;
+        let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce)?;
+        let tag = self
+            .key
+            .seal_in_place_separate_tag(nonce, Aad::from(aad), plaintext)?;
         Ok(tag.as_ref().to_vec())
     }
 }

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -17,9 +17,7 @@
 
 //! Configuration and utilities for decryption of files using Parquet Modular Encryption
 
-use crate::encryption::ciphers::{
-    BlockDecryptor, RingGcmBlockDecryptor, TAG_LEN,
-};
+use crate::encryption::ciphers::{BlockDecryptor, RingGcmBlockDecryptor, TAG_LEN};
 use crate::encryption::modules::{create_footer_aad, create_module_aad, ModuleType};
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::ColumnCryptoMetaData;
@@ -558,7 +556,10 @@ impl FileDecryptor {
     }
 
     /// Verify the signature of the footer
-    pub(crate) fn verify_plaintext_footer_signature(&self, plaintext_footer: &mut [u8]) -> Result<()> {
+    pub(crate) fn verify_plaintext_footer_signature(
+        &self,
+        plaintext_footer: &mut [u8],
+    ) -> Result<()> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
         let tag = plaintext_footer[plaintext_footer.len() - TAG_LEN..].to_vec();
         let aad = create_footer_aad(self.file_aad())?;

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -565,7 +565,7 @@ impl FileDecryptor {
         let aad = create_footer_aad(self.file_aad())?;
         let footer_decryptor = self.get_footer_decryptor()?;
 
-        let computed_tag = footer_decryptor.compute_plaintext_footer_tag(&aad, plaintext_footer)?;
+        let computed_tag = footer_decryptor.compute_plaintext_tag(&aad, plaintext_footer)?;
 
         if computed_tag != tag {
             return Err(general_err!(

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -352,7 +352,7 @@ impl FileDecryptionProperties {
         self.aad_prefix.as_ref()
     }
 
-    /// Returns true if footer signature verification is enabled.
+    /// Returns true if footer signature verification is enabled for files with plaintext footers.
     pub fn check_plaintext_footer_integrity(&self) -> bool {
         self.footer_signature_verification
     }
@@ -507,7 +507,7 @@ impl DecryptionPropertiesBuilder {
         Ok(self)
     }
 
-    /// Specify if footer signature verification should be disabled.
+    /// Disable verification of footer tags for files that use plaintext footers.
     /// Signature verification is enabled by default.
     pub fn disable_footer_signature_verification(mut self) -> Self {
         self.footer_signature_verification = false;

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -17,18 +17,20 @@
 
 //! Configuration and utilities for decryption of files using Parquet Modular Encryption
 
-use crate::encryption::ciphers::{BlockDecryptor, RingGcmBlockDecryptor, NONCE_LEN, TAG_LEN, SIZE_LEN};
+use crate::encryption::ciphers::{
+    BlockDecryptor, RingGcmBlockDecryptor, NONCE_LEN, SIZE_LEN, TAG_LEN,
+};
 use crate::encryption::modules::{create_footer_aad, create_module_aad, ModuleType};
 use crate::errors::{ParquetError, Result};
 use crate::file::column_crypto_metadata::ColumnCryptoMetaData;
+use crate::format::FileMetaData as TFileMetaData;
+use crate::thrift::TSerializable;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::io::Read;
 use std::sync::Arc;
 use thrift::protocol::TCompactOutputProtocol;
-use crate::thrift::TSerializable;
-use crate::format::{FileMetaData as TFileMetaData};
 
 /// Trait for retrieving an encryption key using the key's metadata
 ///
@@ -574,11 +576,7 @@ impl FileDecryptor {
         // let aad = self.file_aad();
         let footer_decryptor = self.get_footer_decryptor()?;
 
-        let computed_tag = footer_decryptor.compute_tag(
-            nonce,
-            aad.as_ref(),
-            &mut plaintext,
-        )?;
+        let computed_tag = footer_decryptor.compute_tag(nonce, aad.as_ref(), &mut plaintext)?;
 
         if computed_tag != tag {
             return Err(general_err!(

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -556,12 +556,9 @@ impl FileDecryptor {
     }
 
     /// Verify the signature of the footer
-    pub(crate) fn verify_plaintext_footer_signature(
-        &self,
-        plaintext_footer: &mut [u8],
-    ) -> Result<()> {
+    pub(crate) fn verify_plaintext_footer_signature(&self, plaintext_footer: &[u8]) -> Result<()> {
         // Plaintext footer format is: [plaintext metadata, nonce, authentication tag]
-        let tag = plaintext_footer[plaintext_footer.len() - TAG_LEN..].to_vec();
+        let tag = &plaintext_footer[plaintext_footer.len() - TAG_LEN..];
         let aad = create_footer_aad(self.file_aad())?;
         let footer_decryptor = self.get_footer_decryptor()?;
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1999,7 +1999,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let base_expected_size = 2312;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2640;
+        let base_expected_size = 2648;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2029,7 +2029,7 @@ mod tests {
         #[cfg(not(feature = "encryption"))]
         let bigger_expected_size = 2816;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3144;
+        let bigger_expected_size = 3152;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -975,10 +975,11 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?);
             if file_decryption_properties.check_plaintext_footer_integrity() {
+                let mut cpy_buf = buf.to_vec();
                 file_decryptor
                     .clone()
                     .unwrap()
-                    .verify_signature(&t_file_metadata, buf.as_ref())?;
+                    .verify_plaintext_footer_signature(cpy_buf.as_mut())?;
             }
         }
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -972,7 +972,7 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?;
             if file_decryption_properties.check_plaintext_footer_integrity() && !encrypted_footer {
-                file_decryptor_value.verify_plaintext_footer_signature(buf.to_vec().as_mut())?;
+                file_decryptor_value.verify_plaintext_footer_signature(buf)?;
             }
             file_decryptor = Some(file_decryptor_value);
         }

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -975,11 +975,10 @@ impl ParquetMetaDataReader {
                 file_decryption_properties,
             )?);
             if file_decryption_properties.check_plaintext_footer_integrity() {
-                let mut cpy_buf = buf.to_vec();
                 file_decryptor
                     .clone()
                     .unwrap()
-                    .verify_plaintext_footer_signature(cpy_buf.as_mut())?;
+                    .verify_plaintext_footer_signature(buf.to_vec().as_mut())?;
             }
         }
 

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -95,7 +95,6 @@ fn test_plaintext_footer_signature_verification() {
         .unwrap_err()
         .to_string()
         .starts_with("Parquet error: Footer signature verification failed. Computed: ["));
-    // verify_encryption_test_file_read(file, decryption_properties);
 }
 
 #[test]

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -43,13 +43,24 @@ use std::sync::Arc;
 fn test_non_uniform_encryption_plaintext_footer() {
     let test_data = arrow::util::test_util::parquet_test_data();
     let path = format!("{test_data}/encrypt_columns_plaintext_footer.parquet.encrypted");
-    let file = File::open(path).unwrap();
+    let file = File::open(path.clone()).unwrap();
 
     // There is always a footer key even with a plaintext footer,
     // but this is used for signing the footer.
     let footer_key = "0123456789012345".as_bytes(); // 128bit/16
     let column_1_key = "1234567890123450".as_bytes();
     let column_2_key = "1234567890123451".as_bytes();
+
+    let decryption_properties = FileDecryptionProperties::builder(footer_key.to_vec())
+        .disable_footer_signature_verification()
+        .with_column_key("double_field", column_1_key.to_vec())
+        .with_column_key("float_field", column_2_key.to_vec())
+        .build()
+        .unwrap();
+
+    verify_encryption_test_file_read(file, decryption_properties);
+
+    let file = File::open(path.clone()).unwrap();
 
     let decryption_properties = FileDecryptionProperties::builder(footer_key.to_vec())
         .with_column_key("double_field", column_1_key.to_vec())


### PR DESCRIPTION
# Which issue does this PR close?

From #7255

> Follow up task to #6637, which adds initial support for reading files that use [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md).
>
> The Parquet format allows encrypting some or all column data while keeping footers in plaintext for compatibility with readers that don't support encryption. Readers that support encryption can still verify the integrity of the footer though, as a 28 byte nonce and GCM tag are written after the plaintext footer metadata (see https://github.com/apache/parquet-format/blob/master/Encryption.md#55-plaintext-footer-mode).
>
>This should be supported in arrow-rs to allow readers to verify the integrity of plaintext footers.
>
>This should probably be optional, eg. in C++ Parquet there's a `FileDecryptionProperties::Builder::disable_footer_signature_verification` method to allow disabling this.


Closes #7255.

# Rationale for this change
 
This adds a mechanism that willl prevent tampering with metadata.

# What changes are included in this PR?

This adds a read-time integrity verification of footer metadata of read file.

# Are there any user-facing changes?

Users get an opaque integrity verification check by default (will throw if failed) and can choose to opt out by calling `FileDecryptionProperties::Builder::disable_footer_signature_verification` method.