### PR TITLE
Speedup `filter_bytes` ~-20-40%, `filter_native` low selectivity (~-37%)

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -654,7 +654,7 @@ where
         (start, end, len)
     }
 
-    fn set_capacity_idx(&mut self, iter: impl Iterator<Item = usize>) {
+    fn extend_offsets_idx(&mut self, iter: impl Iterator<Item = usize>) {
         self.dst_offsets.extend(iter.map(|idx| {
             let start = self.src_offsets[idx].as_usize();
             let end = self.src_offsets[idx + 1].as_usize();
@@ -676,7 +676,7 @@ where
         }
     }
 
-    fn set_capacity_slices(&mut self, iter: impl Iterator<Item = (usize, usize)>, count: usize) {
+    fn extend_offsets_slices(&mut self, iter: impl Iterator<Item = (usize, usize)>, count: usize) {
         self.dst_offsets.reserve_exact(count);
         for (start, end) in iter {
             // These can only fail if `array` contains invalid data
@@ -712,19 +712,19 @@ where
 
     match &predicate.strategy {
         IterationStrategy::SlicesIterator => {
-            filter.set_capacity_slices(SlicesIterator::new(&predicate.filter), predicate.count);
+            filter.extend_offsets_slices(SlicesIterator::new(&predicate.filter), predicate.count);
             filter.extend_slices(SlicesIterator::new(&predicate.filter))
         }
         IterationStrategy::Slices(slices) => {
-            filter.set_capacity_slices(slices.iter().cloned(), predicate.count);
+            filter.extend_offsets_slices(slices.iter().cloned(), predicate.count);
             filter.extend_slices(slices.iter().cloned())
         }
         IterationStrategy::IndexIterator => {
-            filter.set_capacity_idx(IndexIterator::new(&predicate.filter, predicate.count));
+            filter.extend_offsets_idx(IndexIterator::new(&predicate.filter, predicate.count));
             filter.extend_idx(IndexIterator::new(&predicate.filter, predicate.count))
         }
         IterationStrategy::Indices(indices) => {
-            filter.set_capacity_idx(indices.iter().cloned());
+            filter.extend_offsets_idx(indices.iter().cloned());
             filter.extend_idx(indices.iter().cloned())
         }
         IterationStrategy::All | IterationStrategy::None => unreachable!(),

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -662,11 +662,12 @@ where
 
             self.cur_offset
         }));
-        self.dst_values.reserve_exact(self.cur_offset.as_usize());
     }
 
     /// Extends the in-progress array by the indexes in the provided iterator
     fn extend_idx(&mut self, iter: impl Iterator<Item = usize>) {
+        self.dst_values.reserve_exact(self.cur_offset.as_usize());
+
         for idx in iter {
             let start = self.src_offsets[idx].as_usize();
             let end = self.src_offsets[idx + 1].as_usize();
@@ -685,11 +686,12 @@ where
                 self.dst_offsets.push(self.cur_offset);
             }
         }
-        self.dst_values.reserve_exact(self.cur_offset.as_usize());
     }
 
     /// Extends the in-progress array by the ranges in the provided iterator
     fn extend_slices(&mut self, iter: impl Iterator<Item = (usize, usize)>) {
+        self.dst_values.reserve_exact(self.cur_offset.as_usize());
+
         for (start, end) in iter {
             let value_start = self.get_value_offset(start);
             let value_end = self.get_value_offset(end);

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -615,25 +615,6 @@ struct FilterBytes<'a, OffsetSize> {
     cur_offset: OffsetSize,
 }
 
-/// abc
-pub trait PushUnchecked<T> {
-    /// Will push an item and not check if there is enough capacity
-    ///
-    /// # Safety
-    /// Caller must ensure the array has enough capacity to hold `T`.
-    unsafe fn push_unchecked(&mut self, value: T);
-}
-
-impl<T> PushUnchecked<T> for Vec<T> {
-    #[inline]
-    unsafe fn push_unchecked(&mut self, value: T) {
-        debug_assert!(self.capacity() > self.len());
-        let end = self.as_mut_ptr().add(self.len());
-        std::ptr::write(end, value);
-        self.set_len(self.len() + 1);
-    }
-}
-
 impl<'a, OffsetSize> FilterBytes<'a, OffsetSize>
 where
     OffsetSize: OffsetSizeTrait,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7465

* We can precalculate capacity for the 
* Use `Vec` api for `filter_native` to generate some faster code.

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

<details>

```
filter context string (kept 1/2)
                        time:   [494.54 µs 496.78 µs 499.12 µs]
                        change: [-4.6353% -2.8403% -1.1083%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe

filter context string high selectivity (kept 1023/1024)
                        time:   [655.05 µs 657.74 µs 660.21 µs]
                        change: [-42.752% -41.103% -39.592%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 24 outliers among 100 measurements (24.00%)
  5 (5.00%) low severe
  8 (8.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe

filter context string low selectivity (kept 1/1024)
                        time:   [616.29 ns 617.36 ns 618.40 ns]
                        change: [-26.996% -26.638% -26.282%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe


filter context i32 low selectivity (kept 1/1024)
                        time:   [139.28 ns 139.80 ns 140.41 ns]
                        change: [-37.655% -37.164% -36.612%] (p = 0.00 < 0.05)
                        Performance has improved.

```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
