### PR TITLE
support merging primitive dictionaries in interleave and concat

### DIFF
--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -132,7 +132,7 @@ fn merge_concat_byte_dictionaries<K: ArrowDictionaryKeyType>(
     dictionaries: &[&DictionaryArray<K>],
     output_len: usize,
 ) -> Result<ArrayRef, ArrowError> {
-    let merged = merge_dictionary_values(&dictionaries, None)?;
+    let merged = merge_dictionary_values(dictionaries, None)?;
 
     // Recompute keys
     let mut key_values = Vec::with_capacity(output_len);
@@ -341,7 +341,7 @@ where
 
 macro_rules! dict_helper {
     ($t:ty, $value_type:expr, $arrays:expr) => {
-        return Ok(concat_dictionaries::<$t>($value_type.as_ref(), $arrays)?)
+        concat_dictionaries::<$t>($value_type.as_ref(), $arrays)
     };
 }
 

--- a/arrow-select/src/dictionary.rs
+++ b/arrow-select/src/dictionary.rs
@@ -102,7 +102,7 @@ fn bytes_ptr_eq<T: ByteArrayType>(a: &dyn Array, b: &dyn Array) -> bool {
 }
 
 /// A type-erased function that compares two array for pointer equality
-type PtrEq = dyn Fn(&dyn Array, &dyn Array) -> bool;
+type PtrEq = fn(&dyn Array, &dyn Array) -> bool;
 
 /// A weak heuristic of whether to merge dictionary values that aims to only
 /// perform the expensive merge computation when it is likely to yield at least
@@ -115,12 +115,12 @@ pub fn should_merge_dictionary_values<K: ArrowDictionaryKeyType>(
 ) -> bool {
     use DataType::*;
     let first_values = dictionaries[0].values().as_ref();
-    let ptr_eq: Box<PtrEq> = match first_values.data_type() {
-        Utf8 => Box::new(bytes_ptr_eq::<Utf8Type>),
-        LargeUtf8 => Box::new(bytes_ptr_eq::<LargeUtf8Type>),
-        Binary => Box::new(bytes_ptr_eq::<BinaryType>),
-        LargeBinary => Box::new(bytes_ptr_eq::<LargeBinaryType>),
-        _ => return false,
+    let ptr_eq: PtrEq = match first_values.data_type() {
+        Utf8 => bytes_ptr_eq::<Utf8Type>,
+        LargeUtf8 => bytes_ptr_eq::<LargeUtf8Type>,
+        Binary => bytes_ptr_eq::<BinaryType>,
+        LargeBinary => bytes_ptr_eq::<LargeBinaryType>,
+        _ => |_, _| false,
     };
 
     let mut single_dictionary = true;

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -249,7 +249,7 @@ fn merge_interleave_byte_dictionaries<K: ArrowDictionaryKeyType>(
         })
         .collect();
 
-    let merged = merge_dictionary_values(&dictionaries, Some(&masks))?;
+    let merged = merge_dictionary_values(dictionaries, Some(&masks))?;
 
     // Recompute keys
     let mut keys = PrimitiveBuilder::<K>::with_capacity(indices.len());


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7466 

# Rationale for this change
 
Fixes a panic :)

# What changes are included in this PR?

Introduces a strategy for merging primitive dictionaries to deduplicate values when naive concatentation would overflow the key type.

Tests for both `interleave` and `concat` are included.

# Are there any user-facing changes?

Just the bugfix.
