### PR TITLE
Document Arrow <--> Parquet schema conversion better

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -316,10 +316,11 @@ impl ArrowReaderOptions {
 
     /// Provide a schema to use when reading the Parquet file.
     ///
-    /// If provided, this schema takes precedence over the schema inferred from
-    /// the file or the schema defined  in the file's metadata (see the [`arrow`]
-    /// documentation for more details). If the provided schema is not compatible
-    /// with the file's schema, an error will be returned when constructing the builder.
+    /// If provided, this schema takes precedence over the schema defined in the 
+    /// arrow file's metadata (see the [`arrow`] documentation for more details). 
+    /// If the provided schema is not compatible with the data stored in the 
+    /// parquet file schema, an error will be returned when constructing the 
+    /// builder.
     ///
     /// This option is only required if you want to explicitly control the
     /// conversion of Parquet types to Arrow types, such as casting a column to

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -286,7 +286,10 @@ impl<T> ArrowReaderBuilder<T> {
 pub struct ArrowReaderOptions {
     /// Should the reader strip any user defined metadata from the Arrow schema
     skip_arrow_metadata: bool,
-    /// If provided used as the schema for the file, otherwise the schema is read from the file
+    /// If provided used as the schema hint when determining the Arrow schema,
+    /// otherwise the schema hint is read from the [ARROW_SCHEMA_META_KEY]
+    ///
+    /// [ARROW_SCHEMA_META_KEY]: crate::arrow::ARROW_SCHEMA_META_KEY
     supplied_schema: Option<SchemaRef>,
     /// If true, attempt to read `OffsetIndex` and `ColumnIndex`
     pub(crate) page_index: bool,
@@ -316,10 +319,10 @@ impl ArrowReaderOptions {
 
     /// Provide a schema to use when reading the Parquet file.
     ///
-    /// If provided, this schema takes precedence over the schema defined in the 
-    /// arrow file's metadata (see the [`arrow`] documentation for more details). 
-    /// If the provided schema is not compatible with the data stored in the 
-    /// parquet file schema, an error will be returned when constructing the 
+    /// If provided, this schema takes precedence over the schema defined in the
+    /// arrow file's metadata (see the [`arrow`] documentation for more details).
+    /// If the provided schema is not compatible with the data stored in the
+    /// parquet file schema, an error will be returned when constructing the
     /// builder.
     ///
     /// This option is only required if you want to explicitly control the

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -319,8 +319,8 @@ impl ArrowReaderOptions {
 
     /// Provide a schema to use when reading the Parquet file.
     ///
-    /// If provided, this schema takes precedence over the schema defined in the
-    /// arrow file's metadata (see the [`arrow`] documentation for more details).
+    /// If provided, this schema takes precedence over any schema defined in the
+    /// file's schema hint in the metadata (see the [`arrow`] documentation for more details).
     /// If the provided schema is not compatible with the data stored in the
     /// parquet file schema, an error will be returned when constructing the
     /// builder.
@@ -335,8 +335,8 @@ impl ArrowReaderOptions {
     ///
     /// # Notes
     ///
-    /// The supplied schema must have the same number of columns as the parquet schema and
-    /// the column names need to be the same.
+    /// The provided schema must have the same number of columns as the parquet schema and
+    /// the column names must be the same.
     ///
     /// # Example
     /// ```

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -314,14 +314,19 @@ impl ArrowReaderOptions {
         }
     }
 
-    /// Provide a schema to use when reading the parquet file. If provided it
-    /// takes precedence over the schema inferred from the file or the schema defined
-    /// in the file's metadata. If the schema is not compatible with the file's
-    /// schema an error will be returned when constructing the builder.
+    /// Provide a schema to use when reading the Parquet file.
     ///
-    /// This option is only required if you want to cast columns to a different type.
-    /// For example, if you wanted to cast from an Int64 in the Parquet file to a Timestamp
-    /// in the Arrow schema.
+    /// If provided, this schema takes precedence over the schema inferred from
+    /// the file or the schema defined  in the file's metadata (see [`arrow`]
+    /// documentation for more details). If the provided schema is not compatible
+    /// with the file's schema, an error will be returned when constructing the builder.
+    ///
+    /// This option is only required if you want to explicitly control the
+    /// conversion of Parquet types to Arrow types, such as casting a column to
+    /// a different type. For example, if you wanted to read an Int64 in
+    /// a Parquet file to a [`TimestampMicrosecondArray`] in the Arrow schema.
+    ///
+    /// # Notes
     ///
     /// The supplied schema must have the same number of columns as the parquet schema and
     /// the column names need to be the same.

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -317,10 +317,11 @@ impl ArrowReaderOptions {
         }
     }
 
-    /// Provide a schema to use when reading the Parquet file.
+    /// Provide a schema hint to use when reading the Parquet file.
     ///
-    /// If provided, this schema takes precedence over any schema defined in the
-    /// file's schema hint in the metadata (see the [`arrow`] documentation for more details).
+    /// If provided, this schema takes precedence over any arrow schema embedded
+    /// in the metadata (see the [`arrow`] documentation for more details).
+    ///
     /// If the provided schema is not compatible with the data stored in the
     /// parquet file schema, an error will be returned when constructing the
     /// builder.

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -317,7 +317,7 @@ impl ArrowReaderOptions {
     /// Provide a schema to use when reading the Parquet file.
     ///
     /// If provided, this schema takes precedence over the schema inferred from
-    /// the file or the schema defined  in the file's metadata (see [`arrow`]
+    /// the file or the schema defined  in the file's metadata (see the [`arrow`]
     /// documentation for more details). If the provided schema is not compatible
     /// with the file's schema, an error will be returned when constructing the builder.
     ///
@@ -325,6 +325,9 @@ impl ArrowReaderOptions {
     /// conversion of Parquet types to Arrow types, such as casting a column to
     /// a different type. For example, if you wanted to read an Int64 in
     /// a Parquet file to a [`TimestampMicrosecondArray`] in the Arrow schema.
+    ///
+    /// [`arrow`]: crate::arrow
+    /// [`TimestampMicrosecondArray`]: arrow_array::TimestampMicrosecondArray
     ///
     /// # Notes
     ///

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -32,9 +32,9 @@
 //!
 //! To recover the original Arrow types, the writers in this module add
 //! metadata in the [`ARROW_SCHEMA_META_KEY`] key to record the original Arrow
-//! schema. The metadata follows the same convention as arrow-cpp based 
-//! implementations such as `pyarrow`. The reader looks for this metadata to 
-//! determine Arrow types, and if it is not present, use reasonable defaults. 
+//! schema. The metadata follows the same convention as arrow-cpp based
+//! implementations such as `pyarrow`. The reader looks for this metadata to
+//! determine Arrow types, and if it is not present, use reasonable defaults.
 //! You can also control the type conversion process in more detail using:
 //!
 //! * [`ArrowSchemaConverter`] control the conversion of Arrow types to Parquet
@@ -206,7 +206,7 @@ pub use self::schema::{
 };
 
 /// Schema metadata key used to store serialized Arrow schema
-/// 
+///
 /// The Arrow schema is encoded using the Arrow IPC format, and then base64
 /// encoded. This is the same format used by arrow-cpp systems, such as pyarrow.
 pub const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -32,9 +32,10 @@
 //!
 //! To recover the original Arrow types, the writers in this module add
 //! metadata in the [`ARROW_SCHEMA_META_KEY`] key to record the original Arrow
-//! schema. The readers look for this metadata to determine Arrow types, and if
-//! it is not present, use reasonable defaults. You can also control the type
-//! conversion process in more detail using:
+//! schema. The metadata follows the same convention as arrow-cpp based 
+//! implementations such as `pyarrow`. The reader looks for this metadata to 
+//! determine Arrow types, and if it is not present, use reasonable defaults. 
+//! You can also control the type conversion process in more detail using:
 //!
 //! * [`ArrowSchemaConverter`] control the conversion of Arrow types to Parquet
 //!   types.
@@ -204,7 +205,10 @@ pub use self::schema::{
     parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns, ArrowSchemaConverter, FieldLevels,
 };
 
-/// Schema metadata key used to store serialized Arrow IPC schema
+/// Schema metadata key used to store serialized Arrow schema
+/// 
+/// The Arrow schema is encoded using the Arrow IPC format, and then base64
+/// encoded. This is the same format used by arrow-cpp systems, such as pyarrow.
 pub const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 
 /// The value of this metadata key, if present on [`Field::metadata`], will be used

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -30,17 +30,17 @@
 //! stored as a Parquet [`BYTE_ARRAY`] can be read as either an Arrow
 //! [`BinaryViewArray`] or [`BinaryArray`].
 //!
-//! To recover the original Arrow types, the writers in this module add
-//! metadata in the [`ARROW_SCHEMA_META_KEY`] key to record the original Arrow
-//! schema. The metadata follows the same convention as arrow-cpp based
-//! implementations such as `pyarrow`. The reader looks for this metadata to
-//! determine Arrow types, and if it is not present, use reasonable defaults.
+//! To recover the original Arrow types, the writers in this module add a "hint" to
+//! the metadata in the [`ARROW_SCHEMA_META_KEY`] key which records the original Arrow
+//! schema. The metadata hint follows the same convention as arrow-cpp based
+//! implementations such as `pyarrow`. The reader looks for the schema hint in the
+//! metadata to determine Arrow types, and if it is not present, use reasonable defaults.
 //! You can also control the type conversion process in more detail using:
 //!
 //! * [`ArrowSchemaConverter`] control the conversion of Arrow types to Parquet
 //!   types.
 //!
-//! * [`ArrowReaderOptions::with_schema`] to explicitly specify what Arrow types
+//! * [`ArrowReaderOptions::with_schema`] to explicitly specify your own Arrow schema hint
 //!   to use when reading Parquet, overriding any metadata that may be present.
 //!
 //! [`RecordBatch`]: arrow_array::RecordBatch

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -34,10 +34,10 @@
 //! the metadata in the [`ARROW_SCHEMA_META_KEY`] key which records the original Arrow
 //! schema. The metadata hint follows the same convention as arrow-cpp based
 //! implementations such as `pyarrow`. The reader looks for the schema hint in the
-//! metadata to determine Arrow types, and if it is not present, infers the arrow schema
-//! from the parquet schema.
+//! metadata to determine Arrow types, and if it is not present, infers the Arrow schema
+//! from the Parquet schema.
 //!
-//! In situations where the embedded Arrow schema is not compatible with the parquet
+//! In situations where the embedded Arrow schema is not compatible with the Parquet
 //! schema, the parquet schema takes precedence and no error is raised.
 //! See [#1663](https://github.com/apache/arrow-rs/issues/1663)
 //!

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -34,7 +34,12 @@
 //! the metadata in the [`ARROW_SCHEMA_META_KEY`] key which records the original Arrow
 //! schema. The metadata hint follows the same convention as arrow-cpp based
 //! implementations such as `pyarrow`. The reader looks for the schema hint in the
-//! metadata to determine Arrow types, and if it is not present, use reasonable defaults.
+//! metadata to determine Arrow types, and if it is not present, infers the arrow schema
+//! from the parquet schema.
+//!
+//! In situations where the embedded arrow schema is not compatible with the parquet
+//! schema, the parquet schema takes precedence - see [#1663](https://github.com/apache/arrow-rs/issues/1663)
+//!
 //! You can also control the type conversion process in more detail using:
 //!
 //! * [`ArrowSchemaConverter`] control the conversion of Arrow types to Parquet

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -37,8 +37,9 @@
 //! metadata to determine Arrow types, and if it is not present, infers the arrow schema
 //! from the parquet schema.
 //!
-//! In situations where the embedded arrow schema is not compatible with the parquet
-//! schema, the parquet schema takes precedence - see [#1663](https://github.com/apache/arrow-rs/issues/1663)
+//! In situations where the embedded Arrow schema is not compatible with the parquet
+//! schema, the parquet schema takes precedence and no error is raised.
+//! See [#1663](https://github.com/apache/arrow-rs/issues/1663)
 //!
 //! You can also control the type conversion process in more detail using:
 //!

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -38,7 +38,7 @@
 //! from the Parquet schema.
 //!
 //! In situations where the embedded Arrow schema is not compatible with the Parquet
-//! schema, the parquet schema takes precedence and no error is raised.
+//! schema, the Parquet schema takes precedence and no error is raised.
 //! See [#1663](https://github.com/apache/arrow-rs/issues/1663)
 //!
 //! You can also control the type conversion process in more detail using:

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -223,8 +223,8 @@ pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterP
 }
 
 /// Converter for Arrow schema to Parquet schema
-/// 
-/// See the documentation on the [`arrow`] module for background 
+///
+/// See the documentation on the [`arrow`] module for background
 /// information on how Arrow schema is represented in Parquet.
 ///
 /// [`arrow`]: crate::arrow

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -104,7 +104,13 @@ pub struct FieldLevels {
 /// Convert a parquet [`SchemaDescriptor`] to [`FieldLevels`]
 ///
 /// Columns not included within [`ProjectionMask`] will be ignored.
-///
+/// 
+/// The optional `hint` parameter is the desired Arrow schema. See the
+/// [`arrow`] module documentation for more information.
+/// 
+/// [`arrow`]: crate::arrow
+/// 
+/// # Notes:
 /// Where a field type in `hint` is compatible with the corresponding parquet type in `schema`, it
 /// will be used, otherwise the default arrow type for the given parquet column type will be used.
 ///
@@ -192,8 +198,12 @@ pub fn encode_arrow_schema(schema: &Schema) -> String {
     BASE64_STANDARD.encode(&len_prefix_schema)
 }
 
-/// Mutates writer metadata by storing the encoded Arrow schema.
+/// Mutates writer metadata by storing the encoded Arrow schema hint in
+/// [`ARROW_SCHEMA_META_KEY`].
+/// 
 /// If there is an existing Arrow schema metadata, it is replaced.
+/// 
+/// [`ARROW_SCHEMA_META_KEY`]: crate::arrow::ARROW_SCHEMA_META_KEY
 pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterProperties) {
     let encoded = encode_arrow_schema(schema);
 

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -104,12 +104,12 @@ pub struct FieldLevels {
 /// Convert a parquet [`SchemaDescriptor`] to [`FieldLevels`]
 ///
 /// Columns not included within [`ProjectionMask`] will be ignored.
-/// 
+///
 /// The optional `hint` parameter is the desired Arrow schema. See the
 /// [`arrow`] module documentation for more information.
-/// 
+///
 /// [`arrow`]: crate::arrow
-/// 
+///
 /// # Notes:
 /// Where a field type in `hint` is compatible with the corresponding parquet type in `schema`, it
 /// will be used, otherwise the default arrow type for the given parquet column type will be used.
@@ -200,9 +200,9 @@ pub fn encode_arrow_schema(schema: &Schema) -> String {
 
 /// Mutates writer metadata by storing the encoded Arrow schema hint in
 /// [`ARROW_SCHEMA_META_KEY`].
-/// 
+///
 /// If there is an existing Arrow schema metadata, it is replaced.
-/// 
+///
 /// [`ARROW_SCHEMA_META_KEY`]: crate::arrow::ARROW_SCHEMA_META_KEY
 pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterProperties) {
     let encoded = encode_arrow_schema(schema);

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -223,6 +223,9 @@ pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterP
 }
 
 /// Converter for Arrow schema to Parquet schema
+/// 
+/// See the documentation on the [`arrow`] module for background 
+/// information on how Arrow schema is represented in Parquet.
 ///
 /// Example:
 /// ```

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -227,7 +227,9 @@ pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterP
 /// See the documentation on the [`arrow`] module for background 
 /// information on how Arrow schema is represented in Parquet.
 ///
-/// Example:
+/// [`arrow`]: crate::arrow
+///
+/// # Example:
 /// ```
 /// # use std::sync::Arc;
 /// # use arrow_schema::{Field, Schema, DataType};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
There have been several questions / changes related to Arrow and Parquet schema recently for example
- https://github.com/apache/arrow-rs/pull/7446#issuecomment-2849267829 from @albertlockett 
- https://github.com/apache/arrow-rs/issues/7220 from @mbutrovich 
- https://github.com/apache/arrow-rs/issues/5625 from @Liyixin95

I realized the high level behavior was not well documented anywhere so I wanted to do that (so I have a place to refer people to mostly)

# What changes are included in this PR?

Document the schema conversion process

# Are there any user-facing changes?
Documentation only changes, no code or behavior changes
