### PR TITLE
Improve error messages if schema hint mismatches with parquet schema

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -1073,8 +1073,8 @@ mod tests {
 
         let a = Int64Array::from(vec![1, 2, 3, 4, 5]);
 
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]);
-        assert!(batch.is_err());
+        let err = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap_err();
+        assert_eq!(err.to_string(), "Invalid argument error: column types must match schema types, expected Int32 but found Int64 at column index 0");
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -109,7 +109,6 @@ where
 /// not contiguous.
 ///
 /// [`RowSelection`]: crate::arrow::arrow_reader::RowSelection
-
 pub struct RowFilter {
     /// A list of [`ArrowPredicate`]
     pub(crate) predicates: Vec<Box<dyn ArrowPredicate>>,

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -18,6 +18,7 @@
 use crate::arrow::ProjectionMask;
 use arrow_array::{BooleanArray, RecordBatch};
 use arrow_schema::ArrowError;
+use std::fmt::{Debug, Formatter};
 
 /// A predicate operating on [`RecordBatch`]
 ///
@@ -108,9 +109,16 @@ where
 /// not contiguous.
 ///
 /// [`RowSelection`]: crate::arrow::arrow_reader::RowSelection
+
 pub struct RowFilter {
     /// A list of [`ArrowPredicate`]
     pub(crate) predicates: Vec<Box<dyn ArrowPredicate>>,
+}
+
+impl Debug for RowFilter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RowFilter {{ {} predicates: }}", self.predicates.len())
+    }
 }
 
 impl RowFilter {

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -565,6 +565,14 @@ impl ArrowReaderMetadata {
                     field2.is_nullable()
                 ));
             }
+            if field1.metadata() != field2.metadata() {
+                errors.push(format!(
+                    "metadata mismatch for field {}: expected {:?} but found {:?}",
+                    field1.name(),
+                    field1.metadata(),
+                    field2.metadata()
+                ));
+            }
         }
 
         if !errors.is_empty() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/arrow-rs/issues/7460

# Rationale for this change
 
Per https://github.com/apache/arrow-rs/pull/7479#issuecomment-2859515712 the error messages are pretty bad as they tell you what fields were mismatched but not what about them was different

# What changes are included in this PR?

1. Improve error messages
2. Add some `Debug` impls for the reader builders so I could use `unwrap_err`

# Are there any user-facing changes?
better errors, new Debug impls
