### PR TITLE
fix: `rustdoc::unportable_markdown` was removed

### DIFF
--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -45,7 +45,6 @@ use prost::Message;
 
 #[allow(clippy::all)]
 mod gen {
-    #![allow(rustdoc::unportable_markdown)]
     // Since this file is auto-generated, we suppress all warnings
     #![allow(missing_docs)]
     include!("arrow.flight.protocol.sql.rs");


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
Nightly CI fails with:

```text
  Documenting arrow-flight v55.0.0 (/__w/arrow-rs/arrow-rs/arrow-flight)
error: lint `rustdoc::unportable_markdown` has been removed: old parser removed
  --> arrow-flight/src/sql/mod.rs:48:14
   |
48 |     #![allow(rustdoc::unportable_markdown)]
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D renamed-and-removed-lints` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: could not document `arrow-flight`
```

due to https://github.com/rust-lang/rust/pull/140709 .

# What changes are included in this PR?
\-

# Are there any user-facing changes?
\-