### PR TITLE
[Variant] Add (empty) `parquet-variant` crate, update `parquet-testing` pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "arrow-select",
     "arrow-string",
     "parquet",
+    "parquet-variant",
     "parquet_derive",
     "parquet_derive_test",
 ]

--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "parquet-variant"
+# This package is still in development and thus the version does
+# not follow the versions of the rest of the crates in this repo.
+version = "0.1.0"
+license = { workspace = true }
+description = "Apache Parquet Variant implementation in Rust"
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+keywords = ["arrow", "parquet", "variant"]
+readme = "README.md"
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+
+[lib]
+
+

--- a/parquet-variant/README.md
+++ b/parquet-variant/README.md
@@ -22,8 +22,8 @@
 [![crates.io](https://img.shields.io/crates/v/parquet-variant.svg)](https://crates.io/crates/parquet-variant)
 [![docs.rs](https://img.shields.io/docsrs/parquet-variant.svg)](https://docs.rs/parquet/latest/parquet-variant/)
 
-This crate contains an implementation of [Variant Binary Encoding], part of
-[Apache Parquet], which is part of the [Apache Arrow] project.
+This crate contains an implementation of [Variant Binary Encoding] from
+[Apache Parquet]. This software is developed as part of the [Apache Arrow] project.
 
 [Variant Binary Encoding]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
 [Apache Parquet]: https://parquet.apache.org/

--- a/parquet-variant/README.md
+++ b/parquet-variant/README.md
@@ -1,0 +1,44 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache Parquet Variant Rust Implementation
+
+[![crates.io](https://img.shields.io/crates/v/parquet-variant.svg)](https://crates.io/crates/parquet-variant)
+[![docs.rs](https://img.shields.io/docsrs/parquet-variant.svg)](https://docs.rs/parquet/latest/parquet-variant/)
+
+This crate contains an implementation of [Variant Binary Encoding], part of
+[Apache Parquet], which is part of the [Apache Arrow] project.
+
+[Variant Binary Encoding]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
+[Apache Parquet]: https://parquet.apache.org/
+[Apache Arrow]: https://arrow.apache.org/
+
+Please see the [API documentation](https://docs.rs/parquet-variant/latest) for more details.
+
+## 🚧 Work In Progress
+
+NOTE: This crate is under active development and is not yet ready for production use. 
+If you are interested in helping, you can find more information on the GitHub [Variant issue]
+
+[Variant issue]: https://github.com/apache/arrow-rs/issues/6736
+
+
+## License
+
+Licensed under the Apache License, Version 2.0: <http://www.apache.org/licenses/LICENSE-2.0>.

--- a/parquet-variant/src/lib.rs
+++ b/parquet-variant/src/lib.rs
@@ -19,7 +19,6 @@
 //!
 //! [Variant Binary Encoding]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
 //! [Apache Parquet]: https://parquet.apache.org/
-//! [Apache Arrow]: https://arrow.apache.org/
 //!
 //! ## 🚧 Work In Progress
 //!

--- a/parquet-variant/src/lib.rs
+++ b/parquet-variant/src/lib.rs
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Implementation of [Variant Binary Encoding] from [Apache Parquet].
+//!
+//! [Variant Binary Encoding]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
+//! [Apache Parquet]: https://parquet.apache.org/
+//! [Apache Arrow]: https://arrow.apache.org/
+//!
+//! ## 🚧 Work In Progress
+//!
+//! This crate is under active development and is not yet ready for production use.
+//! If you are interested in helping, you can find more information on the GitHub [Variant issue]
+//!
+//! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/6736

# Rationale for this change
 
We are adding support for Variant and thus we should add a new crate where the new code will live and that clearly explains the current status. 

# What changes are included in this PR?

1. Add a new `parquet-variant` crate
2. Add README
3. Update `parquet-testing` submodule to include variant test data added in https://github.com/apache/parquet-testing/pull/76

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Not yet

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
