### PR TITLE
Prevent FlightSQL server panics for `do_put` when stream is empty or 1st stream element is an Err

### DIFF
--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -113,6 +113,8 @@ pub mod client;
 pub mod metadata;
 pub mod server;
 
+pub use crate::streams::FallibleRequestStream;
+
 /// ProstMessageExt are useful utility methods for prost::Message types
 pub trait ProstMessageExt: prost::Message + Default {
     /// type_url for this Message

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -722,10 +722,9 @@ where
             })]);
             return Ok(Response::new(Box::pin(output)));
         };
-        let cmd = cmd?;
 
         let message =
-            Any::decode(&*cmd.flight_descriptor.unwrap().cmd).map_err(decode_error_to_status)?;
+            Any::decode(&*cmd?.flight_descriptor.unwrap().cmd).map_err(decode_error_to_status)?;
         match Command::try_from(message).map_err(arrow_error_to_status)? {
             Command::CommandStatementUpdate(command) => {
                 let record_count = self.do_put_statement_update(command, request).await?;

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -20,9 +20,6 @@
 use std::fmt::{Display, Formatter};
 use std::pin::Pin;
 
-use futures::{stream::Peekable, Stream, StreamExt};
-use prost::Message;
-use tonic::{Request, Response, Status, Streaming};
 use super::{
     ActionBeginSavepointRequest, ActionBeginSavepointResult, ActionBeginTransactionRequest,
     ActionBeginTransactionResult, ActionCancelQueryRequest, ActionCancelQueryResult,
@@ -41,6 +38,9 @@ use crate::{
     FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult,
     SchemaResult, Ticket,
 };
+use futures::{stream::Peekable, Stream, StreamExt};
+use prost::Message;
+use tonic::{Request, Response, Status, Streaming};
 
 pub(crate) static CREATE_PREPARED_STATEMENT: &str = "CreatePreparedStatement";
 pub(crate) static CLOSE_PREPARED_STATEMENT: &str = "ClosePreparedStatement";

--- a/arrow-flight/src/streams.rs
+++ b/arrow-flight/src/streams.rs
@@ -32,7 +32,7 @@ use std::task::{ready, Poll};
 ///
 /// This can be used to accept a stream of `Result<_>` from a client API and send
 /// them to the remote server that wants only the successful results.
-pub(crate) struct FallibleRequestStream<T, E> {
+pub struct FallibleRequestStream<T, E> {
     /// sender to notify error
     sender: Option<Sender<E>>,
     /// fallible stream
@@ -40,7 +40,8 @@ pub(crate) struct FallibleRequestStream<T, E> {
 }
 
 impl<T, E> FallibleRequestStream<T, E> {
-    pub(crate) fn new(
+    /// Create a FallibleRequestStream
+    pub fn new(
         sender: Sender<E>,
         fallible_stream: Pin<Box<dyn Stream<Item = std::result::Result<T, E>> + Send + 'static>>,
     ) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?
Closes #7329 .

# Rationale for this change
 When executing a `do_put` call, there are currently 2 cases that will cause the FlightSQL server to panic:
- the request stream is empty
- the first element of the request stream is an Err

This change stops the FlightSQL server from panicking in both cases.

# Are there any user-facing changes?

- If the client sends an empty request stream, the server reports that 0 records were affected.
- If the client sends a stream where the first element is an Err, the Err is reported back by the client and stream processing stops. This is the same as the current behavior when the Err is not the first element.

The server does not panic in either case.