### PR TITLE
Speed up arithmetic kernels, reduce `unsafe` usage

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -21,7 +21,7 @@ use arrow_array::builder::BufferBuilder;
 use arrow_array::*;
 use arrow_buffer::buffer::NullBuffer;
 use arrow_buffer::ArrowNativeType;
-use arrow_buffer::{Buffer, MutableBuffer};
+use arrow_buffer::MutableBuffer;
 use arrow_data::ArrayData;
 use arrow_schema::ArrowError;
 

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -130,7 +130,8 @@ where
         .zip(b.values())
         .map(|(l, r)| op(*l, *r));
 
-    let buffer: Vec<_> = values.collect();    Ok(PrimitiveArray::new(buffer.into(), nulls))
+    let buffer: Vec<_> = values.collect();
+    Ok(PrimitiveArray::new(buffer.into(), nulls))
 }
 
 /// Applies a binary and infallible function to values in two arrays, replacing

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -124,14 +124,13 @@ where
 
     let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
-    let values = a.values().iter().zip(b.values()).map(|(l, r)| op(*l, *r));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size from a PrimitiveArray
-    let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
-    Ok(PrimitiveArray::new(buffer.into(), nulls))
+    let values = a
+        .values()
+        .into_iter()
+        .zip(b.values())
+        .map(|(l, r)| op(*l, *r));
+
+    let buffer: Vec<_> = values.collect();    Ok(PrimitiveArray::new(buffer.into(), nulls))
 }
 
 /// Applies a binary and infallible function to values in two arrays, replacing

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -730,7 +730,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Creates a PrimitiveArray based on a constant value with `count` elements
     pub fn from_value(value: T::Native, count: usize) -> Self {
         let val_buf: Vec<_> = vec![value; count];
-        Self::new(val_buf.into(), None)        }
+        Self::new(val_buf.into(), None)
     }
 
     /// Returns an iterator that returns the values of `array.value(i)` for an iterator with each element `i`

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -828,7 +828,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     {
         let nulls = self.nulls().cloned();
         let values = self.values().into_iter().map(|v| op(*v));
-        let buffer:Vec<_> = values.collect();
+        let buffer: Vec<_> = values.collect();
         PrimitiveArray::new(buffer.into(), nulls)
     }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -827,13 +827,8 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         F: Fn(T::Native) -> O::Native,
     {
         let nulls = self.nulls().cloned();
-        let values = self.values().iter().map(|v| op(*v));
-        // JUSTIFICATION
-        //  Benefit
-        //      ~60% speedup
-        //  Soundness
-        //      `values` is an iterator with a known size because arrays are sized.
-        let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
+        let values = self.values().into_iter().map(|v| op(*v));
+        let buffer:Vec<_> = values.collect();
         PrimitiveArray::new(buffer.into(), nulls)
     }
 
@@ -1035,13 +1030,10 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         F: FnMut(U::Item) -> T::Native,
     {
         let nulls = left.logical_nulls();
-        let buffer = unsafe {
+        let buffer: Vec<_> = (0..left.len())
             // SAFETY: i in range 0..left.len()
-            let iter = (0..left.len()).map(|i| op(left.value_unchecked(i)));
-            // SAFETY: upper bound is trusted because `iter` is over a range
-            Buffer::from_trusted_len_iter(iter)
-        };
-
+            .map(|i| op(unsafe { left.value_unchecked(i) }))
+            .collect();
         PrimitiveArray::new(buffer.into(), nulls)
     }
 

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -729,10 +729,8 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
     /// Creates a PrimitiveArray based on a constant value with `count` elements
     pub fn from_value(value: T::Native, count: usize) -> Self {
-        unsafe {
-            let val_buf = Buffer::from_trusted_len_iter((0..count).map(|_| value));
-            Self::new(val_buf.into(), None)
-        }
+        let val_buf: Vec<_> = vec![value; count];
+        Self::new(val_buf.into(), None)        }
     }
 
     /// Returns an iterator that returns the values of `array.value(i)` for an iterator with each element `i`


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7494

<details>

```
add(0)                  time:   [6.4821 µs 6.4910 µs 6.5021 µs]
                        change: [-19.934% -18.915% -17.753%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

add_checked(0)          time:   [6.4683 µs 6.4811 µs 6.4968 µs]
                        change: [-20.065% -19.129% -18.000%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

add_scalar(0)           time:   [3.7622 µs 3.8155 µs 3.8785 µs]
                        change: [-27.847% -25.770% -23.413%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

subtract(0)             time:   [6.4670 µs 6.4979 µs 6.5382 µs]
                        change: [-21.056% -20.048% -18.927%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  3 (3.00%) high mild
  14 (14.00%) high severe

subtract_checked(0)     time:   [6.4643 µs 6.4894 µs 6.5301 µs]
                        change: [-20.731% -19.624% -18.022%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

subtract_scalar(0)      time:   [3.7351 µs 3.7820 µs 3.8389 µs]
                        change: [-24.080% -21.711% -19.214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

multiply(0)             time:   [6.6112 µs 6.7054 µs 6.8188 µs]
                        change: [-15.626% -14.183% -12.472%] (p = 0.00 < 0.05)
                        Performance has improved.

multiply_checked(0)     time:   [6.4615 µs 6.4715 µs 6.4835 µs]
                        change: [-20.333% -19.516% -18.569%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe

multiply_scalar(0)      time:   [3.8698 µs 3.9090 µs 3.9474 µs]
                        change: [-18.145% -15.365% -12.281%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

divide(0)               time:   [6.4552 µs 6.4607 µs 6.4674 µs]
                        change: [-21.795% -21.073% -20.470%] (p = 0.00 < 0.05)
                        Performance has improved.
```
</details>

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
