### PR TITLE
Introduce `ReadPlan` to encapsulate the calculation of what parquet rows to decode

### DIFF
--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -1,0 +1,249 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`ReadPlan`] and [`ReadPlanBuilder`] for determining which rows to read
+//! from a Parquet file
+
+use crate::arrow::array_reader::ArrayReader;
+use crate::arrow::arrow_reader::{
+    ArrowPredicate, ParquetRecordBatchReader, RowSelection, RowSelector,
+};
+use crate::errors::{ParquetError, Result};
+use arrow_array::Array;
+use arrow_select::filter::prep_null_mask_filter;
+use std::collections::VecDeque;
+
+/// A builder for [`ReadPlan`]
+#[derive(Clone)]
+pub(crate) struct ReadPlanBuilder {
+    batch_size: usize,
+    /// Current to apply, includes all filters
+    selection: Option<RowSelection>,
+}
+
+impl ReadPlanBuilder {
+    /// Create a `ReadPlanBuilder` with the given batch size
+    pub(crate) fn new(batch_size: usize) -> Self {
+        Self {
+            batch_size,
+            selection: None,
+        }
+    }
+
+    /// Set the current selection to the given value
+    pub(crate) fn with_selection(mut self, selection: Option<RowSelection>) -> Self {
+        self.selection = selection;
+        self
+    }
+
+    /// Returns the current selection, if any
+    pub(crate) fn selection(&self) -> Option<&RowSelection> {
+        self.selection.as_ref()
+    }
+
+    /// Specifies the number of rows in the row group, before filtering is applied.
+    ///
+    /// Returns a [`LimitedReadPlanBuilder`] that can apply
+    /// offset and limit.
+    ///
+    /// Call [`LimitedReadPlanBuilder::build_limited`] to apply the limits to this
+    /// selection.
+    pub(crate) fn limited(self, row_count: usize) -> LimitedReadPlanBuilder {
+        LimitedReadPlanBuilder::new(self, row_count)
+    }
+
+    /// Returns true if the current plan selects any rows
+    pub(crate) fn selects_any(&self) -> bool {
+        self.selection
+            .as_ref()
+            .map(|s| s.selects_any())
+            .unwrap_or(true)
+    }
+
+    /// Returns the number of rows selected, or `None` if all rows are selected.
+    pub(crate) fn num_rows_selected(&self) -> Option<usize> {
+        self.selection.as_ref().map(|s| s.row_count())
+    }
+
+    /// Evaluates an [`ArrowPredicate`], updating this plan's `selection`
+    ///
+    /// If the current `selection` is `Some`, the resulting [`RowSelection`]
+    /// will be the conjunction of the existing selection and the rows selected
+    /// by `predicate`.
+    ///
+    /// Note: pre-existing selections may come from evaluating a previous predicate
+    /// or if the [`ParquetRecordBatchReader`] specified an explicit
+    /// [`RowSelection`] in addition to one or more predicates.
+    pub(crate) fn with_predicate(
+        mut self,
+        array_reader: Box<dyn ArrayReader>,
+        predicate: &mut dyn ArrowPredicate,
+    ) -> Result<Self> {
+        let reader = ParquetRecordBatchReader::new(array_reader, self.clone().build());
+        let mut filters = vec![];
+        for maybe_batch in reader {
+            let maybe_batch = maybe_batch?;
+            let input_rows = maybe_batch.num_rows();
+            let filter = predicate.evaluate(maybe_batch)?;
+            // Since user supplied predicate, check error here to catch bugs quickly
+            if filter.len() != input_rows {
+                return Err(arrow_err!(
+                    "ArrowPredicate predicate returned {} rows, expected {input_rows}",
+                    filter.len()
+                ));
+            }
+            match filter.null_count() {
+                0 => filters.push(filter),
+                _ => filters.push(prep_null_mask_filter(&filter)),
+            };
+        }
+
+        let raw = RowSelection::from_filters(&filters);
+        self.selection = match self.selection.take() {
+            Some(selection) => Some(selection.and_then(&raw)),
+            None => Some(raw),
+        };
+        Ok(self)
+    }
+
+    /// Create a final `ReadPlan` the read plan for the scan
+    pub(crate) fn build(mut self) -> ReadPlan {
+        // If selection is empty, truncate
+        if !self.selects_any() {
+            self.selection = Some(RowSelection::from(vec![]));
+        }
+        let Self {
+            batch_size,
+            selection,
+        } = self;
+
+        let selection = selection.map(|s| s.trim().into());
+
+        ReadPlan {
+            batch_size,
+            selection,
+        }
+    }
+}
+
+/// Bbuilder for [`ReadPlan`] that applies a limit and offset to the read plan
+///
+/// See [`ReadPlanBuilder::limited`] to create this builder.
+pub(crate) struct LimitedReadPlanBuilder {
+    /// The underlying builder
+    inner: ReadPlanBuilder,
+    /// Total number of rows in the row group before the selection, limit or
+    /// offset are applied
+    row_count: usize,
+    /// The offset to apply, if any
+    offset: Option<usize>,
+    /// The limit to apply, if any
+    limit: Option<usize>,
+}
+
+impl LimitedReadPlanBuilder {
+    /// Create a new `LimitedReadPlanBuilder` from the existing builder and number of rows
+    fn new(inner: ReadPlanBuilder, row_count: usize) -> Self {
+        Self {
+            inner,
+            row_count,
+            offset: None,
+            limit: None,
+        }
+    }
+
+    /// Set the offset to apply to the read plan
+    pub(crate) fn with_offset(mut self, offset: Option<usize>) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Set the limit to apply to the read plan
+    pub(crate) fn with_limit(mut self, limit: Option<usize>) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Apply offset and limit, updating the selection on the underlying builder
+    /// and returning it.
+    pub(crate) fn build_limited(self) -> ReadPlanBuilder {
+        let Self {
+            mut inner,
+            row_count,
+            offset,
+            limit,
+        } = self;
+
+        // If the selection is empty, truncate
+        if !inner.selects_any() {
+            inner.selection = Some(RowSelection::from(vec![]));
+        }
+
+        // If an offset is defined, apply it to the `selection`
+        if let Some(offset) = offset {
+            inner.selection = Some(match row_count.checked_sub(offset) {
+                None => RowSelection::from(vec![]),
+                Some(remaining) => inner
+                    .selection
+                    .map(|selection| selection.offset(offset))
+                    .unwrap_or_else(|| {
+                        RowSelection::from(vec![
+                            RowSelector::skip(offset),
+                            RowSelector::select(remaining),
+                        ])
+                    }),
+            });
+        }
+
+        // If a limit is defined, apply it to the final `selection`
+        if let Some(limit) = limit {
+            inner.selection = Some(
+                inner
+                    .selection
+                    .map(|selection| selection.limit(limit))
+                    .unwrap_or_else(|| {
+                        RowSelection::from(vec![RowSelector::select(limit.min(row_count))])
+                    }),
+            );
+        }
+
+        inner
+    }
+}
+
+/// A plan reading specific rows from a Parquet Row Group.
+///
+/// See [`ReadPlanBuilder`] to create `ReadPlan`s
+pub(crate) struct ReadPlan {
+    /// The number of rows to read in each batch
+    batch_size: usize,
+    /// Row ranges to be selected from the data source
+    selection: Option<VecDeque<RowSelector>>,
+}
+
+impl ReadPlan {
+    /// Returns a mutable reference to the selection, if any
+    pub(crate) fn selection_mut(&mut self) -> Option<&mut VecDeque<RowSelector>> {
+        self.selection.as_mut()
+    }
+
+    /// Return the number of rows to read in each output batch
+    #[inline(always)]
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -140,7 +140,7 @@ impl ReadPlanBuilder {
     }
 }
 
-/// Bbuilder for [`ReadPlan`] that applies a limit and offset to the read plan
+/// Builder for [`ReadPlan`] that applies a limit and offset to the read plan
 ///
 /// See [`ReadPlanBuilder::limited`] to create this builder.
 pub(crate) struct LimitedReadPlanBuilder {


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/7456

# Rationale for this change

We are trying to improve the performance of filter pushdown in the Parquet reader

This is currently challening for at least a few reasons:
1. The filtering is spread out through several structs (`RowSelection`, `RowFilter`, limit, offset). 
2. There is non trivial duplication between the sync and async_readers when preparing these selections

This makes the complexity of trying to implement more sophisticated strategies for iteration very hard (see @zhuqi-lucas 's comment here for example https://github.com/apache/arrow-rs/pull/7454#issuecomment-2875783776)

The high level plan to improve filter performance is a combination of
1. Saving some/all of the previously evaluated filter columns somewhere to avoid decoding them a second time
2. Changing the representation of what rows are selected based on the results of applying `RowFilter` (aka https://github.com/apache/arrow-rs/issues/5523)

This I would like a place to put all "what rows to read" information so we can implement more sophisticated strategies without getting too hung up. 

Here is an example of how this code is used when caching results:
- https://github.com/apache/arrow-rs/pull/7513

# What changes are included in this PR?
1. Pull the `RowSelection` manipulation code into `ReadPlan` and `ReadPlanBuilder
2. Remove the duplication of logic between sync/async readers

In addition to preparing for faster filter pushdown, I also happen to think this makes the code easier to understand so it would be a useful change in its own right

# Are there any user-facing changes?

No. This is entirely an internal code reorganization
