### PR TITLE
RecordBatchDecoder: skip RecordBatch validation when `skip_validation` property is enabled

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -518,6 +518,7 @@ impl<'a> RecordBatchDecoder<'a> {
             }
 
             if self.skip_validation.get() {
+                // Safety: setting `skip_validation` requires `unsafe`, user assures data is valid
                 unsafe {
                     Ok(RecordBatch::new_unchecked(
                         schema,

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -490,13 +490,24 @@ impl<'a> RecordBatchDecoder<'a> {
                     self.skip_field(field, &mut variadic_counts)?;
                 }
             }
-            assert!(variadic_counts.is_empty());
+
             arrays.sort_by_key(|t| t.0);
-            RecordBatch::try_new_with_options(
-                Arc::new(schema.project(projection)?),
-                arrays.into_iter().map(|t| t.1).collect(),
-                &options,
-            )
+
+            let schema = Arc::new(schema.project(projection)?);
+            let columns = arrays.into_iter().map(|t| t.1).collect::<Vec<_>>();
+
+            if self.skip_validation.get() {
+                unsafe {
+                    Ok(RecordBatch::new_unchecked(
+                        schema,
+                        columns,
+                        self.batch.length() as usize,
+                    ))
+                }
+            } else {
+                assert!(variadic_counts.is_empty());
+                RecordBatch::try_new_with_options(schema, columns, &options)
+            }
         } else {
             let mut children = vec![];
             // keep track of index as lists require more than one node
@@ -504,8 +515,19 @@ impl<'a> RecordBatchDecoder<'a> {
                 let child = self.create_array(field, &mut variadic_counts)?;
                 children.push(child);
             }
-            assert!(variadic_counts.is_empty());
-            RecordBatch::try_new_with_options(schema, children, &options)
+
+            if self.skip_validation.get() {
+                unsafe {
+                    Ok(RecordBatch::new_unchecked(
+                        schema,
+                        children,
+                        self.batch.length() as usize,
+                    ))
+                }
+            } else {
+                assert!(variadic_counts.is_empty());
+                RecordBatch::try_new_with_options(schema, children, &options)
+            }
         }
     }
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -497,6 +497,7 @@ impl<'a> RecordBatchDecoder<'a> {
             let columns = arrays.into_iter().map(|t| t.1).collect::<Vec<_>>();
 
             if self.skip_validation.get() {
+                // Safety: setting `skip_validation` requires `unsafe`, user assures data is valid
                 unsafe {
                     Ok(RecordBatch::new_unchecked(
                         schema,


### PR DESCRIPTION
# Which issue does this PR close?
This is kind of a niche issue, but at the very least there should be some performance gains. We have to deal with legacy files that don't exactly follow the spec, so we rely on skipping the validation not because of performance reasons, but because the spec is incorrectly implemented by custom legacy libs (on the consuming and the producing side).

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7508.

# Rationale for this change
When you create a `StreamReader` with the unsafe config `with_skip_validation(true)`, the `RecordBatch`'es still get validated [here](https://github.com/nilskch/arrow-rs/blob/1f15130414bdfc01c8989ec95702655bf553c5c5/arrow-array/src/record_batch.rs#L300), because the `read_record_batch` func of the `RecordBatchDecoder` did not respect the `skip_validation` property.



<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The validation logic for creating `RecordBatch`es gets skipped if `skip_validation` is set to true.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No, unless they relied on the validation logic even though they explicitly set the `skip_validation` property to true.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
