### PR TITLE
Fix record API support for reading INT32 encoded TIME_MILLIS

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -1055,6 +1055,10 @@ mod tests {
         let row = Field::convert_int32(&descr, 14611);
         assert_eq!(row, Field::Date(14611));
 
+        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::TIME_MILLIS];
+        let row = Field::convert_int32(&descr, 14611);
+        assert_eq!(row, Field::TimestampMillis(14611));
+
         let descr = make_column_descr![PhysicalType::INT32, ConvertedType::DECIMAL, 0, 8, 2];
         let row = Field::convert_int32(&descr, 444);
         assert_eq!(row, Field::Decimal(Decimal::from_i32(444, 8, 2)));

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -671,6 +671,7 @@ impl Field {
             ConvertedType::UINT_16 => Field::UShort(value as u16),
             ConvertedType::UINT_32 => Field::UInt(value as u32),
             ConvertedType::DATE => Field::Date(value),
+            ConvertedType::TIME_MILLIS => Field::TimestampMillis(value as i64),
             ConvertedType::DECIMAL => Field::Decimal(Decimal::from_i32(
                 value,
                 descr.type_precision(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7510

# Rationale for this change
 
Snowflake exports with this encoding, so (I'm assuming) it's a valid representation, and we should support parsing it.

# What changes are included in this PR?

The ability to parse INT32 encoded TIME_MILLIS in the record API, and a test.

# Are there any user-facing changes?

No

