### PR TITLE
Fix Clippy in CI for Rust 1.87 release

### DIFF
--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -485,6 +485,7 @@ impl<K: ArrowDictionaryKeyType> DictionaryArray<K> {
 
     /// Returns `PrimitiveDictionaryBuilder` of this dictionary array for mutating
     /// its keys and values if the underlying data buffer is not shared by others.
+    #[allow(clippy::result_large_err)]
     pub fn into_primitive_dict_builder<V>(self) -> Result<PrimitiveDictionaryBuilder<K, V>, Self>
     where
         V: ArrowPrimitiveType,
@@ -541,6 +542,7 @@ impl<K: ArrowDictionaryKeyType> DictionaryArray<K> {
     /// assert_eq!(typed.value(1), 11);
     /// assert_eq!(typed.value(2), 21);
     /// ```
+    #[allow(clippy::result_large_err)]
     pub fn unary_mut<F, V>(self, op: F) -> Result<DictionaryArray<K>, DictionaryArray<K>>
     where
         V: ArrowPrimitiveType,

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -112,6 +112,7 @@ static TABLES: Lazy<Vec<&'static str>> = Lazy::new(|| vec!["flight_sql.example.t
 pub struct FlightSqlServiceImpl {}
 
 impl FlightSqlServiceImpl {
+    #[allow(clippy::result_large_err)]
     fn check_token<T>(&self, req: &Request<T>) -> Result<(), Status> {
         let metadata = req.metadata();
         let auth = metadata.get("authorization").ok_or_else(|| {

--- a/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
@@ -76,7 +76,7 @@ pub async fn run_scenario(host: &str, port: u16) -> Result {
     Ok(())
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[allow(clippy::result_large_err)]
 fn middleware_interceptor(mut req: Request<()>) -> Result<Request<()>, Status> {
     let metadata = req.metadata_mut();
     metadata.insert("x-middleware", "expected value".parse().unwrap());

--- a/arrow-string/src/binary_predicate.rs
+++ b/arrow-string/src/binary_predicate.rs
@@ -21,6 +21,7 @@ use memchr::memmem::Finder;
 use std::iter::zip;
 
 /// A binary based predicate
+#[allow(clippy::large_enum_variant)]
 pub enum BinaryPredicate<'a> {
     Contains(Finder<'a>),
     StartsWith(&'a [u8]),

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,6 +24,7 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),

--- a/parquet/benches/arrow_reader_clickbench.rs
+++ b/parquet/benches/arrow_reader_clickbench.rs
@@ -711,7 +711,7 @@ impl ReadTest {
             .schema_descr();
 
         // Determine the correct selection ("ProjectionMask")
-        let projection_mask = if projection_columns.iter().any(|&name| name == "*") {
+        let projection_mask = if projection_columns.contains(&"*") {
             // * means all columns
             ProjectionMask::all()
         } else {

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -702,9 +702,7 @@ mod lz4_hadoop_codec {
             input_len -= PREFIX_LEN;
 
             if input_len < expected_compressed_size as usize {
-                return Err(io::Error::other(
-                    "Not enough bytes for Hadoop frame",
-                ));
+                return Err(io::Error::other("Not enough bytes for Hadoop frame"));
             }
 
             if output_len < expected_decompressed_size as usize {
@@ -716,9 +714,7 @@ mod lz4_hadoop_codec {
                 lz4_flex::decompress_into(&input[..expected_compressed_size as usize], output)
                     .map_err(|e| ParquetError::External(Box::new(e)))?;
             if decompressed_size != expected_decompressed_size as usize {
-                return Err(io::Error::other(
-                    "Unexpected decompressed size",
-                ));
+                return Err(io::Error::other("Unexpected decompressed size"));
             }
             input_len -= expected_compressed_size as usize;
             output_len -= expected_decompressed_size as usize;
@@ -733,9 +729,7 @@ mod lz4_hadoop_codec {
         if input_len == 0 {
             Ok(read_bytes)
         } else {
-            Err(io::Error::other(
-                "Not all input are consumed",
-            ))
+            Err(io::Error::other("Not all input are consumed"))
         }
     }
 

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -702,15 +702,13 @@ mod lz4_hadoop_codec {
             input_len -= PREFIX_LEN;
 
             if input_len < expected_compressed_size as usize {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "Not enough bytes for Hadoop frame",
                 ));
             }
 
             if output_len < expected_decompressed_size as usize {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "Not enough bytes to hold advertised output",
                 ));
             }
@@ -718,8 +716,7 @@ mod lz4_hadoop_codec {
                 lz4_flex::decompress_into(&input[..expected_compressed_size as usize], output)
                     .map_err(|e| ParquetError::External(Box::new(e)))?;
             if decompressed_size != expected_decompressed_size as usize {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "Unexpected decompressed size",
                 ));
             }
@@ -736,8 +733,7 @@ mod lz4_hadoop_codec {
         if input_len == 0 {
             Ok(read_bytes)
         } else {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
+            Err(io::Error::other(
                 "Not all input are consumed",
             ))
         }

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -147,7 +147,7 @@ pub type Result<T, E = ParquetError> = result::Result<T, E>;
 
 impl From<ParquetError> for io::Error {
     fn from(e: ParquetError) -> Self {
-        io::Error::new(io::ErrorKind::Other, e)
+        io::Error::other(e)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
Rust 1.87 was released today https://releases.rs/docs/1.87.0/ and with it some new clippy lints

Some new clippy failures now happen on main as a result, for example https://github.com/apache/arrow-rs/actions/runs/15054299671/job/42316440085



# What changes are included in this PR?

1. Run `cargo update` and fix all clippy errors


# Are there any user-facing changes?
No, this is all internal changes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
