### PR TITLE
arrow: add concat structs benchmark

### DIFF
--- a/arrow/benches/concatenate_kernel.rs
+++ b/arrow/benches/concatenate_kernel.rs
@@ -15,13 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+extern crate arrow;
 #[macro_use]
 extern crate criterion;
 use std::sync::Arc;
 
 use criterion::Criterion;
-
-extern crate arrow;
 
 use arrow::array::*;
 use arrow::compute::concat;
@@ -178,6 +177,50 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("concat fixed size lists", |b| {
         b.iter(|| bench_concat(&v1, &v2))
     });
+
+    {
+        let batch_size = 1024;
+        let batch_count = 2;
+        let struct_arrays = (0..batch_count)
+            .map(|_| {
+                let ints = create_primitive_array::<Int32Type>(batch_size, 0.0);
+                let string_dict = create_sparse_dict_from_values::<Int32Type>(
+                    batch_size,
+                    0.0,
+                    &create_string_array_with_len::<i32>(20, 0.0, 10),
+                    0..10,
+                );
+                let int_dict = create_sparse_dict_from_values::<UInt16Type>(
+                    batch_size,
+                    0.0,
+                    &create_primitive_array::<Int64Type>(20, 0.0),
+                    0..10,
+                );
+                let fields = vec![
+                    Field::new("int_field", ints.data_type().clone(), false),
+                    Field::new("strings_dict_field", string_dict.data_type().clone(), false),
+                    Field::new("int_dict_field", int_dict.data_type().clone(), false),
+                ];
+
+                StructArray::try_new(
+                    fields.clone().into(),
+                    vec![Arc::new(ints), Arc::new(string_dict), Arc::new(int_dict)],
+                    None,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let array_refs = struct_arrays
+            .iter()
+            .map(|a| a as &dyn Array)
+            .collect::<Vec<_>>();
+
+        c.bench_function(
+            &format!("concat struct with int32 and dicts size={batch_size} count={batch_count}"),
+            |b| b.iter(|| bench_concat_arrays(&array_refs)),
+        );
+    }
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Rationale for this change
 
A struct concatenation benchmark was requested in https://github.com/apache/arrow-rs/pull/7517#pullrequestreview-2846228798

# What changes are included in this PR?

This PR creates a struct with a primitive field, and two sparse dictionary fields (one primitive, one utf8) and benchmarks concatenation.