### PR TITLE
fix: Panic in pretty_format function when displaying DurationSecondsA…

### DIFF
--- a/arrow-array/src/temporal_conversions.rs
+++ b/arrow-array/src/temporal_conversions.rs
@@ -215,28 +215,28 @@ pub(crate) fn split_second(v: i64, base: i64) -> (i64, u32) {
     (v.div_euclid(base), v.rem_euclid(base) as u32)
 }
 
-/// converts a `i64` representing a `duration(s)` to [`Duration`]
+/// converts a `i64` representing a `duration(s)` to [`Option<Duration>`]
 #[inline]
-pub fn duration_s_to_duration(v: i64) -> Duration {
-    Duration::try_seconds(v).unwrap()
+pub fn duration_s_to_duration(v: i64) -> Option<Duration> {
+    Duration::try_seconds(v)
 }
 
-/// converts a `i64` representing a `duration(ms)` to [`Duration`]
+/// converts a `i64` representing a `duration(ms)` to [`Option<Duration>`]
 #[inline]
-pub fn duration_ms_to_duration(v: i64) -> Duration {
-    Duration::try_milliseconds(v).unwrap()
+pub fn duration_ms_to_duration(v: i64) -> Option<Duration> {
+    Duration::try_milliseconds(v)
 }
 
-/// converts a `i64` representing a `duration(us)` to [`Duration`]
+/// converts a `i64` representing a `duration(us)` to [`Option<Duration>`]
 #[inline]
-pub fn duration_us_to_duration(v: i64) -> Duration {
-    Duration::microseconds(v)
+pub fn duration_us_to_duration(v: i64) -> Option<Duration> {
+    Some(Duration::microseconds(v))
 }
 
-/// converts a `i64` representing a `duration(ns)` to [`Duration`]
+/// converts a `i64` representing a `duration(ns)` to [`Option<Duration>`]
 #[inline]
-pub fn duration_ns_to_duration(v: i64) -> Duration {
-    Duration::nanoseconds(v)
+pub fn duration_ns_to_duration(v: i64) -> Option<Duration> {
+    Some(Duration::nanoseconds(v))
 }
 
 /// Converts an [`ArrowPrimitiveType`] to [`NaiveDateTime`]
@@ -296,10 +296,10 @@ pub fn as_time<T: ArrowPrimitiveType>(v: i64) -> Option<NaiveTime> {
 pub fn as_duration<T: ArrowPrimitiveType>(v: i64) -> Option<Duration> {
     match T::DATA_TYPE {
         DataType::Duration(unit) => match unit {
-            TimeUnit::Second => Some(duration_s_to_duration(v)),
-            TimeUnit::Millisecond => Some(duration_ms_to_duration(v)),
-            TimeUnit::Microsecond => Some(duration_us_to_duration(v)),
-            TimeUnit::Nanosecond => Some(duration_ns_to_duration(v)),
+            TimeUnit::Second => duration_s_to_duration(v),
+            TimeUnit::Millisecond => duration_ms_to_duration(v),
+            TimeUnit::Microsecond => duration_us_to_duration(v),
+            TimeUnit::Nanosecond => duration_ns_to_duration(v),
         },
         _ => None,
     }

--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -37,6 +37,7 @@ all-features = true
 
 [features]
 prettyprint = ["comfy-table"]
+default     = ["prettyprint"]
 force_validate = []
 
 [dependencies]


### PR DESCRIPTION
…rray with i64::MIN / i64::MAX

# Which issue does this PR close?

[Closes #7533](https://github.com/apache/arrow-rs/issues/7533)

# Rationale for this change
 
Support panic handling and print invalid result.


Also added testing
```rust
 #[test]
    fn duration_pretty_and_iso_extremes() {
        // Build [MIN, MAX, 3661, NULL]
        let arr = DurationSecondArray::from(vec![Some(i64::MIN), Some(i64::MAX), Some(3661), None]);
        let array: ArrayRef = Arc::new(arr);

        // Pretty formatting
        let opts = FormatOptions::default().with_null("<NULL>");
        let opts = opts.with_duration_format(DurationFormat::Pretty);
        let pretty = pretty_format_columns_with_options("pretty", &[array.clone()], &opts)
            .unwrap()
            .to_string();
        assert_eq!(pretty.matches("<invalid>").count(), 2);
        assert!(pretty.contains("0 days 1 hours 1 mins 1 secs"));
        assert!(pretty.contains("<NULL>"));

        // ISO8601 formatting
        let opts_iso = FormatOptions::default()
            .with_null("<NULL>")
            .with_duration_format(DurationFormat::ISO8601);
        let iso = pretty_format_columns_with_options("iso", &[array], &opts_iso)
            .unwrap()
            .to_string();
        assert_eq!(iso.matches("<invalid>").count(), 2);
        assert!(iso.contains("PT3661S"));
        assert!(iso.contains("<NULL>"));
    }
```

# What changes are included in this PR?

Support panic handling and print invalid result.
# Are there any user-facing changes?


Support panic handling and print invalid result.
