### PR TITLE
Fix `filter_record_batch` panics with empty struct array

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -857,7 +857,14 @@ fn filter_struct(
         None
     };
 
-    Ok(unsafe { StructArray::new_unchecked(array.fields().clone(), columns, nulls) })
+    Ok(unsafe {
+        StructArray::new_unchecked_with_length(
+            array.fields().clone(),
+            columns,
+            nulls,
+            predicate.count(),
+        )
+    })
 }
 
 /// `filter` implementation for sparse unions


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7538 

# Rationale for this change
 
This prevents a panic that can happen with empty struct arrays.

# What changes are included in this PR?

Small unit test that exacerbates the panic by attempting to filter a struct array with no columns. 
Fix was to call `StructArray:new_unchecked_with_length` since the predicate of the filter contains the number rows the array requires.

# Are there any user-facing changes?
No


