### PR TITLE
WIP: Avoid allocations when applying filters to RowSelection

### DIFF
--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -112,10 +112,9 @@ impl ReadPlanBuilder {
             };
         }
 
-        let raw = RowSelection::from_filters(&filters);
         self.selection = match self.selection.take() {
-            Some(selection) => Some(selection.and_then(&raw)),
-            None => Some(raw),
+            Some(selection) => Some(selection.apply_filters(&filters)),
+            None => Some(RowSelection::from_filters(&filters)),
         };
         Ok(self)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Related to #7458 

# Rationale for this change
It has been observed that `and_then` is slow. Let's try and optimize it by avoiding an extra copy

# What changes are included in this PR?

1. Refactor code into explicit iterators so we can build the final output RowSelection directly from filters, rather than instantiating the intermediate selectors first.

# Are there any user-facing changes?
No (other than hopefully faster performance)

