### PR TITLE
Fix CI on main due to logical conflict

### DIFF
--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -422,7 +422,7 @@ fn make_data_type<'a>(
                 "Enum of {e:?} not currently supported"
             ))),
             ComplexType::Map(m) => {
-                let val = make_data_type(&m.values, namespace, resolver)?;
+                let val = make_data_type(&m.values, namespace, resolver, use_utf8view)?;
                 Ok(AvroDataType {
                     nullability: None,
                     metadata: m.attributes.field_metadata(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
- https://github.com/apache/arrow-rs/pull/7451 had a logical conflict with 
- https://github.com/apache/arrow-rs/pull/7434

Which results in an error: https://github.com/apache/arrow-rs/actions/runs/15216929616/job/42804494443

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> arrow-avro/src/codec.rs:425:27
    |
425 |                 let val = make_data_type(&m.values, namespace, resolver)?;
    |                           ^^^^^^^^^^^^^^-------------------------------- argument #4 of type `bool` is missing
    |
note: function defined here
   --> arrow-avro/src/codec.rs:334:4
    |
334 | fn make_data_type<'a>(
    |    ^^^^^^^^^^^^^^
...
338 |     use_utf8view: bool,
    |     ------------------
help: provide the argument
    |
4[25](https://github.com/apache/arrow-rs/actions/runs/15216929616/job/42804494443#step:14:26) |                 let val = make_data_type(&m.values, namespace, resolver, /* bool */)?;
    |                                                                        ++++++++++++
```

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Fix compilation

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
