### PR TITLE
Fix: Converted feature flight-sql-experimental to flight-sql

### DIFF
--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -60,7 +60,7 @@ jobs:
           cargo test -p arrow-flight --all-features
       - name: Test --examples
         run: |
-          cargo test -p arrow-flight  --features=flight-sql-experimental,tls --examples
+          cargo test -p arrow-flight  --features=flight-sql,tls --examples
 
   vendor:
     name: Verify Vendored Code

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -85,18 +85,18 @@ uuid = { version = "1.10.0", features = ["v4"] }
 
 [[example]]
 name = "flight_sql_server"
-required-features = ["flight-sql-experimental", "tls"]
+required-features = ["flight-sql", "tls"]
 
 [[bin]]
 name = "flight_sql_client"
-required-features = ["cli", "flight-sql-experimental", "tls"]
+required-features = ["cli", "flight-sql", "tls"]
 
 [[test]]
 name = "flight_sql_client"
 path = "tests/flight_sql_client.rs"
-required-features = ["flight-sql-experimental", "tls"]
+required-features = ["flight-sql", "tls"]
 
 [[test]]
 name = "flight_sql_client_cli"
 path = "tests/flight_sql_client_cli.rs"
-required-features = ["cli", "flight-sql-experimental", "tls"]
+required-features = ["cli", "flight-sql", "tls"]

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -61,7 +61,9 @@ all-features = true
 
 [features]
 default = []
-flight-sql-experimental = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
+flight-sql = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
+# TODO: Remove in the next release
+flight-sql-experimental = ["flight-sql"]
 tls = ["tonic/tls"]
 # Enable CLI tools
 cli = ["arrow-array/chrono-tz", "arrow-cast/prettyprint", "tonic/tls-webpki-roots", "dep:anyhow", "dep:clap", "dep:tracing-log", "dep:tracing-subscriber"]

--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -43,8 +43,10 @@ that demonstrate how to build a Flight server implemented with [tonic](https://d
 
 ## Feature Flags
 
-- `flight-sql-experimental`: Enables experimental support for
+- `flight-sql`: Enables experimental support for
   [Apache Arrow FlightSQL], a protocol for interacting with SQL databases.
+
+- `flight-sql-experimental` : Deprecated feature and will be removed in next release
 
 - `tls`: Enables `tls` on `tonic`
 
@@ -55,7 +57,7 @@ This crates offers a basic [Apache Arrow FlightSQL] command line interface.
 The client can be installed from the repository:
 
 ```console
-$ cargo install --features=cli,flight-sql-experimental,tls --bin=flight_sql_client --path=. --locked
+$ cargo install --features=cli,flight-sql,tls --bin=flight_sql_client --path=. --locked
 ```
 
 The client comes with extensive help text:

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -32,8 +32,10 @@
 //! 2. Low level [tonic] generated [`flight_service_client`] and
 //!    [`flight_service_server`].
 //!
-//! 3. Experimental support for [Flight SQL] in [`sql`]. Requires the
-//!    `flight-sql-experimental` feature of this crate to be activated.
+//! 3. Support for [Flight SQL] in [`sql`]. Requires the
+//!    `flight-sql` feature of this crate to be activated.
+//! 
+//! 4. The feature [`flight-sql-experimental`] is deprecated and will be removed in a future release.
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
 
@@ -128,7 +130,7 @@ mod trailers;
 
 pub mod utils;
 
-#[cfg(feature = "flight-sql-experimental")]
+#[cfg(feature = "flight-sql")]
 pub mod sql;
 mod streams;
 

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! 3. Support for [Flight SQL] in [`sql`]. Requires the
 //!    `flight-sql` feature of this crate to be activated.
-//! 
+//!
 //! 4. The feature [`flight-sql-experimental`] is deprecated and will be removed in a future release.
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #7498

# Rationale for this change

Just some Cargo.toml changes 
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Changed the `flight-sql-experimental` feature flag to `flight-sql` with backwards compatibility in [arrow-flight](https://github.com/apache/arrow-rs/blob/main/arrow-flight/Cargo.toml#L64)

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
