### PR TITLE
Fix `Result` name collision in parquet_derive

### DIFF
--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -114,7 +114,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
       fn write_to_row_group<W: ::std::io::Write + Send>(
         &self,
         row_group_writer: &mut ::parquet::file::writer::SerializedRowGroupWriter<'_, W>
-      ) -> std::result::Result<(), ::parquet::errors::ParquetError> {
+      ) -> ::std::result::Result<(), ::parquet::errors::ParquetError> {
         use ::parquet::column::writer::ColumnWriter;
 
         let mut row_group_writer = row_group_writer;
@@ -135,7 +135,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         Ok(())
       }
 
-      fn schema(&self) -> std::result::Result<::parquet::schema::types::TypePtr, ::parquet::errors::ParquetError> {
+      fn schema(&self) -> ::std::result::Result<::parquet::schema::types::TypePtr, ::parquet::errors::ParquetError> {
         use ::parquet::schema::types::Type as ParquetType;
         use ::parquet::schema::types::TypePtr;
         use ::parquet::basic::LogicalType;
@@ -211,7 +211,7 @@ pub fn parquet_record_reader(input: proc_macro::TokenStream) -> proc_macro::Toke
         &mut self,
         row_group_reader: &mut dyn ::parquet::file::reader::RowGroupReader,
         num_records: usize,
-      ) -> std::result::Result<(), ::parquet::errors::ParquetError> {
+      ) -> ::std::result::Result<(), ::parquet::errors::ParquetError> {
         use ::parquet::column::reader::ColumnReader;
 
         let mut row_group_reader = row_group_reader;

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -114,7 +114,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
       fn write_to_row_group<W: ::std::io::Write + Send>(
         &self,
         row_group_writer: &mut ::parquet::file::writer::SerializedRowGroupWriter<'_, W>
-      ) -> Result<(), ::parquet::errors::ParquetError> {
+      ) -> std::result::Result<(), ::parquet::errors::ParquetError> {
         use ::parquet::column::writer::ColumnWriter;
 
         let mut row_group_writer = row_group_writer;
@@ -135,7 +135,7 @@ pub fn parquet_record_writer(input: proc_macro::TokenStream) -> proc_macro::Toke
         Ok(())
       }
 
-      fn schema(&self) -> Result<::parquet::schema::types::TypePtr, ::parquet::errors::ParquetError> {
+      fn schema(&self) -> std::result::Result<::parquet::schema::types::TypePtr, ::parquet::errors::ParquetError> {
         use ::parquet::schema::types::Type as ParquetType;
         use ::parquet::schema::types::TypePtr;
         use ::parquet::basic::LogicalType;
@@ -211,7 +211,7 @@ pub fn parquet_record_reader(input: proc_macro::TokenStream) -> proc_macro::Toke
         &mut self,
         row_group_reader: &mut dyn ::parquet::file::reader::RowGroupReader,
         num_records: usize,
-      ) -> Result<(), ::parquet::errors::ParquetError> {
+      ) -> std::result::Result<(), ::parquet::errors::ParquetError> {
         use ::parquet::column::reader::ColumnReader;
 
         let mut row_group_reader = row_group_reader;

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -354,7 +354,13 @@ mod tests {
 
         mod aliased_result {
             use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};
-            pub type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+            // This is the normal pattern that raised this issue
+            // pub type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+            // not an actual result type
+            // Used here only to make the harder.
+            pub type Result = ();
 
             #[derive(ParquetRecordReader, ParquetRecordWriter, Debug)]
             pub struct ARecord {
@@ -363,7 +369,8 @@ mod tests {
             }
 
             impl ARecord {
-                pub fn validate(&self) -> Result {
+                pub fn do_nothing(&self) -> Result {}
+                pub fn validate(&self) -> std::result::Result<(), Box<dyn std::error::Error>> {
                     Ok(())
                 }
             }
@@ -374,6 +381,7 @@ mod tests {
             bool: true,
             string: "test".to_string(),
         };
+        foo.do_nothing();
         assert!(foo.validate().is_ok());
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7547

# Rationale for this change
 
Explained in the issue.

# What changes are included in this PR?

Pretty simple change from `Result` to `std::result::Result` to prevent the 'name collision' on the code/text generated from the macro.

# Are there any user-facing changes?

None that I can think of.


Please let me know if there is anything else you might want/need on my end! and thank you very much for this project.