### PR TITLE
Remove old `flight-sql-experimental` feature flag

### DIFF
--- a/arrow-flight/README.md
+++ b/arrow-flight/README.md
@@ -43,10 +43,7 @@ that demonstrate how to build a Flight server implemented with [tonic](https://d
 
 ## Feature Flags
 
-- `flight-sql`: Enables experimental support for
-  [Apache Arrow FlightSQL], a protocol for interacting with SQL databases.
-
-- `flight-sql-experimental` : Deprecated feature and will be removed in next release
+- `flight-sql`: Support for [Apache Arrow FlightSQL], a protocol for interacting with SQL databases.
 
 - `tls`: Enables `tls` on `tonic`
 

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -35,8 +35,6 @@
 //! 3. Support for [Flight SQL] in [`sql`]. Requires the
 //!    `flight-sql` feature of this crate to be activated.
 //!
-//! 4. The feature [`flight-sql-experimental`] is deprecated and will be removed in a future release.
-//!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
 
 #![doc(


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to https://github.com/apache/arrow-rs/pull/7546
- Related to https://github.com/apache/arrow-rs/issues/7498

# Rationale for this change
We added a better named `flight-sql` feature in https://github.com/apache/arrow-rs/pull/7546 and I wanted to make a PR to remove the old flag while it was top of mind

# What changes are included in this PR?

Remove old feature flag
# Are there any user-facing changes?

Old feature flag will no longer work
