### PR TITLE
fix: Correct docs for `WriterPropertiesBuilder::set_column_index_truncate_length`

### DIFF
--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -799,7 +799,7 @@ impl WriterPropertiesBuilder {
     }
 
     /// Sets the max length of min/max value fields when writing the column
-    /// [`Index`] (defaults to `None` (no limit)).
+    /// [`Index`] (defaults to `Some(64)`).
     ///
     /// This can be used to prevent columns with very long values (hundreds of
     /// bytes long) from causing the parquet metadata to become huge.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
While looking into #7490 I found the docs incorrectly state that the default value for `column_index_truncate_length` is `None` (i.e. no truncation performed). The default value is actually `Some(64)`.

# What changes are included in this PR?

Change the docs to reflect reality.

# Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
