### PR TITLE
Clarify Docs: NullBuffer::len is in bits

### DIFF
--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -116,7 +116,7 @@ impl NullBuffer {
         }
     }
 
-    /// Returns the length of this [`NullBuffer`]
+    /// Returns the length of this [`NullBuffer`] in bits
     #[inline]
     pub fn len(&self) -> usize {
         self.buffer.len()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
I ran across this code and had to double check again so I would like the documentation to just make it 100% clear

# What changes are included in this PR?

Update docs
# Are there any user-facing changes?

Just docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
