### PR TITLE
Use PR title and description for commit message

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 # Documentation can be found here:
-# https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=127405038
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 
 notifications:
   commits:      commits@arrow.apache.org
@@ -33,6 +33,7 @@ github:
     - rust
   enabled_merge_buttons:
     squash: true
+    squash_commit_message: PR_TITLE_AND_DESC
     merge: false
     rebase: false
   features:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7562.

# Rationale for this change
 
We have our PR template and it has very useful information than the current default commit message:

* The commit message of the first commit if only one commit exists in the PR
* The commit title of the first commit as a title and list of commit titles of all commits if multiple commits exist in the PR

# What changes are included in this PR?

Changed the default commit message to the PR title and description.

# Are there any user-facing changes?

No.