### PR TITLE
[benches/row_format] fix typo in array lengths

### DIFF
--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -57,7 +57,7 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
 }
 
 fn bench_iter(c: &mut Criterion) {
-    let col = create_string_view_array_with_len(40960, 0., 100, false);
+    let col = create_string_view_array_with_len(4096, 0., 100, false);
     let converter = RowConverter::new(vec![SortField::new(col.data_type().clone())]).unwrap();
     let rows = converter
         .convert_columns(&[Arc::new(col) as ArrayRef])
@@ -109,8 +109,8 @@ fn row_bench(c: &mut Criterion) {
     let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 30, false)) as ArrayRef];
     do_bench(c, "4096 string view(30, 0)", cols);
 
-    let cols = vec![Arc::new(create_string_view_array_with_len(40960, 0., 100, false)) as ArrayRef];
-    do_bench(c, "40960 string view(100, 0)", cols);
+    let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0., 100, false)) as ArrayRef];
+    do_bench(c, "4096 string view(100, 0)", cols);
 
     let cols = vec![Arc::new(create_string_view_array_with_len(4096, 0.5, 100, false)) as ArrayRef];
     do_bench(c, "4096 string view(100, 0.5)", cols);


### PR DESCRIPTION
# Which issue does this PR close?

For some reason, some of the benchmarks create arrays of length `40960` .... that looks like a 0 too much to me =)

# What changes are included in this PR?

Changes 40960 to 4096 for some of the row_format benches

# Are there any user-facing changes?

No.