### PR TITLE
[array] Remove unwrap checks from GenericByteArray::value_unchecked

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -292,7 +292,9 @@ impl<T: ByteArrayType> GenericByteArray<T> {
         // both of which should cleanly cast to isize on an architecture that supports
         // 32/64-bit offsets
         let b = std::slice::from_raw_parts(
-            self.value_data.as_ptr().offset(start.to_isize().unwrap_unchecked()),
+            self.value_data
+                .as_ptr()
+                .offset(start.to_isize().unwrap_unchecked()),
             (end - start).to_usize().unwrap_unchecked(),
         );
 


### PR DESCRIPTION
# Which issue does this PR close?

`GenericByteArray::value_unchecked` permits `unsafe` code, but still introduces a check due to `unwrap` being called here:

```diff
        let b = std::slice::from_raw_parts(
-           self.value_data.as_ptr().offset(start.to_isize().unwrap()),
-           (end - start).to_usize().unwrap(),
+           self.value_data.as_ptr().offset(start.to_isize().unwrap_unchecked()),
+           (end - start).to_usize().unwrap_unchecked(),
        );
```

I believe it is sensible to use `unwrap_unsafe` here instead. While the compiler may be able to prune the first unwrap as unreachable, I believe it can **not** prove at compile time that `end >= start` and eliminate the second unwrap. This is an invariant of GenericByteArray.

# Are there any user-facing changes?

No.