### PR TITLE
Fixed a warning build build: function never used.

### DIFF
--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -51,7 +51,7 @@ impl ReadPlanBuilder {
     }
 
     /// Returns the current selection, if any
-    #[allow(dead_code)]
+    #[cfg(feature = "async")]
     pub(crate) fn selection(&self) -> Option<&RowSelection> {
         self.selection.as_ref()
     }
@@ -76,7 +76,7 @@ impl ReadPlanBuilder {
     }
 
     /// Returns the number of rows selected, or `None` if all rows are selected.
-    #[allow(dead_code)]
+    #[cfg(feature = "async")]
     pub(crate) fn num_rows_selected(&self) -> Option<usize> {
         self.selection.as_ref().map(|s| s.row_count())
     }

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -51,6 +51,7 @@ impl ReadPlanBuilder {
     }
 
     /// Returns the current selection, if any
+    #[allow(dead_code)]
     pub(crate) fn selection(&self) -> Option<&RowSelection> {
         self.selection.as_ref()
     }
@@ -75,6 +76,7 @@ impl ReadPlanBuilder {
     }
 
     /// Returns the number of rows selected, or `None` if all rows are selected.
+    #[allow(dead_code)]
     pub(crate) fn num_rows_selected(&self) -> Option<usize> {
         self.selection.as_ref().map(|s| s.row_count())
     }


### PR DESCRIPTION
# Which issue does this PR close?

No issue but I could create one

# Rationale for this change
 
 This PR is simply fix the warning during building:
 ```
 warning: methods `selection` and `num_rows_selected` are never used
  --> parquet/src/arrow/arrow_reader/read_plan.rs:54:19
   |
38 | impl ReadPlanBuilder {
   | -------------------- methods in this implementation
...
54 |     pub(crate) fn selection(&self) -> Option<&RowSelection> {
   |                   ^^^^^^^^^
...
78 |     pub(crate) fn num_rows_selected(&self) -> Option<usize> {
   |                   ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

   Compiling parquet_derive_test v55.1.0 (..../arrow-rs/parquet_derive_test)
warning: `parquet` (lib) generated 1 warning
 ```


# What changes are included in this PR?

No

# Are there any user-facing changes?

No
