### PR TITLE
fix: error reading multiple batches of `Dict(_, FixedSizeBinary(_))`

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -169,7 +169,7 @@ where
             // once the record_reader has been consumed, we've replaced its values with the default
             // variant of DictionaryBuffer (Offset). If `consume_batch`` then gets called again, we
             // avoid using the wrong variant of the buffer by returning empty array.
-            return Ok(new_empty_array(&self.data_type))
+            return Ok(new_empty_array(&self.data_type));
         }
 
         let buffer = self.record_reader.consume_record_data();

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -167,7 +167,7 @@ where
     fn consume_batch(&mut self) -> Result<ArrayRef> {
         if self.record_reader.num_values() == 0 {
             // once the record_reader has been consumed, we've replaced its values with the default
-            // variant of DictionaryBuffer (Offset). If `consume_batch`` then gets called again, we
+            // variant of DictionaryBuffer (Offset). If `consume_batch` then gets called again, we
             // avoid using the wrong variant of the buffer by returning empty array.
             return Ok(new_empty_array(&self.data_type));
         }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes # https://github.com/apache/arrow-rs/issues/7545

# Rationale for this change
 
See comment here for what I think is the root cause of the issue: https://github.com/apache/arrow-rs/issues/7545#issuecomment-2927239790

# What changes are included in this PR?

# Are there any user-facing changes?

No breaking changes. Users may notice that if they try to collect batches with arrow type `Dictionary(_, FixedSizeBinary(_))` when reading their parquet file, that there will no longer be an error