### PR TITLE
Improve the PR template for usable as commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,20 @@
 # Which issue does this PR close?
 
-<!--
-We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
--->
+We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
 
-Closes #.
+Closes #NNN.
 
 # Rationale for this change
- 
-<!--
+
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
--->
 
 # What changes are included in this PR?
 
-<!--
 There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
--->
 
 # Are there any user-facing changes?
 
-
-<!--
 If there are user-facing changes then we may require documentation to be updated before approving the PR.
--->
 
-<!---
 If there are any breaking changes to public APIs, please call them out.
--->


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7581.

# Rationale for this change
 
If we keep using the current pull request template, we may close unrelated #123 accidentally again.

# What changes are included in this PR?

* Don't use  #123 as example in comment
* Use raw text instead of comment to describe contents

# Are there any user-facing changes?

No.
