### PR TITLE
Fix GenericBinaryArray docstring.

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -20,7 +20,7 @@ use crate::{Array, GenericByteArray, GenericListArray, GenericStringArray, Offse
 use arrow_data::ArrayData;
 use arrow_schema::DataType;
 
-/// A [`GenericBinaryArray`] for storing `[u8]`
+/// A [`GenericByteArray`] for storing `[u8]`
 pub type GenericBinaryArray<OffsetSize> = GenericByteArray<GenericBinaryType<OffsetSize>>;
 
 impl<OffsetSize: OffsetSizeTrait> GenericBinaryArray<OffsetSize> {


### PR DESCRIPTION
The doc used to say that GenericBinaryArray is a GenericBinaryArray for storing `[u8]`.

The intention is actually to say that GenericBinaryArray is a GenericByteArray for storing `[u8]`.

This PR fixes that.

# Which issue does this PR close?

none -- it's a small typo fix.