### PR TITLE
Add FixedSizeBinary to `take_kernel` benchmark

### DIFF
--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -192,6 +192,19 @@ fn add_benchmark(c: &mut Criterion) {
         "take primitive run logical len: 1024, physical len: 512, indices: 1024",
         |b| b.iter(|| bench_take(&values, &indices)),
     );
+
+    let values = create_fsb_array(1024, 0.0, 12);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take primitive fsb value len: 12, indices: 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_fsb_array(1024, 0.5, 12);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function(
+        "take primitive fsb value len: 12, null values, indices: 1024",
+        |b| b.iter(|| bench_take(&values, &indices)),
+    );
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/7591

# Rationale for this change

I would like a benchmark that shows improvements in https://github.com/apache/arrow-rs/pull/7590

`take` with FixedSizeBinary  is the only one I know of now

# What changes are included in this PR?

Add `fsb` to the take_kernel benchmarks


# Are there any user-facing changes?

No, this is a benchmark