### PR TITLE
Include footer key metadata when writing encrypted Parquet with a plaintext footer

### DIFF
--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -140,11 +140,12 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // in any Statistics or ColumnIndex object in the whole file.
         // But for simplicity we always set this field.
         let column_orders = Some(column_orders);
-
         let (row_groups, unencrypted_row_groups) = self
             .object_writer
             .apply_row_group_encryption(self.row_groups)?;
 
+        let (encryption_algorithm, footer_signing_key_metadata) =
+            self.object_writer.get_plaintext_footer_metadata();
         let mut file_metadata = FileMetaData {
             num_rows,
             row_groups,
@@ -153,8 +154,8 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             schema: types::to_thrift(self.schema.as_ref())?,
             created_by: self.created_by.clone(),
             column_orders,
-            encryption_algorithm: self.object_writer.get_footer_encryption_algorithm(),
-            footer_signing_key_metadata: None,
+            encryption_algorithm,
+            footer_signing_key_metadata,
         };
 
         // Write file metadata
@@ -479,8 +480,8 @@ impl MetadataObjectWriter {
         get_file_magic()
     }
 
-    fn get_footer_encryption_algorithm(&self) -> Option<EncryptionAlgorithm> {
-        None
+    fn get_plaintext_footer_metadata(&self) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
+        (None, None)
     }
 }
 
@@ -635,11 +636,17 @@ impl MetadataObjectWriter {
         }
     }
 
-    fn get_footer_encryption_algorithm(&self) -> Option<EncryptionAlgorithm> {
-        if let Some(file_encryptor) = &self.file_encryptor {
-            return Some(Self::encryption_algorithm_from_encryptor(file_encryptor));
+    fn get_plaintext_footer_metadata(&self) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
+        if let Some(file_encryptor) = self.file_encryptor.as_ref() {
+            let encryption_properties = file_encryptor.properties();
+            if !encryption_properties.encrypt_footer() {
+                return (
+                    Some(Self::encryption_algorithm_from_encryptor(file_encryptor)),
+                    encryption_properties.footer_key_metadata().cloned(),
+                );
+            }
         }
-        None
+        (None, None)
     }
 
     fn encryption_algorithm_from_encryptor(file_encryptor: &FileEncryptor) -> EncryptionAlgorithm {

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -145,7 +145,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             .apply_row_group_encryption(self.row_groups)?;
 
         let (encryption_algorithm, footer_signing_key_metadata) =
-            self.object_writer.get_plaintext_footer_metadata();
+            self.object_writer.get_plaintext_footer_crypto_metadata();
         let mut file_metadata = FileMetaData {
             num_rows,
             row_groups,
@@ -480,7 +480,9 @@ impl MetadataObjectWriter {
         get_file_magic()
     }
 
-    fn get_plaintext_footer_metadata(&self) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
+    fn get_plaintext_footer_crypto_metadata(
+        &self,
+    ) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
         (None, None)
     }
 }
@@ -636,7 +638,10 @@ impl MetadataObjectWriter {
         }
     }
 
-    fn get_plaintext_footer_metadata(&self) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
+    fn get_plaintext_footer_crypto_metadata(
+        &self,
+    ) -> (Option<EncryptionAlgorithm>, Option<Vec<u8>>) {
+        // Only plaintext footers may contain encryption algorithm and footer key metadata.
         if let Some(file_encryptor) = self.file_encryptor.as_ref() {
             let encryption_properties = file_encryptor.properties();
             if !encryption_properties.encrypt_footer() {

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -261,13 +261,18 @@ fn test_uniform_encryption_plaintext_footer_with_key_retriever() {
     let test_data = arrow::util::test_util::parquet_test_data();
     let path = format!("{test_data}/encrypt_columns_plaintext_footer.parquet.encrypted");
     let file = File::open(path).unwrap();
+    let temp_file = tempfile::tempfile().unwrap();
 
-    let footer_key = b"0123456789012345";
     let key_retriever = TestKeyRetriever::new()
-        .with_key("kf".to_owned(), "0123456789012345".as_bytes().to_vec())
-        .with_key("kc1".to_owned(), "1234567890123450".as_bytes().to_vec())
-        .with_key("kc2".to_owned(), "1234567890123451".as_bytes().to_vec());
-    let encryption_properties = FileEncryptionProperties::builder(footer_key.to_vec())
+        .with_key("kf".to_owned(), b"0123456789012345".to_vec())
+        .with_key("kc1".to_owned(), b"1234567890123450".to_vec())
+        .with_key("kc2".to_owned(), b"1234567890123451".to_vec());
+
+    let encryption_properties = FileEncryptionProperties::builder(b"0123456789012345".to_vec())
+        .with_footer_key_metadata("kf".into())
+        .with_column_key_and_metadata("double_field", b"1234567890123450".to_vec(), b"kc1".into())
+        .with_column_key_and_metadata("float_field", b"1234567890123451".to_vec(), b"kc2".into())
+        .with_plaintext_footer(true)
         .build()
         .unwrap();
 
@@ -276,7 +281,6 @@ fn test_uniform_encryption_plaintext_footer_with_key_retriever() {
             .build()
             .unwrap();
 
-    // read example data
     let options = ArrowReaderOptions::default()
         .with_file_decryption_properties(decryption_properties.clone());
     let metadata = ArrowReaderMetadata::load(&file, options.clone()).unwrap();
@@ -287,8 +291,6 @@ fn test_uniform_encryption_plaintext_footer_with_key_retriever() {
         .collect::<parquet::errors::Result<Vec<RecordBatch>, _>>()
         .unwrap();
 
-    let temp_file = tempfile::tempfile().unwrap();
-    // write example data
     let props = WriterProperties::builder()
         .with_file_encryption_properties(encryption_properties)
         .build();
@@ -298,7 +300,7 @@ fn test_uniform_encryption_plaintext_footer_with_key_retriever() {
         metadata.schema().clone(),
         Some(props),
     )
-        .unwrap();
+    .unwrap();
     for batch in batches {
         writer.write(&batch).unwrap();
     }
@@ -306,25 +308,18 @@ fn test_uniform_encryption_plaintext_footer_with_key_retriever() {
     writer.close().unwrap();
 
     let key_retriever = TestKeyRetriever::new()
-        .with_key("kf".to_owned(), "0123456789012345".as_bytes().to_vec())
-        .with_key("kc1".to_owned(), "1234567890123450".as_bytes().to_vec())
-        .with_key("kc2".to_owned(), "1234567890123451".as_bytes().to_vec());
+        .with_key("kf".to_owned(), b"0123456789012345".to_vec())
+        .with_key("kc1".to_owned(), b"1234567890123450".to_vec())
+        .with_key("kc2".to_owned(), b"1234567890123451".to_vec());
 
     let decryption_properties =
         FileDecryptionProperties::with_key_retriever(Arc::new(key_retriever))
             .build()
             .unwrap();
 
-    // read example data
     let options = ArrowReaderOptions::default()
         .with_file_decryption_properties(decryption_properties.clone());
-    let metadata = ArrowReaderMetadata::load(&temp_file, options.clone()).unwrap();
-
-    let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(temp_file, options).unwrap();
-    let batch_reader = builder.build().unwrap();
-    let batches = batch_reader
-        .collect::<parquet::errors::Result<Vec<RecordBatch>, _>>()
-        .unwrap();
+    let _ = ArrowReaderMetadata::load(&temp_file, options.clone()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7599.

# Rationale for this change

Written plaintext footer file will not include `footer_signing_key_metadata`, see proposed test for reproduction.
Written encrypted non-plaintext footer files shouldn't include `encryption_algorithm`, see proposed test for reproduction.

# What changes are included in this PR?

`footer_signing_key_metadata` is now included in plaintext footer file and `encryption_algorithm` is not included in the footer if footer is non-plaintext.

# Are there any user-facing changes?

This doesn't change user facing API.