### PR TITLE
Add CI tests for `parquet-variant` crate and fix clippy

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -44,7 +44,9 @@ arrow-flight:
 
 parquet:
   - changed-files:
-    - any-glob-to-any-file: [ 'parquet/**/*' ]
+    - any-glob-to-any-file:
+      - 'parquet/**/*'
+      - 'parquet-variant/**/*'
 
 parquet-derive:
   - changed-files:

--- a/.github/workflows/parquet-variant.yml
+++ b/.github/workflows/parquet-variant.yml
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+# tests for parquet-variant crate
+name: "parquet-variant"
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+# trigger for all PRs that touch certain files and changes to main
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - parquet-variant/**
+      - .github/**
+
+jobs:
+  # test the crate
+  linux-test:
+    name: Test
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Test
+        run: cargo test -p parquet-variant
+
+  # test compilation
+  linux-features:
+    name: Check Compilation
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Check compilation
+        run: cargo check -p parquet-variant
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Setup Clippy
+        run: rustup component add clippy
+      - name: Run clippy
+        run: cargo clippy -p parquet-variant --all-targets --all-features -- -D warnings

--- a/parquet-variant/src/decoder.rs
+++ b/parquet-variant/src/decoder.rs
@@ -124,12 +124,12 @@ mod tests {
     fn test_short_string() -> Result<(), ArrowError> {
         let value = [
             1 | 5 << 2, // Basic type for short string | length of short string
-            'H' as u8,
-            'e' as u8,
-            'l' as u8,
-            'l' as u8,
-            'o' as u8,
-            'o' as u8,
+            b'H',
+            b'e',
+            b'l',
+            b'l',
+            b'o',
+            b'o',
         ];
         let result = decode_short_string(&value)?;
         assert_eq!(result, "Hello");
@@ -144,12 +144,12 @@ mod tests {
             0,
             0,
             0, // Length of string
-            'H' as u8,
-            'e' as u8,
-            'l' as u8,
-            'l' as u8,
-            'o' as u8,
-            'o' as u8,
+            b'H',
+            b'e',
+            b'l',
+            b'l',
+            b'o',
+            b'o',
         ];
         let result = decode_long_string(&value)?;
         assert_eq!(result, "Hello");

--- a/parquet-variant/src/decoder.rs
+++ b/parquet-variant/src/decoder.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_i8() -> Result<(), ArrowError> {
         let value = [
-            0 | 3 << 2, // Primitive type for i8
+            3 << 2, // Primitive type for i8
             42,
         ];
         let result = decode_int8(&value)?;
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_string() -> Result<(), ArrowError> {
         let value = [
-            0 | 16 << 2, // Basic type for short string | length of short string
+            16 << 2, // Basic type for short string | length of short string
             5,
             0,
             0,

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -22,7 +22,6 @@ use std::fmt::Debug;
 use std::slice::SliceIndex;
 
 #[inline]
-
 pub(crate) fn slice_from_slice<I: SliceIndex<[u8]> + Clone + Debug>(
     bytes: &[u8],
     index: I,
@@ -49,7 +48,7 @@ pub(crate) fn map_try_from_slice_error(e: TryFromSliceError) -> ArrowError {
 
 pub(crate) fn first_byte_from_slice(slice: &[u8]) -> Result<&u8, ArrowError> {
     slice
-        .get(0)
+        .first()
         .ok_or_else(|| ArrowError::InvalidArgumentError("Received empty bytes".to_string()))
 }
 

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -19,10 +19,7 @@ use crate::decoder::{
 };
 use crate::utils::{array_from_slice, first_byte_from_slice, slice_from_slice, string_from_slice};
 use arrow_schema::ArrowError;
-use std::{
-    num::TryFromIntError,
-    ops::{Range},
-};
+use std::{num::TryFromIntError, ops::Range};
 
 #[derive(Clone, Debug, Copy, PartialEq)]
 enum OffsetSizeBytes {


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- part of https://github.com/apache/arrow-rs/issues/6736
- Follow on to https://github.com/apache/arrow-rs/pull/7535 from @mkarbo 


# Rationale for this change

While doing local development I found there were several clippy failures in the parquet-variant crate which failed when running `cargo clippy --workspace`

I fixed them to get a clean run and added some CI checks to avoid in the future

# What changes are included in this PR?

1. Add basic CI checks for `parquet-variant` (test, clippy, and compile)
2. Fix clippy errors

# Are there any user-facing changes?

No, this is all internal work only
