### PR TITLE
feat: add AsyncArrowWriter::into_inner

### DIFF
--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -262,6 +262,14 @@ impl<W: AsyncFileWriter> AsyncArrowWriter<W> {
         self.finish().await
     }
 
+    /// Consumes the [`AsyncArrowWriter`] and returns the underlying [`AsyncFileWriter`]
+    ///
+    /// Note that this does not flush or finalize the writer, so any data in the
+    /// inner buffer will be lost
+    pub fn into_inner(self) -> W {
+        self.async_writer
+    }
+
     /// Flush the data written by `sync_writer` into the `async_writer`
     ///
     /// # Notes

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -264,8 +264,10 @@ impl<W: AsyncFileWriter> AsyncArrowWriter<W> {
 
     /// Consumes the [`AsyncArrowWriter`] and returns the underlying [`AsyncFileWriter`]
     ///
-    /// Note that this does not flush or finalize the writer, so any data in the
-    /// inner buffer will be lost
+    /// # Notes
+    ///
+    /// This method does **not** flush or finalize the writer, so buffered data
+    /// will be lost if you have not called [`Self::finish`].
     pub fn into_inner(self) -> W {
         self.async_writer
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7603.

# What changes are included in this PR?

I've added an `into_inner` function for the `AsyncArrowWriter`

# Are there any user-facing changes?

This is not a breaking change. I've added some documentation to describe the methods and possible pitfalls
