### PR TITLE
feat: support  on additional builders

### DIFF
--- a/arrow-array/src/builder/fixed_size_binary_dictionary_builder.rs
+++ b/arrow-array/src/builder/fixed_size_binary_dictionary_builder.rs
@@ -192,6 +192,12 @@ where
         self.keys_builder.append_null()
     }
 
+    /// Appends `n` `null`s into the builder.
+    #[inline]
+    pub fn append_nulls(&mut self, n: usize) {
+        self.keys_builder.append_nulls(n);
+    }
+
     /// Infallibly append a value to this builder
     ///
     /// # Panics
@@ -265,11 +271,12 @@ mod tests {
         assert_eq!(b.append(values[1]).unwrap(), 1);
         assert_eq!(b.append(values[1]).unwrap(), 1);
         assert_eq!(b.append(values[0]).unwrap(), 0);
+        b.append_nulls(2);
         let array = b.finish();
 
         assert_eq!(
             array.keys(),
-            &Int8Array::from(vec![Some(0), None, Some(1), Some(1), Some(0)]),
+            &Int8Array::from(vec![Some(0), None, Some(1), Some(1), Some(0), None, None]),
         );
 
         // Values are polymorphic and so require a downcast.

--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -129,6 +129,14 @@ impl<T: ByteArrayType> GenericByteBuilder<T> {
         self.offsets_builder.append(self.next_offset());
     }
 
+    /// Appends `n` `null`s into the builder.
+    #[inline]
+    pub fn append_nulls(&mut self, n: usize) {
+        self.null_buffer_builder.append_n_nulls(n);
+        let next_offset = self.next_offset();
+        self.offsets_builder.append_n(n, next_offset);
+    }
+
     /// Appends array values and null to this builder as is
     /// (this means that underlying null values are copied as is).
     #[inline]
@@ -439,15 +447,18 @@ mod tests {
         builder.append_null();
         builder.append_null();
         builder.append_null();
-        assert_eq!(3, builder.len());
+        builder.append_nulls(2);
+        assert_eq!(5, builder.len());
         assert!(!builder.is_empty());
 
         let array = builder.finish();
-        assert_eq!(3, array.null_count());
-        assert_eq!(3, array.len());
+        assert_eq!(5, array.null_count());
+        assert_eq!(5, array.len());
         assert!(array.is_null(0));
         assert!(array.is_null(1));
         assert!(array.is_null(2));
+        assert!(array.is_null(3));
+        assert!(array.is_null(4));
     }
 
     #[test]
@@ -475,14 +486,18 @@ mod tests {
         builder.append_null();
         builder.append_value(b"arrow");
         builder.append_value(b"");
+        builder.append_nulls(2);
         let array = builder.finish();
 
-        assert_eq!(4, array.len());
-        assert_eq!(1, array.null_count());
+        assert_eq!(6, array.len());
+        assert_eq!(3, array.null_count());
         assert_eq!(b"parquet", array.value(0));
         assert!(array.is_null(1));
+        assert!(array.is_null(4));
+        assert!(array.is_null(5));
         assert_eq!(b"arrow", array.value(2));
         assert_eq!(b"", array.value(1));
+
         assert_eq!(O::zero(), array.value_offsets()[0]);
         assert_eq!(O::from_usize(7).unwrap(), array.value_offsets()[2]);
         assert_eq!(O::from_usize(5).unwrap(), array.value_length(2));
@@ -509,7 +524,8 @@ mod tests {
         builder.append_option(Some("rust"));
         builder.append_option(None::<&str>);
         builder.append_option(None::<String>);
-        assert_eq!(7, builder.len());
+        builder.append_nulls(2);
+        assert_eq!(9, builder.len());
 
         assert_eq!(
             GenericStringArray::<O>::from(vec![
@@ -519,7 +535,9 @@ mod tests {
                 None,
                 Some("rust"),
                 None,
-                None
+                None,
+                None,
+                None,
             ]),
             builder.finish()
         );

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -270,6 +270,14 @@ where
         self.null_buffer_builder.append_null();
     }
 
+    /// Appends `n` `null`s into the builder.
+    #[inline]
+    pub fn append_nulls(&mut self, n: usize) {
+        let next_offset = self.next_offset();
+        self.offsets_builder.append_n(n, next_offset);
+        self.null_buffer_builder.append_n_nulls(n);
+    }
+
     /// Appends an optional value into this [`GenericListBuilder`]
     ///
     /// If `Some` calls [`Self::append_value`] otherwise calls [`Self::append_null`]
@@ -406,7 +414,7 @@ mod tests {
         let values_builder = Int32Builder::with_capacity(10);
         let mut builder = GenericListBuilder::<O, _>::new(values_builder);
 
-        //  [[0, 1, 2], null, [3, null, 5], [6, 7]]
+        //  [[0, 1, 2], null, [3, null, 5], [6, 7], null, null]
         builder.values().append_value(0);
         builder.values().append_value(1);
         builder.values().append_value(2);
@@ -419,14 +427,17 @@ mod tests {
         builder.values().append_value(6);
         builder.values().append_value(7);
         builder.append(true);
+        builder.append_nulls(2);
 
         let list_array = builder.finish();
 
         assert_eq!(DataType::Int32, list_array.value_type());
-        assert_eq!(4, list_array.len());
-        assert_eq!(1, list_array.null_count());
+        assert_eq!(6, list_array.len());
+        assert_eq!(3, list_array.null_count());
         assert_eq!(O::from_usize(3).unwrap(), list_array.value_offsets()[2]);
         assert_eq!(O::from_usize(3).unwrap(), list_array.value_length(2));
+        assert!(list_array.is_null(4));
+        assert!(list_array.is_null(5));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

Closes https://github.com/apache/arrow-rs/issues/7605

# Rationale for this change

I thought it would be nice if `append_nulls` was supported for additional types of array builders. Currently it is available on some builder types, but not all.

# What changes are included in this PR?

Add an `append_nulls` method to:
- FixedSizeBinaryDictionaryBuilder
- FixedSizedBinaryBuilder
- GenericBytesBuilder
- GenericListBuilder
- StructBuilder

# Are there any user-facing changes?
