### PR TITLE
fix: allow `AsyncFileWriter` to be not `Send`

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -110,6 +110,8 @@ test_common = ["arrow/test_utils"]
 experimental = []
 # Enable async APIs
 async = ["futures", "tokio"]
+# Enable `!Send` with async APIs
+async-no-send = ["async"]
 # Enable object_store integration
 object_store = ["dep:object_store", "async"]
 # Group Zstd dependencies

--- a/parquet/src/arrow/async_writer/store.rs
+++ b/parquet/src/arrow/async_writer/store.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use bytes::Bytes;
-use futures::future::BoxFuture;
 use std::sync::Arc;
 
 use crate::arrow::async_writer::AsyncFileWriter;
 use crate::errors::{ParquetError, Result};
+use crate::util::async_util::MaybeLocalBoxFuture;
 use object_store::buffered::BufWriter;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -93,7 +93,7 @@ impl ParquetObjectWriter {
 }
 
 impl AsyncFileWriter for ParquetObjectWriter {
-    fn write(&mut self, bs: Bytes) -> BoxFuture<'_, Result<()>> {
+    fn write(&mut self, bs: Bytes) -> MaybeLocalBoxFuture<'_, Result<()>> {
         Box::pin(async {
             self.w
                 .put(bs)
@@ -102,7 +102,7 @@ impl AsyncFileWriter for ParquetObjectWriter {
         })
     }
 
-    fn complete(&mut self) -> BoxFuture<'_, Result<()>> {
+    fn complete(&mut self) -> MaybeLocalBoxFuture<'_, Result<()>> {
         Box::pin(async {
             self.w
                 .shutdown()

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -1303,7 +1303,6 @@ mod tests {
 mod async_tests {
     use super::*;
     use bytes::Bytes;
-    use futures::future::BoxFuture;
     use futures::FutureExt;
     use std::fs::File;
     use std::future::Future;
@@ -1312,6 +1311,7 @@ mod async_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::file::reader::Length;
+    use crate::util::async_util::MaybeLocalBoxFuture;
     use crate::util::test_common::file_util::get_test_file;
 
     struct MetadataFetchFn<F>(F);
@@ -1321,7 +1321,7 @@ mod async_tests {
         F: FnMut(Range<u64>) -> Fut + Send,
         Fut: Future<Output = Result<Bytes>> + Send,
     {
-        fn fetch(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
+        fn fetch(&mut self, range: Range<u64>) -> MaybeLocalBoxFuture<'_, Result<Bytes>> {
             async move { self.0(range).await }.boxed()
         }
     }
@@ -1334,7 +1334,7 @@ mod async_tests {
         Fut: Future<Output = Result<Bytes>> + Send,
         F2: Send,
     {
-        fn fetch(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
+        fn fetch(&mut self, range: Range<u64>) -> MaybeLocalBoxFuture<'_, Result<Bytes>> {
             async move { self.0(range).await }.boxed()
         }
     }
@@ -1345,7 +1345,7 @@ mod async_tests {
         F2: FnMut(usize) -> Fut + Send,
         Fut: Future<Output = Result<Bytes>> + Send,
     {
-        fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
+        fn fetch_suffix(&mut self, suffix: usize) -> MaybeLocalBoxFuture<'_, Result<Bytes>> {
             async move { self.1(suffix).await }.boxed()
         }
     }

--- a/parquet/src/util/async_util.rs
+++ b/parquet/src/util/async_util.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "async-no-send")]
+mod send_impl {
+    pub trait MaybeSend {}
+    impl<T: ?Sized> MaybeSend for T {}
+    pub type MaybeLocalBoxFuture<'a, T> = futures::future::LocalBoxFuture<'a, T>;
+}
+
+#[cfg(not(feature = "async-no-send"))]
+mod send_impl {
+    pub use std::marker::Send as MaybeSend;
+    pub type MaybeLocalBoxFuture<'a, T> = futures::future::BoxFuture<'a, T>;
+}
+
+pub use send_impl::*;
+
+pub trait MaybeLocalFutureExt: std::future::Future {
+    fn boxed_maybe_local<'a>(self) -> MaybeLocalBoxFuture<'a, Self::Output>
+    where
+        Self: Sized + MaybeSend + 'a,
+    {
+        Box::pin(self)
+    }
+}
+
+impl<T> MaybeLocalFutureExt for T where T: std::future::Future {}

--- a/parquet/src/util/mod.rs
+++ b/parquet/src/util/mod.rs
@@ -24,6 +24,9 @@ pub(crate) mod interner;
 pub(crate) mod test_common;
 pub mod utf8;
 
+#[cfg(feature = "async")]
+pub(crate) mod async_util;
+
 #[cfg(any(test, feature = "test_common"))]
 pub use self::test_common::page_util::{
     DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7612.

# What changes are included in this PR?

Changes `BoxFuture` to `LocalBoxFuture`. I tried a few implementations like using `async` in the trait or using associated types for the futures, but I find this one to be the easiest to manage, although it unfortunately does not allow for the future to be send if the user so desires. I think generally, using poll and context would make this more flexible, but I didn't want to overcomplicate this PR as generally I think people implement this trait just for use with `AsyncArrowWriter`

# Are there any user-facing changes?

This is a breaking change as it changes the trait implementation and would be fixed wherever a user implements that trait. It's an easy fix however because `LocalBoxFuture` is always compatible to `BoxFuture` so the user would just have to call `boxed_local` instead of `boxed`.
