### PR TITLE
Improve `coalesce` and `concat` performance for views

### DIFF
--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -210,9 +210,12 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// and add the (adapted) views.
     pub fn append_array(&mut self, array: &GenericByteViewArray<T>) {
         self.flush_in_progress();
+        // keep original views if the array is empty or if there are no data buffers (all inline views)
+        let keep_views = self.completed.is_empty() || array.data_buffers().is_empty();
+
         self.completed.extend(array.data_buffers().iter().cloned());
 
-        if self.completed.is_empty() {
+        if keep_views {
             self.views_buffer.extend_from_slice(array.views());
         } else {
             let starting_buffer = self.completed.len() as u32;

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -220,7 +220,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
             self.views_buffer.extend(array.views().iter().map(|v| {
                 let mut byte_view = ByteView::from(*v);
                 if byte_view.length > 12 {
-                    // If the view is small enough, we can inline it
+                    // Small views (<=12 bytes) are inlined, so only need to update large views
                     byte_view.buffer_index += starting_buffer;
                 };
 

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -339,8 +339,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
                 Entry::Occupied(occupied) => {
                     // If the string already exists, we will directly use the view
                     let idx = occupied.get();
-                    self.views_builder
-                        .push(self.views_builder[*idx]);
+                    self.views_builder.push(self.views_builder[*idx]);
                     self.null_buffer_builder.append_non_null();
                     self.string_tracker = Some((ht, hasher));
                     return;

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -205,7 +205,9 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         self.null_buffer_builder.append_non_null();
     }
 
-    /// Appends an array
+    /// Appends an array to the builder.
+    /// This will flush any in-progress block and append the data buffers
+    /// and add the (adapted) views.
     pub fn append_array(&mut self, array: &GenericByteViewArray<T>) {
         self.flush_in_progress();
         self.completed.extend(array.data_buffers().iter().cloned());

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -210,7 +210,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// and add the (adapted) views.
     pub fn append_array(&mut self, array: &GenericByteViewArray<T>) {
         self.flush_in_progress();
-        // keep original views if the array is empty or if there are no data buffers (all inline views)
+        // keep original views if this array is the first to be added or if there are no data buffers (all inline views)
         let keep_views = self.completed.is_empty() || array.data_buffers().is_empty();
 
         self.completed.extend(array.data_buffers().iter().cloned());

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -446,7 +446,7 @@ impl<T: ByteViewType + ?Sized> std::fmt::Debug for GenericByteViewBuilder<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}ViewBuilder", T::PREFIX)?;
         f.debug_struct("")
-            .field("views_builder", &self.views_buffer)
+            .field("views_buffer", &self.views_buffer)
             .field("in_progress", &self.in_progress)
             .field("completed", &self.completed)
             .field("null_buffer_builder", &self.null_buffer_builder)

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -210,7 +210,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         self.flush_in_progress();
         self.completed.extend(array.data_buffers().iter().cloned());
 
-        if self.completed.len() == 0 {
+        if self.completed.is_empty() == 0 {
             self.views_builder.extend_from_slice(array.views());
         } else {
             let starting_buffer = self.completed.len() as u32;

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -210,7 +210,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         self.flush_in_progress();
         self.completed.extend(array.data_buffers().iter().cloned());
 
-        if self.completed.is_empty() == 0 {
+        if self.completed.is_empty() {
             self.views_builder.extend_from_slice(array.views());
         } else {
             let starting_buffer = self.completed.len() as u32;

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -319,7 +319,7 @@ fn gc_string_view_batch(batch: RecordBatch) -> RecordBatch {
 mod tests {
     use super::*;
     use arrow_array::builder::{ArrayBuilder, StringViewBuilder};
-    use arrow_array::{StringViewArray, UInt32Array};
+    use arrow_array::{RecordBatchOptions, StringViewArray, UInt32Array};
     use arrow_schema::{DataType, Field, Schema};
     use std::ops::Range;
 

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -22,7 +22,7 @@
 //! [`take`]: crate::take::take
 use crate::concat::concat_batches;
 use arrow_array::StringViewArray;
-use arrow_array::{cast::AsArray, Array, ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow_array::{cast::AsArray, Array, ArrayRef, RecordBatch};
 use arrow_data::ByteView;
 use arrow_schema::{ArrowError, SchemaRef};
 use std::collections::VecDeque;
@@ -312,10 +312,7 @@ fn gc_string_view_batch(batch: RecordBatch) -> RecordBatch {
             }
         })
         .collect();
-    let mut options = RecordBatchOptions::new();
-    options = options.with_row_count(Some(num_rows));
-    RecordBatch::try_new_with_options(schema, new_columns, &options)
-        .expect("Failed to re-create the gc'ed record batch")
+    unsafe { RecordBatch::new_unchecked(schema, new_columns, num_rows) }
 }
 
 #[cfg(test)]

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -251,6 +251,10 @@ fn gc_string_view_batch(batch: RecordBatch) -> RecordBatch {
             let Some(s) = c.as_string_view_opt() else {
                 return c;
             };
+            if s.data_buffers().is_empty() {
+                // If there are no data buffers, we can just return the array as is
+                return c;
+            }
             let ideal_buffer_size: usize = s
                 .views()
                 .iter()

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -21,9 +21,9 @@
 //! [`filter`]: crate::filter::filter
 //! [`take`]: crate::take::take
 use crate::concat::concat_batches;
-use arrow_array::{
-    builder::StringViewBuilder, cast::AsArray, Array, ArrayRef, RecordBatch, RecordBatchOptions,
-};
+use arrow_array::StringViewArray;
+use arrow_array::{cast::AsArray, Array, ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow_data::ByteView;
 use arrow_schema::{ArrowError, SchemaRef};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -164,7 +164,7 @@ impl BatchCoalescer {
             return Ok(());
         }
 
-        let mut batch = gc_string_view_batch(&batch);
+        let mut batch = gc_string_view_batch(batch);
 
         // If pushing this batch would exceed the target batch size,
         // finish the current batch and start a new one
@@ -242,14 +242,14 @@ impl BatchCoalescer {
 /// However, after a while (e.g., after `FilterExec` or `HashJoinExec`) the
 /// `StringViewArray` may only refer to a small portion of the buffer,
 /// significantly increasing memory usage.
-fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
-    let new_columns: Vec<ArrayRef> = batch
-        .columns()
-        .iter()
+fn gc_string_view_batch(batch: RecordBatch) -> RecordBatch {
+    let (schema, columns, num_rows) = batch.into_parts();
+    let new_columns: Vec<ArrayRef> = columns
+        .into_iter()
         .map(|c| {
             // Try to re-create the `StringViewArray` to prevent holding the underlying buffer too long.
             let Some(s) = c.as_string_view_opt() else {
-                return Arc::clone(c);
+                return c;
             };
             let ideal_buffer_size: usize = s
                 .views()
@@ -264,41 +264,65 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
                 })
                 .sum();
             let actual_buffer_size = s.get_buffer_memory_size();
+            let buffers = s.data_buffers();
 
             // Re-creating the array copies data and can be time consuming.
             // We only do it if the array is sparse
             if actual_buffer_size > (ideal_buffer_size * 2) {
                 // We set the block size to `ideal_buffer_size` so that the new StringViewArray only has one buffer, which accelerate later concat_batches.
                 // See https://github.com/apache/arrow-rs/issues/6094 for more details.
-                let mut builder = StringViewBuilder::with_capacity(s.len());
-                if ideal_buffer_size > 0 {
-                    builder = builder.with_fixed_block_size(ideal_buffer_size as u32);
-                }
+                let mut buffer: Vec<u8> = Vec::with_capacity(ideal_buffer_size);
 
-                for v in s.iter() {
-                    builder.append_option(v);
-                }
+                let views: Vec<u128> = s
+                    .views()
+                    .as_ref()
+                    .iter()
+                    .cloned()
+                    .map(|v| {
+                        // SAFETY: ByteView has same memory layout as u128
+                        let mut b: ByteView = ByteView::from(v);
 
-                let gc_string = builder.finish();
+                        if b.length > 12 {
+                            let offset = buffer.len() as u32;
+                            buffer.extend_from_slice(
+                                buffers[b.buffer_index as usize]
+                                    .get(b.offset as usize..b.offset as usize + b.length as usize)
+                                    .expect("Invalid buffer slice"),
+                            );
+                            b.offset = offset;
+                            b.buffer_index = 0; // Set buffer index to 0, as we only have one buffer
+                        }
 
-                debug_assert!(gc_string.data_buffers().len() <= 1); // buffer count can be 0 if the `ideal_buffer_size` is 0
+                        b.into()
+                    })
+                    .collect();
+
+                let buffers = if buffer.is_empty() {
+                    vec![]
+                } else {
+                    vec![buffer.into()]
+                };
+
+                let gc_string = unsafe {
+                    StringViewArray::new_unchecked(views.into(), buffers, s.nulls().cloned())
+                };
 
                 Arc::new(gc_string)
             } else {
-                Arc::clone(c)
+                c
             }
         })
         .collect();
     let mut options = RecordBatchOptions::new();
-    options = options.with_row_count(Some(batch.num_rows()));
-    RecordBatch::try_new_with_options(batch.schema(), new_columns, &options)
+    options = options.with_row_count(Some(num_rows));
+    RecordBatch::try_new_with_options(schema, new_columns, &options)
         .expect("Failed to re-create the gc'ed record batch")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::builder::ArrayBuilder;
+    use arrow_array::builder::{ArrayBuilder, StringViewBuilder};
     use arrow_array::{StringViewArray, UInt32Array};
     use arrow_schema::{DataType, Field, Schema};
     use std::ops::Range;
@@ -518,9 +542,11 @@ mod tests {
     fn test_gc_string_view_test_batch_empty() {
         let schema = Schema::empty();
         let batch = RecordBatch::new_empty(schema.into());
-        let output_batch = gc_string_view_batch(&batch);
-        assert_eq!(batch.num_columns(), output_batch.num_columns());
-        assert_eq!(batch.num_rows(), output_batch.num_rows());
+        let cols = batch.num_columns();
+        let num_rows = batch.num_rows();
+        let output_batch = gc_string_view_batch(batch);
+        assert_eq!(cols, output_batch.num_columns());
+        assert_eq!(num_rows, output_batch.num_rows());
     }
 
     #[test]
@@ -568,9 +594,11 @@ mod tests {
     /// and ensures the number of rows are the same
     fn do_gc(array: StringViewArray) -> StringViewArray {
         let batch = RecordBatch::try_from_iter(vec![("a", Arc::new(array) as ArrayRef)]).unwrap();
-        let gc_batch = gc_string_view_batch(&batch);
-        assert_eq!(batch.num_rows(), gc_batch.num_rows());
-        assert_eq!(batch.schema(), gc_batch.schema());
+        let rows = batch.num_rows();
+        let schema = batch.schema();
+        let gc_batch = gc_string_view_batch(batch);
+        assert_eq!(rows, gc_batch.num_rows());
+        assert_eq!(schema, gc_batch.schema());
         gc_batch
             .column(0)
             .as_any()

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -279,7 +279,6 @@ fn gc_string_view_batch(batch: RecordBatch) -> RecordBatch {
                     .iter()
                     .cloned()
                     .map(|v| {
-                        // SAFETY: ByteView has same memory layout as u128
                         let mut b: ByteView = ByteView::from(v);
 
                         if b.length > 12 {


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #7615
- Follow on to https://github.com/apache/arrow-rs/pull/7597



# Rationale for this change

Improve performance of `gc_string_view_batch`

```
filter: mixed_utf8view, 8192, nulls: 0, selectivity: 0.001       1.00     30.4±1.05ms        ? ?/sec    1.29     39.3±0.88ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0, selectivity: 0.01        1.00      4.3±0.17ms        ? ?/sec    1.20      5.2±0.15ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0, selectivity: 0.1         1.00  1805.1±25.77µs        ? ?/sec    1.32      2.4±0.20ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0, selectivity: 0.8         1.00      2.6±0.12ms        ? ?/sec    1.48      3.8±0.11ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0.1, selectivity: 0.001     1.00     42.5±0.48ms        ? ?/sec    1.23     52.2±1.33ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0.1, selectivity: 0.01      1.00      5.8±0.12ms        ? ?/sec    1.28      7.4±0.20ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0.1, selectivity: 0.1       1.00      2.2±0.02ms        ? ?/sec    1.37      3.1±0.18ms        ? ?/sec
filter: mixed_utf8view, 8192, nulls: 0.1, selectivity: 0.8       1.00      3.6±0.15ms        ? ?/sec    1.43      5.1±0.12ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0, selectivity: 0.001      1.00     51.0±0.59ms        ? ?/sec    1.38     70.3±1.11ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0, selectivity: 0.01       1.00      6.7±0.03ms        ? ?/sec    1.32      8.8±0.16ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0, selectivity: 0.1        1.00      3.0±0.01ms        ? ?/sec    1.41      4.3±0.09ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0, selectivity: 0.8        1.00      4.5±0.34ms        ? ?/sec    1.71      7.7±0.28ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0.1, selectivity: 0.001    1.00     64.2±0.74ms        ? ?/sec    1.33     85.1±1.52ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0.1, selectivity: 0.01     1.00      9.4±0.09ms        ? ?/sec    1.35     12.6±0.26ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0.1, selectivity: 0.1      1.00      3.8±0.03ms        ? ?/sec    1.46      5.6±0.11ms        ? ?/sec
filter: single_utf8view, 8192, nulls: 0.1, selectivity: 0.8      1.00      5.7±0.28ms        ? ?/sec    1.73      9.9±0.27ms        ? ?/sec
```

# What changes are included in this PR?

* Avoiding recreating the views from scratch.
* Specialize concat for view types
* Takes owned RecordBatch (effect on performance is small, might be measurable with smaller batch size / more columns).

# Are there any user-facing changes?

no