### PR TITLE
Revert "Improve `coalesce` and `concat` performance for views (#7614)"

### DIFF
--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -31,9 +31,7 @@
 //! ```
 
 use crate::dictionary::{merge_dictionary_values, should_merge_dictionary_values};
-use arrow_array::builder::{
-    BooleanBuilder, GenericByteBuilder, GenericByteViewBuilder, PrimitiveBuilder,
-};
+use arrow_array::builder::{BooleanBuilder, GenericByteBuilder, PrimitiveBuilder};
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
@@ -84,15 +82,6 @@ fn fixed_size_list_capacity(arrays: &[&dyn Array], data_type: &DataType) -> Capa
     } else {
         unreachable!("illegal data type for fixed size list")
     }
-}
-
-fn concat_byte_view<B: ByteViewType>(arrays: &[&dyn Array]) -> Result<ArrayRef, ArrowError> {
-    let mut builder =
-        GenericByteViewBuilder::<B>::with_capacity(arrays.iter().map(|a| a.len()).sum());
-    for &array in arrays.iter() {
-        builder.append_array(array.as_byte_view());
-    }
-    Ok(Arc::new(builder.finish()))
 }
 
 fn concat_dictionaries<K: ArrowDictionaryKeyType>(
@@ -436,8 +425,6 @@ pub fn concat(arrays: &[&dyn Array]) -> Result<ArrayRef, ArrowError> {
                 _ => unreachable!("Unsupported run end index type: {r:?}"),
             }
         }
-        DataType::Utf8View => concat_byte_view::<StringViewType>(arrays),
-        DataType::BinaryView => concat_byte_view::<BinaryViewType>(arrays),
         _ => {
             let capacity = get_capacity(arrays, d);
             concat_fallback(arrays, capacity)


### PR DESCRIPTION
This reverts commit 7739a83fe007455dc88e2d926f11d9019905c6a6.

# Which issue does this PR close?



# Rationale for this change
I found this errors in DataFusion (see https://github.com/apache/datafusion/pull/16249#issuecomment-2952353060), so let's revert it and find the error.


# What changes are included in this PR?


# Are there any user-facing changes?

