### PR TITLE
Improve `coalesce` kernel tests

### DIFF
--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -510,17 +510,21 @@ mod tests {
 
     #[test]
     fn test_string_view_mixed() {
-        let large_view_batch = stringview_batch_repeated(1000, [Some("This string is longer than 12 bytes")]);
+        let large_view_batch =
+            stringview_batch_repeated(1000, [Some("This string is longer than 12 bytes")]);
         let small_view_batch = stringview_batch_repeated(1000, [Some("SmallString")]);
-        let mixed_batch = stringview_batch_repeated(1000, [
-            Some("This string is longer than 12 bytes"),
-            Some("Small"),
-        ]);
-        let mixed_batch_nulls = stringview_batch_repeated(1000, [
-            Some("This string is longer than 12 bytes"),
-            Some("Small"),
-            None,
-        ]);
+        let mixed_batch = stringview_batch_repeated(
+            1000,
+            [Some("This string is longer than 12 bytes"), Some("Small")],
+        );
+        let mixed_batch_nulls = stringview_batch_repeated(
+            1000,
+            [
+                Some("This string is longer than 12 bytes"),
+                Some("Small"),
+                None,
+            ],
+        );
 
         // Several batches with mixed inline / non inline
         // 4k rows in
@@ -538,9 +542,8 @@ mod tests {
 
         let gc_array = col_as_string_view("c0", gc_batches.first().unwrap());
 
-        assert_eq!(gc_array.data_buffers().len(), 5); 
+        assert_eq!(gc_array.data_buffers().len(), 5);
     }
-
 
     /// Test for [`BatchCoalescer`]
     ///
@@ -717,10 +720,10 @@ mod tests {
     }
 
     /// Returns the named column as a StringViewArray
-    fn col_as_string_view<'a, 'b>(name: &'a str, batch: &'b RecordBatch) -> &'b StringViewArray {
+    fn col_as_string_view<'b>(name: &str, batch: &'b RecordBatch) -> &'b StringViewArray {
         batch
             .column_by_name(name)
-            .expect(format!("Column '{}' not found", name).as_str())
+            .expect("column not found")
             .as_string_view_opt()
             .expect("column is not a string view")
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to https://github.com/apache/arrow-rs/pull/7625 from @Dandandan 

# Rationale for this change

I want to eventually remove `gc_string_view` but currently the unit tests are in terms of that function

# What changes are included in this PR?

Rewrite tests to be in terms of `coalesce` instead

Also, 
1. Add additional coverage for the issue we saw in https://github.com/apache/arrow-rs/pull/7623
2. Add add coverage for the case where there are data buffers in the view, but they are not referenced by any view https://github.com/apache/arrow-rs/pull/7625#discussion_r2134634467

Codecov of this module is now 100%

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
