### PR TITLE
Fix RowConverter panic when encoding `DictionaryArray`s in `StructArray` / `ListArray`

### DIFF
--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{fixed, null_sentinel, LengthTracker, RowConverter, Rows, SortField};
+use crate::{
+    fixed, null_sentinel, rebuild_field_with_child_type, LengthTracker, RowConverter, Rows,
+    SortField,
+};
 use arrow_array::{new_null_array, Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, SortOptions};
-use std::ops::Range;
+use std::{ops::Range, sync::Arc};
 
 pub fn compute_lengths<O: OffsetSizeTrait>(
     lengths: &mut [usize],
@@ -179,7 +182,20 @@ pub unsafe fn decode<O: OffsetSizeTrait>(
 
     let child_data = child[0].to_data();
 
-    let builder = ArrayDataBuilder::new(field.data_type.clone())
+    // Since RowConverter flattens certian data types (i.e. Dictionary),
+    // we need to use updated data type instead of original field
+    let corrected_type = match &field.data_type {
+        DataType::List(inner_field) => DataType::List(Arc::new(rebuild_field_with_child_type(
+            inner_field,
+            &child_data,
+        ))),
+        DataType::LargeList(inner_field) => DataType::LargeList(Arc::new(
+            rebuild_field_with_child_type(inner_field, &child_data),
+        )),
+        _ => unreachable!(),
+    };
+
+    let builder = ArrayDataBuilder::new(corrected_type)
         .len(rows.len())
         .null_count(null_count)
         .null_bit_buffer(Some(nulls.into()))

--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    fixed, null_sentinel, rebuild_field_with_child_type, LengthTracker, RowConverter, Rows,
-    SortField,
-};
+use crate::{fixed, null_sentinel, LengthTracker, RowConverter, Rows, SortField};
 use arrow_array::{new_null_array, Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::ArrayDataBuilder;
@@ -182,15 +179,20 @@ pub unsafe fn decode<O: OffsetSizeTrait>(
 
     let child_data = child[0].to_data();
 
-    // Since RowConverter flattens certian data types (i.e. Dictionary),
+    // Since RowConverter flattens certain data types (i.e. Dictionary),
     // we need to use updated data type instead of original field
     let corrected_type = match &field.data_type {
-        DataType::List(inner_field) => DataType::List(Arc::new(rebuild_field_with_child_type(
-            inner_field,
-            &child_data,
-        ))),
+        DataType::List(inner_field) => DataType::List(Arc::new(
+            inner_field
+                .as_ref()
+                .clone()
+                .with_data_type(child_data.data_type().clone()),
+        )),
         DataType::LargeList(inner_field) => DataType::LargeList(Arc::new(
-            rebuild_field_with_child_type(inner_field, &child_data),
+            inner_field
+                .as_ref()
+                .clone()
+                .with_data_type(child_data.data_type().clone()),
         )),
         _ => unreachable!(),
     };


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #7165 
- Closes #7169

# Rationale for this change
Although `RowConverter` flattens data type on converting columns into rows, it builds array with original `SortField` which contains unflattened types when converting rows back into columns. Therefore, output array has inconsistent data type although it is actually flattened. 

# What changes are included in this PR?
When decoding columns, instead of using original `SortField`, it uses new field with updated data type of child `ArrayData`, which is flattened.  

I've also considered alternative approaches like recursively modify all the `fields` on `convert_rows` or `convert_raw`, but considering that we already visit each field recursively, I just corrected the field in `decode_column` for simplicity. 

I'd be happy to hear about the feedback on correctness of this pr and any other suggestions. 

# Are there any user-facing changes?
