### PR TITLE
[Variant] Add commented out primitive test casees

### DIFF
--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -40,16 +40,29 @@ fn load_case(name: &str) -> Result<(Vec<u8>, Vec<u8>), ArrowError> {
     Ok((meta, val))
 }
 
+/// Return a list of the values from the parquet testing repository:
+/// <https://github.com/apache/parquet-testing/tree/master/variant>
 fn get_primitive_cases() -> Vec<(&'static str, Variant<'static, 'static>)> {
+    // Cases are commented out
+    // Enabling is tracked in  https://github.com/apache/arrow-rs/issues/7630
     vec![
-        ("primitive_null", Variant::Null),
+        // ("primitive_binary", Variant::Binary),
         ("primitive_boolean_false", Variant::BooleanFalse),
         ("primitive_boolean_true", Variant::BooleanTrue),
+        // ("primitive_date", Variant::Null),
+        //("primitive_decimal4", Variant::Null),
+        //("primitive_decimal8", Variant::Null),
+        //("primitive_decimal16", Variant::Null),
+        //("primitive_float", Variant::Null),
         ("primitive_int8", Variant::Int8(42)),
-        // Using the From<String> trait
-        ("primitive_string", Variant::from("This string is longer than 64 bytes and therefore does not fit in a short_string and it also includes several non ascii characters such as 🐢, 💖, ♥\u{fe0f}, 🎣 and 🤦!!")),
-        // Using the From<String> trait
-        ("short_string", Variant::from("Less than 64 bytes (❤\u{fe0f} with utf8)")), 
+        //("primitive_int16", Variant::Null),
+        //("primitive_int32", Variant::Null),
+        //("primitive_int64", Variant::Null),
+        ("primitive_null", Variant::Null),
+        ("primitive_string", Variant::String("This string is longer than 64 bytes and therefore does not fit in a short_string and it also includes several non ascii characters such as 🐢, 💖, ♥\u{fe0f}, 🎣 and 🤦!!")),
+        //("primitive_timestamp", Variant::Null),
+        //("primitive_timestampntz", Variant::Null),
+        ("short_string", Variant::ShortString("Less than 64 bytes (❤\u{fe0f} with utf8)")),
     ]
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/7630

# Rationale for this change

Make it easy to add this feature by preparing the path with tests

# What changes are included in this PR?

Add tests (commented out) that should pass after https://github.com/apache/arrow-rs/issues/7630 is done

# Are there any user-facing changes?

No