### PR TITLE
Fix reading encrypted Parquet pages when using the page index

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -36,7 +36,9 @@ use crate::format::{PageHeader, PageLocation, PageType};
 use crate::record::reader::RowIter;
 use crate::record::Row;
 use crate::schema::types::Type as SchemaType;
-use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
+#[cfg(feature = "encryption")]
+use crate::thrift::TCompactSliceInputProtocol;
+use crate::thrift::TSerializable;
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::iter;
@@ -722,7 +724,6 @@ impl<R: ChunkReader> SerializedPageReader<R> {
 
 #[cfg(not(feature = "encryption"))]
 impl SerializedPageReaderContext {
-    #[cfg(not(feature = "encryption"))]
     fn read_page_header<T: Read>(
         &self,
         input: &mut T,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -961,16 +961,15 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                         self.context
                             .decrypt_page_data(bytes, *page_index, is_dictionary_page)?;
 
-                    let page = decode_page(
+                    if !is_dictionary_page {
+                        *page_index += 1;
+                    }
+                    decode_page(
                         header,
                         bytes,
                         self.physical_type,
                         self.decompressor.as_mut(),
-                    )?;
-                    if !is_dictionary_page {
-                        *page_index += 1;
-                    }
-                    page
+                    )?
                 }
             };
 
@@ -1103,8 +1102,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                     dictionary_page.take();
                 } else {
                     // If no dictionary page exists, simply pop the data page from page_locations
-                    let popped = page_locations.pop_front();
-                    if popped.is_some() {
+                    if page_locations.pop_front().is_some() {
                         *page_index += 1;
                     }
                 }

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -450,7 +450,7 @@ fn uniform_encryption_roundtrip(
         .with_file_encryption_properties(file_encryption_properties)
         .build();
 
-    let mut writer = ArrowWriter::try_new(file.try_clone().unwrap(), schema.clone(), Some(props))?;
+    let mut writer = ArrowWriter::try_new(file.try_clone()?, schema.clone(), Some(props))?;
 
     for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays.into_iter()) {
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(x0), Arc::new(x1)])?;
@@ -554,7 +554,7 @@ fn uniform_encryption_page_skipping(page_index: bool) -> parquet::errors::Result
         .with_file_encryption_properties(file_encryption_properties)
         .build();
 
-    let mut writer = ArrowWriter::try_new(file.try_clone().unwrap(), schema.clone(), Some(props))?;
+    let mut writer = ArrowWriter::try_new(file.try_clone()?, schema.clone(), Some(props))?;
 
     for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays.into_iter()) {
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(x0), Arc::new(x1)])?;

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -50,8 +50,7 @@ async fn test_non_uniform_encryption_plaintext_footer() {
         .build()
         .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -91,9 +90,7 @@ async fn test_misspecified_encryption_keys() {
 
         let decryption_properties = decryption_properties.build().unwrap();
 
-        let options =
-            ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-        match verify_encryption_test_file_read_async(&mut file, options).await {
+        match verify_encryption_test_file_read_async(&mut file, decryption_properties).await {
             Ok(_) => {
                 panic!("did not get expected error")
             }
@@ -187,8 +184,7 @@ async fn test_non_uniform_encryption() {
         .build()
         .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -204,8 +200,7 @@ async fn test_uniform_encryption() {
         .build()
         .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -344,8 +339,7 @@ async fn test_non_uniform_encryption_plaintext_footer_with_key_retriever() {
             .build()
             .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -366,8 +360,7 @@ async fn test_non_uniform_encryption_with_key_retriever() {
             .build()
             .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -386,8 +379,7 @@ async fn test_uniform_encryption_with_key_retriever() {
             .build()
             .unwrap();
 
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options)
+    verify_encryption_test_file_read_async(&mut file, decryption_properties)
         .await
         .unwrap();
 }
@@ -446,8 +438,10 @@ async fn test_decrypt_page_index(
 
 async fn verify_encryption_test_file_read_async(
     file: &mut tokio::fs::File,
-    options: ArrowReaderOptions,
+    decryption_properties: FileDecryptionProperties,
 ) -> Result<(), ParquetError> {
+    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
+
     let arrow_metadata = ArrowReaderMetadata::load_async(file, options).await?;
     let metadata = arrow_metadata.metadata();
 
@@ -495,6 +489,5 @@ async fn read_and_roundtrip_to_encrypted_file_async(
     writer.close().await.unwrap();
 
     let mut file = tokio::fs::File::from_std(temp_file.try_clone().unwrap());
-    let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
-    verify_encryption_test_file_read_async(&mut file, options).await
+    verify_encryption_test_file_read_async(&mut file, decryption_properties).await
 }

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -427,26 +427,6 @@ async fn test_decrypt_page_index_non_uniform() {
         .unwrap();
 }
 
-#[tokio::test]
-async fn test_read_with_page_index() {
-    let test_data = arrow::util::test_util::parquet_test_data();
-    let path = format!("{test_data}/uniform_encryption.parquet.encrypted");
-    let mut file = File::open(&path).await.unwrap();
-
-    let key_code: &[u8] = "0123456789012345".as_bytes();
-    let decryption_properties = FileDecryptionProperties::builder(key_code.to_vec())
-        .build()
-        .unwrap();
-
-    let options = ArrowReaderOptions::new()
-        .with_file_decryption_properties(decryption_properties)
-        .with_page_index(true);
-
-    verify_encryption_test_file_read_async(&mut file, options)
-        .await
-        .unwrap();
-}
-
 async fn test_decrypt_page_index(
     path: &str,
     decryption_properties: FileDecryptionProperties,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7629.

I also noticed that skipping pages in encrypted files was broken so have fixed that too.

# What changes are included in this PR?

* Refactors `SerializedPageReader` to reduce the use of `#[cfg(...)]` inline. To work with the borrow checker, I created a new `SerializedPageReaderContext` type to hold the `CryptoContext`.
* Updates `SerializedPageReader::get_next_page` so that page headers and page data are decrypted when page indexes are used.
* Updates `SerializedPageReader::skip_next_page` to update the page index so that encryption AADs are calculated correctly.
* Adds new unit tests for reading with a page index and skipping pages in encrypted files.

# Are there any user-facing changes?

Only bug fixes.
