### PR TITLE
Fix the error info of `StructArray::try_new`

### DIFF
--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -108,7 +108,7 @@ impl StructArray {
         arrays: Vec<ArrayRef>,
         nulls: Option<NullBuffer>,
     ) -> Result<Self, ArrowError> {
-        let len = arrays.first().map(|x| x.len()).ok_or_else(||ArrowError::InvalidArgumentError("use StructArray::try_new_with_length or StructArray::new_empty to create a struct array with no fields so that the length can be set correctly".to_string()))?;
+        let len = arrays.first().map(|x| x.len()).ok_or_else(||ArrowError::InvalidArgumentError("use StructArray::try_new_with_length or StructArray::new_empty_fields to create a struct array with no fields so that the length can be set correctly".to_string()))?;
 
         Self::try_new_with_length(fields, arrays, nulls, len)
     }


### PR DESCRIPTION
# Rationale for this change

 There isn't `StructArray::new_empty`, it's `StructArray::new_empty_fields`, the error info is misleading.
