### PR TITLE
Minor: Remove outdated FIXME from `ParquetMetaDataReader`

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -336,15 +336,6 @@ impl ParquetMetaDataReader {
             ));
         }
 
-        // FIXME: there are differing implementations in the case where page indexes are missing
-        // from the file. `MetadataLoader` will leave them as `None`, while the parser in
-        // `index_reader::read_columns_indexes` returns a vector of empty vectors.
-        // It is best for this function to replicate the latter behavior for now, but in a future
-        // breaking release, the two paths to retrieve metadata should be made consistent. Note that this is only
-        // an issue if the user requested page indexes, so there is no need to provide empty
-        // vectors in `try_parse_sized()`.
-        // https://github.com/apache/arrow-rs/issues/6447
-
         // Get bounds needed for page indexes (if any are present in the file).
         let Some(range) = self.range_for_page_index() else {
             return Ok(());


### PR DESCRIPTION
# Which issue does this PR close?
Related to #6447.

While reviewing other PRs I happened to notice an old FIXME I left behind that should have been removed in #6639. 

# Rationale for this change


# What changes are included in this PR?


# Are there any user-facing changes?
No, just removes a comment
