### PR TITLE
Update FlightSQL `GetDbSchemas` and `GetTables` schemas to fully match the protocol

### DIFF
--- a/arrow-flight/src/sql/metadata/db_schemas.rs
+++ b/arrow-flight/src/sql/metadata/db_schemas.rs
@@ -38,7 +38,7 @@ use crate::sql::CommandGetDbSchemas;
 /// Builds rows like this:
 ///
 /// * catalog_name: utf8,
-/// * db_schema_name: utf8,
+/// * db_schema_name: utf8 not null
 pub struct GetDbSchemasBuilder {
     // Specifies the Catalog to search for the tables.
     // - An empty string retrieves those without a catalog.
@@ -177,7 +177,7 @@ fn get_db_schemas_schema() -> SchemaRef {
 /// The schema for GetDbSchemas
 static GET_DB_SCHEMAS_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
     Arc::new(Schema::new(vec![
-        Field::new("catalog_name", DataType::Utf8, false),
+        Field::new("catalog_name", DataType::Utf8, true),
         Field::new("db_schema_name", DataType::Utf8, false),
     ]))
 });

--- a/arrow-flight/src/sql/metadata/tables.rs
+++ b/arrow-flight/src/sql/metadata/tables.rs
@@ -291,8 +291,8 @@ fn get_tables_schema(include_schema: bool) -> SchemaRef {
 /// The schema for GetTables without `table_schema` column
 static GET_TABLES_SCHEMA_WITHOUT_TABLE_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
     Arc::new(Schema::new(vec![
-        Field::new("catalog_name", DataType::Utf8, false),
-        Field::new("db_schema_name", DataType::Utf8, false),
+        Field::new("catalog_name", DataType::Utf8, true),
+        Field::new("db_schema_name", DataType::Utf8, true),
         Field::new("table_name", DataType::Utf8, false),
         Field::new("table_type", DataType::Utf8, false),
     ]))
@@ -301,8 +301,8 @@ static GET_TABLES_SCHEMA_WITHOUT_TABLE_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
 /// The schema for GetTables with `table_schema` column
 static GET_TABLES_SCHEMA_WITH_TABLE_SCHEMA: Lazy<SchemaRef> = Lazy::new(|| {
     Arc::new(Schema::new(vec![
-        Field::new("catalog_name", DataType::Utf8, false),
-        Field::new("db_schema_name", DataType::Utf8, false),
+        Field::new("catalog_name", DataType::Utf8, true),
+        Field::new("db_schema_name", DataType::Utf8, true),
         Field::new("table_name", DataType::Utf8, false),
         Field::new("table_type", DataType::Utf8, false),
         Field::new("table_schema", DataType::Binary, false),


### PR DESCRIPTION
# Which issue does this PR close?

PR updates FlightSQL `GetDbSchemas` and `GetTables` schemas to fully match the FlightSQL protocol.

Closes https://github.com/apache/arrow-rs/issues/7637

# What changes are included in this PR?

There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.

# Are there any user-facing changes?

It could technically be considered a user-facing breaking change, as the schema returned by the `CommandGetDbSchemas` and `CommandGetTables` FlightSQL commands will change. HHowever, since the change only affects field nullability, there should be no practical impact, or it is very unlikely.
