### PR TITLE
Minor: Add version to deprecation notice for `ParquetMetaDataReader::decode_footer`

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -858,7 +858,7 @@ impl ParquetMetaDataReader {
     }
 
     /// Decodes the Parquet footer, returning the metadata length in bytes
-    #[deprecated(note = "use decode_footer_tail instead")]
+    #[deprecated(since = "54.3.0", note = "Use decode_footer_tail instead")]
     pub fn decode_footer(slice: &[u8; FOOTER_SIZE]) -> Result<usize> {
         Self::decode_footer_tail(slice).map(|f| f.metadata_length)
     }


### PR DESCRIPTION
# Which issue does this PR close?

Found a `#[deprecated]` missing a `since` while preparing to remove deprecated APIs.

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

No, just adds clarification
