### PR TITLE
Deprecate old Parquet page index parsing functions

### DIFF
--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -48,6 +48,10 @@ pub(crate) fn acc_range(a: Option<Range<u64>>, b: Option<Range<u64>>) -> Option<
 /// See [Page Index Documentation] for more details.
 ///
 /// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+#[deprecated(
+    since = "55.2.0",
+    note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
+)]
 pub fn read_columns_indexes<R: ChunkReader>(
     reader: &R,
     chunks: &[ColumnChunkMetaData],
@@ -128,6 +132,10 @@ pub fn read_pages_locations<R: ChunkReader>(
 /// See [Page Index Documentation] for more details.
 ///
 /// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+#[deprecated(
+    since = "55.2.0",
+    note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
+)]
 pub fn read_offset_indexes<R: ChunkReader>(
     reader: &R,
     chunks: &[ColumnChunkMetaData],

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1051,6 +1051,7 @@ mod tests {
     use crate::data_type::private::ParquetValueType;
     use crate::data_type::{AsBytes, FixedLenByteArrayType, Int32Type};
     use crate::file::page_index::index::{Index, NativeIndex};
+    #[allow(deprecated)]
     use crate::file::page_index::index_reader::{read_columns_indexes, read_offset_indexes};
     use crate::file::writer::SerializedFileWriter;
     use crate::record::RowAccessor;
@@ -1883,6 +1884,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_page_index_reader_out_of_order() {
         let test_file = get_test_file("alltypes_tiny_pages_plain.parquet");
         let options = ReadOptionsBuilder::new().with_page_index().build();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #6447.

# Rationale for this change

This deprecates the last of the old standalone Parquet metadata parsing functions that have since been replaced by `ParquetMetaDataReader`.

# What changes are included in this PR?

# Are there any user-facing changes?

No, only adds deprecation warnings to public API
