### PR TITLE
Ensure page encoding statistics are written to Parquet file

### DIFF
--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -481,7 +481,7 @@ mod test {
             .unwrap();
         assert_eq!(
             err.to_string(),
-            "EOF: Parquet file too small. Page index range 82..115 overlaps with file metadata 0..341"
+            "EOF: Parquet file too small. Page index range 82..115 overlaps with file metadata 0..357"
         );
     }
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -689,6 +689,9 @@ impl<'a, W: Write + Send> SerializedRowGroupWriter<'a, W> {
         if let Some(statistics) = metadata.statistics() {
             builder = builder.set_statistics(statistics.clone())
         }
+        if let Some(page_encoding_stats) = metadata.page_encoding_stats() {
+            builder = builder.set_page_encoding_stats(page_encoding_stats.clone())
+        }
         builder = self.set_column_crypto_metadata(builder, &metadata);
         close.metadata = builder.build()?;
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7616.

# Rationale for this change

Page encoding statistics are not copied from the column chunk result to the final output metadata.

# What changes are included in this PR?

Make sure stats are copied and add a round trip test to make sure they end up in the Parquet file.

# Are there any user-facing changes?

No
