### PR TITLE
Optimize coalesce kernel for StringView (10-50% faster)

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -478,7 +478,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
 
         builder.finish()
     }
-    
+
     /// Returns the total number of bytes used by all non inlined views in all buffers.
     pub fn total_buffer_bytes_used(&self) -> usize {
         self.views()
@@ -493,7 +493,6 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
             })
             .sum()
     }
-    
 
     /// Compare two [`GenericByteViewArray`] at index `left_idx` and `right_idx`
     ///

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -479,7 +479,18 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         builder.finish()
     }
 
-    /// Returns the total number of bytes used by all non inlined views in all buffers.
+    /// Returns the total number of bytes used by all non inlined views in all
+    /// buffers.
+    ///
+    /// Note this does not account for views that point at the same underlying
+    /// data in buffers
+    ///
+    /// For example, if the array has three strings views:
+    /// * View with length = 9 (inlined)
+    /// * View with length = 32 (non inlined)
+    /// * View with length = 16 (non inlined)
+    ///
+    /// Then this method would report 48
     pub fn total_buffer_bytes_used(&self) -> usize {
         self.views()
             .iter()

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -478,6 +478,22 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
 
         builder.finish()
     }
+    
+    /// Returns the total number of bytes used by all non inlined views in all buffers.
+    pub fn total_buffer_bytes_used(&self) -> usize {
+        self.views()
+            .iter()
+            .map(|v| {
+                let len = (*v as u32) as usize;
+                if len > 12 {
+                    len
+                } else {
+                    0
+                }
+            })
+            .sum()
+    }
+    
 
     /// Compare two [`GenericByteViewArray`] at index `left_idx` and `right_idx`
     ///

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -361,6 +361,7 @@ impl InProgressStringViewArray {
     }
 
     /// Append views to self.views, updating the buffer index if necessary
+    #[inline(never)]
     fn append_views_and_update_buffer_index(&mut self, views: &[u128], buffers: &[Buffer]) {
         if let Some(buffer) = self.current.take() {
             self.completed.push(buffer.into());
@@ -393,6 +394,7 @@ impl InProgressStringViewArray {
     /// - `views` - the views to append
     /// - `actual_buffer_size` - the size of the bytes pointed to by the views
     /// - `buffers` - the buffers the reviews point to
+    #[inline(never)]
     fn append_views_and_copy_strings(
         &mut self,
         views: &[u128],

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -620,8 +620,6 @@ impl BufferSource {
     /// Return a new buffer, with a capacity of at least `min_size`
     fn next_buffer(&mut self, min_size: usize) -> Vec<u8> {
         let size = self.next_size(min_size);
-        println!("Allocating buffer of size {size}");
-
         Vec::with_capacity(size)
     }
 

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -532,11 +532,11 @@ impl InProgressStringViewArray {
         let new_views = views.iter().map(|v| {
             let mut b: ByteView = ByteView::from(*v);
             if b.length > 12 {
-                // TODO optimize (we know there is enough space, in bounds, etc...)
                 let buffer_index = b.buffer_index as usize;
                 let buffer_offset = b.offset as usize;
                 let str_len = b.length as usize;
-                // New location of the view data in the current buffer
+
+                // Update view to location in current
                 b.offset = current.len() as u32;
                 b.buffer_index = new_buffer_index;
 
@@ -619,7 +619,10 @@ impl BufferSource {
 
     /// Return a new buffer, with a capacity of at least `min_size`
     fn next_buffer(&mut self, min_size: usize) -> Vec<u8> {
-        Vec::with_capacity(self.next_size(min_size))
+        let size = self.next_size(min_size);
+        println!("Allocating buffer of size {size}");
+
+        Vec::with_capacity(size)
     }
 
     fn next_size(&mut self, min_size: usize) -> usize {

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -503,7 +503,7 @@ impl InProgressArray for InProgressStringViewArray {
 }
 
 const STARTING_BLOCK_SIZE: usize = 4 * 1024; // (note the first size used is actually 8KiB)
-const MAX_BLOCK_SIZE: usize = 2 * 1024 * 1024; // 2MiB
+const MAX_BLOCK_SIZE: usize = 1 * 1024 * 1024; // 1MiB
 
 /// Manages allocating new buffers for `StringViewArray`
 ///

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -465,6 +465,12 @@ impl InProgressArray for InProgressStringViewArray {
         let actual_buffer_size = s.get_buffer_memory_size();
         let buffers = s.data_buffers();
 
+        // None of the views references the buffers (e.g. sliced)
+        if ideal_buffer_size == 0 {
+            self.views.extend_from_slice(s.views().as_ref());
+            return;
+        }
+
         // Copying the strings into a buffer can be time-consuming so
         // only do it if the array is sparse
         if actual_buffer_size > (ideal_buffer_size * 2) {

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -42,7 +42,8 @@ use generic::GenericInProgressArray;
 /// [`RecordBatch`]es.
 ///
 /// This is useful after operations such as [`filter`] and [`take`] that produce
-/// smaller batches, and we want to coalesce them into larger
+/// smaller batches, and we want to coalesce them into larger batches for
+/// further processing.
 ///
 /// [`filter`]: crate::filter::filter
 /// [`take`]: crate::take::take
@@ -117,10 +118,6 @@ use generic::GenericInProgressArray;
 ///
 /// 2. The output is a sequence of batches, with all but the last being at exactly
 ///    `target_batch_size` rows.
-///
-/// 3. Eventually this may also be able to handle other optimizations such as a
-///    combined filter/coalesce operation. See <https://github.com/apache/arrow-rs/issues/6692>
-///
 #[derive(Debug)]
 pub struct BatchCoalescer {
     /// The input schema

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -343,6 +343,9 @@ impl InProgressStringViewArray {
     }
 
     /// Allocate space for output views and nulls if needed
+    ///
+    /// This is done when on write (when we know it is needed) rather than
+    /// eagerly to avoid allocations that are not used.
     fn ensure_capacity(&mut self) {
         self.views.reserve(self.batch_size);
     }

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -293,7 +293,9 @@ impl<B: ByteViewType> InProgressArray for InProgressByteViewArray<B> {
     fn copy_rows(&mut self, offset: usize, len: usize) -> Result<(), ArrowError> {
         self.ensure_capacity();
         let source = self.source.take().ok_or_else(|| {
-            ArrowError::InvalidArgumentError("InProgressByteViewArray: source not set".to_string())
+            ArrowError::InvalidArgumentError(
+                "Internal Error: InProgressByteViewArray: source not set".to_string(),
+            )
         })?;
 
         // If creating StringViewArray output, ensure input was valid utf8 too

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -1,0 +1,398 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::coalesce::InProgressArray;
+use arrow_array::cast::AsArray;
+use arrow_array::types::ByteViewType;
+use arrow_array::{Array, ArrayRef, GenericByteViewArray};
+use arrow_buffer::{Buffer, NullBufferBuilder};
+use arrow_data::ByteView;
+use arrow_schema::ArrowError;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// InProgressArray for StringViewArray and BinaryViewArray
+pub(crate) struct InProgressByteViewArray<B: ByteViewType> {
+    /// the target batch size (and thus size for views allocation)
+    batch_size: usize,
+    /// The in progress vies
+    views: Vec<u128>,
+    /// In progress nulls
+    nulls: NullBufferBuilder,
+    /// current buffer
+    current: Option<Vec<u8>>,
+    /// completed buffers
+    completed: Vec<Buffer>,
+    /// Where to get the next buffer
+    buffer_source: BufferSource,
+    /// Phantom so we can use the same struct for both StringViewArray and
+    /// BinaryViewArray
+    _phantom: PhantomData<B>,
+}
+
+// manually implement Debug because ByteViewType doesn't implement Debug
+impl<B: ByteViewType> std::fmt::Debug for InProgressByteViewArray<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProgressByteViewArray")
+            .field("batch_size", &self.batch_size)
+            .field("views", &self.views.len())
+            .field("nulls", &self.nulls)
+            .field("current", &self.current.as_ref().map(|_| "Some(...)"))
+            .field("completed", &self.completed.len())
+            .finish()
+    }
+}
+
+impl<B: ByteViewType> InProgressByteViewArray<B> {
+    pub(crate) fn new(batch_size: usize) -> Self {
+        let buffer_source = BufferSource::new();
+
+        Self {
+            batch_size,
+            views: Vec::new(),                         // allocate in push
+            nulls: NullBufferBuilder::new(batch_size), // no allocation
+            current: None,
+            completed: vec![],
+            buffer_source,
+            _phantom: PhantomData::default(),
+        }
+    }
+
+    /// Allocate space for output views and nulls if needed
+    ///
+    /// This is done when on write (when we know it is necessary) rather than
+    /// eagerly to avoid allocations that are not used.
+    fn ensure_capacity(&mut self) {
+        self.views.reserve(self.batch_size);
+    }
+
+    /// Update self.nulls with the nulls from the StringViewArray
+    fn push_nulls(&mut self, s: &GenericByteViewArray<B>) {
+        if let Some(nulls) = s.nulls().as_ref() {
+            self.nulls.append_buffer(nulls);
+        } else {
+            self.nulls.append_n_non_nulls(s.len());
+        }
+    }
+
+    /// Finishes in progress block, if any
+    fn finish_current(&mut self) {
+        let Some(next_buffer) = self.current.take() else {
+            return;
+        };
+        self.completed.push(next_buffer.into());
+    }
+
+    /// Append views to self.views, updating the buffer index if necessary
+    #[inline(never)]
+    fn append_views_and_update_buffer_index(&mut self, views: &[u128], buffers: &[Buffer]) {
+        if let Some(buffer) = self.current.take() {
+            self.completed.push(buffer.into());
+        }
+        let starting_buffer: u32 = self.completed.len().try_into().expect("too many buffers");
+        self.completed.extend_from_slice(buffers);
+
+        if starting_buffer == 0 {
+            // If there are no buffers, we can just use the views as is
+            self.views.extend_from_slice(views);
+        } else {
+            // If there are buffers, we need to update the buffer index
+            let updated_views = views.iter().map(|v| {
+                let mut byte_view = ByteView::from(*v);
+                if byte_view.length > 12 {
+                    // Small views (<=12 bytes) are inlined, so only need to update large views
+                    byte_view.buffer_index += starting_buffer;
+                };
+                byte_view.as_u128()
+            });
+
+            self.views.extend(updated_views);
+        }
+    }
+
+    /// Append views to self.views, copying data from the buffers into
+    /// self.buffers
+    ///
+    /// # Arguments
+    /// - `views` - the views to append
+    /// - `view_buffer_size` - the total number of bytes pointed to by the views
+    /// - `buffers` - the buffers the reviews point to
+    #[inline(never)]
+    fn append_views_and_copy_strings(
+        &mut self,
+        views: &[u128],
+        view_buffer_size: usize,
+        buffers: &[Buffer],
+    ) {
+        // Note: the calculations below are designed to avoid any reallocations
+        // of the current buffer, and to only allocate new buffers when
+        // necessary, which is critical for performance.
+
+        // If there is no current buffer, allocate a new one
+        let Some(current) = self.current.take() else {
+            let new_buffer = self.buffer_source.next_buffer(view_buffer_size);
+            self.append_views_and_copy_strings_inner(views, new_buffer, buffers);
+            return;
+        };
+
+        // If there is a current buffer with enough space, append the views and
+        // copy the strings into the existing buffer.
+        let mut remaining_capacity = current.capacity() - current.len();
+        if view_buffer_size <= remaining_capacity {
+            self.append_views_and_copy_strings_inner(views, current, buffers);
+            return;
+        }
+
+        // Here there is a current buffer, but it doesn't have enough space to
+        // hold all the strings. Copy as many views as we can into the current
+        // buffer and then allocate a new buffer for the remaining views
+        //
+        // TODO: maybe we can copy the strings too at the same time?
+        let mut num_view_to_current = 0;
+        for view in views {
+            let b = ByteView::from(*view);
+            let str_len = b.length;
+            if remaining_capacity < str_len as usize {
+                break;
+            }
+            if str_len > 12 {
+                remaining_capacity -= str_len as usize;
+            }
+            num_view_to_current += 1;
+        }
+
+        let first_views = &views[0..num_view_to_current];
+        let string_bytes_to_copy = current.capacity() - current.len() - remaining_capacity;
+        let remaining_view_buffer_size = view_buffer_size - string_bytes_to_copy;
+
+        self.append_views_and_copy_strings_inner(first_views, current, buffers);
+        let completed = self.current.take().expect("completed");
+        self.completed.push(completed.into());
+
+        // Copy any remaining views into a new buffer
+        let remaining_views = &views[num_view_to_current..];
+        let new_buffer = self.buffer_source.next_buffer(remaining_view_buffer_size);
+        self.append_views_and_copy_strings_inner(remaining_views, new_buffer, buffers);
+    }
+
+    /// Append views to self.views, copying data from the buffers into
+    /// dst_buffer, which is then set as self.current
+    ///
+    /// # Panics:
+    /// If `self.current` is `Some`
+    ///
+    /// See `append_views_and_copy_strings` for more details
+    #[inline(never)]
+    fn append_views_and_copy_strings_inner(
+        &mut self,
+        views: &[u128],
+        mut dst_buffer: Vec<u8>,
+        buffers: &[Buffer],
+    ) {
+        assert!(self.current.is_none(), "current buffer should be None");
+
+        if views.is_empty() {
+            self.current = Some(dst_buffer);
+            return;
+        }
+
+        let new_buffer_index: u32 = self.completed.len().try_into().expect("too many buffers");
+
+        // In debug builds, check that the vector has enough capacity to copy
+        // the views into it without reallocating.
+        #[cfg(debug_assertions)]
+        {
+            let total_length: usize = views
+                .iter()
+                .filter_map(|v| {
+                    let b = ByteView::from(*v);
+                    if b.length > 12 {
+                        Some(b.length as usize)
+                    } else {
+                        None
+                    }
+                })
+                .sum();
+            debug_assert!(
+                dst_buffer.capacity() >= total_length,
+                "dst_buffer capacity {} is less than total length {}",
+                dst_buffer.capacity(),
+                total_length
+            );
+        }
+
+        // Copy the views, updating the buffer index and copying the data as needed
+        let new_views = views.iter().map(|v| {
+            let mut b: ByteView = ByteView::from(*v);
+            if b.length > 12 {
+                let buffer_index = b.buffer_index as usize;
+                let buffer_offset = b.offset as usize;
+                let str_len = b.length as usize;
+
+                // Update view to location in current
+                b.offset = dst_buffer.len() as u32;
+                b.buffer_index = new_buffer_index;
+
+                // safety: input views are validly constructed
+                let src = unsafe {
+                    buffers
+                        .get_unchecked(buffer_index)
+                        .get_unchecked(buffer_offset..buffer_offset + str_len)
+                };
+                dst_buffer.extend_from_slice(src);
+            }
+            b.as_u128()
+        });
+        self.views.extend(new_views);
+        self.current = Some(dst_buffer);
+    }
+}
+
+impl<B: ByteViewType> InProgressArray for InProgressByteViewArray<B> {
+    fn push_array(&mut self, array: ArrayRef) {
+        // If creating StringViewArray output, ensure input was valid utf8 too
+        self.ensure_capacity();
+        let s = array.as_byte_view::<B>();
+
+        // add any nulls, as necessary
+        self.push_nulls(s);
+
+        // If there are no data buffers in s (all inlined views), can append the
+        // views/nulls and done
+        if s.data_buffers().is_empty() {
+            self.views.extend_from_slice(s.views().as_ref());
+            return;
+        }
+
+        let ideal_buffer_size = s.total_buffer_bytes_used();
+        let actual_buffer_size = s.get_buffer_memory_size();
+        let buffers = s.data_buffers();
+
+        // None of the views references the buffers (e.g. sliced)
+        if ideal_buffer_size == 0 {
+            self.views.extend_from_slice(s.views().as_ref());
+            return;
+        }
+
+        // Copying the strings into a buffer can be time-consuming so
+        // only do it if the array is sparse
+        if actual_buffer_size > (ideal_buffer_size * 2) {
+            self.append_views_and_copy_strings(s.views(), ideal_buffer_size, buffers);
+        } else {
+            self.append_views_and_update_buffer_index(s.views(), buffers);
+        }
+    }
+
+    fn finish(&mut self) -> Result<ArrayRef, ArrowError> {
+        self.finish_current();
+        assert!(self.current.is_none());
+        let buffers = std::mem::take(&mut self.completed);
+        let views = std::mem::take(&mut self.views);
+        let nulls = self.nulls.finish();
+        self.nulls = NullBufferBuilder::new(self.batch_size);
+
+        // Safety: we created valid views and buffers above and the
+        // input arrays had value data and nulls
+        let new_array =
+            unsafe { GenericByteViewArray::<B>::new_unchecked(views.into(), buffers, nulls) };
+        Ok(Arc::new(new_array))
+    }
+}
+
+const STARTING_BLOCK_SIZE: usize = 4 * 1024; // (note the first size used is actually 8KiB)
+const MAX_BLOCK_SIZE: usize = 1024 * 1024; // 1MiB
+
+/// Manages allocating new buffers for `StringViewArray`
+#[derive(Debug)]
+struct BufferSource {
+    current_size: usize,
+}
+
+impl BufferSource {
+    fn new() -> Self {
+        Self {
+            current_size: STARTING_BLOCK_SIZE,
+        }
+    }
+
+    /// Return a new buffer, with a capacity of at least `min_size`
+    fn next_buffer(&mut self, min_size: usize) -> Vec<u8> {
+        let size = self.next_size(min_size);
+        Vec::with_capacity(size)
+    }
+
+    fn next_size(&mut self, min_size: usize) -> usize {
+        if self.current_size < MAX_BLOCK_SIZE {
+            // If the current size is less than the max size, we can double it
+            // we have fixed start/end block sizes, so we can't overflow
+            self.current_size = self.current_size.saturating_mul(2);
+        }
+        if self.current_size >= min_size {
+            self.current_size
+        } else {
+            // increase next size until we hit min_size or max  size
+            while self.current_size <= min_size && self.current_size < MAX_BLOCK_SIZE {
+                self.current_size = self.current_size.saturating_mul(2);
+            }
+            self.current_size.max(min_size)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_source() {
+        let mut source = BufferSource::new();
+        assert_eq!(source.next_buffer(1000).capacity(), 8192);
+        assert_eq!(source.next_buffer(1000).capacity(), 16384);
+        assert_eq!(source.next_buffer(1000).capacity(), 32768);
+        assert_eq!(source.next_buffer(1000).capacity(), 65536);
+        assert_eq!(source.next_buffer(1000).capacity(), 131072);
+        assert_eq!(source.next_buffer(1000).capacity(), 262144);
+        assert_eq!(source.next_buffer(1000).capacity(), 524288);
+        assert_eq!(source.next_buffer(1000).capacity(), 1024 * 1024);
+        // clamped to max size
+        assert_eq!(source.next_buffer(1000).capacity(), 1024 * 1024);
+        // Can override with larger size request
+        assert_eq!(source.next_buffer(10_000_000).capacity(), 10_000_000);
+    }
+
+    #[test]
+    fn test_buffer_source_with_min_small() {
+        let mut source = BufferSource::new();
+        // First buffer should be 8kb
+        assert_eq!(source.next_buffer(5_600).capacity(), 8 * 1024);
+        // then 16kb
+        assert_eq!(source.next_buffer(5_600).capacity(), 16 * 1024);
+        // then 32kb
+        assert_eq!(source.next_buffer(5_600).capacity(), 32 * 1024);
+    }
+
+    #[test]
+    fn test_buffer_source_with_min_large() {
+        let mut source = BufferSource::new();
+        assert_eq!(source.next_buffer(500_000).capacity(), 512 * 1024);
+        assert_eq!(source.next_buffer(500_000).capacity(), 1024 * 1024);
+        // clamped to max size
+        assert_eq!(source.next_buffer(500_000).capacity(), 1024 * 1024);
+        // Can override with larger size request
+        assert_eq!(source.next_buffer(2_000_000).capacity(), 2_000_000);
+    }
+}

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -28,9 +28,13 @@ use std::sync::Arc;
 /// InProgressArray for [`StringViewArray`] and [`BinaryViewArray`]
 ///
 /// This structure buffers the views and data buffers as they are copied from
-/// the source array, and then produces a new array when `finish` is called. It also
-/// handles "garbage collection" by copying strings to a new buffer when the source
-/// buffer is sparse (i.e. uses at least 2x more than the memory it needs).
+/// the source array, and then produces a new array when `finish` is called. It
+/// also handles "garbage collection" by copying strings to a new buffer when
+/// the source buffer is sparse (i.e. uses at least 2x more than the memory it
+/// needs).
+/// 
+/// [`StringViewArray`]: arrow_array::StringViewArray
+/// [`BinaryViewArray`]: arrow_array::BinaryViewArray
 pub(crate) struct InProgressByteViewArray<B: ByteViewType> {
     /// The source array and information
     source: Option<Source>,

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 /// also handles "garbage collection" by copying strings to a new buffer when
 /// the source buffer is sparse (i.e. uses at least 2x more than the memory it
 /// needs).
-/// 
+///
 /// [`StringViewArray`]: arrow_array::StringViewArray
 /// [`BinaryViewArray`]: arrow_array::BinaryViewArray
 pub(crate) struct InProgressByteViewArray<B: ByteViewType> {

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -68,7 +68,7 @@ impl<B: ByteViewType> InProgressByteViewArray<B> {
             current: None,
             completed: vec![],
             buffer_source,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 

--- a/arrow-select/src/coalesce/generic.rs
+++ b/arrow-select/src/coalesce/generic.rs
@@ -49,7 +49,9 @@ impl InProgressArray for GenericInProgressArray {
 
     fn copy_rows(&mut self, offset: usize, len: usize) -> Result<(), ArrowError> {
         let source = self.source.as_ref().ok_or_else(|| {
-            ArrowError::InvalidArgumentError("GenericInProgressArray: source not set".to_string())
+            ArrowError::InvalidArgumentError(
+                "Internal Error: GenericInProgressArray: source not set".to_string(),
+            )
         })?;
         let array = source.slice(offset, len);
         self.buffered_arrays.push(array);

--- a/arrow-select/src/coalesce/generic.rs
+++ b/arrow-select/src/coalesce/generic.rs
@@ -20,9 +20,11 @@ use crate::concat::concat;
 use arrow_array::ArrayRef;
 use arrow_schema::ArrowError;
 
-/// Fallback implementation for [`InProgressArray`]
+/// Generic implementation for [`InProgressArray`] that works with any type of
+/// array.
 ///
-/// Internally, buffers arrays and calls [`concat`]
+/// Internally, this buffers arrays and then calls other kernels such as
+/// [`concat`] to produce the final array.
 ///
 /// [`concat`]: crate::concat::concat
 #[derive(Debug)]

--- a/arrow-select/src/coalesce/generic.rs
+++ b/arrow-select/src/coalesce/generic.rs
@@ -17,7 +17,7 @@
 
 use super::InProgressArray;
 use crate::concat::concat;
-use arrow_array::{Array, ArrayRef};
+use arrow_array::ArrayRef;
 use arrow_schema::ArrowError;
 
 /// Fallback implementation for [`InProgressArray`]
@@ -51,7 +51,7 @@ impl InProgressArray for GenericInProgressArray {
             &self
                 .buffered_arrays
                 .iter()
-                .map(|array| array as &dyn Array)
+                .map(|array| array.as_ref())
                 .collect::<Vec<_>>(),
         )?;
         self.buffered_arrays.clear();

--- a/arrow-select/src/coalesce/generic.rs
+++ b/arrow-select/src/coalesce/generic.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::InProgressArray;
+use crate::concat::concat;
+use arrow_array::{Array, ArrayRef};
+use arrow_schema::ArrowError;
+
+/// Fallback implementation for [`InProgressArray`]
+///
+/// Internally, buffers arrays and calls [`concat`]
+///
+/// [`concat`]: crate::concat::concat
+#[derive(Debug)]
+pub(crate) struct GenericInProgressArray {
+    /// The buffered arrays
+    buffered_arrays: Vec<ArrayRef>,
+}
+
+impl GenericInProgressArray {
+    /// Create a new `GenericInProgressArray`
+    pub(crate) fn new() -> Self {
+        Self {
+            buffered_arrays: vec![],
+        }
+    }
+}
+impl InProgressArray for GenericInProgressArray {
+    fn push_array(&mut self, array: ArrayRef) {
+        self.buffered_arrays.push(array);
+    }
+
+    fn finish(&mut self) -> Result<ArrayRef, ArrowError> {
+        // Concatenate all buffered arrays into a single array, which uses 2x
+        // peak memory
+        let array = concat(
+            &self
+                .buffered_arrays
+                .iter()
+                .map(|array| array as &dyn Array)
+                .collect::<Vec<_>>(),
+        )?;
+        self.buffered_arrays.clear();
+        Ok(array)
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?


- Part of https://github.com/apache/arrow-rs/issues/7456

# Rationale for this change

Currently the `coalesce` kernel buffers views / data until there are enough rows and then concat's the results together. StringViewArrays can be even worse as there is a second copy in `gc_string_view_batch`

This is wasteful because it
1. Buffers memory (has 2x the peak usage)
2. Copies the data twice

We can make it faster and more memory efficient by directly creating the output array

# What changes are included in this PR?
1. Add a specialization for incrementally building `StringViewArray` without buffering

Note this PR does NOT (yet) add specialized filtering -- instead it focuses on reducing the
overhead of appending views by not copying them (again!) with `gc_string_view_batch`

# Open questions:
1. There is substantial overlap / duplication with StringViewBuilder -- I wonder if we can / should consolidate them somehow

The differences are that the
1. Block size calculation management (aka look at the buffer sizes of the incoming buffers)
2. Finishing array allocates sufficient space for views

# Are there any user-facing changes?
The kernel is faster, no API changes
