### PR TITLE
ci: add cargo deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,20 @@ jobs:
           # cargo fmt -p parquet -- --config skip_children=true `find . -name "*.rs" \! -name format.rs`
           cargo fmt -p parquet -- --check --config skip_children=true `find . -name "*.rs" \! -name format.rs`
 
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+      - name: Setup cargo deny
+        run: rustup component add deny
+      - name: Run cargo deny
+        run: cargo deny check
+
   msrv:
     name: Verify MSRV (Minimum Supported Rust Version)
     runs-on: ubuntu-latest

--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -48,7 +48,7 @@ prost = { version = "0.13.1", default-features = false, features = ["prost-deriv
 # For Timestamp type
 prost-types = { version = "0.13.1", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"], optional = true }
-tonic = { version = "0.12.3", default-features = false, features = ["transport", "codegen", "prost"] }
+tonic = { version = "0.13.1", default-features = false, features = ["transport", "codegen", "prost"] }
 
 # CLI-related dependencies
 anyhow = { version = "1.0", optional = true }
@@ -64,7 +64,7 @@ default = []
 flight-sql = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
 # TODO: Remove in the next release
 flight-sql-experimental = ["flight-sql"]
-tls = ["tonic/tls"]
+tls = ["tonic/tls-native-roots"]
 # Enable CLI tools
 cli = ["arrow-array/chrono-tz", "arrow-cast/prettyprint", "tonic/tls-webpki-roots", "dep:anyhow", "dep:clap", "dep:tracing-log", "dep:tracing-subscriber"]
 

--- a/arrow-integration-testing/Cargo.toml
+++ b/arrow-integration-testing/Cargo.toml
@@ -43,7 +43,7 @@ prost = { version = "0.13", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["rc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = [ "rt-multi-thread"] }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13.1", default-features = false }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt"], optional = true }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # https://github.com/EmbarkStudios/cargo-deny
 #
 # cargo-deny checks our dependency tree for copy-left licenses,

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,71 @@
+# https://github.com/EmbarkStudios/cargo-deny
+#
+# cargo-deny checks our dependency tree for copy-left licenses,
+# duplicate dependencies, and rustsec advisories (https://rustsec.org/advisories).
+#
+# Install: `cargo install cargo-deny`
+# Check: `cargo deny check`.
+
+# Note: running just `cargo deny check` without a `--target` can result in
+# false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+[graph]
+targets = [
+  { triple = "aarch64-apple-darwin" },
+  { triple = "i686-pc-windows-gnu" },
+  { triple = "i686-pc-windows-msvc" },
+  { triple = "i686-unknown-linux-gnu" },
+  { triple = "wasm32-unknown-unknown" },
+  { triple = "x86_64-apple-darwin" },
+  { triple = "x86_64-pc-windows-gnu" },
+  { triple = "x86_64-pc-windows-msvc" },
+  { triple = "x86_64-unknown-linux-gnu" },
+  { triple = "x86_64-unknown-linux-musl" },
+  { triple = "x86_64-unknown-redox" },
+]
+all-features = true
+
+
+[advisories]
+version = 2
+ignore = [
+  "RUSTSEC-2024-0436", # https://rustsec.org/advisories/RUSTSEC-2024-0436 - paste is unmaintained - https://github.com/dtolnay/paste
+]
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow" # We use them for examples
+deny = [
+]
+skip = [
+  { name = "getrandom" },    # Blocked by https://github.com/briansmith/ring/issues/2341
+  { name = "twox-hash" },    # Remove once https://github.com/PSeitz/lz4_flex/issues/184 closes
+  { name = "webpki-roots" }, # Remove once tonic releases 0.13.2
+]
+skip-tree = [
+  { name = "windows-sys" },        # Requires hyper-util to update socket2 and tokio update
+  { name = "tracing-subscriber" }, # Remove once https://github.com/tokio-rs/tracing/issues/3282 completes
+  { name = "rand" },               # Remove once https://github.com/rust-phf/rust-phf/issues/331 completes
+]
+
+[licenses]
+version = 2
+private = { ignore = true }
+confidence-threshold = 0.93 # We want really high confidence when inferring licenses from text
+allow = [
+  "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
+  "Apache-2.0",                     # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+  "BSD-2-Clause",                   # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+  "BSD-3-Clause",                   # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
+  "BSL-1.0",                        # https://tldrlegal.com/license/boost-software-license-1.0-explained
+  "CC0-1.0",                        # https://creativecommons.org/publicdomain/zero/1.0/
+  "CDLA-Permissive-2.0",            # https://cdla.dev/permissive-2-0/
+  "ISC",                            # https://www.tldrlegal.com/license/isc-license
+  "MIT",                            # https://tldrlegal.com/license/mit-license
+  "Unicode-3.0",                    # https://www.unicode.org/license.txt
+  "Zlib",                           # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+]
+exceptions = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -31,7 +31,7 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-arrow-schema = "55.1.0"
+arrow-schema = { workspace = true }
 
 [lib]
 


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

Closes #[7648](https://github.com/apache/arrow-rs/issues/7648).

# Rationale for this change

This change helps to ensure code quality by reducing duplicate dependencies and to check for vulnerabilities.

# What changes are included in this PR?

Update dependency for `tonic` which removes some of the duplicate dependencies we have right now. It also adds a cargo deny configuration with details about the remaining duplicates in the repository with links to the issues or PRs to resolve them.

# Are there any user-facing changes?

None