### PR TITLE
Add `BatchCoalescer::push_filtered_batch` and docs

### DIFF
--- a/arrow/benches/coalesce_kernels.rs
+++ b/arrow/benches/coalesce_kernels.rs
@@ -214,10 +214,9 @@ fn filter_streams(
     while num_output_batches > 0 {
         let filter = filter_stream.next_filter();
         let batch = data_stream.next_batch();
-        // Apply the filter to the input batch
-        let filtered_batch = arrow_select::filter::filter_record_batch(batch, filter).unwrap();
-        // Add the filtered batch to the coalescer
-        coalescer.push_batch(filtered_batch).unwrap();
+        coalescer
+            .push_batch_with_filter(batch.clone(), filter)
+            .unwrap();
         // consume (but discard) the output batch
         if coalescer.next_completed_batch().is_some() {
             num_output_batches -= 1;


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Part of https://github.com/apache/arrow-rs/pull/7650

# Rationale for this change

In order to coalesce the result of applying a filter currently requires first copying the results into an intermediate array (calling `filter`). 

My plan is to remove this extra copy by building the final array up directly incrementally

To do to so, there needs to be an API that can take the original data and the filter

# What changes are included in this PR?

1. Add `BatchCoalescer::push_filtered_batch` and docs
2. Update benchmarks to use it

# Are there any user-facing changes?
New API
