### PR TITLE
chore: group prost dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,15 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     target-branch: main
-    labels: [ auto-dependencies, arrow ]
+    labels: [auto-dependencies, arrow]
+    groups:
+      prost:
+        applies-to: version-updates
+        patterns:
+          - "prost*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    labels: [ auto-dependencies ]
+    labels: [auto-dependencies]


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Group PRs like
- #7656 
- #7657
- #7658

# What changes are included in this PR?

Group for prost updates in dependabot config.

# Are there any user-facing changes?

No.