### PR TITLE
[Variant] Simplify creation of Variants from metadata and value

### DIFF
--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -76,8 +76,7 @@ fn get_non_primitive_cases() -> Vec<&'static str> {
 fn variant_primitive() -> Result<(), ArrowError> {
     let cases = get_primitive_cases();
     for (case, want) in cases {
-        let (metadata_bytes, value) = load_case(case)?;
-        let metadata = VariantMetadata::try_new(&metadata_bytes)?;
+        let (metadata, value) = load_case(case)?;
         let got = Variant::try_new(&metadata, &value)?;
         assert_eq!(got, want);
     }
@@ -89,13 +88,13 @@ fn variant_non_primitive() -> Result<(), ArrowError> {
     let cases = get_non_primitive_cases();
     for case in cases {
         let (metadata, value) = load_case(case)?;
-        let metadata = VariantMetadata::try_new(&metadata)?;
+        let variant_metadata = VariantMetadata::try_new(&metadata)?;
         let variant = Variant::try_new(&metadata, &value)?;
         match case {
             "object_primitive" => {
                 assert!(matches!(variant, Variant::Object(_)));
-                assert_eq!(metadata.dictionary_size(), 7);
-                let dict_val = metadata.get_field_by(0)?;
+                assert_eq!(variant_metadata.dictionary_size(), 7);
+                let dict_val = variant_metadata.get_field_by(0)?;
                 assert_eq!(dict_val, "int_field");
             }
             "array_primitive" => match variant {


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/6736

# Rationale for this change

While making documentation / examples for working with `Variant` in https://github.com/apache/arrow-rs/pull/7661, I found it was somewhat awkward to make `Variant` values directly from the metadata and value. Specifically you have to

```rust
let metadata = [0x01, 0x00, 0x00];
let value = [0x09, 0x48, 0x49];
// parse the header metadata
let metadata = VariantMetadata::try_new(&metadata).unwrap();
// and only then can you make the Variant
Variant::try_new(&metadata, &value).unwrap()
```

I would really like to be able to create `Variant `directly from `metadata` and `value` without having to make a `VariantMetadata` structure

# What changes are included in this PR?

This PR proposes a small change to the API so creating a Variant now looks like:

```rust
let metadata = [0x01, 0x00, 0x00];
let value = [0x09, 0x48, 0x49];
// You can now make the Variant directly from the metadata and value
Variant::try_new(&metadata, &value).unwrap()
```


# Are there any user-facing changes?
Yes, the API for creating APIs is slightly different (and I think better)