### PR TITLE
Finish implementing Variant::Object and Variant::List

### DIFF
--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -97,7 +97,7 @@ fn variant_non_primitive() -> Result<(), ArrowError> {
                 assert_eq!(dict_val, "int_field");
             }
             "array_primitive" => match variant {
-                Variant::Array(arr) => {
+                Variant::List(arr) => {
                     let v = arr.get(0)?;
                     assert!(matches!(v, Variant::Int8(2)));
                     let v = arr.get(1)?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/7665

# Rationale for this change

Continuing the ongoing variant implementation effort.

# What changes are included in this PR?

As per title -- implement fairly complete support for variant objects and arrays. Also add some unit tests.

Note: This PR renames `VariantArray` as `VariantList` to align with parquet and arrow terminology, and to not conflict with the `VariantArray` we will eventually need to define for holding an arrow array of variant-typed data.

# Are there any user-facing changes?

Those variant subtypes should now be usable.