### PR TITLE
chore(dependabot): explicitly include root workspace and arrow-pyarrow-integration-testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,8 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directories:
-      - "**/*"
+      - "/"
+      - "/arrow-pyarrow-integration-testing"
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Which issue does this PR close?

The attempt in #7672 to include `arrow-pyarrow-integration-testing` using a wildcard did not work: https://github.com/apache/arrow-rs/actions/runs/15678211946/job/44163362777#step:3:6376

# Rationale for this change

Using a wildcard does not work.

# What changes are included in this PR?

Explicitly include root workspace and `arrow-pyarrow-integration-testing` in dependabot config for cargo.

# Are there any user-facing changes?

No.