### PR TITLE
Make variant iterators safely infallible

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -113,11 +113,11 @@ fn make_room_for_header(buffer: &mut Vec<u8>, start_pos: usize, header_size: usi
 ///   panic!("unexpected variant type")
 /// };
 /// assert_eq!(
-///   variant_object.field("first_name").unwrap(),
+///   variant_object.field_by_name("first_name").unwrap(),
 ///   Some(Variant::ShortString("Jiaying"))
 /// );
 /// assert_eq!(
-///   variant_object.field("last_name").unwrap(),
+///   variant_object.field_by_name("last_name").unwrap(),
 ///   Some(Variant::ShortString("Li"))
 /// );
 /// ```

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -103,7 +103,5 @@ where
 pub(crate) fn validate_fallible_iterator<T, E>(
     mut it: impl Iterator<Item = Result<T, E>>,
 ) -> Result<(), E> {
-    // NOTE: It should really be `let None = ...`, but the compiler can't prove that.
-    let _ = it.find(Result::is_err).transpose()?;
-    Ok(())
+    it.find(Result::is_err).transpose().map(|_| ())
 }

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -85,11 +85,9 @@ where
     F: FnMut(usize) -> Result<K, E>,
 {
     let Range { mut start, mut end } = range;
-
     while start < end {
         let mid = start + (end - start) / 2;
         let key = key_extractor(mid)?;
-
         match key.cmp(target) {
             std::cmp::Ordering::Equal => return Ok(Ok(mid)),
             std::cmp::Ordering::Greater => end = mid,

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -137,7 +137,7 @@ fn variant_object_primitive() {
             Variant::ShortString("2025-04-16T12:34:56.78"),
         ),
     ];
-    let actual_fields: Vec<_> = variant_object.fields().unwrap().collect();
+    let actual_fields: Vec<_> = variant_object.fields().collect();
     assert_eq!(actual_fields, expected_fields);
 }
 #[test]
@@ -163,7 +163,7 @@ fn variant_array_primitive() {
         Variant::Int8(5),
         Variant::Int8(9),
     ];
-    let actual: Vec<_> = list.values().unwrap().collect();
+    let actual: Vec<_> = list.values().collect();
     assert_eq!(actual, expected);
 
     // Call `get` for each individual element

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -137,7 +137,7 @@ fn variant_object_primitive() {
             Variant::ShortString("2025-04-16T12:34:56.78"),
         ),
     ];
-    let actual_fields: Vec<_> = variant_object.fields().collect();
+    let actual_fields: Vec<_> = variant_object.iter().collect();
     assert_eq!(actual_fields, expected_fields);
 }
 #[test]
@@ -163,7 +163,7 @@ fn variant_array_primitive() {
         Variant::Int8(5),
         Variant::Int8(9),
     ];
-    let actual: Vec<_> = list.values().collect();
+    let actual: Vec<_> = list.iter().collect();
     assert_eq!(actual, expected);
 
     // Call `get` for each individual element


### PR DESCRIPTION
# Which issue does this PR close?

* Closes https://github.com/apache/arrow-rs/issues/7684
* Closes https://github.com/apache/arrow-rs/issues/7685
* Part of https://github.com/apache/arrow-rs/issues/6736  

# Rationale for this change

Infallible iteration is _much_ easier to work with, vs. Iterator of Result or Result of Iterator. Iteration and validation are strongly correlated, because the iterator can only be infallible if the constructor previously validated everything the iterator depends on. 

# What changes are included in this PR?

In all three of `VariantMetadata,` `VariantList,` and `VariantObject`:
* The header object is cleaned up to _only_ consider actual header state. Other state is moved to the object itself.
* Constructors fully validate the object by consuming a fallible iterator
* The externally visible iterator does a `map(Result::unwrap)` on the same fallible iterator, relying on the constructor to prove the unwrap is safe.
* The externally visible iterator is obtained by calling `iter()` method.

In addition:
* `VariantObject` methods no longer materialize the whole offset+field array
* Removed validation that is covered by the new iterator testing
* A bunch of dead code removed, several methods renamed for clarity
* `first_byte_from_slice` now returns `u8` instead of `&u8`

# Are there any user-facing changes?

Visibility and signatures of some methods changed.