### PR TITLE
[Variant] Use `BTreeMap` for `VariantBuilder.dict` and `ObjectBuilder.fields` to maintain invariants upon entry writes

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -822,7 +822,7 @@ mod tests {
 
         builder.finish();
     }
-  
+
     #[test]
     fn test_append_object() {
         let (object_metadata, object_value) = {

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -1,5 +1,3 @@
-use arrow_schema::ArrowError;
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -486,33 +484,13 @@ impl<'a> ObjectBuilder<'a> {
         }
     }
 
-    fn check_duplicate_field_name(&self, key: &str) -> Result<(), ArrowError> {
-        if let Some(field_name_id) = self.parent.dict.get(key) {
-            if self.fields.contains_key(field_name_id) {
-                return Err(ArrowError::InvalidArgumentError(
-                    "field name must be unique and already exists in this object".to_string(),
-                ));
-            }
-        }
-
-        Ok(())
-    }
-
     /// Add a field with key and value to the object
-    pub fn append_value<'m, 'd, T: Into<Variant<'m, 'd>>>(
-        &mut self,
-        key: &str,
-        value: T,
-    ) -> Result<(), ArrowError> {
-        self.check_duplicate_field_name(key)?;
-
-        let field_name_id = self.parent.add_key(key);
+    pub fn append_value<'m, 'd, T: Into<Variant<'m, 'd>>>(&mut self, key: &str, value: T) {
+        let id = self.parent.add_key(key);
         let field_start = self.parent.offset() - self.start_pos;
         self.parent.append_value(value);
-        let res = self.fields.insert(field_name_id, field_start);
-        debug_assert!(res.is_none()); // this is almost like an unreachable!(), since we check if a duplicate field name already exists
-
-        Ok(())
+        let res = self.fields.insert(id, field_start);
+        debug_assert!(res.is_none());
     }
 
     /// Finalize object with sorted fields
@@ -726,8 +704,8 @@ mod tests {
 
         {
             let mut obj = builder.new_object();
-            obj.append_value("name", "John").unwrap();
-            obj.append_value("age", 42i8).unwrap();
+            obj.append_value("name", "John");
+            obj.append_value("age", 42i8);
             obj.finish();
         }
 
@@ -742,9 +720,9 @@ mod tests {
 
         {
             let mut obj = builder.new_object();
-            obj.append_value("zebra", "stripes").unwrap(); // ID = 0
-            obj.append_value("apple", "red").unwrap(); // ID = 1
-            obj.append_value("banana", "yellow").unwrap(); // ID = 2
+            obj.append_value("zebra", "stripes"); // ID = 0
+            obj.append_value("apple", "red"); // ID = 1
+            obj.append_value("banana", "yellow"); // ID = 2
             obj.finish();
         }
 
@@ -769,8 +747,8 @@ mod tests {
 
         let mut obj = builder.new_object();
 
-        obj.append_value("zebra", "stripes").unwrap(); // ID = 0
-        obj.append_value("apple", "red").unwrap(); // ID = 1
+        obj.append_value("zebra", "stripes"); // ID = 0
+        obj.append_value("apple", "red"); // ID = 1
 
         {
             // fields_map is ordered by insertion order (field id)
@@ -798,7 +776,7 @@ mod tests {
             assert_eq!(dict_keys, vec!["zebra", "apple"]);
         }
 
-        obj.append_value("banana", "yellow").unwrap(); // ID = 2
+        obj.append_value("banana", "yellow"); // ID = 2
 
         {
             // fields_map is ordered by insertion order (field id)
@@ -832,19 +810,5 @@ mod tests {
         obj.finish();
 
         builder.finish();
-    }
-
-    #[test]
-    fn test_duplicate_field_name_in_same_object() {
-        let mut builder = VariantBuilder::new();
-
-        let mut obj = builder.new_object();
-        obj.append_value("name", "John").unwrap();
-
-        let res = obj.append_value("name", 42i8);
-        assert!(
-            res.is_err(),
-            "ObjectBuilder should error when trying to append duplicate field name in same object"
-        );
     }
 }

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -206,16 +206,18 @@ fn variant_object_builder() {
     let mut builder = VariantBuilder::new();
 
     let mut obj = builder.new_object();
-    obj.append_value("int_field", 1i8);
+    obj.append_value("int_field", 1i8).unwrap();
 
     // The double field is actually encoded as decimal4 with scale 8
     // Value: 123456789, Scale: 8 -> 1.23456789
-    obj.append_value("double_field", (123456789i32, 8u8));
-    obj.append_value("boolean_true_field", true);
-    obj.append_value("boolean_false_field", false);
-    obj.append_value("string_field", "Apache Parquet");
-    obj.append_value("null_field", ());
-    obj.append_value("timestamp_field", "2025-04-16T12:34:56.78");
+    obj.append_value("double_field", (123456789i32, 8u8))
+        .unwrap();
+    obj.append_value("boolean_true_field", true).unwrap();
+    obj.append_value("boolean_false_field", false).unwrap();
+    obj.append_value("string_field", "Apache Parquet").unwrap();
+    obj.append_value("null_field", ()).unwrap();
+    obj.append_value("timestamp_field", "2025-04-16T12:34:56.78")
+        .unwrap();
 
     obj.finish();
 

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -206,18 +206,16 @@ fn variant_object_builder() {
     let mut builder = VariantBuilder::new();
 
     let mut obj = builder.new_object();
-    obj.append_value("int_field", 1i8).unwrap();
+    obj.append_value("int_field", 1i8);
 
     // The double field is actually encoded as decimal4 with scale 8
     // Value: 123456789, Scale: 8 -> 1.23456789
-    obj.append_value("double_field", (123456789i32, 8u8))
-        .unwrap();
-    obj.append_value("boolean_true_field", true).unwrap();
-    obj.append_value("boolean_false_field", false).unwrap();
-    obj.append_value("string_field", "Apache Parquet").unwrap();
-    obj.append_value("null_field", ()).unwrap();
-    obj.append_value("timestamp_field", "2025-04-16T12:34:56.78")
-        .unwrap();
+    obj.append_value("double_field", (123456789i32, 8u8));
+    obj.append_value("boolean_true_field", true);
+    obj.append_value("boolean_false_field", false);
+    obj.append_value("string_field", "Apache Parquet");
+    obj.append_value("null_field", ());
+    obj.append_value("timestamp_field", "2025-04-16T12:34:56.78");
 
     obj.finish();
 


### PR DESCRIPTION
# Which issue does this PR close?

- It doesn't directly close the issue, but it's related to https://github.com/apache/arrow-rs/issues/7698

# Rationale for this change

This commit  changes the `dict` field in `VariantBuilder` + the `fields` field in `ObjectBuilder` to be `BTreeMap`s, and checks for existing field names in a object before appending a new field.

These collections are often used in places where having an already sorted structure would be more performant. Inside of `ObjectBuilder::finish()`, we sort the fields by `field_name` and we can use the fact that `VariantBuilder`'s `dict` maintains a sorted mapping to `field_id` by `field_name`. 

To check whether an existing field name exists in a object, it is simply two lookups: 1) to find the `field_name: &str`'s unique `field_name_id`, and 2) check if the `ObjectBuilder` `fields` already has a key with that `field_name_id`. 

We make `ObjectBuilder` `fields` a `BTreeMap` sorted by `field_id`. Since `field_id`s correlate to insertion order, we now have some notion of which fields were inserted first. This also improves the time to look up the max field id, as it changes the linear scan over the entire `fields` collection to a logarithmic call using `fields.keys().last()`. 

