### PR TITLE
fix JSON decoder error checking for UTF16 / surrogate parsing panic

### DIFF
--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -711,11 +711,9 @@ fn char_from_surrogate_pair(low: u16, high: u16) -> Result<char, ArrowError> {
             char::from_u32(n)
                 .ok_or_else(|| ArrowError::JsonError(format!("Invalid UTF-16 surrogate pair {n}")))
         }
-        _ => {
-            Err(ArrowError::JsonError(format!(
-                "Invalid UTF-16 surrogate pair. High: {high:#02X}, Low: {low:#02X}"
-            )))
-        }
+        _ => Err(ArrowError::JsonError(format!(
+            "Invalid UTF-16 surrogate pair. High: {high:#02X}, Low: {low:#02X}"
+        ))),
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7712 .

# Rationale for this change

Shouldn't panic, especially in a fallible function.

# What changes are included in this PR?

Validate that the high and low surrogates are in the expected range, which guarantees that the subtractions won't overflow.

# Are there any user-facing changes?

No (well, things that used to panic now won't, but I don't think that counts)