### PR TITLE
Allow per-column parquet dictionary page size limit

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -742,7 +742,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     #[inline]
     fn should_dict_fallback(&self) -> bool {
         match self.encoder.estimated_dict_page_size() {
-            Some(size) => size >= self.props.dictionary_page_size_limit(),
+            Some(size) => {
+                size >= self
+                    .props
+                    .column_dictionary_page_size_limit(self.descr.path())
+            }
             None => false,
         }
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -213,6 +213,15 @@ impl WriterProperties {
         self.dictionary_page_size_limit
     }
 
+    /// Returns dictionary page size limit for a specific column.
+    pub fn column_dictionary_page_size_limit(&self, col: &ColumnPath) -> usize {
+        self.column_properties
+            .get(col)
+            .and_then(|c| c.dictionary_page_size_limit())
+            .or_else(|| self.default_column_properties.dictionary_page_size_limit())
+            .unwrap_or(self.dictionary_page_size_limit)
+    }
+
     /// Returns the maximum page row count
     ///
     /// Note: this is a best effort limit based on the write batch size
@@ -549,7 +558,7 @@ impl WriterPropertiesBuilder {
     /// Note: this is a best effort limit based on value of
     /// [`set_write_batch_size`](Self::set_write_batch_size).
     pub fn set_dictionary_page_size_limit(mut self, value: usize) -> Self {
-        self.dictionary_page_size_limit = value;
+        self.default_column_properties.set_dictionary_page_size_limit(value);
         self
     }
 
@@ -850,6 +859,15 @@ impl WriterPropertiesBuilder {
         self
     }
 
+    /// Sets dictionary page size limit for a specific column.
+    ///
+    /// Takes precedence over [`Self::set_dictionary_page_size_limit`].
+    pub fn set_column_dictionary_page_size_limit(mut self, col: ColumnPath, value: usize) -> Self {
+        self.get_mut_props(col)
+            .set_dictionary_page_size_limit(value);
+        self
+    }
+
     /// Sets statistics level for a specific column
     ///
     /// Takes precedence over [`Self::set_statistics_enabled`].
@@ -988,6 +1006,7 @@ impl Default for BloomFilterProperties {
 struct ColumnProperties {
     encoding: Option<Encoding>,
     codec: Option<Compression>,
+    dictionary_page_size_limit: Option<usize>,
     dictionary_enabled: Option<bool>,
     statistics_enabled: Option<EnabledStatistics>,
     #[deprecated(since = "54.0.0", note = "Unused; will be removed in 56.0.0")]
@@ -1021,6 +1040,11 @@ impl ColumnProperties {
     /// Sets whether dictionary encoding is enabled for this column.
     fn set_dictionary_enabled(&mut self, enabled: bool) {
         self.dictionary_enabled = Some(enabled);
+    }
+
+    /// Sets dictionary page size limit for this column.
+    fn set_dictionary_page_size_limit(&mut self, value: usize) {
+        self.dictionary_page_size_limit = Some(value);
     }
 
     /// Sets the statistics level for this column.
@@ -1086,6 +1110,11 @@ impl ColumnProperties {
     /// been provided.
     fn dictionary_enabled(&self) -> Option<bool> {
         self.dictionary_enabled
+    }
+
+    /// Returns optional dictionary page size limit for this column.
+    fn dictionary_page_size_limit(&self) -> Option<usize> {
+        self.dictionary_page_size_limit
     }
 
     /// Returns optional statistics level requested for this column. If result is `None`,
@@ -1430,6 +1459,24 @@ mod tests {
                 fpp: 0.1,
                 ndv: 1_000_000_u64
             })
+        );
+    }
+
+    #[test]
+    fn test_writer_properties_column_dictionary_page_size_limit() {
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(100)
+            .set_column_dictionary_page_size_limit(ColumnPath::from("col"), 10)
+            .build();
+
+        assert_eq!(props.dictionary_page_size_limit(), 100);
+        assert_eq!(
+            props.column_dictionary_page_size_limit(&ColumnPath::from("col")),
+            10
+        );
+        assert_eq!(
+            props.column_dictionary_page_size_limit(&ColumnPath::from("other")),
+            100
         );
     }
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -156,7 +156,6 @@ pub type WriterPropertiesPtr = Arc<WriterProperties>;
 #[derive(Debug, Clone)]
 pub struct WriterProperties {
     data_page_size_limit: usize,
-    dictionary_page_size_limit: usize,
     data_page_row_count_limit: usize,
     write_batch_size: usize,
     max_row_group_size: usize,
@@ -210,7 +209,9 @@ impl WriterProperties {
     ///
     /// For more details see [`WriterPropertiesBuilder::set_dictionary_page_size_limit`]
     pub fn dictionary_page_size_limit(&self) -> usize {
-        self.dictionary_page_size_limit
+        self.default_column_properties
+            .dictionary_page_size_limit()
+            .unwrap_or(DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT)
     }
 
     /// Returns dictionary page size limit for a specific column.
@@ -219,7 +220,7 @@ impl WriterProperties {
             .get(col)
             .and_then(|c| c.dictionary_page_size_limit())
             .or_else(|| self.default_column_properties.dictionary_page_size_limit())
-            .unwrap_or(self.dictionary_page_size_limit)
+            .unwrap_or(DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT)
     }
 
     /// Returns the maximum page row count
@@ -434,7 +435,6 @@ impl WriterProperties {
 /// See example on [`WriterProperties`]
 pub struct WriterPropertiesBuilder {
     data_page_size_limit: usize,
-    dictionary_page_size_limit: usize,
     data_page_row_count_limit: usize,
     write_batch_size: usize,
     max_row_group_size: usize,
@@ -458,7 +458,6 @@ impl WriterPropertiesBuilder {
     fn with_defaults() -> Self {
         Self {
             data_page_size_limit: DEFAULT_PAGE_SIZE,
-            dictionary_page_size_limit: DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT,
             data_page_row_count_limit: DEFAULT_DATA_PAGE_ROW_COUNT_LIMIT,
             write_batch_size: DEFAULT_WRITE_BATCH_SIZE,
             max_row_group_size: DEFAULT_MAX_ROW_GROUP_SIZE,
@@ -482,7 +481,6 @@ impl WriterPropertiesBuilder {
     pub fn build(self) -> WriterProperties {
         WriterProperties {
             data_page_size_limit: self.data_page_size_limit,
-            dictionary_page_size_limit: self.dictionary_page_size_limit,
             data_page_row_count_limit: self.data_page_row_count_limit,
             write_batch_size: self.write_batch_size,
             max_row_group_size: self.max_row_group_size,
@@ -558,7 +556,8 @@ impl WriterPropertiesBuilder {
     /// Note: this is a best effort limit based on value of
     /// [`set_write_batch_size`](Self::set_write_batch_size).
     pub fn set_dictionary_page_size_limit(mut self, value: usize) -> Self {
-        self.default_column_properties.set_dictionary_page_size_limit(value);
+        self.default_column_properties
+            .set_dictionary_page_size_limit(value);
         self
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

#7723 

Please see the issue for more details.


We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

Closes #NNN.

# Rationale for this change

Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

# What changes are included in this PR?

There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
