### PR TITLE
fix: Do not add null buffer for `NullArray`

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -798,8 +798,8 @@ impl<'a> MutableArrayData<'a> {
         };
 
         let nulls = match data.data_type {
-            // RunEndEncoded arrays cannot have top-level null bitmasks
-            DataType::RunEndEncoded(_, _) => None,
+            // RunEndEncoded and Null arrays cannot have top-level null bitmasks
+            DataType::RunEndEncoded(_, _) | DataType::Null => None,
             _ => data
                 .null_buffer
                 .map(|nulls| {


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

Closes #7725.

# Rationale for this change

Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

Do not populate null buffers when building `MutableArrayData`

# What changes are included in this PR?

There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
