### PR TITLE
Perf: Optimize comparison kernels for inlined views

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -542,13 +542,16 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     ) -> std::cmp::Ordering {
         if left.data_buffers().is_empty() && right.data_buffers().is_empty() {
             // If both arrays have no buffers, we can compare the views directly
-            return left.views.get_unchecked(left_idx).cmp(right.views.get_unchecked(right_idx));
+            return left
+                .views
+                .get_unchecked(left_idx)
+                .cmp(right.views.get_unchecked(right_idx));
         }
 
         let l_view = left.views().get_unchecked(left_idx);
         let r_view = right.views().get_unchecked(right_idx);
-        let l_len  = *l_view as u32;
-        let r_len  = *r_view as u32;
+        let l_len = *l_view as u32;
+        let r_len = *r_view as u32;
 
         if l_len <= 12 && r_len <= 12 {
             return l_view.cmp(r_view);

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -507,7 +507,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
 
     /// Compare two [`GenericByteViewArray`] at index `left_idx` and `right_idx`
     ///
-    /// Comparing two ByteView types is non-trivial.
+    /// Comparing two ByteView types are non-trivial.
     /// It takes a bit of patience to understand why we don't just compare two &[u8] directly.
     ///
     /// ByteView types give us the following two advantages, and we need to be careful not to lose them:
@@ -525,36 +525,29 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     ///   e.g., if the inlined 4 bytes are different, we can directly return unequal without looking at the full string.
     ///
     /// # Order check flow
-    /// (1) if both strings do not contain buffers, we don't need to compute the len of the view,
-    /// we can compare the views directly. The first 4 bytes of the view is the length of the string, and the rest is the inlined data.
-    /// (2) if any has no empty buffer, both strings are smaller than 12 bytes, we can directly compare the view.
-    /// (3) if any of the strings is larger than 12 bytes, we need to compare the full string.
+    /// (1) if both string are smaller than 12 bytes, we can directly compare the data inlined to the view.
+    /// (2) if any of the string is larger than 12 bytes, we need to compare the full string.
     ///     (2.1) if the inlined 4 bytes are different, we can return the result immediately.
     ///     (2.2) o.w., we need to compare the full string.
     ///
     /// # Safety
-    /// The left/right_idx must be within range of each array
+    /// The left/right_idx must within range of each array
     pub unsafe fn compare_unchecked(
         left: &GenericByteViewArray<T>,
         left_idx: usize,
         right: &GenericByteViewArray<T>,
         right_idx: usize,
     ) -> std::cmp::Ordering {
-        if left.data_buffers().is_empty() && right.data_buffers().is_empty() {
-            // If both arrays have no buffers, we can compare the views directly
-            return left
-                .views
-                .get_unchecked(left_idx)
-                .cmp(right.views.get_unchecked(right_idx));
-        }
-
         let l_view = left.views().get_unchecked(left_idx);
-        let r_view = right.views().get_unchecked(right_idx);
         let l_len = *l_view as u32;
+
+        let r_view = right.views().get_unchecked(right_idx);
         let r_len = *r_view as u32;
 
         if l_len <= 12 && r_len <= 12 {
-            return l_view.cmp(r_view);
+            let l_data = unsafe { GenericByteViewArray::<T>::inline_value(l_view, l_len as usize) };
+            let r_data = unsafe { GenericByteViewArray::<T>::inline_value(r_view, r_len as usize) };
+            return l_data.cmp(r_data);
         }
 
         // one of the string is larger than 12 bytes,

--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -565,6 +565,7 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
     /// Item.0 is the array, Item.1 is the index
     type Item = (&'a GenericByteViewArray<T>, usize);
 
+    #[inline(always)]
     fn is_eq(l: Self::Item, r: Self::Item) -> bool {
         let l_view = unsafe { l.0.views().get_unchecked(l.1) };
         let r_view = unsafe { r.0.views().get_unchecked(r.1) };
@@ -575,8 +576,6 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
             return l_bytes.cmp(r_bytes).is_eq();
         }
 
-        // # Safety
-        // The index is within bounds as it is checked in value()
         let l_len = *l_view as u32;
         let r_len = *r_view as u32;
         // This is a fast path for equality check.
@@ -585,12 +584,13 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
             return false;
         }
 
+        // # Safety
+        // The index is within bounds as it is checked in value()
         unsafe { GenericByteViewArray::compare_unchecked(l.0, l.1, r.0, r.1).is_eq() }
     }
 
+    #[inline(always)]
     fn is_lt(l: Self::Item, r: Self::Item) -> bool {
-        // # Safety
-        // The index is within bounds as it is checked in value()
         if l.0.data_buffers().is_empty() && r.0.data_buffers().is_empty() {
             // Only need to compare the inlined bytes
             let l_bytes = unsafe {
@@ -601,6 +601,8 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
             };
             return l_bytes.cmp(r_bytes).is_lt();
         }
+        // # Safety
+        // The index is within bounds as it is checked in value()
         unsafe { GenericByteViewArray::compare_unchecked(l.0, l.1, r.0, r.1).is_lt() }
     }
 
@@ -634,6 +636,7 @@ impl<'a> ArrayOrd for &'a FixedSizeBinaryArray {
 }
 
 /// Compares two [`GenericByteViewArray`] at index `left_idx` and `right_idx`
+#[inline(always)]
 pub fn compare_byte_view<T: ByteViewType>(
     left: &GenericByteViewArray<T>,
     left_idx: usize,

--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -569,24 +569,17 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
     fn is_eq(l: Self::Item, r: Self::Item) -> bool {
         let l_view = unsafe { l.0.views().get_unchecked(l.1) };
         let r_view = unsafe { r.0.views().get_unchecked(r.1) };
+        if l.0.data_buffers().is_empty() && r.0.data_buffers().is_empty() {
+            // For eq case, we can directly compare the inlined bytes
+            return l_view.cmp(r_view).is_eq();
+        }
+
         let l_len = *l_view as u32;
         let r_len = *r_view as u32;
         // This is a fast path for equality check.
         // We don't need to look at the actual bytes to determine if they are equal.
         if l_len != r_len {
             return false;
-        }
-
-        // When both len are same, we can compare the inlined bytes, this can handle the corner case after
-        // the len compare, for example:
-        // > println!("{:?}", "\0".cmp(""))
-        // > Greater
-        if l.0.data_buffers().is_empty() && r.0.data_buffers().is_empty() {
-            // If the lengths are equal, we can compare the inlined bytes
-            // Only need to compare the inlined bytes
-            let l_bytes = unsafe { GenericByteViewArray::<T>::inline_value(l_view, 12) };
-            let r_bytes = unsafe { GenericByteViewArray::<T>::inline_value(r_view, 12) };
-            return l_bytes.cmp(r_bytes).is_eq();
         }
 
         // # Safety

--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -581,8 +581,8 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
 
         if l.0.data_buffers().is_empty() && r.0.data_buffers().is_empty() {
             // Only need to compare the inlined bytes
-            let l_bytes = unsafe { GenericByteViewArray::<T>::inline_value(&l_view, 12) };
-            let r_bytes = unsafe { GenericByteViewArray::<T>::inline_value(&r_view, 12) };
+            let l_bytes = unsafe { GenericByteViewArray::<T>::inline_value(l_view, 12) };
+            let r_bytes = unsafe { GenericByteViewArray::<T>::inline_value(r_view, 12) };
             return l_bytes.cmp(r_bytes).is_eq();
         }
 
@@ -595,10 +595,10 @@ impl<'a, T: ByteViewType> ArrayOrd for &'a GenericByteViewArray<T> {
         if l.0.data_buffers().is_empty() && r.0.data_buffers().is_empty() {
             // Only need to compare the inlined bytes
             let l_bytes = unsafe {
-                GenericByteViewArray::<T>::inline_value(&l.0.views().get_unchecked(l.1), 12)
+                GenericByteViewArray::<T>::inline_value(l.0.views().get_unchecked(l.1), 12)
             };
             let r_bytes = unsafe {
-                GenericByteViewArray::<T>::inline_value(&r.0.views().get_unchecked(r.1), 12)
+                GenericByteViewArray::<T>::inline_value(r.0.views().get_unchecked(r.1), 12)
             };
             return l_bytes.cmp(r_bytes).is_lt();
         }
@@ -646,10 +646,10 @@ pub fn compare_byte_view<T: ByteViewType>(
     if left.data_buffers().is_empty() && right.data_buffers().is_empty() {
         // Only need to compare the inlined bytes
         let l_bytes = unsafe {
-            GenericByteViewArray::<T>::inline_value(&left.views().get_unchecked(left_idx), 12)
+            GenericByteViewArray::<T>::inline_value(left.views().get_unchecked(left_idx), 12)
         };
         let r_bytes = unsafe {
-            GenericByteViewArray::<T>::inline_value(&right.views().get_unchecked(right_idx), 12)
+            GenericByteViewArray::<T>::inline_value(right.views().get_unchecked(right_idx), 12)
         };
         return l_bytes.cmp(r_bytes);
     }


### PR DESCRIPTION
# Which issue does this PR close?

Add fast path for empty buffer case to skip compute len, and use view(u128) to compare directly.

Closes [#7621](https://github.com/apache/arrow-rs/issues/7621)

# Rationale for this change

Add fast path for empty buffer case to skip compute len, and use view(u128) to compare directly.


# What changes are included in this PR?

Add fast path for empty buffer case to skip compute len, and use view(u128) to compare directly.


# Are there any user-facing changes?
No

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
