### PR TITLE
[Variant] Improve write API in `Variant::Object`

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -277,8 +277,8 @@ impl MetadataBuilder {
 /// let mut builder = VariantBuilder::new();
 /// // Create an object builder that will write fields to the object
 /// let mut object_builder = builder.new_object();
-/// object_builder.append_value("first_name", "Jiaying");
-/// object_builder.append_value("last_name", "Li");
+/// object_builder.insert("first_name", "Jiaying");
+/// object_builder.insert("last_name", "Li");
 /// object_builder.finish();
 /// // Finish the builder to get the metadata and value
 /// let (metadata, value) = builder.finish();
@@ -342,15 +342,15 @@ impl MetadataBuilder {
 ///
 /// {
 ///     let mut object_builder = list_builder.new_object();
-///     object_builder.append_value("id", 1);
-///     object_builder.append_value("type", "Cauliflower");
+///     object_builder.insert("id", 1);
+///     object_builder.insert("type", "Cauliflower");
 ///     object_builder.finish();
 /// }
 ///
 /// {
 ///     let mut object_builder = list_builder.new_object();
-///     object_builder.append_value("id", 2);
-///     object_builder.append_value("type", "Beets");
+///     object_builder.insert("id", 2);
+///     object_builder.insert("type", "Beets");
 ///     object_builder.finish();
 /// }
 ///
@@ -592,12 +592,16 @@ impl<'a> ObjectBuilder<'a> {
     }
 
     /// Add a field with key and value to the object
-    pub fn append_value<'m, 'd, T: Into<Variant<'m, 'd>>>(&mut self, key: &str, value: T) {
+    ///
+    /// Note: when inserting duplicate keys, the new value overwrites the previous mapping,
+    /// but the old value remains in the buffer, resulting in a larger variant
+    pub fn insert<'m, 'd, T: Into<Variant<'m, 'd>>>(&mut self, key: &str, value: T) {
         let field_id = self.metadata_builder.add_field_name(key);
         let field_start = self.buffer.offset();
+
+        self.fields.insert(field_id, field_start);
+
         self.buffer.append_value(value);
-        let res = self.fields.insert(field_id, field_start);
-        debug_assert!(res.is_none());
     }
 
     /// Finalize object with sorted fields
@@ -815,8 +819,8 @@ mod tests {
 
         {
             let mut obj = builder.new_object();
-            obj.append_value("name", "John");
-            obj.append_value("age", 42i8);
+            obj.insert("name", "John");
+            obj.insert("age", 42i8);
             obj.finish();
         }
 
@@ -831,9 +835,9 @@ mod tests {
 
         {
             let mut obj = builder.new_object();
-            obj.append_value("zebra", "stripes"); // ID = 0
-            obj.append_value("apple", "red"); // ID = 1
-            obj.append_value("banana", "yellow"); // ID = 2
+            obj.insert("zebra", "stripes"); // ID = 0
+            obj.insert("apple", "red"); // ID = 1
+            obj.insert("banana", "yellow"); // ID = 2
             obj.finish();
         }
 
@@ -858,8 +862,8 @@ mod tests {
 
         let mut obj = builder.new_object();
 
-        obj.append_value("zebra", "stripes"); // ID = 0
-        obj.append_value("apple", "red"); // ID = 1
+        obj.insert("zebra", "stripes"); // ID = 0
+        obj.insert("apple", "red"); // ID = 1
 
         {
             // fields_map is ordered by insertion order (field id)
@@ -886,7 +890,7 @@ mod tests {
             assert_eq!(dict_keys, vec!["zebra", "apple"]);
         }
 
-        obj.append_value("banana", "yellow"); // ID = 2
+        obj.insert("banana", "yellow"); // ID = 2
 
         {
             // fields_map is ordered by insertion order (field id)
@@ -919,6 +923,27 @@ mod tests {
         obj.finish();
 
         builder.finish();
+    }
+
+    #[test]
+    fn test_duplicate_fields_in_object() {
+        let mut builder = VariantBuilder::new();
+        let mut object_builder = builder.new_object();
+        object_builder.insert("name", "Ron Artest");
+        object_builder.insert("name", "Metta World Peace");
+        object_builder.finish();
+
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+
+        let obj = variant.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert_eq!(obj.field(0).unwrap(), Variant::from("Metta World Peace"));
+
+        assert_eq!(
+            vec![("name", Variant::from("Metta World Peace"))],
+            obj.iter().collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -1025,15 +1050,15 @@ mod tests {
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("id", 1);
-            object_builder.append_value("type", "Cauliflower");
+            object_builder.insert("id", 1);
+            object_builder.insert("type", "Cauliflower");
             object_builder.finish();
         }
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("id", 2);
-            object_builder.append_value("type", "Beets");
+            object_builder.insert("id", 2);
+            object_builder.insert("type", "Beets");
             object_builder.finish();
         }
 
@@ -1074,13 +1099,13 @@ mod tests {
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("a", 1);
+            object_builder.insert("a", 1);
             object_builder.finish();
         }
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("b", 2);
+            object_builder.insert("b", 2);
             object_builder.finish();
         }
 
@@ -1127,7 +1152,7 @@ mod tests {
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("a", 1);
+            object_builder.insert("a", 1);
             object_builder.finish();
         }
 
@@ -1135,7 +1160,7 @@ mod tests {
 
         {
             let mut object_builder = list_builder.new_object();
-            object_builder.append_value("b", 2);
+            object_builder.insert("b", 2);
             object_builder.finish();
         }
 

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -600,7 +600,6 @@ impl<'a> ObjectBuilder<'a> {
         let field_start = self.buffer.offset();
 
         self.fields.insert(field_id, field_start);
-
         self.buffer.append_value(value);
     }
 

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -912,7 +912,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// # let (metadata, value) = {
     /// # let mut builder = VariantBuilder::new();
     /// #   let mut obj = builder.new_object();
-    /// #   obj.append_value("name", "John");
+    /// #   obj.insert("name", "John");
     /// #   obj.finish();
     /// #   builder.finish()
     /// # };

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -206,19 +206,19 @@ fn variant_object_builder() {
     let mut builder = VariantBuilder::new();
 
     let mut obj = builder.new_object();
-    obj.append_value("int_field", 1i8);
+    obj.insert("int_field", 1i8);
 
     // The double field is actually encoded as decimal4 with scale 8
     // Value: 123456789, Scale: 8 -> 1.23456789
-    obj.append_value(
+    obj.insert(
         "double_field",
         VariantDecimal4::try_new(123456789i32, 8u8).unwrap(),
     );
-    obj.append_value("boolean_true_field", true);
-    obj.append_value("boolean_false_field", false);
-    obj.append_value("string_field", "Apache Parquet");
-    obj.append_value("null_field", ());
-    obj.append_value("timestamp_field", "2025-04-16T12:34:56.78");
+    obj.insert("boolean_true_field", true);
+    obj.insert("boolean_false_field", false);
+    obj.insert("string_field", "Apache Parquet");
+    obj.insert("null_field", ());
+    obj.insert("timestamp_field", "2025-04-16T12:34:56.78");
 
     obj.finish();
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/7730

# Rationale for this change

This commit changes the function name `ObjectBuilder::append_value` to `ObjectBuilder::insert`.

Right now, calling insert() with a duplicate key results in two fields with the same key in the object, which deviates from the Variant spec. This PR updates the logic such that the second `insert()` with a duplicate key will update the value. The old value still exists in the backing buffer, but is unreferenced. One side effect from this approach is a larger variant size. 


The Parquet Variant spec states: 

> Field names are case-sensitive. Field names are required to be unique for each object. It is an error for an object to contain two fields with the same name, whether or not they have distinct dictionary IDs.