### PR TITLE
[55_maintenance] Fix verify-release-candidate.sh by skipping `arrow-pyarrow` and `parquet-variant`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -113,7 +113,9 @@ test_source_distribution() {
   export ARROW_TEST_DATA=$PWD/arrow-testing-data/data
   export PARQUET_TEST_DATA=$PWD/parquet-testing-data/data
 
-  cargo test --all
+  # ignore arrow-pyarrow due to
+  # https://github.com/apache/arrow-rs/issues/7736
+  cargo test --all --exclude arrow-pyarrow
 
   # verify that the leaf crates can be published to crates.io
   # we can't verify crates that depend on others

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -115,7 +115,9 @@ test_source_distribution() {
 
   # ignore arrow-pyarrow due to
   # https://github.com/apache/arrow-rs/issues/7736
-  cargo test --all --exclude arrow-pyarrow
+  # ignore parquet-variant due to
+  # https://github.com/apache/arrow-rs/issues/7746
+  cargo test --all --exclude arrow-pyarrow --exclude parquet-variant
 
   # verify that the leaf crates can be published to crates.io
   # we can't verify crates that depend on others


### PR DESCRIPTION
Note this targets a release branch, not main

I have a different proposed fix for `main`:
- https://github.com/apache/arrow-rs/pull/7742

I will also make a fix for parquet-variant test failures

# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/7394
- Related to https://github.com/apache/arrow-rs/issues/7736
- Related to https://github.com/apache/arrow-rs/issues/7746

# Rationale for this change

`cargo test --all` requires python and pyarrow installed, where it did not in previous versions of arrow due to breaking out `arrow-pyarrow` into its own crate in
- https://github.com/apache/arrow-rs/pull/7694

Also the new `parquet-variant` crate tests fail as part of the verification script too -- see ttps://github.com/apache/arrow-rs/issues/7746


In order to get a script that can automatically verify a release candidate, let's ignore this new module for now. 

More details 
- https://github.com/apache/arrow-rs/issues/7736 
- https://github.com/apache/arrow-rs/pull/7742

Note that the arrow-pyarrow tests do run as part of CI and succeed on this branch


# What changes are included in this PR?

1. Exclude running the `arrow-pyarrow` and `parquet-variant` tests as part of `verify-release-acndidate`


# Testing
I verified locally that `./dev/release/verify-release-candidate.sh 55.2.0 1` passes with this script

# Are there any user-facing changes?
No this is a development process only change


