### PR TITLE
Add testing section to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
 
-Closes #NNN.
+- Closes #NNN.
 
 # Rationale for this change
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

It is critical and generally required to add tests for any changes to arrow-rs and it something we look for in our PR reviews. It would be nice to remind people of this explicitly in the PR 

# What changes are included in this PR?

1. Update the PR template to include a section on testing
2. Add a list marker (`-`) to the closes section which causes github to render the name of the PR in markdown not just the number (see rationale on https://github.com/apache/datafusion/pull/14507)

I copied the wording from DataFusion: https://github.com/apache/datafusion/blob/b6c8cc57760686fffe4878e69c1be27e4d9f5e68/.github/pull_request_template.md?plain=1#L22


# Are there any user-facing changes?

A new section on PR descriptions