### PR TITLE
[Variant] Fix several overflow panic risks for 32-bit arch

### DIFF
--- a/parquet-variant/src/decoder.rs
+++ b/parquet-variant/src/decoder.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use crate::utils::{array_from_slice, slice_from_slice, string_from_slice};
+use crate::utils::{array_from_slice, slice_from_slice_at_offset, string_from_slice};
 use crate::ShortString;
 
 use arrow_schema::ArrowError;
@@ -22,6 +22,9 @@ use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, Utc};
 
 use std::array::TryFromSliceError;
 use std::num::TryFromIntError;
+
+// Makes the code a bit more readable
+pub(crate) const VARIANT_VALUE_HEADER_BYTES: usize = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VariantBasicType {
@@ -262,21 +265,19 @@ pub(crate) fn decode_timestampntz_micros(data: &[u8]) -> Result<NaiveDateTime, A
 /// Decodes a Binary from the value section of a variant.
 pub(crate) fn decode_binary(data: &[u8]) -> Result<&[u8], ArrowError> {
     let len = u32::from_le_bytes(array_from_slice(data, 0)?) as usize;
-    let value = slice_from_slice(data, 4..4 + len)?;
-    Ok(value)
+    slice_from_slice_at_offset(data, 4, 0..len)
 }
 
 /// Decodes a long string from the value section of a variant.
 pub(crate) fn decode_long_string(data: &[u8]) -> Result<&str, ArrowError> {
     let len = u32::from_le_bytes(array_from_slice(data, 0)?) as usize;
-    let string = string_from_slice(data, 4..4 + len)?;
-    Ok(string)
+    string_from_slice(data, 4, 0..len)
 }
 
 /// Decodes a short string from the value section of a variant.
 pub(crate) fn decode_short_string(metadata: u8, data: &[u8]) -> Result<ShortString, ArrowError> {
     let len = (metadata >> 2) as usize;
-    let string = string_from_slice(data, 0..len)?;
+    let string = string_from_slice(data, 0, 0..len)?;
     ShortString::try_new(string)
 }
 
@@ -518,10 +519,11 @@ mod tests {
 
         let width = OffsetSizeBytes::Two;
 
-        // dictionary_size starts immediately after the header
+        // dictionary_size starts immediately after the header byte
         let dict_size = width.unpack_usize(&buf, 1, 0).unwrap();
         assert_eq!(dict_size, 2);
 
+        // offset array immediately follows the dictionary size
         let first = width.unpack_usize(&buf, 1, 1).unwrap();
         assert_eq!(first, 0);
 

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -33,11 +33,31 @@ pub(crate) fn slice_from_slice<I: SliceIndex<[u8]> + Clone + Debug>(
         ))
     })
 }
+
+/// Helper to safely slice bytes with offset calculations.
+///
+/// Equivalent to `slice_from_slice(bytes, (base_offset + range.start)..(base_offset + range.end))`
+/// but using checked addition to prevent integer overflow panics on 32-bit systems.
+#[inline]
+pub(crate) fn slice_from_slice_at_offset(
+    bytes: &[u8],
+    base_offset: usize,
+    range: Range<usize>,
+) -> Result<&[u8], ArrowError> {
+    let start_byte = base_offset.checked_add(range.start).ok_or_else(|| {
+        ArrowError::InvalidArgumentError("Overflow computing start byte".to_string())
+    })?;
+    let end_byte = base_offset.checked_add(range.end).ok_or_else(|| {
+        ArrowError::InvalidArgumentError("Overflow computing end byte".to_string())
+    })?;
+    slice_from_slice(bytes, start_byte..end_byte)
+}
+
 pub(crate) fn array_from_slice<const N: usize>(
     bytes: &[u8],
     offset: usize,
 ) -> Result<[u8; N], ArrowError> {
-    let bytes = slice_from_slice(bytes, offset..offset + N)?;
+    let bytes = slice_from_slice_at_offset(bytes, offset, 0..N)?;
     bytes.try_into().map_err(map_try_from_slice_error)
 }
 
@@ -53,9 +73,13 @@ pub(crate) fn first_byte_from_slice(slice: &[u8]) -> Result<u8, ArrowError> {
         .ok_or_else(|| ArrowError::InvalidArgumentError("Received empty bytes".to_string()))
 }
 
-/// Helper to get a &str from a slice based on range, if it's valid or an error otherwise
-pub(crate) fn string_from_slice(slice: &[u8], range: Range<usize>) -> Result<&str, ArrowError> {
-    str::from_utf8(slice_from_slice(slice, range)?)
+/// Helper to get a &str from a slice at the given offset and range, or an error if invalid.
+pub(crate) fn string_from_slice(
+    slice: &[u8],
+    offset: usize,
+    range: Range<usize>,
+) -> Result<&str, ArrowError> {
+    str::from_utf8(slice_from_slice_at_offset(slice, offset, range)?)
         .map_err(|_| ArrowError::InvalidArgumentError("invalid UTF-8 string".to_string()))
 }
 

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -62,13 +62,9 @@ pub(crate) fn array_from_slice<const N: usize>(
     bytes: &[u8],
     offset: usize,
 ) -> Result<[u8; N], ArrowError> {
-    let bytes = slice_from_slice_at_offset(bytes, offset, 0..N)?;
-    bytes.try_into().map_err(map_try_from_slice_error)
-}
-
-/// To be used in `map_err` when unpacking an integer from a slice of bytes.
-pub(crate) fn map_try_from_slice_error(e: TryFromSliceError) -> ArrowError {
-    ArrowError::InvalidArgumentError(e.to_string())
+    slice_from_slice_at_offset(bytes, offset, 0..N)?
+        .try_into()
+        .map_err(|e: TryFromSliceError| ArrowError::InvalidArgumentError(e.to_string()))
 }
 
 pub(crate) fn first_byte_from_slice(slice: &[u8]) -> Result<u8, ArrowError> {

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -76,13 +76,13 @@ impl<'a> TryFrom<&'a str> for ShortString<'a> {
     }
 }
 
-impl<'a> AsRef<str> for ShortString<'a> {
+impl AsRef<str> for ShortString<'_> {
     fn as_ref(&self) -> &str {
         self.0
     }
 }
 
-impl<'a> Deref for ShortString<'a> {
+impl Deref for ShortString<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/parquet-variant/src/variant/list.rs
+++ b/parquet-variant/src/variant/list.rs
@@ -90,7 +90,7 @@ impl<'m, 'v> VariantList<'m, 'v> {
             .checked_add(1)
             .and_then(|n| n.checked_mul(header.offset_size as usize))
             .and_then(|n| n.checked_add(first_offset_byte))
-            .ok_or_else(|| ArrowError::InvalidArgumentError("Integer overflow computing first_value_byte".into()))?;
+            .ok_or_else(|| ArrowError::InvalidArgumentError("Integer overflow".into()))?;
 
         let new_self = Self {
             metadata,

--- a/parquet-variant/src/variant/list.rs
+++ b/parquet-variant/src/variant/list.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 use crate::decoder::OffsetSizeBytes;
-use crate::utils::{first_byte_from_slice, slice_from_slice, validate_fallible_iterator};
+use crate::utils::{first_byte_from_slice, slice_from_slice_at_offset, validate_fallible_iterator};
 use crate::variant::{Variant, VariantMetadata};
 
 use arrow_schema::ArrowError;

--- a/parquet-variant/src/variant/list.rs
+++ b/parquet-variant/src/variant/list.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 use crate::decoder::OffsetSizeBytes;
-use crate::utils::{first_byte_from_slice, slice_from_slice_at_offset, validate_fallible_iterator};
+use crate::utils::{
+    first_byte_from_slice, overflow_error, slice_from_slice_at_offset, validate_fallible_iterator,
+};
 use crate::variant::{Variant, VariantMetadata};
 
 use arrow_schema::ArrowError;
@@ -90,7 +92,7 @@ impl<'m, 'v> VariantList<'m, 'v> {
             .checked_add(1)
             .and_then(|n| n.checked_mul(header.offset_size as usize))
             .and_then(|n| n.checked_add(first_offset_byte))
-            .ok_or_else(|| ArrowError::InvalidArgumentError("Integer overflow".into()))?;
+            .ok_or_else(|| overflow_error("offset of variant list values"))?;
 
         let new_self = Self {
             metadata,

--- a/parquet-variant/src/variant/metadata.rs
+++ b/parquet-variant/src/variant/metadata.rs
@@ -17,7 +17,8 @@
 
 use crate::decoder::OffsetSizeBytes;
 use crate::utils::{
-    first_byte_from_slice, slice_from_slice, string_from_slice, validate_fallible_iterator,
+    first_byte_from_slice, overflow_error, slice_from_slice, string_from_slice,
+    validate_fallible_iterator,
 };
 
 use arrow_schema::ArrowError;
@@ -119,7 +120,7 @@ impl<'m> VariantMetadata<'m> {
             .checked_add(2)
             .and_then(|n| n.checked_mul(header.offset_size as usize))
             .and_then(|n| n.checked_add(NUM_HEADER_BYTES))
-            .ok_or_else(|| ArrowError::InvalidArgumentError("Integer overflow".into()))?;
+            .ok_or_else(|| overflow_error("offset of variant metadata dictionary"))?;
 
         let new_self = Self {
             bytes,


### PR DESCRIPTION
# Which issue does this PR close?

Part of
* https://github.com/apache/arrow-rs/issues/6736

# Rationale for this change

The variant spec makes extensive use of 4-byte offsets. On a 32-bit system, this can lead to integer overflow panics when doing offset arithmetic on malicious or malformed variant data, because `usize` is 32 bits. That is bad.

# What changes are included in this PR?

Use checked arithmetic in code that operates on offsets extracted from (untrusted) variant byte buffers.

Of particular interest, we define and use a new `slice_from_slice_at_offset` helper, which safely adds an offset to a range.

# Are there any user-facing changes?

No.
