### PR TITLE
POC: Parquet predicate results cache

### DIFF
--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -318,6 +318,11 @@ impl BatchCoalescer {
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
         self.completed.pop_front()
     }
+
+    /// Returns all the completed batches
+    pub fn take_completed_batches(&mut self) -> VecDeque<RecordBatch> {
+        std::mem::take(&mut self.completed)
+    }
 }
 
 /// Return a new `InProgressArray` for the given data type

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -324,6 +324,8 @@ impl IterationStrategy {
 }
 
 /// A filtering predicate that can be applied to an [`Array`]
+///
+/// See [`FilterBuilder`] to create a [`FilterPredicate`].
 #[derive(Debug)]
 pub struct FilterPredicate {
     filter: BooleanArray,
@@ -502,6 +504,9 @@ fn filter_null_mask(
 }
 
 /// Filter the packed bitmask `buffer`, with `predicate` starting at bit offset `offset`
+///
+/// Panics for `IterationStrategy::All` or `IterationStrategy::None` which must
+/// be handled by the caller
 fn filter_bits(buffer: &BooleanBuffer, predicate: &FilterPredicate) -> Buffer {
     let src = buffer.values();
     let offset = buffer.offset();
@@ -536,7 +541,8 @@ fn filter_bits(buffer: &BooleanBuffer, predicate: &FilterPredicate) -> Buffer {
             }
             builder.into()
         }
-        IterationStrategy::All | IterationStrategy::None => unreachable!(),
+        IterationStrategy::All => unreachable!(),
+        IterationStrategy::None => unreachable!(),
     }
 }
 

--- a/parquet/src/arrow/array_reader/cached/builder.rs
+++ b/parquet/src/arrow/array_reader/cached/builder.rs
@@ -1,0 +1,235 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::arrow::array_reader::CachedPredicateResult;
+use crate::arrow::arrow_reader::RowSelection;
+use crate::arrow::ProjectionMask;
+use arrow_array::{Array, BooleanArray, RecordBatch};
+use arrow_schema::{ArrowError, Schema, SchemaRef};
+use arrow_select::filter::prep_null_mask_filter;
+use std::sync::Arc;
+use arrow_select::coalesce::BatchCoalescer;
+
+/// Incrementally builds the result of evaluating an ArrowPredicate on
+/// a RowGroup.
+#[derive(Debug)]
+pub(crate) struct CachedPredicateResultBuilder {
+    /// What is being cached
+    strategy: CacheStrategy,
+    /// Total number of columns in the original parquet schema
+    num_original_columns: usize,
+    /// Any filters that have been applied. Note this the complete set of filters
+    /// that have been applied to the cached batches.
+    filters: Vec<BooleanArray>,
+}
+
+#[derive(Debug)]
+enum CacheStrategy {
+    /// Don't cache any results
+    None,
+    /// Cache the result of filtering all columns in the filter schema
+    All {
+        /// The builder for the cached batches
+        cached_batches_builder: BatchCoalescer,
+        /// The indexes of the columns in the original parquet schema that are in the projection
+        original_projection: Vec<usize>,
+    },
+    /// Cache the result of filtering a subset of the columns in the filter schema
+    Subset {
+        /// The builder for the cached batches
+        cached_batches_builder: BatchCoalescer,
+        /// The indexes of the columns in the filter schema that are in the projection
+        filter_projection: Vec<usize>,
+        /// The indexes of the columns in the original parquet schema that are in the projection
+        original_projection: Vec<usize>,
+    },
+}
+
+impl CachedPredicateResultBuilder {
+    /// Create a new CachedPredicateResultBuilder
+    ///
+    /// # Arguments:
+    /// * `num_original_columns`: The number of columns in the original parquet schema
+    /// * `schema`: The schema of the filtered record batch (not the original parquet schema)
+    /// * `filter_mask`: which columns of the original parquet schema did the filter columns come from?
+    /// * `projection_mask`: which columns of the original parquet schema are in the final projection?
+    ///
+    /// This structure does not cache filter results for the columns that are not
+    /// in the projection mask. This is because the filter results are not needed
+    pub(crate) fn try_new(
+        num_original_columns: usize,
+        filter_schema: &SchemaRef,
+        filter_mask: &ProjectionMask,
+        projection_mask: &ProjectionMask,
+        batch_size: usize,
+    ) -> Result<Self, ArrowError> {
+        let (filter_mask_inner, projection_mask_inner) =
+            match (filter_mask.mask(), projection_mask.mask()) {
+                (Some(filter_mask), Some(projection_mask)) => (filter_mask, projection_mask),
+                // None means "select all columns" so in this case cache all filtered columns
+                (Some(filter_mask), None) => (filter_mask, filter_mask),
+                // None means "select all columns" so in this case cache all columns used in projection
+                (None, Some(projection_mask)) => (projection_mask, projection_mask),
+                (None, None) => {
+                    // this means all columns are in the projection *and* filter so cache them all when possible
+                    let cached_batches_builder = BatchCoalescer::new(
+                        Arc::clone(filter_schema),
+                        batch_size,
+                    );
+                    let strategy = CacheStrategy::All {
+                        cached_batches_builder,
+                        original_projection: (0..num_original_columns).collect(),
+                    };
+                    return {
+                        Ok(Self {
+                            strategy,
+                            num_original_columns,
+                            filters: vec![],
+                        })
+                    };
+                }
+            };
+
+        // Otherwise, need to select a subset of the fields from each batch to cache
+
+        // This is an iterator over the fields of the schema of batches passed
+        // to the filter.
+        let mut filter_field_iter = filter_schema.fields.iter().enumerate();
+
+        let mut filter_projection = vec![];
+        let mut original_projection = vec![];
+        let mut fields = vec![];
+
+        // Iterate over the masks from the original schema
+        assert_eq!(filter_mask_inner.len(), projection_mask_inner.len());
+        for (original_index, (&in_filter, &in_projection)) in filter_mask_inner
+            .iter()
+            .zip(projection_mask_inner.iter())
+            .enumerate()
+        {
+            if !in_filter {
+                continue;
+            }
+            // take next field from the filter schema
+            let (filter_index, field) =
+                filter_field_iter.next().expect("mismatch in field lengths");
+            if !in_projection {
+                // this field is not in the projection, so don't cache it
+                continue;
+            }
+            // this field is both in filter and the projection, so cache the results
+            filter_projection.push(filter_index);
+            original_projection.push(original_index);
+            fields.push(Arc::clone(field));
+        }
+        let strategy = if fields.is_empty() {
+            CacheStrategy::None
+        } else {
+            let cached_batches_builder =
+                BatchCoalescer::new(Arc::new(Schema::new(fields)), batch_size);
+            CacheStrategy::Subset {
+                cached_batches_builder,
+                filter_projection,
+                original_projection,
+            }
+        };
+
+        Ok(Self {
+            strategy,
+            num_original_columns,
+            filters: vec![],
+        })
+    }
+
+    /// Add a new batch and filter to the builder
+    pub(crate) fn add(
+        &mut self,
+        batch: RecordBatch,
+        mut filter: BooleanArray,
+    ) -> crate::errors::Result<()> {
+        if filter.null_count() > 0 {
+            filter = prep_null_mask_filter(&filter);
+        }
+
+        match &mut self.strategy {
+            CacheStrategy::None => {}
+            CacheStrategy::All {
+                cached_batches_builder,
+                ..
+            } => {
+                cached_batches_builder.push_batch_with_filter(batch, &filter)?;
+            }
+            CacheStrategy::Subset {
+                cached_batches_builder,
+                ref filter_projection,
+                ..
+            } => {
+                // If we have a filter projection, we need to project the batch
+                // to only the columns that are in the filter projection
+                let projected_batch = batch.project(filter_projection)?;
+                cached_batches_builder.push_batch_with_filter(projected_batch, &filter)?;
+            }
+        }
+
+        self.filters.push(filter);
+
+        Ok(())
+    }
+
+    /// Return (selection, maybe_cached_predicate_result) that represents the rows
+    /// that were selected and batches that were evaluated.
+    pub(crate) fn build(
+        self,
+    ) -> crate::errors::Result<(RowSelection, Option<CachedPredicateResult>)> {
+        let Self {
+            strategy,
+            num_original_columns,
+            filters,
+        } = self;
+
+        let new_selection = RowSelection::from_filters(&filters);
+
+        match strategy {
+            CacheStrategy::None => Ok((new_selection, None)),
+            CacheStrategy::All {
+                mut cached_batches_builder,
+                original_projection,
+            }
+            | CacheStrategy::Subset {
+                mut cached_batches_builder,
+                original_projection,
+                ..
+            } => {
+                // explode out the cached batches into the proper place in the original schema
+                cached_batches_builder.finish_buffered_batch()?;
+                let completed_batches = cached_batches_builder
+                    .take_completed_batches();
+
+                let mut cached_result = CachedPredicateResult::new(num_original_columns, filters);
+                for (batch_index, original_idx) in original_projection.iter().enumerate() {
+                    let mut column_arrays = Vec::with_capacity(completed_batches.len());
+                    for batch in &completed_batches {
+                        column_arrays.push(Arc::clone(batch.column(batch_index)));
+                    }
+                    cached_result.add_result(*original_idx, column_arrays);
+                }
+
+                Ok((new_selection, Some(cached_result)))
+            }
+        }
+    }
+}

--- a/parquet/src/arrow/array_reader/cached/mod.rs
+++ b/parquet/src/arrow/array_reader/cached/mod.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Implements a cached column reader that provides data using
+//! previously decoded / filtered arrays
+
+mod builder;
+mod reader;
+
+pub(crate) use builder::CachedPredicateResultBuilder;
+use reader::CachedArrayReader;
+
+use crate::arrow::array_reader::ArrayReader;
+use crate::errors::Result;
+use arrow_array::{ArrayRef, BooleanArray};
+
+/// The result of evaluating a predicate on a RowGroup with a specific
+/// RowSelection
+///
+/// The flow is:
+/// * Decode with a RowSelection
+/// * Apply a predicate --> this result
+#[derive(Clone)]
+pub(crate) struct CachedPredicateResult {
+    /// Map of parquet schema column index to the result of evaluating the predicate
+    /// on that column.
+    ///
+    /// NOTE each array already has had `filters` applied
+    ///
+    /// If `Some`, it is a set of arrays that make up the result. Each has
+    /// batch_rows rows except for the last
+    arrays: Vec<Option<Vec<ArrayRef>>>,
+    /// The results of evaluating the predicate (this has already been applied to the
+    /// cached results).
+    filters: Vec<BooleanArray>,
+}
+
+impl CachedPredicateResult {
+    pub(crate) fn new(num_columns: usize, filters: Vec<BooleanArray>) -> Self {
+        Self {
+            arrays: vec![None; num_columns],
+            filters,
+        }
+    }
+
+    /// Add the specified array to the cached result
+    pub fn add_result(&mut self, column_index: usize, arrays: Vec<ArrayRef>) {
+        // TODO how is this possible to end up with previously cached arrays?
+        //assert!(self.arrays.get(column_index).is_none(), "column index {} already has a cached array", column_index);
+        self.arrays[column_index] = Some(arrays);
+    }
+
+    /// Returns an array reader for the given column index, if any, that reads from the cache rather
+    /// than the original column chunk
+    pub(crate) fn build_reader(&self, col_index: usize) -> Result<Option<Box<dyn ArrayReader>>> {
+        let Some(array) = &self.arrays[col_index] else {
+            return Ok(None);
+        };
+
+        Ok(Some(Box::new(CachedArrayReader::new(
+            array.clone(),
+            &self.filters,
+        ))))
+    }
+}

--- a/parquet/src/arrow/array_reader/cached/reader.rs
+++ b/parquet/src/arrow/array_reader/cached/reader.rs
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::arrow::array_reader::ArrayReader;
+use arrow_array::{new_empty_array, Array, ArrayRef, BooleanArray};
+use arrow_schema::DataType;
+use std::any::Any;
+use std::collections::VecDeque;
+
+pub(crate) struct CachedArrayReader {
+    /// The cached arrays. These should already be broken down into the correct batch_size chunks
+    cached_arrays: VecDeque<ArrayRef>,
+    data_type: DataType,
+    // /// The filter that was applied to the cached array (that has already been applied)
+    //filter: BooleanArray,
+    /// The length of the currently "in progress" array
+    current_length: usize,
+}
+
+impl CachedArrayReader {
+    pub(crate) fn new(cached_arrays: Vec<ArrayRef>, _filters: &[BooleanArray]) -> Self {
+        //let input: Vec<&dyn Array> = filters.iter().map(|b| b as &dyn Array).collect::<Vec<_>>();
+        //let filter = concat(&input).unwrap().as_boolean().clone();
+        let data_type = cached_arrays
+            .first()
+            .expect("had at least one array")
+            .data_type()
+            .clone();
+        Self {
+            cached_arrays: VecDeque::from(cached_arrays),
+            data_type,
+            current_length: 0,
+        }
+    }
+}
+
+impl ArrayReader for CachedArrayReader {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn read_records(&mut self, batch_size: usize) -> crate::errors::Result<usize> {
+        // since the entire array is cached, reads always succeed
+        self.current_length += batch_size;
+        Ok(batch_size)
+    }
+
+    // Produce the "in progress" batch
+    fn consume_batch(&mut self) -> crate::errors::Result<ArrayRef> {
+        if self.current_length == 0 {
+            return Ok(new_empty_array(&self.data_type));
+        }
+
+        let mut next_array = self.cached_arrays.pop_front().ok_or_else(|| {
+            crate::errors::ParquetError::General(
+                "Internal error: no more cached arrays".to_string(),
+            )
+        })?;
+
+        // the next batch is the next array in the queue
+        // when a limit is applied, the next array may be smaller than the cached batch size, which is fine as we are
+        // just consuming the next available array
+        // TODO take this limit into account as part of the filter creation
+        // TODO this was hit by DataFusion tests, not arrow-rs tests, so there is a gap in our testing
+        // TODO add coverage
+        if self.current_length < next_array.len() {
+            next_array = next_array.slice(0, self.current_length);
+        }
+        assert_eq!(self.current_length, next_array.len());
+        self.current_length = 0;
+        Ok(next_array)
+    }
+
+    fn skip_records(&mut self, num_records: usize) -> crate::errors::Result<usize> {
+        // todo!()
+        // it would be good to verify the pattern of read/consume matches
+        // the boolean array
+        Ok(num_records)
+    }
+
+    fn get_def_levels(&self) -> Option<&[i16]> {
+        None // TODO this is likely not right for structured types
+    }
+
+    fn get_rep_levels(&self) -> Option<&[i16]> {
+        None // TODO this is likely not right for structured types
+    }
+}

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -563,7 +563,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut array_reader = ArrayReaderBuilder::new(&file_reader)
+        let cached_predicate_result = None;
+        let mut array_reader = ArrayReaderBuilder::new(&file_reader, cached_predicate_result)
             .build_array_reader(fields.as_ref(), &mask)
             .unwrap();
 

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -42,6 +42,7 @@ mod null_array;
 mod primitive_array;
 mod struct_array;
 
+mod cached;
 #[cfg(test)]
 mod test_util;
 
@@ -50,6 +51,7 @@ pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
 #[allow(unused_imports)] // Only used for benchmarks
 pub use byte_view_array::make_byte_view_array_reader;
+pub(crate) use cached::{CachedPredicateResult, CachedPredicateResultBuilder};
 #[allow(unused_imports)] // Only used for benchmarks
 pub use fixed_len_byte_array::make_fixed_len_byte_array_reader;
 pub use fixed_size_list_array::FixedSizeListArrayReader;

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -599,6 +599,11 @@ where
 
         let filter = self.filter.as_mut();
         let mut plan_builder = ReadPlanBuilder::new(batch_size).with_selection(selection);
+        let num_original_columns = row_group
+            .metadata
+            .file_metadata()
+            .schema_descr()
+            .num_columns();
 
         // Update selection based on any filters
         if let Some(filter) = filter {
@@ -613,10 +618,16 @@ where
                     .fetch(&mut self.input, predicate.projection(), selection)
                     .await?;
 
-                let array_reader = ArrayReaderBuilder::new(&row_group)
-                    .build_array_reader(self.fields.as_deref(), predicate.projection())?;
+                let array_reader =
+                    ArrayReaderBuilder::new(&row_group, plan_builder.cached_predicate_result())
+                        .build_array_reader(self.fields.as_deref(), predicate.projection())?;
 
-                plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
+                plan_builder = plan_builder.with_predicate(
+                    num_original_columns,
+                    array_reader,
+                    predicate.as_mut(),
+                    &projection,
+                )?;
             }
         }
 
@@ -661,7 +672,7 @@ where
 
         let plan = plan_builder.build();
 
-        let array_reader = ArrayReaderBuilder::new(&row_group)
+        let array_reader = ArrayReaderBuilder::new(&row_group, plan.cached_predicate_result())
             .build_array_reader(self.fields.as_deref(), &projection)?;
 
         let reader = ParquetRecordBatchReader::new(array_reader, plan);

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -251,17 +251,15 @@ pub const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectionMask {
-    /// If `Some`, a leaf column should be included if the value at
+    /// If present, a leaf column should be included if the value at
     /// the corresponding index is true
     ///
-    /// If `None`, all columns should be included
+    /// If `None`, include all columns
     ///
-    /// # Examples
+    /// # Example
     ///
-    /// Given the original parquet schema with leaf columns is `[a, b, c, d]`
-    ///
-    /// A mask of `[true, false, true, false]` will result in a schema 2
-    /// elements long:
+    /// If the original parquet schema is `[a, b, c, d]` and the mask is `[true,
+    /// false, true, false]`, then the resulting schema will be 2 elements long:
     /// * `fields[0]`: `a`
     /// * `fields[1]`: `c`    
     ///
@@ -277,6 +275,11 @@ impl ProjectionMask {
     /// Create a [`ProjectionMask`] which selects all columns
     pub fn all() -> Self {
         Self { mask: None }
+    }
+
+    // TODO better interface
+    pub(crate) fn mask(&self) -> Option<&Vec<bool>> {
+        self.mask.as_ref()
     }
 
     /// Create a [`ProjectionMask`] which selects only the specified leaf columns


### PR DESCRIPTION
# Which issue does this PR close?

- Next iteration of https://github.com/apache/arrow-rs/pull/7513
- Part of https://github.com/apache/arrow-rs/issues/7456

TODO:
- [x] Avoid double buffering of intermediate results (via `coalesce`)
- [x] File ticket to optimize coalesce kernel more: https://github.com/apache/arrow-rs/issues/7761
- [ ] Add memory limit for results cache
- [ ] Review actual predicates that are pushed down in DataFusion (are they multiple single column predicates or is it a single set of cached results....) -- aka do we have to handle multiple ArrowPredicates (probably...)

# Rationale for this change
 
I am working on not decoding predicate columns twice when evaluating filters in the reader

In https://github.com/apache/arrow-rs/pull/7513 we prototyped several APIs that we have now started making real (like `BatchCoalescer`) so I made a new PR that used those APIs which doesn't have hundreds of comments.  

I am pleased with how it is looking now, and as before I don't really plan to merge this PR as is, I am using it as a design vehicle


# What changes are included in this PR?

1. Add code to cache columns which are reused in filter and scan

# Are there any user-facing changes?
Not yet, 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please call them out.
-->
