### PR TITLE
[Variant] Minor: make fields in `VariantDecimal*` private, add examples

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -161,22 +161,22 @@ impl ValueBuffer {
         self.append_slice(&micros.to_le_bytes());
     }
 
-    fn append_decimal4(&mut self, integer: i32, scale: u8) {
+    fn append_decimal4(&mut self, decimal4: VariantDecimal4) {
         self.append_primitive_header(VariantPrimitiveType::Decimal4);
-        self.append_u8(scale);
-        self.append_slice(&integer.to_le_bytes());
+        self.append_u8(decimal4.scale());
+        self.append_slice(&decimal4.integer().to_le_bytes());
     }
 
-    fn append_decimal8(&mut self, integer: i64, scale: u8) {
+    fn append_decimal8(&mut self, decimal8: VariantDecimal8) {
         self.append_primitive_header(VariantPrimitiveType::Decimal8);
-        self.append_u8(scale);
-        self.append_slice(&integer.to_le_bytes());
+        self.append_u8(decimal8.scale());
+        self.append_slice(&decimal8.integer.to_le_bytes());
     }
 
-    fn append_decimal16(&mut self, integer: i128, scale: u8) {
+    fn append_decimal16(&mut self, decimal16: VariantDecimal16) {
         self.append_primitive_header(VariantPrimitiveType::Decimal16);
-        self.append_u8(scale);
-        self.append_slice(&integer.to_le_bytes());
+        self.append_u8(decimal16.scale());
+        self.append_slice(&decimal16.integer().to_le_bytes());
     }
 
     fn append_binary(&mut self, value: &[u8]) {
@@ -214,15 +214,9 @@ impl ValueBuffer {
             Variant::Date(v) => self.append_date(v),
             Variant::TimestampMicros(v) => self.append_timestamp_micros(v),
             Variant::TimestampNtzMicros(v) => self.append_timestamp_ntz_micros(v),
-            Variant::Decimal4(VariantDecimal4 { integer, scale }) => {
-                self.append_decimal4(integer, scale)
-            }
-            Variant::Decimal8(VariantDecimal8 { integer, scale }) => {
-                self.append_decimal8(integer, scale)
-            }
-            Variant::Decimal16(VariantDecimal16 { integer, scale }) => {
-                self.append_decimal16(integer, scale)
-            }
+            Variant::Decimal4(decimal4) => self.append_decimal4(decimal4),
+            Variant::Decimal8(decimal8) => self.append_decimal8(decimal8),
+            Variant::Decimal16(decimal16) => self.append_decimal16(decimal16),
             Variant::Float(v) => self.append_float(v),
             Variant::Double(v) => self.append_double(v),
             Variant::Binary(v) => self.append_binary(v),

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 use crate::decoder::{VariantBasicType, VariantPrimitiveType};
-use crate::{ShortString, Variant, VariantDecimal16, VariantDecimal4, VariantDecimal8};
+use crate::{ShortString, Variant};
 use std::collections::BTreeMap;
 
 const BASIC_TYPE_BITS: u8 = 2;
@@ -384,14 +384,14 @@ impl VariantBuilder {
             Variant::Date(v) => self.append_date(v),
             Variant::TimestampMicros(v) => self.append_timestamp_micros(v),
             Variant::TimestampNtzMicros(v) => self.append_timestamp_ntz_micros(v),
-            Variant::Decimal4(VariantDecimal4 { integer, scale }) => {
-                self.append_decimal4(integer, scale)
+            Variant::Decimal4(decimal4) => {
+                self.append_decimal4(decimal4.integer(), decimal4.scale())
             }
-            Variant::Decimal8(VariantDecimal8 { integer, scale }) => {
-                self.append_decimal8(integer, scale)
+            Variant::Decimal8(decimal8) => {
+                self.append_decimal8(decimal8.integer(), decimal8.scale())
             }
-            Variant::Decimal16(VariantDecimal16 { integer, scale }) => {
-                self.append_decimal16(integer, scale)
+            Variant::Decimal16(decimal16) => {
+                self.append_decimal16(decimal16.integer(), decimal16.scale())
             }
             Variant::Float(v) => self.append_float(v),
             Variant::Double(v) => self.append_double(v),

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -170,7 +170,7 @@ impl ValueBuffer {
     fn append_decimal8(&mut self, decimal8: VariantDecimal8) {
         self.append_primitive_header(VariantPrimitiveType::Decimal8);
         self.append_u8(decimal8.scale());
-        self.append_slice(&decimal8.integer.to_le_bytes());
+        self.append_slice(&decimal8.integer().to_le_bytes());
     }
 
     fn append_decimal16(&mut self, decimal16: VariantDecimal16) {

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -14,9 +14,8 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use crate::VariantDecimal16;
 use crate::decoder::{VariantBasicType, VariantPrimitiveType};
-use crate::{ShortString, Variant};
+use crate::{ShortString, Variant, VariantDecimal16, VariantDecimal4, VariantDecimal8};
 use std::collections::BTreeMap;
 
 const BASIC_TYPE_BITS: u8 = 2;

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -47,7 +47,8 @@ impl<'a> ShortString<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if  `value` is longer than [`MAX_SHORT_STRING_BYTES`]
+    /// Returns an error if  `value` is longer than the maximum allowed length
+    /// of a Variant short string (63 bytes).
     pub fn try_new(value: &'a str) -> Result<Self, ArrowError> {
         if value.len() > MAX_SHORT_STRING_BYTES {
             return Err(ArrowError::InvalidArgumentError(format!(

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -48,10 +48,16 @@ pub struct ShortString<'a>(pub(crate) &'a str);
 /// For valid precision and scale values, see the Variant specification:
 /// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
 ///
+/// # Example: Create a VariantDecimal4
+/// ```
+/// # use parquet_variant::VariantDecimal4;
+/// // Create a value representing the decimal 123.4567
+/// let decimal = VariantDecimal4::try_new(1234567, 4).expect("Failed to create decimal");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal4 {
-    pub(crate) integer: i32,
-    pub(crate) scale: u8,
+    integer: i32,
+    scale: u8,
 }
 
 impl VariantDecimal4 {
@@ -61,12 +67,26 @@ impl VariantDecimal4 {
         // Validate that scale doesn't exceed precision
         if scale as u32 > PRECISION_MAX {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "Scale {} cannot be greater than precision  9 for 4-byte decimal",
+                "Scale {} cannot be greater than precision 9 for 4-byte decimal",
                 scale
             )));
         }
 
         Ok(VariantDecimal4 { integer, scale })
+    }
+
+    /// Returns the underlying value of the decimal.
+    ///
+    /// For example, if the decimal is `123.4567`, this will return `1234567`.
+    pub fn integer(&self) -> i32 {
+        self.integer
+    }
+
+    /// Returns the scale of the decimal (how many digits after the decimal point).
+    ///
+    /// For example, if the decimal is `123.4567`, this will return `4`.
+    pub fn scale(&self) -> u8 {
+        self.scale
     }
 }
 
@@ -79,10 +99,16 @@ impl VariantDecimal4 {
 ///
 /// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
 ///
+/// # Example: Create a VariantDecimal8
+/// ```
+/// # use parquet_variant::VariantDecimal8;
+/// // Create a value representing the decimal 123456.78
+/// let decimal = VariantDecimal8::try_new(12345678, 2).expect("Failed to create decimal");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal8 {
-    pub(crate) integer: i64,
-    pub(crate) scale: u8,
+    integer: i64,
+    scale: u8,
 }
 
 impl VariantDecimal8 {
@@ -99,6 +125,20 @@ impl VariantDecimal8 {
 
         Ok(VariantDecimal8 { integer, scale })
     }
+
+    /// Returns the underlying value of the decimal.
+    ///
+    /// For example, if the decimal is `123456.78`, this will return `12345678`.
+    pub fn integer(&self) -> i64 {
+        self.integer
+    }
+
+    /// Returns the scale of the decimal (how many digits after the decimal point).
+    ///
+    /// For example, if the decimal is `123456.78`, this will return `2`.
+    pub fn scale(&self) -> u8 {
+        self.scale
+    }
 }
 
 /// Represents an 16-byte decimal value in the Variant format.
@@ -110,10 +150,16 @@ impl VariantDecimal8 {
 ///
 /// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
 ///
+/// # Example: Create a VariantDecimal16
+/// ```
+/// # use parquet_variant::VariantDecimal16;
+/// // Create a value representing the decimal 12345678901234567.890
+/// let decimal = VariantDecimal16::try_new(12345678901234567890, 3).unwrap();
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal16 {
-    pub(crate) integer: i128,
-    pub(crate) scale: u8,
+    integer: i128,
+    scale: u8,
 }
 
 impl VariantDecimal16 {
@@ -129,6 +175,20 @@ impl VariantDecimal16 {
         }
 
         Ok(VariantDecimal16 { integer, scale })
+    }
+
+    /// Returns the underlying value of the decimal.
+    ///
+    /// For example, if the decimal is `12345678901234567.890`, this will return `12345678901234567890`.
+    pub fn integer(&self) -> i128 {
+        self.integer
+    }
+
+    /// Returns the scale of the decimal (how many digits after the decimal point).
+    ///
+    /// For example, if the decimal is `12345678901234567.890`, this will return `3`.
+    pub fn scale(&self) -> u8 {
+        self.scale
     }
 }
 

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -275,11 +275,11 @@ impl<'m, 'v> Variant<'m, 'v> {
                 }
                 VariantPrimitiveType::Decimal8 => {
                     let (integer, scale) = decoder::decode_decimal8(value_data)?;
-                    Variant::Decimal8(VariantDecimal8 { integer, scale })
+                    Variant::Decimal8(VariantDecimal8::try_new(integer, scale)?)
                 }
                 VariantPrimitiveType::Decimal16 => {
                     let (integer, scale) = decoder::decode_decimal16(value_data)?;
-                    Variant::Decimal16(VariantDecimal16 { integer, scale })
+                    Variant::Decimal16(VariantDecimal16::try_new(integer, scale)?)
                 }
                 VariantPrimitiveType::Float => Variant::Float(decoder::decode_float(value_data)?),
                 VariantPrimitiveType::Double => {
@@ -671,8 +671,8 @@ impl<'m, 'v> Variant<'m, 'v> {
                 }
             }
             Variant::Decimal16(decimal16) => {
-                if let Ok(converted_integer) = decimal16.integer.try_into() {
-                    Some((converted_integer, decimal16.scale))
+                if let Ok(converted_integer) = decimal16.integer().try_into() {
+                    Some((converted_integer, decimal16.scale()))
                 } else {
                     None
                 }
@@ -746,7 +746,7 @@ impl<'m, 'v> Variant<'m, 'v> {
         match *self {
             Variant::Decimal4(decimal) => Some((decimal.integer().into(), decimal.scale())),
             Variant::Decimal8(decimal) => Some((decimal.integer().into(), decimal.scale())),
-            Variant::Decimal16(decimal) => Some((decimal.integer(), decimal.scale)),
+            Variant::Decimal16(decimal) => Some((decimal.integer(), decimal.scale())),
             _ => None,
         }
     }

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -16,6 +16,7 @@ use std::ops::Deref;
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+pub use self::decimal::{VariantDecimal16, VariantDecimal4, VariantDecimal8};
 pub use self::list::VariantList;
 pub use self::metadata::VariantMetadata;
 pub use self::object::VariantObject;
@@ -27,6 +28,7 @@ use crate::utils::{first_byte_from_slice, slice_from_slice};
 use arrow_schema::ArrowError;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 
+mod decimal;
 mod list;
 mod metadata;
 mod object;
@@ -39,158 +41,6 @@ const MAX_SHORT_STRING_BYTES: usize = 0x3F;
 /// the length of the underlying string is a valid Variant short string (63 bytes or less)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ShortString<'a>(pub(crate) &'a str);
-
-/// Represents a 4-byte decimal value in the Variant format.
-///
-/// This struct stores a decimal number using a 32-bit signed integer for the coefficient
-/// and an 8-bit unsigned integer for the scale (number of decimal places). Its precision is limited to 9 digits.
-///
-/// For valid precision and scale values, see the Variant specification:
-/// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
-///
-/// # Example: Create a VariantDecimal4
-/// ```
-/// # use parquet_variant::VariantDecimal4;
-/// // Create a value representing the decimal 123.4567
-/// let decimal = VariantDecimal4::try_new(1234567, 4).expect("Failed to create decimal");
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct VariantDecimal4 {
-    integer: i32,
-    scale: u8,
-}
-
-impl VariantDecimal4 {
-    pub fn try_new(integer: i32, scale: u8) -> Result<Self, ArrowError> {
-        const PRECISION_MAX: u32 = 9;
-
-        // Validate that scale doesn't exceed precision
-        if scale as u32 > PRECISION_MAX {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "Scale {} cannot be greater than precision 9 for 4-byte decimal",
-                scale
-            )));
-        }
-
-        Ok(VariantDecimal4 { integer, scale })
-    }
-
-    /// Returns the underlying value of the decimal.
-    ///
-    /// For example, if the decimal is `123.4567`, this will return `1234567`.
-    pub fn integer(&self) -> i32 {
-        self.integer
-    }
-
-    /// Returns the scale of the decimal (how many digits after the decimal point).
-    ///
-    /// For example, if the decimal is `123.4567`, this will return `4`.
-    pub fn scale(&self) -> u8 {
-        self.scale
-    }
-}
-
-/// Represents an 8-byte decimal value in the Variant format.
-///
-/// This struct stores a decimal number using a 64-bit signed integer for the coefficient
-/// and an 8-bit unsigned integer for the scale (number of decimal places). Its precision is between 10 and 18 digits.
-///
-/// For valid precision and scale values, see the Variant specification:
-///
-/// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
-///
-/// # Example: Create a VariantDecimal8
-/// ```
-/// # use parquet_variant::VariantDecimal8;
-/// // Create a value representing the decimal 123456.78
-/// let decimal = VariantDecimal8::try_new(12345678, 2).expect("Failed to create decimal");
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct VariantDecimal8 {
-    integer: i64,
-    scale: u8,
-}
-
-impl VariantDecimal8 {
-    pub fn try_new(integer: i64, scale: u8) -> Result<Self, ArrowError> {
-        const PRECISION_MAX: u32 = 18;
-
-        // Validate that scale doesn't exceed precision
-        if scale as u32 > PRECISION_MAX {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "Scale {} cannot be greater than precision  18 for 8-byte decimal",
-                scale
-            )));
-        }
-
-        Ok(VariantDecimal8 { integer, scale })
-    }
-
-    /// Returns the underlying value of the decimal.
-    ///
-    /// For example, if the decimal is `123456.78`, this will return `12345678`.
-    pub fn integer(&self) -> i64 {
-        self.integer
-    }
-
-    /// Returns the scale of the decimal (how many digits after the decimal point).
-    ///
-    /// For example, if the decimal is `123456.78`, this will return `2`.
-    pub fn scale(&self) -> u8 {
-        self.scale
-    }
-}
-
-/// Represents an 16-byte decimal value in the Variant format.
-///
-/// This struct stores a decimal number using a 128-bit signed integer for the coefficient
-/// and an 8-bit unsigned integer for the scale (number of decimal places). Its precision is between 19 and 38 digits.
-///
-/// For valid precision and scale values, see the Variant specification:
-///
-/// <https://github.com/apache/parquet-format/blob/87f2c8bf77eefb4c43d0ebaeea1778bd28ac3609/VariantEncoding.md?plain=1#L418-L420>
-///
-/// # Example: Create a VariantDecimal16
-/// ```
-/// # use parquet_variant::VariantDecimal16;
-/// // Create a value representing the decimal 12345678901234567.890
-/// let decimal = VariantDecimal16::try_new(12345678901234567890, 3).unwrap();
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct VariantDecimal16 {
-    integer: i128,
-    scale: u8,
-}
-
-impl VariantDecimal16 {
-    pub fn try_new(integer: i128, scale: u8) -> Result<Self, ArrowError> {
-        const PRECISION_MAX: u32 = 38;
-
-        // Validate that scale doesn't exceed precision
-        if scale as u32 > PRECISION_MAX {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "Scale {} cannot be greater than precision 38 for 16-byte decimal",
-                scale
-            )));
-        }
-
-        Ok(VariantDecimal16 { integer, scale })
-    }
-
-    /// Returns the underlying value of the decimal.
-    ///
-    /// For example, if the decimal is `12345678901234567.890`, this will return `12345678901234567890`.
-    pub fn integer(&self) -> i128 {
-        self.integer
-    }
-
-    /// Returns the scale of the decimal (how many digits after the decimal point).
-    ///
-    /// For example, if the decimal is `12345678901234567.890`, this will return `3`.
-    pub fn scale(&self) -> u8 {
-        self.scale
-    }
-}
 
 impl<'a> ShortString<'a> {
     /// Attempts to interpret `value` as a variant short string value.
@@ -228,13 +78,13 @@ impl<'a> TryFrom<&'a str> for ShortString<'a> {
     }
 }
 
-impl<'a> AsRef<str> for ShortString<'a> {
+impl AsRef<str> for ShortString<'_> {
     fn as_ref(&self) -> &str {
         self.0
     }
 }
 
-impl<'a> Deref for ShortString<'a> {
+impl Deref for ShortString<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -972,7 +822,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// # let (metadata, value) = {
     /// # let mut builder = VariantBuilder::new();
     /// #   let mut obj = builder.new_object();
-    /// #   obj.append_value("name", "John");
+    /// #   obj.insert("name", "John");
     /// #   obj.finish();
     /// #   builder.finish()
     /// # };
@@ -980,7 +830,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     ///  let variant = Variant::try_new(&metadata, &value).unwrap();
     /// // use the `as_object` method to access the object
     /// let obj = variant.as_object().expect("variant should be an object");
-    /// assert_eq!(obj.field_by_name("name").unwrap(), Some(Variant::from("John")));
+    /// assert_eq!(obj.get("name"), Some(Variant::from("John")));
     /// ```
     pub fn as_object(&'m self) -> Option<&'m VariantObject<'m, 'v>> {
         if let Variant::Object(obj) = self {
@@ -1040,6 +890,15 @@ impl From<()> for Variant<'_, '_> {
     }
 }
 
+impl From<bool> for Variant<'_, '_> {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Variant::BooleanTrue,
+            false => Variant::BooleanFalse,
+        }
+    }
+}
+
 impl From<i8> for Variant<'_, '_> {
     fn from(value: i8) -> Self {
         Variant::Int8(value)
@@ -1091,16 +950,6 @@ impl From<f32> for Variant<'_, '_> {
 impl From<f64> for Variant<'_, '_> {
     fn from(value: f64) -> Self {
         Variant::Double(value)
-    }
-}
-
-impl From<bool> for Variant<'_, '_> {
-    fn from(value: bool) -> Self {
-        if value {
-            Variant::BooleanTrue
-        } else {
-            Variant::BooleanFalse
-        }
     }
 }
 
@@ -1197,11 +1046,5 @@ mod tests {
             variant.as_decimal_int128(),
             Some((123456789012345678901234567890_i128, 2))
         );
-    }
-
-    #[test]
-    fn test_invalid_variant_decimal_conversion() {
-        let decimal4 = VariantDecimal4::try_new(123456789_i32, 20);
-        assert!(decimal4.is_err(), "i32 overflow should fail");
     }
 }

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -45,9 +45,9 @@ pub struct ShortString<'a>(pub(crate) &'a str);
 impl<'a> ShortString<'a> {
     /// Attempts to interpret `value` as a variant short string value.
     ///
-    /// # Validation
+    /// # Errors
     ///
-    /// This constructor verifies that `value` is shorter than or equal to `MAX_SHORT_STRING_BYTES`
+    /// Returns an error if  `value` is longer than [`MAX_SHORT_STRING_BYTES`]
     pub fn try_new(value: &'a str) -> Result<Self, ArrowError> {
         if value.len() > MAX_SHORT_STRING_BYTES {
             return Err(ArrowError::InvalidArgumentError(format!(

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -271,7 +271,7 @@ impl<'m, 'v> Variant<'m, 'v> {
                 VariantPrimitiveType::Int64 => Variant::Int64(decoder::decode_int64(value_data)?),
                 VariantPrimitiveType::Decimal4 => {
                     let (integer, scale) = decoder::decode_decimal4(value_data)?;
-                    Variant::Decimal4(VariantDecimal4 { integer, scale })
+                    Variant::Decimal4(VariantDecimal4::try_new(integer, scale)?)
                 }
                 VariantPrimitiveType::Decimal8 => {
                     let (integer, scale) = decoder::decode_decimal8(value_data)?;
@@ -662,10 +662,10 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_decimal_int32(&self) -> Option<(i32, u8)> {
         match *self {
-            Variant::Decimal4(decimal4) => Some((decimal4.integer, decimal4.scale)),
+            Variant::Decimal4(decimal4) => Some((decimal4.integer(), decimal4.scale())),
             Variant::Decimal8(decimal8) => {
-                if let Ok(converted_integer) = decimal8.integer.try_into() {
-                    Some((converted_integer, decimal8.scale))
+                if let Ok(converted_integer) = decimal8.integer().try_into() {
+                    Some((converted_integer, decimal8.scale()))
                 } else {
                     None
                 }
@@ -710,11 +710,11 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_decimal_int64(&self) -> Option<(i64, u8)> {
         match *self {
-            Variant::Decimal4(decimal) => Some((decimal.integer.into(), decimal.scale)),
-            Variant::Decimal8(decimal) => Some((decimal.integer, decimal.scale)),
+            Variant::Decimal4(decimal) => Some((decimal.integer().into(), decimal.scale())),
+            Variant::Decimal8(decimal) => Some((decimal.integer(), decimal.scale())),
             Variant::Decimal16(decimal) => {
-                if let Ok(converted_integer) = decimal.integer.try_into() {
-                    Some((converted_integer, decimal.scale))
+                if let Ok(converted_integer) = decimal.integer().try_into() {
+                    Some((converted_integer, decimal.scale()))
                 } else {
                     None
                 }
@@ -744,9 +744,9 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_decimal_int128(&self) -> Option<(i128, u8)> {
         match *self {
-            Variant::Decimal4(decimal) => Some((decimal.integer.into(), decimal.scale)),
-            Variant::Decimal8(decimal) => Some((decimal.integer.into(), decimal.scale)),
-            Variant::Decimal16(decimal) => Some((decimal.integer, decimal.scale)),
+            Variant::Decimal4(decimal) => Some((decimal.integer().into(), decimal.scale())),
+            Variant::Decimal8(decimal) => Some((decimal.integer().into(), decimal.scale())),
+            Variant::Decimal16(decimal) => Some((decimal.integer(), decimal.scale)),
             _ => None,
         }
     }

--- a/parquet-variant/src/variant/decimal.rs
+++ b/parquet-variant/src/variant/decimal.rs
@@ -56,8 +56,8 @@ macro_rules! format_decimal {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal4 {
-    pub(crate) integer: i32,
-    pub(crate) scale: u8,
+    integer: i32,
+    scale: u8,
 }
 
 impl VariantDecimal4 {

--- a/parquet-variant/src/variant/decimal.rs
+++ b/parquet-variant/src/variant/decimal.rs
@@ -124,8 +124,8 @@ impl fmt::Display for VariantDecimal4 {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal8 {
-    pub(crate) integer: i64,
-    pub(crate) scale: u8,
+    integer: i64,
+    scale: u8,
 }
 
 impl VariantDecimal8 {
@@ -192,8 +192,8 @@ impl fmt::Display for VariantDecimal8 {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VariantDecimal16 {
-    pub(crate) integer: i128,
-    pub(crate) scale: u8,
+    integer: i128,
+    scale: u8,
 }
 
 impl VariantDecimal16 {


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- part of https://github.com/apache/arrow-rs/issues/6736

# Rationale for this change

I noticed this while reviewing @Weijun-H's PR
- https://github.com/apache/arrow-rs/pull/7738

I didn't know what part of the crate were using the fields directly and thus what part could potentially be creating invalid variants. By making the fields non `pub(crate)` I think it makes it clear these can not be constructed invalidly

This also gave me a good excuse to write some more examples

# What changes are included in this PR?
1. make fields in `VariantDecimal*` private
2. Add doc examples examples

# Are these changes tested?
By CI 

# Are there any user-facing changes?

API change in a non-published crate, so no end user impact yet