### PR TITLE
Add sort_kernel benchmark for StringViewArray case

### DIFF
--- a/arrow/benches/sort_kernel.rs
+++ b/arrow/benches/sort_kernel.rs
@@ -113,6 +113,43 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_sort_to_indices(&arr, None))
     });
 
+    // This will generate string view arrays with 2^12 elements, each with a length fixed 10, and without nulls.
+    let arr = create_string_view_array_with_fixed_len(2usize.pow(12), 0.0, 10);
+    c.bench_function("sort string_view[10] to indices 2^12", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    // This will generate string view arrays with 2^12 elements, each with a length fixed 10, and with 50% nulls.
+    let arr = create_string_view_array_with_fixed_len(2usize.pow(12), 0.5, 10);
+    c.bench_function("sort string_view[10] nulls to indices 2^12", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    // This will generate string view arrays with 2^12 elements, each with a length randomly chosen from 0 to max 400, and without nulls.
+    let arr = create_string_view_array(2usize.pow(12), 0.0);
+    c.bench_function("sort string_view[0-400] to indices 2^12", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    // This will generate string view arrays with 2^12 elements, each with a length randomly chosen from 0 to max 400, and with 50% nulls.
+    let arr = create_string_view_array(2usize.pow(12), 0.5);
+    c.bench_function("sort string_view[0-400] nulls to indices 2^12", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    // This will generate string view arrays with 2^12 elements, each with a length < 12 bytes which is inlined data, and without nulls.
+    let arr = create_string_view_array_with_max_len(2usize.pow(12), 0.0, 12);
+    c.bench_function("sort string_view_inlined[0-12] to indices 2^12", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    // This will generate string view arrays with 2^12 elements, each with a length < 12 bytes which is inlined data, and with 50% nulls.
+    let arr = create_string_view_array_with_max_len(2usize.pow(12), 0.5, 12);
+    c.bench_function(
+        "sort string_view_inlined[0-12] nulls to indices 2^12",
+        |b| b.iter(|| bench_sort_to_indices(&arr, None)),
+    );
+
     let arr = create_string_dict_array::<Int32Type>(2usize.pow(12), 0.0, 10);
     c.bench_function("sort string[10] dict to indices 2^12", |b| {
         b.iter(|| bench_sort_to_indices(&arr, None))

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -298,6 +298,26 @@ pub fn create_string_view_array_with_max_len(
 }
 
 /// Creates a random (but fixed-seeded) array of a given size, null density and length
+pub fn create_string_view_array_with_fixed_len(
+    size: usize,
+    null_density: f32,
+    str_len: usize,
+) -> StringViewArray {
+    let rng = &mut seedable_rng();
+    (0..size)
+        .map(|_| {
+            if rng.random::<f32>() < null_density {
+                None
+            } else {
+                let value = rng.sample_iter(&Alphanumeric).take(str_len).collect();
+                let value = String::from_utf8(value).unwrap();
+                Some(value)
+            }
+        })
+        .collect()
+}
+
+/// Creates a random (but fixed-seeded) array of a given size, null density and length
 pub fn create_string_view_array_with_len(
     size: usize,
     null_density: f32,


### PR DESCRIPTION
# Which issue does this PR close?

Add sort_kernel benchmark for StringViewArray case

- Closes [#7758](https://github.com/apache/arrow-rs/issues/7758)

# Rationale for this change

Add sort_kernel benchmark for StringViewArray case

# What changes are included in this PR?

Add sort_kernel benchmark for StringViewArray case

# Are these changes tested?

Yes
# Are there any user-facing changes?

No