### PR TITLE
fix: Change panic to error in`take` kernel for StringArrary/BinaryArray on overflow

### DIFF
--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -60,6 +60,8 @@ pub enum ArrowError {
     DictionaryKeyOverflowError,
     /// Error when the run end index in a REE array is bigger than the array length
     RunEndIndexOverflowError,
+    /// Error when the offset overflows.
+    OffsetOverflowError(usize),
 }
 
 impl ArrowError {
@@ -125,6 +127,9 @@ impl Display for ArrowError {
             }
             ArrowError::RunEndIndexOverflowError => {
                 write!(f, "Run end encoded array index overflow error")
+            }
+            ArrowError::OffsetOverflowError(offset) => {
+                write!(f, "Offset overflow error: {offset}")
             }
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/16252 .

# Rationale for this change

arrow will panic if offset overflows.

# What changes are included in this PR?

return an error instead of panic.

# Are these changes tested?

UT

# Are there any user-facing changes?

No