### PR TITLE
POC: try using Arc<Vec<Buffer>> instead of Arc<[Buffer]>

### DIFF
--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -64,7 +64,7 @@ name = "occupancy"
 harness = false
 
 [[bench]]
-name = "gc_view_types"
+name = "view_types"
 harness = false
 
 [[bench]]

--- a/arrow-array/benches/view_types.rs
+++ b/arrow-array/benches/view_types.rs
@@ -43,6 +43,12 @@ fn criterion_benchmark(c: &mut Criterion) {
             hint::black_box(sliced.gc());
         });
     });
+
+    c.bench_function("view types slice", |b| {
+        b.iter(|| {
+            black_box(array.slice(0, 100_000 / 2));
+        });
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -748,9 +748,7 @@ impl<T: ByteViewType + ?Sized> From<GenericByteViewArray<T>> for ArrayData {
         let new_buffers = {
             let mut buffers = Vec::with_capacity(array.buffers.len() + 1);
             buffers.push(array.views.into_inner());
-            for buffer in array.buffers.iter() {
-                buffers.push(buffer.clone());
-            }
+            buffers.extend_from_slice(&array.buffers.0);
             buffers
         };
 

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -748,7 +748,7 @@ impl<T: ByteViewType + ?Sized> From<GenericByteViewArray<T>> for ArrayData {
         let new_buffers = {
             let mut buffers = Vec::with_capacity(array.buffers.len() + 1);
             buffers.push(array.views.into_inner());
-            buffers.extend_from_slice(&array.buffers.0);
+            buffers.extend_from_slice(&array.buffers);
             buffers
         };
 

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -259,6 +259,8 @@ pub mod temporal_conversions;
 pub mod timezone;
 mod trusted_len;
 pub mod types;
+mod view_buffers;
+pub use view_buffers::ViewBuffers;
 
 #[cfg(test)]
 mod tests {

--- a/arrow-array/src/view_buffers.rs
+++ b/arrow-array/src/view_buffers.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use arrow_buffer::Buffer;
 
@@ -40,5 +40,13 @@ impl From<Vec<Buffer>> for ViewBuffers {
 impl From<&[Buffer]> for ViewBuffers {
     fn from(value: &[Buffer]) -> Self {
         Self(value.into())
+    }
+}
+
+impl Deref for ViewBuffers {
+    type Target = [Buffer];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
     }
 }

--- a/arrow-array/src/view_buffers.rs
+++ b/arrow-array/src/view_buffers.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use arrow_buffer::Buffer;
+
+/// A cheaply cloneable, owned slice of [`Buffer`]
+///
+/// Similar to `Arc<Vec<Buffer>>` or `Arc<[Buffer]>`
+#[derive(Clone, Debug)]
+pub struct ViewBuffers(pub(crate) Arc<[Buffer]>);
+
+impl FromIterator<Buffer> for ViewBuffers {
+    fn from_iter<T: IntoIterator<Item = Buffer>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl From<Vec<Buffer>> for ViewBuffers {
+    fn from(value: Vec<Buffer>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&[Buffer]> for ViewBuffers {
+    fn from(value: &[Buffer]) -> Self {
+        Self(value.into())
+    }
+}

--- a/arrow-array/src/view_buffers.rs
+++ b/arrow-array/src/view_buffers.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::sync::Arc;
 
 use arrow_buffer::Buffer;

--- a/arrow-array/src/view_buffers.rs
+++ b/arrow-array/src/view_buffers.rs
@@ -23,22 +23,31 @@ use arrow_buffer::Buffer;
 ///
 /// Similar to `Arc<Vec<Buffer>>` or `Arc<[Buffer]>`
 #[derive(Clone, Debug)]
-pub struct ViewBuffers(pub(crate) Arc<[Buffer]>);
+pub struct ViewBuffers(Arc<Vec<Buffer>>);
+
+impl ViewBuffers {
+    /// Return a mutable reference to the underlying buffers, copying the buffers if necessary.
+    pub fn make_mut(&mut self) -> &mut Vec<Buffer> {
+        // If the underlying Arc is unique, we can mutate it in place
+        Arc::make_mut(&mut self.0)
+    }
+
+    /// Convertes this ViewBuffers into a Vec<Buffer>, cloning the underlying buffers if
+    /// they are shared.
+    pub fn unwrap_or_clone(self) -> Vec<Buffer> {
+        Arc::unwrap_or_clone(self.0)
+    }
+}
 
 impl FromIterator<Buffer> for ViewBuffers {
     fn from_iter<T: IntoIterator<Item = Buffer>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+        let v: Vec<_> = iter.into_iter().collect();
+        Self(v.into())
     }
 }
 
 impl From<Vec<Buffer>> for ViewBuffers {
     fn from(value: Vec<Buffer>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<&[Buffer]> for ViewBuffers {
-    fn from(value: &[Buffer]) -> Self {
         Self(value.into())
     }
 }


### PR DESCRIPTION
This is an experiment built on top of @ctsk 's PR here: https://github.com/apache/arrow-rs/pull/7773

The idea is to just use the Vec directly rather than discarding the vec overhead. This change is in 
- 180636b216bdb24276438cf7d2efb88eb984cd12

I will run benchmarks against this PR and see how they look compared to 
- https://github.com/apache/arrow-rs/pull/7773/files