### PR TITLE
[VARIANT] Support both fallible and infallible access to variants

### DIFF
--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -63,6 +63,11 @@ pub struct VariantObject<'m, 'v> {
 }
 
 impl<'m, 'v> VariantObject<'m, 'v> {
+    pub fn new(metadata: VariantMetadata<'m>, value: &'v [u8]) -> Self {
+        // TODO!
+        Self::try_new(metadata, value).unwrap()
+    }
+
     /// Attempts to interpret `value` as a variant object value.
     ///
     /// # Validation
@@ -147,8 +152,10 @@ impl<'m, 'v> VariantObject<'m, 'v> {
     /// Get a field's value by index in `0..self.len()`
     ///
     /// # Panics
-    /// If the variant object is corrupted (e.g., invalid offsets or field IDs).
-    /// This should never happen since the constructor validates all data upfront.
+    ///
+    /// If the index is out of bounds. Also if variant object is corrupted (e.g., invalid offsets or
+    /// field IDs). The latter can only happen when working with an unvalidated object produced by
+    /// [`Self::new`].
     pub fn field(&self, i: usize) -> Option<Variant<'m, 'v>> {
         Some(
             self.try_field(i)


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #https://github.com/apache/arrow-rs/issues/7711

# Rationale for this change

Full validation is nice, but expensive when not needed.

# What changes are included in this PR?

Allow both validated+infallible and unvalidated+fallible access combinations.

# Are these changes tested?

TODO

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

TODO

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
