### PR TITLE
[Variant] Speedup `ObjectBuilder` (62x faster)

### DIFF
--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -39,6 +39,11 @@ serde_json = "1.0"
 base64 = "0.22"
 indexmap = "2.10.0"
 
+
+[lib]
+name = "parquet_variant"
+bench = false
+
 [dev-dependencies]
 paste = { version = "1.0" }
 criterion = { version = "0.6", default-features = false }
@@ -48,9 +53,7 @@ rand = { version = "0.9", default-features = false, features = [
     "thread_rng",
 ] }
 
-[lib]
-
 
 [[bench]]
-name = "builder"
+name = "variant_builder"
 harness = false

--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -40,6 +40,16 @@ base64 = "0.22"
 
 [dev-dependencies]
 paste = { version = "1.0" }
-
+criterion = { version = "0.6", default-features = false }
+rand = { version = "0.9", default-features = false, features = [
+    "std",
+    "std_rng",
+    "thread_rng",
+] }
 
 [lib]
+
+
+[[bench]]
+name = "builder"
+harness = false

--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -37,6 +37,7 @@ arrow-schema = { workspace = true }
 chrono = { workspace = true }
 serde_json = "1.0"
 base64 = "0.22"
+indexmap = "2.10.0"
 
 [dev-dependencies]
 paste = { version = "1.0" }

--- a/parquet-variant/benches/builder.rs
+++ b/parquet-variant/benches/builder.rs
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate parquet_variant;
+
+use criterion::*;
+
+use parquet_variant::VariantBuilder;
+use rand::{
+    distr::{uniform::SampleUniform, Alphanumeric},
+    rngs::ThreadRng,
+    Rng,
+};
+use std::{hint, ops::Range};
+
+fn random<T: SampleUniform + PartialEq + PartialOrd>(rng: &mut ThreadRng, range: Range<T>) -> T {
+    rng.random_range::<T, _>(range)
+}
+
+// generates a string with a 50/50 chance whether it's a short or a long string
+fn random_string(rng: &mut ThreadRng) -> String {
+    let len = rng.random_range::<usize, _>(1..128);
+
+    rng.sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
+}
+
+// generates a string guaranteed to be longer than 64 bytes
+fn random_long_string(rng: &mut ThreadRng) -> String {
+    let len = rng.random_range::<usize, _>(65..200);
+
+    rng.sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
+}
+
+// Creates an object with field names inserted in reverse lexicographical order
+fn bench_object_field_names_reverse_order(c: &mut Criterion) {
+    c.bench_function("bench_object_field_names_reverse_order", |b| {
+        b.iter(|| {
+            let mut rng = rand::rng();
+
+            let mut variant = VariantBuilder::new();
+            let mut object_builder = variant.new_object();
+
+            for i in 0..50_000 {
+                object_builder.insert(
+                    format!("{}", 1000 - i).as_str(),
+                    random_string(&mut rng).as_str(),
+                );
+            }
+
+            object_builder.finish();
+            hint::black_box(variant.finish());
+        })
+    });
+}
+
+// Creates a list of objects with the same schema (same field names)
+/*
+    {
+        name: String,
+        age: i32,
+        likes_cilantro: bool,
+        comments: Long string
+        dishes: Vec<String>
+    }
+*/
+fn bench_object_list_same_schemas(c: &mut Criterion) {
+    c.bench_function("bench_object_list_same_schema", |b| {
+        b.iter(|| {
+            let mut rng = rand::rng();
+
+            let mut variant = VariantBuilder::new();
+
+            let mut list_builder = variant.new_list();
+
+            for _ in 0..25_000 {
+                let mut object_builder = list_builder.new_object();
+                object_builder.insert("name", random_string(&mut rng).as_str());
+                object_builder.insert("age", random::<u32>(&mut rng, 18..100) as i32);
+                object_builder.insert("likes_cilantro", rng.random_bool(0.5));
+                object_builder.insert("comments", random_long_string(&mut rng).as_str());
+
+                let mut list_builder = object_builder.new_list("dishes");
+                list_builder.append_value(random_string(&mut rng).as_str());
+                list_builder.append_value(random_string(&mut rng).as_str());
+                list_builder.append_value(random_string(&mut rng).as_str());
+
+                list_builder.finish();
+                object_builder.finish();
+            }
+
+            list_builder.finish();
+            hint::black_box(variant.finish());
+        })
+    });
+}
+
+// Creates a list of variant objects with an undefined schema (random field names)
+// values are randomly generated, with an equal distribution to whether it's a String, Object, or List
+fn bench_object_list_unknown_schema(c: &mut Criterion) {
+    c.bench_function("bench_object_list_unknown_schema", |b| {
+        b.iter(|| {
+            let mut rng = rand::rng();
+
+            let mut variant = VariantBuilder::new();
+
+            let mut list_builder = variant.new_list();
+
+            for _ in 0..200 {
+                let mut object_builder = list_builder.new_object();
+
+                for _num_fields in 0..random::<u8>(&mut rng, 0..100) {
+                    if rng.random_bool(0.33) {
+                        object_builder.insert(
+                            random_string(&mut rng).as_str(),
+                            random_string(&mut rng).as_str(),
+                        );
+                        continue;
+                    }
+
+                    if rng.random_bool(0.5) {
+                        let mut inner_object_builder = object_builder.new_object("rand_object");
+
+                        for _num_fields in 0..random::<u8>(&mut rng, 0..25) {
+                            inner_object_builder.insert(
+                                random_string(&mut rng).as_str(),
+                                random_string(&mut rng).as_str(),
+                            );
+                        }
+                        inner_object_builder.finish();
+
+                        continue;
+                    }
+
+                    let mut inner_list_builder = object_builder.new_list("rand_list");
+
+                    for _num_elements in 0..random::<u8>(&mut rng, 0..25) {
+                        inner_list_builder.append_value(random_string(&mut rng).as_str());
+                    }
+
+                    inner_list_builder.finish();
+                }
+                object_builder.finish();
+            }
+
+            list_builder.finish();
+            hint::black_box(variant.finish());
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_object_field_names_reverse_order,
+    bench_object_list_same_schemas,
+    bench_object_list_unknown_schema,
+);
+
+criterion_main!(benches);

--- a/parquet-variant/benches/variant_builder.rs
+++ b/parquet-variant/benches/variant_builder.rs
@@ -22,17 +22,17 @@ use criterion::*;
 use parquet_variant::VariantBuilder;
 use rand::{
     distr::{uniform::SampleUniform, Alphanumeric},
-    rngs::ThreadRng,
-    Rng,
+    rngs::StdRng,
+    Rng, SeedableRng,
 };
 use std::{hint, ops::Range};
 
-fn random<T: SampleUniform + PartialEq + PartialOrd>(rng: &mut ThreadRng, range: Range<T>) -> T {
+fn random<T: SampleUniform + PartialEq + PartialOrd>(rng: &mut StdRng, range: Range<T>) -> T {
     rng.random_range::<T, _>(range)
 }
 
 // generates a string with a 50/50 chance whether it's a short or a long string
-fn random_string(rng: &mut ThreadRng) -> String {
+fn random_string(rng: &mut StdRng) -> String {
     let len = rng.random_range::<usize, _>(1..128);
 
     rng.sample_iter(&Alphanumeric)
@@ -47,7 +47,7 @@ struct RandomStringGenerator {
 }
 
 impl RandomStringGenerator {
-    pub fn new(rng: &mut ThreadRng, capacity: usize) -> Self {
+    pub fn new(rng: &mut StdRng, capacity: usize) -> Self {
         let table = (0..capacity)
             .map(|_| random_string(rng))
             .collect::<Vec<_>>();
@@ -67,7 +67,7 @@ impl RandomStringGenerator {
 // Creates an object with field names inserted in reverse lexicographical order
 fn bench_object_field_names_reverse_order(c: &mut Criterion) {
     c.bench_function("bench_object_field_names_reverse_order", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 117);
         b.iter(|| {
             let mut variant = VariantBuilder::new();
@@ -94,7 +94,7 @@ fn bench_object_field_names_reverse_order(c: &mut Criterion) {
     }
 */
 fn bench_object_same_schema(c: &mut Criterion) {
-    let mut rng = rand::rng();
+    let mut rng = StdRng::seed_from_u64(42);
     let mut string_table = RandomStringGenerator::new(&mut rng, 117);
 
     c.bench_function("bench_object_same_schema", |b| {
@@ -133,7 +133,7 @@ fn bench_object_same_schema(c: &mut Criterion) {
 */
 fn bench_object_list_same_schema(c: &mut Criterion) {
     c.bench_function("bench_object_list_same_schema", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 101);
 
         b.iter(|| {
@@ -167,7 +167,7 @@ fn bench_object_list_same_schema(c: &mut Criterion) {
 // values are randomly generated, with an equal distribution to whether it's a String, Object, or List
 fn bench_object_unknown_schema(c: &mut Criterion) {
     c.bench_function("bench_object_unknown_schema", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 1001);
 
         b.iter(|| {
@@ -213,11 +213,11 @@ fn bench_object_unknown_schema(c: &mut Criterion) {
 // values are randomly generated, with an equal distribution to whether it's a String, Object, or List
 fn bench_object_list_unknown_schema(c: &mut Criterion) {
     c.bench_function("bench_object_list_unknown_schema", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 1001);
 
         b.iter(|| {
-            let mut rng = rand::rng();
+            let mut rng = StdRng::seed_from_u64(42);
 
             let mut variant = VariantBuilder::new();
 
@@ -279,11 +279,11 @@ fn bench_object_list_unknown_schema(c: &mut Criterion) {
 */
 fn bench_object_partially_same_schema(c: &mut Criterion) {
     c.bench_function("bench_object_partially_same_schema", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 117);
 
         b.iter(|| {
-            let mut rng = rand::rng();
+            let mut rng = StdRng::seed_from_u64(42);
 
             for _ in 0..200 {
                 let mut variant = VariantBuilder::new();
@@ -340,7 +340,7 @@ fn bench_object_partially_same_schema(c: &mut Criterion) {
 */
 fn bench_object_list_partially_same_schema(c: &mut Criterion) {
     c.bench_function("bench_object_list_partially_same_schema", |b| {
-        let mut rng = rand::rng();
+        let mut rng = StdRng::seed_from_u64(42);
         let mut string_table = RandomStringGenerator::new(&mut rng, 117);
 
         b.iter(|| {

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -16,6 +16,7 @@
 // under the License.
 use crate::decoder::{VariantBasicType, VariantPrimitiveType};
 use crate::{ShortString, Variant, VariantDecimal16, VariantDecimal4, VariantDecimal8};
+use indexmap::IndexSet;
 use std::collections::HashMap;
 
 const BASIC_TYPE_BITS: u8 = 2;
@@ -233,23 +234,15 @@ impl ValueBuffer {
 
 #[derive(Default)]
 struct MetadataBuilder {
-    field_name_to_id: HashMap<String, u32>,
-    field_names: Vec<String>,
+    field_names: IndexSet<String>,
 }
 
 impl MetadataBuilder {
     /// Upsert field name to dictionary, return its ID
     fn upsert_field_name(&mut self, field_name: &str) -> u32 {
-        use std::collections::hash_map::Entry;
-        match self.field_name_to_id.entry(field_name.to_string()) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let id = self.field_names.len() as u32;
-                entry.insert(id);
-                self.field_names.push(field_name.to_string());
-                id
-            }
-        }
+        let (id, _) = self.field_names.insert_full(field_name.to_string());
+
+        id as u32
     }
 
     fn num_field_names(&self) -> usize {


### PR DESCRIPTION
- Part of this PR closes https://github.com/apache/arrow-rs/issues/7814

# Rationale for this change
This PR modifies the backing data structure for `ObjectBuilder.fields` and `MetadataBuilder.field_name_to_id` to speedup the builder code by 62x.

I started to profile our variant builder code and noticed `ObjectBuilder::finish` took a very long time to complete. The profile involved building up a `VariantList` with 20,000 `VariantObject`s, each with a unique field name.

The code on main took 628ms to run, with `Object::finish` consuming all of its runtime:

<img width="1512" alt="Screenshot 2025-06-27 at 1 45 22 PM" src="https://github.com/user-attachments/assets/6ea7b7d6-9056-4cc1-986a-ff4536bce60f" />

<br>

The profile shows iterating over the `MetadataBuilder`'s `BTreeMap` and filtering by relative field ids was the bottleneck:

https://github.com/apache/arrow-rs/blob/2754ce5e0b6e3c811ede87d2cd2c54ecaa216117/parquet-variant/src/builder.rs#L652-L657

<br>

This is very bad. We can improve by making the following observations. 

1. Field ids also serve as indices into `MetadataBuilder.fields`, so field name lookup time is O(1)
2. `Vec` sorting is faster

By changing `ObjectBuilder.fields` to use a `Vec`, the code takes 10ms to run, with `Object::finish` taking 30% of the runtime. 

<img width="1512" alt="Screenshot 2025-06-27 at 1 53 59 PM" src="https://github.com/user-attachments/assets/63a5d30d-b30c-4ca2-b2ea-54eaacd073ea" />

<br>

<details>
<summary>To reproduce</summary>

```sh
cargo b --profile profiling
samply record ./target/profiling/object_list
```

```rs
// object_list.rs
use parquet_variant::VariantBuilder;

fn main() {
    let mut builder = VariantBuilder::new();

    let mut list_builder = builder.new_list();

    for i in 0..20_000 {
        let mut obj = list_builder.new_object();
        obj.insert(format!("{}", 20_000 - i).as_str(), i);
        obj.finish();
    }

    list_builder.finish();

    std::hint::black_box(builder.finish());
}
```
</details>