### PR TITLE
Remove deprecated temporal functions

### DIFF
--- a/arrow-arith/src/temporal.rs
+++ b/arrow-arith/src/temporal.rs
@@ -31,7 +31,6 @@ use arrow_array::temporal_conversions::{
 use arrow_array::timezone::Tz;
 use arrow_array::types::*;
 use arrow_array::*;
-use arrow_buffer::ArrowNativeType;
 use arrow_schema::{ArrowError, DataType, IntervalUnit, TimeUnit};
 
 /// Valid parts to extract from date/time/timestamp arrays.
@@ -195,16 +194,6 @@ pub fn date_part(array: &dyn Array, part: DatePart) -> Result<ArrayRef, ArrowErr
         }
         t => return_compute_error_with!(format!("{part} does not support"), t),
     )
-}
-
-/// Used to integrate new [`date_part()`] method with deprecated shims such as
-/// [`hour()`] and [`week()`].
-fn date_part_primitive<T: ArrowTemporalType>(
-    array: &PrimitiveArray<T>,
-    part: DatePart,
-) -> Result<Int32Array, ArrowError> {
-    let array = date_part(array, part)?;
-    Ok(array.as_primitive::<Int32Type>().to_owned())
 }
 
 /// Extract optional [`Tz`] from timestamp data types, returning error
@@ -685,300 +674,26 @@ impl<T: Datelike> ChronoDateExt for T {
     }
 }
 
-/// Extracts the hours of a given array as an array of integers within
-/// the range of [0, 23]. If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn hour_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Hour)
-}
-
-/// Extracts the hours of a given temporal primitive array as an array of integers within
-/// the range of [0, 23].
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn hour<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Hour)
-}
-
-/// Extracts the years of a given temporal array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn year_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Year)
-}
-
-/// Extracts the years of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn year<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Year)
-}
-
-/// Extracts the quarter of a given temporal array as an array of integersa within
-/// the range of [1, 4]. If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn quarter_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Quarter)
-}
-
-/// Extracts the quarter of a given temporal primitive array as an array of integers within
-/// the range of [1, 4].
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn quarter<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Quarter)
-}
-
-/// Extracts the month of a given temporal array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn month_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Month)
-}
-
-/// Extracts the month of a given temporal primitive array as an array of integers within
-/// the range of [1, 12].
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn month<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Month)
-}
-
-/// Extracts the day of week of a given temporal array as an array of
-/// integers.
-///
-/// Monday is encoded as `0`, Tuesday as `1`, etc.
-///
-/// See also [`num_days_from_sunday`] which starts at Sunday.
-///
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn num_days_from_monday_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::DayOfWeekMonday0)
-}
-
-/// Extracts the day of week of a given temporal primitive array as an array of
-/// integers.
-///
-/// Monday is encoded as `0`, Tuesday as `1`, etc.
-///
-/// See also [`num_days_from_sunday`] which starts at Sunday.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn num_days_from_monday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::DayOfWeekMonday0)
-}
-
-/// Extracts the day of week of a given temporal array as an array of
-/// integers, starting at Sunday.
-///
-/// Sunday is encoded as `0`, Monday as `1`, etc.
-///
-/// See also [`num_days_from_monday`] which starts at Monday.
-///
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn num_days_from_sunday_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::DayOfWeekSunday0)
-}
-
-/// Extracts the day of week of a given temporal primitive array as an array of
-/// integers, starting at Sunday.
-///
-/// Sunday is encoded as `0`, Monday as `1`, etc.
-///
-/// See also [`num_days_from_monday`] which starts at Monday.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn num_days_from_sunday<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::DayOfWeekSunday0)
-}
-
-/// Extracts the day of a given temporal array as an array of integers.
-///
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn day_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Day)
-}
-
-/// Extracts the day of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn day<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Day)
-}
-
-/// Extracts the day of year of a given temporal array as an array of integers.
-///
-/// The day of year that ranges from 1 to 366.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn doy_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::DayOfYear)
-}
-
-/// Extracts the day of year of a given temporal primitive array as an array of integers.
-///
-/// The day of year that ranges from 1 to 366
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn doy<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    T::Native: ArrowNativeType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::DayOfYear)
-}
-
-/// Extracts the minutes of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn minute<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Minute)
-}
-
-/// Extracts the week of a given temporal array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn week_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Week)
-}
-
-/// Extracts the week of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn week<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Week)
-}
-
-/// Extracts the seconds of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn second<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Second)
-}
-
-/// Extracts the nanoseconds of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn nanosecond<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Nanosecond)
-}
-
-/// Extracts the nanoseconds of a given temporal primitive array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn nanosecond_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Nanosecond)
-}
-
-/// Extracts the microseconds of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn microsecond<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Microsecond)
-}
-
-/// Extracts the microseconds of a given temporal primitive array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn microsecond_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Microsecond)
-}
-
-/// Extracts the milliseconds of a given temporal primitive array as an array of integers
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn millisecond<T>(array: &PrimitiveArray<T>) -> Result<Int32Array, ArrowError>
-where
-    T: ArrowTemporalType + ArrowNumericType,
-    i64: From<T::Native>,
-{
-    date_part_primitive(array, DatePart::Millisecond)
-}
-
-/// Extracts the milliseconds of a given temporal primitive array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn millisecond_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Millisecond)
-}
-
-/// Extracts the minutes of a given temporal array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn minute_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Minute)
-}
-
-/// Extracts the seconds of a given temporal array as an array of integers.
-/// If the given array isn't temporal primitive or dictionary array,
-/// an `Err` will be returned.
-#[deprecated(since = "51.0.0", note = "Use `date_part` instead")]
-pub fn second_dyn(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
-    date_part(array, DatePart::Second)
-}
-
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
+
+    /// Used to integrate new [`date_part()`] method with deprecated shims such as
+    /// [`hour()`] and [`week()`].
+    fn date_part_primitive<T: ArrowTemporalType>(
+        array: &PrimitiveArray<T>,
+        part: DatePart,
+    ) -> Result<Int32Array, ArrowError> {
+        let array = date_part(array, part)?;
+        Ok(array.as_primitive::<Int32Type>().to_owned())
+    }
 
     #[test]
     fn test_temporal_array_date64_hour() {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(4, b.value(2));
@@ -988,7 +703,7 @@ mod tests {
     fn test_temporal_array_date32_hour() {
         let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15148)].into();
 
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(0, b.value(2));
@@ -998,7 +713,7 @@ mod tests {
     fn test_temporal_array_time32_second_hour() {
         let a: PrimitiveArray<Time32SecondType> = vec![37800, 86339].into();
 
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(23, b.value(1));
     }
@@ -1007,7 +722,7 @@ mod tests {
     fn test_temporal_array_time64_micro_hour() {
         let a: PrimitiveArray<Time64MicrosecondType> = vec![37800000000, 86339000000].into();
 
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(23, b.value(1));
     }
@@ -1016,7 +731,7 @@ mod tests {
     fn test_temporal_array_timestamp_micro_hour() {
         let a: TimestampMicrosecondArray = vec![37800000000, 86339000000].into();
 
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(23, b.value(1));
     }
@@ -1026,7 +741,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = year(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Year).unwrap();
         assert_eq!(2018, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2019, b.value(2));
@@ -1036,7 +751,7 @@ mod tests {
     fn test_temporal_array_date32_year() {
         let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15448)].into();
 
-        let b = year(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Year).unwrap();
         assert_eq!(2011, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2012, b.value(2));
@@ -1049,7 +764,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1566275025000)].into();
 
-        let b = quarter(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Quarter).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(3, b.value(2));
@@ -1059,7 +774,7 @@ mod tests {
     fn test_temporal_array_date32_quarter() {
         let a: PrimitiveArray<Date32Type> = vec![Some(1), None, Some(300)].into();
 
-        let b = quarter(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Quarter).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(4, b.value(2));
@@ -1069,10 +784,10 @@ mod tests {
     fn test_temporal_array_timestamp_quarter_with_timezone() {
         // 24 * 60 * 60 = 86400
         let a = TimestampSecondArray::from(vec![86400 * 90]).with_timezone("+00:00".to_string());
-        let b = quarter(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Quarter).unwrap();
         assert_eq!(2, b.value(0));
         let a = TimestampSecondArray::from(vec![86400 * 90]).with_timezone("-10:00".to_string());
-        let b = quarter(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Quarter).unwrap();
         assert_eq!(1, b.value(0));
     }
 
@@ -1083,7 +798,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = month(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Month).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2, b.value(2));
@@ -1093,7 +808,7 @@ mod tests {
     fn test_temporal_array_date32_month() {
         let a: PrimitiveArray<Date32Type> = vec![Some(1), None, Some(31)].into();
 
-        let b = month(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Month).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2, b.value(2));
@@ -1103,10 +818,10 @@ mod tests {
     fn test_temporal_array_timestamp_month_with_timezone() {
         // 24 * 60 * 60 = 86400
         let a = TimestampSecondArray::from(vec![86400 * 31]).with_timezone("+00:00".to_string());
-        let b = month(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Month).unwrap();
         assert_eq!(2, b.value(0));
         let a = TimestampSecondArray::from(vec![86400 * 31]).with_timezone("-10:00".to_string());
-        let b = month(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Month).unwrap();
         assert_eq!(1, b.value(0));
     }
 
@@ -1114,10 +829,10 @@ mod tests {
     fn test_temporal_array_timestamp_day_with_timezone() {
         // 24 * 60 * 60 = 86400
         let a = TimestampSecondArray::from(vec![86400]).with_timezone("+00:00".to_string());
-        let b = day(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Day).unwrap();
         assert_eq!(2, b.value(0));
         let a = TimestampSecondArray::from(vec![86400]).with_timezone("-10:00".to_string());
-        let b = day(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Day).unwrap();
         assert_eq!(1, b.value(0));
     }
 
@@ -1128,7 +843,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = num_days_from_monday(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::DayOfWeekMonday0).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2, b.value(2));
@@ -1147,7 +862,7 @@ mod tests {
         ]
         .into();
 
-        let b = num_days_from_sunday(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::DayOfWeekSunday0).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(1, b.value(2));
@@ -1161,7 +876,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = day(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Day).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(20, b.value(2));
@@ -1171,7 +886,7 @@ mod tests {
     fn test_temporal_array_date32_day() {
         let a: PrimitiveArray<Date32Type> = vec![Some(0), None, Some(31)].into();
 
-        let b = day(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Day).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(1, b.value(2));
@@ -1190,7 +905,7 @@ mod tests {
         ]
         .into();
 
-        let b = doy(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::DayOfYear).unwrap();
         assert_eq!(1, b.value(0));
         assert_eq!(1, b.value(1));
         assert!(!b.is_valid(2));
@@ -1202,7 +917,7 @@ mod tests {
         let a: TimestampMicrosecondArray =
             vec![Some(1612025847000000), None, Some(1722015847000000)].into();
 
-        let b = year(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Year).unwrap();
         assert_eq!(2021, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2024, b.value(2));
@@ -1213,7 +928,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = minute(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Minute).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(23, b.value(2));
@@ -1224,7 +939,7 @@ mod tests {
         let a: TimestampMicrosecondArray =
             vec![Some(1612025847000000), None, Some(1722015847000000)].into();
 
-        let b = minute(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Minute).unwrap();
         assert_eq!(57, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(44, b.value(2));
@@ -1234,7 +949,7 @@ mod tests {
     fn test_temporal_array_date32_week() {
         let a: PrimitiveArray<Date32Type> = vec![Some(0), None, Some(7)].into();
 
-        let b = week(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Week).unwrap();
         assert_eq!(1, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(2, b.value(2));
@@ -1252,7 +967,7 @@ mod tests {
         ]
         .into();
 
-        let b = week(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Week).unwrap();
         assert_eq!(9, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(1, b.value(2));
@@ -1266,7 +981,7 @@ mod tests {
         let a: TimestampMicrosecondArray =
             vec![Some(1612025847000000), None, Some(1722015847000000)].into();
 
-        let b = week(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Week).unwrap();
         assert_eq!(4, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(30, b.value(2));
@@ -1277,7 +992,7 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        let b = second(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Second).unwrap();
         assert_eq!(0, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(45, b.value(2));
@@ -1288,7 +1003,7 @@ mod tests {
         let a: TimestampMicrosecondArray =
             vec![Some(1612025847000000), None, Some(1722015847000000)].into();
 
-        let b = second(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Second).unwrap();
         assert_eq!(27, b.value(0));
         assert!(!b.is_valid(1));
         assert_eq!(7, b.value(2));
@@ -1297,7 +1012,7 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_second_with_timezone() {
         let a = TimestampSecondArray::from(vec![10, 20]).with_timezone("+00:00".to_string());
-        let b = second(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Second).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(20, b.value(1));
     }
@@ -1305,7 +1020,7 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_minute_with_timezone() {
         let a = TimestampSecondArray::from(vec![0, 60]).with_timezone("+00:50".to_string());
-        let b = minute(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Minute).unwrap();
         assert_eq!(50, b.value(0));
         assert_eq!(51, b.value(1));
     }
@@ -1313,42 +1028,46 @@ mod tests {
     #[test]
     fn test_temporal_array_timestamp_minute_with_negative_timezone() {
         let a = TimestampSecondArray::from(vec![60 * 55]).with_timezone("-00:50".to_string());
-        let b = minute(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Minute).unwrap();
         assert_eq!(5, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone() {
         let a = TimestampSecondArray::from(vec![60 * 60 * 10]).with_timezone("+01:00".to_string());
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(11, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_without_colon() {
         let a = TimestampSecondArray::from(vec![60 * 60 * 10]).with_timezone("+0100".to_string());
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(11, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_without_minutes() {
         let a = TimestampSecondArray::from(vec![60 * 60 * 10]).with_timezone("+01".to_string());
-        let b = hour(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Hour).unwrap();
         assert_eq!(11, b.value(0));
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_without_initial_sign() {
         let a = TimestampSecondArray::from(vec![60 * 60 * 10]).with_timezone("0100".to_string());
-        let err = hour(&a).unwrap_err().to_string();
+        let err = date_part_primitive(&a, DatePart::Hour)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("Invalid timezone"), "{}", err);
     }
 
     #[test]
     fn test_temporal_array_timestamp_hour_with_timezone_with_only_colon() {
         let a = TimestampSecondArray::from(vec![60 * 60 * 10]).with_timezone("01:00".to_string());
-        let err = hour(&a).unwrap_err().to_string();
+        let err = date_part_primitive(&a, DatePart::Hour)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("Invalid timezone"), "{}", err);
     }
 
@@ -1358,7 +1077,7 @@ mod tests {
         // 1970-01-01T00:00:00 + 4 days            -> 1970-01-05T00:00:00 Monday   (week 2)
         // 1970-01-01T00:00:00 + 4 days - 1 second -> 1970-01-04T23:59:59 Sunday   (week 1)
         let a = TimestampSecondArray::from(vec![0, 86400 * 4, 86400 * 4 - 1]);
-        let b = week(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Week).unwrap();
         assert_eq!(1, b.value(0));
         assert_eq!(2, b.value(1));
         assert_eq!(1, b.value(2));
@@ -1371,7 +1090,7 @@ mod tests {
         // 1970-01-01T01:00:00+01:00 + 4 days - 1 second -> 1970-01-05T00:59:59+01:00 Monday   (week 2)
         let a = TimestampSecondArray::from(vec![0, 86400 * 4, 86400 * 4 - 1])
             .with_timezone("+01:00".to_string());
-        let b = week(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Week).unwrap();
         assert_eq!(1, b.value(0));
         assert_eq!(2, b.value(1));
         assert_eq!(2, b.value(2));
@@ -1389,7 +1108,7 @@ mod tests {
         let keys = Int8Array::from_iter_values([0_i8, 0, 1, 2, 1]);
         let dict = DictionaryArray::try_new(keys.clone(), Arc::new(a)).unwrap();
 
-        let b = hour_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Hour).unwrap();
 
         let expected_dict =
             DictionaryArray::new(keys.clone(), Arc::new(Int32Array::from(vec![11, 21, 7])));
@@ -1398,7 +1117,7 @@ mod tests {
 
         let b = date_part(&dict, DatePart::Minute).unwrap();
 
-        let b_old = minute_dyn(&dict).unwrap();
+        let b_old = date_part(&dict, DatePart::Minute).unwrap();
 
         let expected_dict =
             DictionaryArray::new(keys.clone(), Arc::new(Int32Array::from(vec![1, 2, 3])));
@@ -1408,7 +1127,7 @@ mod tests {
 
         let b = date_part(&dict, DatePart::Second).unwrap();
 
-        let b_old = second_dyn(&dict).unwrap();
+        let b_old = date_part(&dict, DatePart::Second).unwrap();
 
         let expected_dict =
             DictionaryArray::new(keys.clone(), Arc::new(Int32Array::from(vec![1, 2, 3])));
@@ -1431,7 +1150,7 @@ mod tests {
         let keys = Int8Array::from_iter_values([0_i8, 1, 1, 0]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
 
-        let b = year_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Year).unwrap();
 
         let expected_dict = DictionaryArray::new(
             keys,
@@ -1450,13 +1169,13 @@ mod tests {
         let keys = Int8Array::from_iter_values([0_i8, 1, 1, 0]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
 
-        let b = quarter_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Quarter).unwrap();
 
         let expected =
             DictionaryArray::new(keys.clone(), Arc::new(Int32Array::from(vec![1, 3, 3, 1])));
         assert_eq!(b.as_ref(), &expected);
 
-        let b = month_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Month).unwrap();
 
         let expected = DictionaryArray::new(keys, Arc::new(Int32Array::from(vec![1, 8, 8, 1])));
         assert_eq!(b.as_ref(), &expected);
@@ -1471,31 +1190,31 @@ mod tests {
         let keys = Int8Array::from(vec![Some(0_i8), Some(1), Some(1), Some(0), None]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
 
-        let b = num_days_from_monday_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::DayOfWeekMonday0).unwrap();
 
         let a = Int32Array::from(vec![Some(0), Some(2), Some(2), Some(0), None]);
         let expected = DictionaryArray::new(keys.clone(), Arc::new(a));
         assert_eq!(b.as_ref(), &expected);
 
-        let b = num_days_from_sunday_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::DayOfWeekSunday0).unwrap();
 
         let a = Int32Array::from(vec![Some(1), Some(3), Some(3), Some(1), None]);
         let expected = DictionaryArray::new(keys.clone(), Arc::new(a));
         assert_eq!(b.as_ref(), &expected);
 
-        let b = day_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Day).unwrap();
 
         let a = Int32Array::from(vec![Some(1), Some(20), Some(20), Some(1), None]);
         let expected = DictionaryArray::new(keys.clone(), Arc::new(a));
         assert_eq!(b.as_ref(), &expected);
 
-        let b = doy_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::DayOfYear).unwrap();
 
         let a = Int32Array::from(vec![Some(1), Some(51), Some(51), Some(1), None]);
         let expected = DictionaryArray::new(keys.clone(), Arc::new(a));
         assert_eq!(b.as_ref(), &expected);
 
-        let b = week_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Week).unwrap();
 
         let a = Int32Array::from(vec![Some(1), Some(8), Some(8), Some(1), None]);
         let expected = DictionaryArray::new(keys, Arc::new(a));
@@ -1512,13 +1231,13 @@ mod tests {
 
         let a: PrimitiveArray<Date64Type> = vec![None, Some(1667328721453)].into();
 
-        let b = nanosecond(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Nanosecond).unwrap();
         assert!(!b.is_valid(0));
         assert_eq!(453_000_000, b.value(1));
 
         let keys = Int8Array::from(vec![Some(0_i8), Some(1), Some(1)]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
-        let b = nanosecond_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Nanosecond).unwrap();
 
         let a = Int32Array::from(vec![None, Some(453_000_000)]);
         let expected_dict = DictionaryArray::new(keys, Arc::new(a));
@@ -1530,13 +1249,13 @@ mod tests {
     fn test_temporal_array_date64_microsecond() {
         let a: PrimitiveArray<Date64Type> = vec![None, Some(1667328721453)].into();
 
-        let b = microsecond(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Microsecond).unwrap();
         assert!(!b.is_valid(0));
         assert_eq!(453_000, b.value(1));
 
         let keys = Int8Array::from(vec![Some(0_i8), Some(1), Some(1)]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
-        let b = microsecond_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Microsecond).unwrap();
 
         let a = Int32Array::from(vec![None, Some(453_000)]);
         let expected_dict = DictionaryArray::new(keys, Arc::new(a));
@@ -1548,13 +1267,13 @@ mod tests {
     fn test_temporal_array_date64_millisecond() {
         let a: PrimitiveArray<Date64Type> = vec![None, Some(1667328721453)].into();
 
-        let b = millisecond(&a).unwrap();
+        let b = date_part_primitive(&a, DatePart::Millisecond).unwrap();
         assert!(!b.is_valid(0));
         assert_eq!(453, b.value(1));
 
         let keys = Int8Array::from(vec![Some(0_i8), Some(1), Some(1)]);
         let dict = DictionaryArray::new(keys.clone(), Arc::new(a));
-        let b = millisecond_dyn(&dict).unwrap();
+        let b = date_part(&dict, DatePart::Millisecond).unwrap();
 
         let a = Int32Array::from(vec![None, Some(453)]);
         let expected_dict = DictionaryArray::new(keys, Arc::new(a));


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7810

# Rationale for this change

Remove shim functions that were deprecated in early 2024.

# What changes are included in this PR?

# Are these changes tested?

Tests modified to not use removed shim functions

# Are there any user-facing changes?

Yes, public functions are removed
