### PR TITLE
Use in-memory buffer for arrow_writer benchmark

### DIFF
--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -19,8 +19,6 @@
 extern crate criterion;
 
 use criterion::{Criterion, Throughput};
-use std::env;
-use std::fs::File;
 
 extern crate arrow;
 extern crate parquet;
@@ -349,9 +347,8 @@ fn write_batch_enable_bloom_filter(batch: &RecordBatch) -> Result<()> {
 
 #[inline]
 fn write_batch_with_option(batch: &RecordBatch, props: Option<WriterProperties>) -> Result<()> {
-    let path = env::temp_dir().join("arrow_writer.temp");
-    let file = File::create(path).unwrap();
-    let mut writer = ArrowWriter::try_new(file, batch.schema(), props)?;
+    let mut file = vec![];
+    let mut writer = ArrowWriter::try_new(&mut file, batch.schema(), props)?;
 
     writer.write(batch)?;
     writer.close()?;


### PR DESCRIPTION
# Which issue does this PR close?

Prerequisite for investigating parquet writing performance (#7822).

# Rationale for this change

The benchmark should measure the cpu overhead of parquet writing, not the os or filesystem parts of it. Running the benchmark showed that the file has nearly a 50% overhead, which makes profiling more difficult by hiding the bottlenecks inside the parquet code itself.

# What changes are included in this PR?

Use a Vec instead of an unbuffered File as the sink.

# Are these changes tested?

Tested by running the benchmark.

# Are there any user-facing changes?

No