### PR TITLE
Add features to configure flate2

### DIFF
--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -113,6 +113,13 @@ jobs:
         run: cargo check -p parquet --all-targets --no-default-features --features json
       - name: Check compilation --no-default-features --features encryption --features async
         run: cargo check -p parquet --no-default-features --features encryption --features async
+      - name: Check compilation --no-default-features --features flate2, this is expected to fail
+        run: if `cargo check -p parquet --no-default-features --features flate2 2>/dev/null`; then false; else true; fi
+      - name: Check compilation --no-default-features --features flate2 --features flate2-rust_backened
+        run: cargo check -p parquet --no-default-features --features flate2 --features flate2-rust_backened
+      - name: Check compilation --no-default-features --features flate2 --features flate2-zlib-rs
+        run: cargo check -p parquet --no-default-features --features flate2 --features flate2-zlib-rs
+        
 
   # test the parquet crate builds against wasm32 in stable rust
   wasm32-build:

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -92,7 +92,7 @@ sysinfo = { version = "0.35.0", default-features = false, features = ["system"] 
 all-features = true
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
+default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64", "simdutf8"]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -122,6 +122,7 @@ encryption = ["dep:ring"]
 # Explicitely enabling rust_backend and zlib-rs features for flate2
 flate2-rust_backened = ["flate2/rust_backend"]
 flate2-zlib-rs = ["flate2/zlib-rs"]
+flate2 = ["flate2-zlib-rs"]
 
 
 [[example]]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -51,7 +51,7 @@ bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
-flate2 = { version = "1.1", default-features = false, features = ["zlib-rs"], optional = true }
+flate2 = { version = "1.1", default-features = false, optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 chrono = { workspace = true }
@@ -119,6 +119,9 @@ crc = ["dep:crc32fast"]
 simdutf8 = ["dep:simdutf8"]
 # Enable Parquet modular encryption support
 encryption = ["dep:ring"]
+# Explicitely enabling rust_backend and zlib-rs features for flate2
+flate2-rust_backened = ["flate2/rust_backend"]
+flate2-zlib-rs = ["flate2/zlib-rs"]
 
 
 [[example]]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -92,7 +92,7 @@ sysinfo = { version = "0.35.0", default-features = false, features = ["system"] 
 all-features = true
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64", "simdutf8"]
+default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -51,6 +51,7 @@ bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
+# To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-zlib-rs` backends
 flate2 = { version = "1.1", default-features = false, optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -51,7 +51,7 @@ bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
-# To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-zlib-rs` backends
+# To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backened` backends
 flate2 = { version = "1.1", default-features = false, optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -92,7 +92,7 @@ sysinfo = { version = "0.35.0", default-features = false, features = ["system"] 
 all-features = true
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64", "simdutf8"]
+default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs
@@ -122,7 +122,6 @@ encryption = ["dep:ring"]
 # Explicitely enabling rust_backend and zlib-rs features for flate2
 flate2-rust_backened = ["flate2/rust_backend"]
 flate2-zlib-rs = ["flate2/zlib-rs"]
-flate2 = ["flate2-zlib-rs"]
 
 
 [[example]]

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -130,12 +130,6 @@ macro_rules! experimental {
     }
 }
 
-#[cfg(all(
-    feature = "flate2",
-    not(any(feature = "flate2-zlib-rs", feature = "flate2-rust_backened"))
-))]
-compile_error!("When enabling `flate2` you must enable one of the features: `flate2-zlib-rs` or `flate2-rust_backened`.");
-
 #[macro_use]
 pub mod errors;
 pub mod basic;

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -130,6 +130,12 @@ macro_rules! experimental {
     }
 }
 
+#[cfg(all(
+    feature = "flate2",
+    not(any(feature = "flate2-zlib-rs", feature = "flate2-rust_backened"))
+))]
+compile_error!("When enabling `flate2` you must enable one of the features: `flate2-zlib-rs` or `flate2-rust_backened`.");
+
 #[macro_use]
 pub mod errors;
 pub mod basic;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7826

# Rationale for this change

Allow choosing the previously default "rust_backend" instead of "libz-rs-sys" for flate2 dependency.

# What changes are included in this PR?

Two new features, "flate2-rust_backened" and "flate2-zlib-rs".

# Are there any user-facing changes?

When enabling "flate2", one of these must also be enabled.

