### PR TITLE
Add Decimal type support to arrow-avro 

### DIFF
--- a/arrow-avro/Cargo.toml
+++ b/arrow-avro/Cargo.toml
@@ -53,7 +53,7 @@ crc = { version = "3.0", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-criterion = { version = "0.5", default-features = false }
+criterion = { version = "0.6.0", default-features = false }
 tempfile = "3.3"
 arrow = { workspace = true }
 

--- a/arrow-avro/benches/avro_reader.rs
+++ b/arrow-avro/benches/avro_reader.rs
@@ -163,7 +163,7 @@ fn bench_array_creation(c: &mut Criterion) {
                 )
                 .unwrap();
 
-                criterion::black_box(batch)
+                std::hint::black_box(batch)
             })
         });
 
@@ -187,7 +187,7 @@ fn bench_array_creation(c: &mut Criterion) {
                 )
                 .unwrap();
 
-                criterion::black_box(batch)
+                std::hint::black_box(batch)
             })
         });
     }
@@ -214,7 +214,7 @@ fn bench_string_operations(c: &mut Criterion) {
                 for i in 0..rows {
                     sum_len += string_array.value(i).len();
                 }
-                criterion::black_box(sum_len)
+                std::hint::black_box(sum_len)
             })
         });
 
@@ -224,7 +224,7 @@ fn bench_string_operations(c: &mut Criterion) {
                 for i in 0..rows {
                     sum_len += string_view_array.value(i).len();
                 }
-                criterion::black_box(sum_len)
+                std::hint::black_box(sum_len)
             })
         });
     }
@@ -246,7 +246,7 @@ fn bench_avro_reader(c: &mut Criterion) {
             b.iter(|| {
                 let options = ReadOptions::default();
                 let batch = read_avro_test_file(file_path, &options).unwrap();
-                criterion::black_box(batch)
+                std::hint::black_box(batch)
             })
         });
 
@@ -254,7 +254,7 @@ fn bench_avro_reader(c: &mut Criterion) {
             b.iter(|| {
                 let options = ReadOptions::default().with_utf8view(true);
                 let batch = read_avro_test_file(file_path, &options).unwrap();
-                criterion::black_box(batch)
+                std::hint::black_box(batch)
             })
         });
     }

--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -510,8 +510,7 @@ fn make_data_type<'a>(
                     }
                     _ => {
                         return Err(ArrowError::SchemaError(format!(
-                            "Decimal logical type can only be backed by Fixed or Bytes, found {:?}",
-                            c,
+                            "Decimal logical type can only be backed by Fixed or Bytes, found {c:?}"
                         )))
                     }
                 },

--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -21,16 +21,20 @@ use crate::reader::cursor::AvroCursor;
 use crate::reader::header::Header;
 use crate::reader::ReadOptions;
 use crate::schema::*;
+use arrow_array::builder::{Decimal128Builder, Decimal256Builder};
 use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::*;
 use arrow_schema::{
     ArrowError, DataType, Field as ArrowField, FieldRef, Fields, Schema as ArrowSchema, SchemaRef,
+    DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION,
 };
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::Arc;
+
+const DEFAULT_CAPACITY: usize = 1024;
 
 /// Decodes avro encoded data into [`RecordBatch`]
 pub struct RecordDecoder {
@@ -123,6 +127,8 @@ enum Decoder {
         Box<Decoder>,
     ),
     Fixed(i32, Vec<u8>),
+    Decimal128(usize, Option<usize>, Option<usize>, Decimal128Builder),
+    Decimal256(usize, Option<usize>, Option<usize>, Decimal256Builder),
     Nullable(Nullability, NullBufferBuilder, Box<Decoder>),
 }
 
@@ -159,6 +165,40 @@ impl Decoder {
                 Self::TimestampMicros(*is_utc, Vec::with_capacity(DEFAULT_CAPACITY))
             }
             Codec::Fixed(sz) => Self::Fixed(*sz, Vec::with_capacity(DEFAULT_CAPACITY)),
+            Codec::Decimal(precision, scale, size) => {
+                let p = *precision;
+                let s = *scale;
+                let sz = *size;
+                let prec = p as u8;
+                let scl = s.unwrap_or(0) as i8;
+                if let Some(fixed_size) = sz {
+                    if fixed_size <= 16 {
+                        let builder =
+                            Decimal128Builder::new().with_precision_and_scale(prec, scl)?;
+                        return Ok(Self::Decimal128(p, s, sz, builder));
+                    }
+                    if fixed_size <= 32 {
+                        let builder =
+                            Decimal256Builder::new().with_precision_and_scale(prec, scl)?;
+                        return Ok(Self::Decimal256(p, s, sz, builder));
+                    }
+                    return Err(ArrowError::ParseError(format!(
+                        "Unsupported decimal size: {fixed_size:?}"
+                    )));
+                }
+                if p <= DECIMAL128_MAX_PRECISION as usize {
+                    let builder = Decimal128Builder::new().with_precision_and_scale(prec, scl)?;
+                    Self::Decimal128(p, s, sz, builder)
+                } else if p <= DECIMAL256_MAX_PRECISION as usize {
+                    let builder = Decimal256Builder::new().with_precision_and_scale(prec, scl)?;
+                    Self::Decimal256(p, s, sz, builder)
+                } else {
+                    return Err(ArrowError::ParseError(format!(
+                        "Decimal precision {} exceeds maximum supported",
+                        p
+                    )));
+                }
+            }
             Codec::Interval => return nyi("decoding interval"),
             Codec::List(item) => {
                 let decoder = Self::try_new(item)?;
@@ -199,7 +239,6 @@ impl Decoder {
             }
             Codec::Uuid => Self::Fixed(16, Vec::with_capacity(DEFAULT_CAPACITY)),
         };
-
         Ok(match data_type.nullability() {
             Some(nullability) => Self::Nullable(
                 nullability,
@@ -233,10 +272,12 @@ impl Decoder {
             Self::Map(_, _koff, moff, _, _) => {
                 moff.push_length(0);
             }
-            Self::Nullable(_, _, _) => unreachable!("Nulls cannot be nested"),
             Self::Fixed(sz, accum) => {
                 accum.extend(std::iter::repeat(0u8).take(*sz as usize));
             }
+            Self::Decimal128(_, _, _, builder) => builder.append_value(0),
+            Self::Decimal256(_, _, _, builder) => builder.append_value(i256::ZERO),
+            Self::Nullable(_, _, _) => unreachable!("Nulls cannot be nested"),
         }
     }
 
@@ -279,6 +320,30 @@ impl Decoder {
                 })?;
                 moff.push_length(newly_added);
             }
+            Self::Fixed(sz, accum) => {
+                let fx = buf.get_fixed(*sz as usize)?;
+                accum.extend_from_slice(fx);
+            }
+            Self::Decimal128(_, _, size, builder) => {
+                let raw = if let Some(s) = size {
+                    buf.get_fixed(*s)?
+                } else {
+                    buf.get_bytes()?
+                };
+                let ext = sign_extend_to::<16>(raw)?;
+                let val = i128::from_be_bytes(ext);
+                builder.append_value(val);
+            }
+            Self::Decimal256(_, _, size, builder) => {
+                let raw = if let Some(s) = size {
+                    buf.get_fixed(*s)?
+                } else {
+                    buf.get_bytes()?
+                };
+                let ext = sign_extend_to::<32>(raw)?;
+                let val = i256::from_be_bytes(ext);
+                builder.append_value(val);
+            }
             Self::Nullable(nullability, nulls, e) => {
                 let is_valid = buf.get_bool()? == matches!(nullability, Nullability::NullFirst);
                 nulls.append(is_valid);
@@ -286,10 +351,6 @@ impl Decoder {
                     true => e.decode(buf)?,
                     false => e.append_null(),
                 }
-            }
-            Self::Fixed(sz, accum) => {
-                let fx = buf.get_fixed(*sz as usize)?;
-                accum.extend_from_slice(fx);
             }
         }
         Ok(())
@@ -334,7 +395,6 @@ impl Decoder {
                 let offsets = flush_offsets(offsets);
                 let values = flush_values(values);
                 let array = StringArray::new(offsets, values.into(), nulls.clone());
-
                 let values: Vec<&str> = (0..array.len())
                     .map(|i| {
                         if array.is_valid(i) {
@@ -397,6 +457,24 @@ impl Decoder {
                 let arr = FixedSizeBinaryArray::try_new(*sz, b, nulls)
                     .map_err(|e| ArrowError::ParseError(e.to_string()))?;
                 Arc::new(arr)
+            }
+            Self::Decimal128(precision, scale, _, builder) => {
+                let mut b = std::mem::take(builder);
+                let (_, vals, _) = b.finish().into_parts();
+                let scl = scale.unwrap_or(0);
+                let dec = Decimal128Array::new(vals, nulls)
+                    .with_precision_and_scale(*precision as u8, scl as i8)
+                    .map_err(|e| ArrowError::ParseError(e.to_string()))?;
+                Arc::new(dec)
+            }
+            Self::Decimal256(precision, scale, _, builder) => {
+                let mut b = std::mem::take(builder);
+                let (_, vals, _) = b.finish().into_parts();
+                let scl = scale.unwrap_or(0);
+                let dec = Decimal256Array::new(vals, nulls)
+                    .with_precision_and_scale(*precision as u8, scl as i8)
+                    .map_err(|e| ArrowError::ParseError(e.to_string()))?;
+                Arc::new(dec)
             }
         })
     }
@@ -466,7 +544,30 @@ fn flush_primitive<T: ArrowPrimitiveType>(
     PrimitiveArray::new(flush_values(values).into(), nulls)
 }
 
-const DEFAULT_CAPACITY: usize = 1024;
+/// Sign extends a byte slice to a fixed-size array of N bytes.
+/// This is done by filling the leading bytes with 0x00 for positive numbers
+/// or 0xFF for negative numbers.
+#[inline]
+fn sign_extend_to<const N: usize>(raw: &[u8]) -> Result<[u8; N], ArrowError> {
+    if raw.len() > N {
+        return Err(ArrowError::ParseError(format!(
+            "Cannot extend a slice of length {} to {} bytes.",
+            raw.len(),
+            N
+        )));
+    }
+    let mut arr = [0u8; N];
+    let pad_len = N - raw.len();
+    // Determine the byte to use for padding based on the sign bit of the raw data.
+    let extension_byte = if raw.is_empty() || (raw[0] & 0x80 == 0) {
+        0x00
+    } else {
+        0xFF
+    };
+    arr[..pad_len].fill(extension_byte);
+    arr[pad_len..].copy_from_slice(raw);
+    Ok(arr)
+}
 
 #[cfg(test)]
 mod tests {
@@ -731,5 +832,123 @@ mod tests {
         let list_arr = array.as_any().downcast_ref::<ListArray>().unwrap();
         assert_eq!(list_arr.len(), 1);
         assert_eq!(list_arr.value_length(0), 0);
+    }
+
+    #[test]
+    fn test_decimal_decoding_fixed256() {
+        let dt = avro_from_codec(Codec::Decimal(5, Some(2), Some(32)));
+        let mut decoder = Decoder::try_new(&dt).unwrap();
+        let row1 = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x30, 0x39,
+        ];
+        let row2 = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0x85,
+        ];
+        let mut data = Vec::new();
+        data.extend_from_slice(&row1);
+        data.extend_from_slice(&row2);
+        let mut cursor = AvroCursor::new(&data);
+        decoder.decode(&mut cursor).unwrap();
+        decoder.decode(&mut cursor).unwrap();
+        let arr = decoder.flush(None).unwrap();
+        let dec = arr.as_any().downcast_ref::<Decimal256Array>().unwrap();
+        assert_eq!(dec.len(), 2);
+        assert_eq!(dec.value_as_string(0), "123.45");
+        assert_eq!(dec.value_as_string(1), "-1.23");
+    }
+
+    #[test]
+    fn test_decimal_decoding_fixed128() {
+        let dt = avro_from_codec(Codec::Decimal(5, Some(2), Some(16)));
+        let mut decoder = Decoder::try_new(&dt).unwrap();
+        let row1 = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x30, 0x39,
+        ];
+        let row2 = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0x85,
+        ];
+        let mut data = Vec::new();
+        data.extend_from_slice(&row1);
+        data.extend_from_slice(&row2);
+        let mut cursor = AvroCursor::new(&data);
+        decoder.decode(&mut cursor).unwrap();
+        decoder.decode(&mut cursor).unwrap();
+        let arr = decoder.flush(None).unwrap();
+        let dec = arr.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert_eq!(dec.len(), 2);
+        assert_eq!(dec.value_as_string(0), "123.45");
+        assert_eq!(dec.value_as_string(1), "-1.23");
+    }
+
+    #[test]
+    fn test_decimal_decoding_bytes_with_nulls() {
+        let dt = avro_from_codec(Codec::Decimal(4, Some(1), None));
+        let inner = Decoder::try_new(&dt).unwrap();
+        let mut decoder = Decoder::Nullable(
+            Nullability::NullSecond,
+            NullBufferBuilder::new(DEFAULT_CAPACITY),
+            Box::new(inner),
+        );
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_int(0));
+        data.extend_from_slice(&encode_avro_bytes(&[0x04, 0xD2]));
+        data.extend_from_slice(&encode_avro_int(1));
+        data.extend_from_slice(&encode_avro_int(0));
+        data.extend_from_slice(&encode_avro_bytes(&[0xFB, 0x2E]));
+        let mut cursor = AvroCursor::new(&data);
+        decoder.decode(&mut cursor).unwrap(); // row1
+        decoder.decode(&mut cursor).unwrap(); // row2
+        decoder.decode(&mut cursor).unwrap(); // row3
+        let arr = decoder.flush(None).unwrap();
+        let dec_arr = arr.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert_eq!(dec_arr.len(), 3);
+        assert!(dec_arr.is_valid(0));
+        assert!(!dec_arr.is_valid(1));
+        assert!(dec_arr.is_valid(2));
+        assert_eq!(dec_arr.value_as_string(0), "123.4");
+        assert_eq!(dec_arr.value_as_string(2), "-123.4");
+    }
+
+    #[test]
+    fn test_decimal_decoding_bytes_with_nulls_fixed_size() {
+        let dt = avro_from_codec(Codec::Decimal(6, Some(2), Some(16)));
+        let inner = Decoder::try_new(&dt).unwrap();
+        let mut decoder = Decoder::Nullable(
+            Nullability::NullSecond,
+            NullBufferBuilder::new(DEFAULT_CAPACITY),
+            Box::new(inner),
+        );
+        let row1 = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0xE2, 0x40,
+        ];
+        let row3 = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+            0x1D, 0xC0,
+        ];
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_int(0));
+        data.extend_from_slice(&row1);
+        data.extend_from_slice(&encode_avro_int(1));
+        data.extend_from_slice(&encode_avro_int(0));
+        data.extend_from_slice(&row3);
+        let mut cursor = AvroCursor::new(&data);
+        decoder.decode(&mut cursor).unwrap();
+        decoder.decode(&mut cursor).unwrap();
+        decoder.decode(&mut cursor).unwrap();
+        let arr = decoder.flush(None).unwrap();
+        let dec_arr = arr.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert_eq!(dec_arr.len(), 3);
+        assert!(dec_arr.is_valid(0));
+        assert!(!dec_arr.is_valid(1));
+        assert!(dec_arr.is_valid(2));
+        assert_eq!(dec_arr.value_as_string(0), "1234.56");
+        assert_eq!(dec_arr.value_as_string(2), "-1234.56");
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/4886

- Related to https://github.com/apache/arrow-rs/pull/6965

# Rationale for this change

This PR addresses a feature gap by introducing support for the Avro `decimal` logical type, which is currently unimplemented as indicated by the `test_decimal_logical_type_not_implemented` test case. The `decimal` type is crucial for handling precise numerical data common in financial and scientific applications, making this a necessary addition for broader Avro compatibility.

# What changes are included in this PR?

This PR introduces the necessary changes to both parse and decode the Avro `decimal` logical type into the corresponding Arrow `Decimal128` or `Decimal256` data types.

The main changes are:
1.  **Schema Parsing (`codec.rs`):**
    *   Implemented the logic within `make_data_type` to correctly parse the `decimal` logical type from the Avro schema.
    *   The `Codec` enum's `Decimal` variant now correctly stores the precision, scale, and optional fixed-size from the schema's attributes.

2.  **Decoding Logic (`record.rs`):**
    *   Added `Decoder::Decimal128` and `Decoder::Decimal256` variants to handle decoding of decimal values from both `bytes` and `fixed` Avro types.
    *   The implementation correctly handles sign extension for negative numbers to ensure accurate representation in Arrow's decimal arrays.

# Are these changes tested?

This PR includes comprehensive tests to validate the new functionality:
*   The existing `test_decimal_logical_type_not_implemented` test has been replaced with concrete test cases.
*   Added unit tests in `record.rs` (`test_decimal_decoding_fixed256`, `test_decimal_decoding_fixed128`, `test_decimal_decoding_bytes_with_nulls`, etc.) to cover various scenarios, including:
    *   Decoding from Avro `fixed` and `bytes` primitive types.
    *   Handling different precisions to select between `Decimal128` and `Decimal256`.
    *   Correctly processing null values within decimal arrays.

# Are there any user-facing changes?

N/A
