### PR TITLE
[Variant] Support creating sorted dictionaries

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -252,12 +252,6 @@ impl MetadataBuilder {
 
             self.is_sorted =
                 n == 1 || self.is_sorted & (self.field_names[n - 2] < self.field_names[n - 1]);
-
-            if n == 1 {
-                self.is_sorted = true;
-            } else {
-                self.is_sorted &= self.field_names[n - 2] < self.field_names[n - 1];
-            }
         }
 
         id as u32

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -250,8 +250,12 @@ impl MetadataBuilder {
         if new_entry {
             let n = self.num_field_names();
 
+            // Dictionary sort order tracking:
+            // - An empty dictionary is unsorted (ambiguous in spec but required by interop tests)
+            // - A single-entry dictionary is trivially sorted
+            // - Otherwise, an already-sorted dictionary becomes unsorted if the new entry breaks order
             self.is_sorted =
-                n == 1 || self.is_sorted & (self.field_names[n - 2] < self.field_names[n - 1]);
+                n == 1 || self.is_sorted && (self.field_names[n - 2] < self.field_names[n - 1]);
         }
 
         id as u32

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -506,9 +506,9 @@ impl VariantBuilder {
         self
     }
 
-    /// Adds a single field name to the [`MetadataBuilder`].
+    /// Adds a single field name to the field name directory in the Variant metadata.
     ///
-    /// This method does the same thing as [`with_field_names`] but adds one field name at a time.
+    /// This method does the same thing as [`VariantBuilder::with_field_names`] but adds one field name at a time.
     pub fn add_field_name(&mut self, field_name: &str) {
         self.metadata_builder.upsert_field_name(field_name);
     }

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -490,6 +490,46 @@ impl<S: AsRef<str>> Extend<S> for MetadataBuilder {
 /// let result = obj.finish(); // returns Err
 /// assert!(result.is_err());
 /// ```
+///
+/// # Example: Sorted dictionaries
+///
+/// This example shows how to create a [`VariantBuilder`] with a pre-sorted field dictionary
+/// to improve field access performance when reading [`Variant`] objects.
+///
+/// You can use [`VariantBuilder::with_field_names`] to add multiple field names at once:
+/// ```
+/// use parquet_variant::{Variant, VariantBuilder};
+/// let mut builder = VariantBuilder::new()
+///     .with_field_names(["age", "name", "score"].into_iter());
+///
+/// let mut obj = builder.new_object();
+/// obj.insert("name", "Alice");
+/// obj.insert("age", 30);
+/// obj.insert("score", 95.5);
+/// obj.finish().unwrap();
+///
+/// let (metadata, value) = builder.finish();
+/// let variant = Variant::try_new(&metadata, &value).unwrap();
+/// ```
+///
+/// Alternatively, you can use [`VariantBuilder::add_field_name`] to add field names one by one:
+/// ```
+/// use parquet_variant::{Variant, VariantBuilder};
+/// let mut builder = VariantBuilder::new();
+/// builder.add_field_name("age"); // field id = 0
+/// builder.add_field_name("name"); // field id = 1
+/// builder.add_field_name("score"); // field id = 2
+///
+/// let mut obj = builder.new_object();
+/// obj.insert("name", "Bob"); // field id = 3
+/// obj.insert("age", 25);
+/// obj.insert("score", 88.0);
+/// obj.finish().unwrap();
+///
+/// let (metadata, value) = builder.finish();
+/// let variant = Variant::try_new(&metadata, &value).unwrap();
+/// ```
+///
 #[derive(Default)]
 pub struct VariantBuilder {
     buffer: ValueBuffer,

--- a/parquet-variant/tests/test_json_to_variant.rs
+++ b/parquet-variant/tests/test_json_to_variant.rs
@@ -542,7 +542,7 @@ fn test_json_to_variant_unicode() -> Result<(), ArrowError> {
     );
     assert_eq!(
         metadata,
-        &[1u8, 2u8, 0u8, 1u8, 4u8, 97u8, 0xe7u8, 0x88u8, 0xb1u8]
+        &[0b10001u8, 2u8, 0u8, 1u8, 4u8, 97u8, 0xe7u8, 0x88u8, 0xb1u8]
     );
     JsonToVariantTest {
         json,


### PR DESCRIPTION
~_note: this PR is based off of https://github.com/apache/arrow-rs/pull/7808_~

# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/7698.

# Rationale for this change

The Parquet variant supports creating objects with sorted dictionaries, where field names are sorted in lexicographical order. Sorting the dictionary and reassigning field IDs afterward can be computationally expensive. This PR offers an alternative: allowing users to specify the field names upfront, so that the correct field IDs can be assigned directly. (The correct field ids being correlated to the lexicographical sort order). 

This PR introduces two new public methods to `VariantBuilder`: 

- `with_field_names`, a builder method that takes in a `self`, initializes the dictionary, and returns the modified builder
- `add_field_name`, a method to add individual field names to the dictionary manually