### PR TITLE
[Variant] Make sure ObjectBuilder and ListBuilder to be finalized before its parent builder

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -774,7 +774,6 @@ impl<'a, 'b> ObjectBuilder<'a, 'b> {
     }
 }
 
-
 /// Drop implementation for ObjectBuilder does nothing
 /// as the `finish` method must be called to finalize the object.
 /// This is to ensure that the object is always finalized before its parent builder


### PR DESCRIPTION
# Which issue does this PR close?


- Closes #7780.


# Rationale for this change

This minor patch adds some comments to ObjectBuilder and ListBuilder and fixes one existing test.

This patch makes sure ObjectBuilder and ListBuilder to be finalized before its parent builder is finalized. If `finish` is forgotten to be called on them, the compiler will show error.


# What changes are included in this PR?


# Are these changes tested?

Updated tests.

# Are there any user-facing changes?

No