### PR TITLE
Pushdown v4

### DIFF
--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -1,0 +1,420 @@
+use crate::arrow::array_reader::{row_group_cache::RowGroupCache, ArrayReader};
+use crate::errors::Result;
+use arrow_array::{new_empty_array, ArrayRef, BooleanArray};
+use arrow_buffer::BooleanBufferBuilder;
+use arrow_schema::DataType as ArrowType;
+use arrow_select::concat::concat;
+use arrow_select::filter::filter;
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+/// Row selector indicating whether to read or skip rows
+#[derive(Debug, Clone)]
+struct RowSelector {
+    /// Number of rows in this selection
+    row_count: usize,
+    /// Whether to skip (true) or read (false) these rows
+    skip: bool,
+}
+
+impl RowSelector {
+    fn select(row_count: usize) -> Self {
+        Self {
+            row_count,
+            skip: false,
+        }
+    }
+
+    fn skip(row_count: usize) -> Self {
+        Self {
+            row_count,
+            skip: true,
+        }
+    }
+}
+
+/// A cached wrapper around an ArrayReader that avoids duplicate decoding
+/// when the same column appears in both filter predicates and output projection.
+///
+/// This reader accumulates read/skip selections and processes them efficiently
+/// using cached batch data when consume_batch() is called.
+pub struct CachedArrayReader {
+    /// The underlying array reader
+    inner: Box<dyn ArrayReader>,
+    /// Shared cache for this row group
+    cache: Arc<Mutex<RowGroupCache>>,
+    /// Column index for cache key generation
+    column_idx: usize,
+    /// Current row position in the row group
+    current_row: usize,
+    /// Inner reader's row position (to keep it in sync)
+    inner_reader_position: usize,
+    /// Queue of read/skip selections to process
+    selection: VecDeque<RowSelector>,
+}
+
+impl CachedArrayReader {
+    /// Creates a new cached array reader
+    pub fn new(
+        inner: Box<dyn ArrayReader>,
+        cache: Arc<Mutex<RowGroupCache>>,
+        column_idx: usize,
+    ) -> Self {
+        Self {
+            inner,
+            cache,
+            column_idx,
+            current_row: 0,
+            inner_reader_position: 0,
+            selection: VecDeque::new(),
+        }
+    }
+
+    /// Gets the batch size from the cache
+    fn batch_size(&self) -> usize {
+        self.cache.lock().unwrap().batch_size()
+    }
+
+    /// Calculates the batch ID for a given row position
+    fn batch_id_from_row(&self, row: usize) -> usize {
+        row / self.batch_size()
+    }
+
+    /// Ensures a batch is cached by fetching it from the inner reader if needed.
+    ///
+    /// Returns the number of rows cached for this batch. If `0` is returned it
+    /// indicates the inner reader has no more data (EOF).
+    fn ensure_cached(&mut self, batch_id: usize) -> Result<usize> {
+        let batch_start_row = batch_id * self.batch_size();
+
+        // Check if already cached
+        if let Some(array) = self
+            .cache
+            .lock()
+            .unwrap()
+            .get(self.column_idx, batch_start_row)
+        {
+            return Ok(array.len());
+        }
+
+        // Sync inner reader to batch start if needed
+        if self.inner_reader_position < batch_start_row {
+            let to_skip = batch_start_row - self.inner_reader_position;
+            let skipped = self.inner.skip_records(to_skip)?;
+            self.inner_reader_position += skipped;
+
+            // Reached EOF before desired position
+            if skipped < to_skip {
+                return Ok(0);
+            }
+        }
+
+        // Read the batch
+        let expected_batch = self.batch_size();
+        let records_read = self.inner.read_records(expected_batch)?;
+
+        // If no more rows, signal EOF
+        if records_read == 0 {
+            return Ok(0);
+        }
+
+        let array = self.inner.consume_batch()?;
+
+        // Cache it
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(self.column_idx, batch_start_row, array.clone());
+        self.inner_reader_position += records_read;
+
+        Ok(array.len())
+    }
+
+    /// Converts selection queue to boolean buffer for filtering
+    fn selection_to_boolean_buffer(&self, total_rows: usize) -> arrow_buffer::BooleanBuffer {
+        let mut builder = BooleanBufferBuilder::new(total_rows);
+        for selector in &self.selection {
+            builder.append_n(selector.row_count, !selector.skip);
+        }
+        builder.finish()
+    }
+}
+
+impl ArrayReader for CachedArrayReader {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_data_type(&self) -> &ArrowType {
+        self.inner.get_data_type()
+    }
+
+    fn read_records(&mut self, mut requested: usize) -> Result<usize> {
+        let mut total_read = 0;
+
+        while requested > 0 {
+            let batch_id = self.batch_id_from_row(self.current_row);
+
+            // Ensure the batch is cached and determine its length
+            let cached_len = self.ensure_cached(batch_id)?;
+
+            // EOF reached
+            if cached_len == 0 {
+                break;
+            }
+
+            let batch_start = batch_id * self.batch_size();
+            let offset_in_batch = self.current_row - batch_start;
+
+            // If current position is past the cached length, advance to next batch.
+            // If this batch was partial (i.e. smaller than the configured batch size)
+            // this indicates we have reached EOF and should stop.
+            if offset_in_batch >= cached_len {
+                self.current_row = batch_start + cached_len;
+
+                // Partial batch implies EOF has been reached
+                if cached_len < self.batch_size() {
+                    break;
+                }
+
+                continue;
+            }
+
+            let available = cached_len - offset_in_batch;
+            let to_read = available.min(requested);
+
+            // Record the selection
+            if to_read > 0 {
+                self.selection.push_back(RowSelector::select(to_read));
+                self.current_row += to_read;
+                requested -= to_read;
+                total_read += to_read;
+            }
+        }
+
+        Ok(total_read)
+    }
+
+    fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+        // Add selection for skipping these records
+        self.selection.push_back(RowSelector::skip(num_records));
+        self.current_row += num_records;
+        // Note: we don't cache or sync inner reader for skips
+        Ok(num_records)
+    }
+
+    fn consume_batch(&mut self) -> Result<ArrayRef> {
+        if self.selection.is_empty() {
+            // Return empty array of correct type
+            return Ok(new_empty_array(self.get_data_type()));
+        }
+
+        // Calculate total row count and starting position
+        let total_rows: usize = self.selection.iter().map(|s| s.row_count).sum();
+        let start_row = self.current_row - total_rows;
+
+        if total_rows == 0 {
+            self.selection.clear();
+            return Ok(new_empty_array(self.get_data_type()));
+        }
+
+        // Create boolean selection buffer
+        let selection_buffer = self.selection_to_boolean_buffer(total_rows);
+
+        // Determine batch range
+        let batch_size = self.batch_size();
+        let start_batch = start_row / batch_size;
+        let end_batch = (start_row + total_rows - 1) / batch_size;
+
+        let mut result_arrays = Vec::new();
+
+        for batch_id in start_batch..=end_batch {
+            let batch_start = batch_id * batch_size;
+            let batch_end = batch_start + batch_size - 1;
+
+            // Calculate overlap between our selection and this batch
+            let overlap_start = start_row.max(batch_start);
+            let overlap_end = (start_row + total_rows - 1).min(batch_end);
+
+            if overlap_start > overlap_end {
+                continue; // No overlap
+            }
+
+            // Get selection slice for this batch
+            let selection_start = overlap_start - start_row;
+            let selection_length = overlap_end - overlap_start + 1;
+            let batch_selection = selection_buffer.slice(selection_start, selection_length);
+
+            if batch_selection.count_set_bits() == 0 {
+                continue; // Nothing selected in this batch
+            }
+
+            // Get cached array and apply filter
+            let cached_array = self
+                .cache
+                .lock()
+                .unwrap()
+                .get(self.column_idx, batch_start)
+                .unwrap();
+            let mask = BooleanArray::from(batch_selection);
+
+            // Calculate offset within the batch
+            let batch_offset = overlap_start - batch_start;
+            let batch_slice = if batch_offset > 0 || selection_length < batch_size {
+                cached_array.slice(batch_offset, selection_length)
+            } else {
+                cached_array
+            };
+
+            let filtered = filter(&batch_slice, &mask)?;
+            if filtered.len() > 0 {
+                result_arrays.push(filtered);
+            }
+        }
+
+        // Clear selection queue
+        self.selection.clear();
+
+        // Concatenate results
+        match result_arrays.len() {
+            0 => Ok(new_empty_array(self.get_data_type())),
+            1 => Ok(result_arrays.into_iter().next().unwrap()),
+            _ => {
+                let array_refs: Vec<&dyn arrow_array::Array> =
+                    result_arrays.iter().map(|a| a.as_ref()).collect();
+                Ok(concat(&array_refs)?)
+            }
+        }
+    }
+
+    fn get_def_levels(&self) -> Option<&[i16]> {
+        self.inner.get_def_levels()
+    }
+
+    fn get_rep_levels(&self) -> Option<&[i16]> {
+        self.inner.get_rep_levels()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::array_reader::row_group_cache::RowGroupCache;
+    use crate::arrow::array_reader::ArrayReader;
+    use arrow_array::{ArrayRef, Int32Array};
+    use std::sync::{Arc, Mutex};
+
+    // Mock ArrayReader for testing
+    struct MockArrayReader {
+        data: Vec<i32>,
+        position: usize,
+        read_position: usize,
+        data_type: ArrowType,
+    }
+
+    impl MockArrayReader {
+        fn new(data: Vec<i32>) -> Self {
+            Self {
+                data,
+                position: 0,
+                read_position: 0,
+                data_type: ArrowType::Int32,
+            }
+        }
+    }
+
+    impl ArrayReader for MockArrayReader {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn get_data_type(&self) -> &ArrowType {
+            &self.data_type
+        }
+
+        fn read_records(&mut self, batch_size: usize) -> Result<usize> {
+            let remaining = self.data.len() - self.position;
+            let to_read = std::cmp::min(batch_size, remaining);
+            self.read_position = self.position;
+            self.position += to_read;
+            Ok(to_read)
+        }
+
+        fn consume_batch(&mut self) -> Result<ArrayRef> {
+            // Return data from read_position to current position
+            let slice = &self.data[self.read_position..self.position];
+            Ok(Arc::new(Int32Array::from(slice.to_vec())))
+        }
+
+        fn skip_records(&mut self, num_records: usize) -> Result<usize> {
+            let remaining = self.data.len() - self.position;
+            let to_skip = std::cmp::min(num_records, remaining);
+            self.position += to_skip;
+            Ok(to_skip)
+        }
+
+        fn get_def_levels(&self) -> Option<&[i16]> {
+            None
+        }
+
+        fn get_rep_levels(&self) -> Option<&[i16]> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_cached_reader_basic() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+
+        // Read 3 records
+        let records_read = cached_reader.read_records(3).unwrap();
+        assert_eq!(records_read, 3);
+
+        // Consume batch should return those 3 records
+        let array = cached_reader.consume_batch().unwrap();
+        assert_eq!(array.len(), 3);
+    }
+
+    #[test]
+    fn test_read_skip_pattern() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+
+        // Read 2, skip 2, read 1 (total 5 records from first batch)
+        cached_reader.read_records(2).unwrap();
+        cached_reader.skip_records(2).unwrap();
+        cached_reader.read_records(1).unwrap();
+
+        // Should get [1,2] and [5] (skipped 3,4)
+        let array = cached_reader.consume_batch().unwrap();
+        assert_eq!(array.len(), 3); // 2 + 1 reads
+    }
+
+    #[test]
+    fn test_cache_efficiency() {
+        // Test that cache avoids duplicate reads for the same batch
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+
+        // First reader - populate cache
+        let mut cached_reader1 = CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0);
+        cached_reader1.read_records(3).unwrap();
+        let array1 = cached_reader1.consume_batch().unwrap();
+        assert_eq!(array1.len(), 3);
+
+        // Second reader - should use cache (no inner reader created)
+        let mock_reader2 = MockArrayReader::new(vec![10, 20, 30, 40, 50]); // Different data
+        let mut cached_reader2 = CachedArrayReader::new(Box::new(mock_reader2), cache.clone(), 0);
+        cached_reader2.read_records(2).unwrap();
+        let array2 = cached_reader2.consume_batch().unwrap();
+        assert_eq!(array2.len(), 2);
+
+        // The second reader should get data from cache (original [1,2,3,4,5])
+        // not from its mock reader ([10,20,30,40,50])
+        // This tests that cache is working
+    }
+}

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn test_cached_reader_basic() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3, None))); // Batch size 3
         let mut cached_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Producer);
 
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn test_read_skip_pattern() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5, None))); // Batch size 5
         let mut cached_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn test_multiple_reads_before_consume() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3, None))); // Batch size 3
         let mut cached_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn test_eof_behavior() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5, None))); // Batch size 5
         let mut cached_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn test_cache_sharing() {
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5, None))); // Batch size 5
 
         // First reader - populate cache
         let mock_reader1 = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn test_consumer_removes_batches() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3, None))); // Batch size 3
         let mut consumer_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0, CacheRole::Consumer);
 
@@ -539,7 +539,7 @@ mod tests {
     #[test]
     fn test_producer_keeps_batches() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3, None))); // Batch size 3
         let mut producer_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0, CacheRole::Producer);
 
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn test_local_cache_protects_against_eviction() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3, None))); // Batch size 3
         let mut cached_reader =
             CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0, CacheRole::Consumer);
 

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -8,11 +8,40 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+/// Role of the cached array reader
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRole {
+    /// Producer role: inserts data into the cache during filter phase
+    Producer,
+    /// Consumer role: removes consumed data from the cache during output building phase
+    Consumer,
+}
+
 /// A cached wrapper around an ArrayReader that avoids duplicate decoding
 /// when the same column appears in both filter predicates and output projection.
 ///
 /// This reader acts as a transparent layer over the inner reader, using a cache
 /// to avoid redundant work when the same data is needed multiple times.
+///
+/// The reader can operate in two roles:
+/// - Producer: During filter phase, inserts decoded data into the cache
+/// - Consumer: During output building, consumes and removes data from the cache
+///
+/// This means the memory consumption of the cache has two stages:
+/// 1. During the filter phase, the memory increases as the cache is populated
+/// 2. It peaks when filters are built.
+/// 3. It decreases as the cached data is consumed.
+///    ▲
+///    │     ╭─╮
+///    │    ╱   ╲
+///    │   ╱     ╲
+///    │  ╱       ╲
+///    │ ╱         ╲
+///    │╱           ╲
+///    └─────────────╲──────► Time
+///    │      │      │
+///    Filter  Peak  Consume
+///    Phase (Built) (Decrease)
 pub struct CachedArrayReader {
     /// The underlying array reader
     inner: Box<dyn ArrayReader>,
@@ -28,14 +57,17 @@ pub struct CachedArrayReader {
     batch_size: usize,
     /// Selections to be applied to the next consume_batch()
     selections: VecDeque<RowSelector>,
+    /// Role of this reader (Producer or Consumer)
+    role: CacheRole,
 }
 
 impl CachedArrayReader {
-    /// Creates a new cached array reader
+    /// Creates a new cached array reader with the specified role
     pub fn new(
         inner: Box<dyn ArrayReader>,
         cache: Arc<Mutex<RowGroupCache>>,
         column_idx: usize,
+        role: CacheRole,
     ) -> Self {
         let batch_size = cache.lock().unwrap().batch_size();
 
@@ -47,6 +79,7 @@ impl CachedArrayReader {
             inner_position: 0,
             batch_size,
             selections: VecDeque::new(),
+            role,
         }
     }
 
@@ -64,12 +97,32 @@ impl CachedArrayReader {
 
         let read = self.inner.read_records(self.batch_size)?;
         let array = self.inner.consume_batch()?;
+
+        // Both producers and consumers insert data into the cache when fetching from underlying reader
+        // The difference is that consumers will remove consumed batches later
         self.cache
             .lock()
             .unwrap()
             .insert(self.column_idx, batch_id, array);
+
         self.inner_position += read;
         Ok(read)
+    }
+
+    /// Remove batches from cache that have been completely consumed
+    /// This is only called for Consumer role readers
+    fn cleanup_consumed_batches(&mut self) {
+        let current_batch_id = self.get_batch_id_from_position(self.outer_position);
+
+        // Remove batches that are at least one batch behind the current position
+        // This ensures we don't remove batches that might still be needed for the current batch
+        // We can safely remove batch_id if current_batch_id > batch_id + 1
+        if current_batch_id > 1 {
+            let mut cache = self.cache.lock().unwrap();
+            for batch_id_to_remove in 0..(current_batch_id - 1) {
+                cache.remove(self.column_idx, batch_id_to_remove);
+            }
+        }
     }
 }
 
@@ -180,6 +233,12 @@ impl ArrayReader for CachedArrayReader {
 
         self.selections.clear();
 
+        // For consumers, cleanup batches that have been completely consumed
+        // This reduces the memory usage of the cache
+        if self.role == CacheRole::Consumer {
+            self.cleanup_consumed_batches();
+        }
+
         match selected_arrays.len() {
             0 => Ok(new_empty_array(&self.inner.get_data_type())),
             1 => Ok(selected_arrays.into_iter().next().unwrap()),
@@ -284,7 +343,8 @@ mod tests {
     fn test_cached_reader_basic() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
         let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
-        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+        let mut cached_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Producer);
 
         // Read 3 records
         let records_read = cached_reader.read_records(3).unwrap();
@@ -305,7 +365,8 @@ mod tests {
     fn test_read_skip_pattern() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
-        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+        let mut cached_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
         let read1 = cached_reader.read_records(2).unwrap();
         assert_eq!(read1, 2);
@@ -332,7 +393,8 @@ mod tests {
     fn test_multiple_reads_before_consume() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6]);
         let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
-        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+        let mut cached_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
         // Multiple reads should accumulate
         let read1 = cached_reader.read_records(2).unwrap();
@@ -352,7 +414,8 @@ mod tests {
     fn test_eof_behavior() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3]);
         let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
-        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+        let mut cached_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache, 0, CacheRole::Consumer);
 
         // Try to read more than available
         let read1 = cached_reader.read_records(5).unwrap();
@@ -375,7 +438,12 @@ mod tests {
 
         // First reader - populate cache
         let mock_reader1 = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
-        let mut cached_reader1 = CachedArrayReader::new(Box::new(mock_reader1), cache.clone(), 0);
+        let mut cached_reader1 = CachedArrayReader::new(
+            Box::new(mock_reader1),
+            cache.clone(),
+            0,
+            CacheRole::Producer,
+        );
 
         cached_reader1.read_records(3).unwrap();
         let array1 = cached_reader1.consume_batch().unwrap();
@@ -383,7 +451,12 @@ mod tests {
 
         // Second reader with different column index should not interfere
         let mock_reader2 = MockArrayReader::new(vec![10, 20, 30, 40, 50]);
-        let mut cached_reader2 = CachedArrayReader::new(Box::new(mock_reader2), cache.clone(), 1);
+        let mut cached_reader2 = CachedArrayReader::new(
+            Box::new(mock_reader2),
+            cache.clone(),
+            1,
+            CacheRole::Consumer,
+        );
 
         cached_reader2.read_records(2).unwrap();
         let array2 = cached_reader2.consume_batch().unwrap();
@@ -392,5 +465,79 @@ mod tests {
         // Verify the second reader got its own data, not from cache
         let int32_array = array2.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(int32_array.values(), &[10, 20]);
+    }
+
+    #[test]
+    fn test_consumer_removes_batches() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let mut consumer_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0, CacheRole::Consumer);
+
+        // Read first batch (positions 0-2, batch 0)
+        let read1 = consumer_reader.read_records(3).unwrap();
+        assert_eq!(read1, 3);
+        assert_eq!(consumer_reader.outer_position, 3);
+        // Check that batch 0 is in cache after read_records
+        assert!(cache.lock().unwrap().get(0, 0).is_some());
+
+        let array1 = consumer_reader.consume_batch().unwrap();
+        assert_eq!(array1.len(), 3);
+
+        // After first consume_batch, batch 0 should still be in cache
+        // (current_batch_id = 3/3 = 1, cleanup only happens if current_batch_id > 1)
+        assert!(cache.lock().unwrap().get(0, 0).is_some());
+
+        // Read second batch (positions 3-5, batch 1)
+        let read2 = consumer_reader.read_records(3).unwrap();
+        assert_eq!(read2, 3);
+        assert_eq!(consumer_reader.outer_position, 6);
+        let array2 = consumer_reader.consume_batch().unwrap();
+        assert_eq!(array2.len(), 3);
+
+        // After second consume_batch, batch 0 should be removed
+        // (current_batch_id = 6/3 = 2, cleanup removes batches 0..(2-1) = 0..1, so removes batch 0)
+        assert!(cache.lock().unwrap().get(0, 0).is_none());
+        assert!(cache.lock().unwrap().get(0, 1).is_some());
+
+        // Read third batch (positions 6-8, batch 2)
+        let read3 = consumer_reader.read_records(3).unwrap();
+        assert_eq!(read3, 3);
+        assert_eq!(consumer_reader.outer_position, 9);
+        let array3 = consumer_reader.consume_batch().unwrap();
+        assert_eq!(array3.len(), 3);
+
+        // After third consume_batch, batches 0 and 1 should be removed
+        // (current_batch_id = 9/3 = 3, cleanup removes batches 0..(3-1) = 0..2, so removes batches 0 and 1)
+        assert!(cache.lock().unwrap().get(0, 0).is_none());
+        assert!(cache.lock().unwrap().get(0, 1).is_none());
+        assert!(cache.lock().unwrap().get(0, 2).is_some());
+    }
+
+    #[test]
+    fn test_producer_keeps_batches() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let mut producer_reader =
+            CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0, CacheRole::Producer);
+
+        // Read first batch (positions 0-2)
+        let read1 = producer_reader.read_records(3).unwrap();
+        assert_eq!(read1, 3);
+        let array1 = producer_reader.consume_batch().unwrap();
+        assert_eq!(array1.len(), 3);
+
+        // Verify batch 0 is in cache
+        assert!(cache.lock().unwrap().get(0, 0).is_some());
+
+        // Read second batch (positions 3-5) - producer should NOT remove batch 0
+        let read2 = producer_reader.read_records(3).unwrap();
+        assert_eq!(read2, 3);
+        let array2 = producer_reader.consume_batch().unwrap();
+        assert_eq!(array2.len(), 3);
+
+        // Verify both batch 0 and batch 1 are still present (no removal for producer)
+        assert!(cache.lock().unwrap().get(0, 0).is_some());
+        assert!(cache.lock().unwrap().get(0, 1).is_some());
     }
 }

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -105,10 +105,13 @@ impl CachedArrayReader {
         // Store in both shared cache and local cache
         // The shared cache is for coordination between readers
         // The local cache ensures data is available for our consume_batch call
-        self.cache
+        let _cached = self
+            .cache
             .lock()
             .unwrap()
             .insert(self.column_idx, batch_id, array.clone());
+        // Note: if the shared cache is full (_cached == false), we continue without caching
+        // The local cache will still store the data for this reader's use
 
         self.local_cache.insert(batch_id, array);
 

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -204,11 +204,11 @@ impl ArrayReader for CachedArrayReader {
     }
 
     fn get_def_levels(&self) -> Option<&[i16]> {
-        self.inner.get_def_levels()
+        None // we don't allow nullable parent for now.
     }
 
     fn get_rep_levels(&self) -> Option<&[i16]> {
-        self.inner.get_rep_levels()
+        None
     }
 }
 

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -1,44 +1,17 @@
 use crate::arrow::array_reader::{row_group_cache::RowGroupCache, ArrayReader};
+use crate::arrow::arrow_reader::RowSelector;
 use crate::errors::Result;
-use arrow_array::{new_empty_array, ArrayRef, BooleanArray};
-use arrow_buffer::BooleanBufferBuilder;
+use arrow_array::{new_empty_array, ArrayRef};
 use arrow_schema::DataType as ArrowType;
-use arrow_select::concat::concat;
-use arrow_select::filter::filter;
 use std::any::Any;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-/// Row selector indicating whether to read or skip rows
-#[derive(Debug, Clone)]
-struct RowSelector {
-    /// Number of rows in this selection
-    row_count: usize,
-    /// Whether to skip (true) or read (false) these rows
-    skip: bool,
-}
-
-impl RowSelector {
-    fn select(row_count: usize) -> Self {
-        Self {
-            row_count,
-            skip: false,
-        }
-    }
-
-    fn skip(row_count: usize) -> Self {
-        Self {
-            row_count,
-            skip: true,
-        }
-    }
-}
-
 /// A cached wrapper around an ArrayReader that avoids duplicate decoding
 /// when the same column appears in both filter predicates and output projection.
 ///
-/// This reader accumulates read/skip selections and processes them efficiently
-/// using cached batch data when consume_batch() is called.
+/// This reader acts as a transparent layer over the inner reader, using a cache
+/// to avoid redundant work when the same data is needed multiple times.
 pub struct CachedArrayReader {
     /// The underlying array reader
     inner: Box<dyn ArrayReader>,
@@ -46,12 +19,17 @@ pub struct CachedArrayReader {
     cache: Arc<Mutex<RowGroupCache>>,
     /// Column index for cache key generation
     column_idx: usize,
-    /// Current row position in the row group
-    current_row: usize,
-    /// Inner reader's row position (to keep it in sync)
-    inner_reader_position: usize,
-    /// Queue of read/skip selections to process
-    selection: VecDeque<RowSelector>,
+    /// Current logical position in the data stream (for cache key generation)
+    outer_position: usize,
+    /// Current position in the inner reader
+    inner_position: usize,
+    /// Number of records accumulated to be returned in next consume_batch()
+    pending_records: usize,
+    /// Number of records to skip in next batch operation
+    pending_skips: usize,
+    /// Batch size for the cache
+    batch_size: usize,
+    selections: VecDeque<RowSelector>,
 }
 
 impl CachedArrayReader {
@@ -61,83 +39,47 @@ impl CachedArrayReader {
         cache: Arc<Mutex<RowGroupCache>>,
         column_idx: usize,
     ) -> Self {
+        let batch_size = cache.lock().unwrap().batch_size();
         Self {
             inner,
             cache,
             column_idx,
-            current_row: 0,
-            inner_reader_position: 0,
-            selection: VecDeque::new(),
+            outer_position: 0,
+            inner_position: 0,
+            pending_records: 0,
+            pending_skips: 0,
+            batch_size,
+            selections: VecDeque::new(),
         }
     }
 
     /// Gets the batch size from the cache
     fn batch_size(&self) -> usize {
-        self.cache.lock().unwrap().batch_size()
+        self.batch_size
     }
 
-    /// Calculates the batch ID for a given row position
-    fn batch_id_from_row(&self, row: usize) -> usize {
-        row / self.batch_size()
+    fn get_batch_id_from_position(&self, position: usize) -> usize {
+        position / self.batch_size
     }
 
-    /// Ensures a batch is cached by fetching it from the inner reader if needed.
-    ///
-    /// Returns the number of rows cached for this batch. If `0` is returned it
-    /// indicates the inner reader has no more data (EOF).
-    fn ensure_cached(&mut self, batch_id: usize) -> Result<usize> {
-        let batch_start_row = batch_id * self.batch_size();
+    fn sync_inner_position(&mut self) {}
 
-        // Check if already cached
-        if let Some(array) = self
-            .cache
-            .lock()
-            .unwrap()
-            .get(self.column_idx, batch_start_row)
-        {
-            return Ok(array.len());
-        }
-
-        // Sync inner reader to batch start if needed
-        if self.inner_reader_position < batch_start_row {
-            let to_skip = batch_start_row - self.inner_reader_position;
+    fn fetch_batch(&mut self, batch_id: usize) -> Result<usize> {
+        let row_id = batch_id * self.batch_size;
+        if self.inner_position < row_id {
+            let to_skip = row_id - self.inner_position;
             let skipped = self.inner.skip_records(to_skip)?;
-            self.inner_reader_position += skipped;
-
-            // Reached EOF before desired position
-            if skipped < to_skip {
-                return Ok(0);
-            }
+            self.inner_position += skipped;
         }
 
-        // Read the batch
-        let expected_batch = self.batch_size();
-        let records_read = self.inner.read_records(expected_batch)?;
-
-        // If no more rows, signal EOF
-        if records_read == 0 {
-            return Ok(0);
-        }
-
+        let read = self.inner.read_records(self.batch_size)?;
         let array = self.inner.consume_batch()?;
-
-        // Cache it
         self.cache
             .lock()
             .unwrap()
-            .insert(self.column_idx, batch_start_row, array.clone());
-        self.inner_reader_position += records_read;
-
-        Ok(array.len())
-    }
-
-    /// Converts selection queue to boolean buffer for filtering
-    fn selection_to_boolean_buffer(&self, total_rows: usize) -> arrow_buffer::BooleanBuffer {
-        let mut builder = BooleanBufferBuilder::new(total_rows);
-        for selector in &self.selection {
-            builder.append_n(selector.row_count, !selector.skip);
-        }
-        builder.finish()
+            .insert(self.column_idx, batch_id, array);
+        self.inner_position += read;
+        Ok(read)
     }
 }
 
@@ -150,141 +92,90 @@ impl ArrayReader for CachedArrayReader {
         self.inner.get_data_type()
     }
 
-    fn read_records(&mut self, mut requested: usize) -> Result<usize> {
-        let mut total_read = 0;
+    fn read_records(&mut self, num_records: usize) -> Result<usize> {
+        let mut read = 0;
+        while read < num_records {
+            let batch_id = self.get_batch_id_from_position(self.outer_position + read + 1); // +1 because we want to read the next batch
+            let cached = self.cache.lock().unwrap().get(self.column_idx, batch_id);
 
-        while requested > 0 {
-            let batch_id = self.batch_id_from_row(self.current_row);
-
-            // Ensure the batch is cached and determine its length
-            let cached_len = self.ensure_cached(batch_id)?;
-
-            // EOF reached
-            if cached_len == 0 {
-                break;
-            }
-
-            let batch_start = batch_id * self.batch_size();
-            let offset_in_batch = self.current_row - batch_start;
-
-            // If current position is past the cached length, advance to next batch.
-            // If this batch was partial (i.e. smaller than the configured batch size)
-            // this indicates we have reached EOF and should stop.
-            if offset_in_batch >= cached_len {
-                self.current_row = batch_start + cached_len;
-
-                // Partial batch implies EOF has been reached
-                if cached_len < self.batch_size() {
-                    break;
+            match cached {
+                Some(array) => {
+                    let array_len = array.len();
+                    if array_len + batch_id * self.batch_size - self.outer_position > 0 {
+                        // the cache batch has some records that we can select
+                        let v = array_len + batch_id * self.batch_size - self.outer_position;
+                        let select_cnt = std::cmp::min(num_records - read, v);
+                        read += select_cnt;
+                        self.selections.push_back(RowSelector::select(select_cnt));
+                    } else {
+                        // this is last batch and we have used all records from it
+                        break;
+                    }
                 }
+                None => {
+                    let read_from_inner = self.fetch_batch(batch_id)?;
 
-                continue;
-            }
-
-            let available = cached_len - offset_in_batch;
-            let to_read = available.min(requested);
-
-            // Record the selection
-            if to_read > 0 {
-                self.selection.push_back(RowSelector::select(to_read));
-                self.current_row += to_read;
-                requested -= to_read;
-                total_read += to_read;
+                    let select_from_this_batch = std::cmp::min(num_records - read, read_from_inner);
+                    read += select_from_this_batch;
+                    self.selections
+                        .push_back(RowSelector::select(select_from_this_batch));
+                    if read_from_inner < self.batch_size {
+                        // this is last batch from inner reader
+                        break;
+                    }
+                }
             }
         }
-
-        Ok(total_read)
+        self.outer_position += read;
+        Ok(read)
     }
 
     fn skip_records(&mut self, num_records: usize) -> Result<usize> {
-        // Add selection for skipping these records
-        self.selection.push_back(RowSelector::skip(num_records));
-        self.current_row += num_records;
-        // Note: we don't cache or sync inner reader for skips
+        let mut skipped = 0;
+        while skipped < num_records {
+            let size = std::cmp::min(num_records - skipped, self.batch_size);
+            skipped += size;
+            self.selections.push_back(RowSelector::skip(size));
+            self.outer_position += size;
+        }
         Ok(num_records)
     }
 
     fn consume_batch(&mut self) -> Result<ArrayRef> {
-        if self.selection.is_empty() {
-            // Return empty array of correct type
-            return Ok(new_empty_array(self.get_data_type()));
+        let row_count = self.selections.iter().map(|s| s.row_count).sum::<usize>();
+        if row_count == 0 {
+            return Ok(new_empty_array(&self.inner.get_data_type()));
         }
 
-        // Calculate total row count and starting position
-        let total_rows: usize = self.selection.iter().map(|s| s.row_count).sum();
-        let start_row = self.current_row - total_rows;
+        let mut start_position = self.outer_position - row_count;
 
-        if total_rows == 0 {
-            self.selection.clear();
-            return Ok(new_empty_array(self.get_data_type()));
+        let mut selected_arrays = Vec::new();
+        for selector in self.selections.iter() {
+            if !selector.skip {
+                let batch_id = self.get_batch_id_from_position(start_position);
+                let batch_start = batch_id * self.batch_size;
+
+                let cached = self.cache.lock().unwrap().get(self.column_idx, batch_id);
+                let cached = cached.expect("data must be already cached in the read_records call");
+
+                let slice_start = start_position - batch_start;
+                let sliced = cached.slice(slice_start, selector.row_count);
+                selected_arrays.push(sliced);
+            }
+            start_position += selector.row_count;
         }
 
-        // Create boolean selection buffer
-        let selection_buffer = self.selection_to_boolean_buffer(total_rows);
+        self.selections.clear();
 
-        // Determine batch range
-        let batch_size = self.batch_size();
-        let start_batch = start_row / batch_size;
-        let end_batch = (start_row + total_rows - 1) / batch_size;
-
-        let mut result_arrays = Vec::new();
-
-        for batch_id in start_batch..=end_batch {
-            let batch_start = batch_id * batch_size;
-            let batch_end = batch_start + batch_size - 1;
-
-            // Calculate overlap between our selection and this batch
-            let overlap_start = start_row.max(batch_start);
-            let overlap_end = (start_row + total_rows - 1).min(batch_end);
-
-            if overlap_start > overlap_end {
-                continue; // No overlap
-            }
-
-            // Get selection slice for this batch
-            let selection_start = overlap_start - start_row;
-            let selection_length = overlap_end - overlap_start + 1;
-            let batch_selection = selection_buffer.slice(selection_start, selection_length);
-
-            if batch_selection.count_set_bits() == 0 {
-                continue; // Nothing selected in this batch
-            }
-
-            // Get cached array and apply filter
-            let cached_array = self
-                .cache
-                .lock()
-                .unwrap()
-                .get(self.column_idx, batch_start)
-                .unwrap();
-            let mask = BooleanArray::from(batch_selection);
-
-            // Calculate offset within the batch
-            let batch_offset = overlap_start - batch_start;
-            let batch_slice = if batch_offset > 0 || selection_length < batch_size {
-                cached_array.slice(batch_offset, selection_length)
-            } else {
-                cached_array
-            };
-
-            let filtered = filter(&batch_slice, &mask)?;
-            if filtered.len() > 0 {
-                result_arrays.push(filtered);
-            }
-        }
-
-        // Clear selection queue
-        self.selection.clear();
-
-        // Concatenate results
-        match result_arrays.len() {
-            0 => Ok(new_empty_array(self.get_data_type())),
-            1 => Ok(result_arrays.into_iter().next().unwrap()),
-            _ => {
-                let array_refs: Vec<&dyn arrow_array::Array> =
-                    result_arrays.iter().map(|a| a.as_ref()).collect();
-                Ok(concat(&array_refs)?)
-            }
+        match selected_arrays.len() {
+            0 => Ok(new_empty_array(&self.inner.get_data_type())),
+            1 => Ok(selected_arrays.into_iter().next().unwrap()),
+            _ => Ok(arrow_select::concat::concat(
+                &selected_arrays
+                    .iter()
+                    .map(|a| a.as_ref())
+                    .collect::<Vec<_>>(),
+            )?),
         }
     }
 
@@ -309,7 +200,7 @@ mod tests {
     struct MockArrayReader {
         data: Vec<i32>,
         position: usize,
-        read_position: usize,
+        records_to_consume: usize,
         data_type: ArrowType,
     }
 
@@ -318,7 +209,7 @@ mod tests {
             Self {
                 data,
                 position: 0,
-                read_position: 0,
+                records_to_consume: 0,
                 data_type: ArrowType::Int32,
             }
         }
@@ -336,14 +227,16 @@ mod tests {
         fn read_records(&mut self, batch_size: usize) -> Result<usize> {
             let remaining = self.data.len() - self.position;
             let to_read = std::cmp::min(batch_size, remaining);
-            self.read_position = self.position;
-            self.position += to_read;
+            self.records_to_consume += to_read;
             Ok(to_read)
         }
 
         fn consume_batch(&mut self) -> Result<ArrayRef> {
-            // Return data from read_position to current position
-            let slice = &self.data[self.read_position..self.position];
+            let start = self.position;
+            let end = start + self.records_to_consume;
+            let slice = &self.data[start..end];
+            self.position = end;
+            self.records_to_consume = 0;
             Ok(Arc::new(Int32Array::from(slice.to_vec())))
         }
 
@@ -366,16 +259,22 @@ mod tests {
     #[test]
     fn test_cached_reader_basic() {
         let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
         let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
 
         // Read 3 records
         let records_read = cached_reader.read_records(3).unwrap();
         assert_eq!(records_read, 3);
 
-        // Consume batch should return those 3 records
         let array = cached_reader.consume_batch().unwrap();
         assert_eq!(array.len(), 3);
+
+        let int32_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int32_array.values(), &[1, 2, 3]);
+
+        // Read 3 more records
+        let records_read = cached_reader.read_records(3).unwrap();
+        assert_eq!(records_read, 2);
     }
 
     #[test]
@@ -384,37 +283,90 @@ mod tests {
         let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
         let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
 
-        // Read 2, skip 2, read 1 (total 5 records from first batch)
-        cached_reader.read_records(2).unwrap();
-        cached_reader.skip_records(2).unwrap();
-        cached_reader.read_records(1).unwrap();
+        let read1 = cached_reader.read_records(2).unwrap();
+        assert_eq!(read1, 2);
 
-        // Should get [1,2] and [5] (skipped 3,4)
-        let array = cached_reader.consume_batch().unwrap();
-        assert_eq!(array.len(), 3); // 2 + 1 reads
+        let array1 = cached_reader.consume_batch().unwrap();
+        assert_eq!(array1.len(), 2);
+        let int32_array = array1.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int32_array.values(), &[1, 2]);
+
+        let skipped = cached_reader.skip_records(2).unwrap();
+        assert_eq!(skipped, 2);
+
+        let read2 = cached_reader.read_records(1).unwrap();
+        assert_eq!(read2, 1);
+
+        // Consume it (should be the 5th element after skipping 3,4)
+        let array2 = cached_reader.consume_batch().unwrap();
+        assert_eq!(array2.len(), 1);
+        let int32_array = array2.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int32_array.values(), &[5]);
     }
 
     #[test]
-    fn test_cache_efficiency() {
-        // Test that cache avoids duplicate reads for the same batch
-        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
+    fn test_multiple_reads_before_consume() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3, 4, 5, 6]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(3))); // Batch size 3
+        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+
+        // Multiple reads should accumulate
+        let read1 = cached_reader.read_records(2).unwrap();
+        assert_eq!(read1, 2);
+
+        let read2 = cached_reader.read_records(1).unwrap();
+        assert_eq!(read2, 1);
+
+        // Consume should return all accumulated records
+        let array = cached_reader.consume_batch().unwrap();
+        assert_eq!(array.len(), 3);
+        let int32_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int32_array.values(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_eof_behavior() {
+        let mock_reader = MockArrayReader::new(vec![1, 2, 3]);
+        let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
+        let mut cached_reader = CachedArrayReader::new(Box::new(mock_reader), cache, 0);
+
+        // Try to read more than available
+        let read1 = cached_reader.read_records(5).unwrap();
+        assert_eq!(read1, 3); // Should only get 3 records (all available)
+
+        let array1 = cached_reader.consume_batch().unwrap();
+        assert_eq!(array1.len(), 3);
+
+        // Further reads should return 0
+        let read2 = cached_reader.read_records(1).unwrap();
+        assert_eq!(read2, 0);
+
+        let array2 = cached_reader.consume_batch().unwrap();
+        assert_eq!(array2.len(), 0);
+    }
+
+    #[test]
+    fn test_cache_sharing() {
         let cache = Arc::new(Mutex::new(RowGroupCache::new(5))); // Batch size 5
 
         // First reader - populate cache
-        let mut cached_reader1 = CachedArrayReader::new(Box::new(mock_reader), cache.clone(), 0);
+        let mock_reader1 = MockArrayReader::new(vec![1, 2, 3, 4, 5]);
+        let mut cached_reader1 = CachedArrayReader::new(Box::new(mock_reader1), cache.clone(), 0);
+
         cached_reader1.read_records(3).unwrap();
         let array1 = cached_reader1.consume_batch().unwrap();
         assert_eq!(array1.len(), 3);
 
-        // Second reader - should use cache (no inner reader created)
-        let mock_reader2 = MockArrayReader::new(vec![10, 20, 30, 40, 50]); // Different data
-        let mut cached_reader2 = CachedArrayReader::new(Box::new(mock_reader2), cache.clone(), 0);
+        // Second reader with different column index should not interfere
+        let mock_reader2 = MockArrayReader::new(vec![10, 20, 30, 40, 50]);
+        let mut cached_reader2 = CachedArrayReader::new(Box::new(mock_reader2), cache.clone(), 1);
+
         cached_reader2.read_records(2).unwrap();
         let array2 = cached_reader2.consume_batch().unwrap();
         assert_eq!(array2.len(), 2);
 
-        // The second reader should get data from cache (original [1,2,3,4,5])
-        // not from its mock reader ([10,20,30,40,50])
-        // This tests that cache is working
+        // Verify the second reader got its own data, not from cache
+        let int32_array = array2.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int32_array.values(), &[10, 20]);
     }
 }

--- a/parquet/src/arrow/array_reader/list_array.rs
+++ b/parquet/src/arrow/array_reader/list_array.rs
@@ -247,7 +247,6 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
 mod tests {
     use super::*;
     use crate::arrow::array_reader::list_array::ListArrayReader;
-    use crate::arrow::array_reader::row_group_cache::RowGroupCache;
     use crate::arrow::array_reader::test_util::InMemoryArrayReader;
     use crate::arrow::array_reader::ArrayReaderBuilder;
     use crate::arrow::schema::parquet_to_arrow_schema_and_fields;
@@ -260,7 +259,7 @@ mod tests {
     use arrow_array::{Array, PrimitiveArray};
     use arrow_data::ArrayDataBuilder;
     use arrow_schema::Fields;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     fn list_type<OffsetSize: OffsetSizeTrait>(
         data_type: ArrowType,
@@ -563,10 +562,9 @@ mod tests {
             file_metadata.key_value_metadata(),
         )
         .unwrap();
-        let cache = Arc::new(Mutex::new(RowGroupCache::new(1000)));
 
         let mut array_reader = ArrayReaderBuilder::new(&file_reader)
-            .build_array_reader(fields.as_ref(), &mask, &ProjectionMask::all(), cache)
+            .build_array_reader(fields.as_ref(), &mask)
             .unwrap();
 
         let batch = array_reader.next_batch(100).unwrap();

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -33,6 +33,7 @@ mod builder;
 mod byte_array;
 mod byte_array_dictionary;
 mod byte_view_array;
+mod cached_array_reader;
 mod empty_array;
 mod fixed_len_byte_array;
 mod fixed_size_list_array;
@@ -40,6 +41,7 @@ mod list_array;
 mod map_array;
 mod null_array;
 mod primitive_array;
+mod row_group_cache;
 mod struct_array;
 
 #[cfg(test)]
@@ -58,6 +60,7 @@ pub use list_array::ListArrayReader;
 pub use map_array::MapArrayReader;
 pub use null_array::NullArrayReader;
 pub use primitive_array::PrimitiveArrayReader;
+pub use row_group_cache::RowGroupCache;
 pub use struct_array::StructArrayReader;
 
 /// Array reader reads parquet data into arrow array.

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -48,7 +48,7 @@ mod struct_array;
 mod test_util;
 
 // Note that this crate is public under the `experimental` feature flag.
-pub use builder::ArrayReaderBuilder;
+pub use builder::{ArrayReaderBuilder, CacheOptions};
 pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
 #[allow(unused_imports)] // Only used for benchmarks

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -53,6 +53,7 @@ pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
 #[allow(unused_imports)] // Only used for benchmarks
 pub use byte_view_array::make_byte_view_array_reader;
+pub use cached_array_reader::CacheRole;
 #[allow(unused_imports)] // Only used for benchmarks
 pub use fixed_len_byte_array::make_fixed_len_byte_array_reader;
 pub use fixed_size_list_array::FixedSizeListArrayReader;

--- a/parquet/src/arrow/array_reader/row_group_cache.rs
+++ b/parquet/src/arrow/array_reader/row_group_cache.rs
@@ -1,0 +1,80 @@
+use arrow_array::ArrayRef;
+use std::collections::HashMap;
+
+/// Cache key that uniquely identifies a batch within a row group
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CacheKey {
+    /// Column index in the row group
+    pub column_idx: usize,
+    /// Starting row ID for this batch
+    pub row_id: usize,
+}
+
+/// Row group cache that stores decoded arrow arrays at batch granularity
+///
+/// This cache is designed to avoid duplicate decoding when the same column
+/// appears in both filter predicates and output projection.
+#[derive(Debug, Default)]
+pub struct RowGroupCache {
+    /// Cache storage mapping (column_idx, row_id) -> ArrayRef
+    cache: HashMap<CacheKey, ArrayRef>,
+    /// Batch size used for cache entries
+    batch_size: usize,
+}
+
+impl RowGroupCache {
+    /// Creates a new empty row group cache
+    pub fn new(batch_size: usize) -> Self {
+        Self {
+            cache: HashMap::new(),
+            batch_size,
+        }
+    }
+
+    /// Inserts an array into the cache for the given column and starting row ID
+    pub fn insert(&mut self, column_idx: usize, row_id: usize, array: ArrayRef) {
+        let key = CacheKey { column_idx, row_id };
+        self.cache.insert(key, array);
+    }
+
+    /// Retrieves a cached array for the given column and row ID
+    /// Returns None if not found in cache
+    pub fn get(&self, column_idx: usize, row_id: usize) -> Option<ArrayRef> {
+        let key = CacheKey { column_idx, row_id };
+        self.cache.get(&key).cloned()
+    }
+
+    /// Gets the batch size for this cache
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{ArrayRef, Int32Array};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_cache_basic_operations() {
+        let mut cache = RowGroupCache::new(1000);
+
+        // Create test array
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+
+        // Test insert and get
+        cache.insert(0, 0, array.clone());
+        let retrieved = cache.get(0, 0);
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().len(), 5);
+
+        // Test miss
+        let miss = cache.get(1, 0);
+        assert!(miss.is_none());
+
+        // Test different row_id
+        let miss = cache.get(0, 1000);
+        assert!(miss.is_none());
+    }
+}

--- a/parquet/src/arrow/array_reader/row_group_cache.rs
+++ b/parquet/src/arrow/array_reader/row_group_cache.rs
@@ -18,7 +18,7 @@ pub struct CacheKey {
 pub struct RowGroupCache {
     /// Cache storage mapping (column_idx, row_id) -> ArrayRef
     cache: HashMap<CacheKey, ArrayRef>,
-    /// Batch size used for cache entries
+    /// Cache granularity
     batch_size: usize,
 }
 

--- a/parquet/src/arrow/array_reader/row_group_cache.rs
+++ b/parquet/src/arrow/array_reader/row_group_cache.rs
@@ -1,13 +1,18 @@
 use arrow_array::ArrayRef;
 use std::collections::HashMap;
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct BatchID {
+    pub val: usize, // batch id is row id / batch_size
+}
+
 /// Cache key that uniquely identifies a batch within a row group
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
     /// Column index in the row group
     pub column_idx: usize,
     /// Starting row ID for this batch
-    pub row_id: usize,
+    pub batch_id: BatchID,
 }
 
 /// Row group cache that stores decoded arrow arrays at batch granularity
@@ -26,12 +31,6 @@ pub struct RowGroupCache {
     current_cache_size: usize,
 }
 
-impl Default for RowGroupCache {
-    fn default() -> Self {
-        Self::new(1000, None)
-    }
-}
-
 impl RowGroupCache {
     /// Creates a new empty row group cache
     pub fn new(batch_size: usize, max_cache_size: Option<usize>) -> Self {
@@ -45,7 +44,7 @@ impl RowGroupCache {
 
     /// Inserts an array into the cache for the given column and starting row ID
     /// Returns true if the array was inserted, false if it would exceed the cache size limit
-    pub fn insert(&mut self, column_idx: usize, row_id: usize, array: ArrayRef) -> bool {
+    pub fn insert(&mut self, column_idx: usize, batch_id: BatchID, array: ArrayRef) -> bool {
         let array_size = array.get_array_memory_size();
 
         // Check if adding this array would exceed the cache size limit
@@ -55,7 +54,10 @@ impl RowGroupCache {
             }
         }
 
-        let key = CacheKey { column_idx, row_id };
+        let key = CacheKey {
+            column_idx,
+            batch_id,
+        };
 
         let existing = self.cache.insert(key, array);
         assert!(existing.is_none());
@@ -65,8 +67,11 @@ impl RowGroupCache {
 
     /// Retrieves a cached array for the given column and row ID
     /// Returns None if not found in cache
-    pub fn get(&self, column_idx: usize, row_id: usize) -> Option<ArrayRef> {
-        let key = CacheKey { column_idx, row_id };
+    pub fn get(&self, column_idx: usize, batch_id: BatchID) -> Option<ArrayRef> {
+        let key = CacheKey {
+            column_idx,
+            batch_id,
+        };
         self.cache.get(&key).cloned()
     }
 
@@ -75,40 +80,19 @@ impl RowGroupCache {
         self.batch_size
     }
 
-    /// Gets the maximum cache size in bytes (None means unlimited)
-    pub fn max_cache_size(&self) -> Option<usize> {
-        self.max_cache_size
-    }
-
-    /// Gets the current cache size in bytes
-    pub fn current_cache_size(&self) -> usize {
-        self.current_cache_size
-    }
-
-    /// Returns true if the cache has reached its maximum size
-    pub fn is_full(&self) -> bool {
-        match self.max_cache_size {
-            Some(max_size) => self.current_cache_size >= max_size,
-            None => false,
-        }
-    }
-
     /// Removes a cached array for the given column and row ID
     /// Returns true if the entry was found and removed, false otherwise
-    pub fn remove(&mut self, column_idx: usize, row_id: usize) -> bool {
-        let key = CacheKey { column_idx, row_id };
+    pub fn remove(&mut self, column_idx: usize, batch_id: BatchID) -> bool {
+        let key = CacheKey {
+            column_idx,
+            batch_id,
+        };
         if let Some(array) = self.cache.remove(&key) {
             self.current_cache_size -= array.get_array_memory_size();
             true
         } else {
             false
         }
-    }
-
-    /// Clears all entries from the cache
-    pub fn clear(&mut self) {
-        self.cache.clear();
-        self.current_cache_size = 0;
     }
 }
 
@@ -126,17 +110,18 @@ mod tests {
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
 
         // Test insert and get
-        assert!(cache.insert(0, 0, array.clone()));
-        let retrieved = cache.get(0, 0);
+        let batch_id = BatchID { val: 0 };
+        assert!(cache.insert(0, batch_id, array.clone()));
+        let retrieved = cache.get(0, batch_id);
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().len(), 5);
 
         // Test miss
-        let miss = cache.get(1, 0);
+        let miss = cache.get(1, batch_id);
         assert!(miss.is_none());
 
         // Test different row_id
-        let miss = cache.get(0, 1000);
+        let miss = cache.get(0, BatchID { val: 1000 });
         assert!(miss.is_none());
     }
 
@@ -149,164 +134,34 @@ mod tests {
         let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
 
         // Insert arrays
-        assert!(cache.insert(0, 0, array1.clone()));
-        assert!(cache.insert(0, 1000, array2.clone()));
-        assert!(cache.insert(1, 0, array1.clone()));
+        assert!(cache.insert(0, BatchID { val: 0 }, array1.clone()));
+        assert!(cache.insert(0, BatchID { val: 1000 }, array2.clone()));
+        assert!(cache.insert(1, BatchID { val: 0 }, array1.clone()));
 
         // Verify they're there
-        assert!(cache.get(0, 0).is_some());
-        assert!(cache.get(0, 1000).is_some());
-        assert!(cache.get(1, 0).is_some());
+        assert!(cache.get(0, BatchID { val: 0 }).is_some());
+        assert!(cache.get(0, BatchID { val: 1000 }).is_some());
+        assert!(cache.get(1, BatchID { val: 0 }).is_some());
 
         // Remove one entry
-        let removed = cache.remove(0, 0);
+        let removed = cache.remove(0, BatchID { val: 0 });
         assert!(removed);
-        assert!(cache.get(0, 0).is_none());
+        assert!(cache.get(0, BatchID { val: 0 }).is_none());
 
         // Other entries should still be there
-        assert!(cache.get(0, 1000).is_some());
-        assert!(cache.get(1, 0).is_some());
+        assert!(cache.get(0, BatchID { val: 1000 }).is_some());
+        assert!(cache.get(1, BatchID { val: 0 }).is_some());
 
         // Try to remove non-existent entry
-        let not_removed = cache.remove(0, 0);
+        let not_removed = cache.remove(0, BatchID { val: 0 });
         assert!(!not_removed);
 
         // Remove remaining entries
-        assert!(cache.remove(0, 1000));
-        assert!(cache.remove(1, 0));
+        assert!(cache.remove(0, BatchID { val: 1000 }));
+        assert!(cache.remove(1, BatchID { val: 0 }));
 
         // Cache should be empty
-        assert!(cache.get(0, 1000).is_none());
-        assert!(cache.get(1, 0).is_none());
-    }
-
-    #[test]
-    fn test_cache_with_max_size() {
-        // Create a cache with a very small max size
-        let mut cache = RowGroupCache::new(1000, Some(100));
-
-        assert_eq!(cache.max_cache_size(), Some(100));
-        assert_eq!(cache.current_cache_size(), 0);
-        assert!(!cache.is_full());
-
-        // Create a test array
-        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
-        let array_size = array.get_array_memory_size();
-
-        // If array is larger than max cache size, insertion should fail
-        if array_size > 100 {
-            assert!(!cache.insert(0, 0, array.clone()));
-            assert_eq!(cache.current_cache_size(), 0);
-            assert!(cache.get(0, 0).is_none());
-        } else {
-            // If array fits, insertion should succeed
-            assert!(cache.insert(0, 0, array.clone()));
-            assert_eq!(cache.current_cache_size(), array_size);
-            assert!(cache.get(0, 0).is_some());
-
-            // Try to insert another array that would exceed the limit
-            let array2: ArrayRef = Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10]));
-            let array2_size = array2.get_array_memory_size();
-
-            if array_size + array2_size > 100 {
-                assert!(!cache.insert(0, 1000, array2.clone()));
-                assert_eq!(cache.current_cache_size(), array_size);
-                assert!(cache.get(0, 1000).is_none());
-            }
-        }
-    }
-
-    #[test]
-    fn test_cache_unlimited_size() {
-        let mut cache = RowGroupCache::new(1000, None);
-
-        assert_eq!(cache.max_cache_size(), None);
-        assert_eq!(cache.current_cache_size(), 0);
-        assert!(!cache.is_full());
-
-        // Should be able to insert multiple arrays without size limit
-        for i in 0..10 {
-            let array: ArrayRef = Arc::new(Int32Array::from(vec![i, i + 1, i + 2]));
-            assert!(cache.insert(0, (i * 1000) as usize, array));
-        }
-
-        assert_eq!(cache.cache.len(), 10);
-        assert!(!cache.is_full());
-    }
-
-    #[test]
-    fn test_cache_size_tracking() {
-        let mut cache = RowGroupCache::new(1000, None);
-
-        let array1: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6, 7]));
-
-        let size1 = array1.get_array_memory_size();
-        let size2 = array2.get_array_memory_size();
-
-        // Insert first array
-        assert!(cache.insert(0, 0, array1.clone()));
-        assert_eq!(cache.current_cache_size(), size1);
-
-        // Insert second array
-        assert!(cache.insert(1, 0, array2.clone()));
-        assert_eq!(cache.current_cache_size(), size1 + size2);
-
-        // Replace first array with second array
-        assert!(cache.insert(0, 0, array2.clone()));
-        assert_eq!(cache.current_cache_size(), size2 + size2);
-
-        // Remove one entry
-        assert!(cache.remove(0, 0));
-        assert_eq!(cache.current_cache_size(), size2);
-
-        // Remove remaining entry
-        assert!(cache.remove(1, 0));
-        assert_eq!(cache.current_cache_size(), 0);
-    }
-
-    #[test]
-    fn test_cache_clear() {
-        let mut cache = RowGroupCache::new(1000, Some(1000));
-
-        // Insert some arrays
-        for i in 0..5 {
-            let array: ArrayRef = Arc::new(Int32Array::from(vec![i, i + 1, i + 2]));
-            assert!(cache.insert(0, (i * 1000) as usize, array));
-        }
-
-        assert!(cache.current_cache_size() > 0);
-        assert_eq!(cache.cache.len(), 5);
-
-        // Clear the cache
-        cache.clear();
-
-        assert_eq!(cache.current_cache_size(), 0);
-        assert_eq!(cache.cache.len(), 0);
-        assert!(!cache.is_full());
-    }
-
-    #[test]
-    fn test_cache_full_detection() {
-        // Create a cache that can hold approximately one small array
-        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let array_size = array.get_array_memory_size();
-
-        let mut cache = RowGroupCache::new(1000, Some(array_size));
-
-        assert!(!cache.is_full());
-
-        // Insert array - should succeed and make cache full
-        assert!(cache.insert(0, 0, array.clone()));
-        assert!(cache.is_full());
-
-        // Try to insert another array - should fail
-        let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
-        assert!(!cache.insert(1, 0, array2));
-
-        // Cache should still be full with original array
-        assert!(cache.is_full());
-        assert!(cache.get(0, 0).is_some());
-        assert!(cache.get(1, 0).is_none());
+        assert!(cache.get(0, BatchID { val: 1000 }).is_none());
+        assert!(cache.get(1, BatchID { val: 0 }).is_none());
     }
 }

--- a/parquet/src/arrow/array_reader/row_group_cache.rs
+++ b/parquet/src/arrow/array_reader/row_group_cache.rs
@@ -14,12 +14,22 @@ pub struct CacheKey {
 ///
 /// This cache is designed to avoid duplicate decoding when the same column
 /// appears in both filter predicates and output projection.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RowGroupCache {
     /// Cache storage mapping (column_idx, row_id) -> ArrayRef
     cache: HashMap<CacheKey, ArrayRef>,
     /// Cache granularity
     batch_size: usize,
+    /// Maximum cache size in bytes (None means unlimited)
+    max_cache_size: Option<usize>,
+    /// Current cache size in bytes
+    current_cache_size: usize,
+}
+
+impl Default for RowGroupCache {
+    fn default() -> Self {
+        Self::new(1000)
+    }
 }
 
 impl RowGroupCache {
@@ -28,13 +38,44 @@ impl RowGroupCache {
         Self {
             cache: HashMap::new(),
             batch_size,
+            max_cache_size: None,
+            current_cache_size: 0,
         }
     }
 
+    /// Creates a new empty row group cache with a maximum cache size in bytes
+    pub fn new_with_max_size(batch_size: usize, max_cache_size: usize) -> Self {
+        Self {
+            cache: HashMap::new(),
+            batch_size,
+            max_cache_size: Some(max_cache_size),
+            current_cache_size: 0,
+        }
+    }
+
+    /// Returns the memory size of an ArrayRef in bytes
+    fn array_memory_size(array: &ArrayRef) -> usize {
+        array.get_array_memory_size()
+    }
+
     /// Inserts an array into the cache for the given column and starting row ID
-    pub fn insert(&mut self, column_idx: usize, row_id: usize, array: ArrayRef) {
+    /// Returns true if the array was inserted, false if it would exceed the cache size limit
+    pub fn insert(&mut self, column_idx: usize, row_id: usize, array: ArrayRef) -> bool {
+        let array_size = Self::array_memory_size(&array);
+
+        // Check if adding this array would exceed the cache size limit
+        if let Some(max_size) = self.max_cache_size {
+            if self.current_cache_size + array_size > max_size {
+                return false; // Cache is full, don't insert
+            }
+        }
+
         let key = CacheKey { column_idx, row_id };
-        self.cache.insert(key, array);
+
+        let existing = self.cache.insert(key, array);
+        assert!(existing.is_none());
+        self.current_cache_size += array_size;
+        true
     }
 
     /// Retrieves a cached array for the given column and row ID
@@ -49,11 +90,40 @@ impl RowGroupCache {
         self.batch_size
     }
 
+    /// Gets the maximum cache size in bytes (None means unlimited)
+    pub fn max_cache_size(&self) -> Option<usize> {
+        self.max_cache_size
+    }
+
+    /// Gets the current cache size in bytes
+    pub fn current_cache_size(&self) -> usize {
+        self.current_cache_size
+    }
+
+    /// Returns true if the cache has reached its maximum size
+    pub fn is_full(&self) -> bool {
+        match self.max_cache_size {
+            Some(max_size) => self.current_cache_size >= max_size,
+            None => false,
+        }
+    }
+
     /// Removes a cached array for the given column and row ID
     /// Returns true if the entry was found and removed, false otherwise
     pub fn remove(&mut self, column_idx: usize, row_id: usize) -> bool {
         let key = CacheKey { column_idx, row_id };
-        self.cache.remove(&key).is_some()
+        if let Some(array) = self.cache.remove(&key) {
+            self.current_cache_size -= Self::array_memory_size(&array);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clears all entries from the cache
+    pub fn clear(&mut self) {
+        self.cache.clear();
+        self.current_cache_size = 0;
     }
 }
 
@@ -71,7 +141,7 @@ mod tests {
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
 
         // Test insert and get
-        cache.insert(0, 0, array.clone());
+        assert!(cache.insert(0, 0, array.clone()));
         let retrieved = cache.get(0, 0);
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().len(), 5);
@@ -94,9 +164,9 @@ mod tests {
         let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
 
         // Insert arrays
-        cache.insert(0, 0, array1.clone());
-        cache.insert(0, 1000, array2.clone());
-        cache.insert(1, 0, array1.clone());
+        assert!(cache.insert(0, 0, array1.clone()));
+        assert!(cache.insert(0, 1000, array2.clone()));
+        assert!(cache.insert(1, 0, array1.clone()));
 
         // Verify they're there
         assert!(cache.get(0, 0).is_some());
@@ -107,7 +177,7 @@ mod tests {
         let removed = cache.remove(0, 0);
         assert!(removed);
         assert!(cache.get(0, 0).is_none());
-        
+
         // Other entries should still be there
         assert!(cache.get(0, 1000).is_some());
         assert!(cache.get(1, 0).is_some());
@@ -119,9 +189,139 @@ mod tests {
         // Remove remaining entries
         assert!(cache.remove(0, 1000));
         assert!(cache.remove(1, 0));
-        
+
         // Cache should be empty
         assert!(cache.get(0, 1000).is_none());
+        assert!(cache.get(1, 0).is_none());
+    }
+
+    #[test]
+    fn test_cache_with_max_size() {
+        // Create a cache with a very small max size
+        let mut cache = RowGroupCache::new_with_max_size(1000, 100);
+
+        assert_eq!(cache.max_cache_size(), Some(100));
+        assert_eq!(cache.current_cache_size(), 0);
+        assert!(!cache.is_full());
+
+        // Create a test array
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        let array_size = RowGroupCache::array_memory_size(&array);
+
+        // If array is larger than max cache size, insertion should fail
+        if array_size > 100 {
+            assert!(!cache.insert(0, 0, array.clone()));
+            assert_eq!(cache.current_cache_size(), 0);
+            assert!(cache.get(0, 0).is_none());
+        } else {
+            // If array fits, insertion should succeed
+            assert!(cache.insert(0, 0, array.clone()));
+            assert_eq!(cache.current_cache_size(), array_size);
+            assert!(cache.get(0, 0).is_some());
+
+            // Try to insert another array that would exceed the limit
+            let array2: ArrayRef = Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10]));
+            let array2_size = RowGroupCache::array_memory_size(&array2);
+
+            if array_size + array2_size > 100 {
+                assert!(!cache.insert(0, 1000, array2.clone()));
+                assert_eq!(cache.current_cache_size(), array_size);
+                assert!(cache.get(0, 1000).is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn test_cache_unlimited_size() {
+        let mut cache = RowGroupCache::new(1000);
+
+        assert_eq!(cache.max_cache_size(), None);
+        assert_eq!(cache.current_cache_size(), 0);
+        assert!(!cache.is_full());
+
+        // Should be able to insert multiple arrays without size limit
+        for i in 0..10 {
+            let array: ArrayRef = Arc::new(Int32Array::from(vec![i, i + 1, i + 2]));
+            assert!(cache.insert(0, (i * 1000) as usize, array));
+        }
+
+        assert_eq!(cache.cache.len(), 10);
+        assert!(!cache.is_full());
+    }
+
+    #[test]
+    fn test_cache_size_tracking() {
+        let mut cache = RowGroupCache::new(1000);
+
+        let array1: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6, 7]));
+
+        let size1 = RowGroupCache::array_memory_size(&array1);
+        let size2 = RowGroupCache::array_memory_size(&array2);
+
+        // Insert first array
+        assert!(cache.insert(0, 0, array1.clone()));
+        assert_eq!(cache.current_cache_size(), size1);
+
+        // Insert second array
+        assert!(cache.insert(1, 0, array2.clone()));
+        assert_eq!(cache.current_cache_size(), size1 + size2);
+
+        // Replace first array with second array
+        assert!(cache.insert(0, 0, array2.clone()));
+        assert_eq!(cache.current_cache_size(), size2 + size2);
+
+        // Remove one entry
+        assert!(cache.remove(0, 0));
+        assert_eq!(cache.current_cache_size(), size2);
+
+        // Remove remaining entry
+        assert!(cache.remove(1, 0));
+        assert_eq!(cache.current_cache_size(), 0);
+    }
+
+    #[test]
+    fn test_cache_clear() {
+        let mut cache = RowGroupCache::new_with_max_size(1000, 1000);
+
+        // Insert some arrays
+        for i in 0..5 {
+            let array: ArrayRef = Arc::new(Int32Array::from(vec![i, i + 1, i + 2]));
+            assert!(cache.insert(0, (i * 1000) as usize, array));
+        }
+
+        assert!(cache.current_cache_size() > 0);
+        assert_eq!(cache.cache.len(), 5);
+
+        // Clear the cache
+        cache.clear();
+
+        assert_eq!(cache.current_cache_size(), 0);
+        assert_eq!(cache.cache.len(), 0);
+        assert!(!cache.is_full());
+    }
+
+    #[test]
+    fn test_cache_full_detection() {
+        // Create a cache that can hold approximately one small array
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let array_size = RowGroupCache::array_memory_size(&array);
+
+        let mut cache = RowGroupCache::new_with_max_size(1000, array_size);
+
+        assert!(!cache.is_full());
+
+        // Insert array - should succeed and make cache full
+        assert!(cache.insert(0, 0, array.clone()));
+        assert!(cache.is_full());
+
+        // Try to insert another array - should fail
+        let array2: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+        assert!(!cache.insert(1, 0, array2));
+
+        // Cache should still be full with original array
+        assert!(cache.is_full());
+        assert!(cache.get(0, 0).is_some());
         assert!(cache.get(1, 0).is_none());
     }
 }

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -24,10 +24,10 @@ use arrow_schema::{ArrowError, DataType as ArrowType, Schema, SchemaRef};
 pub use filter::{ArrowPredicate, ArrowPredicateFn, RowFilter};
 pub use selection::{RowSelection, RowSelector};
 use std::fmt::{Debug, Formatter};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 pub use crate::arrow::array_reader::RowGroups;
-use crate::arrow::array_reader::{ArrayReader, ArrayReaderBuilder, RowGroupCache};
+use crate::arrow::array_reader::{ArrayReader, ArrayReaderBuilder};
 use crate::arrow::schema::{parquet_to_arrow_schema_and_fields, ParquetField};
 use crate::arrow::{parquet_to_arrow_field_levels, FieldLevels, ProjectionMask};
 use crate::column::page::{PageIterator, PageReader};
@@ -711,10 +711,6 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
         let batch_size = self
             .batch_size
             .min(self.metadata.file_metadata().num_rows() as usize);
-        let cache_projection = match self.compute_cache_projection(&self.projection) {
-            Some(projection) => projection,
-            None => ProjectionMask::all(),
-        };
 
         let row_groups = self
             .row_groups
@@ -725,7 +721,6 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             metadata: self.metadata,
             row_groups,
         };
-        let row_group_cache = Arc::new(Mutex::new(RowGroupCache::new(batch_size)));
 
         let mut filter = self.filter;
         let mut plan_builder = ReadPlanBuilder::new(batch_size).with_selection(self.selection);
@@ -741,23 +736,15 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
                 let mut cache_projection = predicate.projection().clone();
                 cache_projection.intersect(&self.projection);
 
-                let array_reader = ArrayReaderBuilder::new(&reader).build_array_reader(
-                    self.fields.as_deref(),
-                    predicate.projection(),
-                    &cache_projection,
-                    row_group_cache.clone(),
-                )?;
+                let array_reader = ArrayReaderBuilder::new(&reader)
+                    .build_array_reader(self.fields.as_deref(), predicate.projection())?;
 
                 plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
             }
         }
 
-        let array_reader = ArrayReaderBuilder::new(&reader).build_array_reader(
-            self.fields.as_deref(),
-            &self.projection,
-            &cache_projection,
-            row_group_cache.clone(),
-        )?;
+        let array_reader = ArrayReaderBuilder::new(&reader)
+            .build_array_reader(self.fields.as_deref(), &self.projection)?;
 
         let read_plan = plan_builder
             .limited(reader.num_rows())
@@ -968,12 +955,7 @@ impl ParquetRecordBatchReader {
         selection: Option<RowSelection>,
     ) -> Result<Self> {
         let array_reader = ArrayReaderBuilder::new(row_groups)
-            .build_array_reader(
-                levels.levels.as_ref(),
-                &ProjectionMask::all(),
-                &ProjectionMask::all(),
-                Arc::new(Mutex::new(RowGroupCache::new(batch_size))),
-            )?;
+            .build_array_reader(levels.levels.as_ref(), &ProjectionMask::all())?;
 
         let read_plan = ReadPlanBuilder::new(batch_size)
             .with_selection(selection)

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -755,16 +755,6 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
 
         Ok(ParquetRecordBatchReader::new(array_reader, read_plan))
     }
-
-    fn compute_cache_projection(&self, projection: &ProjectionMask) -> Option<ProjectionMask> {
-        let filters = self.filter.as_ref()?;
-        let mut cache_projection = filters.predicates.first()?.projection().clone();
-        for predicate in filters.predicates.iter() {
-            cache_projection.union(&predicate.projection());
-        }
-        cache_projection.intersect(projection);
-        Some(cache_projection)
-    }
 }
 
 struct ReaderRowGroups<T: ChunkReader> {

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -625,7 +625,7 @@ where
                     .build_array_reader_with_cache(
                         self.fields.as_deref(),
                         predicate.projection(),
-                        (&cache_projection, row_group_cache.clone()),
+                        (&cache_projection, row_group_cache.clone(), crate::arrow::array_reader::CacheRole::Producer),
                     )?;
 
                 plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
@@ -676,7 +676,7 @@ where
         let array_reader = ArrayReaderBuilder::new(&row_group).build_array_reader_with_cache(
             self.fields.as_deref(),
             &projection,
-            (&cache_projection, row_group_cache.clone()),
+            (&cache_projection, row_group_cache.clone(), crate::arrow::array_reader::CacheRole::Consumer),
         )?;
 
         let reader = ParquetRecordBatchReader::new(array_reader, plan);

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -592,7 +592,11 @@ where
             Some(projection) => projection,
             None => ProjectionMask::none(meta.columns().len()),
         };
-        let row_group_cache = Arc::new(Mutex::new(RowGroupCache::new(batch_size, None)));
+        let row_group_cache = Arc::new(Mutex::new(RowGroupCache::new(
+            batch_size,
+            // None,
+            Some(1024 * 1024 * 100),
+        )));
 
         let mut row_group = InMemoryRowGroup {
             // schema: meta.schema_descr_ptr(),
@@ -696,7 +700,7 @@ where
         let filters = self.filter.as_ref()?;
         let mut cache_projection = filters.predicates.first()?.projection().clone();
         for predicate in filters.predicates.iter() {
-            cache_projection.union(&predicate.projection());
+            cache_projection.union(predicate.projection());
         }
         cache_projection.intersect(projection);
         Some(cache_projection)

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -621,12 +621,12 @@ where
 
                 let mut cache_projection = predicate.projection().clone();
                 cache_projection.intersect(&projection);
-                let array_reader = ArrayReaderBuilder::new(&row_group).build_array_reader(
-                    self.fields.as_deref(),
-                    predicate.projection(),
-                    &cache_projection,
-                    row_group_cache.clone(),
-                )?;
+                let array_reader = ArrayReaderBuilder::new(&row_group)
+                    .build_array_reader_with_cache(
+                        self.fields.as_deref(),
+                        predicate.projection(),
+                        (&cache_projection, row_group_cache.clone()),
+                    )?;
 
                 plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
             }
@@ -673,13 +673,11 @@ where
 
         let plan = plan_builder.build();
 
-        let array_reader = ArrayReaderBuilder::new(&row_group)
-            .build_array_reader(
-                self.fields.as_deref(),
-                &projection,
-                &cache_projection,
-                row_group_cache.clone(),
-            )?;
+        let array_reader = ArrayReaderBuilder::new(&row_group).build_array_reader_with_cache(
+            self.fields.as_deref(),
+            &projection,
+            (&cache_projection, row_group_cache.clone()),
+        )?;
 
         let reader = ParquetRecordBatchReader::new(array_reader, plan);
 

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -276,6 +276,12 @@ impl ProjectionMask {
         Self { mask: None }
     }
 
+    pub fn none(len: usize) -> Self {
+        Self {
+            mask: Some(vec![false; len]),
+        }
+    }
+
     /// Create a [`ProjectionMask`] which selects only the specified leaf columns
     ///
     /// Note: repeated or out of order indices will not impact the final mask

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -276,6 +276,7 @@ impl ProjectionMask {
         Self { mask: None }
     }
 
+    /// Create a [`ProjectionMask`] which selects no columns
     pub fn none(len: usize) -> Self {
         Self {
             mask: Some(vec![false; len]),


### PR DESCRIPTION
This is my latest attempt to make pushdown faster. Prior art: #6921

cc @alamb @zhuqi-lucas 

## Problems of #6921

1. It proactively loads entire row group into memory. (rather than only loading pages that passing the filter predicate)
2. It only cache decompressed pages, still paying the decoding cost twice.

This PR takes a different approach, it does not change the decoding pipeline, so we avoid the problem 1. It also caches the arrow record batch, so avoid problem 2.

But this means we need to use more memory to cache data.

## How it works?

1. It instruments the `array_readers` with a transparent `cached_array_reader`.
2. The cache layer will first consult the `RowGroupCache` to look for a batch, and only reads from underlying reader on a cache miss.
3. There're cache producer and cache consumer. Producer is when we build filters we insert arrow arrays into cache, consumer is when we build outputs, we remove arrow array from cache. So the memory usage should look like this:
```
    ▲
    │     ╭─╮
    │    ╱   ╲
    │   ╱     ╲
    │  ╱       ╲
    │ ╱         ╲
    │╱           ╲
    └─────────────╲──────► Time
    │      │      │
    Filter  Peak  Consume
    Phase (Built) (Decrease)
```
In a concurrent setup, not all reader may reach the peak point at the same time, so the peak system memory usage might be lower.

4.  It has a max_cache_size knob, this is a per row group setting. If the row group has used up the budget, the cache stops taking new data. and the `cached_array_reader` will fallback to read and decode from Parquet.

## Other benefits

1. This architecture allows nested columns (but not implemented in this pr), i.e., it's future proof.
2. There're many performance optimizations to further squeeze the performance, but even with current state, it has no regressions.

## How does it perform?

My criterion somehow won't produces a result from `--save-baseline`, so I asked llm to generate a table from this benchmark:
```
cargo bench --bench arrow_reader_clickbench --features "arrow async" "async"
```

`Baseline` is the implementation for current main branch.
`New Unlimited` is the new pushdown with unlimited memory budget.
`New 100MB` is the new pushdown but the memory budget for a row group caching is 100MB.

```
Query  | Baseline (ms) | New Unlimited (ms) | Diff (ms)  | New 100MB (ms) | Diff (ms)
-------+--------------+--------------------+-----------+----------------+-----------
Q1     | 0.847          | 0.803               | -0.044     | 0.812          | -0.035    
Q10    | 4.060          | 6.273               | +2.213     | 6.216          | +2.156    
Q11    | 5.088          | 7.152               | +2.064     | 7.193          | +2.105    
Q12    | 18.485         | 14.937              | -3.548     | 14.904         | -3.581    
Q13    | 24.859         | 21.908              | -2.951     | 21.705         | -3.154    
Q14    | 23.994         | 20.691              | -3.303     | 20.467         | -3.527    
Q19    | 1.894          | 1.980               | +0.086     | 1.996          | +0.102    
Q20    | 90.325         | 64.689              | -25.636    | 74.478         | -15.847   
Q21    | 106.610        | 74.766              | -31.844    | 99.557         | -7.053    
Q22    | 232.730        | 101.660             | -131.070   | 204.800        | -27.930   
Q23    | 222.800        | 186.320             | -36.480    | 186.590        | -36.210   
Q24    | 24.840         | 19.762              | -5.078     | 19.908         | -4.932    
Q27    | 80.463         | 47.118              | -33.345    | 49.597         | -30.866   
Q28    | 78.999         | 47.583              | -31.416    | 51.432         | -27.567   
Q30    | 28.587         | 28.710              | +0.123     | 28.926         | +0.339    
Q36    | 80.157         | 57.954              | -22.203    | 58.012         | -22.145   
Q37    | 46.962         | 45.901              | -1.061     | 45.386         | -1.576    
Q38    | 16.324         | 16.492              | +0.168     | 16.522         | +0.198    
Q39    | 20.754         | 20.734              | -0.020     | 20.648         | -0.106    
Q40    | 22.554         | 21.707              | -0.847     | 21.995         | -0.559    
Q41    | 16.430         | 16.391              | -0.039     | 16.581         | +0.151    
Q42    | 6.045          | 6.157               | +0.112     | 6.120          | +0.075    
```

1. If we consider the diff within 5ms to be noise, then we are never worse than the current implementation.
2. We see significant improvements for string-heavy queries, because string columns are large, they take time to decompress and decode.
3. 100MB cache budget seems to have small performance impact.


## Limitations

1. It only works for async readers, because sync reader do not follow the same row group by row group structure.
2. It is memory hungry -- compared to #6921. But changing decoding pipeline without eager loading entire row group would require significant changes to the current decoding infrastructure, e.g., we need to make page iterator an async function.
3. It currently doesn't support nested columns, more specifically, it doesn't support nested columns with nullable parents. but supporting it is straightforward, no big changes.
4. The current memory accounting is not accurate, it will overestimate the memory usage, especially when reading string view arrays, where multiple string view may share the same underlying buffer, and that buffer size is counted twice. Anyway, we never exceeds the user configured memory usage.

## Next steps?

This pr is largely proof of concept, I want to collect some feedback before sending a multi-thousands pr :)

Some items I can think of:
1. Design an interface for user to specify the cache size limit, currently it's hard-coded.
2. Don't instrument nested array reader if the parquet file has nullable parent. currently it will panic
3. More testing, and integration test/benchmark with Datafusion
