### PR TITLE
Speedup sorting for inline views: 1.4x - 1.7x improvement

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -567,18 +567,8 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         }
 
         // unfortunately, we need to compare the full data
-        // we can skip the first 4 bytes of the view, those are known to be equal
-        let data = left
-            .buffers
-            .get_unchecked(l_byte_view.buffer_index as usize);
-        let offset = l_byte_view.offset as usize;
-        let l_full_data = data.get_unchecked(offset + 4..offset + l_byte_view.length as usize);
-
-        let data = right
-            .buffers
-            .get_unchecked(r_byte_view.buffer_index as usize);
-        let offset = r_byte_view.offset as usize;
-        let r_full_data = data.get_unchecked(offset + 4..offset + r_byte_view.length as usize);
+        let l_full_data: &[u8] = unsafe { left.value_unchecked(left_idx).as_ref() };
+        let r_full_data: &[u8] = unsafe { right.value_unchecked(right_idx).as_ref() };
 
         l_full_data.cmp(r_full_data)
     }

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -567,8 +567,18 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         }
 
         // unfortunately, we need to compare the full data
-        let l_full_data: &[u8] = unsafe { left.value_unchecked(left_idx).as_ref() };
-        let r_full_data: &[u8] = unsafe { right.value_unchecked(right_idx).as_ref() };
+        // we can skip the first 4 bytes of the view, those are known to be equal
+        let data = left
+            .buffers
+            .get_unchecked(l_byte_view.buffer_index as usize);
+        let offset = l_byte_view.offset as usize;
+        let l_full_data = data.get_unchecked(offset + 4..offset + l_byte_view.length as usize);
+
+        let data = right
+            .buffers
+            .get_unchecked(r_byte_view.buffer_index as usize);
+        let offset = r_byte_view.offset as usize;
+        let r_full_data = data.get_unchecked(offset + 4..offset + r_byte_view.length as usize);
 
         l_full_data.cmp(r_full_data)
     }

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -319,50 +319,51 @@ fn sort_byte_view<T: ByteViewType>(
             (idx, raw)
         })
         .collect();
-    // Compute the number of non-null entries to partially sort
+    // 2. Compute the number of non-null entries to partially sort
     let vlimit: usize = match (limit, options.nulls_first) {
         (Some(l), true) => l.saturating_sub(nulls.len()).min(valids.len()),
         _ => valids.len(),
     };
-    // 2. Check if all views are inline (no data buffers)
+    // 3.a Check if all views are inline (no data buffers)
     if values.data_buffers().is_empty() {
         let cmp_inline = |a: &(u32, u128), b: &(u32, u128)| {
             GenericByteViewArray::<T>::inline_key_fast(a.1)
                 .cmp(&GenericByteViewArray::<T>::inline_key_fast(b.1))
         };
 
+        // Partially sort according to ascending/descending
         if !options.descending {
             sort_unstable_by(&mut valids, vlimit, cmp_inline);
         } else {
             sort_unstable_by(&mut valids, vlimit, |x, y| cmp_inline(x, y).reverse());
         }
     } else {
-        // 3. Mixed comparator: first prefix, then inline vs full comparison
+        // 3.b Mixed comparator: first prefix, then inline vs full comparison
         let cmp_mixed = |a: &(u32, u128), b: &(u32, u128)| {
             let (_, raw_a) = *a;
             let (_, raw_b) = *b;
             let len_a = raw_a as u32;
             let len_b = raw_b as u32;
-            // 3.1 Both inline (≤12 bytes): compare full 128-bit key including length
+            // 3.b.1 Both inline (≤12 bytes): compare full 128-bit key including length
             if len_a <= MAX_INLINE_VIEW_LEN && len_b <= MAX_INLINE_VIEW_LEN {
                 return GenericByteViewArray::<T>::inline_key_fast(raw_a)
                     .cmp(&GenericByteViewArray::<T>::inline_key_fast(raw_b));
             }
 
-            // 3.2 Compare 4-byte prefix in big-endian order
+            // 3.b.2 Compare 4-byte prefix in big-endian order
             let pref_a = ByteView::from(raw_a).prefix.swap_bytes();
             let pref_b = ByteView::from(raw_b).prefix.swap_bytes();
             if pref_a != pref_b {
                 return pref_a.cmp(&pref_b);
             }
 
-            // 3.3 Fallback to full byte-slice comparison
+            // 3.b.3 Fallback to full byte-slice comparison
             let full_a: &[u8] = unsafe { values.value_unchecked(a.0 as usize).as_ref() };
             let full_b: &[u8] = unsafe { values.value_unchecked(b.0 as usize).as_ref() };
             full_a.cmp(full_b)
         };
 
-        // 4. Partially sort according to ascending/descending
+        // 3.b.4 Partially sort according to ascending/descending
         if !options.descending {
             sort_unstable_by(&mut valids, vlimit, cmp_mixed);
         } else {

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -323,7 +323,6 @@ fn sort_byte_view<T: ByteViewType>(
             .into_iter()
             .map(|idx| {
                 let raw = unsafe { *values.views().get_unchecked(idx as usize) };
-                // SAFETY: we know raw is a valid inline view
                 let inline_key = GenericByteViewArray::<T>::inline_key_fast(raw);
                 (idx, inline_key)
             })

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -322,6 +322,7 @@ fn sort_byte_view<T: ByteViewType>(
         valids = value_indices
             .into_iter()
             .map(|idx| {
+                // SAFETY: we know idx < values.len()
                 let raw = unsafe { *values.views().get_unchecked(idx as usize) };
                 let inline_key = GenericByteViewArray::<T>::inline_key_fast(raw);
                 (idx, inline_key)


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #7857

# Rationale for this change

```
sort string_view[0-400] nulls to indices 2^12                                      1.00     45.2±1.37µs        ? ?/sec    1.01     45.8±1.74µs        ? ?/sec
sort string_view[0-400] to indices 2^12                                            1.00     69.1±1.98µs        ? ?/sec    1.00     69.1±4.24µs        ? ?/sec
sort string_view[10] nulls to indices 2^12                                         1.00     40.8±1.81µs        ? ?/sec    1.37     55.7±3.90µs        ? ?/sec
sort string_view[10] to indices 2^12                                               1.00     52.8±0.35µs        ? ?/sec    1.63     85.9±1.46µs        ? ?/sec
sort string_view_inlined[0-12] nulls to indices 2^12                               1.00     40.9±1.99µs        ? ?/sec    1.29     52.6±1.76µs        ? ?/sec
sort string_view_inlined[0-12] to indices 2^12                                     1.00     50.6±0.27µs        ? ?/sec    1.68    85.0±12.24µs        ? ?/sec
```
# What changes are included in this PR?

Speedup by specializing on batches with only inline views.

# Are these changes tested?, are they covered by existing tests)?

existing tests

# Are there any user-facing changes?

no
