### PR TITLE
[Variant] List and object builders have no effect until finalized

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -1565,4 +1565,116 @@ mod tests {
         let valid_result = valid_obj.finish();
         assert!(valid_result.is_ok());
     }
+
+    #[test]
+    fn test_variant_builder_to_list_builder_no_finish() {
+        // Create a list builder but never finish it
+        let mut builder = VariantBuilder::new();
+        let _list_builder = builder.new_list();
+
+        builder.append_value(42i8);
+
+        // The original builder should be unchanged
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        assert_eq!(variant, Variant::Int8(42));
+    }
+
+    #[test]
+    fn test_variant_builder_to_object_builder_no_finish() {
+        // Create an object builder but never finish it
+        let mut builder = VariantBuilder::new();
+        let _object_builder = builder.new_object();
+
+        builder.append_value(42i8);
+
+        // The original builder should be unchanged
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        assert_eq!(variant, Variant::Int8(42));
+    }
+
+    #[test]
+    fn test_list_builder_to_list_builder_no_finish() {
+        let mut builder = VariantBuilder::new();
+        let mut list_builder = builder.new_list();
+        list_builder.append_value(1i8);
+
+        // Create a nested list builder but never finish it
+        let _nested_list_builder = list_builder.new_list();
+
+        list_builder.append_value(2i8);
+
+        // The parent list should only contain the original values
+        list_builder.finish();
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        let list = variant.as_list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get(0).unwrap(), Variant::Int8(1));
+        assert_eq!(list.get(1).unwrap(), Variant::Int8(2));
+    }
+
+    #[test]
+    fn test_list_builder_to_object_builder_no_finish() {
+        let mut builder = VariantBuilder::new();
+        let mut list_builder = builder.new_list();
+        list_builder.append_value(1i8);
+
+        // Create a nested object builder but never finish it
+        let _nested_object_builder = list_builder.new_object();
+
+        list_builder.append_value(2i8);
+
+        // The parent list should only contain the original values
+        list_builder.finish();
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        let list = variant.as_list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get(0).unwrap(), Variant::Int8(1));
+        assert_eq!(list.get(1).unwrap(), Variant::Int8(2));
+    }
+
+    #[test]
+    fn test_object_builder_to_list_builder_no_finish() {
+        let mut builder = VariantBuilder::new();
+        let mut object_builder = builder.new_object();
+        object_builder.insert("first", 1i8);
+
+        // Create a nested list builder but never finish it
+        let _nested_list_builder = object_builder.new_list("nested");
+
+        object_builder.insert("second", 2i8);
+
+        // The parent object should only contain the original fields
+        object_builder.finish().unwrap();
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        let obj = variant.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("first"), Some(Variant::Int8(1)));
+        assert_eq!(obj.get("second"), Some(Variant::Int8(2)));
+    }
+
+    #[test]
+    fn test_object_builder_to_object_builder_no_finish() {
+        let mut builder = VariantBuilder::new();
+        let mut object_builder = builder.new_object();
+        object_builder.insert("first", 1i8);
+
+        // Create a nested object builder but never finish it
+        let _nested_object_builder = object_builder.new_object("nested");
+
+        object_builder.insert("second", 2i8);
+
+        // The parent object should only contain the original fields
+        object_builder.finish().unwrap();
+        let (metadata, value) = builder.finish();
+        let variant = Variant::try_new(&metadata, &value).unwrap();
+        let obj = variant.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("first"), Some(Variant::Int8(1)));
+        assert_eq!(obj.get("second"), Some(Variant::Int8(2)));
+    }
 }

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -809,7 +809,7 @@ impl<'a> ObjectBuilder<'a> {
 
         // Write field IDs (sorted order)
         let ids = self.fields.keys().map(|id| *id as usize);
-        parent_buffer.append_offset_array(ids, None, offset_size);
+        parent_buffer.append_offset_array(ids, None, id_size);
 
         // Write the field offset array, followed by the value bytes
         let offsets = self.fields.into_values();

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -750,7 +750,7 @@ impl<'a> ObjectBuilder<'a> {
         (state, self.validate_unique_fields)
     }
 
-    /// Returns an object builder that can be used to append a new (nested) object to this list.
+    /// Returns an object builder that can be used to append a new (nested) object to this object.
     ///
     /// WARNING: The builder will have no effect unless/until [`ObjectBuilder::finish`] is called.
     pub fn new_object<'b>(&'b mut self, key: &'b str) -> ObjectBuilder<'b> {
@@ -758,7 +758,7 @@ impl<'a> ObjectBuilder<'a> {
         ObjectBuilder::new(parent_state, validate_unique_fields)
     }
 
-    /// Returns a list builder that can be used to append a new (nested) list to this list.
+    /// Returns a list builder that can be used to append a new (nested) list to this object.
     ///
     /// WARNING: The builder will have no effect unless/until [`ListBuilder::finish`] is called.
     pub fn new_list<'b>(&'b mut self, key: &'b str) -> ListBuilder<'b> {

--- a/parquet-variant/src/from_json.rs
+++ b/parquet-variant/src/from_json.rs
@@ -131,9 +131,9 @@ fn append_json<'m, 'v>(
     Ok(())
 }
 
-struct ObjectFieldBuilder<'s, 'o, 'v> {
+struct ObjectFieldBuilder<'o, 'v, 's> {
     key: &'s str,
-    builder: &'o mut ObjectBuilder<'v, 's>,
+    builder: &'o mut ObjectBuilder<'v>,
 }
 
 impl<'m, 'v> VariantBuilderExt<'m, 'v> for ObjectFieldBuilder<'_, '_, '_> {

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -72,7 +72,6 @@ pub(crate) fn first_byte_from_slice(slice: &[u8]) -> Result<u8, ArrowError> {
         .first()
         .copied()
         .ok_or_else(|| ArrowError::InvalidArgumentError("Received empty bytes".to_string()))
-        .inspect_err(|e| panic!("{e}"))
 }
 
 /// Helper to get a &str from a slice at the given offset and range, or an error if invalid.

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -72,6 +72,7 @@ pub(crate) fn first_byte_from_slice(slice: &[u8]) -> Result<u8, ArrowError> {
         .first()
         .copied()
         .ok_or_else(|| ArrowError::InvalidArgumentError("Received empty bytes".to_string()))
+        .inspect_err(|e| panic!("{e}"))
 }
 
 /// Helper to get a &str from a slice at the given offset and range, or an error if invalid.

--- a/parquet-variant/src/variant/metadata.rs
+++ b/parquet-variant/src/variant/metadata.rs
@@ -206,6 +206,16 @@ impl<'m> VariantMetadata<'m> {
         Ok(new_self)
     }
 
+    /// The number of metadata dictionary entries
+    pub fn len(&self) -> usize {
+        self.dictionary_size
+    }
+
+    /// True if this metadata dictionary contains no entries
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// True if this instance is fully [validated] for panic-free infallible accesses.
     ///
     /// [validated]: Self#Validation

--- a/parquet-variant/tests/test_json_to_variant.rs
+++ b/parquet-variant/tests/test_json_to_variant.rs
@@ -28,7 +28,7 @@ struct JsonToVariantTest<'a> {
     expected: Variant<'a, 'a>,
 }
 
-impl<'a> JsonToVariantTest<'a> {
+impl JsonToVariantTest<'_> {
     fn run(self) -> Result<(), ArrowError> {
         let mut variant_builder = VariantBuilder::new();
         json_to_variant(self.json, &mut variant_builder)?;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/7863
- Closes https://github.com/apache/arrow-rs/issues/7798

# Rationale for this change

Reviews and testing on https://github.com/apache/arrow-rs/pull/7843 exposed the fact that creating a variant list or object builder has side effects that leave the parent in an inconsistent/invalid state if the child builder is never finalized. Rework the finalization logic to be more direct so that child builders have no effect on their parents before their `finish` method is called.

# What changes are included in this PR?

* Define a new `ParentState` enum that tracks the necessary information for a child to fully finalize its parent.
* Remove the `pending` machinery from builders

# Are these changes tested?

Existing unit tests mostly cover this change. 

Added new tests to verify that failing to call `finish` leaves the parent unmodified.

# Are there any user-facing changes?

No.
