### PR TITLE
fix: Incorrect inlined string view comparison after Add prefix compar…

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -620,15 +620,15 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     pub fn inline_key_fast(raw: u128) -> u128 {
         let raw_bytes = raw.to_le_bytes();
 
-        // Extract length field from little-endian raw input and convert to big-endian
-        let length_be = u32::from_le_bytes(raw_bytes[0..4].try_into().unwrap()).to_be();
+        // Parse native length from LE, then write BE bytes
+        let length = u32::from_le_bytes(raw_bytes[0..4].try_into().unwrap());
 
         // Build a 16-byte buffer with:
         // - bytes [0..12] = inline string data
         // - bytes [12..16] = big-endian length
         let mut buf = [0u8; 16];
         buf[0..12].copy_from_slice(&raw_bytes[4..16]);
-        buf[12..16].copy_from_slice(&length_be.to_be_bytes());
+        buf[12..16].copy_from_slice(&length.to_be_bytes());
 
         // Interpret as a big-endian u128 for final comparison key
         u128::from_be_bytes(buf)

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -1277,10 +1277,13 @@ mod tests {
             b"than12Byt",
             b"than12Bytes",
             b"than12Bytes\0",
+            b"than12Bytesx",
+            b"than12Bytex",
             b"than12Bytez",
             // Additional lexical tests
             b"xyy",
             b"xyz",
+            b"xza",
         ];
 
         // Create a GenericBinaryArray for cross-comparison of lex order

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -632,7 +632,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         //    - buf[0..12]  = inline string bytes (in original order)
         //    - buf[12..16] = length.to_be_bytes() (BE)
         let mut buf = [0u8; 16];
-        buf[0..12].copy_from_slice(&raw_bytes[4..16]);        // inline data
+        buf[0..12].copy_from_slice(&raw_bytes[4..16]); // inline data
 
         // Why convert length to big-endian for comparison?
         //
@@ -661,7 +661,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         // `.to_be_bytes()` allows us to construct
         // keys where standard numeric comparison (e.g., `<`, `>`) behaves
         // like lexicographic byte comparison.
-        buf[12..16].copy_from_slice(&length.to_be_bytes());   // length in BE
+        buf[12..16].copy_from_slice(&length.to_be_bytes()); // length in BE
 
         // 4. Deserialize the buffer as a big‑endian u128:
         //    buf[0] is MSB, buf[15] is LSB.
@@ -1236,11 +1236,14 @@ mod tests {
         /// the following 12 bytes contain the inline string data (unpadded).
         fn make_raw_inline(length: u32, data: &[u8]) -> u128 {
             assert!(length as usize <= 12, "Inline length must be ≤ 12");
-            assert!(data.len() == length as usize, "Data length must match `length`");
+            assert!(
+                data.len() == length as usize,
+                "Data length must match `length`"
+            );
 
             let mut raw_bytes = [0u8; 16];
             raw_bytes[0..4].copy_from_slice(&length.to_le_bytes()); // length stored little-endian
-            raw_bytes[4..(4 + data.len())].copy_from_slice(data);   // inline data
+            raw_bytes[4..(4 + data.len())].copy_from_slice(data); // inline data
             u128::from_le_bytes(raw_bytes)
         }
 
@@ -1278,7 +1281,6 @@ mod tests {
             // Additional lexical tests
             b"xyy",
             b"xyz",
-
         ];
 
         // Create a GenericBinaryArray for cross-comparison of lex order

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -607,7 +607,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     /// ```
     ///
     /// ### Why the old code failed
-    /// Fixed in: https://github.com/apache/arrow-rs/pull/7875
+    /// Fixed in: <https://github.com/apache/arrow-rs/pull/7875>
     /// In the previous implementation, we did:
     /// ```ignore
     /// let word_be = u128::from_le_bytes(raw.to_le_bytes()).to_be();

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -621,7 +621,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         let raw_bytes = raw.to_le_bytes();
 
         // Parse native length from LE, then write BE bytes
-        let length = u32::from_le_bytes(raw_bytes[0..4].try_into().unwrap());
+        let length = raw as u32;
 
         // Build a 16-byte buffer with:
         // - bytes [0..12] = inline string data

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -2800,6 +2800,34 @@ mod tests {
             .collect()
     }
 
+    fn generate_fixed_stringview_column(len: usize) -> StringViewArray {
+        let edge_cases = vec![
+            Some("bar".to_string()),
+            Some("bar\0".to_string()),
+            Some("LongerThan12Bytes".to_string()),
+            Some("LongerThan12Bytez".to_string()),
+            Some("LongerThan12Bytes\0".to_string()),
+            Some("LongerThan12Byt".to_string()),
+            Some("backend one".to_string()),
+            Some("backend two".to_string()),
+            Some("a".repeat(257)),
+            Some("a".repeat(300)),
+        ];
+
+        // Fill up to `len` by repeating edge cases and trimming
+        let mut values = Vec::with_capacity(len);
+        for i in 0..len {
+            values.push(
+                edge_cases
+                    .get(i % edge_cases.len())
+                    .cloned()
+                    .unwrap_or(None),
+            );
+        }
+
+        StringViewArray::from(values)
+    }
+
     fn generate_dictionary<K>(
         values: ArrayRef,
         len: usize,
@@ -2880,7 +2908,7 @@ mod tests {
 
     fn generate_column(len: usize) -> ArrayRef {
         let mut rng = rng();
-        match rng.random_range(0..16) {
+        match rng.random_range(0..17) {
             0 => Arc::new(generate_primitive_array::<Int32Type>(len, 0.8)),
             1 => Arc::new(generate_primitive_array::<UInt32Type>(len, 0.8)),
             2 => Arc::new(generate_primitive_array::<Int64Type>(len, 0.8)),
@@ -2916,6 +2944,7 @@ mod tests {
             })),
             14 => Arc::new(generate_string_view(len, 0.8)),
             15 => Arc::new(generate_byte_view(len, 0.8)),
+            16 => Arc::new(generate_fixed_stringview_column(len)),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
…e for inlined

# Which issue does this PR close?


- Closes [#7874](https://github.com/apache/arrow-rs/issues/7874)

# Rationale for this change

## Change Summary  
Rework `inline_key_fast` to avoid reversing the inline data bytes by removing the global `.to_be()` on the entire 128‑bit word and instead manually constructing the big‑endian key in two parts: the 96‑bit data portion and the 32‑bit length tiebreaker.

---

### Problem  
In the original implementation:

```rust
let inline_u128 = u128::from_le_bytes(raw_bytes).to_be();
```

- **What went wrong**: Calling `.to_be()` on the full 16‑byte value flips _all_ bytes, including the 12 bytes of inline data.  
- **Consequences**: Multi‑byte strings are compared in reverse order — e.g. `"backend one"` would sort as if it were `"eno dnekcab"` — so lexicographical ordering is completely inverted.  
- **Corner cases exposed**:  
  **“backend one” vs. “backend two”**: suffixes “one”/“two” compare incorrectly once reversed.  

---

### Solution  

```rust
#[inline(always)]
    pub fn inline_key_fast(raw: u128) -> u128 {
        // 1. Decompose `raw` into little‑endian bytes:
        //    - raw_bytes[0..4]  = length in LE
        //    - raw_bytes[4..16] = inline string data
        let raw_bytes = raw.to_le_bytes();

        // 2. Numerically truncate to get the low 32‑bit length (endianness‑free).
        let length = raw as u32;

        // 3. Build a 16‑byte buffer in big‑endian order:
        //    - buf[0..12]  = inline string bytes (in original order)
        //    - buf[12..16] = length.to_be_bytes() (BE)
        let mut buf = [0u8; 16];
        buf[0..12].copy_from_slice(&raw_bytes[4..16]); // inline data

        // Why convert length to big-endian for comparison?
        //
        // Rust (on most platforms) stores integers in little-endian format,
        // meaning the least significant byte is at the lowest memory address.
        // For example, an u32 value like 0x22345677 is stored in memory as:
        //
        //   [0x77, 0x56, 0x34, 0x22]  // little-endian layout
        //    ^     ^     ^     ^
        //  LSB   ↑↑↑           MSB
        //
        // This layout is efficient for arithmetic but *not* suitable for
        // lexicographic (dictionary-style) comparison of byte arrays.
        //
        // To compare values by byte order—e.g., for sorted keys or binary trees—
        // we must convert them to **big-endian**, where:
        //
        //   - The most significant byte (MSB) comes first (index 0)
        //   - The least significant byte (LSB) comes last (index N-1)
        //
        // In big-endian, the same u32 = 0x22345677 would be represented as:
        //
        //   [0x22, 0x34, 0x56, 0x77]
        //
        // This ordering aligns with natural string/byte sorting, so calling
        // `.to_be_bytes()` allows us to construct
        // keys where standard numeric comparison (e.g., `<`, `>`) behaves
        // like lexicographic byte comparison.
        buf[12..16].copy_from_slice(&length.to_be_bytes()); // length in BE

        // 4. Deserialize the buffer as a big‑endian u128:
        //    buf[0] is MSB, buf[15] is LSB.
        // Details:
        // Note on endianness and layout:
        //
        // Although `buf[0]` is stored at the lowest memory address,
        // calling `u128::from_be_bytes(buf)` interprets it as the **most significant byte (MSB)**,
        // and `buf[15]` as the **least significant byte (LSB)**.
        //
        // This is the core principle of **big-endian decoding**:
        //   - Byte at index 0 maps to bits 127..120 (highest)
        //   - Byte at index 1 maps to bits 119..112
        //   - ...
        //   - Byte at index 15 maps to bits 7..0 (lowest)
        //
        // So even though memory layout goes from low to high (left to right),
        // big-endian treats the **first byte** as highest in value.
        //
        // This guarantees that comparing two `u128` keys is equivalent to lexicographically
        // comparing the original inline bytes, followed by length.
        u128::from_be_bytes(buf)
    }
```
---

### Testing  
All existing tests — including the “backend one” vs. “backend two” and `"bar"` vs. `"bar\0"` cases — now pass, confirming both lexicographical correctness and proper length‑based tiebreaking.


# What changes are included in this PR?

# Are these changes tested?

Yes

# Are there any user-facing changes?

No