### PR TITLE
Improve Decimal to Float Casting with Error Propagation and Overflow Handling

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -620,10 +620,10 @@ pub(crate) fn cast_decimal_to_float<D: DecimalType, T: ArrowPrimitiveType, F>(
     op: F,
 ) -> Result<ArrayRef, ArrowError>
 where
-    F: Fn(D::Native) -> T::Native,
+    F: Fn(D::Native) -> Result<T::Native, ArrowError>,
 {
     let array = array.as_primitive::<D>();
-    let array = array.unary::<_, T>(op);
+    let array = array.try_unary::<_, T, _>(op)?;
     Ok(Arc::new(array))
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7886.

# Rationale for this change

The existing decimal-to-float casting logic assumes infallible conversions, which may cause panics or incorrect results when the underlying conversion fails (e.g., when casting large `Decimal256` values to `f64`). By propagating errors properly, this change improves robustness and safety.

# What changes are included in this PR?

- Updated the decimal-to-float casting function signatures to return `Result` instead of direct values.
- Replaced `.unary()` with `.try_unary()` to handle potential conversion errors.
- Modified closures used in `cast_with_options` and `cast_from_decimal` to return `Result`.
- Added a unit test for `Decimal256` to `f64` conversion that checks for overflow and ensures an appropriate error is returned.
- Updated `parquet-testing` submodule to latest commit.

# Are there any user-facing changes?

Yes.

- Users casting from `Decimal256` to `f64` may now receive an explicit error instead of encountering a panic or invalid result if the value exceeds representable bounds.
- This improves safety and predictability but may result in casting failures where none were previously surfaced.
