### PR TITLE
Add arrow-avro support for bzip2 and xz compression

### DIFF
--- a/arrow-avro/Cargo.toml
+++ b/arrow-avro/Cargo.toml
@@ -36,7 +36,7 @@ bench = false
 all-features = true
 
 [features]
-default = ["deflate", "snappy", "zstd"]
+default = ["deflate", "snappy", "zstd", "bzip2", "xz"]
 deflate = ["flate2"]
 snappy = ["snap", "crc"]
 
@@ -49,6 +49,8 @@ serde = { version = "1.0.188", features = ["derive"] }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
 snap = { version = "1.0", default-features = false, optional = true }
 zstd = { version = "0.13", default-features = false, optional = true }
+bzip2 = { version = "0.4.4", default-features = false, optional = true }
+xz = { version = "0.1", default-features = false, optional = true }
 crc = { version = "3.0", optional = true }
 
 [dev-dependencies]

--- a/arrow-avro/src/compression.rs
+++ b/arrow-avro/src/compression.rs
@@ -34,6 +34,10 @@ pub enum CompressionCodec {
     Snappy,
     /// ZStandard compression
     ZStandard,
+    /// Bzip2 compression
+    Bzip2,
+    /// Xz compression
+    Xz,
 }
 
 impl CompressionCodec {
@@ -83,6 +87,28 @@ impl CompressionCodec {
             #[cfg(not(feature = "zstd"))]
             CompressionCodec::ZStandard => Err(ArrowError::ParseError(
                 "ZStandard codec requires zstd feature".to_string(),
+            )),
+            #[cfg(feature = "bzip2")]
+            CompressionCodec::Bzip2 => {
+                let mut decoder = bzip2::read::BzDecoder::new(block);
+                let mut out = Vec::new();
+                decoder.read_to_end(&mut out)?;
+                Ok(out)
+            }
+            #[cfg(not(feature = "bzip2"))]
+            CompressionCodec::Bzip2 => Err(ArrowError::ParseError(
+                "Bzip2 codec requires bzip2 feature".to_string(),
+            )),
+            #[cfg(feature = "xz")]
+            CompressionCodec::Xz => {
+                let mut decoder = xz::read::XzDecoder::new(block);
+                let mut out = Vec::new();
+                decoder.read_to_end(&mut out)?;
+                Ok(out)
+            }
+            #[cfg(not(feature = "xz"))]
+            CompressionCodec::Xz => Err(ArrowError::ParseError(
+                "XZ codec requires xz feature".to_string(),
             )),
         }
     }

--- a/arrow-avro/src/reader/header.rs
+++ b/arrow-avro/src/reader/header.rs
@@ -77,12 +77,13 @@ impl Header {
     /// Returns the [`CompressionCodec`] if any
     pub fn compression(&self) -> Result<Option<CompressionCodec>, ArrowError> {
         let v = self.get(CODEC_METADATA_KEY);
-
         match v {
             None | Some(b"null") => Ok(None),
             Some(b"deflate") => Ok(Some(CompressionCodec::Deflate)),
             Some(b"snappy") => Ok(Some(CompressionCodec::Snappy)),
             Some(b"zstandard") => Ok(Some(CompressionCodec::ZStandard)),
+            Some(b"bzip2") => Ok(Some(CompressionCodec::Bzip2)),
+            Some(b"xz") => Ok(Some(CompressionCodec::Xz)),
             Some(v) => Err(ArrowError::ParseError(format!(
                 "Unrecognized compression codec \'{}\'",
                 String::from_utf8_lossy(v)

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -222,6 +222,8 @@ mod test {
             "avro/alltypes_plain.avro",
             "avro/alltypes_plain.snappy.avro",
             "avro/alltypes_plain.zstandard.avro",
+            "avro/alltypes_plain.bzip2.avro",
+            "avro/alltypes_plain.xz.avro",
         ];
 
         let expected = RecordBatch::try_from_iter_with_nullable([


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/4886

- Related to https://github.com/apache/arrow-rs/pull/6965

# Rationale for this change

The `arrow-avro` crate currently lacks support for reading `bzip2` and `xz` compression. This prevents users from reading Avro files compressed using these compression types, limiting the crate's utility.

# What changes are included in this PR?

* Added `bzip2` compression and feature flag.
* Added `xz` compression and feature flag.
* Updated header decoder to use new compression types.

# Are these changes tested?

Yes, I added new test cases covering these changes to the `test_alltypes` integration test.

# Are there any user-facing changes?

N/A