### PR TITLE
fix: view types slice should follow by correct len array

### DIFF
--- a/arrow-array/benches/view_types.rs
+++ b/arrow-array/benches/view_types.rs
@@ -42,6 +42,12 @@ fn gen_view_array_without_nulls(size: usize) -> StringViewArray {
 fn criterion_benchmark(c: &mut Criterion) {
     let array = gen_view_array(100_000);
 
+    c.bench_function("view types slice", |b| {
+        b.iter(|| {
+            black_box(array.slice(0, 100_000 / 2));
+        });
+    });
+
     c.bench_function("gc view types all[100000]", |b| {
         b.iter(|| {
             black_box(array.gc());
@@ -97,12 +103,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("gc view types slice half without nulls[8000]", |b| {
         b.iter(|| {
             black_box(sliced.gc());
-        });
-    });
-
-    c.bench_function("view types slice", |b| {
-        b.iter(|| {
-            black_box(array.slice(0, 100_000 / 2));
         });
     });
 }


### PR DESCRIPTION
# Which issue does this PR close?

Fix the bug that view types slice benchmark not using the right len after we added new benchmark.


# Rationale for this change

Fix the bug that view types slice benchmark not using the right len after we added new benchmark.

# What changes are included in this PR?

Fix the bug that view types slice benchmark not using the right len after we added new benchmark.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No