### PR TITLE
Remove redundant is_err checks

### DIFF
--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -493,7 +493,6 @@ mod tests {
             b'e',
         ];
         let err = VariantMetadata::try_new(&metadata_bytes);
-        assert!(err.is_err());
         let err = err.unwrap_err();
         assert!(matches!(
             err,
@@ -541,7 +540,6 @@ mod tests {
         ];
 
         let err = VariantObject::try_new(metadata, &object_value);
-        assert!(err.is_err());
         let err = err.unwrap_err();
         assert!(matches!(
             err,


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Address the comment https://github.com/apache/arrow-rs/pull/7885#discussion_r2195436015.

# What changes are included in this PR?

Remove redundant `is_err` checks.

# Are these changes tested?

Existing tests.

# Are there any user-facing changes?

None
