### PR TITLE
Fix current CI failure

### DIFF
--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -273,7 +273,7 @@ fn compare_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, 
                     let r = r.inner().bit_chunks().iter_padded();
                     let ne = values.bit_chunks().iter_padded();
 
-                    let c = |((l, r), n)| ((l ^ r) | (l & r & n));
+                    let c = |((l, r), n)| (l ^ r) | (l & r & n);
                     let buffer = l.zip(r).zip(ne).map(c).collect();
                     BooleanBuffer::new(buffer, 0, len).into()
                 }


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Currently the CI is failed:

https://github.com/apache/arrow-rs/actions/runs/16210835231/job/45770459574?pr=7897

```
 error: unnecessary parentheses around closure body
   --> arrow-ord/src/cmp.rs:276:43
    |
276 |                     let c = |((l, r), n)| ((l ^ r) | (l & r & n));
    |                                           ^                     ^
    |
    = note: `-D unused-parens` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_parens)]`
help: remove these parentheses
    |
276 -                     let c = |((l, r), n)| ((l ^ r) | (l & r & n));
276 +                     let c = |((l, r), n)| (l ^ r) | (l & r & n);
    |
```

# What changes are included in this PR?

Fix CI.

# Are these changes tested?

Existing test.

# Are there any user-facing changes?

No
