### PR TITLE
Convert JSON to VariantArray without copying

### DIFF
--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -21,7 +21,6 @@
 use crate::{VariantArray, VariantArrayBuilder};
 use arrow::array::{Array, ArrayRef, StringArray};
 use arrow_schema::ArrowError;
-use parquet_variant::VariantBuilder;
 use parquet_variant_json::json_to_variant;
 
 /// Parse a batch of JSON strings into a batch of Variants represented as
@@ -41,10 +40,9 @@ pub fn batch_json_string_to_variant(input: &ArrayRef) -> Result<VariantArray, Ar
             // The subfields are expected to be non-nullable according to the parquet variant spec.
             variant_array_builder.append_null();
         } else {
-            let mut vb = VariantBuilder::new();
-            json_to_variant(input_string_array.value(i), &mut vb)?;
-            let (metadata, value) = vb.finish();
-            variant_array_builder.append_variant_buffers(&metadata, &value);
+            let mut vb = variant_array_builder.variant_builder();
+            json_to_variant(input_string_array.value(i), vb.inner_mut())?;
+            vb.finish()
         }
     }
     Ok(variant_array_builder.build())

--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -17,6 +17,11 @@
 
 mod from_json;
 mod to_json;
+mod variant_array;
+mod variant_array_builder;
+
+pub use variant_array::VariantArray;
+pub use variant_array_builder::VariantArrayBuilder;
 
 pub use from_json::batch_json_string_to_variant;
 pub use to_json::batch_variant_to_json_string;

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -32,6 +32,8 @@ use std::sync::Arc;
 ///
 /// See [`VariantArrayBuilder`] for constructing a `VariantArray`.
 ///
+/// [`VariantArrayBuilder`]: crate::VariantArrayBuilder
+///
 /// # Specification
 /// 1. This code follows the conventions for storing variants in Arrow Struct Array
 ///    defined by [Extension Type for Parquet Variant arrow] and this [document].

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1,0 +1,225 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`VariantArray`] implementation
+
+use arrow::array::{Array, ArrayData, ArrayRef, AsArray, StructArray};
+use arrow::buffer::NullBuffer;
+use arrow_schema::{ArrowError, DataType};
+use parquet_variant::Variant;
+use std::any::Any;
+use std::sync::Arc;
+
+/// An array of Parquet [`Variant`] values
+///
+/// A [`VariantArray`] wraps an Arrow [`StructArray`] that stores the underlying
+/// `metadata` and `value` fields, and adds convenience methods to access
+/// the `Variant`s
+///
+/// See [`VariantArrayBuilder`] for constructing a `VariantArray`.
+///
+/// # Specification
+/// 1. This code follows the conventions for storing variants in Arrow Struct Array
+///    defined by [Extension Type for Parquet Variant arrow] and this [document].
+///    At the time of this writing, this is not yet a standardized Arrow extension type.
+///
+/// [Extension Type for Parquet Variant arrow]: https://github.com/apache/arrow/issues/46908
+/// [document]: https://docs.google.com/document/d/1pw0AWoMQY3SjD7R4LgbPvMjG_xSCtXp3rZHkVp9jpZ4/edit?usp=sharing
+#[derive(Debug)]
+pub struct VariantArray {
+    /// StructArray or up to three fields:
+    /// 1. A required field named metadata which is binary, large_binary, or binary_view
+    /// 2. An optional field named value that is binary, large_binary, or binary_view
+    /// 3. An optional field named typed_value which can be any primitive type or be a list, large_list, list_view or struct
+    ///
+    /// If typed_value is a nested type, its elements must be required and must
+    /// be a struct containing only one of the following:
+    ///
+    /// 1. A single required field, of type binary, large_binary, or binary_view named value
+    ///
+    /// 2. An optional field named value of type binary, large_binary, or
+    ///    binary_view AND an optional field named typed_value which follows these
+    ///    same rules
+    ///
+    /// NOTE: It is also permissible for the metadata field to be
+    /// Dictionary-Encoded, preferably (but not required) with an index type of
+    /// int8.
+    inner: StructArray,
+}
+
+impl VariantArray {
+    /// Creates a new `VariantArray` from a [`StructArray`].
+    ///
+    /// # Arguments
+    /// - `inner` - The underlying [`StructArray`] that contains the variant data.
+    ///
+    /// # Returns
+    /// - A new instance of `VariantArray`.
+    ///
+    /// # Errors:
+    /// If the `StructArray` does not contain the required fields
+    pub fn try_new(inner: ArrayRef) -> Result<Self, ArrowError> {
+        let Some(inner) = inner.as_struct_opt() else {
+            return Err(ArrowError::InvalidArgumentError(
+                "Invalid VariantArray: requires StructArray as input".to_string(),
+            ));
+        };
+        // Ensure the StructArray has the expected fields
+        if !inner.fields().iter().any(|f| f.name() == "metadata") {
+            return Err(ArrowError::InvalidArgumentError(
+                "Invalid VariantArray: StructArray must contain a 'metadata' field".to_string(),
+            ));
+        }
+        if !inner.fields().iter().any(|f| f.name() == "value") {
+            return Err(ArrowError::InvalidArgumentError(
+                "Invalid VariantArray: StructArray must contain a 'value' field".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            inner: inner.clone(),
+        })
+    }
+
+    /// Returns a reference to the underlying [`StructArray`].
+    pub fn inner(&self) -> &StructArray {
+        &self.inner
+    }
+
+    /// Returns the inner [`StructArray`], consuming self
+    pub fn into_inner(self) -> StructArray {
+        self.inner
+    }
+
+    /// Return the [`Variant`] instance stored at the given row
+    ///
+    /// Panics if the index is out of bounds.
+    ///
+    /// Note: Does not do deep validation of the [`Variant`], so it is up to the
+    /// caller to ensure that the metadata and value were constructed correctly.
+    pub fn value(&self, index: usize) -> Variant {
+        let metadata = self.metadata_field().as_binary_view().value(index);
+        let value = self.value_field().as_binary_view().value(index);
+        Variant::new(metadata, value)
+    }
+
+    /// Return a reference to the metadata field of the [`StructArray`]
+    pub fn metadata_field(&self) -> &ArrayRef {
+        // spec says fields order is not guaranteed, so we search by name
+        self.inner.column_by_name("metadata").unwrap()
+    }
+
+    /// Return a reference to the value field of the `StructArray`
+    pub fn value_field(&self) -> &ArrayRef {
+        // spec says fields order is not guaranteed, so we search by name
+        self.inner.column_by_name("value").unwrap()
+    }
+}
+
+impl Array for VariantArray {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn to_data(&self) -> ArrayData {
+        self.inner.to_data()
+    }
+
+    fn into_data(self) -> ArrayData {
+        self.inner.into_data()
+    }
+
+    fn data_type(&self) -> &DataType {
+        self.inner.data_type()
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> ArrayRef {
+        Arc::new(Self {
+            inner: self.inner.slice(offset, length),
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    fn offset(&self) -> usize {
+        self.inner.offset()
+    }
+
+    fn nulls(&self) -> Option<&NullBuffer> {
+        self.inner.nulls()
+    }
+
+    fn get_buffer_memory_size(&self) -> usize {
+        self.inner.get_buffer_memory_size()
+    }
+
+    fn get_array_memory_size(&self) -> usize {
+        self.inner.get_array_memory_size()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::array::BinaryViewArray;
+    use arrow_schema::{Field, Fields};
+
+    #[test]
+    fn invalid_not_a_struct_array() {
+        let array = test_array();
+        // Should fail because the input is not a StructArray
+        let err = VariantArray::try_new(array);
+        assert_eq!(
+            err.unwrap_err().to_string(),
+            "Invalid argument error: Invalid VariantArray: requires StructArray as input"
+        );
+    }
+
+    #[test]
+    fn invalid_missing_metadata() {
+        let fields = Fields::from(vec![Field::new("value", DataType::BinaryView, true)]);
+        let array = StructArray::new(fields, vec![test_array()], None);
+        // Should fail because the StructArray does not contain a 'metadata' field
+        let err = VariantArray::try_new(Arc::new(array));
+        assert_eq!(
+            err.unwrap_err().to_string(),
+            "Invalid argument error: Invalid VariantArray: StructArray must contain a 'metadata' field"
+        );
+    }
+
+    #[test]
+    fn invalid_missing_value() {
+        let fields = Fields::from(vec![Field::new("metadata", DataType::BinaryView, false)]);
+        let array = StructArray::new(fields, vec![test_array()], None);
+        // Should fail because the StructArray does not contain a 'value' field
+        let err = VariantArray::try_new(Arc::new(array));
+        assert_eq!(
+            err.unwrap_err().to_string(),
+            "Invalid argument error: Invalid VariantArray: StructArray must contain a 'value' field"
+        );
+    }
+
+    fn test_array() -> ArrayRef {
+        Arc::new(BinaryViewArray::from(vec![b"test" as &[u8]]))
+    }
+}

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`VariantArrayBuilder`] implementation
+
+use crate::VariantArray;
+use arrow::array::{ArrayRef, BinaryViewArray, BinaryViewBuilder, NullBufferBuilder, StructArray};
+use arrow_schema::{DataType, Field, Fields};
+use parquet_variant::{Variant, VariantBuilder};
+use std::sync::Arc;
+
+/// A builder for [`VariantArray`]
+///
+/// This builder is used to construct a `VariantArray` and allows APIs for
+/// adding metadata
+///
+/// This builder always creates a `VariantArray` using [`BinaryViewArray`] for both
+/// the metadata and value fields.
+///
+/// # TODO
+/// 1. Support shredding: <https://github.com/apache/arrow-rs/issues/7895>
+///
+/// ## Example:
+/// ```
+/// # use arrow::array::Array;
+/// # use parquet_variant::{Variant, VariantBuilder};
+/// # use parquet_variant_compute::VariantArrayBuilder;
+/// // Create a new VariantArrayBuilder with a capacity of 100 rows
+/// let mut builder = VariantArrayBuilder::new(100);
+/// // append variant values
+/// builder.append_variant(Variant::from(42));
+/// // append a null row
+/// builder.append_null();
+/// // append a pre-constructed metadata and value buffers
+/// let (metadata, value) = {
+///   let mut vb = VariantBuilder::new();
+///   let mut obj = vb.new_object();
+///   obj.insert("foo", "bar");
+///   obj.finish().unwrap();
+///   vb.finish()
+/// };
+/// builder.append_variant_buffers(&metadata, &value);
+///
+/// // create the final VariantArray
+/// let variant_array = builder.build();
+/// assert_eq!(variant_array.len(), 3);
+/// // // Access the values
+/// // row 1 is not null and is an integer
+/// assert!(!variant_array.is_null(0));
+/// assert_eq!(variant_array.value(0), Variant::from(42i32));
+/// // row 1 is null
+/// assert!(variant_array.is_null(1));
+/// // row 2 is not null and is an object
+/// assert!(!variant_array.is_null(2));
+/// assert!(variant_array.value(2).as_object().is_some());
+/// ```
+#[derive(Debug)]
+pub struct VariantArrayBuilder {
+    /// Nulls
+    nulls: NullBufferBuilder,
+    /// buffer for all the metadata
+    metadata_buffer: Vec<u8>,
+    /// (offset, len) pairs for locations of metadata in the buffer
+    metadata_locations: Vec<(usize, usize)>,
+    /// buffer for values
+    value_buffer: Vec<u8>,
+    /// (offset, len) pairs for locations of values in the buffer
+    value_locations: Vec<(usize, usize)>,
+    /// The fields of the final `StructArray`
+    ///
+    /// TODO: 1) Add extension type metadata
+    /// TODO: 2) Add support for shredding
+    fields: Fields,
+}
+
+impl VariantArrayBuilder {
+    pub fn new(row_capacity: usize) -> Self {
+        // The subfields are expected to be non-nullable according to the parquet variant spec.
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        Self {
+            nulls: NullBufferBuilder::new(row_capacity),
+            metadata_buffer: Vec::new(), // todo allocation capacity
+            metadata_locations: Vec::with_capacity(row_capacity),
+            value_buffer: Vec::new(),
+            value_locations: Vec::with_capacity(row_capacity),
+            fields: Fields::from(vec![metadata_field, value_field]),
+        }
+    }
+
+    /// Build the final builder
+    pub fn build(self) -> VariantArray {
+        let Self {
+            mut nulls,
+            metadata_buffer,
+            metadata_locations,
+            value_buffer,
+            value_locations,
+            fields,
+        } = self;
+
+        let metadata_array = binary_view_array_from_buffers(metadata_buffer, metadata_locations);
+
+        let value_array = binary_view_array_from_buffers(value_buffer, value_locations);
+
+        // The build the final struct array
+        let inner = StructArray::new(
+            fields,
+            vec![
+                Arc::new(metadata_array) as ArrayRef,
+                Arc::new(value_array) as ArrayRef,
+            ],
+            nulls.finish(),
+        );
+        // TODO add arrow extension type metadata
+
+        VariantArray::try_new(Arc::new(inner)).expect("valid VariantArray by construction")
+    }
+
+    /// Appends a null row to the builder.
+    pub fn append_null(&mut self) {
+        self.nulls.append_null();
+        // The subfields are expected to be non-nullable according to the parquet variant spec.
+        let metadata_offset = self.metadata_buffer.len();
+        let metadata_length = 0;
+        self.metadata_locations
+            .push((metadata_offset, metadata_length));
+        let value_offset = self.value_buffer.len();
+        let value_length = 0;
+        self.value_locations.push((value_offset, value_length));
+    }
+
+    /// Append the [`Variant`] to the builder as the next row
+    pub fn append_variant(&mut self, variant: Variant) {
+        // TODO make this more efficient by avoiding the intermediate buffers
+        let mut variant_builder = VariantBuilder::new();
+        variant_builder.append_value(variant);
+        let (metadata, value) = variant_builder.finish();
+        self.append_variant_buffers(&metadata, &value);
+    }
+
+    /// Append a metadata and values buffer to the builder
+    pub fn append_variant_buffers(&mut self, metadata: &[u8], value: &[u8]) {
+        self.nulls.append_non_null();
+        let metadata_length = metadata.len();
+        let metadata_offset = self.metadata_buffer.len();
+        self.metadata_locations
+            .push((metadata_offset, metadata_length));
+        self.metadata_buffer.extend_from_slice(metadata);
+        let value_length = value.len();
+        let value_offset = self.value_buffer.len();
+        self.value_locations.push((value_offset, value_length));
+        self.value_buffer.extend_from_slice(value);
+    }
+
+    // TODO: Return a Variant builder that will write to the underlying buffers (TODO)
+}
+
+fn binary_view_array_from_buffers(
+    buffer: Vec<u8>,
+    locations: Vec<(usize, usize)>,
+) -> BinaryViewArray {
+    let mut builder = BinaryViewBuilder::with_capacity(locations.len());
+    let block = builder.append_block(buffer.into());
+    // TODO this can be much faster if it creates the views directly during append
+    for (offset, length) in locations {
+        let offset = offset.try_into().expect("offset should fit in u32");
+        let length = length.try_into().expect("length should fit in u32");
+        builder
+            .try_append_view(block, offset, length)
+            .expect("Failed to append view");
+    }
+    builder.finish()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::array::Array;
+
+    /// Test that both the metadata and value buffers are non nullable
+    #[test]
+    fn test_variant_array_builder_non_nullable() {
+        let mut builder = VariantArrayBuilder::new(10);
+        builder.append_null(); // should not panic
+        builder.append_variant(Variant::from(42i32));
+        let variant_array = builder.build();
+
+        assert_eq!(variant_array.len(), 2);
+        assert!(variant_array.is_null(0));
+        assert!(!variant_array.is_null(1));
+        assert_eq!(variant_array.value(1), Variant::from(42i32));
+
+        // the metadata and value fields of non shredded variants should not be null
+        assert!(variant_array.metadata_field().nulls().is_none());
+        assert!(variant_array.value_field().nulls().is_none());
+        let DataType::Struct(fields) = variant_array.data_type() else {
+            panic!("Expected VariantArray to have Struct data type");
+        };
+        for field in fields {
+            assert!(
+                !field.is_nullable(),
+                "Field {} should be non-nullable",
+                field.name()
+            );
+        }
+    }
+}

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -147,11 +147,9 @@ impl VariantArrayBuilder {
 
     /// Append the [`Variant`] to the builder as the next row
     pub fn append_variant(&mut self, variant: Variant) {
-        // TODO make this more efficient by avoiding the intermediate buffers
-        let mut variant_builder = VariantBuilder::new();
-        variant_builder.append_value(variant);
-        let (metadata, value) = variant_builder.finish();
-        self.append_variant_buffers(&metadata, &value);
+        let mut direct_builder = self.variant_builder();
+        direct_builder.variant_builder.append_value(variant);
+        direct_builder.finish()
     }
 
     /// Append a metadata and values buffer to the builder
@@ -168,7 +166,105 @@ impl VariantArrayBuilder {
         self.value_buffer.extend_from_slice(value);
     }
 
-    // TODO: Return a Variant builder that will write to the underlying buffers (TODO)
+    /// Return a DirectVariantBuilder that writes directly to the buffers of this builder.
+    pub fn variant_builder(&mut self) -> DirectVariantBuilder {
+        // append directly into the metadata and value buffers
+        let metadata_buffer = std::mem::take(&mut self.metadata_buffer);
+        let value_buffer = std::mem::take(&mut self.value_buffer);
+        let metadata_offset = metadata_buffer.len();
+        let value_offset = value_buffer.len();
+        DirectVariantBuilder {
+            finished: false,
+            metadata_offset,
+            value_offset,
+            variant_builder: VariantBuilder::new_with_buffers(metadata_buffer, value_buffer),
+            array_builder: self,
+        }
+    }
+}
+
+/// A `VariantBuilder` that writes directly to the buffers of a `VariantArrayBuilder`.
+///
+/// See [`VariantArray::variant_builder`] for an example
+pub struct DirectVariantBuilder<'a> {
+    /// was finish called?
+    finished: bool,
+    /// starting metadata offset
+    metadata_offset: usize,
+    /// starting value offset
+    value_offset: usize,
+    array_builder: &'a mut VariantArrayBuilder,
+    variant_builder: VariantBuilder,
+}
+
+impl DirectVariantBuilder<'_> {
+    /// Return a reference to the underlying `VariantBuilder`
+    pub fn inner(&self) -> &VariantBuilder {
+        &self.variant_builder
+    }
+
+    /// Return a mutable reference to the underlying `VariantBuilder`
+    pub fn inner_mut(&mut self) -> &mut VariantBuilder {
+        &mut self.variant_builder
+    }
+
+    /// Called to finalize the variant and write it to the underlying buffers
+    ///
+    /// Note if you do not call finish, the struct will be reset and the buffers
+    /// will not be updated.
+    ///
+    pub fn finish(mut self) {
+        let metadata_offset = self.metadata_offset;
+        let value_offset = self.value_offset;
+
+        // get the buffers back
+        let (metadata_buffer, value_buffer) = std::mem::take(&mut self.variant_builder).finish();
+        let metadata_len = metadata_buffer
+            .len()
+            .checked_sub(metadata_offset)
+            .expect("metadata length decreased unexpectedly");
+        let value_len = value_buffer
+            .len()
+            .checked_sub(value_offset)
+            .expect("value length decreased unexpectedly");
+
+        // put the buffers back
+        self.array_builder.metadata_buffer = metadata_buffer;
+        self.array_builder.value_buffer = value_buffer;
+
+        // Append offsets and lengths for new nulls into the array builder
+        self.array_builder
+            .metadata_locations
+            .push((metadata_offset, metadata_len));
+        self.array_builder
+            .value_locations
+            .push((value_offset, value_len));
+        self.array_builder.nulls.append_non_null();
+        self.finished = true;
+    }
+}
+
+impl<'a> Drop for DirectVariantBuilder<'a> {
+    fn drop(&mut self) {
+        if self.finished {
+            // if the object was finished, we do not need to do anything
+            return;
+        }
+        // if the object was not finished, we need to reset any partial state put the buffers back
+        println!("DirectVariantBuilder::drop");
+        let variant_builder = std::mem::take(&mut self.variant_builder);
+        let (mut metadata_buffer, mut value_buffer) = variant_builder.finish();
+        assert!(
+            metadata_buffer.len() >= self.metadata_offset,
+            "metadata got smaller"
+        );
+        assert!(value_buffer.len() >= self.value_offset, "value got smaller");
+        metadata_buffer.truncate(self.metadata_offset);
+        value_buffer.truncate(self.value_offset);
+        // put the buffers back
+        self.array_builder.metadata_buffer = metadata_buffer;
+        self.array_builder.value_buffer = value_buffer;
+    }
 }
 
 fn binary_view_array_from_buffers(


### PR DESCRIPTION
Draft as it Builds on https://github.com/apache/arrow-rs/pull/7905

# Which issue does this PR close?


- Follow on to https://github.com/apache/arrow-rs/pull/7905

# Rationale for this change

In a quest to have the fastest and most efficient Variant implementation I would like to avoid copies if at all possible
Right now, to make a VariantArray first requires completing an individual buffer and appending it
to the array.

Let's make that faster by having the VariantBuilder append directly into the buffer


# What changes are included in this PR?

1. Add `VariantBuilder::new_from_existing`
2. Add a `VariantArrayBuilder::variant_builder` that reuses the buffers

TODO: 
- [ ] Tests for internal builder (both with and without calling `drop`)
- [ ] Doc examples
- [ ] Performance tests


# Are these changes tested?

1. New unit tests 
1. Yes by existing tests

# Are there any user-facing changes?

Hopefully faster performance