### PR TITLE
[Variant] Add `VariantBuilder::new_with_buffers` to write to existing buffers

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -600,7 +600,7 @@ impl ParentState<'_> {
 /// ```
 /// # Example: Reusing Buffers
 ///
-/// You can use the [`VariantBuffer`] to write into existing buffers (for
+/// You can use the [`VariantBuilder`] to write into existing buffers (for
 /// example to write multiple variants back to back in the same buffer)
 ///
 /// ```


### PR DESCRIPTION
# Which issue does this PR close?

- closes https://github.com/apache/arrow-rs/issues/7805
- part of https://github.com/apache/arrow-rs/issues/6736
- part of https://github.com/apache/arrow-rs/pull/7911

# Rationale for this change

I would like to be able to write Variants directly into the target buffer when writing multiple variants However, the current VariantBuilder allocates a new bufffer for each variant

# What changes are included in this PR?

1. Add `VariantBuilder::new_with_buffers` and docs and tests

You can see how this API can be used to write directly into a buffer in VariantArrayBuilder in this PR:
- https://github.com/apache/arrow-rs/pull/7911

# Are these changes tested?
Yes new tests

# Are there any user-facing changes?
New API