### PR TITLE
Restructure compare_greater function used in parquet statistics for better performance

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1395,49 +1395,42 @@ fn update_stat<T: ParquetValueType, F>(
 
 /// Evaluate `a > b` according to underlying logical type.
 fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) -> bool {
-    if let Some(LogicalType::Integer { is_signed, .. }) = descr.logical_type() {
-        if !is_signed {
-            // need to compare unsigned
-            return a.as_u64().unwrap() > b.as_u64().unwrap();
-        }
-    }
+    match T::PHYSICAL_TYPE {
+        Type::INT32 | Type::INT64 => {
+            if let Some(LogicalType::Integer {
+                is_signed: false, ..
+            }) = descr.logical_type()
+            {
+                // need to compare unsigned
+                return compare_greater_unsigned_int(a, b);
+            }
 
-    match descr.converted_type() {
-        ConvertedType::UINT_8
-        | ConvertedType::UINT_16
-        | ConvertedType::UINT_32
-        | ConvertedType::UINT_64 => {
-            return a.as_u64().unwrap() > b.as_u64().unwrap();
+            match descr.converted_type() {
+                ConvertedType::UINT_8
+                | ConvertedType::UINT_16
+                | ConvertedType::UINT_32
+                | ConvertedType::UINT_64 => {
+                    return compare_greater_unsigned_int(a, b);
+                }
+                _ => {}
+            };
         }
+        Type::FIXED_LEN_BYTE_ARRAY | Type::BYTE_ARRAY => {
+            if let Some(LogicalType::Decimal { .. }) = descr.logical_type() {
+                return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
+            }
+            if let ConvertedType::DECIMAL = descr.converted_type() {
+                return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
+            }
+            if let Some(LogicalType::Float16) = descr.logical_type() {
+                return compare_greater_f16(a.as_bytes(), b.as_bytes());
+            }
+        }
+
         _ => {}
-    };
-
-    if let Some(LogicalType::Decimal { .. }) = descr.logical_type() {
-        match T::PHYSICAL_TYPE {
-            Type::FIXED_LEN_BYTE_ARRAY | Type::BYTE_ARRAY => {
-                return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
-            }
-            _ => {}
-        };
     }
 
-    if descr.converted_type() == ConvertedType::DECIMAL {
-        match T::PHYSICAL_TYPE {
-            Type::FIXED_LEN_BYTE_ARRAY | Type::BYTE_ARRAY => {
-                return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
-            }
-            _ => {}
-        };
-    };
-
-    if let Some(LogicalType::Float16) = descr.logical_type() {
-        let a = a.as_bytes();
-        let a = f16::from_le_bytes([a[0], a[1]]);
-        let b = b.as_bytes();
-        let b = f16::from_le_bytes([b[0], b[1]]);
-        return a > b;
-    }
-
+    // compare independent of logical / converted type
     a > b
 }
 
@@ -1469,6 +1462,18 @@ fn has_dictionary_support(kind: Type, props: &WriterProperties) -> bool {
         (Type::FIXED_LEN_BYTE_ARRAY, WriterVersion::PARQUET_2_0) => true,
         _ => true,
     }
+}
+
+#[inline]
+fn compare_greater_unsigned_int<T: ParquetValueType>(a: &T, b: &T) -> bool {
+    a.as_u64().unwrap() > b.as_u64().unwrap()
+}
+
+#[inline]
+fn compare_greater_f16(a: &[u8], b: &[u8]) -> bool {
+    let a = f16::from_le_bytes(a.try_into().unwrap());
+    let b = f16::from_le_bytes(b.try_into().unwrap());
+    a > b
 }
 
 /// Signed comparison of bytes arrays


### PR DESCRIPTION
# Which issue does this PR close?

Another small optimization to parquet writing, followup to #7822 (I can create a separate issue if needed).

# Rationale for this change

Improves the performance in the microbenchmark for writing primitive types by around 6%:

```
write_batch primitive/4096 values primitive
                        time:   [437.72 µs 439.91 µs 442.40 µs]
                        thrpt:  [397.68 MiB/s 399.93 MiB/s 401.93 MiB/s]
                 change:
                        time:   [-6.7582% -6.2865% -5.7391%] (p = 0.00 < 0.05)
                        thrpt:  [+6.0885% +6.7082% +7.2480%]
                        Performance has improved.
write_batch primitive/4096 values primitive non-null
                        time:   [358.86 µs 359.39 µs 359.98 µs]
                        thrpt:  [479.24 MiB/s 480.03 MiB/s 480.74 MiB/s]
                 change:
                        time:   [-6.7127% -6.4322% -6.1675%] (p = 0.00 < 0.05)
                        thrpt:  [+6.5729% +6.8744% +7.1957%]
                        Performance has improved.
```

# What changes are included in this PR?

This restructures the code in `compare_greater` to check the generic type parameter first, and also for all special cases. The main difference, and what seems to enable llvm to generate better code, is probably that the `as_u64` is only called for types where the implementation is actually infallible.

I looked into also specializing the `get_min_max` function by moving the logical type checks outside of the loop, but that did not bring any further measurable improvement.

# Are these changes tested?

Should already be covered by existing unit tests.

# Are there any user-facing changes?

No, as far as I'm aware, the logical types for unsigned integers should only ever be used for the INT32 and INT64 physical types. The previous code would have failed at runtime in `as_u64` if that would not be the case.