### PR TITLE
[Parquet] Use `u64` for `SerializedPageReaderState.offset` & `remaining_bytes`, instead of `usize`

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -469,9 +469,11 @@ pub(crate) fn decode_page(
 enum SerializedPageReaderState {
     Values {
         /// The current byte offset in the reader
+        /// Note that offset is u64 (i.e., not usize) to support 32-bit architectures such as WASM
         offset: u64,
 
         /// The length of the chunk in bytes
+        /// Note that remaining_bytes is u64 (i.e., not usize) to support 32-bit architectures such as WASM
         remaining_bytes: u64,
 
         // If the next page header has already been "peeked", we will cache it and it`s length here


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7910

# Rationale for this change

There is a copy from my issue page:
https://github.com/apache/arrow-rs/blob/2be261b78b16a4aa7b5b9aece648bec663c0dbf1/parquet/src/file/serialized_reader.rs#L471-L472
> My concern is about the type of offset in SerializedPageReaderState. Should it be u64 instead of usize? If I understand correctly, this offset represents a global position within a Parquet file, which can easily exceed 4 GB. On 32-bit environments (e.g., WebAssembly), usize is limited to u32's max, which could lead to problems with larger files.

# What changes are included in this PR?

This PR does type changes only for  `SerializedPageReaderState.offset` & `remaining_bytes`

# Are these changes tested?

I can pass with local unit tests via `cargo test -p parquet`

# Are there any user-facing changes?

No
