### PR TITLE
[Variant] Define shredding schema for `VariantArrayBuilder`

### DIFF
--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -21,7 +21,6 @@
 use crate::{VariantArray, VariantArrayBuilder};
 use arrow::array::{Array, ArrayRef, StringArray};
 use arrow_schema::{ArrowError, DataType, Field, Fields};
-use parquet_variant::VariantBuilder;
 use parquet_variant_json::json_to_variant;
 
 /// Parse a batch of JSON strings into a batch of Variants represented as
@@ -78,7 +77,7 @@ mod test {
         let variant_array = batch_json_string_to_variant(&array_ref).unwrap();
 
         let metadata_array = variant_array.metadata_field().as_binary_view();
-        let value_array = variant_array.value_field().as_binary_view();
+        let value_array = variant_array.value_field().unwrap().as_binary_view();
 
         // Compare row 0
         assert!(!variant_array.is_null(0));

--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 mod from_json;
+mod shredding;
 mod to_json;
 mod variant_array;
 mod variant_array_builder;

--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 mod from_json;
-mod shredding;
+pub mod shredding;
 mod to_json;
 mod variant_array;
 mod variant_array_builder;

--- a/parquet-variant-compute/src/shredding.rs
+++ b/parquet-variant-compute/src/shredding.rs
@@ -1,0 +1,350 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_schema::{ArrowError, DataType, FieldRef, Fields};
+
+// Keywords defined by the shredding spec
+pub const METADATA: &str = "metadata";
+pub const VALUE: &str = "value";
+pub const TYPED_VALUE: &str = "typed_value";
+
+#[derive(Debug)]
+pub struct VariantSchema {
+    metadata_ref: FieldRef,
+    typed_value_ref: Option<FieldRef>,
+    value_ref: Option<FieldRef>,
+}
+
+impl VariantSchema {
+    pub fn try_new(fields: Fields) -> Result<Self, ArrowError> {
+        todo!()
+    }
+}
+
+pub fn validate_value_and_typed_value(
+    fields: &Fields,
+    allow_both_null: bool,
+) -> Result<(), ArrowError> {
+    let value_field_res = fields.iter().find(|f| f.name() == VALUE);
+    let typed_value_field_res = fields.iter().find(|f| f.name() == TYPED_VALUE);
+
+    if !allow_both_null {
+        if let (None, None) = (value_field_res, typed_value_field_res) {
+            return Err(ArrowError::InvalidArgumentError(
+                "Invalid VariantArray: StructArray must contain either `value` or `typed_value` fields or both.".to_string()
+            ));
+        }
+    }
+
+    if let Some(value_field) = value_field_res {
+        if value_field.data_type() != &DataType::BinaryView {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "VariantArray 'value' field must be BinaryView, got {}",
+                value_field.data_type()
+            )));
+        }
+    }
+
+    if let Some(typed_value_field) = fields.iter().find(|f| f.name() == TYPED_VALUE) {
+        // this is directly mapped from the spec's parquet physical types
+        // note, there are more data types we can support
+        // but for the sake of simplicity, I chose the smallest subset
+        match typed_value_field.data_type() {
+            DataType::Boolean
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::BinaryView => {}
+            DataType::Union(union_fields, _) => {
+                union_fields
+                    .iter()
+                    .map(|(_, f)| f.clone())
+                    .try_for_each(|f| {
+                        let DataType::Struct(fields) = f.data_type().clone() else {
+                            return Err(ArrowError::InvalidArgumentError(
+                                "Expected struct".to_string(),
+                            ));
+                        };
+
+                        validate_value_and_typed_value(&fields, false)
+                    })?;
+            }
+
+            foreign => {
+                return Err(ArrowError::NotYetImplemented(format!(
+                    "Unsupported VariantArray 'typed_value' field, got {foreign}"
+                )))
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates that the provided [`Fields`] conform to the Variant shredding specification.
+///
+/// # Requirements
+/// - Must contain a "metadata" field of type BinaryView
+/// - Must contain at least one of "value" (optional BinaryView) or "typed_value" (optional with valid Parquet type)
+/// - Both "value" and "typed_value" can only be null simultaneously for shredded object fields
+pub fn validate_shredded_schema(fields: &Fields) -> Result<(), ArrowError> {
+    let metadata_field = fields
+        .iter()
+        .find(|f| f.name() == METADATA)
+        .ok_or_else(|| {
+            ArrowError::InvalidArgumentError(
+                "Invalid VariantArray: StructArray must contain a 'metadata' field".to_string(),
+            )
+        })?;
+
+    if metadata_field.is_nullable() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Invalid VariantArray: metadata field can not be nullable".to_string(),
+        ));
+    }
+
+    if metadata_field.data_type() != &DataType::BinaryView {
+        return Err(ArrowError::NotYetImplemented(format!(
+            "VariantArray 'metadata' field must be BinaryView, got {}",
+            metadata_field.data_type()
+        )));
+    }
+
+    validate_value_and_typed_value(fields, false)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_schema::{Field, UnionFields, UnionMode};
+
+    #[test]
+    fn test_regular_variant_schema() {
+        // a regular variant schema
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let schema = Fields::from(vec![metadata_field, value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_regular_variant_schema_order_agnostic() {
+        // a regular variant schema
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let schema = Fields::from(vec![value_field, metadata_field]); // note the order switch
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_regular_variant_schema_allow_other_columns() {
+        // a regular variant schema
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let trace_field = Field::new("trace_id", DataType::Utf8View, false);
+        let created_at_field = Field::new("created_at", DataType::Date64, false);
+
+        let schema = Fields::from(vec![
+            metadata_field,
+            trace_field,
+            created_at_field,
+            value_field,
+        ]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_regular_variant_schema_missing_metadata() {
+        let value_field = Field::new("value", DataType::BinaryView, false);
+        let schema = Fields::from(vec![value_field]);
+
+        let err = validate_shredded_schema(&schema).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument error: Invalid VariantArray: StructArray must contain a 'metadata' field"
+        );
+    }
+
+    #[test]
+    fn test_regular_variant_schema_nullable_metadata() {
+        let metadata_field = Field::new("metadata", DataType::BinaryView, true);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let schema = Fields::from(vec![metadata_field, value_field]);
+
+        let err = validate_shredded_schema(&schema).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument error: Invalid VariantArray: metadata field can not be nullable"
+        );
+    }
+
+    #[test]
+    fn test_regular_variant_schema_allow_nullable_value() {
+        // a regular variant schema
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, true);
+
+        let schema = Fields::from(vec![metadata_field, value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_shredded_variant_schema() {
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let typed_value_field = Field::new("typed_value", DataType::Int64, false);
+        let schema = Fields::from(vec![metadata_field, typed_value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_partially_shredded_variant_schema() {
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+        let typed_value_field = Field::new("typed_value", DataType::Int64, false);
+        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_partially_shredded_variant_list_schema() {
+        /*
+        optional group tags (VARIANT) {
+            required binary metadata;
+            optional binary value;
+            optional group typed_value (LIST) {   # must be optional to allow a null list
+                repeated group list {
+                    required group element {          # shredded element
+                        optional binary value;
+                        optional binary typed_value (STRING);
+                    }
+                    required group element {          # shredded element
+                        optional binary value;
+                        optional int64 typed_value ;
+                    }
+                }
+            }
+        }
+        */
+
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        // Define union fields for different element types
+        let string_element = {
+            let value_field = Field::new("value", DataType::BinaryView, true);
+            let typed_value = Field::new("typed_value", DataType::BinaryView, true);
+            DataType::Struct(Fields::from(vec![value_field, typed_value]))
+        };
+
+        let int_element = {
+            let value_field = Field::new("value", DataType::BinaryView, true);
+            let typed_value = Field::new("typed_value", DataType::Int64, true);
+            DataType::Struct(Fields::from(vec![value_field, typed_value]))
+        };
+
+        // Create union of different element types
+        let union_fields = UnionFields::new(
+            vec![0, 1],
+            vec![
+                Field::new("string_element", string_element, true),
+                Field::new("int_element", int_element, true),
+            ],
+        );
+
+        let typed_value_field = Field::new(
+            "typed_value",
+            DataType::Union(union_fields, UnionMode::Sparse),
+            false,
+        );
+        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+
+    #[test]
+    fn test_partially_shredded_variant_object_schema() {
+        /*
+        optional group event (VARIANT) {
+            required binary metadata;
+            optional binary value;                # a variant, expected to be an object
+            optional group typed_value {          # shredded fields for the variant object
+                required group event_type {         # shredded field for event_type
+                    optional binary value;
+                    optional binary typed_value (STRING);
+                }
+                required group event_ts {           # shredded field for event_ts
+                    optional binary value;
+                    optional int64 typed_value (TIMESTAMP(true, MICROS));
+                }
+            }
+        }
+        */
+
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        // event_type
+        let element_group_1 = {
+            let value_field = Field::new("value", DataType::BinaryView, false);
+            let typed_value = Field::new("typed_value", DataType::BinaryView, false); // this is the string case
+
+            Fields::from(vec![value_field, typed_value])
+        };
+
+        // event_ts
+        let element_group_2 = {
+            let value_field = Field::new("value", DataType::BinaryView, false);
+            let typed_value = Field::new("typed_value", DataType::Int64, false);
+
+            Fields::from(vec![value_field, typed_value])
+        };
+
+        let typed_value_field = Field::new(
+            "typed_value",
+            DataType::Union(
+                UnionFields::new(
+                    vec![0, 1],
+                    vec![
+                        Field::new("event_type", DataType::Struct(element_group_1), true),
+                        Field::new("event_ts", DataType::Struct(element_group_2), true),
+                    ],
+                ),
+                UnionMode::Sparse,
+            ),
+            false,
+        );
+        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
+
+        validate_shredded_schema(&schema).unwrap();
+    }
+}

--- a/parquet-variant-compute/src/shredding.rs
+++ b/parquet-variant-compute/src/shredding.rs
@@ -22,159 +22,219 @@ pub const METADATA: &str = "metadata";
 pub const VALUE: &str = "value";
 pub const TYPED_VALUE: &str = "typed_value";
 
+#[derive(Debug, PartialEq)]
+pub enum ValueSchema {
+    MissingValue,
+    Value(usize),
+    ShreddedValue(usize),
+    PartiallyShredded {
+        value_idx: usize,
+        shredded_value_idx: usize,
+    },
+}
+
 #[derive(Debug)]
 pub struct VariantSchema {
-    metadata_ref: FieldRef,
-    typed_value_ref: Option<FieldRef>,
-    value_ref: Option<FieldRef>,
+    inner: Fields,
+
+    metadata_idx: usize,
+
+    // these indicies are for the top-level most `value` and `typed_value` columns
+    value_schema: ValueSchema,
 }
 
 impl VariantSchema {
-    pub fn try_new(fields: Fields) -> Result<Self, ArrowError> {
-        todo!()
-    }
-}
+    /// find column metadata and ensure
+    /// returns the column index
+    /// # Requirements
+    /// - Must contain a "metadata" field of type BinaryView
+    /// - Must contain at least one of "value" (optional BinaryView) or "typed_value" (optional with valid Parquet type)
+    /// - Both "value" and "typed_value" can only be null simultaneously for shredded object fields
+    fn validate_metadata(fields: &Fields) -> Result<usize, ArrowError> {
+        let (metadata_idx, metadata_field) = fields
+            .iter()
+            .enumerate()
+            .find(|(i, f)| f.name() == METADATA)
+            .ok_or_else(|| {
+                ArrowError::InvalidArgumentError(
+                    "Invalid VariantArray: StructArray must contain a 'metadata' field".to_string(),
+                )
+            })?;
 
-pub fn validate_value_and_typed_value(
-    fields: &Fields,
-    allow_both_null: bool,
-) -> Result<(), ArrowError> {
-    let value_field_res = fields.iter().find(|f| f.name() == VALUE);
-    let typed_value_field_res = fields.iter().find(|f| f.name() == TYPED_VALUE);
-
-    if !allow_both_null {
-        if let (None, None) = (value_field_res, typed_value_field_res) {
+        if metadata_field.is_nullable() {
             return Err(ArrowError::InvalidArgumentError(
-                "Invalid VariantArray: StructArray must contain either `value` or `typed_value` fields or both.".to_string()
+                "Invalid VariantArray: metadata field can not be nullable".to_string(),
             ));
         }
-    }
 
-    if let Some(value_field) = value_field_res {
-        if value_field.data_type() != &DataType::BinaryView {
+        if metadata_field.data_type() != &DataType::BinaryView {
             return Err(ArrowError::NotYetImplemented(format!(
-                "VariantArray 'value' field must be BinaryView, got {}",
-                value_field.data_type()
+                "VariantArray 'metadata' field must be BinaryView, got {}",
+                metadata_field.data_type()
             )));
         }
+
+        Ok(metadata_idx)
     }
 
-    if let Some(typed_value_field) = fields.iter().find(|f| f.name() == TYPED_VALUE) {
-        // this is directly mapped from the spec's parquet physical types
-        // note, there are more data types we can support
-        // but for the sake of simplicity, I chose the smallest subset
-        match typed_value_field.data_type() {
-            DataType::Boolean
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::BinaryView => {}
-            DataType::Union(union_fields, _) => {
-                union_fields
-                    .iter()
-                    .map(|(_, f)| f.clone())
-                    .try_for_each(|f| {
-                        let DataType::Struct(fields) = f.data_type().clone() else {
-                            return Err(ArrowError::InvalidArgumentError(
-                                "Expected struct".to_string(),
-                            ));
-                        };
+    /// Both `value` and `typed_value` are optional fields used together to encode a single value.
+    ///
+    /// Values in the two fields must be interpreted according to the following table:
+    ///
+    /// | `value`  | `typed_value` | Meaning                                                     |
+    /// |----------|---------------|-------------------------------------------------------------|
+    /// | null     | null          | The value is missing; only valid for shredded object fields |
+    /// | non-null | null          | The value is present and may be any type, including null    |
+    /// | null     | non-null      | The value is present and is the shredded type               |
+    /// | non-null | non-null      | The value is present and is a partially shredded object     |
+    fn validate_value_and_typed_value(
+        fields: &Fields,
+        inside_shredded_object: bool,
+    ) -> Result<ValueSchema, ArrowError> {
+        let value_field_res = fields.iter().enumerate().find(|(_, f)| f.name() == VALUE);
+        let typed_value_field_res = fields
+            .iter()
+            .enumerate()
+            .find(|(_, f)| f.name() == TYPED_VALUE);
 
-                        validate_value_and_typed_value(&fields, false)
-                    })?;
-            }
-
-            foreign => {
+        // validate types
+        if let Some((_, value_field)) = value_field_res {
+            if value_field.data_type() != &DataType::BinaryView {
                 return Err(ArrowError::NotYetImplemented(format!(
-                    "Unsupported VariantArray 'typed_value' field, got {foreign}"
-                )))
+                    "VariantArray 'value' field must be BinaryView, got {}",
+                    value_field.data_type()
+                )));
+            }
+        }
+
+        if let Some((_, typed_value_field)) = typed_value_field_res {
+            match typed_value_field.data_type() {
+                DataType::Boolean
+                | DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Decimal32(_, _)
+                | DataType::Decimal64(_, _)
+                | DataType::Decimal128(_, _)
+                | DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
+                | DataType::Utf8View
+                | DataType::BinaryView
+                | DataType::ListView(_)
+                | DataType::Struct(_) => {}
+                foreign => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Unsupported VariantArray 'typed_value' field, got {foreign}"
+                    )))
+                }
+            }
+        }
+
+        match (value_field_res, typed_value_field_res) {
+            (None, None) => {
+                if inside_shredded_object {
+                    return Ok(ValueSchema::MissingValue);
+                }
+
+                Err(ArrowError::InvalidArgumentError("Invalid VariantArray: StructArray must contain either `value` or `typed_value` fields or both.".to_string()))
+            }
+            (Some(value_field), None) => Ok(ValueSchema::Value(value_field.0)),
+            (None, Some(shredded_field)) => Ok(ValueSchema::ShreddedValue(shredded_field.0)),
+            (Some(_value_field), Some(_shredded_field)) => {
+                todo!("how does a shredded value look like?");
+                // ideally here, i would unpack the shredded_field
+                // and recursively call validate_value_and_typed_value with inside_shredded_object set to true
             }
         }
     }
 
-    Ok(())
-}
+    pub fn try_new(fields: Fields) -> Result<Self, ArrowError> {
+        let metadata_idx = Self::validate_metadata(&fields)?;
+        let value_schema = Self::validate_value_and_typed_value(&fields, false)?;
 
-/// Validates that the provided [`Fields`] conform to the Variant shredding specification.
-///
-/// # Requirements
-/// - Must contain a "metadata" field of type BinaryView
-/// - Must contain at least one of "value" (optional BinaryView) or "typed_value" (optional with valid Parquet type)
-/// - Both "value" and "typed_value" can only be null simultaneously for shredded object fields
-pub fn validate_shredded_schema(fields: &Fields) -> Result<(), ArrowError> {
-    let metadata_field = fields
-        .iter()
-        .find(|f| f.name() == METADATA)
-        .ok_or_else(|| {
-            ArrowError::InvalidArgumentError(
-                "Invalid VariantArray: StructArray must contain a 'metadata' field".to_string(),
-            )
-        })?;
-
-    if metadata_field.is_nullable() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Invalid VariantArray: metadata field can not be nullable".to_string(),
-        ));
+        Ok(Self {
+            inner: fields.clone(),
+            metadata_idx,
+            value_schema,
+        })
     }
 
-    if metadata_field.data_type() != &DataType::BinaryView {
-        return Err(ArrowError::NotYetImplemented(format!(
-            "VariantArray 'metadata' field must be BinaryView, got {}",
-            metadata_field.data_type()
-        )));
+    pub fn inner(self) -> Fields {
+        self.inner
     }
 
-    validate_value_and_typed_value(fields, false)?;
+    pub fn metadata(&self) -> &FieldRef {
+        self.inner.get(self.metadata_idx).unwrap()
+    }
 
-    Ok(())
+    pub fn value(&self) -> Option<&FieldRef> {
+        match self.value_schema {
+            ValueSchema::MissingValue => None,
+            ValueSchema::ShreddedValue(_) => None,
+            ValueSchema::Value(value_idx) => self.inner.get(value_idx),
+            ValueSchema::PartiallyShredded { value_idx, .. } => self.inner.get(value_idx),
+        }
+    }
+
+    pub fn shredded_value(&self) -> Option<&FieldRef> {
+        match self.value_schema {
+            ValueSchema::MissingValue => None,
+            ValueSchema::Value(_) => None,
+            ValueSchema::ShreddedValue(shredded_idx) => self.inner.get(shredded_idx),
+            ValueSchema::PartiallyShredded {
+                shredded_value_idx, ..
+            } => self.inner.get(shredded_value_idx),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use arrow_schema::{Field, UnionFields, UnionMode};
+    use arrow_schema::Field;
 
     #[test]
-    fn test_regular_variant_schema() {
+    fn test_unshredded_variant_schema() {
         // a regular variant schema
         let metadata_field = Field::new("metadata", DataType::BinaryView, false);
         let value_field = Field::new("value", DataType::BinaryView, false);
 
-        let schema = Fields::from(vec![metadata_field, value_field]);
+        let fields = Fields::from(vec![metadata_field, value_field]);
+        let variant_schema = VariantSchema::try_new(fields).unwrap();
 
-        validate_shredded_schema(&schema).unwrap();
+        assert_eq!(variant_schema.metadata_idx, 0);
+        assert_eq!(variant_schema.value_schema, ValueSchema::Value(1));
     }
 
     #[test]
-    fn test_regular_variant_schema_order_agnostic() {
-        // a regular variant schema
+    fn test_unshredded_variant_schema_order_agnostic() {
         let metadata_field = Field::new("metadata", DataType::BinaryView, false);
         let value_field = Field::new("value", DataType::BinaryView, false);
 
-        let schema = Fields::from(vec![value_field, metadata_field]); // note the order switch
+        let fields = Fields::from(vec![value_field, metadata_field]); // note the order switch
+        let variant_schema = VariantSchema::try_new(fields).unwrap();
 
-        validate_shredded_schema(&schema).unwrap();
+        assert_eq!(variant_schema.value_schema, ValueSchema::Value(0));
+        assert_eq!(variant_schema.metadata_idx, 1);
     }
 
     #[test]
-    fn test_regular_variant_schema_allow_other_columns() {
-        // a regular variant schema
+    fn test_shredded_variant_schema() {
         let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let value_field = Field::new("value", DataType::BinaryView, false);
+        let shredded_field = Field::new("typed_value", DataType::Int8, true);
 
-        let trace_field = Field::new("trace_id", DataType::Utf8View, false);
-        let created_at_field = Field::new("created_at", DataType::Date64, false);
+        let fields = Fields::from(vec![metadata_field, shredded_field]);
+        let variant_schema = VariantSchema::try_new(fields).unwrap();
 
-        let schema = Fields::from(vec![
-            metadata_field,
-            trace_field,
-            created_at_field,
-            value_field,
-        ]);
-
-        validate_shredded_schema(&schema).unwrap();
+        assert_eq!(variant_schema.metadata_idx, 0);
+        assert_eq!(variant_schema.value_schema, ValueSchema::ShreddedValue(1));
     }
 
     #[test]
@@ -182,7 +242,7 @@ mod tests {
         let value_field = Field::new("value", DataType::BinaryView, false);
         let schema = Fields::from(vec![value_field]);
 
-        let err = validate_shredded_schema(&schema).unwrap_err();
+        let err = VariantSchema::try_new(schema).unwrap_err();
 
         assert_eq!(
             err.to_string(),
@@ -197,154 +257,11 @@ mod tests {
 
         let schema = Fields::from(vec![metadata_field, value_field]);
 
-        let err = validate_shredded_schema(&schema).unwrap_err();
+        let err = VariantSchema::try_new(schema).unwrap_err();
 
         assert_eq!(
             err.to_string(),
             "Invalid argument error: Invalid VariantArray: metadata field can not be nullable"
         );
-    }
-
-    #[test]
-    fn test_regular_variant_schema_allow_nullable_value() {
-        // a regular variant schema
-        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let value_field = Field::new("value", DataType::BinaryView, true);
-
-        let schema = Fields::from(vec![metadata_field, value_field]);
-
-        validate_shredded_schema(&schema).unwrap();
-    }
-
-    #[test]
-    fn test_shredded_variant_schema() {
-        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let typed_value_field = Field::new("typed_value", DataType::Int64, false);
-        let schema = Fields::from(vec![metadata_field, typed_value_field]);
-
-        validate_shredded_schema(&schema).unwrap();
-    }
-
-    #[test]
-    fn test_partially_shredded_variant_schema() {
-        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let value_field = Field::new("value", DataType::BinaryView, false);
-        let typed_value_field = Field::new("typed_value", DataType::Int64, false);
-        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
-
-        validate_shredded_schema(&schema).unwrap();
-    }
-
-    #[test]
-    fn test_partially_shredded_variant_list_schema() {
-        /*
-        optional group tags (VARIANT) {
-            required binary metadata;
-            optional binary value;
-            optional group typed_value (LIST) {   # must be optional to allow a null list
-                repeated group list {
-                    required group element {          # shredded element
-                        optional binary value;
-                        optional binary typed_value (STRING);
-                    }
-                    required group element {          # shredded element
-                        optional binary value;
-                        optional int64 typed_value ;
-                    }
-                }
-            }
-        }
-        */
-
-        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let value_field = Field::new("value", DataType::BinaryView, false);
-
-        // Define union fields for different element types
-        let string_element = {
-            let value_field = Field::new("value", DataType::BinaryView, true);
-            let typed_value = Field::new("typed_value", DataType::BinaryView, true);
-            DataType::Struct(Fields::from(vec![value_field, typed_value]))
-        };
-
-        let int_element = {
-            let value_field = Field::new("value", DataType::BinaryView, true);
-            let typed_value = Field::new("typed_value", DataType::Int64, true);
-            DataType::Struct(Fields::from(vec![value_field, typed_value]))
-        };
-
-        // Create union of different element types
-        let union_fields = UnionFields::new(
-            vec![0, 1],
-            vec![
-                Field::new("string_element", string_element, true),
-                Field::new("int_element", int_element, true),
-            ],
-        );
-
-        let typed_value_field = Field::new(
-            "typed_value",
-            DataType::Union(union_fields, UnionMode::Sparse),
-            false,
-        );
-        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
-
-        validate_shredded_schema(&schema).unwrap();
-    }
-
-    #[test]
-    fn test_partially_shredded_variant_object_schema() {
-        /*
-        optional group event (VARIANT) {
-            required binary metadata;
-            optional binary value;                # a variant, expected to be an object
-            optional group typed_value {          # shredded fields for the variant object
-                required group event_type {         # shredded field for event_type
-                    optional binary value;
-                    optional binary typed_value (STRING);
-                }
-                required group event_ts {           # shredded field for event_ts
-                    optional binary value;
-                    optional int64 typed_value (TIMESTAMP(true, MICROS));
-                }
-            }
-        }
-        */
-
-        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
-        let value_field = Field::new("value", DataType::BinaryView, false);
-
-        // event_type
-        let element_group_1 = {
-            let value_field = Field::new("value", DataType::BinaryView, false);
-            let typed_value = Field::new("typed_value", DataType::BinaryView, false); // this is the string case
-
-            Fields::from(vec![value_field, typed_value])
-        };
-
-        // event_ts
-        let element_group_2 = {
-            let value_field = Field::new("value", DataType::BinaryView, false);
-            let typed_value = Field::new("typed_value", DataType::Int64, false);
-
-            Fields::from(vec![value_field, typed_value])
-        };
-
-        let typed_value_field = Field::new(
-            "typed_value",
-            DataType::Union(
-                UnionFields::new(
-                    vec![0, 1],
-                    vec![
-                        Field::new("event_type", DataType::Struct(element_group_1), true),
-                        Field::new("event_ts", DataType::Struct(element_group_2), true),
-                    ],
-                ),
-                UnionMode::Sparse,
-            ),
-            false,
-        );
-        let schema = Fields::from(vec![metadata_field, value_field, typed_value_field]);
-
-        validate_shredded_schema(&schema).unwrap();
     }
 }

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -24,8 +24,6 @@ use parquet_variant::Variant;
 use std::any::Any;
 use std::sync::Arc;
 
-use crate::shredding::validate_shredded_schema;
-
 /// An array of Parquet [`Variant`] values
 ///
 /// A [`VariantArray`] wraps an Arrow [`StructArray`] that stores the underlying
@@ -95,8 +93,6 @@ impl VariantArray {
                 "Invalid VariantArray: requires StructArray as input".to_string(),
             ));
         };
-
-        validate_shredded_schema(inner.fields())?;
 
         // todo, remove this since we already do it in validate_shredded_schema
         let Some(metadata_field) = VariantArray::find_metadata_field(inner) else {

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -19,7 +19,7 @@
 
 use crate::{shredding::VariantSchema, VariantArray};
 use arrow::array::{ArrayRef, BinaryViewArray, BinaryViewBuilder, NullBufferBuilder, StructArray};
-use arrow_schema::{ArrowError, DataType, Field, Fields};
+use arrow_schema::{ArrowError, Fields};
 use parquet_variant::{ListBuilder, ObjectBuilder, Variant, VariantBuilder, VariantBuilderExt};
 use std::sync::Arc;
 
@@ -119,7 +119,7 @@ impl VariantArrayBuilder {
 
         // The build the final struct array
         let inner = StructArray::new(
-            schema.inner(),
+            schema.into_inner(),
             vec![
                 Arc::new(metadata_array) as ArrayRef,
                 Arc::new(value_array) as ArrayRef,
@@ -358,6 +358,7 @@ fn binary_view_array_from_buffers(
 mod test {
     use super::*;
     use arrow::array::Array;
+    use arrow_schema::{DataType, Field};
 
     /// Test that both the metadata and value buffers are non nullable
     #[test]
@@ -379,7 +380,7 @@ mod test {
 
         // the metadata and value fields of non shredded variants should not be null
         assert!(variant_array.metadata_field().nulls().is_none());
-        assert!(variant_array.value_field().nulls().is_none());
+        assert!(variant_array.value_field().unwrap().nulls().is_none());
         let DataType::Struct(fields) = variant_array.data_type() else {
             panic!("Expected VariantArray to have Struct data type");
         };

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -160,7 +160,13 @@ impl VariantArrayBuilder {
     /// ```
     /// # use parquet_variant::{Variant, VariantBuilder, VariantBuilderExt};
     /// # use parquet_variant_compute::{VariantArray, VariantArrayBuilder};
-    /// let mut array_builder = VariantArrayBuilder::new(10);
+    /// # use arrow_schema::{Field, Fields, DataType};
+    ///
+    /// let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+    /// let value_field = Field::new("value", DataType::BinaryView, false);
+    /// let schema = Fields::from(vec![metadata_field, value_field]);
+    ///
+    /// let mut array_builder = VariantArrayBuilder::try_new(10, schema).unwrap();
     ///
     /// // First row has a string
     /// let mut variant_builder = array_builder.variant_builder();
@@ -396,7 +402,13 @@ mod test {
     /// Test using sub builders to append variants
     #[test]
     fn test_variant_array_builder_variant_builder() {
-        let mut builder = VariantArrayBuilder::new(10);
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let schema = Fields::from(vec![metadata_field, value_field]);
+
+        let mut builder = VariantArrayBuilder::try_new(10, schema).unwrap();
+
         builder.append_null(); // should not panic
         builder.append_variant(Variant::from(42i32));
 
@@ -436,7 +448,12 @@ mod test {
     /// Test using non-finished sub builders to append variants
     #[test]
     fn test_variant_array_builder_variant_builder_reset() {
-        let mut builder = VariantArrayBuilder::new(10);
+        let metadata_field = Field::new("metadata", DataType::BinaryView, false);
+        let value_field = Field::new("value", DataType::BinaryView, false);
+
+        let schema = Fields::from(vec![metadata_field, value_field]);
+
+        let mut builder = VariantArrayBuilder::try_new(10, schema).unwrap();
 
         // make a sub-object in the first row
         let mut sub_builder = builder.variant_builder();

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -49,7 +49,7 @@ pub fn variant_get(
         )));
     }
 
-    let mut builder = VariantArrayBuilder::try_new(variant_array.len(), shredded_schema).unwrap();
+    let mut builder = VariantArrayBuilder::try_new(variant_array.len(), shredded_schema)?;
     for i in 0..variant_array.len() {
         let new_variant = variant_array.value(i);
         // TODO: perf?


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/7895

My initial PR is getting too large so I figured it would be better to split these up.

# Rationale for this change

This PR updates the `VariantArrayBuilder` to pass in the desired shredded output schema in the constructor. It also contains validation logic that defines what is a valid schema and what is not. 

In other words, the schema that you define ahead of time gets checked if it is spec-compliant