### PR TITLE
chore(dependabot): group tonic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
         applies-to: version-updates
         patterns:
           - "prost*"
+      tonic:
+        applies-to: version-updates
+        patterns:
+          - "tonic*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Group `tonic` and `tonic-build` in one dependabot update PR.

# What changes are included in this PR?

Add a dependabot update group for tonic crates.

# Are these changes tested?

No.

# Are there any user-facing changes?

No.