### PR TITLE
chore: bump MSRV to 1.84

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,6 @@ on:
   pull_request:
 
 jobs:
-
   # Check workspace wide compile and test with default features for
   # mac
   macos:
@@ -53,7 +52,6 @@ jobs:
           export RUSTFLAGS="-C debuginfo=0"
           # PyArrow tests happen in integration.yml.
           cargo test --workspace
-
 
   # Check workspace wide compile and test with default features for
   # windows
@@ -84,8 +82,7 @@ jobs:
           # do not produce debug symbols to keep memory usage down
           export RUSTFLAGS="-C debuginfo=0"
           export PATH=$PATH:/d/protoc/bin
-          cargo test --workspace 
-
+          cargo test --workspace
 
   # Run cargo fmt for all crates
   lint:
@@ -121,15 +118,6 @@ jobs:
         uses: ./.github/actions/setup-builder
       - name: Install cargo-msrv
         run: cargo install cargo-msrv
-      - name: Downgrade arrow-pyarrow-integration-testing dependencies
-        working-directory: arrow-pyarrow-integration-testing
-        # Necessary because half 2.5 requires rust 1.81 or newer
-        run: |
-          cargo update -p half --precise 2.4.0
-      - name: Downgrade workspace dependencies
-        # Necessary because half 2.5 requires rust 1.81 or newer
-        run: |
-          cargo update -p half --precise 2.4.0
       - name: Check all packages
         run: |
           # run `cargo msrv verify --manifest-path "path/to/Cargo.toml"` to see problematic dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ include = [
     "NOTICE.txt",
 ]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 
 [workspace.dependencies]
 arrow = { version = "55.2.0", path = "./arrow", default-features = false }
@@ -102,7 +102,7 @@ arrow-string = { version = "55.2.0", path = "./arrow-string" }
 parquet = { version = "55.2.0", path = "./parquet", default-features = false }
 
 # These crates have not yet been released and thus do not use the workspace version
-parquet-variant = { version = "0.1.0", path = "./parquet-variant"}
+parquet-variant = { version = "0.1.0", path = "./parquet-variant" }
 parquet-variant-json = { version = "0.1.0", path = "./parquet-variant-json" }
 parquet-variant-compute = { version = "0.1.0", path = "./parquet-variant-json" }
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,9 @@ Planned Release Schedule
 
 ### Rust Version Compatibility Policy
 
-arrow-rs, parquet and object_store are built and tested with stable Rust, and will keep a rolling MSRV (minimum supported Rust version) that can only be updated in major releases on a need by basis (e.g. project dependencies bump their MSRV or a particular Rust feature is useful for us etc.). The new MSRV if selected will be at least 6 months old. The minor releases are guaranteed to have the same MSRV.
+arrow-rs and parquet are built and tested with stable Rust, and will keep a rolling MSRV (minimum supported Rust version) that can only be updated in major releases on a need by basis (e.g. project dependencies bump their MSRV or a particular Rust feature is useful for us etc.). The new MSRV if selected will be at least 6 months old. The minor releases are guaranteed to have the same MSRV.
 
 Note: If a Rust hotfix is released for the current MSRV, the MSRV will be updated to the specific minor version that includes all applicable hotfixes preceding other policies.
-
-E.g.
-
-in Apr 2025 we will release version 55.0.0 which might have a version bump. But the Rust version selected in this case will be at most version 1.81.
 
 ### Guidelines for `panic` vs `Result`
 

--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -420,13 +420,13 @@ native_type_float_op!(
     1.,
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.81.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(-1_i32)
     },
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.81.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(i32::MAX)
     }
@@ -437,13 +437,13 @@ native_type_float_op!(
     1.,
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.81.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(-1_i64)
     },
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.81.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(i64::MAX)
     }

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 [lib]

--- a/arrow-pyarrow-testing/Cargo.toml
+++ b/arrow-pyarrow-testing/Cargo.toml
@@ -38,9 +38,9 @@ homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-keywords = [ "arrow" ]
+keywords = ["arrow"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.84"
 publish = false
 
 


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

- This allows us to keep up with dependencies bumping their MSRV (e.g. #7924) 
- #7395 is the next release and because this is a major release we can bump MSRV now for all the 56.x.y releases

We can bump to 1.85 in #7835 to unblock #7270. 

# What changes are included in this PR?

- Bump MSRV to 1.84 which was released more than 6 months ago
- Removed half pins from CI

# Are these changes tested?

CI.

# Are there any user-facing changes?

Yes.