### PR TITLE
Make dict ID only an IPC concern

### DIFF
--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -149,9 +149,7 @@ pub struct IpcMessage(pub Bytes);
 
 fn flight_schema_as_encoded_data(arrow_schema: &Schema, options: &IpcWriteOptions) -> EncodedData {
     let data_gen = writer::IpcDataGenerator::default();
-    #[allow(deprecated)]
-    let mut dict_tracker =
-        writer::DictionaryTracker::new_with_preserve_dict_id(false, options.preserve_dict_id());
+    let mut dict_tracker = writer::DictionaryTracker::new(false);
     data_gen.schema_to_bytes_with_dictionary_tracker(arrow_schema, &mut dict_tracker, options)
 }
 

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -707,6 +707,7 @@ pub enum ArrowFlightData {
 pub fn arrow_data_from_flight_data(
     flight_data: FlightData,
     arrow_schema_ref: &SchemaRef,
+    ipc_schema: arrow_ipc::Schema,
 ) -> Result<ArrowFlightData, ArrowError> {
     let ipc_message = root_as_message(&flight_data.data_header[..])
         .map_err(|err| ArrowError::ParseError(format!("Unable to get root as message: {err:?}")))?;
@@ -723,6 +724,7 @@ pub fn arrow_data_from_flight_data(
             let record_batch = read_record_batch(
                 &Buffer::from(flight_data.data_body),
                 ipc_record_batch,
+                ipc_schema,
                 arrow_schema_ref.clone(),
                 &dictionaries_by_field,
                 None,

--- a/arrow-ipc/src/convert.rs
+++ b/arrow-ipc/src/convert.rs
@@ -19,6 +19,7 @@
 
 use arrow_buffer::Buffer;
 use arrow_schema::*;
+use core::panic;
 use flatbuffers::{
     FlatBufferBuilder, ForwardsUOffset, UnionWIPOffset, Vector, Verifiable, Verifier,
     VerifierOptions, WIPOffset,
@@ -127,12 +128,6 @@ impl<'a> IpcSchemaEncoder<'a> {
     }
 }
 
-/// Serialize a schema in IPC format
-#[deprecated(since = "54.0.0", note = "Use `IpcSchemaConverter`.")]
-pub fn schema_to_fb(schema: &Schema) -> FlatBufferBuilder<'_> {
-    IpcSchemaEncoder::new().schema_to_fb(schema)
-}
-
 /// Push a key-value metadata into a FlatBufferBuilder and return [WIPOffset]
 pub fn metadata_to_fb<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
@@ -173,7 +168,7 @@ impl From<crate::Field<'_>> for Field {
                 field.name().unwrap(),
                 get_data_type(field, true),
                 field.nullable(),
-                dictionary.id(),
+                0,
                 dictionary.isOrdered(),
             )
         } else {
@@ -530,24 +525,13 @@ pub(crate) fn build_field<'a>(
         match dictionary_tracker {
             Some(tracker) => Some(get_fb_dictionary(
                 index_type,
-                #[allow(deprecated)]
-                tracker.set_dict_id(field),
+                tracker.next_dict_id(),
                 field
                     .dict_is_ordered()
                     .expect("All Dictionary types have `dict_is_ordered`"),
                 fbb,
             )),
-            None => Some(get_fb_dictionary(
-                index_type,
-                #[allow(deprecated)]
-                field
-                    .dict_id()
-                    .expect("Dictionary type must have a dictionary id"),
-                field
-                    .dict_is_ordered()
-                    .expect("All Dictionary types have `dict_is_ordered`"),
-                fbb,
-            )),
+            None => panic!("IPC must no longer be used without dictionary tracker"),
         }
     } else {
         None

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -39,6 +39,9 @@ use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, Scalar
 use arrow_data::{ArrayData, ArrayDataBuilder, UnsafeFlag};
 use arrow_schema::*;
 
+use crate::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
+use crate::Field as IpcField;
+
 use crate::compression::CompressionCodec;
 use crate::{Block, FieldNode, Message, MetadataVersion, CONTINUATION_MARKER};
 use DataType::*;
@@ -80,6 +83,7 @@ impl RecordBatchDecoder<'_> {
     ///     - cast the 64-bit array to the appropriate data type
     fn create_array(
         &mut self,
+        ipc_field: IpcField,
         field: &Field,
         variadic_counts: &mut VecDeque<i64>,
     ) -> Result<ArrayRef, ArrowError> {
@@ -115,13 +119,21 @@ impl RecordBatchDecoder<'_> {
             List(ref list_field) | LargeList(ref list_field) | Map(ref list_field, _) => {
                 let list_node = self.next_node(field)?;
                 let list_buffers = [self.next_buffer()?, self.next_buffer()?];
-                let values = self.create_array(list_field, variadic_counts)?;
+                let values = self.create_array(
+                    ipc_field.children().unwrap().get(0),
+                    list_field,
+                    variadic_counts,
+                )?;
                 self.create_list_array(list_node, data_type, &list_buffers, values)
             }
             FixedSizeList(ref list_field, _) => {
                 let list_node = self.next_node(field)?;
                 let list_buffers = [self.next_buffer()?];
-                let values = self.create_array(list_field, variadic_counts)?;
+                let values = self.create_array(
+                    ipc_field.children().unwrap().get(0),
+                    list_field,
+                    variadic_counts,
+                )?;
                 self.create_list_array(list_node, data_type, &list_buffers, values)
             }
             Struct(struct_fields) => {
@@ -132,16 +144,22 @@ impl RecordBatchDecoder<'_> {
                 let mut struct_arrays = vec![];
                 // TODO investigate whether just knowing the number of buffers could
                 // still work
-                for struct_field in struct_fields {
-                    let child = self.create_array(struct_field, variadic_counts)?;
+                for (idx, struct_field) in struct_fields.iter().enumerate() {
+                    let child = self.create_array(
+                        ipc_field.children().unwrap().get(idx),
+                        struct_field,
+                        variadic_counts,
+                    )?;
                     struct_arrays.push(child);
                 }
                 self.create_struct_array(struct_node, null_buffer, struct_fields, struct_arrays)
             }
             RunEndEncoded(run_ends_field, values_field) => {
                 let run_node = self.next_node(field)?;
-                let run_ends = self.create_array(run_ends_field, variadic_counts)?;
-                let values = self.create_array(values_field, variadic_counts)?;
+                let children = ipc_field.children().unwrap();
+                let run_ends =
+                    self.create_array(children.get(0), run_ends_field, variadic_counts)?;
+                let values = self.create_array(children.get(1), values_field, variadic_counts)?;
 
                 let run_array_length = run_node.length() as usize;
                 let builder = ArrayData::builder(data_type.clone())
@@ -156,11 +174,7 @@ impl RecordBatchDecoder<'_> {
                 let index_node = self.next_node(field)?;
                 let index_buffers = [self.next_buffer()?, self.next_buffer()?];
 
-                #[allow(deprecated)]
-                let dict_id = field.dict_id().ok_or_else(|| {
-                    ArrowError::ParseError(format!("Field {field} does not have dict id"))
-                })?;
-
+                let dict_id = ipc_field.dictionary().unwrap().id();
                 let value_array = self.dictionaries_by_id.get(&dict_id).ok_or_else(|| {
                     ArrowError::ParseError(format!(
                         "Cannot find a dictionary batch with dict id: {dict_id}"
@@ -198,8 +212,11 @@ impl RecordBatchDecoder<'_> {
 
                 let mut children = Vec::with_capacity(fields.len());
 
-                for (_id, field) in fields.iter() {
-                    let child = self.create_array(field, variadic_counts)?;
+                let ipc_children = ipc_field.children().unwrap();
+                for i in 0..ipc_children.len() {
+                    let ipc_field = ipc_children.get(i);
+                    let field: Field = ipc_field.into();
+                    let child = self.create_array(ipc_field, &field, variadic_counts)?;
                     children.push(child);
                 }
 
@@ -371,6 +388,8 @@ struct RecordBatchDecoder<'a> {
     batch: crate::RecordBatch<'a>,
     /// The output schema
     schema: SchemaRef,
+    /// The schema as it is encoded in the IPC source
+    ipc_schema: crate::Schema<'a>,
     /// Decoded dictionaries indexed by dictionary id
     dictionaries_by_id: &'a HashMap<i64, ArrayRef>,
     /// Optional compression codec
@@ -400,6 +419,7 @@ impl<'a> RecordBatchDecoder<'a> {
     fn try_new(
         buf: &'a Buffer,
         batch: crate::RecordBatch<'a>,
+        ipc_schema: crate::Schema<'a>,
         schema: SchemaRef,
         dictionaries_by_id: &'a HashMap<i64, ArrayRef>,
         metadata: &'a MetadataVersion,
@@ -418,6 +438,7 @@ impl<'a> RecordBatchDecoder<'a> {
 
         Ok(Self {
             batch,
+            ipc_schema,
             schema,
             dictionaries_by_id,
             compression,
@@ -477,23 +498,28 @@ impl<'a> RecordBatchDecoder<'a> {
 
         let options = RecordBatchOptions::new().with_row_count(Some(self.batch.length() as usize));
 
-        let schema = Arc::clone(&self.schema);
         if let Some(projection) = self.projection {
             let mut arrays = vec![];
             // project fields
-            for (idx, field) in schema.fields().iter().enumerate() {
+            let ipc_fields = self.ipc_schema.fields().unwrap();
+            let ipc_fields_len = ipc_fields.len();
+            for idx in 0..ipc_fields_len {
                 // Create array for projected field
                 if let Some(proj_idx) = projection.iter().position(|p| p == &idx) {
-                    let child = self.create_array(field, &mut variadic_counts)?;
+                    let child = self.create_array(
+                        ipc_fields.get(idx),
+                        self.schema.clone().field(idx),
+                        &mut variadic_counts,
+                    )?;
                     arrays.push((proj_idx, child));
                 } else {
-                    self.skip_field(field, &mut variadic_counts)?;
+                    self.skip_field(self.schema.clone().field(idx), &mut variadic_counts)?;
                 }
             }
 
             arrays.sort_by_key(|t| t.0);
 
-            let schema = Arc::new(schema.project(projection)?);
+            let schema = Arc::new(self.schema.project(projection)?);
             let columns = arrays.into_iter().map(|t| t.1).collect::<Vec<_>>();
 
             if self.skip_validation.get() {
@@ -512,8 +538,14 @@ impl<'a> RecordBatchDecoder<'a> {
         } else {
             let mut children = vec![];
             // keep track of index as lists require more than one node
-            for field in schema.fields() {
-                let child = self.create_array(field, &mut variadic_counts)?;
+            let ipc_fields = self.ipc_schema.fields().unwrap();
+            let ipc_fields_len = ipc_fields.len();
+            for idx in 0..ipc_fields_len {
+                let child = self.create_array(
+                    ipc_fields.get(idx),
+                    self.schema.clone().field(idx),
+                    &mut variadic_counts,
+                )?;
                 children.push(child);
             }
 
@@ -521,14 +553,14 @@ impl<'a> RecordBatchDecoder<'a> {
                 // Safety: setting `skip_validation` requires `unsafe`, user assures data is valid
                 unsafe {
                     Ok(RecordBatch::new_unchecked(
-                        schema,
+                        self.schema,
                         children,
                         self.batch.length() as usize,
                     ))
                 }
             } else {
                 assert!(variadic_counts.is_empty());
-                RecordBatch::try_new_with_options(schema, children, &options)
+                RecordBatch::try_new_with_options(self.schema, children, &options)
             }
         }
     }
@@ -638,12 +670,13 @@ impl<'a> RecordBatchDecoder<'a> {
 pub fn read_record_batch(
     buf: &Buffer,
     batch: crate::RecordBatch,
+    ipc_schema: crate::Schema,
     schema: SchemaRef,
     dictionaries_by_id: &HashMap<i64, ArrayRef>,
     projection: Option<&[usize]>,
     metadata: &MetadataVersion,
 ) -> Result<RecordBatch, ArrowError> {
-    RecordBatchDecoder::try_new(buf, batch, schema, dictionaries_by_id, metadata)?
+    RecordBatchDecoder::try_new(buf, batch, ipc_schema, schema, dictionaries_by_id, metadata)?
         .with_projection(projection)
         .with_require_alignment(false)
         .read_record_batch()
@@ -654,14 +687,14 @@ pub fn read_record_batch(
 pub fn read_dictionary(
     buf: &Buffer,
     batch: crate::DictionaryBatch,
-    schema: &Schema,
+    ipc_schema: crate::Schema,
     dictionaries_by_id: &mut HashMap<i64, ArrayRef>,
     metadata: &MetadataVersion,
 ) -> Result<(), ArrowError> {
     read_dictionary_impl(
         buf,
         batch,
-        schema,
+        ipc_schema,
         dictionaries_by_id,
         metadata,
         false,
@@ -669,10 +702,41 @@ pub fn read_dictionary(
     )
 }
 
+fn first_field_with_dict_id_from_schema(schema: crate::Schema, id: i64) -> Option<Field> {
+    let c_fields = schema.fields().unwrap();
+    let len = c_fields.len();
+    for i in 0..len {
+        let c_field: crate::Field = c_fields.get(i);
+        if let Some(field) = first_field_with_dict_id_from_field(c_field, id) {
+            return Some(field);
+        }
+    }
+
+    None
+}
+
+fn first_field_with_dict_id_from_field(field: crate::Field, id: i64) -> Option<Field> {
+    if let Some(dictionary) = field.dictionary() {
+        if dictionary.id() == id {
+            return Some(field.into());
+        }
+    }
+
+    if let Some(children) = field.children() {
+        for child in children.iter() {
+            if let Some(field) = first_field_with_dict_id_from_field(child, id) {
+                return Some(field);
+            }
+        }
+    }
+
+    None
+}
+
 fn read_dictionary_impl(
     buf: &Buffer,
     batch: crate::DictionaryBatch,
-    schema: &Schema,
+    ipc_schema: crate::Schema,
     dictionaries_by_id: &mut HashMap<i64, ArrayRef>,
     metadata: &MetadataVersion,
     require_alignment: bool,
@@ -685,9 +749,7 @@ fn read_dictionary_impl(
     }
 
     let id = batch.id();
-    #[allow(deprecated)]
-    let fields_using_this_dictionary = schema.fields_with_dict_id(id);
-    let first_field = fields_using_this_dictionary.first().ok_or_else(|| {
+    let first_field = first_field_with_dict_id_from_schema(ipc_schema, id).ok_or_else(|| {
         ArrowError::InvalidArgumentError(format!("dictionary id {id} not found in schema"))
     })?;
 
@@ -699,10 +761,22 @@ fn read_dictionary_impl(
             // Make a fake schema for the dictionary batch.
             let value = value_type.as_ref().clone();
             let schema = Schema::new(vec![Field::new("", value, true)]);
+            let gen = IpcDataGenerator::default();
+            let mut dict_tracker = DictionaryTracker::new(false);
+            let data = gen.schema_to_bytes_with_dictionary_tracker(
+                &schema,
+                &mut dict_tracker,
+                &IpcWriteOptions::default(),
+            );
+            let message = crate::root_as_message(&data.ipc_message).map_err(|err| {
+                ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
+            })?;
+            let ipc_schema = message.header_as_schema().unwrap();
             // Read a single column
             let record_batch = RecordBatchDecoder::try_new(
                 buf,
                 batch.data().unwrap(),
+                ipc_schema,
                 Arc::new(schema),
                 dictionaries_by_id,
                 metadata,
@@ -812,7 +886,7 @@ pub fn read_footer_length(buf: [u8; 10]) -> Result<usize, ArrowError> {
 /// let back = fb_to_schema(footer.schema().unwrap());
 /// assert_eq!(&back, schema.as_ref());
 ///
-/// let mut decoder = FileDecoder::new(schema, footer.version());
+/// let mut decoder = FileDecoder::new(buffer[trailer_start - footer_len..trailer_start].to_vec(), Default::default(), footer.version());
 ///
 /// // Read dictionaries
 /// for block in footer.dictionaries().iter().flatten() {
@@ -835,6 +909,8 @@ pub fn read_footer_length(buf: [u8; 10]) -> Result<usize, ArrowError> {
 #[derive(Debug)]
 pub struct FileDecoder {
     schema: SchemaRef,
+    footer_buffer: Vec<u8>,
+    verifier_options: VerifierOptions,
     dictionaries: HashMap<i64, ArrayRef>,
     version: MetadataVersion,
     projection: Option<Vec<usize>>,
@@ -844,9 +920,19 @@ pub struct FileDecoder {
 
 impl FileDecoder {
     /// Create a new [`FileDecoder`] with the given schema and version
-    pub fn new(schema: SchemaRef, version: MetadataVersion) -> Self {
+    pub fn new(
+        footer_buffer: Vec<u8>,
+        verifier_options: VerifierOptions,
+        version: MetadataVersion,
+    ) -> Self {
+        let footer =
+            crate::root_as_footer_with_opts(&verifier_options, &footer_buffer[..]).unwrap();
+        let ipc_schema = footer.schema().unwrap();
+        let schema = crate::convert::fb_to_schema(ipc_schema);
         Self {
-            schema,
+            schema: Arc::new(schema),
+            footer_buffer,
+            verifier_options,
             version,
             dictionaries: Default::default(),
             projection: None,
@@ -911,10 +997,16 @@ impl FileDecoder {
         match message.header_type() {
             crate::MessageHeader::DictionaryBatch => {
                 let batch = message.header_as_dictionary_batch().unwrap();
+                let footer = crate::root_as_footer_with_opts(
+                    &self.verifier_options,
+                    &self.footer_buffer[..],
+                )
+                .unwrap();
+                let ipc_schema = footer.schema().unwrap();
                 read_dictionary_impl(
                     &buf.slice(block.metaDataLength() as _),
                     batch,
-                    &self.schema,
+                    ipc_schema,
                     &mut self.dictionaries,
                     &message.version(),
                     self.require_alignment,
@@ -942,10 +1034,17 @@ impl FileDecoder {
                 let batch = message.header_as_record_batch().ok_or_else(|| {
                     ArrowError::IpcError("Unable to read IPC message as record batch".to_string())
                 })?;
+                let footer = crate::root_as_footer_with_opts(
+                    &self.verifier_options,
+                    &self.footer_buffer[..],
+                )
+                .unwrap();
+                let ipc_schema = footer.schema().unwrap();
                 // read the block that makes up the record batch into a buffer
                 RecordBatchDecoder::try_new(
                     &buf.slice(block.metaDataLength() as _),
                     batch,
+                    ipc_schema,
                     self.schema.clone(),
                     &self.dictionaries,
                     &message.version(),
@@ -1070,8 +1169,6 @@ impl FileReaderBuilder {
             ));
         }
 
-        let schema = crate::convert::fb_to_schema(ipc_schema);
-
         let mut custom_metadata = HashMap::new();
         if let Some(fb_custom_metadata) = footer.custom_metadata() {
             for kv in fb_custom_metadata.into_iter() {
@@ -1082,7 +1179,7 @@ impl FileReaderBuilder {
             }
         }
 
-        let mut decoder = FileDecoder::new(Arc::new(schema), footer.version());
+        let mut decoder = FileDecoder::new(footer_data.clone(), verifier_options, footer.version());
         if let Some(projection) = self.projection {
             decoder = decoder.with_projection(projection)
         }
@@ -1334,6 +1431,10 @@ pub struct StreamReader<R> {
     /// The schema that is read from the stream's first message
     schema: SchemaRef,
 
+    /// The buffer that the IPC schema flatbuffer is stored in. This is needed to satify the
+    /// lifetime requirements of the flatbuffer reader.
+    schema_message_buffer: Vec<u8>,
+
     /// Optional dictionaries for each schema field.
     ///
     /// Dictionaries may be appended to in the streaming format.
@@ -1427,6 +1528,7 @@ impl<R: Read> StreamReader<R> {
         Ok(Self {
             reader,
             schema: Arc::new(schema),
+            schema_message_buffer: meta_buffer.to_vec(),
             finished: false,
             dictionaries_by_id,
             projection,
@@ -1510,10 +1612,20 @@ impl<R: Read> StreamReader<R> {
                 let mut buf = MutableBuffer::from_len_zeroed(message.bodyLength() as usize);
                 self.reader.read_exact(&mut buf)?;
 
+                let message =
+                    crate::root_as_message(&self.schema_message_buffer).map_err(|err| {
+                        ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
+                    })?;
+                // message header is a Schema, so read it
+                let ipc_schema: crate::Schema = message.header_as_schema().ok_or_else(|| {
+                    ArrowError::ParseError("Unable to read IPC message as schema".to_string())
+                })?;
+
                 RecordBatchDecoder::try_new(
                     &buf.into(),
                     batch,
-                    self.schema(),
+                    ipc_schema,
+                    self.schema.clone(),
                     &self.dictionaries_by_id,
                     &message.version(),
                 )?
@@ -1533,10 +1645,19 @@ impl<R: Read> StreamReader<R> {
                 let mut buf = MutableBuffer::from_len_zeroed(message.bodyLength() as usize);
                 self.reader.read_exact(&mut buf)?;
 
+                let message =
+                    crate::root_as_message(&self.schema_message_buffer).map_err(|err| {
+                        ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
+                    })?;
+                // message header is a Schema, so read it
+                let ipc_schema: crate::Schema = message.header_as_schema().ok_or_else(|| {
+                    ArrowError::ParseError("Unable to read IPC message as schema".to_string())
+                })?;
+
                 read_dictionary_impl(
                     &buf.into(),
                     batch,
-                    &self.schema,
+                    ipc_schema,
                     &mut self.dictionaries_by_id,
                     &message.version(),
                     false,
@@ -1892,11 +2013,13 @@ mod tests {
         let footer = root_as_footer(&buffer[trailer_start - footer_len..trailer_start])
             .map_err(|e| ArrowError::InvalidArgumentError(format!("Invalid footer: {e}")))?;
 
-        let schema = fb_to_schema(footer.schema().unwrap());
-
         let mut decoder = unsafe {
-            FileDecoder::new(Arc::new(schema), footer.version())
-                .with_skip_validation(skip_validation)
+            FileDecoder::new(
+                buffer[trailer_start - footer_len..trailer_start].to_vec(),
+                Default::default(),
+                footer.version(),
+            )
+            .with_skip_validation(skip_validation)
         };
         // Read dictionaries
         for block in footer.dictionaries().iter().flatten() {
@@ -2007,8 +2130,7 @@ mod tests {
         let mut writer = crate::writer::FileWriter::try_new_with_options(
             &mut buf,
             batch.schema_ref(),
-            #[allow(deprecated)]
-            IpcWriteOptions::default().with_preserve_dict_id(false),
+            IpcWriteOptions::default(),
         )
         .unwrap();
         writer.write(&batch).unwrap();
@@ -2440,8 +2562,16 @@ mod tests {
         .unwrap();
 
         let gen = IpcDataGenerator {};
-        #[allow(deprecated)]
-        let mut dict_tracker = DictionaryTracker::new_with_preserve_dict_id(false, true);
+        let mut dict_tracker = DictionaryTracker::new(false);
+
+        let encoded_schema = gen.schema_to_bytes_with_dictionary_tracker(
+            &batch.schema(),
+            &mut dict_tracker,
+            &IpcWriteOptions::default(),
+        );
+        let schema_message = root_as_message(&encoded_schema.ipc_message).unwrap();
+        let ipc_schema = schema_message.header_as_schema().unwrap();
+
         let (_, encoded) = gen
             .encoded_batch(&batch, &mut dict_tracker, &Default::default())
             .unwrap();
@@ -2459,6 +2589,7 @@ mod tests {
         let roundtrip = RecordBatchDecoder::try_new(
             &b,
             ipc_batch,
+            ipc_schema,
             batch.schema(),
             &Default::default(),
             &message.version(),
@@ -2479,8 +2610,16 @@ mod tests {
         .unwrap();
 
         let gen = IpcDataGenerator {};
-        #[allow(deprecated)]
-        let mut dict_tracker = DictionaryTracker::new_with_preserve_dict_id(false, true);
+        let mut dict_tracker = DictionaryTracker::new(false);
+
+        let encoded_schema = gen.schema_to_bytes_with_dictionary_tracker(
+            &batch.schema(),
+            &mut dict_tracker,
+            &IpcWriteOptions::default(),
+        );
+        let schema_message = root_as_message(&encoded_schema.ipc_message).unwrap();
+        let ipc_schema = schema_message.header_as_schema().unwrap();
+
         let (_, encoded) = gen
             .encoded_batch(&batch, &mut dict_tracker, &Default::default())
             .unwrap();
@@ -2498,6 +2637,7 @@ mod tests {
         let result = RecordBatchDecoder::try_new(
             &b,
             ipc_batch,
+            ipc_schema,
             batch.schema(),
             &Default::default(),
             &message.version(),
@@ -2691,8 +2831,7 @@ mod tests {
             let mut writer = crate::writer::StreamWriter::try_new_with_options(
                 &mut buf,
                 batch.schema().as_ref(),
-                #[allow(deprecated)]
-                crate::writer::IpcWriteOptions::default().with_preserve_dict_id(false),
+                crate::writer::IpcWriteOptions::default(),
             )
             .expect("Failed to create StreamWriter");
             writer.write(&batch).expect("Failed to write RecordBatch");

--- a/arrow-ipc/src/reader/stream.rs
+++ b/arrow-ipc/src/reader/stream.rs
@@ -35,6 +35,8 @@ use crate::{MessageHeader, CONTINUATION_MARKER};
 pub struct StreamDecoder {
     /// The schema of this decoder, if read
     schema: Option<SchemaRef>,
+    /// The ipc schema and its buffer
+    ipc_schema_message: Option<Arc<MessageBuffer>>,
     /// Lookup table for dictionaries by ID
     dictionaries: HashMap<i64, ArrayRef>,
     /// The decoder state
@@ -189,8 +191,8 @@ impl StreamDecoder {
                     }
                 }
                 DecoderState::Body { message } => {
-                    let message = message.as_ref();
-                    let body_length = message.bodyLength() as usize;
+                    let message_ref = message.as_ref();
+                    let body_length = message_ref.bodyLength() as usize;
 
                     let body = if self.buf.is_empty() && buffer.len() >= body_length {
                         let body = buffer.slice_with_length(0, body_length);
@@ -207,8 +209,8 @@ impl StreamDecoder {
                         std::mem::take(&mut self.buf).into()
                     };
 
-                    let version = message.version();
-                    match message.header_type() {
+                    let version = message_ref.version();
+                    match message_ref.header_type() {
                         MessageHeader::Schema => {
                             if self.schema.is_some() {
                                 return Err(ArrowError::IpcError(
@@ -216,19 +218,34 @@ impl StreamDecoder {
                                 ));
                             }
 
-                            let ipc_schema = message.header_as_schema().unwrap();
+                            // Get a reference to the schema from the message
+                            let ipc_schema = message_ref.header_as_schema().unwrap();
                             let schema = crate::convert::fb_to_schema(ipc_schema);
+
+                            // Store the schema and reset state
+                            self.ipc_schema_message = Some(Arc::new(message.clone()));
                             self.state = DecoderState::default();
                             self.schema = Some(Arc::new(schema));
                         }
                         MessageHeader::RecordBatch => {
-                            let batch = message.header_as_record_batch().unwrap();
+                            let batch = message_ref.header_as_record_batch().unwrap();
+                            let ipc_schema_message =
+                                self.ipc_schema_message.clone().ok_or_else(|| {
+                                    ArrowError::IpcError("Missing IPC schema".to_string())
+                                })?;
+                            let ipc_schema = ipc_schema_message
+                                .as_ref()
+                                .as_ref()
+                                .header_as_schema()
+                                .unwrap();
+
                             let schema = self.schema.clone().ok_or_else(|| {
                                 ArrowError::IpcError("Missing schema".to_string())
                             })?;
                             let batch = RecordBatchDecoder::try_new(
                                 &body,
                                 batch,
+                                ipc_schema,
                                 schema,
                                 &self.dictionaries,
                                 &version,
@@ -239,14 +256,21 @@ impl StreamDecoder {
                             return Ok(Some(batch));
                         }
                         MessageHeader::DictionaryBatch => {
-                            let dictionary = message.header_as_dictionary_batch().unwrap();
-                            let schema = self.schema.as_deref().ok_or_else(|| {
-                                ArrowError::IpcError("Missing schema".to_string())
-                            })?;
+                            let dictionary = message_ref.header_as_dictionary_batch().unwrap();
+                            let ipc_schema_message =
+                                self.ipc_schema_message.clone().ok_or_else(|| {
+                                    ArrowError::IpcError("Missing IPC schema".to_string())
+                                })?;
+                            let ipc_schema = ipc_schema_message
+                                .as_ref()
+                                .as_ref()
+                                .header_as_schema()
+                                .unwrap();
+
                             read_dictionary_impl(
                                 &body,
                                 dictionary,
-                                schema,
+                                ipc_schema,
                                 &mut self.dictionaries,
                                 &version,
                                 self.require_alignment,
@@ -395,8 +419,7 @@ mod tests {
             let mut writer = StreamWriter::try_new_with_options(
                 &mut buffer,
                 &schema,
-                #[allow(deprecated)]
-                IpcWriteOptions::default().with_preserve_dict_id(false),
+                IpcWriteOptions::default(),
             )
             .expect("Failed to create StreamWriter");
             writer.write(&batch).expect("Failed to write RecordBatch");

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -65,15 +65,6 @@ pub struct IpcWriteOptions {
     /// Compression, if desired. Will result in a runtime error
     /// if the corresponding feature is not enabled
     batch_compression_type: Option<crate::CompressionType>,
-    /// Flag indicating whether the writer should preserve the dictionary IDs defined in the
-    /// schema or generate unique dictionary IDs internally during encoding.
-    ///
-    /// Defaults to `false`
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all fields related to it."
-    )]
-    preserve_dict_id: bool,
 }
 
 impl IpcWriteOptions {
@@ -122,7 +113,6 @@ impl IpcWriteOptions {
                 write_legacy_ipc_format,
                 metadata_version,
                 batch_compression_type: None,
-                preserve_dict_id: false,
             }),
             crate::MetadataVersion::V5 => {
                 if write_legacy_ipc_format {
@@ -130,13 +120,11 @@ impl IpcWriteOptions {
                         "Legacy IPC format only supported on metadata version 4".to_string(),
                     ))
                 } else {
-                    #[allow(deprecated)]
                     Ok(Self {
                         alignment,
                         write_legacy_ipc_format,
                         metadata_version,
                         batch_compression_type: None,
-                        preserve_dict_id: false,
                     })
                 }
             }
@@ -145,45 +133,15 @@ impl IpcWriteOptions {
             ))),
         }
     }
-
-    /// Return whether the writer is configured to preserve the dictionary IDs
-    /// defined in the schema
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all functions related to it."
-    )]
-    pub fn preserve_dict_id(&self) -> bool {
-        #[allow(deprecated)]
-        self.preserve_dict_id
-    }
-
-    /// Set whether the IPC writer should preserve the dictionary IDs in the schema
-    /// or auto-assign unique dictionary IDs during encoding (defaults to true)
-    ///
-    /// If this option is true,  the application must handle assigning ids
-    /// to the dictionary batches in order to encode them correctly
-    ///
-    /// The default will change to `false`  in future releases
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all functions related to it."
-    )]
-    #[allow(deprecated)]
-    pub fn with_preserve_dict_id(mut self, preserve_dict_id: bool) -> Self {
-        self.preserve_dict_id = preserve_dict_id;
-        self
-    }
 }
 
 impl Default for IpcWriteOptions {
     fn default() -> Self {
-        #[allow(deprecated)]
         Self {
             alignment: 64,
             write_legacy_ipc_format: false,
             metadata_version: crate::MetadataVersion::V5,
             batch_compression_type: None,
-            preserve_dict_id: false,
         }
     }
 }
@@ -224,10 +182,7 @@ pub struct IpcDataGenerator {}
 
 impl IpcDataGenerator {
     /// Converts a schema to an IPC message along with `dictionary_tracker`
-    /// and returns it encoded inside [EncodedData] as a flatbuffer
-    ///
-    /// Preferred method over [IpcDataGenerator::schema_to_bytes] since it's
-    /// deprecated since Arrow v54.0.0
+    /// and returns it encoded inside [EncodedData] as a flatbuffer.
     pub fn schema_to_bytes_with_dictionary_tracker(
         &self,
         schema: &Schema,
@@ -239,36 +194,6 @@ impl IpcDataGenerator {
             let fb = IpcSchemaEncoder::new()
                 .with_dictionary_tracker(dictionary_tracker)
                 .schema_to_fb_offset(&mut fbb, schema);
-            fb.as_union_value()
-        };
-
-        let mut message = crate::MessageBuilder::new(&mut fbb);
-        message.add_version(write_options.metadata_version);
-        message.add_header_type(crate::MessageHeader::Schema);
-        message.add_bodyLength(0);
-        message.add_header(schema);
-        // TODO: custom metadata
-        let data = message.finish();
-        fbb.finish(data, None);
-
-        let data = fbb.finished_data();
-        EncodedData {
-            ipc_message: data.to_vec(),
-            arrow_data: vec![],
-        }
-    }
-
-    #[deprecated(
-        since = "54.0.0",
-        note = "Use `schema_to_bytes_with_dictionary_tracker` instead. This function signature of `schema_to_bytes_with_dictionary_tracker` in the next release."
-    )]
-    /// Converts a schema to an IPC message and returns it encoded inside [EncodedData] as a flatbuffer
-    pub fn schema_to_bytes(&self, schema: &Schema, write_options: &IpcWriteOptions) -> EncodedData {
-        let mut fbb = FlatBufferBuilder::new();
-        let schema = {
-            #[allow(deprecated)]
-            // This will be replaced with the IpcSchemaConverter in the next release.
-            let fb = crate::convert::schema_to_fb_offset(&mut fbb, schema);
             fb.as_union_value()
         };
 
@@ -441,13 +366,9 @@ impl IpcDataGenerator {
                 // It's importnat to only take the dict_id at this point, because the dict ID
                 // sequence is assigned depth-first, so we need to first encode children and have
                 // them take their assigned dict IDs before we take the dict ID for this field.
-                #[allow(deprecated)]
-                let dict_id = dict_id_seq
-                    .next()
-                    .or_else(|| field.dict_id())
-                    .ok_or_else(|| {
-                        ArrowError::IpcError(format!("no dict id for field {}", field.name()))
-                    })?;
+                let dict_id = dict_id_seq.next().ok_or_else(|| {
+                    ArrowError::IpcError(format!("no dict id for field {}", field.name()))
+                })?;
 
                 let emit = dictionary_tracker.insert(dict_id, column)?;
 
@@ -789,11 +710,6 @@ pub struct DictionaryTracker {
     written: HashMap<i64, ArrayData>,
     dict_ids: Vec<i64>,
     error_on_replacement: bool,
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all fields related to it."
-    )]
-    preserve_dict_id: bool,
 }
 
 impl DictionaryTracker {
@@ -813,52 +729,17 @@ impl DictionaryTracker {
             written: HashMap::new(),
             dict_ids: Vec::new(),
             error_on_replacement,
-            preserve_dict_id: false,
         }
     }
 
-    /// Create a new [`DictionaryTracker`].
-    ///
-    /// If `error_on_replacement`
-    /// is true, an error will be generated if an update to an
-    /// existing dictionary is attempted.
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all functions related to it."
-    )]
-    pub fn new_with_preserve_dict_id(error_on_replacement: bool, preserve_dict_id: bool) -> Self {
-        #[allow(deprecated)]
-        Self {
-            written: HashMap::new(),
-            dict_ids: Vec::new(),
-            error_on_replacement,
-            preserve_dict_id,
-        }
-    }
-
-    /// Set the dictionary ID for `field`.
-    ///
-    /// If `preserve_dict_id` is true, this will return the `dict_id` in `field` (or panic if `field` does
-    /// not have a `dict_id` defined).
-    ///
-    /// If `preserve_dict_id` is false, this will return the value of the last `dict_id` assigned incremented by 1
-    /// or 0 in the case where no dictionary IDs have yet been assigned
-    #[deprecated(
-        since = "54.0.0",
-        note = "The ability to preserve dictionary IDs will be removed. With it, all functions related to it."
-    )]
-    pub fn set_dict_id(&mut self, field: &Field) -> i64 {
-        #[allow(deprecated)]
-        let next = if self.preserve_dict_id {
-            #[allow(deprecated)]
-            field.dict_id().expect("no dict_id in field")
-        } else {
-            self.dict_ids
-                .last()
-                .copied()
-                .map(|i| i + 1)
-                .unwrap_or_default()
-        };
+    /// Record and return the next dictionary ID.
+    pub fn next_dict_id(&mut self) -> i64 {
+        let next = self
+            .dict_ids
+            .last()
+            .copied()
+            .map(|i| i + 1)
+            .unwrap_or_default();
 
         self.dict_ids.push(next);
         next
@@ -995,11 +876,7 @@ impl<W: Write> FileWriter<W> {
         writer.write_all(&super::ARROW_MAGIC)?;
         writer.write_all(&PADDING[..pad_len])?;
         // write the schema, set the written bytes to the schema + header
-        #[allow(deprecated)]
-        let preserve_dict_id = write_options.preserve_dict_id;
-        #[allow(deprecated)]
-        let mut dictionary_tracker =
-            DictionaryTracker::new_with_preserve_dict_id(true, preserve_dict_id);
+        let mut dictionary_tracker = DictionaryTracker::new(true);
         let encoded_message = data_gen.schema_to_bytes_with_dictionary_tracker(
             schema,
             &mut dictionary_tracker,
@@ -1074,11 +951,7 @@ impl<W: Write> FileWriter<W> {
         let mut fbb = FlatBufferBuilder::new();
         let dictionaries = fbb.create_vector(&self.dictionary_blocks);
         let record_batches = fbb.create_vector(&self.record_blocks);
-        #[allow(deprecated)]
-        let preserve_dict_id = self.write_options.preserve_dict_id;
-        #[allow(deprecated)]
-        let mut dictionary_tracker =
-            DictionaryTracker::new_with_preserve_dict_id(true, preserve_dict_id);
+        let mut dictionary_tracker = DictionaryTracker::new(true);
         let schema = IpcSchemaEncoder::new()
             .with_dictionary_tracker(&mut dictionary_tracker)
             .schema_to_fb_offset(&mut fbb, &self.schema);
@@ -1229,11 +1102,7 @@ impl<W: Write> StreamWriter<W> {
         write_options: IpcWriteOptions,
     ) -> Result<Self, ArrowError> {
         let data_gen = IpcDataGenerator::default();
-        #[allow(deprecated)]
-        let preserve_dict_id = write_options.preserve_dict_id;
-        #[allow(deprecated)]
-        let mut dictionary_tracker =
-            DictionaryTracker::new_with_preserve_dict_id(false, preserve_dict_id);
+        let mut dictionary_tracker = DictionaryTracker::new(false);
 
         // write the schema, set the written bytes to the schema
         let encoded_message = data_gen.schema_to_bytes_with_dictionary_tracker(
@@ -1868,7 +1737,6 @@ mod tests {
     use arrow_array::types::*;
     use arrow_buffer::ScalarBuffer;
 
-    use crate::convert::fb_to_schema;
     use crate::reader::*;
     use crate::root_as_footer;
     use crate::MetadataVersion;
@@ -2141,7 +2009,7 @@ mod tests {
 
         // Dict field with id 2
         #[allow(deprecated)]
-        let dctfield = Field::new_dict("dict", array.data_type().clone(), false, 2, false);
+        let dctfield = Field::new_dict("dict", array.data_type().clone(), false, 0, false);
         let union_fields = [(0, Arc::new(dctfield))].into_iter().collect();
 
         let types = [0, 0, 0].into_iter().collect::<ScalarBuffer<i8>>();
@@ -2155,17 +2023,22 @@ mod tests {
             false,
         )]));
 
+        let gen = IpcDataGenerator {};
+        let mut dict_tracker = DictionaryTracker::new(false);
+        gen.schema_to_bytes_with_dictionary_tracker(
+            &schema,
+            &mut dict_tracker,
+            &IpcWriteOptions::default(),
+        );
+
         let batch = RecordBatch::try_new(schema, vec![Arc::new(union)]).unwrap();
 
-        let gen = IpcDataGenerator {};
-        #[allow(deprecated)]
-        let mut dict_tracker = DictionaryTracker::new_with_preserve_dict_id(false, true);
         gen.encoded_batch(&batch, &mut dict_tracker, &Default::default())
             .unwrap();
 
         // The encoder will assign dict IDs itself to ensure uniqueness and ignore the dict ID in the schema
         // so we expect the dict will be keyed to 0
-        assert!(dict_tracker.written.contains_key(&2));
+        assert!(dict_tracker.written.contains_key(&0));
     }
 
     #[test]
@@ -2193,15 +2066,20 @@ mod tests {
             false,
         )]));
 
+        let gen = IpcDataGenerator {};
+        let mut dict_tracker = DictionaryTracker::new(false);
+        gen.schema_to_bytes_with_dictionary_tracker(
+            &schema,
+            &mut dict_tracker,
+            &IpcWriteOptions::default(),
+        );
+
         let batch = RecordBatch::try_new(schema, vec![struct_array]).unwrap();
 
-        let gen = IpcDataGenerator {};
-        #[allow(deprecated)]
-        let mut dict_tracker = DictionaryTracker::new_with_preserve_dict_id(false, true);
         gen.encoded_batch(&batch, &mut dict_tracker, &Default::default())
             .unwrap();
 
-        assert!(dict_tracker.written.contains_key(&2));
+        assert!(dict_tracker.written.contains_key(&0));
     }
 
     fn write_union_file(options: IpcWriteOptions) {
@@ -2977,12 +2855,14 @@ mod tests {
             let footer =
                 root_as_footer(&buffer[trailer_start - footer_len..trailer_start]).unwrap();
 
-            let schema = fb_to_schema(footer.schema().unwrap());
-
             // Importantly we set `require_alignment`, checking that 16-byte alignment is sufficient
             // for `read_record_batch` later on to read the data in a zero-copy manner.
-            let decoder =
-                FileDecoder::new(Arc::new(schema), footer.version()).with_require_alignment(true);
+            let decoder = FileDecoder::new(
+                buffer[trailer_start - footer_len..trailer_start].to_vec(),
+                Default::default(),
+                footer.version(),
+            )
+            .with_require_alignment(true);
 
             let batches = footer.recordBatches().unwrap();
 
@@ -3030,12 +2910,14 @@ mod tests {
         let footer_len = read_footer_length(buffer[trailer_start..].try_into().unwrap()).unwrap();
         let footer = root_as_footer(&buffer[trailer_start - footer_len..trailer_start]).unwrap();
 
-        let schema = fb_to_schema(footer.schema().unwrap());
-
         // Importantly we set `require_alignment`, otherwise the error later is suppressed due to copying
         // to an aligned buffer in `ArrayDataBuilder.build_aligned`.
-        let decoder =
-            FileDecoder::new(Arc::new(schema), footer.version()).with_require_alignment(true);
+        let decoder = FileDecoder::new(
+            buffer[trailer_start - footer_len..trailer_start].to_vec(),
+            Default::default(),
+            footer.version(),
+        )
+        .with_require_alignment(true);
 
         let batches = footer.recordBatches().unwrap();
 

--- a/arrow/examples/zero_copy_ipc.rs
+++ b/arrow/examples/zero_copy_ipc.rs
@@ -24,12 +24,10 @@ use arrow::array::{record_batch, RecordBatch};
 use arrow::error::Result;
 use arrow_buffer::Buffer;
 use arrow_cast::pretty::pretty_format_batches;
-use arrow_ipc::convert::fb_to_schema;
 use arrow_ipc::reader::{read_footer_length, FileDecoder};
 use arrow_ipc::writer::FileWriter;
 use arrow_ipc::{root_as_footer, Block};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 /// This example shows how to read data from an Arrow IPC file without copying
 /// using `mmap` and the [`FileDecoder`] API
@@ -99,11 +97,10 @@ impl IPCBufferDecoder {
     fn new(buffer: Buffer) -> Self {
         let trailer_start = buffer.len() - 10;
         let footer_len = read_footer_length(buffer[trailer_start..].try_into().unwrap()).unwrap();
-        let footer = root_as_footer(&buffer[trailer_start - footer_len..trailer_start]).unwrap();
-
-        let schema = fb_to_schema(footer.schema().unwrap());
-
-        let mut decoder = FileDecoder::new(Arc::new(schema), footer.version());
+        let footer_buf = &buffer[trailer_start - footer_len..trailer_start];
+        let footer = root_as_footer(footer_buf).unwrap();
+        let mut decoder =
+            FileDecoder::new(footer_buf.to_vec(), Default::default(), footer.version());
 
         // Read dictionaries
         for block in footer.dictionaries().iter().flatten() {

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -180,9 +180,7 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
 /// Encodes the Arrow schema into the IPC format, and base64 encodes it
 pub fn encode_arrow_schema(schema: &Schema) -> String {
     let options = writer::IpcWriteOptions::default();
-    #[allow(deprecated)]
-    let mut dictionary_tracker =
-        writer::DictionaryTracker::new_with_preserve_dict_id(true, options.preserve_dict_id());
+    let mut dictionary_tracker = writer::DictionaryTracker::new(true);
     let data_gen = writer::IpcDataGenerator::default();
     let mut serialized_schema =
         data_gen.schema_to_bytes_with_dictionary_tracker(schema, &mut dictionary_tracker, &options);


### PR DESCRIPTION
# Which issue does this PR close?

Does not yet close, but contributes towards:

- https://github.com/apache/arrow-rs/issues/6356 
- https://github.com/apache/arrow-rs/issues/5981 
- https://github.com/apache/arrow-rs/issues/1206

# Rationale for this change

See the above issues. And this is a follow up to 
- https://github.com/apache/arrow-rs/pull/6711
- https://github.com/apache/arrow-rs/pull/6873

This was also split out from: https://github.com/apache/arrow-rs/pull/7467

# What changes are included in this PR?

The required changes, so that nothing depends on the canonical `Schema`'s `Field` containing the `dict_id` field anymore, so that as a follow up, the `dict_id` field can actually be removed from the deprecated function signatures and remove the field itself.

# Are these changes tested?

All tests continue to pass.

# Are there any user-facing changes?

The function signatures of these publicly facing APIs changed to provide the appropriate access to the dict ID as it is represented in the respective IPC message(s):

* flight_data_to_arrow_batch (arrow-flight)
* arrow_data_from_flight_data (arrow-flight; sql)
* read_record_batch (arrow-ipc)
* read_dictionary (arrow-ipc)
* FileDecoder::new (arrow-ipc)

@tustvold @alamb @thinkharderdev @adriangb 