### PR TITLE
[PoC] Alternate implementation of Parquet `ColumnOrder` thrift union

### DIFF
--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -24,7 +24,6 @@ use crate::encryption::{
 };
 #[cfg(feature = "encryption")]
 use crate::errors::ParquetError;
-use crate::errors::Result;
 use crate::file::metadata::{KeyValue, ParquetMetaData};
 use crate::file::page_index::index::Index;
 use crate::file::writer::{get_file_magic, TrackedWrite};
@@ -35,6 +34,7 @@ use crate::format::{ColumnChunk, ColumnIndex, FileMetaData, OffsetIndex, RowGrou
 use crate::schema::types;
 use crate::schema::types::{SchemaDescPtr, SchemaDescriptor, TypePtr};
 use crate::thrift::TSerializable;
+use crate::{errors::Result, format::ColumnOrderDisc};
 use std::io::Write;
 use std::sync::Arc;
 use thrift::protocol::TCompactOutputProtocol;
@@ -134,7 +134,12 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         // Even if the column has an undefined sort order, such as INTERVAL, this
         // is still technically the defined TYPEORDER so it should still be set.
         let column_orders = (0..self.schema_descr.num_columns())
-            .map(|_| crate::format::ColumnOrder::TYPEORDER(crate::format::TypeDefinedOrder {}))
+            .map(|_| {
+                crate::format::ColumnOrder::new(
+                    ColumnOrderDisc::TYPE_ORDER,
+                    crate::format::TypeDefinedOrder {},
+                )
+            })
             .collect();
         // This field is optional, perhaps in cases where no min/max fields are set
         // in any Statistics or ColumnIndex object in the whole file.

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1876,7 +1876,7 @@ mod tests {
         let ret = SerializedFileReader::new(Bytes::copy_from_slice(&data));
         assert_eq!(
             ret.err().unwrap().to_string(),
-            "Parquet error: Could not parse metadata: bad data"
+            "Parquet error: Could not parse metadata: end of file"
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Relates to #7909.

# Rationale for this change

Not for merging, but as a discussion point. This PR implements the thrift union `ColumnOrder` as a rust struct rather than a rust enum, analogously to how the thrift rust generator handles thrift enums.

The current implementation is not very ergonomic, but gets the point across.


