### PR TITLE
fix: Replace invalid lint with clippy::transmute_int_to_float

### DIFF
--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -421,13 +421,13 @@ native_type_float_op!(
     unsafe {
         // Need to allow in clippy because
         // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
-        #[allow(unnecessary_transmutes)]
+        #[allow(clippy::transmute_int_to_float)]
         std::mem::transmute(-1_i32)
     },
     unsafe {
         // Need to allow in clippy because
         // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
-        #[allow(unnecessary_transmutes)]
+        #[allow(clippy::transmute_int_to_float)]
         std::mem::transmute(i32::MAX)
     }
 );
@@ -438,13 +438,13 @@ native_type_float_op!(
     unsafe {
         // Need to allow in clippy because
         // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
-        #[allow(unnecessary_transmutes)]
+        #[allow(clippy::transmute_int_to_float)]
         std::mem::transmute(-1_i64)
     },
     unsafe {
         // Need to allow in clippy because
         // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
-        #[allow(unnecessary_transmutes)]
+        #[allow(clippy::transmute_int_to_float)]
         std::mem::transmute(i64::MAX)
     }
 );


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`#[allow(unnecessary_transmutes)]` is not a valid lint and causes `unknown lint` warnings. This PR replaces it with the correct Clippy lint.

# What changes are included in this PR?

Replaces `#[allow(unnecessary_transmutes)]` with `#[allow(clippy::transmute_int_to_float)]` in `arrow-array`.

# Are these changes tested?

Yes, covered by existing tests and verified with `cargo check` and `cargo clippy`.

# Are there any user-facing changes?

No.
