### PR TITLE
Minor: Restore warning comment on Int96 statistics read

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -209,6 +209,7 @@ pub fn from_thrift(
                     old_format,
                 ),
                 Type::INT96 => {
+                    // INT96 statistics may not be correct, because comparison is signed
                     let min = if let Some(data) = min {
                         assert_eq!(data.len(), 12);
                         Some(Int96::try_from_le_slice(&data)?)


### PR DESCRIPTION
# Which issue does this PR close?


- Follow on to https://github.com/apache/arrow-rs/pull/7687

# Rationale for this change

I merged https://github.com/apache/arrow-rs/pull/7687 without addressing one of @emkornfield 's suggestions: https://github.com/apache/arrow-rs/pull/7687/files#r2205393903 

# What changes are included in this PR?

Implement the suggestion (restore a comment_

# Are these changes tested?

 BY CI

# Are there any user-facing changes?

No