### PR TITLE
Derive `Serialize` and `Deserialize` on `CastOptions`

### DIFF
--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -38,6 +38,7 @@ all-features = true
 [features]
 prettyprint = ["comfy-table"]
 force_validate = []
+serde = ["dep:serde"]
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -53,6 +54,7 @@ atoi = "2.0.0"
 comfy-table = { version = "7.0", optional = true, default-features = false }
 base64 = "0.22"
 ryu = "1.0.16"
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -70,6 +70,7 @@ use num::{NumCast, ToPrimitive};
 
 /// CastOptions provides a way to override the default cast behaviors
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CastOptions<'a> {
     /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
     pub safe: bool,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -75,6 +75,7 @@ pub struct CastOptions<'a> {
     /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
     pub safe: bool,
     /// Formatting options when casting from temporal types to string
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub format_options: FormatOptions<'a>,
 }
 

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -40,6 +40,7 @@ type TimeFormat<'a> = Option<&'a str>;
 
 /// Format for displaying durations
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum DurationFormat {
     /// ISO 8601 - `P198DT72932.972880S`
@@ -54,6 +55,7 @@ pub enum DurationFormat {
 /// according to RFC3339
 ///
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FormatOptions<'a> {
     /// If set to `true` any formatting errors will be written to the output
     /// instead of being converted into a [`std::fmt::Error`]

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -81,6 +81,7 @@ force_validate = ["arrow-array/force_validate", "arrow-data/force_validate"]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi", "arrow-array/ffi"]
 chrono-tz = ["arrow-array/chrono-tz"]
 canonical_extension_types = ["arrow-schema/canonical_extension_types"]
+serde = ["arrow-schema/serde", "arrow-cast/serde"]
 
 [dev-dependencies]
 chrono = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Make `CastOptions` serializable.

# What changes are included in this PR?

Derive Serialize and Deserialize on CastOptions.

# Are these changes tested?

CI.

# Are there any user-facing changes?

No.
