### PR TITLE
doc: remove outdated info from CONTRIBUTING doc in project root dir.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,7 @@ You can also use rust's official docker image:
 docker run --rm -v $(pwd):/arrow-rs -it rust /bin/bash -c "cd /arrow-rs && rustup component add rustfmt && cargo build"
 ```
 
-The command above assumes that are in the root directory of the project, not in the same
-directory as this README.md.
+The command above assumes that are in the root directory of the project.
 
 You can also compile specific workspaces:
 


### PR DESCRIPTION
# Which issue does this PR close?

No issue as this is only a doc improvement.

# Rationale for this change

The removed info in CONTRIBUTING doc is outdated as it is not README file anymore and CONTRIBUTING file is already at project root.

# What changes are included in this PR?

Only root CONTRIBUTING doc update.

# Are these changes tested?

No because of only doc update.

# Are there any user-facing changes?

No.
