### PR TITLE
Minor: Upate `cast_with_options` docs about casting integers --> intervals

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -611,6 +611,20 @@ fn timestamp_to_date32<T: ArrowTimestampType>(
 /// * `List` to `Primitive`
 /// * `Interval` and `Duration`
 ///
+/// # Durations and Intervals
+///
+/// Casting integer types directly to interval types such as
+/// [`IntervalMonthDayNano`] is not supported because the meaning of the integer
+/// is ambiguous. For example, the integer  could represent either nanoseconds
+/// or months.
+///
+/// To cast an integer type to an interval type, first convert to a Duration
+/// type, and then cast that to the desired interval type.
+///
+/// For example, to convert an `Int64` representing nanoseconds to an
+/// `IntervalMonthDayNano` you would first convert the `Int64` to a
+/// `DurationNanoseconds`, and then cast that to `IntervalMonthDayNano`.
+///
 /// # Timestamps and Timezones
 ///
 /// Timestamps are stored with an optional timezone in Arrow.


### PR DESCRIPTION


# Which issue does this PR close?


- Closes https://github.com/apache/arrow-rs/pull/7989
- Closes https://github.com/apache/arrow-rs/issues/7988

# Rationale for this change

It was not initially clear to be or @brancz  how go from integer to interval. Let's make that clear in docs 

# What changes are included in this PR?

Add a doc explaining the rationale and how to do the conversion

# Are these changes tested?

By CI

# Are there any user-facing changes?

Docs only, no behavior chagne