### PR TITLE
[Parquet] Allow writing compatible DictionaryArrays to parquet writer

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -135,7 +135,7 @@ mod levels;
 /// value type.
 ///
 /// Currently, only compatibility between Arrow dictionary and native arrays are supported.
-/// Additional type compatibility may be added in future (see )
+/// Additional type compatibility may be added in future (see [issue #8012](https://github.com/apache/arrow-rs/issues/8012))
 /// ```
 /// # use std::sync::Arc;
 /// # use arrow_array::{DictionaryArray, RecordBatch, StringArray, UInt8Array};

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -128,6 +128,44 @@ mod levels;
 /// [`ListArray`]: https://docs.rs/arrow/latest/arrow/array/type.ListArray.html
 /// [`IntervalMonthDayNanoArray`]: https://docs.rs/arrow/latest/arrow/array/type.IntervalMonthDayNanoArray.html
 /// [support nanosecond intervals]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
+///
+/// ## Type Compatibility
+/// The writer can write Arrow [`RecordBatches`]s that are logically equivalent. This means that for
+/// a  given column, the writer can accept multiple Arrow [`DataType`]s that have contain the same
+/// value type.
+///
+/// Currently, only compatibility between Arrow dictionary and native arrays are supported.
+/// Additional type compatibility may be added in future (see )
+/// ```
+/// # use std::sync::Arc;
+/// # use arrow_array::{DictionaryArray, RecordBatch, StringArray, UInt8Array};
+/// # use arrow_schema::{DataType, Field, Schema};
+/// # use parquet::arrow::arrow_writer::ArrowWriter;
+/// let record_batch1 = RecordBatch::try_new(
+///    Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)])),
+///    vec![Arc::new(StringArray::from_iter_values(vec!["a", "b"]))]
+///  )
+/// .unwrap();
+///
+/// let mut buffer = Vec::new();
+/// let mut writer = ArrowWriter::try_new(&mut buffer, record_batch1.schema(), None).unwrap();
+/// writer.write(&record_batch1).unwrap();
+///
+/// let record_batch2 = RecordBatch::try_new(
+///     Arc::new(Schema::new(vec![Field::new(
+///         "col",
+///         DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8)),
+///          false,
+///     )])),
+///     vec![Arc::new(DictionaryArray::new(
+///          UInt8Array::from_iter_values(vec![0, 1]),
+///          Arc::new(StringArray::from_iter_values(vec!["b", "c"])),
+///      ))],
+///  )
+///  .unwrap();
+///  writer.write(&record_batch2).unwrap();
+///  writer.close();
+/// ```
 pub struct ArrowWriter<W: Write> {
     /// Underlying Parquet writer
     writer: SerializedFileWriter<W>,
@@ -3074,6 +3112,55 @@ mod tests {
                     "parquet", "barquet", "curious",
                 ])),
             ))],
+        )
+        .unwrap();
+
+        assert_eq!(actual_batch, expected_batch)
+    }
+
+    #[test]
+    fn arrow_writer_native_and_dict_compatibility() {
+        let schema1 = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, false)]));
+        let rb1 = RecordBatch::try_new(
+            schema1.clone(),
+            vec![Arc::new(StringArray::from_iter_values(vec![
+                "parquet", "barquet",
+            ]))],
+        )
+        .unwrap();
+
+        let file = tempfile().unwrap();
+        let mut writer =
+            ArrowWriter::try_new(file.try_clone().unwrap(), rb1.schema(), None).unwrap();
+        writer.write(&rb1).unwrap();
+
+        let schema2 = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8)),
+            false,
+        )]));
+
+        let rb2 = RecordBatch::try_new(
+            schema2.clone(),
+            vec![Arc::new(DictionaryArray::new(
+                UInt8Array::from_iter_values(vec![0, 1, 0]),
+                Arc::new(StringArray::from_iter_values(vec!["barquet", "curious"])),
+            ))],
+        )
+        .unwrap();
+        writer.write(&rb2).unwrap();
+
+        writer.close().unwrap();
+
+        let mut record_batch_reader =
+            ParquetRecordBatchReader::try_new(file.try_clone().unwrap(), 1024).unwrap();
+        let actual_batch = record_batch_reader.next().unwrap().unwrap();
+
+        let expected_batch = RecordBatch::try_new(
+            schema1,
+            vec![Arc::new(StringArray::from_iter_values(vec![
+                "parquet", "barquet", "barquet", "curious", "barquet",
+            ]))],
         )
         .unwrap();
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -130,7 +130,7 @@ mod levels;
 /// [support nanosecond intervals]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval
 ///
 /// ## Type Compatibility
-/// The writer can write Arrow [`RecordBatches`]s that are logically equivalent. This means that for
+/// The writer can write Arrow [`RecordBatch`]s that are logically equivalent. This means that for
 /// a  given column, the writer can accept multiple Arrow [`DataType`]s that have contain the same
 /// value type.
 ///

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -131,7 +131,7 @@ mod levels;
 ///
 /// ## Type Compatibility
 /// The writer can write Arrow [`RecordBatch`]s that are logically equivalent. This means that for
-/// a  given column, the writer can accept multiple Arrow [`DataType`]s that have contain the same
+/// a  given column, the writer can accept multiple Arrow [`DataType`]s that contain the same
 /// value type.
 ///
 /// Currently, only compatibility between Arrow dictionary and native arrays are supported.


### PR DESCRIPTION
# Which issue does this PR close?

- closes https://github.com/apache/arrow-rs/issues/8004

# Rationale for this change

I'm opening this PR to explore the idea that for a given column, the `ArrowWriter` should compatible consider either native arrays or dictionary arrays with the same value. 

e.g. if I write two record batches, and in the first batch column `a` is type `Dictionary<_, Utf8>`, I should be able to append a second batch to my writer where column `a` is type `Utf8` (the native array).

# What changes are included in this PR?

This PR relaxes the added in https://github.com/apache/arrow-rs/pull/5341 when creating `LevelsInfoBuilder` to consider the types compatible using the logic explained above.

# Are these changes tested?

There is a basic unit test. I'm happy to add more if this change is something acceptable.

# Are there any user-facing changes?
No
