### PR TITLE
Create empty buffer for a buffer specified in the C Data Interface with length zero

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           cargo test -p arrow-array --all-features
           # Disable feature `force_validate`
-          cargo test -p arrow-array
+          cargo test -p arrow-array --features=ffi
       - name: Test arrow-select
         run: cargo test -p arrow-select --all-features
       - name: Test arrow-cast

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -68,7 +68,10 @@ jobs:
       - name: Test arrow-schema
         run: cargo test -p arrow-schema --all-features
       - name: Test arrow-array
-        run: cargo test -p arrow-array --all-features
+        run: |
+          cargo test -p arrow-array --all-features
+          # Disable feature `force_validate`
+          cargo test -p arrow-array
       - name: Test arrow-select
         run: cargo test -p arrow-select --all-features
       - name: Test arrow-cast

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1672,6 +1672,7 @@ mod tests_from_ffi {
     }
 
     #[test]
+    #[cfg(not(feature = "force_validate"))]
     fn test_utf8_view_ffi_from_dangling_pointer() {
         let empty = GenericByteViewBuilder::<StringViewType>::new().finish();
         let buffers = empty.data_buffers().to_vec();

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1682,7 +1682,8 @@ mod tests_from_ffi {
         let buffer = unsafe { Buffer::from_custom_allocation(NonNull::<u8>::dangling(), 0, alloc) };
         let views = unsafe { ScalarBuffer::new_unchecked(buffer) };
 
-        let str_view: GenericByteViewArray<StringViewType> = unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) };
+        let str_view: GenericByteViewArray<StringViewType> =
+            unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) };
         let imported = roundtrip_byte_view_array(str_view);
         assert_eq!(imported.len(), 0);
         assert_eq!(&imported, &empty);

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -408,7 +408,13 @@ impl ImportedArrowArray<'_> {
             .map(|index| {
                 let len = self.buffer_len(index, variadic_buffer_lens, &self.data_type)?;
                 match unsafe { create_buffer(self.owner.clone(), self.array, index, len) } {
-                    Some(buf) => Ok(buf),
+                    Some(buf) => {
+                        if buf.is_empty() {
+                            Ok(MutableBuffer::new(0).into())
+                        } else {
+                            Ok(buf)
+                        }
+                    }
                     None if len == 0 => {
                         // Null data buffer, which Rust doesn't allow. So create
                         // an empty buffer.

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -409,6 +409,10 @@ impl ImportedArrowArray<'_> {
                 let len = self.buffer_len(index, variadic_buffer_lens, &self.data_type)?;
                 match unsafe { create_buffer(self.owner.clone(), self.array, index, len) } {
                     Some(buf) => {
+                        // External libraries may use a dangling pointer for a buffer with length 0.
+                        // We respect the array length specified in the C Data Interface. Actually,
+                        // if the length is incorrect, we cannot create a correct buffer even if
+                        // the pointer is valid.
                         if buf.is_empty() {
                             Ok(MutableBuffer::new(0).into())
                         } else {

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1306,10 +1306,15 @@ mod tests_to_then_from_ffi {
 
 #[cfg(test)]
 mod tests_from_ffi {
+    #[cfg(not(feature = "force_validate"))]
     use std::ptr::NonNull;
     use std::sync::Arc;
 
+    #[cfg(feature = "force_validate")]
+    use arrow_buffer::{bit_util, buffer::Buffer};
+    #[cfg(not(feature = "force_validate"))]
     use arrow_buffer::{bit_util, buffer::Buffer, ScalarBuffer};
+
     use arrow_data::transform::MutableArrayData;
     use arrow_data::ArrayData;
     use arrow_schema::{DataType, Field};

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -72,6 +72,19 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
         buffer.slice_with_length(byte_offset, byte_len).into()
     }
 
+    /// Unsafe function to create a new [`ScalarBuffer`] from a [`Buffer`].
+    /// Only use for testing purpose.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it does not check if the `buffer` is aligned
+    pub unsafe fn new_unchecked(buffer: Buffer) -> Self {
+       Self {
+           buffer,
+           phantom: Default::default(),
+       }
+    }
+
     /// Free up unused memory.
     pub fn shrink_to_fit(&mut self) {
         self.buffer.shrink_to_fit();
@@ -98,6 +111,11 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
     #[inline]
     pub fn ptr_eq(&self, other: &Self) -> bool {
         self.buffer.ptr_eq(&other.buffer)
+    }
+
+    /// Returns the number of elements in the buffer
+    pub fn len(&self) -> usize {
+        self.buffer.len() / std::mem::size_of::<T>()
     }
 }
 

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -79,10 +79,10 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
     ///
     /// This function is unsafe because it does not check if the `buffer` is aligned
     pub unsafe fn new_unchecked(buffer: Buffer) -> Self {
-       Self {
-           buffer,
-           phantom: Default::default(),
-       }
+        Self {
+            buffer,
+            phantom: Default::default(),
+        }
     }
 
     /// Free up unused memory.

--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -117,6 +117,11 @@ impl<T: ArrowNativeType> ScalarBuffer<T> {
     pub fn len(&self) -> usize {
         self.buffer.len() / std::mem::size_of::<T>()
     }
+
+    /// Returns if the buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<T: ArrowNativeType> Deref for ScalarBuffer<T> {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7549.

# Rationale for this change

The failure was described in the issue. In short, the buffer pointer of an empty buffer array exported from polars is a dangling pointer not aligned. But currently we take the raw pointer from C Data Interface and check its alignment before interpreting it as `ScalarBuffer`. Thus it causes the failure case.

# What changes are included in this PR?

This patch changes FFI module to create an empty buffer for exported buffer with length zero. As we never dereference the dangling pointer, seems it's not necessary to require the alignment for it.

For non empty buffers, we still keep the alignment check.

# Are these changes tested?

Added a unit test with necessary utility functions.

# Are there any user-facing changes?

No
