### PR TITLE
feat: add method for sync Parquet reader read bloom filter

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -4793,15 +4793,15 @@ mod tests {
         let file = File::open(path).unwrap();
         let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
         let schema = builder.schema().clone();
-        let mut reader = builder.build().unwrap();
-        let batches = reader.try_collect::<Vec<_>>().unwrap();
+        let reader = builder.build().unwrap();
 
         let mut parquet_data = Vec::new();
         let props = WriterProperties::builder()
             .set_bloom_filter_enabled(true)
             .build();
         let mut writer = ArrowWriter::try_new(&mut parquet_data, schema, Some(props)).unwrap();
-        for batch in batches {
+        for batch in reader {
+            let batch = batch.unwrap();
             writer.write(&batch).unwrap();
         }
         writer.close().unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8023

# Rationale for this change

Add sync parquet read bloom filter.

# What changes are included in this PR?

Add a sync `get_row_group_column_bloom_filter`

# Are these changes tested?

By unittests

# Are there any user-facing changes?

Api added
