### PR TITLE
Add ADJUSTED_TO_UTC_KEY constant and add it to field metadata when reading TIME logical  types

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1012,7 +1012,7 @@ mod tests {
         ParquetRecordBatchReaderBuilder, RowFilter, RowSelection, RowSelector,
     };
     use crate::arrow::schema::add_encoded_arrow_schema_to_metadata;
-    use crate::arrow::{ArrowWriter, ProjectionMask};
+    use crate::arrow::{ArrowWriter, ProjectionMask, ADJUSTED_TO_UTC_KEY};
     use crate::basic::{ConvertedType, Encoding, Repetition, Type as PhysicalType};
     use crate::column::reader::decoder::REPETITION_LEVELS_BATCH_SIZE;
     use crate::data_type::{
@@ -1298,7 +1298,7 @@ mod tests {
                 true,
             )
             .with_metadata(HashMap::from_iter(vec![(
-                "adjusted_to_utc".to_string(),
+                ADJUSTED_TO_UTC_KEY.to_string(),
                 "".to_string(),
             )])),
             Field::new(
@@ -1307,7 +1307,7 @@ mod tests {
                 true,
             )
             .with_metadata(HashMap::from_iter(vec![(
-                "adjusted_to_utc".to_string(),
+                ADJUSTED_TO_UTC_KEY.to_string(),
                 "".to_string(),
             )])),
         ]));
@@ -1340,7 +1340,10 @@ mod tests {
         writer.write(&original)?;
         writer.close()?;
 
-        let mut reader = ParquetRecordBatchReader::try_new(Bytes::from(buf), 1024)?;
+        let opts = ArrowReaderOptions::new().with_skip_arrow_metadata(true);
+
+        let mut reader =
+            ArrowReaderBuilder::try_new_with_options(Bytes::from(buf), opts)?.build()?;
         let ret = reader.next().unwrap()?;
         assert_eq!(ret, original);
 

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -221,6 +221,15 @@ pub const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 /// [`BasicTypeInfo::id`]: crate::schema::types::BasicTypeInfo::id
 pub const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
 
+/// Metadata key whose presence on [`Field::metadata`] indicates that a
+/// [`DataType::Time32`] or [`DataType::Time64`] is adjusted to UTC as defined
+/// in the parquet spec.
+///
+/// [`Field::metadata`]: arrow_schema::Field::metadata
+/// [`DataType::Time32`]: arrow_schema::DataType::Time32
+/// [`DataType::Time64`]: arrow_schema::DataType::Time64
+pub const ADJUSTED_TO_UTC_KEY: &str = "adjusted_to_utc";
+
 /// A [`ProjectionMask`] identifies a set of columns within a potentially nested schema to project
 ///
 /// In particular, a [`ProjectionMask`] can be constructed from a list of leaf column indices

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -40,7 +40,7 @@ mod primitive;
 use crate::arrow::ProjectionMask;
 pub(crate) use complex::{ParquetField, ParquetFieldType};
 
-use super::PARQUET_FIELD_ID_META_KEY;
+use super::{ADJUSTED_TO_UTC_KEY, PARQUET_FIELD_ID_META_KEY};
 
 /// Convert Parquet schema to Arrow schema including optional metadata
 ///
@@ -569,7 +569,7 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
         }
         DataType::Time32(unit) => Type::primitive_type_builder(name, PhysicalType::INT32)
             .with_logical_type(Some(LogicalType::Time {
-                is_adjusted_to_u_t_c: field.metadata().contains_key("adjusted_to_utc"),
+                is_adjusted_to_u_t_c: field.metadata().contains_key(ADJUSTED_TO_UTC_KEY),
                 unit: match unit {
                     TimeUnit::Millisecond => ParquetTimeUnit::MILLIS(Default::default()),
                     u => unreachable!("Invalid unit for Time32: {:?}", u),
@@ -580,7 +580,7 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
             .build(),
         DataType::Time64(unit) => Type::primitive_type_builder(name, PhysicalType::INT64)
             .with_logical_type(Some(LogicalType::Time {
-                is_adjusted_to_u_t_c: field.metadata().contains_key("adjusted_to_utc"),
+                is_adjusted_to_u_t_c: field.metadata().contains_key(ADJUSTED_TO_UTC_KEY),
                 unit: match unit {
                     TimeUnit::Microsecond => ParquetTimeUnit::MICROS(Default::default()),
                     TimeUnit::Nanosecond => ParquetTimeUnit::NANOS(Default::default()),
@@ -1779,7 +1779,7 @@ mod tests {
                 true,
             )
             .with_metadata(HashMap::from_iter(vec![(
-                "adjusted_to_utc".to_string(),
+                ADJUSTED_TO_UTC_KEY.to_string(),
                 "".to_string(),
             )])),
             Field::new("time_micro", DataType::Time64(TimeUnit::Microsecond), true),
@@ -1789,7 +1789,7 @@ mod tests {
                 true,
             )
             .with_metadata(HashMap::from_iter(vec![(
-                "adjusted_to_utc".to_string(),
+                ADJUSTED_TO_UTC_KEY.to_string(),
                 "".to_string(),
             )])),
             Field::new(


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8027.

# Rationale for this change

This lets users detect when a Time32 or Time64 has the adjusted_to_u_t_c property set in the parquet file.  Previously this only worked if the file was written by arrow-rs and the reader chooses not to skip the arrow metadata.

# What changes are included in this PR?

This adds documented constant for "adjusted_to_utc" so that users are aware of this functionality.  This key gets added when making a `Field` from a parquet type if the logical type as the adjusted_to_u_t_c field set.

# Are these changes tested?

I updated `test_time_utc_roundtrip()` to skip the arrow metadata to simulate reading a file that doesn't have the metadata we expect or if a user chooses to skip the arrow metadata when reading.

# Are there any user-facing changes?

Yes: this adds a new constant "ADJUSTED_TO_UTC_KEY".  It may be helpful to add documentation for this near where `DataType::Time32`/`DataType::Time64` are defined.
