### PR TITLE
Reduce use of `parquet::format` in the public API

### DIFF
--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -15,10 +15,141 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use rand::Rng;
+use thrift::protocol::TCompactOutputProtocol;
+
+use arrow::util::test_util::seedable_rng;
 use bytes::Bytes;
 use criterion::*;
 use parquet::file::reader::SerializedFileReader;
 use parquet::file::serialized_reader::ReadOptionsBuilder;
+use parquet::format::{
+    ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, FieldRepetitionType, FileMetaData,
+    RowGroup, SchemaElement, Type,
+};
+use parquet::thrift::TSerializable;
+
+const NUM_COLUMNS: usize = 10_000;
+const NUM_ROW_GROUPS: usize = 10;
+
+fn encoded_meta() -> Vec<u8> {
+    let mut rng = seedable_rng();
+
+    let mut schema = Vec::with_capacity(NUM_COLUMNS + 1);
+    schema.push(SchemaElement {
+        type_: None,
+        type_length: None,
+        repetition_type: None,
+        name: Default::default(),
+        num_children: Some(NUM_COLUMNS as _),
+        converted_type: None,
+        scale: None,
+        precision: None,
+        field_id: None,
+        logical_type: None,
+    });
+    for i in 0..NUM_COLUMNS {
+        schema.push(SchemaElement {
+            type_: Some(Type::FLOAT),
+            type_length: None,
+            repetition_type: Some(FieldRepetitionType::REQUIRED),
+            name: i.to_string(),
+            num_children: None,
+            converted_type: None,
+            scale: None,
+            precision: None,
+            field_id: None,
+            logical_type: None,
+        })
+    }
+
+    let stats = parquet::format::Statistics {
+        min: None,
+        max: None,
+        null_count: Some(0),
+        distinct_count: None,
+        max_value: Some(vec![rng.random(); 8]),
+        min_value: Some(vec![rng.random(); 8]),
+        is_max_value_exact: Some(true),
+        is_min_value_exact: Some(true),
+    };
+
+    let row_groups = (0..NUM_ROW_GROUPS)
+        .map(|i| {
+            let columns = (0..NUM_COLUMNS)
+                .map(|_| ColumnChunk {
+                    file_path: None,
+                    file_offset: 0,
+                    meta_data: Some(ColumnMetaData {
+                        type_: Type::FLOAT,
+                        encodings: vec![Encoding::PLAIN, Encoding::RLE_DICTIONARY],
+                        path_in_schema: vec![],
+                        codec: CompressionCodec::UNCOMPRESSED,
+                        num_values: rng.random(),
+                        total_uncompressed_size: rng.random(),
+                        total_compressed_size: rng.random(),
+                        key_value_metadata: None,
+                        data_page_offset: rng.random(),
+                        index_page_offset: Some(rng.random()),
+                        dictionary_page_offset: Some(rng.random()),
+                        statistics: Some(stats.clone()),
+                        encoding_stats: None,
+                        bloom_filter_offset: None,
+                        bloom_filter_length: None,
+                        size_statistics: None,
+                        geospatial_statistics: None,
+                    }),
+                    offset_index_offset: Some(rng.random()),
+                    offset_index_length: Some(rng.random()),
+                    column_index_offset: Some(rng.random()),
+                    column_index_length: Some(rng.random()),
+                    crypto_metadata: None,
+                    encrypted_column_metadata: None,
+                })
+                .collect();
+
+            RowGroup {
+                columns,
+                total_byte_size: rng.random(),
+                num_rows: rng.random(),
+                sorting_columns: None,
+                file_offset: None,
+                total_compressed_size: Some(rng.random()),
+                ordinal: Some(i as _),
+            }
+        })
+        .collect();
+
+    let file = FileMetaData {
+        schema,
+        row_groups,
+        version: 1,
+        num_rows: rng.random(),
+        key_value_metadata: None,
+        created_by: Some("parquet-rs".into()),
+        column_orders: None,
+        encryption_algorithm: None,
+        footer_signing_key_metadata: None,
+    };
+
+    let mut buf = Vec::with_capacity(1024);
+    {
+        let mut out = TCompactOutputProtocol::new(&mut buf);
+        file.write_to_out_protocol(&mut out).unwrap();
+    }
+    buf
+}
+
+fn get_footer_bytes(data: Bytes) -> Bytes {
+    let footer_bytes = data.slice(data.len() - 8..);
+    let footer_len = footer_bytes[0] as u32
+        | (footer_bytes[1] as u32) << 8
+        | (footer_bytes[2] as u32) << 16
+        | (footer_bytes[3] as u32) << 24;
+    let meta_start = data.len() - footer_len as usize - 8;
+    let meta_end = data.len() - 8;
+    data.slice(meta_start..meta_end)
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Read file into memory to isolate filesystem performance
@@ -34,6 +165,20 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let options = ReadOptionsBuilder::new().with_page_index().build();
             SerializedFileReader::new_with_options(data.clone(), options).unwrap()
+        })
+    });
+
+    let meta_data = get_footer_bytes(data);
+    c.bench_function("decode file metadata", |b| {
+        b.iter(|| {
+            parquet::thrift::bench_file_metadata(&meta_data);
+        })
+    });
+
+    let buf = black_box(encoded_meta()).into();
+    c.bench_function("decode file metadata (wide)", |b| {
+        b.iter(|| {
+            parquet::thrift::bench_file_metadata(&buf);
         })
     });
 }

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -30,6 +30,7 @@ pub use crate::arrow::array_reader::RowGroups;
 use crate::arrow::array_reader::{ArrayReader, ArrayReaderBuilder};
 use crate::arrow::schema::{parquet_to_arrow_schema_and_fields, ParquetField};
 use crate::arrow::{parquet_to_arrow_field_levels, FieldLevels, ProjectionMask};
+use crate::basic::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 use crate::bloom_filter::{
     chunk_read_bloom_filter_header_and_offset, Sbbf, SBBF_HEADER_SIZE_ESTIMATE,
 };
@@ -39,7 +40,6 @@ use crate::encryption::decrypt::FileDecryptionProperties;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use crate::file::reader::{ChunkReader, SerializedPageReader};
-use crate::format::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 use crate::schema::types::SchemaDescriptor;
 
 pub(crate) use read_plan::{ReadPlan, ReadPlanBuilder};
@@ -737,17 +737,17 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             chunk_read_bloom_filter_header_and_offset(offset, buffer.clone())?;
 
         match header.algorithm {
-            BloomFilterAlgorithm::BLOCK(_) => {
+            BloomFilterAlgorithm::BLOCK => {
                 // this match exists to future proof the singleton algorithm enum
             }
         }
         match header.compression {
-            BloomFilterCompression::UNCOMPRESSED(_) => {
+            BloomFilterCompression::UNCOMPRESSED => {
                 // this match exists to future proof the singleton compression enum
             }
         }
         match header.hash {
-            BloomFilterHash::XXHASH(_) => {
+            BloomFilterHash::XXHASH => {
                 // this match exists to future proof the singleton hash enum
             }
         }

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -30,12 +30,16 @@ pub use crate::arrow::array_reader::RowGroups;
 use crate::arrow::array_reader::{ArrayReader, ArrayReaderBuilder};
 use crate::arrow::schema::{parquet_to_arrow_schema_and_fields, ParquetField};
 use crate::arrow::{parquet_to_arrow_field_levels, FieldLevels, ProjectionMask};
+use crate::bloom_filter::{
+    chunk_read_bloom_filter_header_and_offset, Sbbf, SBBF_HEADER_SIZE_ESTIMATE,
+};
 use crate::column::page::{PageIterator, PageReader};
 #[cfg(feature = "encryption")]
 use crate::encryption::decrypt::FileDecryptionProperties;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use crate::file::reader::{ChunkReader, SerializedPageReader};
+use crate::format::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 use crate::schema::types::SchemaDescriptor;
 
 pub(crate) use read_plan::{ReadPlan, ReadPlanBuilder};
@@ -701,6 +705,66 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
     /// ```
     pub fn new_with_metadata(input: T, metadata: ArrowReaderMetadata) -> Self {
         Self::new_builder(SyncReader(input), metadata)
+    }
+
+    /// Read bloom filter for a column in a row group
+    ///
+    /// Returns `None` if the column does not have a bloom filter
+    ///
+    /// We should call this function after other forms pruning, such as projection and predicate pushdown.
+    pub fn get_row_group_column_bloom_filter(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> Result<Option<Sbbf>> {
+        let metadata = self.metadata.row_group(row_group_idx);
+        let column_metadata = metadata.column(column_idx);
+
+        let offset: u64 = if let Some(offset) = column_metadata.bloom_filter_offset() {
+            offset
+                .try_into()
+                .map_err(|_| ParquetError::General("Bloom filter offset is invalid".to_string()))?
+        } else {
+            return Ok(None);
+        };
+
+        let buffer = match column_metadata.bloom_filter_length() {
+            Some(length) => self.input.0.get_bytes(offset, length as usize),
+            None => self.input.0.get_bytes(offset, SBBF_HEADER_SIZE_ESTIMATE),
+        }?;
+
+        let (header, bitset_offset) =
+            chunk_read_bloom_filter_header_and_offset(offset, buffer.clone())?;
+
+        match header.algorithm {
+            BloomFilterAlgorithm::BLOCK(_) => {
+                // this match exists to future proof the singleton algorithm enum
+            }
+        }
+        match header.compression {
+            BloomFilterCompression::UNCOMPRESSED(_) => {
+                // this match exists to future proof the singleton compression enum
+            }
+        }
+        match header.hash {
+            BloomFilterHash::XXHASH(_) => {
+                // this match exists to future proof the singleton hash enum
+            }
+        }
+
+        let bitset = match column_metadata.bloom_filter_length() {
+            Some(_) => buffer.slice(
+                (TryInto::<usize>::try_into(bitset_offset).unwrap()
+                    - TryInto::<usize>::try_into(offset).unwrap())..,
+            ),
+            None => {
+                let bitset_length: usize = header.num_bytes.try_into().map_err(|_| {
+                    ParquetError::General("Bloom filter length is invalid".to_string())
+                })?;
+                self.input.0.get_bytes(bitset_offset, bitset_length)?
+            }
+        };
+        Ok(Some(Sbbf::new(&bitset)))
     }
 
     /// Build a [`ParquetRecordBatchReader`]
@@ -4719,5 +4783,55 @@ mod tests {
         let c1 = out.column(2).as_list::<i32>();
         assert_eq!(c0.len(), c1.len());
         c0.iter().zip(c1.iter()).for_each(|(l, r)| assert_eq!(l, r));
+    }
+
+    #[test]
+    fn test_get_row_group_column_bloom_filter_with_length() {
+        // convert to new parquet file with bloom_filter_length
+        let testdata = arrow::util::test_util::parquet_test_data();
+        let path = format!("{testdata}/data_index_bloom_encoding_stats.parquet");
+        let file = File::open(path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let schema = builder.schema().clone();
+        let reader = builder.build().unwrap();
+
+        let mut parquet_data = Vec::new();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .build();
+        let mut writer = ArrowWriter::try_new(&mut parquet_data, schema, Some(props)).unwrap();
+        for batch in reader {
+            let batch = batch.unwrap();
+            writer.write(&batch).unwrap();
+        }
+        writer.close().unwrap();
+
+        // test the new parquet file
+        test_get_row_group_column_bloom_filter(parquet_data.into(), true);
+    }
+
+    #[test]
+    fn test_get_row_group_column_bloom_filter_without_length() {
+        let testdata = arrow::util::test_util::parquet_test_data();
+        let path = format!("{testdata}/data_index_bloom_encoding_stats.parquet");
+        let data = Bytes::from(std::fs::read(path).unwrap());
+        test_get_row_group_column_bloom_filter(data, false);
+    }
+
+    fn test_get_row_group_column_bloom_filter(data: Bytes, with_length: bool) {
+        let mut builder = ParquetRecordBatchReaderBuilder::try_new(data.clone()).unwrap();
+
+        let metadata = builder.metadata();
+        assert_eq!(metadata.num_row_groups(), 1);
+        let row_group = metadata.row_group(0);
+        let column = row_group.column(0);
+        assert_eq!(column.bloom_filter_length().is_some(), with_length);
+
+        let sbbf = builder
+            .get_row_group_column_bloom_filter(0, 0)
+            .unwrap()
+            .unwrap();
+        assert!(sbbf.check(&"Hello"));
+        assert!(!sbbf.check(&"Hello_Not_Exists"));
     }
 }

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -21,6 +21,8 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 
+use crate::file::page_index::offset_index::PageLocation;
+
 /// [`RowSelection`] is a collection of [`RowSelector`] used to skip rows when
 /// scanning a parquet file
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -162,7 +164,7 @@ impl RowSelection {
     /// Note: this method does not make any effort to combine consecutive ranges, nor coalesce
     /// ranges that are close together. This is instead delegated to the IO subsystem to optimise,
     /// e.g. [`ObjectStore::get_ranges`](object_store::ObjectStore::get_ranges)
-    pub fn scan_ranges(&self, page_locations: &[crate::format::PageLocation]) -> Vec<Range<u64>> {
+    pub fn scan_ranges(&self, page_locations: &[PageLocation]) -> Vec<Range<u64>> {
         let mut ranges: Vec<Range<u64>> = vec![];
         let mut row_offset = 0;
 
@@ -640,7 +642,6 @@ fn union_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowSelec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::format::PageLocation;
     use rand::{rng, Rng};
 
     #[test]

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -45,6 +45,7 @@ use crate::arrow::arrow_reader::{
 };
 use crate::arrow::ProjectionMask;
 
+use crate::basic::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 use crate::bloom_filter::{
     chunk_read_bloom_filter_header_and_offset, Sbbf, SBBF_HEADER_SIZE_ESTIMATE,
 };
@@ -53,7 +54,6 @@ use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use crate::file::reader::{ChunkReader, Length, SerializedPageReader};
-use crate::format::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
 
 mod metadata;
 pub use metadata::*;
@@ -446,17 +446,17 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             chunk_read_bloom_filter_header_and_offset(offset, buffer.clone())?;
 
         match header.algorithm {
-            BloomFilterAlgorithm::BLOCK(_) => {
+            BloomFilterAlgorithm::BLOCK => {
                 // this match exists to future proof the singleton algorithm enum
             }
         }
         match header.compression {
-            BloomFilterCompression::UNCOMPRESSED(_) => {
+            BloomFilterCompression::UNCOMPRESSED => {
                 // this match exists to future proof the singleton compression enum
             }
         }
         match header.hash {
-            BloomFilterHash::XXHASH(_) => {
+            BloomFilterHash::XXHASH => {
                 // this match exists to future proof the singleton hash enum
             }
         }

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -61,11 +61,13 @@ mod store;
 pub use store::*;
 
 use crate::{
-    arrow::arrow_writer::ArrowWriterOptions,
-    arrow::ArrowWriter,
+    arrow::{arrow_writer::ArrowWriterOptions, ArrowWriter},
     errors::{ParquetError, Result},
-    file::{metadata::RowGroupMetaData, properties::WriterProperties},
-    format::{FileMetaData, KeyValue},
+    file::{
+        metadata::{KeyValue, RowGroupMetaData},
+        properties::WriterProperties,
+    },
+    format::FileMetaData,
 };
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -67,7 +67,6 @@ use crate::{
         metadata::{KeyValue, RowGroupMetaData},
         properties::WriterProperties,
     },
-    format::FileMetaData,
 };
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
@@ -247,7 +246,7 @@ impl<W: AsyncFileWriter> AsyncArrowWriter<W> {
     /// Unlike [`Self::close`] this does not consume self
     ///
     /// Attempting to write after calling finish will result in an error
-    pub async fn finish(&mut self) -> Result<FileMetaData> {
+    pub async fn finish(&mut self) -> Result<crate::format::FileMetaData> {
         let metadata = self.sync_writer.finish()?;
 
         // Force to flush the remaining data.
@@ -260,7 +259,7 @@ impl<W: AsyncFileWriter> AsyncArrowWriter<W> {
     /// Close and finalize the writer.
     ///
     /// All the data in the inner buffer will be force flushed.
-    pub async fn close(mut self) -> Result<FileMetaData> {
+    pub async fn close(mut self) -> Result<crate::format::FileMetaData> {
         self.finish().await
     }
 

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -532,9 +532,9 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
                     is_adjusted_to_u_t_c: matches!(tz, Some(z) if !z.as_ref().is_empty()),
                     unit: match time_unit {
                         TimeUnit::Second => unreachable!(),
-                        TimeUnit::Millisecond => ParquetTimeUnit::MILLIS(Default::default()),
-                        TimeUnit::Microsecond => ParquetTimeUnit::MICROS(Default::default()),
-                        TimeUnit::Nanosecond => ParquetTimeUnit::NANOS(Default::default()),
+                        TimeUnit::Millisecond => ParquetTimeUnit::MILLIS,
+                        TimeUnit::Microsecond => ParquetTimeUnit::MICROS,
+                        TimeUnit::Nanosecond => ParquetTimeUnit::NANOS,
                     },
                 }))
                 .with_repetition(repetition)
@@ -571,7 +571,7 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
             .with_logical_type(Some(LogicalType::Time {
                 is_adjusted_to_u_t_c: field.metadata().contains_key("adjusted_to_utc"),
                 unit: match unit {
-                    TimeUnit::Millisecond => ParquetTimeUnit::MILLIS(Default::default()),
+                    TimeUnit::Millisecond => ParquetTimeUnit::MILLIS,
                     u => unreachable!("Invalid unit for Time32: {:?}", u),
                 },
             }))
@@ -582,8 +582,8 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
             .with_logical_type(Some(LogicalType::Time {
                 is_adjusted_to_u_t_c: field.metadata().contains_key("adjusted_to_utc"),
                 unit: match unit {
-                    TimeUnit::Microsecond => ParquetTimeUnit::MICROS(Default::default()),
-                    TimeUnit::Nanosecond => ParquetTimeUnit::NANOS(Default::default()),
+                    TimeUnit::Microsecond => ParquetTimeUnit::MICROS,
+                    TimeUnit::Nanosecond => ParquetTimeUnit::NANOS,
                     u => unreachable!("Invalid unit for Time64: {:?}", u),
                 },
             }))

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -186,7 +186,7 @@ fn from_int32(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
         (Some(LogicalType::Decimal { scale, precision }), _) => decimal_128_type(scale, precision),
         (Some(LogicalType::Date), _) => Ok(DataType::Date32),
         (Some(LogicalType::Time { unit, .. }), _) => match unit {
-            ParquetTimeUnit::MILLIS(_) => Ok(DataType::Time32(TimeUnit::Millisecond)),
+            ParquetTimeUnit::MILLIS => Ok(DataType::Time32(TimeUnit::Millisecond)),
             _ => Err(arrow_err!(
                 "Cannot create INT32 physical type from {:?}",
                 unit
@@ -225,11 +225,11 @@ fn from_int64(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
             false => Ok(DataType::UInt64),
         },
         (Some(LogicalType::Time { unit, .. }), _) => match unit {
-            ParquetTimeUnit::MILLIS(_) => {
+            ParquetTimeUnit::MILLIS => {
                 Err(arrow_err!("Cannot create INT64 from MILLIS time unit",))
             }
-            ParquetTimeUnit::MICROS(_) => Ok(DataType::Time64(TimeUnit::Microsecond)),
-            ParquetTimeUnit::NANOS(_) => Ok(DataType::Time64(TimeUnit::Nanosecond)),
+            ParquetTimeUnit::MICROS => Ok(DataType::Time64(TimeUnit::Microsecond)),
+            ParquetTimeUnit::NANOS => Ok(DataType::Time64(TimeUnit::Nanosecond)),
         },
         (
             Some(LogicalType::Timestamp {
@@ -239,9 +239,9 @@ fn from_int64(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
             _,
         ) => Ok(DataType::Timestamp(
             match unit {
-                ParquetTimeUnit::MILLIS(_) => TimeUnit::Millisecond,
-                ParquetTimeUnit::MICROS(_) => TimeUnit::Microsecond,
-                ParquetTimeUnit::NANOS(_) => TimeUnit::Nanosecond,
+                ParquetTimeUnit::MILLIS => TimeUnit::Millisecond,
+                ParquetTimeUnit::MICROS => TimeUnit::Microsecond,
+                ParquetTimeUnit::NANOS => TimeUnit::Nanosecond,
             },
             if is_adjusted_to_u_t_c {
                 Some("UTC".into())

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Contains Rust mappings for Thrift definition.
-//! Refer to [`parquet.thrift`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) file to see raw definitions.
+//! Contains Rust mappings for Thrift definition. This module contains only mappings for thrift
+//! enums and unions. Thrift structs are handled elsewhere.
+//! Refer to [`parquet.thrift`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift)
+//! file to see raw definitions.
 
 use std::str::FromStr;
 use std::{fmt, str};
@@ -30,7 +32,7 @@ use crate::errors::{ParquetError, Result};
 // Types from the Thrift definition
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::Type`
+// Mirrors thrift enum `parquet::Type`
 
 /// Types supported by Parquet.
 ///
@@ -60,7 +62,7 @@ pub enum Type {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::ConvertedType`
+// Mirrors thrift enum `parquet::ConvertedType`
 
 /// Common types (converted types) used by frameworks when using Parquet.
 ///
@@ -165,7 +167,7 @@ pub enum ConvertedType {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::TimeUnit`
+// Mirrors thrift union `parquet::TimeUnit`
 
 /// Time unit for `Time` and `Timestamp` logical types.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -179,7 +181,7 @@ pub enum TimeUnit {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::LogicalType`
+// Mirrors thrift union `parquet::LogicalType`
 
 /// Logical types used by version 2.4.0+ of the Parquet format.
 ///
@@ -245,7 +247,7 @@ pub enum LogicalType {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::FieldRepetitionType`
+// Mirrors thrift enum `parquet::FieldRepetitionType`
 
 /// Representation of field types in schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -260,7 +262,7 @@ pub enum Repetition {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::Encoding`
+// Mirrors thrift enum `parquet::Encoding`
 
 /// Encodings supported by Parquet.
 ///
@@ -376,7 +378,7 @@ impl FromStr for Encoding {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::CompressionCodec`
+// Mirrors thrift enum `parquet::CompressionCodec`
 
 /// Supported block compression algorithms.
 ///
@@ -505,7 +507,7 @@ impl FromStr for Compression {
 }
 
 // ----------------------------------------------------------------------
-/// Mirrors `parquet::PageType`
+/// Mirrors thrift enum `parquet::PageType`
 ///
 /// Available data pages for Parquet file format.
 /// Note that some of the page types may not be supported.
@@ -523,7 +525,7 @@ pub enum PageType {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::BoundaryOrder`
+// Mirrors thrift enum `parquet::BoundaryOrder`
 
 /// Enum to annotate whether lists of min/max elements inside ColumnIndex
 /// are ordered and if so, in which direction.
@@ -538,7 +540,7 @@ pub enum BoundaryOrder {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::BloomFilterAlgorithm`
+// Mirrors thrift union `parquet::BloomFilterAlgorithm`
 
 /// The algorithm used in Bloom filter.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -548,7 +550,7 @@ pub enum BloomFilterAlgorithm {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::BloomFilterHash`
+// Mirrors thrift union `parquet::BloomFilterHash`
 
 /// The hash function used in Bloom filter. This function takes the hash of a column value
 /// using plain encoding.
@@ -560,7 +562,7 @@ pub enum BloomFilterHash {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::BloomFilterCompression`
+// Mirrors thrift union `parquet::BloomFilterCompression`
 
 /// The compression used in the Bloom filter.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -570,7 +572,7 @@ pub enum BloomFilterCompression {
 }
 
 // ----------------------------------------------------------------------
-// Mirrors `parquet::ColumnOrder`
+// Mirrors thrift union `parquet::ColumnOrder`
 
 /// Sort order for page and column statistics.
 ///
@@ -714,6 +716,9 @@ impl ColumnOrder {
         }
     }
 }
+
+// ----------------------------------------------------------------------
+// Display handlers
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -37,10 +37,9 @@
 use clap::Parser;
 use parquet::errors::{ParquetError, Result};
 use parquet::file::page_index::index::{Index, PageIndex};
-use parquet::file::page_index::offset_index::OffsetIndexMetaData;
+use parquet::file::page_index::offset_index::{OffsetIndexMetaData, PageLocation};
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::file::serialized_reader::ReadOptionsBuilder;
-use parquet::format::PageLocation;
 use std::fs::File;
 
 #[derive(Debug, Parser)]

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -21,11 +21,14 @@ use bytes::Bytes;
 use half::f16;
 
 use crate::bloom_filter::Sbbf;
-use crate::format::{BoundaryOrder, ColumnIndex, OffsetIndex};
+use crate::file::page_index::index::Index;
+use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use std::collections::{BTreeSet, VecDeque};
 use std::str;
 
-use crate::basic::{Compression, ConvertedType, Encoding, LogicalType, PageType, Type};
+use crate::basic::{
+    BoundaryOrder, Compression, ConvertedType, Encoding, LogicalType, PageType, Type,
+};
 use crate::column::page::{CompressedPage, Page, PageWriteSpec, PageWriter};
 use crate::column::writer::encoder::{ColumnValueEncoder, ColumnValueEncoderImpl, ColumnValues};
 use crate::compression::{create_codec, Codec, CodecOptionsBuilder};
@@ -185,9 +188,9 @@ pub struct ColumnCloseResult {
     /// Optional bloom filter for this column
     pub bloom_filter: Option<Sbbf>,
     /// Optional column index, for filtering
-    pub column_index: Option<ColumnIndex>,
+    pub column_index: Option<Index>,
     /// Optional offset index, identifying page locations
-    pub offset_index: Option<OffsetIndex>,
+    pub offset_index: Option<OffsetIndexMetaData>,
 }
 
 // Metrics per page
@@ -384,7 +387,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         }
 
         // Disable column_index_builder if not collecting page statistics.
-        let mut column_index_builder = ColumnIndexBuilder::new();
+        let mut column_index_builder = ColumnIndexBuilder::new(descr.physical_type());
         if statistics_enabled != EnabledStatistics::Page {
             column_index_builder.to_invalid()
         }
@@ -615,12 +618,12 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         };
         self.column_index_builder.set_boundary_order(boundary_order);
 
-        let column_index = self
-            .column_index_builder
-            .valid()
-            .then(|| self.column_index_builder.build_to_thrift());
+        let column_index = match self.column_index_builder.valid() {
+            true => Some(self.column_index_builder.build()?),
+            false => None,
+        };
 
-        let offset_index = self.offset_index_builder.map(|b| b.build_to_thrift());
+        let offset_index = self.offset_index_builder.map(|b| b.build());
 
         Ok(ColumnCloseResult {
             bytes_written: self.column_metrics.total_bytes_written,
@@ -2939,19 +2942,29 @@ mod tests {
         let r = writer.close().unwrap();
         assert!(r.column_index.is_some());
         let col_idx = r.column_index.unwrap();
+        let col_idx = match col_idx {
+            Index::INT32(col_idx) => col_idx,
+            _ => panic!("wrong stats type"),
+        };
         // null_pages should be true for page 0
-        assert!(col_idx.null_pages[0]);
+        assert!(col_idx.indexes[0].is_null_page());
         // min and max should be empty byte arrays
-        assert_eq!(col_idx.min_values[0].len(), 0);
-        assert_eq!(col_idx.max_values[0].len(), 0);
+        assert!(col_idx.indexes[0].min().is_none());
+        assert!(col_idx.indexes[0].max().is_none());
         // null_counts should be defined and be 4 for page 0
-        assert!(col_idx.null_counts.is_some());
-        assert_eq!(col_idx.null_counts.as_ref().unwrap()[0], 4);
+        assert!(col_idx.indexes[0].null_count().is_some());
+        assert_eq!(col_idx.indexes[0].null_count().unwrap(), 4);
         // there is no repetition so rep histogram should be absent
-        assert!(col_idx.repetition_level_histograms.is_none());
+        assert!(col_idx.indexes[0].repetition_level_histogram().is_none());
         // definition_level_histogram should be present and should be 0:4, 1:0
-        assert!(col_idx.definition_level_histograms.is_some());
-        assert_eq!(col_idx.definition_level_histograms.unwrap(), &[4, 0]);
+        assert!(col_idx.indexes[0].definition_level_histogram().is_some());
+        assert_eq!(
+            col_idx.indexes[0]
+                .definition_level_histogram()
+                .unwrap()
+                .values(),
+            &[4, 0]
+        );
     }
 
     #[test]
@@ -2974,12 +2987,16 @@ mod tests {
         assert_eq!(8, r.rows_written);
 
         // column index
-        assert_eq!(2, column_index.null_pages.len());
+        let column_index = match column_index {
+            Index::INT32(column_index) => column_index,
+            _ => panic!("wrong stats type"),
+        };
+        assert_eq!(2, column_index.indexes.len());
         assert_eq!(2, offset_index.page_locations.len());
         assert_eq!(BoundaryOrder::UNORDERED, column_index.boundary_order);
         for idx in 0..2 {
-            assert!(!column_index.null_pages[idx]);
-            assert_eq!(0, column_index.null_counts.as_ref().unwrap()[idx]);
+            assert!(!column_index.indexes[idx].is_null_page());
+            assert_eq!(0, *column_index.indexes[idx].null_count.as_ref().unwrap());
         }
 
         if let Some(stats) = r.metadata.statistics() {
@@ -2989,14 +3006,8 @@ mod tests {
                 // first page is [1,2,3,4]
                 // second page is [-5,2,4,8]
                 // note that we don't increment here, as this is a non BinaryArray type.
-                assert_eq!(
-                    stats.min_bytes_opt(),
-                    Some(column_index.min_values[1].as_slice())
-                );
-                assert_eq!(
-                    stats.max_bytes_opt(),
-                    column_index.max_values.get(1).map(Vec::as_slice)
-                );
+                assert_eq!(stats.min_opt(), column_index.indexes[1].min());
+                assert_eq!(stats.max_opt(), column_index.indexes[1].max());
             } else {
                 panic!("expecting Statistics::Int32");
             }
@@ -3036,37 +3047,36 @@ mod tests {
         let column_index = r.column_index.unwrap();
         let offset_index = r.offset_index.unwrap();
 
+        let column_index = match column_index {
+            Index::FIXED_LEN_BYTE_ARRAY(column_index) => column_index,
+            _ => panic!("wrong stats type"),
+        };
+
         assert_eq!(3, r.rows_written);
 
         // column index
-        assert_eq!(1, column_index.null_pages.len());
+        assert_eq!(1, column_index.indexes.len());
         assert_eq!(1, offset_index.page_locations.len());
         assert_eq!(BoundaryOrder::ASCENDING, column_index.boundary_order);
-        assert!(!column_index.null_pages[0]);
-        assert_eq!(0, column_index.null_counts.as_ref().unwrap()[0]);
+        assert!(!column_index.indexes[0].is_null_page());
+        assert_eq!(Some(0), column_index.indexes[0].null_count());
 
         if let Some(stats) = r.metadata.statistics() {
             assert_eq!(stats.null_count_opt(), Some(0));
             assert_eq!(stats.distinct_count_opt(), None);
             if let Statistics::FixedLenByteArray(stats) = stats {
-                let column_index_min_value = &column_index.min_values[0];
-                let column_index_max_value = &column_index.max_values[0];
+                let column_index_min_value = column_index.indexes[0].min_bytes().unwrap();
+                let column_index_max_value = column_index.indexes[0].max_bytes().unwrap();
 
                 // Column index stats are truncated, while the column chunk's aren't.
-                assert_ne!(
-                    stats.min_bytes_opt(),
-                    Some(column_index_min_value.as_slice())
-                );
-                assert_ne!(
-                    stats.max_bytes_opt(),
-                    Some(column_index_max_value.as_slice())
-                );
+                assert_ne!(stats.min_bytes_opt().unwrap(), column_index_min_value);
+                assert_ne!(stats.max_bytes_opt().unwrap(), column_index_max_value);
 
                 assert_eq!(
                     column_index_min_value.len(),
                     DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH.unwrap()
                 );
-                assert_eq!(column_index_min_value.as_slice(), &[97_u8; 64]);
+                assert_eq!(column_index_min_value, &[97_u8; 64]);
                 assert_eq!(
                     column_index_max_value.len(),
                     DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH.unwrap()
@@ -3108,27 +3118,32 @@ mod tests {
         let column_index = r.column_index.unwrap();
         let offset_index = r.offset_index.unwrap();
 
+        let column_index = match column_index {
+            Index::FIXED_LEN_BYTE_ARRAY(column_index) => column_index,
+            _ => panic!("wrong stats type"),
+        };
+
         assert_eq!(1, r.rows_written);
 
         // column index
-        assert_eq!(1, column_index.null_pages.len());
+        assert_eq!(1, column_index.indexes.len());
         assert_eq!(1, offset_index.page_locations.len());
         assert_eq!(BoundaryOrder::ASCENDING, column_index.boundary_order);
-        assert!(!column_index.null_pages[0]);
-        assert_eq!(0, column_index.null_counts.as_ref().unwrap()[0]);
+        assert!(!column_index.indexes[0].is_null_page());
+        assert_eq!(Some(0), column_index.indexes[0].null_count());
 
         if let Some(stats) = r.metadata.statistics() {
             assert_eq!(stats.null_count_opt(), Some(0));
             assert_eq!(stats.distinct_count_opt(), None);
             if let Statistics::FixedLenByteArray(_stats) = stats {
-                let column_index_min_value = &column_index.min_values[0];
-                let column_index_max_value = &column_index.max_values[0];
+                let column_index_min_value = column_index.indexes[0].min_bytes().unwrap();
+                let column_index_max_value = column_index.indexes[0].max_bytes().unwrap();
 
                 assert_eq!(column_index_min_value.len(), 1);
                 assert_eq!(column_index_max_value.len(), 1);
 
-                assert_eq!("B".as_bytes(), column_index_min_value.as_slice());
-                assert_eq!("C".as_bytes(), column_index_max_value.as_slice());
+                assert_eq!("B".as_bytes(), column_index_min_value);
+                assert_eq!("C".as_bytes(), column_index_max_value);
 
                 assert_ne!(column_index_min_value, stats.min_bytes_opt().unwrap());
                 assert_ne!(column_index_max_value, stats.max_bytes_opt().unwrap());
@@ -3158,8 +3173,12 @@ mod tests {
         // stats should still be written
         // ensure bytes weren't truncated for column index
         let column_index = r.column_index.unwrap();
-        let column_index_min_bytes = column_index.min_values[0].as_slice();
-        let column_index_max_bytes = column_index.max_values[0].as_slice();
+        let column_index = match column_index {
+            Index::FIXED_LEN_BYTE_ARRAY(column_index) => column_index,
+            _ => panic!("wrong stats type"),
+        };
+        let column_index_min_bytes = column_index.indexes[0].min_bytes().unwrap();
+        let column_index_max_bytes = column_index.indexes[0].min_bytes().unwrap();
         assert_eq!(expected_value, column_index_min_bytes);
         assert_eq!(expected_value, column_index_max_bytes);
 
@@ -3197,8 +3216,12 @@ mod tests {
         // stats should still be written
         // ensure bytes weren't truncated for column index
         let column_index = r.column_index.unwrap();
-        let column_index_min_bytes = column_index.min_values[0].as_slice();
-        let column_index_max_bytes = column_index.max_values[0].as_slice();
+        let column_index = match column_index {
+            Index::FIXED_LEN_BYTE_ARRAY(column_index) => column_index,
+            _ => panic!("wrong stats type"),
+        };
+        let column_index_min_bytes = column_index.indexes[0].min_bytes().unwrap();
+        let column_index_max_bytes = column_index.indexes[0].min_bytes().unwrap();
         assert_eq!(expected_value, column_index_min_bytes);
         assert_eq!(expected_value, column_index_max_bytes);
 
@@ -3678,8 +3701,11 @@ mod tests {
                 &[Some(-5), Some(11)],
             ],
         )?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::ASCENDING));
 
         // min max both descending
         let column_close_result = write_multiple_pages::<Int32Type>(
@@ -3691,34 +3717,49 @@ mod tests {
                 &[Some(-5), Some(0)],
             ],
         )?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::DESCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::DESCENDING));
 
         // min max both equal
         let column_close_result = write_multiple_pages::<Int32Type>(
             &descr,
             &[&[Some(10), Some(11)], &[None], &[Some(10), Some(11)]],
         )?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::ASCENDING));
 
         // only nulls
         let column_close_result =
             write_multiple_pages::<Int32Type>(&descr, &[&[None], &[None], &[None]])?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::ASCENDING));
 
         // one page
         let column_close_result =
             write_multiple_pages::<Int32Type>(&descr, &[&[Some(-10), Some(10)]])?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::ASCENDING));
 
         // one non-null page
         let column_close_result =
             write_multiple_pages::<Int32Type>(&descr, &[&[Some(-10), Some(10)], &[None]])?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::ASCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::ASCENDING));
 
         // min max both unordered
         let column_close_result = write_multiple_pages::<Int32Type>(
@@ -3730,8 +3771,11 @@ mod tests {
                 &[Some(-5), Some(0)],
             ],
         )?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::UNORDERED));
 
         // min max both ordered in different orders
         let column_close_result = write_multiple_pages::<Int32Type>(
@@ -3743,8 +3787,11 @@ mod tests {
                 &[Some(3), Some(7)],
             ],
         )?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::UNORDERED));
 
         Ok(())
     }
@@ -3781,14 +3828,20 @@ mod tests {
         // f16 descending
         let column_close_result =
             write_multiple_pages::<FixedLenByteArrayType>(&f16_descr, values)?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::DESCENDING);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::DESCENDING));
 
         // same bytes, but fba unordered
         let column_close_result =
             write_multiple_pages::<FixedLenByteArrayType>(&fba_descr, values)?;
-        let boundary_order = column_close_result.column_index.unwrap().boundary_order;
-        assert_eq!(boundary_order, BoundaryOrder::UNORDERED);
+        let boundary_order = column_close_result
+            .column_index
+            .unwrap()
+            .get_boundary_order();
+        assert_eq!(boundary_order, Some(BoundaryOrder::UNORDERED));
 
         Ok(())
     }

--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -18,14 +18,15 @@
 //! Memory calculations for [`ParquetMetadata::memory_size`]
 //!
 //! [`ParquetMetadata::memory_size`]: crate::file::metadata::ParquetMetaData::memory_size
-use crate::basic::{ColumnOrder, Compression, Encoding, PageType};
+use crate::basic::{BoundaryOrder, ColumnOrder, Compression, Encoding, PageType};
 use crate::data_type::private::ParquetValueType;
-use crate::file::metadata::{ColumnChunkMetaData, FileMetaData, KeyValue, RowGroupMetaData};
+use crate::file::metadata::{
+    ColumnChunkMetaData, FileMetaData, KeyValue, RowGroupMetaData, SortingColumn,
+};
 use crate::file::page_encoding_stats::PageEncodingStats;
 use crate::file::page_index::index::{Index, NativeIndex, PageIndex};
-use crate::file::page_index::offset_index::OffsetIndexMetaData;
+use crate::file::page_index::offset_index::{OffsetIndexMetaData, PageLocation};
 use crate::file::statistics::{Statistics, ValueStatistics};
-use crate::format::{BoundaryOrder, PageLocation, SortingColumn};
 use std::sync::Arc;
 
 /// Trait for calculating the size of various containers

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -95,6 +95,7 @@ mod memory;
 pub(crate) mod reader;
 mod writer;
 
+use crate::basic::{ColumnOrder, Compression, Encoding, Type};
 #[cfg(feature = "encryption")]
 use crate::encryption::{
     decrypt::FileDecryptor,
@@ -122,10 +123,6 @@ use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 use crate::{
     basic::BoundaryOrder,
     errors::{ParquetError, Result},
-};
-use crate::{
-    basic::{ColumnOrder, Compression, Encoding, Type},
-    format,
 };
 use crate::{
     data_type::private::ParquetValueType, file::page_index::offset_index::OffsetIndexMetaData,
@@ -561,8 +558,8 @@ pub struct SortingColumn {
     pub nulls_first: bool,
 }
 
-impl From<&format::SortingColumn> for SortingColumn {
-    fn from(value: &format::SortingColumn) -> Self {
+impl From<&crate::format::SortingColumn> for SortingColumn {
+    fn from(value: &crate::format::SortingColumn) -> Self {
         Self {
             column_idx: value.column_idx,
             descending: value.descending,
@@ -571,7 +568,7 @@ impl From<&format::SortingColumn> for SortingColumn {
     }
 }
 
-impl From<&SortingColumn> for format::SortingColumn {
+impl From<&SortingColumn> for crate::format::SortingColumn {
     fn from(value: &SortingColumn) -> Self {
         Self {
             column_idx: value.column_idx,
@@ -800,7 +797,7 @@ impl RowGroupMetaData {
         let sorting_columns = self.sorting_columns().map(|scs| {
             scs.iter()
                 .map(|sc| sc.into())
-                .collect::<Vec<format::SortingColumn>>()
+                .collect::<Vec<crate::format::SortingColumn>>()
         });
         crate::format::RowGroup {
             columns: self.columns().iter().map(|v| v.to_thrift()).collect(),
@@ -1349,7 +1346,7 @@ impl ColumnChunkMetaData {
                 .as_ref()
                 .map(|hist| hist.clone().into_inner());
 
-            Some(format::SizeStatistics {
+            Some(crate::format::SizeStatistics {
                 unencoded_byte_array_data_bytes: self.unencoded_byte_array_data_bytes,
                 repetition_level_histogram,
                 definition_level_histogram,

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -427,7 +427,7 @@ impl From<ParquetMetaData> for ParquetMetaDataBuilder {
 }
 
 /// A key-value pair for [`FileMetaData`].
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeyValue {
     /// The key.
     pub key: String,

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -427,7 +427,26 @@ impl From<ParquetMetaData> for ParquetMetaDataBuilder {
 }
 
 /// A key-value pair for [`FileMetaData`].
-pub type KeyValue = crate::format::KeyValue;
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct KeyValue {
+    /// The key.
+    pub key: String,
+    /// An optional value.
+    pub value: Option<String>,
+}
+
+impl KeyValue {
+    /// Create a new key value pair
+    pub fn new<F2>(key: String, value: F2) -> KeyValue
+    where
+        F2: Into<Option<String>>,
+    {
+        KeyValue {
+            key,
+            value: value.into(),
+        }
+    }
+}
 
 /// Reference counted pointer for [`FileMetaData`].
 pub type FileMetaDataPtr = Arc<FileMetaData>;

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -31,7 +31,6 @@ use crate::file::page_index::index::Index;
 use crate::file::page_index::index_reader::{acc_range, decode_column_index, decode_offset_index};
 use crate::file::reader::ChunkReader;
 use crate::file::{FOOTER_SIZE, PARQUET_MAGIC, PARQUET_MAGIC_ENCR_FOOTER};
-use crate::format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
 #[cfg(feature = "encryption")]
 use crate::format::{EncryptionAlgorithm, FileCryptoMetaData as TFileCryptoMetaData};
 use crate::schema::types;
@@ -947,7 +946,7 @@ impl ParquetMetaDataReader {
             }
         }
 
-        let t_file_metadata: TFileMetaData = TFileMetaData::read_from_in_protocol(&mut prot)
+        let t_file_metadata = crate::format::FileMetaData::read_from_in_protocol(&mut prot)
             .map_err(|e| general_err!("Could not parse metadata: {}", e))?;
         let schema = types::from_thrift(&t_file_metadata.schema)?;
         let schema_descr = Arc::new(SchemaDescriptor::new(schema));
@@ -1005,7 +1004,7 @@ impl ParquetMetaDataReader {
     pub fn decode_metadata(buf: &[u8]) -> Result<ParquetMetaData> {
         let mut prot = TCompactSliceInputProtocol::new(buf);
 
-        let t_file_metadata: TFileMetaData = TFileMetaData::read_from_in_protocol(&mut prot)
+        let t_file_metadata = crate::format::FileMetaData::read_from_in_protocol(&mut prot)
             .map_err(|e| general_err!("Could not parse metadata: {}", e))?;
         let schema = types::from_thrift(&t_file_metadata.schema)?;
         let schema_descr = Arc::new(SchemaDescriptor::new(schema));
@@ -1032,7 +1031,7 @@ impl ParquetMetaDataReader {
     /// Parses column orders from Thrift definition.
     /// If no column orders are defined, returns `None`.
     fn parse_column_orders(
-        t_column_orders: Option<Vec<TColumnOrder>>,
+        t_column_orders: Option<Vec<crate::format::ColumnOrder>>,
         schema_descr: &SchemaDescriptor,
     ) -> Result<Option<Vec<ColumnOrder>>> {
         match t_column_orders {
@@ -1044,7 +1043,7 @@ impl ParquetMetaDataReader {
                 let mut res = Vec::new();
                 for (i, column) in schema_descr.columns().iter().enumerate() {
                     match orders[i] {
-                        TColumnOrder::TYPEORDER(_) => {
+                        crate::format::ColumnOrder::TYPEORDER(_) => {
                             let sort_order = ColumnOrder::get_sort_order(
                                 column.logical_type(),
                                 column.converted_type(),
@@ -1099,7 +1098,6 @@ mod tests {
     use crate::basic::SortOrder;
     use crate::basic::Type;
     use crate::file::reader::Length;
-    use crate::format::TypeDefinedOrder;
     use crate::schema::types::Type as SchemaType;
     use crate::util::test_common::file_util::get_test_file;
 
@@ -1153,8 +1151,8 @@ mod tests {
         let schema_descr = SchemaDescriptor::new(Arc::new(schema));
 
         let t_column_orders = Some(vec![
-            TColumnOrder::TYPEORDER(TypeDefinedOrder::new()),
-            TColumnOrder::TYPEORDER(TypeDefinedOrder::new()),
+            crate::format::ColumnOrder::TYPEORDER(Default::default()),
+            crate::format::ColumnOrder::TYPEORDER(Default::default()),
         ]);
 
         assert_eq!(
@@ -1177,7 +1175,9 @@ mod tests {
         let schema = SchemaType::group_type_builder("schema").build().unwrap();
         let schema_descr = SchemaDescriptor::new(Arc::new(schema));
 
-        let t_column_orders = Some(vec![TColumnOrder::TYPEORDER(TypeDefinedOrder::new())]);
+        let t_column_orders = Some(vec![crate::format::ColumnOrder::TYPEORDER(
+            Default::default(),
+        )]);
 
         let res = ParquetMetaDataReader::parse_column_orders(t_column_orders, &schema_descr);
         assert!(res.is_err());

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -17,12 +17,12 @@
 
 use std::{io::Read, ops::Range, sync::Arc};
 
-use crate::basic::ColumnOrder;
 #[cfg(feature = "encryption")]
 use crate::encryption::{
     decrypt::{FileDecryptionProperties, FileDecryptor},
     modules::create_footer_aad,
 };
+use crate::{basic::ColumnOrder, file::metadata::KeyValue};
 use bytes::Bytes;
 
 use crate::errors::{ParquetError, Result};
@@ -979,11 +979,17 @@ impl ParquetMetaDataReader {
         let column_orders =
             Self::parse_column_orders(t_file_metadata.column_orders, &schema_descr)?;
 
+        let key_value_metadata = t_file_metadata.key_value_metadata.map(|vkv| {
+            vkv.into_iter()
+                .map(|kv| KeyValue::new(kv.key, kv.value))
+                .collect::<Vec<KeyValue>>()
+        });
+
         let file_metadata = FileMetaData::new(
             t_file_metadata.version,
             t_file_metadata.num_rows,
             t_file_metadata.created_by,
-            t_file_metadata.key_value_metadata,
+            key_value_metadata,
             schema_descr,
             column_orders,
         );
@@ -1016,11 +1022,17 @@ impl ParquetMetaDataReader {
         let column_orders =
             Self::parse_column_orders(t_file_metadata.column_orders, &schema_descr)?;
 
+        let key_value_metadata = t_file_metadata.key_value_metadata.map(|vkv| {
+            vkv.into_iter()
+                .map(|kv| KeyValue::new(kv.key, kv.value))
+                .collect::<Vec<KeyValue>>()
+        });
+
         let file_metadata = FileMetaData::new(
             t_file_metadata.version,
             t_file_metadata.num_rows,
             t_file_metadata.created_by,
-            t_file_metadata.key_value_metadata,
+            key_value_metadata,
             schema_descr,
             column_orders,
         );

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -153,16 +153,13 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             self.object_writer.get_plaintext_footer_crypto_metadata();
         let key_value_metadata = self.key_value_metadata.map(|vkv| {
             vkv.into_iter()
-                .map(|kv| crate::format::KeyValue {
-                    key: kv.key,
-                    value: kv.value,
-                })
+                .map(|kv| crate::format::KeyValue::new(kv.key, kv.value))
                 .collect::<Vec<crate::format::KeyValue>>()
         });
         let mut file_metadata = crate::format::FileMetaData {
             num_rows,
             row_groups,
-            key_value_metadata: key_value_metadata,
+            key_value_metadata,
             version: self.writer_version,
             schema: types::to_thrift(self.schema.as_ref())?,
             created_by: self.created_by.clone(),

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -31,7 +31,6 @@ use crate::file::writer::{get_file_magic, TrackedWrite};
 use crate::format::EncryptionAlgorithm;
 #[cfg(feature = "encryption")]
 use crate::format::{AesGcmV1, ColumnCryptoMetaData};
-use crate::format::{ColumnChunk, ColumnIndex, FileMetaData, OffsetIndex, RowGroup};
 use crate::schema::types;
 use crate::schema::types::{SchemaDescPtr, SchemaDescriptor, TypePtr};
 use crate::thrift::TSerializable;
@@ -46,9 +45,9 @@ pub(crate) struct ThriftMetadataWriter<'a, W: Write> {
     buf: &'a mut TrackedWrite<W>,
     schema: &'a TypePtr,
     schema_descr: &'a SchemaDescPtr,
-    row_groups: Vec<RowGroup>,
-    column_indexes: Option<&'a [Vec<Option<ColumnIndex>>]>,
-    offset_indexes: Option<&'a [Vec<Option<OffsetIndex>>]>,
+    row_groups: Vec<crate::format::RowGroup>,
+    column_indexes: Option<&'a [Vec<Option<crate::format::ColumnIndex>>]>,
+    offset_indexes: Option<&'a [Vec<Option<crate::format::OffsetIndex>>]>,
     key_value_metadata: Option<Vec<KeyValue>>,
     created_by: Option<String>,
     object_writer: MetadataObjectWriter,
@@ -61,7 +60,10 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
     /// Note: also updates the `ColumnChunk::offset_index_offset` and
     /// `ColumnChunk::offset_index_length` to reflect the position and length
     /// of the serialized offset indexes.
-    fn write_offset_indexes(&mut self, offset_indexes: &[Vec<Option<OffsetIndex>>]) -> Result<()> {
+    fn write_offset_indexes(
+        &mut self,
+        offset_indexes: &[Vec<Option<crate::format::OffsetIndex>>],
+    ) -> Result<()> {
         // iter row group
         // iter each column
         // write offset index to the file
@@ -91,7 +93,10 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
     /// Note: also updates the `ColumnChunk::column_index_offset` and
     /// `ColumnChunk::column_index_length` to reflect the position and length
     /// of the serialized column indexes.
-    fn write_column_indexes(&mut self, column_indexes: &[Vec<Option<ColumnIndex>>]) -> Result<()> {
+    fn write_column_indexes(
+        &mut self,
+        column_indexes: &[Vec<Option<crate::format::ColumnIndex>>],
+    ) -> Result<()> {
         // iter row group
         // iter each column
         // write column index to the file
@@ -146,7 +151,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
 
         let (encryption_algorithm, footer_signing_key_metadata) =
             self.object_writer.get_plaintext_footer_crypto_metadata();
-        let mut file_metadata = FileMetaData {
+        let mut file_metadata = crate::format::FileMetaData {
             num_rows,
             row_groups,
             key_value_metadata: self.key_value_metadata.clone(),
@@ -185,7 +190,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         buf: &'a mut TrackedWrite<W>,
         schema: &'a TypePtr,
         schema_descr: &'a SchemaDescPtr,
-        row_groups: Vec<RowGroup>,
+        row_groups: Vec<crate::format::RowGroup>,
         created_by: Option<String>,
         writer_version: i32,
     ) -> Self {
@@ -203,12 +208,18 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         }
     }
 
-    pub fn with_column_indexes(mut self, column_indexes: &'a [Vec<Option<ColumnIndex>>]) -> Self {
+    pub fn with_column_indexes(
+        mut self,
+        column_indexes: &'a [Vec<Option<crate::format::ColumnIndex>>],
+    ) -> Self {
         self.column_indexes = Some(column_indexes);
         self
     }
 
-    pub fn with_offset_indexes(mut self, offset_indexes: &'a [Vec<Option<OffsetIndex>>]) -> Self {
+    pub fn with_offset_indexes(
+        mut self,
+        offset_indexes: &'a [Vec<Option<crate::format::OffsetIndex>>],
+    ) -> Self {
         self.offset_indexes = Some(offset_indexes);
         self
     }
@@ -365,7 +376,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
         Ok(())
     }
 
-    fn convert_column_indexes(&self) -> Vec<Vec<Option<ColumnIndex>>> {
+    fn convert_column_indexes(&self) -> Vec<Vec<Option<crate::format::ColumnIndex>>> {
         if let Some(row_group_column_indexes) = self.metadata.column_index() {
             (0..self.metadata.row_groups().len())
                 .map(|rg_idx| {
@@ -398,7 +409,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
         }
     }
 
-    fn convert_offset_index(&self) -> Vec<Vec<Option<OffsetIndex>>> {
+    fn convert_offset_index(&self) -> Vec<Vec<Option<crate::format::OffsetIndex>>> {
         if let Some(row_group_offset_indexes) = self.metadata.offset_index() {
             (0..self.metadata.row_groups().len())
                 .map(|rg_idx| {
@@ -439,15 +450,19 @@ impl MetadataObjectWriter {
 #[cfg(not(feature = "encryption"))]
 impl MetadataObjectWriter {
     /// Write [`FileMetaData`] in Thrift format
-    fn write_file_metadata(&self, file_metadata: &FileMetaData, sink: impl Write) -> Result<()> {
+    fn write_file_metadata(
+        &self,
+        file_metadata: &crate::format::FileMetaData,
+        sink: impl Write,
+    ) -> Result<()> {
         Self::write_object(file_metadata, sink)
     }
 
     /// Write a column [`OffsetIndex`] in Thrift format
     fn write_offset_index(
         &self,
-        offset_index: &OffsetIndex,
-        _column_chunk: &ColumnChunk,
+        offset_index: &crate::format::OffsetIndex,
+        _column_chunk: &crate::format::ColumnChunk,
         _row_group_idx: usize,
         _column_idx: usize,
         sink: impl Write,
@@ -458,8 +473,8 @@ impl MetadataObjectWriter {
     /// Write a column [`ColumnIndex`] in Thrift format
     fn write_column_index(
         &self,
-        column_index: &ColumnIndex,
-        _column_chunk: &ColumnChunk,
+        column_index: &crate::format::ColumnIndex,
+        _column_chunk: &crate::format::ColumnChunk,
         _row_group_idx: usize,
         _column_idx: usize,
         sink: impl Write,
@@ -470,8 +485,11 @@ impl MetadataObjectWriter {
     /// No-op implementation of row-group metadata encryption
     fn apply_row_group_encryption(
         &self,
-        row_groups: Vec<RowGroup>,
-    ) -> Result<(Vec<RowGroup>, Option<Vec<RowGroup>>)> {
+        row_groups: Vec<crate::format::RowGroup>,
+    ) -> Result<(
+        Vec<crate::format::RowGroup>,
+        Option<Vec<crate::format::RowGroup>>,
+    )> {
         Ok((row_groups, None))
     }
 
@@ -499,7 +517,7 @@ impl MetadataObjectWriter {
     /// Write [`FileMetaData`] in Thrift format, possibly encrypting it if required
     fn write_file_metadata(
         &self,
-        file_metadata: &FileMetaData,
+        file_metadata: &crate::format::FileMetaData,
         mut sink: impl Write,
     ) -> Result<()> {
         match self.file_encryptor.as_ref() {
@@ -526,8 +544,8 @@ impl MetadataObjectWriter {
     /// Write a column [`OffsetIndex`] in Thrift format, possibly encrypting it if required
     fn write_offset_index(
         &self,
-        offset_index: &OffsetIndex,
-        column_chunk: &ColumnChunk,
+        offset_index: &crate::format::OffsetIndex,
+        column_chunk: &crate::format::ColumnChunk,
         row_group_idx: usize,
         column_idx: usize,
         sink: impl Write,
@@ -549,8 +567,8 @@ impl MetadataObjectWriter {
     /// Write a column [`ColumnIndex`] in Thrift format, possibly encrypting it if required
     fn write_column_index(
         &self,
-        column_index: &ColumnIndex,
-        column_chunk: &ColumnChunk,
+        column_index: &crate::format::ColumnIndex,
+        column_chunk: &crate::format::ColumnChunk,
         row_group_idx: usize,
         column_idx: usize,
         sink: impl Write,
@@ -574,8 +592,11 @@ impl MetadataObjectWriter {
     /// and possibly unencrypted metadata to be returned to clients if data was encrypted.
     fn apply_row_group_encryption(
         &self,
-        row_groups: Vec<RowGroup>,
-    ) -> Result<(Vec<RowGroup>, Option<Vec<RowGroup>>)> {
+        row_groups: Vec<crate::format::RowGroup>,
+    ) -> Result<(
+        Vec<crate::format::RowGroup>,
+        Option<Vec<crate::format::RowGroup>>,
+    )> {
         match &self.file_encryptor {
             Some(file_encryptor) => {
                 let unencrypted_row_groups = row_groups.clone();
@@ -599,7 +620,7 @@ impl MetadataObjectWriter {
         object: &impl TSerializable,
         mut sink: impl Write,
         file_encryptor: &FileEncryptor,
-        column_metadata: &ColumnChunk,
+        column_metadata: &crate::format::ColumnChunk,
         module_type: ModuleType,
         row_group_index: usize,
         column_index: usize,
@@ -682,14 +703,14 @@ impl MetadataObjectWriter {
     }
 
     fn encrypt_row_groups(
-        row_groups: Vec<RowGroup>,
+        row_groups: Vec<crate::format::RowGroup>,
         file_encryptor: &Arc<FileEncryptor>,
-    ) -> Result<Vec<RowGroup>> {
+    ) -> Result<Vec<crate::format::RowGroup>> {
         row_groups
             .into_iter()
             .enumerate()
             .map(|(rg_idx, mut rg)| {
-                let cols: Result<Vec<ColumnChunk>> = rg
+                let cols: Result<Vec<crate::format::ColumnChunk>> = rg
                     .columns
                     .into_iter()
                     .enumerate()
@@ -705,11 +726,11 @@ impl MetadataObjectWriter {
 
     /// Apply column encryption to column chunk metadata
     fn encrypt_column_chunk(
-        mut column_chunk: ColumnChunk,
+        mut column_chunk: crate::format::ColumnChunk,
         file_encryptor: &Arc<FileEncryptor>,
         row_group_index: usize,
         column_index: usize,
-    ) -> Result<ColumnChunk> {
+    ) -> Result<crate::format::ColumnChunk> {
         // Column crypto metadata should have already been set when the column was created.
         // Here we apply the encryption by encrypting the column metadata if required.
         match column_chunk.crypto_metadata.as_ref() {

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -151,10 +151,18 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
 
         let (encryption_algorithm, footer_signing_key_metadata) =
             self.object_writer.get_plaintext_footer_crypto_metadata();
+        let key_value_metadata = self.key_value_metadata.map(|vkv| {
+            vkv.into_iter()
+                .map(|kv| crate::format::KeyValue {
+                    key: kv.key,
+                    value: kv.value,
+                })
+                .collect::<Vec<crate::format::KeyValue>>()
+        });
         let mut file_metadata = crate::format::FileMetaData {
             num_rows,
             row_groups,
-            key_value_metadata: self.key_value_metadata.clone(),
+            key_value_metadata: key_value_metadata,
             version: self.writer_version,
             schema: types::to_thrift(self.schema.as_ref())?,
             created_by: self.created_by.clone(),

--- a/parquet/src/file/page_encoding_stats.rs
+++ b/parquet/src/file/page_encoding_stats.rs
@@ -19,9 +19,6 @@
 
 use crate::basic::{Encoding, PageType};
 use crate::errors::Result;
-use crate::format::{
-    Encoding as TEncoding, PageEncodingStats as TPageEncodingStats, PageType as TPageType,
-};
 
 /// PageEncodingStats for a column chunk and data page.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,7 +32,9 @@ pub struct PageEncodingStats {
 }
 
 /// Converts Thrift definition into `PageEncodingStats`.
-pub fn try_from_thrift(thrift_encoding_stats: &TPageEncodingStats) -> Result<PageEncodingStats> {
+pub fn try_from_thrift(
+    thrift_encoding_stats: &crate::format::PageEncodingStats,
+) -> Result<PageEncodingStats> {
     let page_type = PageType::try_from(thrift_encoding_stats.page_type)?;
     let encoding = Encoding::try_from(thrift_encoding_stats.encoding)?;
     let count = thrift_encoding_stats.count;
@@ -48,12 +47,12 @@ pub fn try_from_thrift(thrift_encoding_stats: &TPageEncodingStats) -> Result<Pag
 }
 
 /// Converts `PageEncodingStats` into Thrift definition.
-pub fn to_thrift(encoding_stats: &PageEncodingStats) -> TPageEncodingStats {
-    let page_type = TPageType::from(encoding_stats.page_type);
-    let encoding = TEncoding::from(encoding_stats.encoding);
+pub fn to_thrift(encoding_stats: &PageEncodingStats) -> crate::format::PageEncodingStats {
+    let page_type = crate::format::PageType::from(encoding_stats.page_type);
+    let encoding = crate::format::Encoding::from(encoding_stats.encoding);
     let count = encoding_stats.count;
 
-    TPageEncodingStats {
+    crate::format::PageEncodingStats {
         page_type,
         encoding,
         count,

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -24,7 +24,6 @@ use crate::file::metadata::ColumnChunkMetaData;
 use crate::file::page_index::index::{Index, NativeIndex};
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use crate::file::reader::ChunkReader;
-use crate::format::{ColumnIndex, OffsetIndex};
 use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 use std::ops::Range;
 
@@ -48,6 +47,7 @@ pub(crate) fn acc_range(a: Option<Range<u64>>, b: Option<Range<u64>>) -> Option<
 /// See [Page Index Documentation] for more details.
 ///
 /// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+/// [`ColumnIndex`]: crate::format::ColumnIndex
 #[deprecated(
     since = "55.2.0",
     note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
@@ -93,6 +93,7 @@ pub fn read_columns_indexes<R: ChunkReader>(
 /// See [Page Index Documentation] for more details.
 ///
 /// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
+/// [`OffsetIndex`]: crate::format::OffsetIndex
 #[deprecated(
     since = "55.2.0",
     note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
@@ -129,14 +130,14 @@ pub fn read_offset_indexes<R: ChunkReader>(
 
 pub(crate) fn decode_offset_index(data: &[u8]) -> Result<OffsetIndexMetaData, ParquetError> {
     let mut prot = TCompactSliceInputProtocol::new(data);
-    let offset = OffsetIndex::read_from_in_protocol(&mut prot)?;
+    let offset = crate::format::OffsetIndex::read_from_in_protocol(&mut prot)?;
     OffsetIndexMetaData::try_new(offset)
 }
 
 pub(crate) fn decode_column_index(data: &[u8], column_type: Type) -> Result<Index, ParquetError> {
     let mut prot = TCompactSliceInputProtocol::new(data);
 
-    let index = ColumnIndex::read_from_in_protocol(&mut prot)?;
+    let index = crate::format::ColumnIndex::read_from_in_protocol(&mut prot)?;
 
     let index = match column_type {
         Type::BOOLEAN => Index::BOOLEAN(NativeIndex::<bool>::try_new(index)?),

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -18,7 +18,40 @@
 //! [`OffsetIndexMetaData`] structure holding decoded [`OffsetIndex`] information
 
 use crate::errors::ParquetError;
-use crate::format::{OffsetIndex, PageLocation};
+
+/// Page location information for [`OffsetIndexMetaData`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PageLocation {
+    /// Offset of the page in the file *
+    pub offset: i64,
+    /// Size of the page, including header. Sum of compressed_page_size and header
+    /// length
+    pub compressed_page_size: i32,
+    /// Index within the RowGroup of the first row of the page. When an
+    /// OffsetIndex is present, pages must begin on row boundaries
+    /// (repetition_level = 0).
+    pub first_row_index: i64,
+}
+
+impl From<&crate::format::PageLocation> for PageLocation {
+    fn from(value: &crate::format::PageLocation) -> Self {
+        Self {
+            offset: value.offset,
+            compressed_page_size: value.compressed_page_size,
+            first_row_index: value.first_row_index,
+        }
+    }
+}
+
+impl From<&PageLocation> for crate::format::PageLocation {
+    fn from(value: &PageLocation) -> Self {
+        Self {
+            offset: value.offset,
+            compressed_page_size: value.compressed_page_size,
+            first_row_index: value.first_row_index,
+        }
+    }
+}
 
 /// [`OffsetIndex`] information for a column chunk. Contains offsets and sizes for each page
 /// in the chunk. Optionally stores fully decoded page sizes for BYTE_ARRAY columns.
@@ -33,9 +66,12 @@ pub struct OffsetIndexMetaData {
 
 impl OffsetIndexMetaData {
     /// Creates a new [`OffsetIndexMetaData`] from an [`OffsetIndex`].
-    pub(crate) fn try_new(index: OffsetIndex) -> Result<Self, ParquetError> {
+    ///
+    /// [`OffsetIndex`]: crate::format::OffsetIndex
+    pub(crate) fn try_new(index: crate::format::OffsetIndex) -> Result<Self, ParquetError> {
+        let page_locations = index.page_locations.iter().map(|loc| loc.into()).collect();
         Ok(Self {
-            page_locations: index.page_locations,
+            page_locations,
             unencoded_byte_array_data_bytes: index.unencoded_byte_array_data_bytes,
         })
     }
@@ -53,9 +89,10 @@ impl OffsetIndexMetaData {
 
     // TODO: remove annotation after merge
     #[allow(dead_code)]
-    pub(crate) fn to_thrift(&self) -> OffsetIndex {
-        OffsetIndex::new(
-            self.page_locations.clone(),
+    pub(crate) fn to_thrift(&self) -> crate::format::OffsetIndex {
+        let page_locations = self.page_locations.iter().map(|loc| loc.into()).collect();
+        crate::format::OffsetIndex::new(
+            page_locations,
             self.unencoded_byte_array_data_bytes.clone(),
         )
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -20,8 +20,7 @@ use crate::basic::{Compression, Encoding};
 use crate::compression::{CodecOptions, CodecOptionsBuilder};
 #[cfg(feature = "encryption")]
 use crate::encryption::encrypt::FileEncryptionProperties;
-use crate::file::metadata::KeyValue;
-use crate::format::SortingColumn;
+use crate::file::metadata::{KeyValue, SortingColumn};
 use crate::schema::types::ColumnPath;
 use std::str::FromStr;
 use std::{collections::HashMap, sync::Arc};

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -25,14 +25,14 @@ use crate::compression::{create_codec, Codec};
 #[cfg(feature = "encryption")]
 use crate::encryption::decrypt::{read_and_decrypt, CryptoContext};
 use crate::errors::{ParquetError, Result};
-use crate::file::page_index::offset_index::OffsetIndexMetaData;
+use crate::file::page_index::offset_index::{OffsetIndexMetaData, PageLocation};
 use crate::file::{
     metadata::*,
     properties::{ReaderProperties, ReaderPropertiesPtr},
     reader::*,
     statistics,
 };
-use crate::format::{PageHeader, PageLocation, PageType};
+use crate::format::{PageHeader, PageType};
 use crate::record::reader::RowIter;
 use crate::record::Row;
 use crate::schema::types::Type as SchemaType;
@@ -1102,9 +1102,8 @@ mod tests {
     use bytes::Buf;
 
     use crate::file::properties::{EnabledStatistics, WriterProperties};
-    use crate::format::BoundaryOrder;
 
-    use crate::basic::{self, ColumnOrder, SortOrder};
+    use crate::basic::{self, BoundaryOrder, ColumnOrder, SortOrder};
     use crate::column::reader::ColumnReader;
     use crate::data_type::private::ParquetValueType;
     use crate::data_type::{AsBytes, FixedLenByteArrayType, Int32Type};

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -41,8 +41,6 @@
 
 use std::fmt;
 
-use crate::format::Statistics as TStatistics;
-
 use crate::basic::Type;
 use crate::data_type::private::ParquetValueType;
 use crate::data_type::*;
@@ -122,7 +120,7 @@ macro_rules! statistics_enum_func {
 /// Converts Thrift definition into `Statistics`.
 pub fn from_thrift(
     physical_type: Type,
-    thrift_stats: Option<TStatistics>,
+    thrift_stats: Option<crate::format::Statistics>,
 ) -> Result<Option<Statistics>> {
     Ok(match thrift_stats {
         Some(stats) => {
@@ -269,7 +267,7 @@ pub fn from_thrift(
 }
 
 /// Convert Statistics into Thrift definition.
-pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
+pub fn to_thrift(stats: Option<&Statistics>) -> Option<crate::format::Statistics> {
     let stats = stats?;
 
     // record null count if it can fit in i64
@@ -282,7 +280,7 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
         .distinct_count_opt()
         .and_then(|value| i64::try_from(value).ok());
 
-    let mut thrift_stats = TStatistics {
+    let mut thrift_stats = crate::format::Statistics {
         max: None,
         min: None,
         null_count,
@@ -702,7 +700,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "General(\"Statistics null count is negative -10\")")]
     fn test_statistics_negative_null_count() {
-        let thrift_stats = TStatistics {
+        let thrift_stats = crate::format::Statistics {
             max: None,
             min: None,
             null_count: Some(-10),
@@ -1017,7 +1015,7 @@ mod tests {
 
     #[test]
     fn test_count_decoding_null_invalid() {
-        let tstatistics = TStatistics {
+        let tstatistics = crate::format::Statistics {
             null_count: Some(-42),
             ..Default::default()
         };

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -178,9 +178,9 @@ fn parse_timeunit(
     value
         .ok_or_else(|| general_err!(not_found_msg))
         .and_then(|v| match v.to_uppercase().as_str() {
-            "MILLIS" => Ok(TimeUnit::MILLIS(Default::default())),
-            "MICROS" => Ok(TimeUnit::MICROS(Default::default())),
-            "NANOS" => Ok(TimeUnit::NANOS(Default::default())),
+            "MILLIS" => Ok(TimeUnit::MILLIS),
+            "MICROS" => Ok(TimeUnit::MICROS),
+            "NANOS" => Ok(TimeUnit::NANOS),
             _ => Err(general_err!(parse_fail_msg)),
         })
 }
@@ -1075,7 +1075,7 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_6", PhysicalType::INT32)
                     .with_logical_type(Some(LogicalType::Time {
-                        unit: TimeUnit::MILLIS(Default::default()),
+                        unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: false,
                     }))
                     .build()
@@ -1084,7 +1084,7 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_7", PhysicalType::INT64)
                     .with_logical_type(Some(LogicalType::Time {
-                        unit: TimeUnit::MICROS(Default::default()),
+                        unit: TimeUnit::MICROS,
                         is_adjusted_to_u_t_c: true,
                     }))
                     .build()
@@ -1093,7 +1093,7 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_8", PhysicalType::INT64)
                     .with_logical_type(Some(LogicalType::Timestamp {
-                        unit: TimeUnit::MILLIS(Default::default()),
+                        unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: true,
                     }))
                     .build()
@@ -1102,7 +1102,7 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_9", PhysicalType::INT64)
                     .with_logical_type(Some(LogicalType::Timestamp {
-                        unit: TimeUnit::NANOS(Default::default()),
+                        unit: TimeUnit::NANOS,
                         is_adjusted_to_u_t_c: false,
                     }))
                     .build()

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -277,9 +277,9 @@ impl<'a> Printer<'a> {
 #[inline]
 fn print_timeunit(unit: &TimeUnit) -> &str {
     match unit {
-        TimeUnit::MILLIS(_) => "MILLIS",
-        TimeUnit::MICROS(_) => "MICROS",
-        TimeUnit::NANOS(_) => "NANOS",
+        TimeUnit::MILLIS => "MILLIS",
+        TimeUnit::MICROS => "MICROS",
+        TimeUnit::NANOS => "NANOS",
     }
 }
 
@@ -645,7 +645,7 @@ mod tests {
                     PhysicalType::INT64,
                     Some(LogicalType::Timestamp {
                         is_adjusted_to_u_t_c: true,
-                        unit: TimeUnit::MILLIS(Default::default()),
+                        unit: TimeUnit::MILLIS,
                     }),
                     ConvertedType::NONE,
                     Repetition::REQUIRED,
@@ -671,7 +671,7 @@ mod tests {
                     None,
                     PhysicalType::INT32,
                     Some(LogicalType::Time {
-                        unit: TimeUnit::MILLIS(Default::default()),
+                        unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: false,
                     }),
                     ConvertedType::TIME_MILLIS,
@@ -686,7 +686,7 @@ mod tests {
                     Some(42),
                     PhysicalType::INT32,
                     Some(LogicalType::Time {
-                        unit: TimeUnit::MILLIS(Default::default()),
+                        unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: false,
                     }),
                     ConvertedType::TIME_MILLIS,

--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -33,6 +33,12 @@ pub trait TSerializable: Sized {
     fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()>;
 }
 
+/// Public function to aid benchmarking.
+pub fn bench_file_metadata(bytes: &bytes::Bytes) {
+    let mut input = TCompactSliceInputProtocol::new(bytes);
+    crate::format::FileMetaData::read_from_in_protocol(&mut input).unwrap();
+}
+
 /// A more performant implementation of [`TCompactInputProtocol`] that reads a slice
 ///
 /// [`TCompactInputProtocol`]: thrift::protocol::TCompactInputProtocol

--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -323,7 +323,6 @@ fn eof_error() -> thrift::Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::format::{BoundaryOrder, ColumnIndex};
     use crate::thrift::{TCompactSliceInputProtocol, TSerializable};
 
     #[test]
@@ -334,12 +333,12 @@ mod tests {
         let bytes = vec![0x19, 0x21, 2, 1, 0x19, 8, 0x19, 8, 0x15, 0, 0];
 
         let mut protocol = TCompactSliceInputProtocol::new(bytes.as_slice());
-        let index = ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
-        let expected = ColumnIndex {
+        let index = crate::format::ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
+        let expected = crate::format::ColumnIndex {
             null_pages: vec![false, true],
             min_values: vec![],
             max_values: vec![],
-            boundary_order: BoundaryOrder::UNORDERED,
+            boundary_order: crate::format::BoundaryOrder::UNORDERED,
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,
@@ -355,12 +354,12 @@ mod tests {
         let bytes = vec![0x19, 0x22, 0, 1, 0x19, 8, 0x19, 8, 0x15, 0, 0];
 
         let mut protocol = TCompactSliceInputProtocol::new(bytes.as_slice());
-        let index = ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
-        let expected = ColumnIndex {
+        let index = crate::format::ColumnIndex::read_from_in_protocol(&mut protocol).unwrap();
+        let expected = crate::format::ColumnIndex {
             null_pages: vec![false, true],
             min_values: vec![],
             max_values: vec![],
-            boundary_order: BoundaryOrder::UNORDERED,
+            boundary_order: crate::format::BoundaryOrder::UNORDERED,
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #5854.

# Rationale for this change

This is the first step towards a rework of Parquet metadata handling. This PR attempts to remove as many references as possible to the `parquet::format` module in the public API. This is done by creating new enums and structs that mirror their `format` counterparts and using them in publicly exposed structures like `FileMetaData`.

# What changes are included in this PR?

# Are these changes tested?

Current tests should suffice for now. More thorough tests will be added as needed.

# Are there any user-facing changes?

Yes, public facing interfaces should no longer expose `format`
