### PR TITLE
Fix RowConverter roundtrip for List of Dictionary

### DIFF
--- a/arrow-row/Cargo.toml
+++ b/arrow-row/Cargo.toml
@@ -40,6 +40,7 @@ arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
+arrow-cast = { workspace = true}
 
 half = { version = "2.1", default-features = false }
 

--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -186,8 +186,9 @@ pub unsafe fn decode<O: OffsetSizeTrait>(
     };
 
     let encoded_child: ArrayRef = match element_dt {
+        // If the list's element type is a dictionary, we need to re-encode it,
+        // since it was hydrated (flattened) during the Array → Row conversion.
         DataType::Dictionary(_, _) => {
-            // pick a key type; Int32 is a sensible default
             let target_dt = element_dt.clone();
             cast(child[0].as_ref(), &target_dt)?
         }


### PR DESCRIPTION
# Which issue does this PR close?


Closes https://github.com/apache/datafusion/issues/17012


# Rationale for this change

The rountrip `List<Dictionary<(),()>> -> Row -> List<Dictionary<(),()>>` is failing:

`Expected infallible creation of GenericListArray from ArrayDataRef failed: InvalidArgumentError("[Large]ListArray's child datatype Utf8 does not correspond to the List's datatype Dictionary(Int8, Utf8)")`

# What changes are included in this PR?

My approach is to encode back to Dictionary when we convert back the rows to Arrays, a straightforward way to do is is ussing `arrow_cast::cast ` that [under the hood](https://github.com/apache/arrow-rs/blob/c25c5a74c1c70cee57558e81a66a2e44725a67a6/arrow-cast/src/cast/dictionary.rs#L323) builds a dictionary from an Array.

# Are these changes tested?

Yes, I added a roundtrip test that verifies that the original Array is the same as the resulting one after the roundtrip


# Are there any user-facing changes?

No

