### PR TITLE
Support writing RunEndEncoded as Parquet

### DIFF
--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -32,12 +32,12 @@ use crate::{
 
 /// An array of [run-end encoded values](https://arrow.apache.org/docs/format/Columnar.html#run-end-encoded-layout)
 ///
-/// This encoding is variation on [run-length encoding (RLE)](https://en.wikipedia.org/wiki/Run-length_encoding)
+/// This encoding is a variation on [run-length encoding (RLE)](https://en.wikipedia.org/wiki/Run-length_encoding)
 /// and is good for representing data containing same values repeated consecutively.
 ///
 /// [`RunArray`] contains `run_ends` array and `values` array of same length.
 /// The `run_ends` array stores the indexes at which the run ends. The `values` array
-/// stores the value of each run. Below example illustrates how a logical array is represented in
+/// stores the value of each run. The below example illustrates how a logical array is represented in
 /// [`RunArray`]
 ///
 ///

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -353,7 +353,7 @@ pub enum DataType {
     /// that contain many repeated values using less memory, but with
     /// a higher CPU overhead for some operations.
     ///
-    /// This type mostly used to represent low cardinality string
+    /// This type is mostly used to represent low cardinality string
     /// arrays or a limited set of primitive types as integers.
     Dictionary(Box<DataType>, Box<DataType>),
     /// Exact 32-bit width decimal value with precision and scale

--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -85,7 +85,7 @@ pub fn make_byte_array_reader(
                 )))
             }
             _ => Err(general_err!(
-                "invalid run end encoded value type for byte array reader - {}",
+                "invalid RunEndEncoded value type for byte array reader - {}",
                 data_type
             )),
         },

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -119,7 +119,13 @@ macro_rules! downcast_op {
                 DataType::LargeUtf8 => {
                     downcast_ree_op!(run_end, LargeStringArray, $array, $op$(, $arg)*)
                 }
+                DataType::Utf8View => {
+                    downcast_ree_op!(run_end, StringViewArray, $array, $op$(, $arg)*)
+                }
                 DataType::Binary => downcast_ree_op!(run_end, BinaryArray, $array, $op$(, $arg)*),
+                DataType::BinaryView => {
+                    downcast_ree_op!(run_end, BinaryViewArray, $array, $op$(, $arg)*)
+                }
                 DataType::LargeBinary => {
                     downcast_ree_op!(run_end, LargeBinaryArray, $array, $op$(, $arg)*)
                 }

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -222,6 +222,10 @@ impl LevelInfoBuilder {
                     _ => unreachable!(),
                 })
             }
+            DataType::RunEndEncoded(_, v) if is_leaf(v.data_type()) => {
+                let levels = ArrayLevels::new(parent_ctx, is_nullable, array.clone());
+                Ok(Self::Primitive(levels))
+            }
             d => Err(nyi_err!("Datatype {} is not yet supported", d)),
         }
     }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1122,6 +1122,17 @@ impl ArrowColumnWriterFactory {
                 ArrowDataType::FixedSizeBinary(_) => out.push(bytes(leaves.next().unwrap())?),
                 _ => out.push(col(leaves.next().unwrap())?),
             },
+            ArrowDataType::RunEndEncoded(_, value_type) => match value_type.data_type() {
+                ArrowDataType::Utf8
+                | ArrowDataType::LargeUtf8
+                | ArrowDataType::Binary
+                | ArrowDataType::LargeBinary => out.push(bytes(leaves.next().unwrap())?),
+                ArrowDataType::Utf8View | ArrowDataType::BinaryView => {
+                    out.push(bytes(leaves.next().unwrap())?)
+                }
+                ArrowDataType::FixedSizeBinary(_) => out.push(bytes(leaves.next().unwrap())?),
+                _ => out.push(col(leaves.next().unwrap())?),
+            },
             _ => {
                 return Err(ParquetError::NYI(format!(
                     "Attempting to write an Arrow type {data_type} to parquet that is not yet implemented"
@@ -1215,6 +1226,41 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                         write_primitive(typed, array.values(), levels)
                     }
                 },
+                ArrowDataType::RunEndEncoded(_, value_type) => match value_type.data_type() {
+                    ArrowDataType::Decimal32(_, _) => {
+                        let array = arrow_cast::cast(column, value_type.data_type())?;
+                        let array = array
+                            .as_primitive::<Decimal32Type>()
+                            .unary::<_, Int32Type>(|v| v);
+                        write_primitive(typed, array.values(), levels)
+                    }
+                    ArrowDataType::Decimal64(_, _) => {
+                        let array = arrow_cast::cast(column, value_type.data_type())?;
+                        let array = array
+                            .as_primitive::<Decimal64Type>()
+                            .unary::<_, Int32Type>(|v| v as i32);
+                        write_primitive(typed, array.values(), levels)
+                    }
+                    ArrowDataType::Decimal128(_, _) => {
+                        let array = arrow_cast::cast(column, value_type.data_type())?;
+                        let array = array
+                            .as_primitive::<Decimal128Type>()
+                            .unary::<_, Int32Type>(|v| v as i32);
+                        write_primitive(typed, array.values(), levels)
+                    }
+                    ArrowDataType::Decimal256(_, _) => {
+                        let array = arrow_cast::cast(column, value_type.data_type())?;
+                        let array = array
+                            .as_primitive::<Decimal256Type>()
+                            .unary::<_, Int32Type>(|v| v.as_i128() as i32);
+                        write_primitive(typed, array.values(), levels)
+                    }
+                    _ => {
+                        let array = arrow_cast::cast(column, &ArrowDataType::Int32)?;
+                        let array = array.as_primitive::<Int32Type>();
+                        write_primitive(typed, array.values(), levels)
+                    }
+                },
                 _ => {
                     let array = arrow_cast::cast(column, &ArrowDataType::Int32)?;
                     let array = array.as_primitive::<Int32Type>();
@@ -1297,6 +1343,12 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                         write_primitive(typed, array.values(), levels)
                     }
                 },
+                ArrowDataType::RunEndEncoded(_run_ends, _values) => {
+                    Err(ParquetError::NYI(
+                        "Int64ColumnWriter: Attempting to write an Arrow REE type that is not yet implemented"
+                            .to_string(),
+                    ))
+                }
                 _ => {
                     let array = arrow_cast::cast(column, &ArrowDataType::Int64)?;
                     let array = array.as_primitive::<Int64Type>();
@@ -1370,6 +1422,12 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                 ArrowDataType::Float16 => {
                     let array = column.as_primitive::<Float16Type>();
                     get_float_16_array_slice(array, indices)
+                }
+                ArrowDataType::RunEndEncoded(_run_ends, _values) => {
+                    return Err(ParquetError::NYI(
+                        "FixedLenByteArrayColumnWriter: Attempting to write an Arrow REE type that is not yet implemented"
+                            .to_string(),
+                    ));
                 }
                 _ => {
                     return Err(ParquetError::NYI(
@@ -4480,5 +4538,154 @@ mod tests {
 
         assert_eq!(get_dict_page_size(col0_meta), 1024 * 1024);
         assert_eq!(get_dict_page_size(col1_meta), 1024 * 1024 * 4);
+    }
+
+    #[test]
+    fn arrow_writer_run_end_encoded_string() {
+        // Create a run array of strings
+        let mut builder = StringRunBuilder::<Int32Type>::new();
+        builder.extend(
+            vec![Some("alpha"); 100000]
+                .into_iter()
+                .chain(vec![Some("beta"); 100000]),
+        );
+        let run_array: RunArray<Int32Type> = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            run_array.data_type().clone(),
+            run_array.is_nullable(),
+        )]));
+
+        // Write to parquet
+        let mut parquet_bytes: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema.clone(), None).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(run_array)]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back and verify
+        let bytes = Bytes::from(parquet_bytes);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+
+        // Check if dictionary was used by examining the metadata
+        let metadata = reader.metadata();
+        let row_group = &metadata.row_groups()[0];
+        let col_meta = &row_group.columns()[0];
+
+        // If dictionary encoding worked, we should see RLE_DICTIONARY encoding
+        // and have a dictionary page offset
+        let has_dict_encoding = col_meta.encodings().any(|e| e == Encoding::RLE_DICTIONARY);
+        let has_dict_page = col_meta.dictionary_page_offset().is_some();
+
+        // Verify the schema is REE encoded when we read it back
+        let expected_schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", arrow_schema::DataType::Int32, false)),
+                Arc::new(Field::new("values", arrow_schema::DataType::Utf8, true)),
+            ),
+            false,
+        )]));
+        assert_eq!(&expected_schema, reader.schema());
+
+        // Read the data back
+        let batches: Vec<_> = reader
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(batches.len(), 196);
+        // Count rows in total
+        let total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(total_rows, 200000);
+
+        // Ensure dictionary encoding
+        assert!(has_dict_encoding, "RunArray should be dictionary encoded");
+        assert!(has_dict_page, "RunArray should have dictionary page");
+    }
+
+    #[test]
+    fn arrow_writer_run_end_encoded_int() {
+        // Create a run array of strings
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
+        builder.extend(
+            vec![Some(1); 100000]
+                .into_iter()
+                .chain(vec![Some(2); 100000]),
+        );
+        let run_array: RunArray<Int32Type> = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            run_array.data_type().clone(),
+            run_array.is_nullable(),
+        )]));
+
+        // Write to parquet
+        let mut parquet_bytes: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema.clone(), None).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(run_array)]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back and verify
+        let bytes = Bytes::from(parquet_bytes);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+
+        // Check if dictionary was used by examining the metadata
+        let metadata = reader.metadata();
+        let row_group = &metadata.row_groups()[0];
+        let col_meta = &row_group.columns()[0];
+        let has_dict_encoding = col_meta.encodings().any(|e| e == Encoding::RLE_DICTIONARY);
+
+        // If dictionary encoding worked, we should see RLE_DICTIONARY encoding
+        // and have a dictionary page offset
+        // let has_dict_encoding = col_meta.encodings().contains(&Encoding::RLE_DICTIONARY);
+        let has_dict_page = col_meta.dictionary_page_offset().is_some();
+
+        // Verify the schema is REE encoded when we read it back
+        let expected_schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", arrow_schema::DataType::Int32, false)),
+                Arc::new(Field::new("values", arrow_schema::DataType::Int32, true)),
+            ),
+            false,
+        )]));
+        assert_eq!(&expected_schema, reader.schema());
+
+        // Read the data back
+        let batches: Vec<_> = reader
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(batches.len(), 196);
+        // Count rows in total
+        let total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(total_rows, 200000);
+
+        // Ensure dictionary encoding
+        assert!(has_dict_encoding, "RunArray should be dictionary encoded");
+        assert!(has_dict_page, "RunArray should have dictionary page");
+    }
+
+    #[test]
+    fn arrow_writer_round_trip_run_end_encoded_string() {
+        // Create a run array of strings (cannot have more than 1024 values per record batch)
+        let mut builder = StringRunBuilder::<Int32Type>::new();
+        builder.extend(
+            vec![Some("alpha"); 512]
+                .into_iter()
+                .chain(vec![Some("beta"); 512]),
+        );
+        let run_array: RunArray<Int32Type> = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            run_array.data_type().clone(),
+            run_array.is_nullable(),
+        )]));
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(run_array)]).unwrap();
+        roundtrip(batch, None);
     }
 }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4720,11 +4720,10 @@ mod tests {
         let metadata = reader.metadata();
         let row_group = &metadata.row_groups()[0];
         let col_meta = &row_group.columns()[0];
-        let has_dict_encoding = col_meta.encodings().any(|e| e == Encoding::RLE_DICTIONARY);
 
         // If dictionary encoding worked, we should see RLE_DICTIONARY encoding
         // and have a dictionary page offset
-        // let has_dict_encoding = col_meta.encodings().contains(&Encoding::RLE_DICTIONARY);
+        let has_dict_encoding = col_meta.encodings().any(|e| e == Encoding::RLE_DICTIONARY);
         let has_dict_page = col_meta.dictionary_page_offset().is_some();
 
         // Verify the schema is REE encoded when we read it back

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1345,7 +1345,7 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                 },
                 ArrowDataType::RunEndEncoded(_run_ends, _values) => {
                     Err(ParquetError::NYI(
-                        "Int64ColumnWriter: Attempting to write an Arrow REE type that is not yet implemented"
+                        "Int64ColumnWriter: Attempting to write an Arrow RunEndEncoded type that is not yet implemented"
                             .to_string(),
                     ))
                 }
@@ -1425,7 +1425,7 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                 }
                 ArrowDataType::RunEndEncoded(_run_ends, _values) => {
                     return Err(ParquetError::NYI(
-                        "FixedLenByteArrayColumnWriter: Attempting to write an Arrow REE type that is not yet implemented"
+                        "FixedLenByteArrayColumnWriter: Attempting to write an Arrow RunEndEncoded type that is not yet implemented"
                             .to_string(),
                     ));
                 }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1445,11 +1445,74 @@ fn write_leaf(writer: &mut ColumnWriter<'_>, levels: &ArrayLevels) -> Result<usi
                     let array = column.as_primitive::<Float16Type>();
                     get_float_16_array_slice(array, indices)
                 }
-                ArrowDataType::RunEndEncoded(_run_ends, _values) => {
-                    return Err(ParquetError::NYI(
-                        "FixedLenByteArrayColumnWriter: Attempting to write an Arrow RunEndEncoded type that is not yet implemented"
-                            .to_string(),
-                    ));
+                ArrowDataType::RunEndEncoded(_run_ends, values_field) => {
+                    match values_field.data_type() {
+                        ArrowDataType::Decimal32(_, _) => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array.as_primitive::<Decimal32Type>();
+                            get_decimal_32_array_slice(array, indices)
+                        }
+                        ArrowDataType::Decimal64(_, _) => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array.as_primitive::<Decimal64Type>();
+                            get_decimal_64_array_slice(array, indices)
+                        }
+                        ArrowDataType::Decimal128(_, _) => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array.as_primitive::<Decimal128Type>();
+                            get_decimal_128_array_slice(array, indices)
+                        }
+                        ArrowDataType::Decimal256(_, _) => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array
+                                .as_any()
+                                .downcast_ref::<arrow_array::Decimal256Array>()
+                                .unwrap();
+                            get_decimal_256_array_slice(array, indices)
+                        }
+                        ArrowDataType::FixedSizeBinary(_) => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array
+                                .as_any()
+                                .downcast_ref::<arrow_array::FixedSizeBinaryArray>()
+                                .unwrap();
+                            get_fsb_array_slice(array, indices)
+                        }
+                        ArrowDataType::Interval(interval_unit) => match interval_unit {
+                            IntervalUnit::YearMonth => {
+                                let array = arrow_cast::cast(column, values_field.data_type())?;
+                                let array = array
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::IntervalYearMonthArray>()
+                                    .unwrap();
+                                get_interval_ym_array_slice(array, indices)
+                            }
+                            IntervalUnit::DayTime => {
+                                let array = arrow_cast::cast(column, values_field.data_type())?;
+                                let array = array
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::IntervalDayTimeArray>()
+                                    .unwrap();
+                                get_interval_dt_array_slice(array, indices)
+                            }
+                            _ => {
+                                return Err(ParquetError::NYI(format!(
+                                    "Attempting to write an Arrow interval type {interval_unit:?} to parquet that is not yet implemented"
+                                )));
+                            }
+                        },
+                        ArrowDataType::Float16 => {
+                            let array = arrow_cast::cast(column, values_field.data_type())?;
+                            let array = array.as_primitive::<Float16Type>();
+                            get_float_16_array_slice(array, indices)
+                        }
+                        _ => {
+                            return Err(ParquetError::NYI(format!(
+                                "FixedLenByteArrayColumnWriter: Attempting to write an Arrow RunEndEncoded type with values {} that is not yet implemented",
+                                values_field.data_type()
+                            )));
+                        }
+                    }
                 }
                 _ => {
                     return Err(ParquetError::NYI(
@@ -4839,5 +4902,131 @@ mod tests {
         // Ensure dictionary encoding
         assert!(has_dict_encoding, "RunArray should be dictionary encoded");
         assert!(has_dict_page, "RunArray should have dictionary page");
+    }
+
+    #[test]
+    fn arrow_writer_run_end_encoded_decimal128() {
+        // Create a run array of Decimal128 values
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Decimal128Type>::new();
+        builder.extend(
+            vec![Some(12345i128); 100000]
+                .into_iter()
+                .chain(vec![Some(56789i128); 100000]),
+        );
+        let run_array: RunArray<Int32Type> = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            run_array.data_type().clone(),
+            run_array.is_nullable(),
+        )]));
+
+        // Write to parquet
+        let mut parquet_bytes: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema.clone(), None).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(run_array)]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back and verify
+        let bytes = Bytes::from(parquet_bytes);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+
+        // Check if RLE encoding was used by examining the metadata
+        let metadata = reader.metadata();
+        let row_group = &metadata.row_groups()[0];
+        let col_meta = &row_group.columns()[0];
+        let has_rle_encoding = col_meta.encodings().any(|e| e == Encoding::RLE);
+
+        // Verify the schema is REE encoded when we read it back
+        let expected_schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", arrow_schema::DataType::Int32, false)),
+                Arc::new(Field::new(
+                    "values",
+                    arrow_schema::DataType::Decimal128(38, 10),
+                    true,
+                )),
+            ),
+            false,
+        )]));
+        assert_eq!(&expected_schema, reader.schema());
+
+        // Read the data back
+        let batches: Vec<_> = reader
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(batches.len(), 196);
+        // Count rows in total
+        let total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(total_rows, 200000);
+
+        // Ensure RLE encoding
+        assert!(has_rle_encoding, "RunArray should be RLE encoded");
+    }
+
+    #[test]
+    fn arrow_writer_run_end_encoded_decimal256() {
+        // Create a run array of Decimal256 values
+        let mut builder = PrimitiveRunBuilder::<Int32Type, Decimal256Type>::new();
+        builder.extend(
+            vec![Some(i256::from_i128(12345i128)); 100000]
+                .into_iter()
+                .chain(vec![Some(i256::from_i128(56789i128)); 100000]),
+        );
+        let run_array: RunArray<Int32Type> = builder.finish();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            run_array.data_type().clone(),
+            run_array.is_nullable(),
+        )]));
+
+        // Write to parquet
+        let mut parquet_bytes: Vec<u8> = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut parquet_bytes, schema.clone(), None).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(run_array)]).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back and verify
+        let bytes = Bytes::from(parquet_bytes);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes).unwrap();
+
+        // Check if RLE encoding was used by examining the metadata
+        let metadata = reader.metadata();
+        let row_group = &metadata.row_groups()[0];
+        let col_meta = &row_group.columns()[0];
+        let has_rle_encoding = col_meta.encodings().any(|e| e == Encoding::RLE);
+
+        // Verify the schema is REE encoded when we read it back
+        let expected_schema = Arc::new(Schema::new(vec![Field::new(
+            "ree",
+            DataType::RunEndEncoded(
+                Arc::new(Field::new("run_ends", arrow_schema::DataType::Int32, false)),
+                Arc::new(Field::new(
+                    "values",
+                    arrow_schema::DataType::Decimal256(76, 10),
+                    true,
+                )),
+            ),
+            false,
+        )]));
+        assert_eq!(&expected_schema, reader.schema());
+
+        // Read the data back
+        let batches: Vec<_> = reader
+            .build()
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(batches.len(), 196);
+        // Count rows in total
+        let total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(total_rows, 200000);
+
+        // Ensure dictionary encoding
+        assert!(has_rle_encoding, "RunArray should be RLE encoded");
     }
 }

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -417,7 +417,7 @@ impl<'a> ArrowSchemaConverter<'a> {
     ///
     /// Setting this option to `true` will result in Parquet files that can be
     /// read by more readers, but may lose precision for Arrow types such as
-    /// [`DataType::Date64`] which have no direct [corresponding Parquet type].
+    /// [`DataType::Date64`] which have no direct corresponding Parquet type.
     ///
     /// By default, this converter does not coerce to native Parquet types. Enabling type
     /// coercion allows for meaningful representations that do not require
@@ -847,12 +847,17 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
         DataType::Union(_, _) => unimplemented!("See ARROW-8817."),
         DataType::Dictionary(_, value) => {
             // Dictionary encoding not handled at the schema level
-            let dict_field = field.clone().with_data_type(value.as_ref().clone());
+            let dict_field = field.to_owned().with_data_type(value.as_ref().clone());
             arrow_to_parquet_type(&dict_field, coerce_types)
         }
-        DataType::RunEndEncoded(_, _) => Err(arrow_err!(
-            "Converting RunEndEncodedType to parquet not supported",
-        )),
+        DataType::RunEndEncoded(_run_end_type, value_type) => {
+            // We want to write REE data as dictionary encoded data,
+            // which is not handled at the schema level.
+            let dict_field = field
+                .to_owned()
+                .with_data_type(value_type.data_type().to_owned());
+            arrow_to_parquet_type(&dict_field, coerce_types)
+        }
     }
 }
 
@@ -2384,5 +2389,23 @@ mod tests {
                 .to_string()
                 .contains("is not a virtual column")
         );
+    }
+
+    #[test]
+    fn test_run_end_encoded_conversion() {
+        use crate::basic::Type;
+        let run_ends_field = Arc::new(Field::new("run_ends", DataType::Int16, false));
+        let values_field = Arc::new(Field::new("values", DataType::Boolean, true));
+        let run_end_encoded_field = Field::new(
+            "run_end_encoded_16",
+            DataType::RunEndEncoded(run_ends_field, values_field),
+            false,
+        );
+
+        let result = arrow_to_parquet_type(&run_end_encoded_field, false).unwrap();
+        // Should convert to the underlying value type (Boolean in this case)
+        assert_eq!(result.get_physical_type(), Type::BOOLEAN);
+        assert_eq!(result.get_basic_info().repetition(), Repetition::REQUIRED); // field is not nullable
+        assert_eq!(result.name(), "run_end_encoded_16");
     }
 }

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -102,6 +102,18 @@ fn apply_hint(parquet: DataType, hint: DataType) -> DataType {
                 false => hinted,
             }
         }
+
+        // Potentially preserve run end encoded encoding
+        (_, DataType::RunEndEncoded(_, value)) => {
+            // Apply hint to inner type
+            let hinted = apply_hint(parquet, value.data_type().clone());
+            // If matches run end encoded value - preserve REE type
+            // otherwise use hinted inner type
+            match &hinted == value.data_type() {
+                true => hint,
+                false => hinted,
+            }
+        }
         _ => parquet,
     }
 }

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -103,7 +103,7 @@ fn apply_hint(parquet: DataType, hint: DataType) -> DataType {
             }
         }
 
-        // Potentially preserve run end encoded encoding
+        // Potentially preserve run-end encoding
         (_, DataType::RunEndEncoded(_, value)) => {
             // Apply hint to inner type
             let hinted = apply_hint(parquet, value.data_type().clone());


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #8016.
- Contribues towards the RunEndEncoded (REE) epic #3520.

# Rationale for this change

It's currently not possible to persist arrow REE records as parquet. This PR adds support for that! Specifically by writing it as dictionary encoded data.

# What changes are included in this PR?
Necessary reader and writer changes. The reader is not particularly efficient, as it casts into the logical type.

# Are these changes tested?
Yes, some tests including roundtrip tests.

# Are there any user-facing changes?
New functionality