### PR TITLE
fix: Validate metadata len in IPC reader 

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1402,12 +1402,11 @@ impl<R: Read> StreamReader<R> {
             i32::from_le_bytes(meta_size)
         };
 
-        if meta_len < 0 {
+        let Ok(meta_len) = usize::try_from(meta_len) else {
             return Err(ArrowError::ParseError(format!(
                 "Invalid metadata length: {meta_len}"
             )));
-        }
-
+        };
         let mut meta_buffer = vec![0; meta_len as usize];
         reader.read_exact(&mut meta_buffer)?;
 
@@ -1490,11 +1489,11 @@ impl<R: Read> StreamReader<R> {
             i32::from_le_bytes(meta_size)
         };
 
-        if meta_len < 0 {
+        let Ok(meta_len) = usize::try_from(meta_len) else {
             return Err(ArrowError::ParseError(format!(
                 "Invalid metadata length: {meta_len}"
             )));
-        }
+        };
 
         if meta_len == 0 {
             // the stream has ended, mark the reader as finished

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1407,7 +1407,7 @@ impl<R: Read> StreamReader<R> {
                 "Invalid metadata length: {meta_len}"
             )));
         };
-        let mut meta_buffer = vec![0; meta_len as usize];
+        let mut meta_buffer = vec![0; meta_len];
         reader.read_exact(&mut meta_buffer)?;
 
         let message = crate::root_as_message(meta_buffer.as_slice()).map_err(|err| {
@@ -1501,7 +1501,7 @@ impl<R: Read> StreamReader<R> {
             return Ok(None);
         }
 
-        let mut meta_buffer = vec![0; meta_len as usize];
+        let mut meta_buffer = vec![0; meta_len];
         self.reader.read_exact(&mut meta_buffer)?;
 
         let vecs = &meta_buffer.to_vec();

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1486,11 +1486,8 @@ impl<R: Read> StreamReader<R> {
             i32::from_le_bytes(meta_size)
         };
 
-        let Ok(meta_len) = usize::try_from(meta_len) else {
-            return Err(ArrowError::ParseError(format!(
-                "Invalid metadata length: {meta_len}"
-            )));
-        };
+        let meta_len = usize::try_from(meta_len)
+            .map_err(|_| ArrowError::ParseError(format!("Invalid metadata length: {meta_len}")))?;
 
         if meta_len == 0 {
             // the stream has ended, mark the reader as finished

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1402,11 +1402,8 @@ impl<R: Read> StreamReader<R> {
             i32::from_le_bytes(meta_size)
         };
 
-        let Ok(meta_len) = usize::try_from(meta_len) else {
-            return Err(ArrowError::ParseError(format!(
-                "Invalid metadata length: {meta_len}"
-            )));
-        };
+        let meta_len = usize::try_from(meta_len)
+            .map_err(|_| ArrowError::ParseError(format!("Invalid metadata length: {meta_len}")))?;
         let mut meta_buffer = vec![0; meta_len];
         reader.read_exact(&mut meta_buffer)?;
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1754,8 +1754,12 @@ mod tests {
         buf.extend(CONTINUATION_MARKER);
         buf.extend(bytes);
 
-        let reader = StreamReader::try_new(Cursor::new(buf), None);
-        assert!(reader.is_err());
+        let reader_err = StreamReader::try_new(Cursor::new(buf), None).err();
+        assert!(reader_err.is_some());
+        assert_eq!(
+            reader_err.unwrap().to_string(),
+            "Parser error: Invalid metadata length: -1"
+        );
     }
 
     #[test]

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1782,7 +1782,12 @@ mod tests {
         // Read the valid value
         assert!(reader.maybe_next().is_ok());
         // Read the invalid meta len
-        assert!(reader.maybe_next().is_err());
+        let batch_err = reader.maybe_next().err();
+        assert!(batch_err.is_some());
+        assert_eq!(
+            batch_err.unwrap().to_string(),
+            "Parser error: Invalid metadata length: -1"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

No issue filed.

# Rationale for this change

We allocate memory based on metadata length - If an untrusted client writes a meta len of < 0 then we'll allocate a large number of bytes due to sign extension and likely panic.

# What changes are included in this PR?

- Update StreamReader in both places it reads metadata length for < 0 which is at the start of the stream to read the schema, and in the middle of the stream between each message.

# Are these changes tested?

Yes, tests for both reads are added

# Are there any user-facing changes?

No