### PR TITLE
feat: change parquet statistics truncate length to column properties

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -943,14 +943,15 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// header or column chunk Statistics
     fn truncate_statistics(&self, statistics: Statistics) -> Statistics {
         let backwards_compatible_min_max = self.descr.sort_order().is_signed();
+        let column_path = self.descr.path();
         match statistics {
             Statistics::ByteArray(stats) if stats._internal_has_min_max_set() => {
                 let (min, did_truncate_min) = self.truncate_min_value(
-                    self.props.statistics_truncate_length(),
+                    self.props.statistics_truncate_length(column_path),
                     stats.min_bytes_opt().unwrap(),
                 );
                 let (max, did_truncate_max) = self.truncate_max_value(
-                    self.props.statistics_truncate_length(),
+                    self.props.statistics_truncate_length(column_path),
                     stats.max_bytes_opt().unwrap(),
                 );
                 Statistics::ByteArray(
@@ -969,11 +970,11 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                 if (stats._internal_has_min_max_set() && self.can_truncate_value()) =>
             {
                 let (min, did_truncate_min) = self.truncate_min_value(
-                    self.props.statistics_truncate_length(),
+                    self.props.statistics_truncate_length(column_path),
                     stats.min_bytes_opt().unwrap(),
                 );
                 let (max, did_truncate_max) = self.truncate_max_value(
-                    self.props.statistics_truncate_length(),
+                    self.props.statistics_truncate_length(column_path),
                     stats.max_bytes_opt().unwrap(),
                 );
                 Statistics::FixedLenByteArray(

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -322,7 +322,7 @@ impl WriterProperties {
             .get(col)
             .and_then(|props| props.statistics_truncate_length())
             .or_else(|| self.default_column_properties.statistics_truncate_length())
-            .or(DEFAULT_STATISTICS_TRUNCATE_LENGTH)
+            .unwrap_or(DEFAULT_STATISTICS_TRUNCATE_LENGTH)
     }
 
     /// Returns `true` if type coercion is enabled.
@@ -667,7 +667,7 @@ impl WriterPropertiesBuilder {
             assert!(value > 0, "Cannot have a 0 statistics truncate length. If you wish to disable min/max value truncation, set it to `None`.");
         }
 
-        self.default_column_properties.statistics_truncate_length = max_length;
+        self.default_column_properties.statistics_truncate_length = Some(max_length);
         self
     }
 
@@ -949,7 +949,7 @@ impl WriterPropertiesBuilder {
         if let Some(length) = max_length {
             assert!(length > 0, "Cannot have a 0 statistics truncate length. If you wish to disable min/max value truncation, set it to `None`.");
         }
-        self.get_mut_props(col).statistics_truncate_length = max_length;
+        self.get_mut_props(col).statistics_truncate_length = Some(max_length);
         self
     }
 }
@@ -1056,7 +1056,7 @@ struct ColumnProperties {
     /// bloom filter related properties
     bloom_filter_properties: Option<BloomFilterProperties>,
     /// statistics truncate length for this column
-    statistics_truncate_length: Option<usize>,
+    statistics_truncate_length: Option<Option<usize>>,
 }
 
 impl ColumnProperties {
@@ -1179,7 +1179,7 @@ impl ColumnProperties {
     }
 
     /// Returns the statistics truncate length for this column.
-    fn statistics_truncate_length(&self) -> Option<usize> {
+    fn statistics_truncate_length(&self) -> Option<Option<usize>> {
         self.statistics_truncate_length
     }
 }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -167,7 +167,6 @@ pub struct WriterProperties {
     column_properties: HashMap<ColumnPath, ColumnProperties>,
     sorting_columns: Option<Vec<SortingColumn>>,
     column_index_truncate_length: Option<usize>,
-    statistics_truncate_length: Option<usize>,
     coerce_types: bool,
     #[cfg(feature = "encryption")]
     pub(crate) file_encryption_properties: Option<FileEncryptionProperties>,
@@ -311,15 +310,19 @@ impl WriterProperties {
         self.column_index_truncate_length
     }
 
-    /// Returns the maximum length of truncated min/max values in [`Statistics`].
+    /// Returns the maximum length of truncated min/max values in [`Statistics`] for a specific column.
     ///
     /// `None` if truncation is disabled, must be greater than 0 otherwise.
     ///
-    /// For more details see [`WriterPropertiesBuilder::set_statistics_truncate_length`]
+    /// For more details see [`WriterPropertiesBuilder::set_column_statistics_truncate_length`]
     ///
     /// [`Statistics`]: crate::file::statistics::Statistics
-    pub fn statistics_truncate_length(&self) -> Option<usize> {
-        self.statistics_truncate_length
+    pub fn statistics_truncate_length(&self, col: &ColumnPath) -> Option<usize> {
+        self.column_properties
+            .get(col)
+            .and_then(|props| props.statistics_truncate_length())
+            .or_else(|| self.default_column_properties.statistics_truncate_length())
+            .or(DEFAULT_STATISTICS_TRUNCATE_LENGTH)
     }
 
     /// Returns `true` if type coercion is enabled.
@@ -449,7 +452,6 @@ pub struct WriterPropertiesBuilder {
     column_properties: HashMap<ColumnPath, ColumnProperties>,
     sorting_columns: Option<Vec<SortingColumn>>,
     column_index_truncate_length: Option<usize>,
-    statistics_truncate_length: Option<usize>,
     coerce_types: bool,
     #[cfg(feature = "encryption")]
     file_encryption_properties: Option<FileEncryptionProperties>,
@@ -472,7 +474,7 @@ impl Default for WriterPropertiesBuilder {
             column_properties: HashMap::new(),
             sorting_columns: None,
             column_index_truncate_length: DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
-            statistics_truncate_length: DEFAULT_STATISTICS_TRUNCATE_LENGTH,
+
             coerce_types: DEFAULT_COERCE_TYPES,
             #[cfg(feature = "encryption")]
             file_encryption_properties: None,
@@ -497,7 +499,7 @@ impl WriterPropertiesBuilder {
             column_properties: self.column_properties,
             sorting_columns: self.sorting_columns,
             column_index_truncate_length: self.column_index_truncate_length,
-            statistics_truncate_length: self.statistics_truncate_length,
+
             coerce_types: self.coerce_types,
             #[cfg(feature = "encryption")]
             file_encryption_properties: self.file_encryption_properties,
@@ -665,7 +667,7 @@ impl WriterPropertiesBuilder {
             assert!(value > 0, "Cannot have a 0 statistics truncate length. If you wish to disable min/max value truncation, set it to `None`.");
         }
 
-        self.statistics_truncate_length = max_length;
+        self.default_column_properties.statistics_truncate_length = max_length;
         self
     }
 
@@ -932,6 +934,24 @@ impl WriterPropertiesBuilder {
         self.get_mut_props(col).set_bloom_filter_ndv(value);
         self
     }
+
+    /// Sets the statistics truncate length for a specific column.
+    ///
+    /// If `Some`, must be greater than 0, otherwise will panic
+    /// If `None`, there's no effective limit.
+    ///
+    /// This method sets column-specific statistics truncate length.
+    pub fn set_column_statistics_truncate_length(
+        mut self,
+        col: ColumnPath,
+        max_length: Option<usize>,
+    ) -> Self {
+        if let Some(length) = max_length {
+            assert!(length > 0, "Cannot have a 0 statistics truncate length. If you wish to disable min/max value truncation, set it to `None`.");
+        }
+        self.get_mut_props(col).statistics_truncate_length = max_length;
+        self
+    }
 }
 
 /// Controls the level of statistics to be computed by the writer and stored in
@@ -1035,6 +1055,8 @@ struct ColumnProperties {
     write_page_header_statistics: Option<bool>,
     /// bloom filter related properties
     bloom_filter_properties: Option<BloomFilterProperties>,
+    /// statistics truncate length for this column
+    statistics_truncate_length: Option<usize>,
 }
 
 impl ColumnProperties {
@@ -1154,6 +1176,11 @@ impl ColumnProperties {
     /// Returns the bloom filter properties, or `None` if not enabled
     fn bloom_filter_properties(&self) -> Option<&BloomFilterProperties> {
         self.bloom_filter_properties.as_ref()
+    }
+
+    /// Returns the statistics truncate length for this column.
+    fn statistics_truncate_length(&self) -> Option<usize> {
+        self.statistics_truncate_length
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8094 .

# Rationale for this change

Change statistics truncate to column level

# What changes are included in this PR?

Change statistics truncate to column level

# Are these changes tested?

* [ ] I plan to add tests if this interface is ok

# Are there any user-facing changes?

Api added
