### PR TITLE
Add "update branch" option in PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,6 +46,9 @@ github:
         strict: true
         # don't require any jobs to pass
         contexts: []
+  pull_requests:
+    # enable updating head branches of pull requests
+    allow_update_branch: true
 
 # publishes the content of the `asf-site` branch to
 # https://arrow.apache.org/rust/


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Closes #NNN.

# Rationale for this change

I would like to be able to quickly merge changes from main into PRs to rerun CI against the latest main branch.

I can do this manually with git commands, but it would be nice to have a button in the github UI to do this automatically.

<img width="991" height="176" alt="Screenshot 2025-08-08 at 3 33 44 PM" src="https://github.com/user-attachments/assets/7d453c31-a534-4c59-a41e-5c1b31e5e8b8" />


# What changes are included in this PR?

Add the magic incantation to `asf.yaml` to enable this button, following the  model that @xudong963 did in https://github.com/apache/datafusion/pull/15904 for DataFusion

# Are these changes tested?

I will verify them manually after merge
# Are there any user-facing changes?

There will be a new button enabled in the github APU