### PR TITLE
Refactor arrow-avro `Decoder` to support partial decoding

### DIFF
--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -182,7 +182,7 @@ impl Decoder {
                     self.awaiting_body = true;
                     self.apply_pending_schema_if_batch_empty();
                     if self.remaining_capacity == 0 {
-                        break;
+                        break; // pending schema change ends the batch
                     }
                 }
             }

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -181,7 +181,7 @@ impl Decoder {
                         self.awaiting_body = false;
                         continue;
                     }
-                    Err(ref e) if is_incomplete_data(e) => return Ok(total_consumed),
+                    Err(ref e) if is_incomplete_data(e) => break,
                     err => return err,
                 };
             }

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -305,7 +305,7 @@ impl Decoder {
         self.remaining_capacity == 0
     }
 
-    // Decode either the block count of remaining capacity from `data` (an OCF block payload).
+    // Decode either the block count or remaining capacity from `data` (an OCF block payload).
     //
     // Returns the number of bytes consumed from `data` along with the number of records decoded.
     fn decode_block(&mut self, data: &[u8], count: usize) -> Result<(usize, usize), ArrowError> {

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -274,10 +274,9 @@ impl Decoder {
     }
 
     fn apply_pending_schema_if_batch_empty(&mut self) {
-        if self.remaining_capacity != self.batch_size {
-            return;
+        if self.batch_is_empty() {
+            self.apply_pending_schema();
         }
-        self.apply_pending_schema();
     }
 
     /// Produce a `RecordBatch` if at least one row is fully decoded, returning

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -180,9 +180,7 @@ impl Decoder {
                     }
                     total_consumed += n;
                     self.awaiting_body = true;
-                    if self.remaining_capacity == self.batch_size && self.pending_schema.is_some() {
-                        self.apply_pending_schema_if_batch_empty();
-                    }
+                    self.apply_pending_schema_if_batch_empty();
                     if self.remaining_capacity == 0 {
                         break;
                     }

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -176,7 +176,7 @@ impl Decoder {
             if !self.awaiting_body {
                 if let Some(n) = self.handle_prefix(&data[total_consumed..])? {
                     if n == 0 {
-                        break;
+                        break; // insufficient bytes
                     }
                     total_consumed += n;
                     self.awaiting_body = true;

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -197,12 +197,8 @@ impl Decoder {
                         "Record decoder consumed 0 bytes".into(),
                     ));
                 }
-                Err(e) => {
-                    return if is_incomplete_data(&e) {
-                        Ok(total_consumed)
-                    } else {
-                        Err(e)
-                    }
+                Err(ref e) if is_incomplete_data(&e) => return Ok(total_consumed),
+                err => return err,
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/4886

# Rationale for this change

Decoding Avro **single-object encoded** streams was brittle when data arrived in partial chunks (e.g., from async or networked sources). The old implementation relied on ad‑hoc prefix handling and assumed a full record would be available, producing hard errors for otherwise normal “incomplete buffer” situations. Additionally, the Avro OCF (Object Container File) path iterated record‑by‑record through a shared row decoder, adding overhead.

This PR introduces a small state machine for single‑object decoding and a block‑aware path for OCF, making streaming more robust and OCF decoding more efficient while preserving the public API surface.

# What changes are included in this PR?

**Single‑object decoding (streaming)**
- Replace ad‑hoc prefix parsing (`expect_prefix`, `handle_prefix`, `handle_fingerprint`) with an explicit state machine:
  - New `enum DecoderState { Magic, Fingerprint, Record, SchemaChange, Finished }`.
  - `Decoder` now tracks `state`, `bytes_remaining`, and a `fingerprint_buf` to incrementally assemble the fingerprint.
- New helper `is_incomplete_data(&ArrowError) -> bool` to treat “Unexpected EOF”, “bad varint”, and “offset overflow” as *incomplete input* instead of fatal errors.
- Reworked `Decoder::decode(&[u8]) -> Result<usize, ArrowError>`:
  - Consumes data according to the state machine.
  - Cleanly returns when more bytes are needed (no spurious errors for partial chunks).
  - Defers schema switching until after flushing currently decoded rows.
- Updated `Decoder::flush()` to emit a batch only when rows are ready and to transition the state correctly (including a staged `SchemaChange`).

**OCF (Object Container File) decoding**
- Add block‑aware decoding methods on `Decoder` used by `Reader`:
  - `decode_block(&[u8], count: usize) -> Result<(consumed, records_decoded), ArrowError>`
  - `flush_block() -> Result<Option<RecordBatch>, ArrowError>`
- `Reader` now tracks `block_count` and decodes up to the number of records in the current block, reducing per‑row overhead and improving throughput.
- `ReaderBuilder::build` initializes the new `block_count` path.

**API / struct adjustments**
- Remove internal `expect_prefix` flag from `Decoder`; behavior is driven by the state machine.
- `ReaderBuilder::make_decoder_with_parts` updated accordingly (no behavior change to public builder methods).
- No public API signature changes for `Reader`, `Decoder`, or `ReaderBuilder`.

**Tests**
- Add targeted streaming tests:
  - `test_two_messages_same_schema`
  - `test_two_messages_schema_switch`
  - `test_split_message_across_chunks`
- Update prefix‑handling tests to validate state transitions (`Magic` → `Fingerprint`, etc.) and new error messages.
- Retain and exercise existing suites (types, lists, nested structures, decimals, enums, strict mode) with minimal adjustments.

# Are these changes tested?

Yes.
- New unit tests cover:
  - Multi‑message streams with/without schema switches
  - Messages split across chunk boundaries
  - Incremental prefix/fingerprint parsing
- Existing tests continue to cover OCF reading, compression, complex/nested types, strict mode, etc.
- The new OCF path is exercised by the unchanged OCF tests since `Reader` now uses `decode_block/flush_block`.

# Are there any user-facing changes?

N/A

