### PR TITLE
[VARIANT] Initial integration tests for variant reads

### DIFF
--- a/parquet/tests/simple_variant_integration.rs
+++ b/parquet/tests/simple_variant_integration.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! Comprehensive integration tests for Parquet files with Variant columns
-//! 
+//!
 //! This test harness reads test case definitions from cases.json, loads expected
 //! Variant values from .variant.bin files, reads Parquet files, converts StructArray
 //! to VariantArray, and verifies that extracted values match expected results.
@@ -27,9 +27,14 @@
 // These tests require the arrow feature
 #![cfg(feature = "arrow")]
 
-use std::{env, fs, path::PathBuf, error::Error};
 use arrow_array::{Array, StructArray};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use std::{
+    env,
+    error::Error,
+    fs,
+    path::{Path, PathBuf},
+};
 
 /// Test case definition structure matching the format from cases.json
 #[derive(Debug, Clone)]
@@ -82,59 +87,73 @@ impl VariantIntegrationHarness {
     fn new() -> Result<Self, Box<dyn Error>> {
         let test_data_dir = find_shredded_variant_test_data()?;
         let test_cases = load_test_cases(&test_data_dir)?;
-        
-        println!("Loaded {} test cases from {}", test_cases.len(), test_data_dir.display());
-        
+
+        println!(
+            "Loaded {} test cases from {}",
+            test_cases.len(),
+            test_data_dir.display()
+        );
+
         Ok(Self {
             test_data_dir,
             test_cases,
         })
     }
-    
+
     /// Run all integration tests
     fn run_all_tests(&self) -> Result<(), Box<dyn Error>> {
         println!("Running Parquet Variant Integration Tests");
         println!("==========================================");
-        
+
         let mut passed = 0;
         let mut failed = 0;
         let mut ignored = 0;
-        
+
         for test_case in &self.test_cases {
             if !test_case.enabled {
-                println!("IGNORED: case-{:03} - {}", test_case.case_number, 
-                    test_case.test.as_deref().unwrap_or("unknown test"));
+                println!(
+                    "IGNORED: case-{:03} - {}",
+                    test_case.case_number,
+                    test_case.test.as_deref().unwrap_or("unknown test")
+                );
                 ignored += 1;
                 continue;
             }
-            
+
             match self.run_single_test(test_case) {
                 Ok(()) => {
-                    println!("PASSED: case-{:03} - {}", test_case.case_number,
-                        test_case.test.as_deref().unwrap_or("unknown test"));
+                    println!(
+                        "PASSED: case-{:03} - {}",
+                        test_case.case_number,
+                        test_case.test.as_deref().unwrap_or("unknown test")
+                    );
                     passed += 1;
                 }
                 Err(e) => {
-                    println!("FAILED: case-{:03} - {} - Error: {}", test_case.case_number,
-                        test_case.test.as_deref().unwrap_or("unknown test"), e);
+                    println!(
+                        "FAILED: case-{:03} - {} - Error: {}",
+                        test_case.case_number,
+                        test_case.test.as_deref().unwrap_or("unknown test"),
+                        e
+                    );
                     failed += 1;
                 }
             }
         }
-        
+
         println!("\nTest Results:");
         println!("  Passed: {}", passed);
         println!("  Failed: {}", failed);
         println!("  Ignored: {}", ignored);
         println!("  Total: {}", passed + failed + ignored);
-        
+
         if failed > 0 {
             Err(format!("{} tests failed", failed).into())
         } else {
             Ok(())
         }
     }
-    
+
     /// Run a single test case
     fn run_single_test(&self, test_case: &VariantTestCase) -> Result<(), Box<dyn Error>> {
         match &test_case.test_category {
@@ -148,7 +167,7 @@ impl VariantIntegrationHarness {
             }
         }
     }
-    
+
     /// Run a test case that should succeed
     fn run_success_test(&self, test_case: &VariantTestCase) -> Result<(), Box<dyn Error>> {
         // Step 1: Load expected Variant data from .variant.bin file (if present)
@@ -157,46 +176,54 @@ impl VariantIntegrationHarness {
         } else {
             None
         };
-        
+
         // Step 2: Read Parquet file and extract StructArray
         let struct_arrays = self.read_parquet_file(test_case)?;
-        
+
         // Step 3: For now, just verify the structure and basic validation
         // TODO: Convert StructArray to VariantArray using cast_to_variant (requires variant crates)
-        // TODO: Extract values using both VariantArray::value() and variant_get kernel  
+        // TODO: Extract values using both VariantArray::value() and variant_get kernel
         // TODO: Compare extracted values with expected values
-        
+
         self.verify_variant_structure(&struct_arrays)?;
-        
-        println!("  {} validation passed for case-{:03}", 
-                 match test_case.test_category {
-                     TestCategory::Primitives => "Primitive type",
-                     TestCategory::Arrays => "Array structure",
-                     TestCategory::Objects => "Object structure", 
-                     TestCategory::SchemaValidation => "Schema",
-                     TestCategory::Complex => "Complex structure",
-                     _ => "Basic structure",
-                 }, test_case.case_number);
-        
+
+        println!(
+            "  {} validation passed for case-{:03}",
+            match test_case.test_category {
+                TestCategory::Primitives => "Primitive type",
+                TestCategory::Arrays => "Array structure",
+                TestCategory::Objects => "Object structure",
+                TestCategory::SchemaValidation => "Schema",
+                TestCategory::Complex => "Complex structure",
+                _ => "Basic structure",
+            },
+            test_case.case_number
+        );
+
         if let Some(data) = expected_variant_data {
             println!("    Expected variant data: {} bytes", data.len());
         }
-        println!("    Found {} StructArray(s) with variant structure", struct_arrays.len());
-        
+        println!(
+            "    Found {} StructArray(s) with variant structure",
+            struct_arrays.len()
+        );
+
         Ok(())
     }
-    
+
     /// Run a test case that should produce an error
     fn run_error_test(&self, test_case: &VariantTestCase) -> Result<(), Box<dyn Error>> {
         println!("  Testing error case for case-{:03}", test_case.case_number);
-        
+
         // Try to read the parquet file - this might fail as expected
         match self.read_parquet_file(test_case) {
             Ok(struct_arrays) => {
                 // If file reading succeeds, the error should come during variant processing
-                println!("    Parquet file read successfully, expecting error during variant processing");
+                println!(
+                    "    Parquet file read successfully, expecting error during variant processing"
+                );
                 println!("    Found {} StructArray(s)", struct_arrays.len());
-                
+
                 // TODO: When variant processing is implemented, capture and validate the error
                 if let Some(expected_error) = &test_case.error_message {
                     println!("    Expected error: {}", expected_error);
@@ -211,48 +238,58 @@ impl VariantIntegrationHarness {
                 }
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Load expected Variant binary data from .variant.bin file
-    fn load_expected_variant_data(&self, test_case: &VariantTestCase) -> Result<Vec<u8>, Box<dyn Error>> {
+    #[allow(dead_code)]
+    fn load_expected_variant_data(
+        &self,
+        test_case: &VariantTestCase,
+    ) -> Result<Vec<u8>, Box<dyn Error>> {
         if let Some(variant_file) = &test_case.variant_file {
             self.load_expected_variant_data_by_file(variant_file)
         } else {
             Err("No variant file specified for this test case".into())
         }
     }
-    
+
     /// Load expected Variant binary data by file name
-    fn load_expected_variant_data_by_file(&self, variant_file: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn load_expected_variant_data_by_file(
+        &self,
+        variant_file: &str,
+    ) -> Result<Vec<u8>, Box<dyn Error>> {
         let variant_path = self.test_data_dir.join(variant_file);
-        
+
         if !variant_path.exists() {
             return Err(format!("Variant file not found: {}", variant_path.display()).into());
         }
-        
+
         let data = fs::read(&variant_path)?;
         Ok(data)
     }
-    
+
     /// Read Parquet file and extract StructArray columns
-    fn read_parquet_file(&self, test_case: &VariantTestCase) -> Result<Vec<StructArray>, Box<dyn Error>> {
+    fn read_parquet_file(
+        &self,
+        test_case: &VariantTestCase,
+    ) -> Result<Vec<StructArray>, Box<dyn Error>> {
         let parquet_path = self.test_data_dir.join(&test_case.parquet_file);
-        
+
         if !parquet_path.exists() {
             return Err(format!("Parquet file not found: {}", parquet_path.display()).into());
         }
-        
+
         let file = fs::File::open(&parquet_path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
         let reader = builder.build()?;
-        
+
         let mut struct_arrays = Vec::new();
-        
+
         for batch_result in reader {
             let batch = batch_result?;
-            
+
             // Look for StructArray columns that could contain Variant data
             for column in batch.columns() {
                 if let Some(struct_array) = column.as_any().downcast_ref::<StructArray>() {
@@ -263,36 +300,45 @@ impl VariantIntegrationHarness {
                 }
             }
         }
-        
+
         if struct_arrays.is_empty() {
             return Err("No valid Variant StructArray columns found in Parquet file".into());
         }
-        
+
         Ok(struct_arrays)
     }
-    
+
     /// Check if a StructArray has the expected Variant structure (metadata, value fields)
     fn is_variant_struct_array(&self, struct_array: &StructArray) -> Result<bool, Box<dyn Error>> {
         let column_names = struct_array.column_names();
-        let field_names: Vec<&str> = column_names.iter().map(|s| s.as_ref()).collect();
-        
+        let field_names: Vec<&str> = column_names.to_vec();
+
         // Check for required Variant fields
         let has_metadata = field_names.contains(&"metadata");
         let has_value = field_names.contains(&"value");
-        
+
         Ok(has_metadata && has_value)
     }
-    
+
     /// Verify that StructArrays have the expected Variant structure
-    fn verify_variant_structure(&self, struct_arrays: &[StructArray]) -> Result<(), Box<dyn Error>> {
+    fn verify_variant_structure(
+        &self,
+        struct_arrays: &[StructArray],
+    ) -> Result<(), Box<dyn Error>> {
         for (i, struct_array) in struct_arrays.iter().enumerate() {
             if !self.is_variant_struct_array(struct_array)? {
-                return Err(format!("StructArray {} does not have expected Variant structure", i).into());
+                return Err(
+                    format!("StructArray {} does not have expected Variant structure", i).into(),
+                );
             }
-            
-            println!("    StructArray {} has {} rows and valid Variant structure", i, struct_array.len());
+
+            println!(
+                "    StructArray {} has {} rows and valid Variant structure",
+                i,
+                struct_array.len()
+            );
         }
-        
+
         Ok(())
     }
 }
@@ -306,7 +352,7 @@ fn find_shredded_variant_test_data() -> Result<PathBuf, Box<dyn Error>> {
             return Ok(shredded_variant_dir);
         }
     }
-    
+
     // Try relative paths from CARGO_MANIFEST_DIR
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let candidates = vec![
@@ -314,26 +360,26 @@ fn find_shredded_variant_test_data() -> Result<PathBuf, Box<dyn Error>> {
         PathBuf::from(&manifest_dir).join("parquet-testing/shredded_variant"),
         PathBuf::from("parquet-testing/shredded_variant"),
     ];
-    
+
     for candidate in candidates {
         if candidate.is_dir() {
             return Ok(candidate);
         }
     }
-    
+
     Err("Could not find shredded_variant test data directory. Ensure parquet-testing submodule is initialized with PR #90 data.".into())
 }
 
 /// Load test cases from cases.json
-fn load_test_cases(test_data_dir: &PathBuf) -> Result<Vec<VariantTestCase>, Box<dyn Error>> {
+fn load_test_cases(test_data_dir: &Path) -> Result<Vec<VariantTestCase>, Box<dyn Error>> {
     let cases_file = test_data_dir.join("cases.json");
-    
+
     if !cases_file.exists() {
         return Err(format!("cases.json not found at {}", cases_file.display()).into());
     }
-    
+
     let content = fs::read_to_string(&cases_file)?;
-    
+
     // Parse JSON manually since serde is not available as a dependency
     parse_cases_json(&content)
 }
@@ -341,16 +387,16 @@ fn load_test_cases(test_data_dir: &PathBuf) -> Result<Vec<VariantTestCase>, Box<
 /// Parse cases.json manually without serde
 fn parse_cases_json(content: &str) -> Result<Vec<VariantTestCase>, Box<dyn Error>> {
     let mut test_cases = Vec::new();
-    
+
     // Simple JSON parsing for the specific format we expect
     // Format: [{"case_number": 1, "test": "...", "parquet_file": "...", "variant_file": "...", "variant": "..."}, ...]
-    
+
     let lines: Vec<&str> = content.lines().collect();
     let mut current_case: Option<VariantTestCase> = None;
-    
+
     for line in lines {
         let trimmed = line.trim();
-        
+
         if trimmed.contains("\"case_number\"") {
             // Extract case number
             if let Some(colon_pos) = trimmed.find(':') {
@@ -424,16 +470,21 @@ fn parse_cases_json(content: &str) -> Result<Vec<VariantTestCase>, Box<dyn Error
                 if let Some(start_quote) = trimmed.rfind('"') {
                     let before_quote = &trimmed[..start_quote];
                     if let Some(second_quote) = before_quote.rfind('"') {
-                        case.variant_description = Some(before_quote[second_quote + 1..].to_string());
+                        case.variant_description =
+                            Some(before_quote[second_quote + 1..].to_string());
                     }
                 }
             }
         } else if trimmed == "}, {" || trimmed == "}" {
             // End of current case
             if let Some(mut case) = current_case.take() {
-                if !case.parquet_file.is_empty() && (case.variant_file.is_some() || case.error_message.is_some()) {
+                if !case.parquet_file.is_empty()
+                    && (case.variant_file.is_some() || case.error_message.is_some())
+                {
                     // Categorize the test based on its name if not already categorized
-                    if case.test_category == TestCategory::Primitives && case.error_message.is_none() {
+                    if case.test_category == TestCategory::Primitives
+                        && case.error_message.is_none()
+                    {
                         case.test_category = categorize_test(&case.test);
                     }
                     test_cases.push(case);
@@ -441,10 +492,12 @@ fn parse_cases_json(content: &str) -> Result<Vec<VariantTestCase>, Box<dyn Error
             }
         }
     }
-    
+
     // Handle the last case if the JSON doesn't end with }, {
     if let Some(mut case) = current_case {
-        if !case.parquet_file.is_empty() && (case.variant_file.is_some() || case.error_message.is_some()) {
+        if !case.parquet_file.is_empty()
+            && (case.variant_file.is_some() || case.error_message.is_some())
+        {
             // Categorize the test based on its name if not already categorized
             if case.test_category == TestCategory::Primitives && case.error_message.is_none() {
                 case.test_category = categorize_test(&case.test);
@@ -452,7 +505,7 @@ fn parse_cases_json(content: &str) -> Result<Vec<VariantTestCase>, Box<dyn Error
             test_cases.push(case);
         }
     }
-    
+
     Ok(test_cases)
 }
 
@@ -460,7 +513,7 @@ fn parse_cases_json(content: &str) -> Result<Vec<VariantTestCase>, Box<dyn Error
 fn categorize_test(test_name: &Option<String>) -> TestCategory {
     match test_name.as_ref().map(|s| s.as_str()) {
         Some(name) if name.contains("Array") => TestCategory::Arrays,
-        Some(name) if name.contains("Object") => TestCategory::Objects, 
+        Some(name) if name.contains("Object") => TestCategory::Objects,
         Some(name) if name.contains("Unshredded") => TestCategory::SchemaValidation,
         Some(name) if name.contains("Mixed") || name.contains("Nested") => TestCategory::Complex,
         Some(name) if name.contains("Primitives") => TestCategory::Primitives,
@@ -475,60 +528,80 @@ fn categorize_test(test_name: &Option<String>) -> TestCategory {
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_001() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 1)
         .expect("case-001 not found");
-        
-    harness.run_single_test(test_case).expect("case-001 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-001 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_002() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 2)
         .expect("case-002 not found");
-        
-    harness.run_single_test(test_case).expect("case-002 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-002 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_004() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 4)
         .expect("case-004 not found");
-        
-    harness.run_single_test(test_case).expect("case-004 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-004 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_005() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 5)
         .expect("case-005 not found");
-        
-    harness.run_single_test(test_case).expect("case-005 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-005 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_006() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 6)
         .expect("case-006 not found");
-        
-    harness.run_single_test(test_case).expect("case-006 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-006 should pass");
 }
 
 // Add more individual test cases for key scenarios
@@ -536,48 +609,64 @@ fn test_variant_integration_case_006() {
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_007() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 7)
         .expect("case-007 not found");
-        
-    harness.run_single_test(test_case).expect("case-007 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-007 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_008() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 8)
         .expect("case-008 not found");
-        
-    harness.run_single_test(test_case).expect("case-008 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-008 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_009() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 9)
         .expect("case-009 not found");
-        
-    harness.run_single_test(test_case).expect("case-009 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-009 should pass");
 }
 
 #[test]
 #[ignore] // Enable once parquet-variant dependencies are added
 fn test_variant_integration_case_010() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 10)
         .expect("case-010 not found");
-        
-    harness.run_single_test(test_case).expect("case-010 should pass");
+
+    harness
+        .run_single_test(test_case)
+        .expect("case-010 should pass");
 }
 
 // Specific tests for error cases that should be enabled to test error handling
@@ -585,25 +674,33 @@ fn test_variant_integration_case_010() {
 #[ignore] // Enable to test error handling - case with conflicting value and typed_value
 fn test_variant_integration_error_case_040() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 40)
         .expect("case-040 not found");
-    
-    // This should handle the error gracefully    
-    harness.run_single_test(test_case).expect("Error case should be handled gracefully");
+
+    // This should handle the error gracefully
+    harness
+        .run_single_test(test_case)
+        .expect("Error case should be handled gracefully");
 }
 
 #[test]
 #[ignore] // Enable to test error handling - case with value and typed_value conflict
 fn test_variant_integration_error_case_042() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let test_case = harness.test_cases.iter()
+
+    let test_case = harness
+        .test_cases
+        .iter()
         .find(|case| case.case_number == 42)
         .expect("case-042 not found");
-        
-    harness.run_single_test(test_case).expect("Error case should be handled gracefully");
+
+    harness
+        .run_single_test(test_case)
+        .expect("Error case should be handled gracefully");
 }
 
 // Test that runs all cases by category
@@ -611,23 +708,27 @@ fn test_variant_integration_error_case_042() {
 #[ignore] // Enable when ready to run all tests
 fn test_variant_integration_all_cases() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    harness.run_all_tests().expect("Integration tests should pass");
+    harness
+        .run_all_tests()
+        .expect("Integration tests should pass");
 }
 
-#[test] 
+#[test]
 #[ignore] // Enable to test primitive type cases
 fn test_variant_integration_primitives_only() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let primitive_cases: Vec<_> = harness.test_cases.iter()
+
+    let primitive_cases: Vec<_> = harness
+        .test_cases
+        .iter()
         .filter(|case| case.test_category == TestCategory::Primitives)
         .collect();
-    
+
     println!("Testing {} primitive cases", primitive_cases.len());
-    
+
     let mut passed = 0;
     let mut failed = 0;
-    
+
     for test_case in primitive_cases {
         match harness.run_single_test(test_case) {
             Ok(()) => {
@@ -640,7 +741,7 @@ fn test_variant_integration_primitives_only() {
             }
         }
     }
-    
+
     println!("Primitive tests: {} passed, {} failed", passed, failed);
     assert!(failed == 0, "All primitive tests should pass");
 }
@@ -649,16 +750,21 @@ fn test_variant_integration_primitives_only() {
 #[ignore] // Enable to test array cases
 fn test_variant_integration_arrays_only() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let array_cases: Vec<_> = harness.test_cases.iter()
+
+    let array_cases: Vec<_> = harness
+        .test_cases
+        .iter()
         .filter(|case| case.test_category == TestCategory::Arrays)
         .collect();
-        
+
     println!("Testing {} array cases", array_cases.len());
-    
+
     for test_case in array_cases {
-        println!("Testing case-{:03}: {}", test_case.case_number, 
-                 test_case.test.as_deref().unwrap_or("unknown"));
+        println!(
+            "Testing case-{:03}: {}",
+            test_case.case_number,
+            test_case.test.as_deref().unwrap_or("unknown")
+        );
         match harness.run_single_test(test_case) {
             Ok(()) => println!("  PASSED"),
             Err(e) => println!("  FAILED: {}", e),
@@ -670,16 +776,21 @@ fn test_variant_integration_arrays_only() {
 #[ignore] // Enable to test object cases
 fn test_variant_integration_objects_only() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let object_cases: Vec<_> = harness.test_cases.iter()
+
+    let object_cases: Vec<_> = harness
+        .test_cases
+        .iter()
         .filter(|case| case.test_category == TestCategory::Objects)
         .collect();
-        
+
     println!("Testing {} object cases", object_cases.len());
-    
+
     for test_case in object_cases {
-        println!("Testing case-{:03}: {}", test_case.case_number,
-                 test_case.test.as_deref().unwrap_or("unknown"));
+        println!(
+            "Testing case-{:03}: {}",
+            test_case.case_number,
+            test_case.test.as_deref().unwrap_or("unknown")
+        );
         match harness.run_single_test(test_case) {
             Ok(()) => println!("  PASSED"),
             Err(e) => println!("  FAILED: {}", e),
@@ -691,17 +802,25 @@ fn test_variant_integration_objects_only() {
 #[ignore] // Enable to test error handling cases
 fn test_variant_integration_error_cases_only() {
     let harness = VariantIntegrationHarness::new().expect("Failed to create test harness");
-    
-    let error_cases: Vec<_> = harness.test_cases.iter()
+
+    let error_cases: Vec<_> = harness
+        .test_cases
+        .iter()
         .filter(|case| case.test_category == TestCategory::ErrorHandling)
         .collect();
-        
+
     println!("Testing {} error cases", error_cases.len());
-    
+
     for test_case in error_cases {
-        println!("Testing error case-{:03}: {}", test_case.case_number,
-                 test_case.test.as_deref().unwrap_or("unknown"));
-        println!("  Expected error: {}", test_case.error_message.as_deref().unwrap_or("none"));
+        println!(
+            "Testing error case-{:03}: {}",
+            test_case.case_number,
+            test_case.test.as_deref().unwrap_or("unknown")
+        );
+        println!(
+            "  Expected error: {}",
+            test_case.error_message.as_deref().unwrap_or("none")
+        );
         match harness.run_single_test(test_case) {
             Ok(()) => println!("  Error case handled gracefully"),
             Err(e) => println!("  Error case processing failed: {}", e),
@@ -714,33 +833,49 @@ fn test_variant_integration_error_cases_only() {
 fn test_variant_structure_validation() {
     // This test attempts to read actual parquet files and validate their structure
     println!("Testing parquet file structure validation");
-    
+
     match VariantIntegrationHarness::new() {
         Ok(harness) => {
-            println!("Successfully loaded test harness with {} test cases", harness.test_cases.len());
-            
+            println!(
+                "Successfully loaded test harness with {} test cases",
+                harness.test_cases.len()
+            );
+
             // Test structural validation on a few test cases
             let test_cases_to_validate = [1, 2, 4, 5];
             let mut validated_cases = 0;
-            
+
             for case_number in test_cases_to_validate {
-                if let Some(test_case) = harness.test_cases.iter().find(|c| c.case_number == case_number) {
-                    println!("\nValidating case-{:03}: {}", case_number, test_case.parquet_file);
-                    
+                if let Some(test_case) = harness
+                    .test_cases
+                    .iter()
+                    .find(|c| c.case_number == case_number)
+                {
+                    println!(
+                        "\nValidating case-{:03}: {}",
+                        case_number, test_case.parquet_file
+                    );
+
                     match harness.run_single_test(test_case) {
                         Ok(()) => {
                             println!("  Structure validation PASSED for case-{:03}", case_number);
                             validated_cases += 1;
                         }
                         Err(e) => {
-                            println!("  Structure validation FAILED for case-{:03}: {}", case_number, e);
+                            println!(
+                                "  Structure validation FAILED for case-{:03}: {}",
+                                case_number, e
+                            );
                             // Don't fail the test for structural issues during development
                         }
                     }
                 }
             }
-            
-            println!("\nValidated {} test case structures successfully", validated_cases);
+
+            println!(
+                "\nValidated {} test case structures successfully",
+                validated_cases
+            );
         }
         Err(e) => {
             println!("Could not find shredded_variant test data: {}", e);
@@ -754,82 +889,137 @@ fn test_variant_structure_validation() {
 fn test_variant_integration_comprehensive_analysis() {
     // This test analyzes the comprehensive shredded_variant test data from PR #90
     println!("Running comprehensive analysis of variant integration test data");
-    
+
     match VariantIntegrationHarness::new() {
         Ok(harness) => {
-            println!("Successfully loaded test harness with {} test cases", harness.test_cases.len());
-            
+            println!(
+                "Successfully loaded test harness with {} test cases",
+                harness.test_cases.len()
+            );
+
             // Analyze test breakdown by category
             let mut category_counts = std::collections::HashMap::new();
             let mut error_cases = Vec::new();
             let mut success_cases = Vec::new();
-            
+
             for test_case in &harness.test_cases {
-                *category_counts.entry(test_case.test_category.clone()).or_insert(0) += 1;
-                
+                *category_counts
+                    .entry(test_case.test_category.clone())
+                    .or_insert(0) += 1;
+
                 if test_case.error_message.is_some() {
                     error_cases.push(test_case);
                 } else {
                     success_cases.push(test_case);
                 }
             }
-            
+
             println!("\nTest Coverage Analysis:");
-            println!("  Primitives: {}", category_counts.get(&TestCategory::Primitives).unwrap_or(&0));
-            println!("  Arrays: {}", category_counts.get(&TestCategory::Arrays).unwrap_or(&0));
-            println!("  Objects: {}", category_counts.get(&TestCategory::Objects).unwrap_or(&0));
-            println!("  Error Handling: {}", category_counts.get(&TestCategory::ErrorHandling).unwrap_or(&0));
-            println!("  Schema Validation: {}", category_counts.get(&TestCategory::SchemaValidation).unwrap_or(&0));
-            println!("  Complex: {}", category_counts.get(&TestCategory::Complex).unwrap_or(&0));
+            println!(
+                "  Primitives: {}",
+                category_counts.get(&TestCategory::Primitives).unwrap_or(&0)
+            );
+            println!(
+                "  Arrays: {}",
+                category_counts.get(&TestCategory::Arrays).unwrap_or(&0)
+            );
+            println!(
+                "  Objects: {}",
+                category_counts.get(&TestCategory::Objects).unwrap_or(&0)
+            );
+            println!(
+                "  Error Handling: {}",
+                category_counts
+                    .get(&TestCategory::ErrorHandling)
+                    .unwrap_or(&0)
+            );
+            println!(
+                "  Schema Validation: {}",
+                category_counts
+                    .get(&TestCategory::SchemaValidation)
+                    .unwrap_or(&0)
+            );
+            println!(
+                "  Complex: {}",
+                category_counts.get(&TestCategory::Complex).unwrap_or(&0)
+            );
             println!("  Total Success Cases: {}", success_cases.len());
             println!("  Total Error Cases: {}", error_cases.len());
-            
+
             // Test a representative sample from each category
             let test_cases_to_check = [1, 2, 4, 5, 6];
             let mut validated_cases = 0;
-            
+
             println!("\nValidating representative test cases:");
             for case_number in test_cases_to_check {
-                if let Some(test_case) = harness.test_cases.iter().find(|c| c.case_number == case_number) {
-                    println!("Case-{:03} ({:?}): {} -> {}", 
-                        case_number, 
+                if let Some(test_case) = harness
+                    .test_cases
+                    .iter()
+                    .find(|c| c.case_number == case_number)
+                {
+                    println!(
+                        "Case-{:03} ({:?}): {} -> {}",
+                        case_number,
                         test_case.test_category,
-                        test_case.parquet_file, 
-                        test_case.variant_file.as_deref().unwrap_or("no variant file"));
-                    
+                        test_case.parquet_file,
+                        test_case
+                            .variant_file
+                            .as_deref()
+                            .unwrap_or("no variant file")
+                    );
+
                     // Verify files exist
                     let parquet_path = harness.test_data_dir.join(&test_case.parquet_file);
-                    assert!(parquet_path.exists(), "Parquet file should exist: {}", parquet_path.display());
-                    
+                    assert!(
+                        parquet_path.exists(),
+                        "Parquet file should exist: {}",
+                        parquet_path.display()
+                    );
+
                     if let Some(variant_file) = &test_case.variant_file {
                         let variant_path = harness.test_data_dir.join(variant_file);
-                        assert!(variant_path.exists(), "Variant file should exist: {}", variant_path.display());
-                        
+                        assert!(
+                            variant_path.exists(),
+                            "Variant file should exist: {}",
+                            variant_path.display()
+                        );
+
                         if let Ok(variant_data) = fs::read(&variant_path) {
                             println!("  Variant data: {} bytes", variant_data.len());
                         }
                     }
-                    
+
                     validated_cases += 1;
                 }
             }
-            
+
             println!("\nError test cases found:");
             for error_case in error_cases.iter().take(3) {
-                println!("  Case-{:03}: {} - {}", 
+                println!(
+                    "  Case-{:03}: {} - {}",
                     error_case.case_number,
                     error_case.test.as_deref().unwrap_or("unknown"),
-                    error_case.error_message.as_deref().unwrap_or("no error message"));
+                    error_case
+                        .error_message
+                        .as_deref()
+                        .unwrap_or("no error message")
+                );
             }
-            
-            assert!(validated_cases >= 3, "Should validate at least 3 test cases");
-            assert!(!harness.test_cases.is_empty(), "Should have loaded test cases");
+
+            assert!(
+                validated_cases >= 3,
+                "Should validate at least 3 test cases"
+            );
+            assert!(
+                !harness.test_cases.is_empty(),
+                "Should have loaded test cases"
+            );
             println!("\nComprehensive analysis completed successfully!");
         }
         Err(e) => {
             println!("Could not find shredded_variant test data: {}", e);
             println!("This is expected if parquet-testing submodule is not at PR #90 branch");
-            
+
             // Don't fail the test if data isn't available, just report it
             // This allows the test to work in different environments
         }
@@ -841,37 +1031,53 @@ fn test_variant_integration_comprehensive_analysis() {
 fn test_variant_integration_error_case_handling() {
     // This test demonstrates that error cases are properly detected and handled
     println!("Testing error case handling with actual error files");
-    
+
     match VariantIntegrationHarness::new() {
         Ok(harness) => {
-            println!("Successfully loaded test harness with {} test cases", harness.test_cases.len());
-            
+            println!(
+                "Successfully loaded test harness with {} test cases",
+                harness.test_cases.len()
+            );
+
             // Find and test a few error cases
-            let error_cases: Vec<_> = harness.test_cases.iter()
+            let error_cases: Vec<_> = harness
+                .test_cases
+                .iter()
                 .filter(|case| case.test_category == TestCategory::ErrorHandling)
                 .take(3)
                 .collect();
-                
+
             println!("Found {} error cases for testing", error_cases.len());
-            
+
             for error_case in &error_cases {
-                println!("\nTesting error case-{:03}: {}", 
+                println!(
+                    "\nTesting error case-{:03}: {}",
                     error_case.case_number,
-                    error_case.test.as_deref().unwrap_or("unknown"));
-                println!("  Expected error: {}", 
-                    error_case.error_message.as_deref().unwrap_or("no error message"));
-                    
+                    error_case.test.as_deref().unwrap_or("unknown")
+                );
+                println!(
+                    "  Expected error: {}",
+                    error_case
+                        .error_message
+                        .as_deref()
+                        .unwrap_or("no error message")
+                );
+
                 // Verify the parquet file exists (error cases should still have readable files)
                 let parquet_path = harness.test_data_dir.join(&error_case.parquet_file);
-                assert!(parquet_path.exists(), "Error case parquet file should exist: {}", parquet_path.display());
-                
+                assert!(
+                    parquet_path.exists(),
+                    "Error case parquet file should exist: {}",
+                    parquet_path.display()
+                );
+
                 // Run the error case test (should handle gracefully)
                 match harness.run_single_test(error_case) {
                     Ok(()) => println!("  Error case handled gracefully"),
                     Err(e) => println!("  Error case processing issue: {}", e),
                 }
             }
-            
+
             assert!(!error_cases.is_empty(), "Should have found error cases");
             println!("\nError case handling test completed successfully!");
         }
@@ -882,49 +1088,70 @@ fn test_variant_integration_error_case_handling() {
     }
 }
 
-// Working test that demonstrates the harness functionality  
+// Working test that demonstrates the harness functionality
 #[test]
 fn test_variant_integration_with_shredded_variant_data() {
     // This test uses the comprehensive shredded_variant test data from PR #90
     println!("Running basic integration test with shredded variant test data");
-    
+
     match VariantIntegrationHarness::new() {
         Ok(harness) => {
-            println!("Successfully loaded test harness with {} test cases", harness.test_cases.len());
-            
+            println!(
+                "Successfully loaded test harness with {} test cases",
+                harness.test_cases.len()
+            );
+
             // Test a few basic cases to verify the framework works
             let test_cases_to_check = [1, 2, 4, 5, 6];
             let mut found_cases = 0;
-            
+
             for case_number in test_cases_to_check {
-                if let Some(test_case) = harness.test_cases.iter().find(|c| c.case_number == case_number) {
-                    println!("Found case-{:03}: {} -> {}", 
-                        case_number, test_case.parquet_file, 
-                        test_case.variant_file.as_deref().unwrap_or("no variant file"));
+                if let Some(test_case) = harness
+                    .test_cases
+                    .iter()
+                    .find(|c| c.case_number == case_number)
+                {
+                    println!(
+                        "Found case-{:03}: {} -> {}",
+                        case_number,
+                        test_case.parquet_file,
+                        test_case
+                            .variant_file
+                            .as_deref()
+                            .unwrap_or("no variant file")
+                    );
                     found_cases += 1;
-                    
+
                     // Verify files exist
                     let parquet_path = harness.test_data_dir.join(&test_case.parquet_file);
-                    assert!(parquet_path.exists(), "Parquet file should exist: {}", parquet_path.display());
-                    
+                    assert!(
+                        parquet_path.exists(),
+                        "Parquet file should exist: {}",
+                        parquet_path.display()
+                    );
+
                     if let Some(variant_file) = &test_case.variant_file {
                         let variant_path = harness.test_data_dir.join(variant_file);
-                        assert!(variant_path.exists(), "Variant file should exist: {}", variant_path.display());
-                        
+                        assert!(
+                            variant_path.exists(),
+                            "Variant file should exist: {}",
+                            variant_path.display()
+                        );
+
                         if let Ok(variant_data) = fs::read(&variant_path) {
                             println!("  Variant data: {} bytes", variant_data.len());
                         }
                     }
                 }
             }
-            
+
             assert!(found_cases >= 3, "Should find at least 3 test cases");
             println!("Successfully validated {} test cases", found_cases);
         }
         Err(e) => {
             println!("Could not find shredded_variant test data: {}", e);
             println!("This is expected if parquet-testing submodule is not at PR #90 branch");
-            
+
             // Don't fail the test if data isn't available, just report it
             // This allows the test to work in different environments
         }
@@ -936,16 +1163,16 @@ fn test_variant_integration_with_shredded_variant_data() {
 fn test_variant_integration_with_existing_data() {
     // This test uses the existing variant test data in parquet-testing/variant/
     // as a fallback until the shredded_variant data from PR #90 is available
-    
+
     println!("Running fallback test with existing variant test data");
-    
+
     // Try to find existing variant test data
     let variant_dir = find_existing_variant_test_data();
-    
+
     match variant_dir {
         Ok(dir) => {
             println!("Found existing variant test data at: {}", dir.display());
-            
+
             // List available test files
             if let Ok(entries) = fs::read_dir(&dir) {
                 let mut metadata_files = Vec::new();
@@ -956,10 +1183,13 @@ fn test_variant_integration_with_existing_data() {
                         }
                     }
                 }
-                
+
                 println!("Found {} metadata files for testing", metadata_files.len());
-                assert!(!metadata_files.is_empty(), "Should find at least some metadata files");
-                
+                assert!(
+                    !metadata_files.is_empty(),
+                    "Should find at least some metadata files"
+                );
+
                 // Test loading a few basic cases
                 for metadata_file in metadata_files.iter().take(3) {
                     let case_name = metadata_file.strip_suffix(".metadata").unwrap();
@@ -985,36 +1215,39 @@ fn find_existing_variant_test_data() -> Result<PathBuf, Box<dyn Error>> {
             return Ok(variant_dir);
         }
     }
-    
+
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let candidates = vec![
         PathBuf::from(&manifest_dir).join("../parquet-testing/variant"),
         PathBuf::from(&manifest_dir).join("parquet-testing/variant"),
     ];
-    
+
     for candidate in candidates {
         if candidate.is_dir() {
             return Ok(candidate);
         }
     }
-    
+
     Err("Could not find existing variant test data directory".into())
 }
 
 /// Test loading a single variant case from existing test data
-fn test_load_existing_variant_case(variant_dir: &PathBuf, case_name: &str) -> Result<(), Box<dyn Error>> {
+fn test_load_existing_variant_case(
+    variant_dir: &Path,
+    case_name: &str,
+) -> Result<(), Box<dyn Error>> {
     let metadata_path = variant_dir.join(format!("{}.metadata", case_name));
     let value_path = variant_dir.join(format!("{}.value", case_name));
-    
+
     if !metadata_path.exists() || !value_path.exists() {
         return Err(format!("Missing files for case: {}", case_name).into());
     }
-    
+
     let _metadata = fs::read(&metadata_path)?;
     let _value = fs::read(&value_path)?;
-    
+
     // TODO: Parse variant when parquet_variant crate is available
     // let _variant = Variant::try_new(&metadata, &value)?;
-    
+
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

- part of  #8084 .

# Rationale for this change
This PR implements comprehensive integration tests for Parquet files with Variant columns, using the real test data from parquet-testing PR #[90](https://github.com/apache/parquet-testing/pull/90).

# Are these changes tested?
Yes

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

No
Thanks to @mprammer
