### PR TITLE
Update labeler configuration to include `avro` and `parquet-variant` …

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -37,6 +37,11 @@ arrow:
       - 'arrow-string/**/*'
       - 'arrow/**/*'
 
+arrow-avro:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'arrow-avro/**/*'
+
 arrow-flight:
   - changed-files:
     - any-glob-to-any-file:
@@ -46,7 +51,13 @@ parquet:
   - changed-files:
     - any-glob-to-any-file:
       - 'parquet/**/*'
-      - 'parquet-variant/**/*'
+
+parquet-variant:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'parquet-variant/**/*'
+          - 'parquet-variant-compute/**/*'
+          - 'parquet-variant-json/**/*'
 
 parquet-derive:
   - changed-files:


### PR DESCRIPTION
As we are adding non trivial code to these crates, it would be nice to get the PRs labeled more nicely

Thus let's mark the PRs automatically with tags
- https://github.com/apache/arrow-rs/issues/labels?q=state%3Aopen%20label%3Aparquet-variant
- https://github.com/apache/arrow-rs/issues/labels?q=state%3Aopen%20label%3Aavro