### PR TITLE
[thrift-remodel] Complete decoding of `FileMetaData` and `RowGroupMetaData`

### DIFF
--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -199,38 +199,38 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let meta_data = get_footer_bytes(data.clone());
-    c.bench_function("parquet metadata", |b| {
+    c.bench_function("decode parquet metadata", |b| {
         b.iter(|| {
             ParquetMetaDataReader::decode_metadata(&meta_data).unwrap();
         })
     });
 
-    c.bench_function("decode file metadata", |b| {
+    c.bench_function("decode thrift file metadata", |b| {
         b.iter(|| {
             parquet::thrift::bench_file_metadata(&meta_data);
         })
     });
 
-    c.bench_function("decode new", |b| {
+    c.bench_function("decode parquet metadata new", |b| {
         b.iter(|| {
             ParquetMetaDataReader::decode_file_metadata(&meta_data).unwrap();
         })
     });
 
     let buf: Bytes = black_box(encoded_meta()).into();
-    c.bench_function("parquet metadata (wide)", |b| {
+    c.bench_function("decode parquet metadata (wide)", |b| {
         b.iter(|| {
             ParquetMetaDataReader::decode_metadata(&buf).unwrap();
         })
     });
 
-    c.bench_function("decode file metadata (wide)", |b| {
+    c.bench_function("decode thrift file metadata (wide)", |b| {
         b.iter(|| {
             parquet::thrift::bench_file_metadata(&buf);
         })
     });
 
-    c.bench_function("decode new (wide)", |b| {
+    c.bench_function("decode parquet metadata new (wide)", |b| {
         b.iter(|| {
             ParquetMetaDataReader::decode_file_metadata(&buf).unwrap();
         })

--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use parquet::file::metadata::ParquetMetaDataReader;
 use rand::Rng;
 use thrift::protocol::TCompactOutputProtocol;
 
@@ -198,16 +199,40 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let meta_data = get_footer_bytes(data.clone());
+    c.bench_function("parquet metadata", |b| {
+        b.iter(|| {
+            ParquetMetaDataReader::decode_metadata(&meta_data).unwrap();
+        })
+    });
+
     c.bench_function("decode file metadata", |b| {
         b.iter(|| {
             parquet::thrift::bench_file_metadata(&meta_data);
         })
     });
 
-    let buf = black_box(encoded_meta()).into();
+    c.bench_function("decode new", |b| {
+        b.iter(|| {
+            ParquetMetaDataReader::decode_file_metadata(&meta_data).unwrap();
+        })
+    });
+
+    let buf: Bytes = black_box(encoded_meta()).into();
+    c.bench_function("parquet metadata (wide)", |b| {
+        b.iter(|| {
+            ParquetMetaDataReader::decode_metadata(&buf).unwrap();
+        })
+    });
+
     c.bench_function("decode file metadata (wide)", |b| {
         b.iter(|| {
             parquet::thrift::bench_file_metadata(&buf);
+        })
+    });
+
+    c.bench_function("decode new (wide)", |b| {
+        b.iter(|| {
+            ParquetMetaDataReader::decode_file_metadata(&buf).unwrap();
         })
     });
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -2278,9 +2278,9 @@ mod tests {
             .build();
 
         #[cfg(not(feature = "encryption"))]
-        let base_expected_size = 2312;
+        let base_expected_size = 2280;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2648;
+        let base_expected_size = 2616;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2308,9 +2308,9 @@ mod tests {
             .build();
 
         #[cfg(not(feature = "encryption"))]
-        let bigger_expected_size = 2816;
+        let bigger_expected_size = 2784;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3152;
+        let bigger_expected_size = 3120;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -22,8 +22,23 @@ use crate::encryption::{
     decrypt::{FileDecryptionProperties, FileDecryptor},
     modules::create_footer_aad,
 };
-use crate::{basic::ColumnOrder, file::metadata::KeyValue};
+use crate::{
+    basic::{ColumnOrder, Compression, Encoding, Type},
+    data_type::{ByteArray, FixedLenByteArray, Int96},
+    file::{
+        metadata::{KeyValue, LevelHistogram, SortingColumn},
+        page_encoding_stats::PageEncodingStats,
+        statistics::ValueStatistics,
+    },
+    parquet_thrift::{FieldType, ThriftCompactInputProtocol},
+    schema::types::{schema_from_thrift_input, ColumnDescriptor},
+    thrift_read_field, thrift_struct,
+    util::bit_util::FromBytes,
+};
 use bytes::Bytes;
+
+#[cfg(feature = "encryption")]
+use crate::file::column_crypto_metadata::ColumnCryptoMetaData;
 
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData};
@@ -42,6 +57,7 @@ use crate::arrow::async_reader::{MetadataFetch, MetadataSuffixFetch};
 #[cfg(feature = "encryption")]
 use crate::encryption::decrypt::CryptoContext;
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
+use crate::thrift_read_list;
 
 /// Reads the [`ParquetMetaData`] from a byte stream.
 ///
@@ -1040,6 +1056,107 @@ impl ParquetMetaDataReader {
         Ok(ParquetMetaData::new(file_metadata, row_groups))
     }
 
+    /// create meta data from thrift encoded bytes
+    pub fn decode_file_metadata(buf: &[u8]) -> Result<ParquetMetaData> {
+        let mut prot = ThriftCompactInputProtocol::new(buf);
+
+        // components of the FileMetaData
+        let mut version: Option<i32> = None;
+        let mut schema_descr: Option<Arc<SchemaDescriptor>> = None;
+        let mut num_rows: Option<i64> = None;
+        let mut row_groups: Option<Vec<RowGroup>> = None;
+        let mut key_value_metadata: Option<Vec<KeyValue>> = None;
+        let mut created_by: Option<String> = None;
+        let mut column_orders: Option<Vec<ColumnOrder>> = None;
+
+        // begin decoding to intermediates
+        prot.read_struct_begin()?;
+        loop {
+            let field_ident = prot.read_field_begin()?;
+            if field_ident.field_type == FieldType::Stop {
+                break;
+            }
+            let prot = &mut prot;
+
+            match field_ident.id {
+                1 => {
+                    thrift_read_field!(version, prot, i32);
+                }
+                2 => {
+                    let val = schema_from_thrift_input(prot)?;
+                    schema_descr = Some(Arc::new(SchemaDescriptor::new(val)));
+                }
+                3 => {
+                    thrift_read_field!(num_rows, prot, i64);
+                }
+                4 => {
+                    // need to get temp struct here and then translate
+                    let val = thrift_read_list!(prot, RowGroup);
+                    row_groups = Some(val);
+                }
+                5 => {
+                    let val = thrift_read_list!(prot, KeyValue);
+                    key_value_metadata = Some(val);
+                }
+                6 => {
+                    thrift_read_field!(created_by, prot, string);
+                }
+                7 => {
+                    let val = thrift_read_list!(prot, ColumnOrder);
+                    column_orders = Some(val);
+                }
+                _ => {
+                    prot.skip(field_ident.field_type)?;
+                }
+            }
+        }
+
+        let version = version.expect("Required field version is missing");
+        let num_rows = num_rows.expect("Required field num_rows is missing");
+        let row_groups = row_groups.expect("Required field row_groups is missing");
+        let schema_descr = schema_descr.expect("Required field schema is missing");
+
+        // need schema_descr to get final RowGroupMetaData
+        let row_groups = convert_row_groups(row_groups, schema_descr.clone())?;
+
+        // need to map read column orders to actual values based on the schema
+        if column_orders
+            .as_ref()
+            .is_some_and(|cos| cos.len() != schema_descr.num_columns())
+        {
+            return Err(general_err!("Column order length mismatch"));
+        }
+
+        let column_orders = column_orders.map(|cos| {
+            let mut res = Vec::with_capacity(cos.len());
+            for (i, column) in schema_descr.columns().iter().enumerate() {
+                match cos[i] {
+                    ColumnOrder::TYPE_DEFINED_ORDER(_) => {
+                        let sort_order = ColumnOrder::get_sort_order(
+                            column.logical_type(),
+                            column.converted_type(),
+                            column.physical_type(),
+                        );
+                        res.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
+                    }
+                    _ => res.push(cos[i]),
+                }
+            }
+            res
+        });
+
+        let fmd = FileMetaData::new(
+            version,
+            num_rows,
+            created_by,
+            key_value_metadata,
+            schema_descr,
+            column_orders,
+        );
+
+        Ok(ParquetMetaData::new(fmd, row_groups))
+    }
+
     /// Parses column orders from Thrift definition.
     /// If no column orders are defined, returns `None`.
     fn parse_column_orders(
@@ -1100,6 +1217,383 @@ fn get_file_decryptor(
             "The AES_GCM_CTR_V1 encryption algorithm is not yet supported"
         )),
     }
+}
+
+// temp structs used to construct RowGroupMetaData
+thrift_struct!(
+struct RowGroup<'a> {
+  1: required list<'a><ColumnChunk> columns
+  2: required i64 total_byte_size
+  3: required i64 num_rows
+  4: optional list<SortingColumn> sorting_columns
+  5: optional i64 file_offset
+  // we don't expose total_compressed_size so skip
+  //6: optional i64 total_compressed_size
+  7: optional i16 ordinal
+}
+);
+
+#[cfg(feature = "encryption")]
+thrift_struct!(
+struct ColumnChunk<'a> {
+  1: optional string file_path
+  2: required i64 file_offset = 0
+  3: optional ColumnMetaData<'a> meta_data
+  4: optional i64 offset_index_offset
+  5: optional i32 offset_index_length
+  6: optional i64 column_index_offset
+  7: optional i32 column_index_length
+  8: optional ColumnCryptoMetaData crypto_metadata
+  9: optional binary<'a> encrypted_column_metadata
+}
+);
+#[cfg(not(feature = "encryption"))]
+thrift_struct!(
+struct ColumnChunk<'a> {
+  1: optional string file_path
+  2: required i64 file_offset = 0
+  3: optional ColumnMetaData<'a> meta_data
+  4: optional i64 offset_index_offset
+  5: optional i32 offset_index_length
+  6: optional i64 column_index_offset
+  7: optional i32 column_index_length
+}
+);
+
+type CompressionCodec = Compression;
+thrift_struct!(
+struct ColumnMetaData<'a> {
+  1: required Type type_
+  2: required list<Encoding> encodings
+  // we don't expose path_in_schema so skip
+  //3: required list<string> path_in_schema
+  4: required CompressionCodec codec
+  5: required i64 num_values
+  6: required i64 total_uncompressed_size
+  7: required i64 total_compressed_size
+  // we don't expose key_value_metadata so skip
+  //8: optional list<KeyValue> key_value_metadata
+  9: required i64 data_page_offset
+  10: optional i64 index_page_offset
+  11: optional i64 dictionary_page_offset
+  12: optional Statistics<'a> statistics
+  13: optional list<PageEncodingStats> encoding_stats;
+  14: optional i64 bloom_filter_offset;
+  15: optional i32 bloom_filter_length;
+  16: optional SizeStatistics size_statistics;
+  17: optional GeospatialStatistics geospatial_statistics;
+}
+);
+
+thrift_struct!(
+struct BoundingBox {
+  1: required double xmin;
+  2: required double xmax;
+  3: required double ymin;
+  4: required double ymax;
+  5: optional double zmin;
+  6: optional double zmax;
+  7: optional double mmin;
+  8: optional double mmax;
+}
+);
+
+thrift_struct!(
+struct GeospatialStatistics {
+  /** A bounding box of geospatial instances */
+  1: optional BoundingBox bbox;
+  /** Geospatial type codes of all instances, or an empty list if not known */
+  2: optional list<i32> geospatial_types;
+}
+);
+
+thrift_struct!(
+struct SizeStatistics {
+   1: optional i64 unencoded_byte_array_data_bytes;
+   2: optional list<i64> repetition_level_histogram;
+   3: optional list<i64> definition_level_histogram;
+}
+);
+
+thrift_struct!(
+struct Statistics<'a> {
+   1: optional binary<'a> max;
+   2: optional binary<'a> min;
+   3: optional i64 null_count;
+   4: optional i64 distinct_count;
+   5: optional binary<'a> max_value;
+   6: optional binary<'a> min_value;
+   7: optional bool is_max_value_exact;
+   8: optional bool is_min_value_exact;
+}
+);
+
+fn convert_row_groups(
+    mut row_groups: Vec<RowGroup>,
+    schema_descr: Arc<SchemaDescriptor>,
+) -> Result<Vec<RowGroupMetaData>> {
+    let mut res: Vec<RowGroupMetaData> = Vec::with_capacity(row_groups.len());
+    for rg in row_groups.drain(0..) {
+        res.push(convert_row_group(rg, schema_descr.clone())?);
+    }
+
+    Ok(res)
+}
+
+fn convert_row_group(
+    row_group: RowGroup,
+    schema_descr: Arc<SchemaDescriptor>,
+) -> Result<RowGroupMetaData> {
+    let num_rows = row_group.num_rows;
+    let sorting_columns = row_group.sorting_columns;
+    let total_byte_size = row_group.total_byte_size;
+    let file_offset = row_group.file_offset;
+    let ordinal = row_group.ordinal;
+
+    let columns = convert_columns(row_group.columns, schema_descr.clone())?;
+
+    Ok(RowGroupMetaData {
+        columns,
+        num_rows,
+        sorting_columns,
+        total_byte_size,
+        schema_descr,
+        file_offset,
+        ordinal,
+    })
+}
+
+fn convert_columns(
+    mut columns: Vec<ColumnChunk>,
+    schema_descr: Arc<SchemaDescriptor>,
+) -> Result<Vec<ColumnChunkMetaData>> {
+    let mut res: Vec<ColumnChunkMetaData> = Vec::with_capacity(columns.len());
+    for (c, d) in columns.drain(0..).zip(schema_descr.columns()) {
+        res.push(convert_column(c, d.clone())?);
+    }
+
+    Ok(res)
+}
+
+fn convert_column(
+    column: ColumnChunk,
+    column_descr: Arc<ColumnDescriptor>,
+) -> Result<ColumnChunkMetaData> {
+    if column.meta_data.is_none() {
+        return Err(general_err!("Expected to have column metadata"));
+    }
+    let col_metadata = column.meta_data.unwrap();
+    let column_type = col_metadata.type_;
+    let encodings = col_metadata.encodings;
+    let compression = col_metadata.codec;
+    let file_path = column.file_path.map(|v| v.to_owned());
+    let file_offset = column.file_offset;
+    let num_values = col_metadata.num_values;
+    let total_compressed_size = col_metadata.total_compressed_size;
+    let total_uncompressed_size = col_metadata.total_uncompressed_size;
+    let data_page_offset = col_metadata.data_page_offset;
+    let index_page_offset = col_metadata.index_page_offset;
+    let dictionary_page_offset = col_metadata.dictionary_page_offset;
+    let statistics = convert_stats(column_type, col_metadata.statistics)?;
+    let encoding_stats = col_metadata.encoding_stats;
+    let bloom_filter_offset = col_metadata.bloom_filter_offset;
+    let bloom_filter_length = col_metadata.bloom_filter_length;
+    let offset_index_offset = column.offset_index_offset;
+    let offset_index_length = column.offset_index_length;
+    let column_index_offset = column.column_index_offset;
+    let column_index_length = column.column_index_length;
+    let (unencoded_byte_array_data_bytes, repetition_level_histogram, definition_level_histogram) =
+        if let Some(size_stats) = col_metadata.size_statistics {
+            (
+                size_stats.unencoded_byte_array_data_bytes,
+                size_stats.repetition_level_histogram,
+                size_stats.definition_level_histogram,
+            )
+        } else {
+            (None, None, None)
+        };
+
+    let repetition_level_histogram = repetition_level_histogram.map(LevelHistogram::from);
+    let definition_level_histogram = definition_level_histogram.map(LevelHistogram::from);
+
+    // FIXME: need column crypto
+
+    let result = ColumnChunkMetaData {
+        column_descr,
+        encodings,
+        file_path,
+        file_offset,
+        num_values,
+        compression,
+        total_compressed_size,
+        total_uncompressed_size,
+        data_page_offset,
+        index_page_offset,
+        dictionary_page_offset,
+        statistics,
+        encoding_stats,
+        bloom_filter_offset,
+        bloom_filter_length,
+        offset_index_offset,
+        offset_index_length,
+        column_index_offset,
+        column_index_length,
+        unencoded_byte_array_data_bytes,
+        repetition_level_histogram,
+        definition_level_histogram,
+        #[cfg(feature = "encryption")]
+        column_crypto_metadata: column.crypto_metadata,
+    };
+    Ok(result)
+}
+
+fn convert_stats(
+    physical_type: Type,
+    thrift_stats: Option<Statistics>,
+) -> Result<Option<crate::file::statistics::Statistics>> {
+    use crate::file::statistics::Statistics as FStatistics;
+    Ok(match thrift_stats {
+        Some(stats) => {
+            // Number of nulls recorded, when it is not available, we just mark it as 0.
+            // TODO this should be `None` if there is no information about NULLS.
+            // see https://github.com/apache/arrow-rs/pull/6216/files
+            let null_count = stats.null_count.unwrap_or(0);
+
+            if null_count < 0 {
+                return Err(ParquetError::General(format!(
+                    "Statistics null count is negative {null_count}",
+                )));
+            }
+
+            // Generic null count.
+            let null_count = Some(null_count as u64);
+            // Generic distinct count (count of distinct values occurring)
+            let distinct_count = stats.distinct_count.map(|value| value as u64);
+            // Whether or not statistics use deprecated min/max fields.
+            let old_format = stats.min_value.is_none() && stats.max_value.is_none();
+            // Generic min value as bytes.
+            let min = if old_format {
+                stats.min
+            } else {
+                stats.min_value
+            };
+            // Generic max value as bytes.
+            let max = if old_format {
+                stats.max
+            } else {
+                stats.max_value
+            };
+
+            fn check_len(min: &Option<&[u8]>, max: &Option<&[u8]>, len: usize) -> Result<()> {
+                if let Some(min) = min {
+                    if min.len() < len {
+                        return Err(ParquetError::General(
+                            "Insufficient bytes to parse min statistic".to_string(),
+                        ));
+                    }
+                }
+                if let Some(max) = max {
+                    if max.len() < len {
+                        return Err(ParquetError::General(
+                            "Insufficient bytes to parse max statistic".to_string(),
+                        ));
+                    }
+                }
+                Ok(())
+            }
+
+            match physical_type {
+                Type::BOOLEAN => check_len(&min, &max, 1),
+                Type::INT32 | Type::FLOAT => check_len(&min, &max, 4),
+                Type::INT64 | Type::DOUBLE => check_len(&min, &max, 8),
+                Type::INT96 => check_len(&min, &max, 12),
+                _ => Ok(()),
+            }?;
+
+            // Values are encoded using PLAIN encoding definition, except that
+            // variable-length byte arrays do not include a length prefix.
+            //
+            // Instead of using actual decoder, we manually convert values.
+            let res = match physical_type {
+                Type::BOOLEAN => FStatistics::boolean(
+                    min.map(|data| data[0] != 0),
+                    max.map(|data| data[0] != 0),
+                    distinct_count,
+                    null_count,
+                    old_format,
+                ),
+                Type::INT32 => FStatistics::int32(
+                    min.map(|data| i32::from_le_bytes(data[..4].try_into().unwrap())),
+                    max.map(|data| i32::from_le_bytes(data[..4].try_into().unwrap())),
+                    distinct_count,
+                    null_count,
+                    old_format,
+                ),
+                Type::INT64 => FStatistics::int64(
+                    min.map(|data| i64::from_le_bytes(data[..8].try_into().unwrap())),
+                    max.map(|data| i64::from_le_bytes(data[..8].try_into().unwrap())),
+                    distinct_count,
+                    null_count,
+                    old_format,
+                ),
+                Type::INT96 => {
+                    // INT96 statistics may not be correct, because comparison is signed
+                    let min = if let Some(data) = min {
+                        assert_eq!(data.len(), 12);
+                        Some(Int96::try_from_le_slice(data)?)
+                    } else {
+                        None
+                    };
+                    let max = if let Some(data) = max {
+                        assert_eq!(data.len(), 12);
+                        Some(Int96::try_from_le_slice(data)?)
+                    } else {
+                        None
+                    };
+                    FStatistics::int96(min, max, distinct_count, null_count, old_format)
+                }
+                Type::FLOAT => FStatistics::float(
+                    min.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
+                    max.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
+                    distinct_count,
+                    null_count,
+                    old_format,
+                ),
+                Type::DOUBLE => FStatistics::double(
+                    min.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
+                    max.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
+                    distinct_count,
+                    null_count,
+                    old_format,
+                ),
+                Type::BYTE_ARRAY => FStatistics::ByteArray(
+                    ValueStatistics::new(
+                        min.map(ByteArray::from),
+                        max.map(ByteArray::from),
+                        distinct_count,
+                        null_count,
+                        old_format,
+                    )
+                    .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
+                    .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),
+                ),
+                Type::FIXED_LEN_BYTE_ARRAY => FStatistics::FixedLenByteArray(
+                    ValueStatistics::new(
+                        min.map(ByteArray::from).map(FixedLenByteArray::from),
+                        max.map(ByteArray::from).map(FixedLenByteArray::from),
+                        distinct_count,
+                        null_count,
+                        old_format,
+                    )
+                    .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
+                    .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),
+                ),
+            };
+
+            Some(res)
+        }
+        None => None,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?
**Note: this targets a feature branch, not main**

- Part of #5854.

# Rationale for this change

# What changes are included in this PR?
This PR completes reading of the `FileMetaData` and `RowGroupMetaData` pieces of the `ParquetMetaData`. Column indexes and encryption will be follow-on work.

This replaces the macro for generating structs with a more general one that can take visibility and lifetime specifiers. Also (temporarily) adds a new function `ParquetMetaDataReader::decode_file_metadata` which should be a drop-in replacement for `ParquetMetaDataReader::decode_metadata`.

Still todo:

1. Add some tests that verify this produces the same output as `ParquetMetaDataReader::decode_metadata`
2. Read column indexes with new decoder
3. Read page headers with new decoder
4. Integrate with @alamb's push decoder work #8080

# Are these changes tested?

Not yet

# Are there any user-facing changes?

Yes
