### PR TITLE
[Variant] Introduce parquet-variant-integration-testing crate

### DIFF
--- a/.github/workflows/parquet-variant.yml
+++ b/.github/workflows/parquet-variant.yml
@@ -33,6 +33,7 @@ on:
       - parquet-variant/**
       - parquet-variant-json/**
       - parquet-variant-compute/**
+      - parquet-variant-integration-testing/**
       - .github/**
 
 jobs:
@@ -54,6 +55,8 @@ jobs:
         run: cargo test -p parquet-variant-json
       - name: Test parquet-variant-compute
         run: cargo test -p parquet-variant-compute
+      - name: Test parquet-variant-compute
+        run: cargo test -p parquet-variant-integration-testing
 
   # test compilation
   linux-features:
@@ -91,3 +94,5 @@ jobs:
         run: cargo clippy -p parquet-variant-json --all-targets --all-features -- -D warnings
       - name: Run clippy (parquet-variant-compute)
         run: cargo clippy -p parquet-variant-compute --all-targets --all-features -- -D warnings
+      - name: Run clippy (parquet-variant-integration-testing)
+        run: cargo clippy -p parquet-variant-integration-testing --all-targets --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "parquet-variant",
     "parquet-variant-compute",
     "parquet-variant-json",
+    "parquet-variant-integration-testing",
     "parquet_derive",
     "parquet_derive_test",
 ]

--- a/parquet-variant-integration-testing/Cargo.toml
+++ b/parquet-variant-integration-testing/Cargo.toml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+## Tests for combining
+
+[package]
+name = "parquet-variant-integration-testing"
+version = "0.1.0"
+license = { workspace = true }
+description = "Apache Parquet Variant Integration Testing"
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+keywords = ["arrow", "parquet", "variant"]
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+
+[dependencies]
+parquet = { workspace = true, features=["arrow", "async", "experimental"] }
+arrow = { workspace = true }
+
+

--- a/parquet-variant-integration-testing/tests/variant_integration.rs
+++ b/parquet-variant-integration-testing/tests/variant_integration.rs
@@ -24,10 +24,7 @@
 //! Based on the parquet-testing PR: https://github.com/apache/parquet-testing/pull/90/files
 //! Inspired by the arrow-go implementation: https://github.com/apache/arrow-go/pull/455/files
 
-// These tests require the arrow feature
-#![cfg(feature = "arrow")]
-
-use arrow_array::{Array, StructArray};
+use arrow::array::{Array, StructArray};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::{
     env,
@@ -1218,8 +1215,8 @@ fn find_existing_variant_test_data() -> Result<PathBuf, Box<dyn Error>> {
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let candidates = vec![
-        PathBuf::from(&manifest_dir).join("../parquet-testing/variant"),
-        PathBuf::from(&manifest_dir).join("parquet-testing/variant"),
+        PathBuf::from(&manifest_dir).join("../../../parquet-testing/variant"),
+        PathBuf::from(&manifest_dir).join("../../parquet-testing/variant"),
     ];
 
     for candidate in candidates {


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Part of https://github.com/apache/arrow-rs/issues/8084
- Follow on to https://github.com/apache/arrow-rs/pull/8104

# Rationale for this change

We are trying to avoid adding new dependencies into the parquet crate while adding Variant support

However, eventually to use Variants with Parquet, a user will need to use code from both the `parquet` crate and the `parquet-variant` and `parquet-variant-compute` crates. To so I propose adding a new parquet-variant-integration-testing crate`

# What changes are included in this PR?

1. Add a new `parquet-variant-integration-testing` crate
2. Move the test from https://github.com/apache/arrow-rs/pull/8104 by @carpecodeum to this new crate
3. Add new crate to various build process

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
