### PR TITLE
feat: support push batch direct to completed and add biggest coalesce batch support

### DIFF
--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -1470,12 +1470,12 @@ mod tests {
 
         // Should be coalesced (not bypass) since it's equal, not greater
         let mut output_count = 0;
-        while let Some(_) = coalescer.next_completed_batch() {
+        while coalescer.next_completed_batch().is_some() {
             output_count += 1;
         }
 
         coalescer.finish_buffered_batch().unwrap();
-        while let Some(_) = coalescer.next_completed_batch() {
+        while coalescer.next_completed_batch().is_some() {
             output_count += 1;
         }
 

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -290,7 +290,6 @@ impl BatchCoalescer {
         Ok(())
     }
 
-
     /// Push a batch directly to the completed batches
     pub fn flush_buffer_and_push_batch_to_completed(
         &mut self,

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -186,7 +186,7 @@ impl BatchCoalescer {
     }
 
     /// Get the current biggest coalesce batch size limit
-    pub fn get_biggest_coalesce_batch_size(&self) -> Option<usize> {
+    pub fn biggest_coalesce_batch_size(&self) -> Option<usize> {
         self.biggest_coalesce_batch_size
     }
 

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -290,6 +290,21 @@ impl BatchCoalescer {
         Ok(())
     }
 
+
+    /// Push a batch directly to the completed batches
+    pub fn flush_buffer_and_push_batch_to_completed(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Result<(), ArrowError> {
+        // This is a convenience method to push a batch directly to the completed
+        // batches without buffering it.
+        if batch.num_rows() > 0 {
+            self.finish_buffered_batch()?;
+            self.completed.push_back(batch);
+        }
+        Ok(())
+    }
+
     /// Concatenates any buffered batches into a single `RecordBatch` and
     /// clears any output buffers
     ///

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -1589,46 +1589,4 @@ mod tests {
         let output = coalescer.next_completed_batch().unwrap();
         assert_eq!(output.num_rows(), 1);
     }
-
-    #[test]
-    fn test_biggest_coalesce_batch_size_getter_setter() {
-        // Test that we can get and set the biggest_coalesce_batch_size
-        let mut coalescer = BatchCoalescer::new(
-            Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, false)])),
-            100,
-        );
-
-        // Initially None
-        assert_eq!(coalescer.biggest_coalesce_batch_size, None);
-
-        // Set a value
-        coalescer.biggest_coalesce_batch_size = Some(500);
-        assert_eq!(coalescer.biggest_coalesce_batch_size, Some(500));
-
-        // Set back to None
-        coalescer.biggest_coalesce_batch_size = None;
-        assert_eq!(coalescer.biggest_coalesce_batch_size, None);
-    }
-
-    #[test]
-    fn test_biggest_coalesce_batch_size_constructor_method() {
-        // Test a potential constructor method for setting the limit
-        // This would need to be added to the BatchCoalescer implementation
-
-        // For now, test the manual setting approach
-        let mut coalescer = BatchCoalescer::new(
-            Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, false)])),
-            100,
-        );
-
-        // Method to set the limit (this could be added to the impl)
-        coalescer.biggest_coalesce_batch_size = Some(1000);
-
-        // Verify it works as expected
-        let large_batch = create_test_batch(1500);
-        coalescer.push_batch(large_batch).unwrap();
-
-        let output = coalescer.next_completed_batch().unwrap();
-        assert_eq!(output.num_rows(), 1500);
-    }
 }

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -329,7 +329,7 @@ impl BatchCoalescer {
     }
 
     /// Push a batch directly to the completed batches
-    pub fn flush_buffer_and_push_batch_to_completed(
+    fn flush_buffer_and_push_batch_to_completed(
         &mut self,
         batch: RecordBatch,
     ) -> Result<(), ArrowError> {

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -142,10 +142,7 @@ pub struct BatchCoalescer {
     buffered_rows: usize,
     /// Completed batches
     completed: VecDeque<RecordBatch>,
-    /// Biggest coalesce batch size, this is used by user to determine the
-    /// maximum size of the coalesce batch, we can skip the coalesce if the
-    /// input batch is smaller than this size.
-    /// Default is `None`, meaning no limit.
+    /// Biggest coalesce batch size. See [`Self::with_biggest_coalesce_batch_size`]
     biggest_coalesce_batch_size: Option<usize>,
 }
 
@@ -175,22 +172,33 @@ impl BatchCoalescer {
         }
     }
 
-    /// Set the biggest coalesce batch size limit
+    /// Set the coalesce batch size limit (default `None`)
     ///
-    /// If set to Some(limit), batches larger than this limit will bypass
-    /// coalescing and be passed through directly. If None, all batches
-    /// will be coalesced according to the target_batch_size.
+    /// This limit determine when batches should bypass coalescing. Intuitively,
+    /// batches that are already large are costly to coalesce and are efficient
+    /// enough to process directly without coalescing.
+    ///
+    /// If `Some(limit)`, batches larger than this limit will bypass coalescing
+    /// when there is no buffered data, or when the previously buffered data
+    /// already exceeds this limit.
+    ///
+    /// If `None`, all batches will be coalesced according to the
+    /// target_batch_size.
     pub fn with_biggest_coalesce_batch_size(mut self, limit: Option<usize>) -> Self {
         self.biggest_coalesce_batch_size = limit;
         self
     }
 
     /// Get the current biggest coalesce batch size limit
+    ///
+    /// See [`Self::with_biggest_coalesce_batch_size`] for details
     pub fn biggest_coalesce_batch_size(&self) -> Option<usize> {
         self.biggest_coalesce_batch_size
     }
 
     /// Set the biggest coalesce batch size limit
+    ///
+    /// See [`Self::with_biggest_coalesce_batch_size`] for details
     pub fn set_biggest_coalesce_batch_size(&mut self, limit: Option<usize>) {
         self.biggest_coalesce_batch_size = limit;
     }

--- a/arrow/benches/coalesce_kernels.rs
+++ b/arrow/benches/coalesce_kernels.rs
@@ -76,7 +76,7 @@ fn add_all_filter_benchmarks(c: &mut Criterion) {
         Field::new("float_val2", DataType::Float64, true),
         // TODO model other dictionary types here (FixedSizeBinary for example)
     ]));
-    
+
     // Null density: 0, 10%
     for null_density in [0.0, 0.1] {
         // Selectivity: 0.1%, 1%, 10%, 80%

--- a/arrow/benches/coalesce_kernels.rs
+++ b/arrow/benches/coalesce_kernels.rs
@@ -76,13 +76,7 @@ fn add_all_filter_benchmarks(c: &mut Criterion) {
         Field::new("float_val2", DataType::Float64, true),
         // TODO model other dictionary types here (FixedSizeBinary for example)
     ]));
-
-    // Test both optimization modes: with and without biggest_coalesce_batch_size
-    let optimization_modes = [
-        ("default", None),                   // No optimization
-        ("optimized", Some(batch_size / 2)), // With optimization
-    ];
-
+    
     // Null density: 0, 10%
     for null_density in [0.0, 0.1] {
         // Selectivity: 0.1%, 1%, 10%, 80%

--- a/arrow/benches/coalesce_kernels.rs
+++ b/arrow/benches/coalesce_kernels.rs
@@ -232,7 +232,8 @@ fn filter_streams(
 ) {
     let schema = data_stream.schema();
     let batch_size = data_stream.batch_size();
-    let mut coalescer = BatchCoalescer::new(Arc::clone(schema), batch_size);
+    let mut coalescer = BatchCoalescer::new(Arc::clone(schema), batch_size)
+        .with_biggest_coalesce_batch_size(Some(batch_size / 2));
 
     while num_output_batches > 0 {
         let filter = filter_stream.next_filter();

--- a/arrow/benches/coalesce_kernels.rs
+++ b/arrow/benches/coalesce_kernels.rs
@@ -77,6 +77,12 @@ fn add_all_filter_benchmarks(c: &mut Criterion) {
         // TODO model other dictionary types here (FixedSizeBinary for example)
     ]));
 
+    // Test both optimization modes: with and without biggest_coalesce_batch_size
+    let optimization_modes = [
+        ("default", None),                   // No optimization
+        ("optimized", Some(batch_size / 2)), // With optimization
+    ];
+
     // Null density: 0, 10%
     for null_density in [0.0, 0.1] {
         // Selectivity: 0.1%, 1%, 10%, 80%
@@ -232,8 +238,7 @@ fn filter_streams(
 ) {
     let schema = data_stream.schema();
     let batch_size = data_stream.batch_size();
-    let mut coalescer = BatchCoalescer::new(Arc::clone(schema), batch_size)
-        .with_biggest_coalesce_batch_size(Some(batch_size / 2));
+    let mut coalescer = BatchCoalescer::new(Arc::clone(schema), batch_size);
 
     while num_output_batches > 0 {
         let filter = filter_stream.next_filter();


### PR DESCRIPTION
# Which issue does this PR close?

needed for:
https://github.com/apache/datafusion/pull/17193

# Rationale for this change
```rust
        // Large batch bypass optimization:
        // When biggest_coalesce_batch_size is configured and a batch exceeds this limit,
        // we can avoid expensive split-and-merge operations by passing it through directly.
        //
        // IMPORTANT: This optimization is OPTIONAL and only active when biggest_coalesce_batch_size
        // is explicitly set via with_biggest_coalesce_batch_size(Some(limit)).
        // If not set (None), ALL batches follow normal coalescing behavior regardless of size.

        // =============================================================================
        // CASE 1: No buffer + large batch → Direct bypass
        // =============================================================================
        // Example scenario (target_batch_size=1000, biggest_coalesce_batch_size=Some(500)):
        // Input sequence: [600, 1200, 300]
        //
        // With biggest_coalesce_batch_size=Some(500) (optimization enabled):
        //   600 → large batch detected! buffered_rows=0 → Case 1: direct bypass
        //        → output: [600] (bypass, preserves large batch)
        //   1200 → large batch detected! buffered_rows=0 → Case 1: direct bypass
        //         → output: [1200] (bypass, preserves large batch)
        //   300 → normal batch, buffer: [300]
        //   Result: [600], [1200], [300] - large batches preserved, mixed sizes

        // =============================================================================
        // CASE 2: Buffer too large + large batch → Flush first, then bypass
        // =============================================================================
        // This case prevents creating extremely large merged batches that would
        // significantly exceed both target_batch_size and biggest_coalesce_batch_size.
        //
        // Example 1: Buffer exceeds limit before large batch arrives
        // target_batch_size=1000, biggest_coalesce_batch_size=Some(400)
        // Input: [350, 200, 800]
        //
        // Step 1: push_batch([350])
        //   → batch_size=350 <= 400, normal path
        //   → buffer: [350], buffered_rows=350
        //
        // Step 2: push_batch([200])
        //   → batch_size=200 <= 400, normal path
        //   → buffer: [350, 200], buffered_rows=550
        //
        // Step 3: push_batch([800])
        //   → batch_size=800 > 400, large batch path
        //   → buffered_rows=550 > 400 → Case 2: flush first
        //   → flush: output [550] (combined [350, 200])
        //   → then bypass: output [800]
        //   Result: [550], [800] - buffer flushed to prevent oversized merge
        //
        // Example 2: Multiple small batches accumulate before large batch
        // target_batch_size=1000, biggest_coalesce_batch_size=Some(300)
        // Input: [150, 100, 80, 900]
        //
        // Step 1-3: Accumulate small batches
        //   150 → buffer: [150], buffered_rows=150
        //   100 → buffer: [150, 100], buffered_rows=250
        //   80  → buffer: [150, 100, 80], buffered_rows=330
        //
        // Step 4: push_batch([900])
        //   → batch_size=900 > 300, large batch path
        //   → buffered_rows=330 > 300 → Case 2: flush first
        //   → flush: output [330] (combined [150, 100, 80])
        //   → then bypass: output [900]
        //   Result: [330], [900] - prevents merge into [1230] which would be too large

        // =============================================================================
        // CASE 3: Small buffer + large batch → Normal coalescing (no bypass)
        // =============================================================================
        // When buffer is small enough, we still merge to maintain efficiency
        // Example: target_batch_size=1000, biggest_coalesce_batch_size=Some(500)
        // Input: [300, 1200]
        //
        // Step 1: push_batch([300])
        //   → batch_size=300 <= 500, normal path
        //   → buffer: [300], buffered_rows=300
        //
        // Step 2: push_batch([1200])
        //   → batch_size=1200 > 500, large batch path
        //   → buffered_rows=300 <= 500 → Case 3: normal merge
        //   → buffer: [300, 1200] (1500 total)
        //   → 1500 > target_batch_size → split: output [1000], buffer [500]
        //   Result: [1000], [500] - normal split/merge behavior maintained

        // =============================================================================
        // Comparison: Default vs Optimized Behavior
        // =============================================================================
        // target_batch_size=1000, biggest_coalesce_batch_size=Some(500)
        // Input: [600, 1200, 300]
        //
        // DEFAULT BEHAVIOR (biggest_coalesce_batch_size=None):
        //   600 → buffer: [600]
        //   1200 → buffer: [600, 1200] (1800 rows total)
        //         → split: output [1000 rows], buffer [800 rows remaining]
        //   300 → buffer: [800, 300] (1100 rows total)
        //        → split: output [1000 rows], buffer [100 rows remaining]
        //   Result: [1000], [1000], [100] - all outputs respect target_batch_size
        //
        // OPTIMIZED BEHAVIOR (biggest_coalesce_batch_size=Some(500)):
        //   600 → Case 1: direct bypass → output: [600]
        //   1200 → Case 1: direct bypass → output: [1200]
        //   300 → normal path → buffer: [300]
        //   Result: [600], [1200], [300] - large batches preserved

        // =============================================================================
        // Benefits and Trade-offs
        // =============================================================================
        // Benefits of the optimization:
        // - Large batches stay intact (better for downstream vectorized processing)
        // - Fewer split/merge operations (better CPU performance)
        // - More predictable memory usage patterns
        // - Maintains streaming efficiency while preserving batch boundaries
        //
        // Trade-offs:
        // - Output batch sizes become variable (not always target_batch_size)
        // - May produce smaller partial batches when flushing before large batches
        // - Requires tuning biggest_coalesce_batch_size parameter for optimal performance

        // TODO, for unsorted batches, we may can filter all large batches, and coalesce all
        // small batches together?
```

# What changes are included in this PR?

Add more public API which is needed for apache datafusion.

# Are these changes tested?

yes

Added unit test.
# Are there any user-facing changes?

No