### PR TITLE
feat: Add NaN-counts support for parquet metadata

### DIFF
--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -70,6 +70,7 @@ fn encoded_meta() -> Vec<u8> {
         distinct_count: None,
         max_value: Some(vec![rng.random(); 8]),
         min_value: Some(vec![rng.random(); 8]),
+        nan_count: None,
         is_max_value_exact: Some(true),
         is_min_value_exact: Some(true),
     };

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -287,6 +287,7 @@ impl FallbackEncoder {
             encoding,
             min_value,
             max_value,
+            nan_count: None,
             variable_length_bytes,
         })
     }
@@ -409,6 +410,7 @@ impl DictEncoder {
             encoding: Encoding::RLE_DICTIONARY,
             min_value,
             max_value,
+            nan_count: None,
             variable_length_bytes,
         }
     }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -774,12 +774,10 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         page_variable_length_bytes: Option<i64>,
     ) {
         // Determine if this is a floating-point column
-        let is_float_column = matches!(
-            self.descr.physical_type(),
-            Type::FLOAT | Type::DOUBLE
-        ) || (self.descr.physical_type() == Type::FIXED_LEN_BYTE_ARRAY
-            && self.descr.logical_type() == Some(LogicalType::Float16));
-        
+        let is_float_column = matches!(self.descr.physical_type(), Type::FLOAT | Type::DOUBLE)
+            || (self.descr.physical_type() == Type::FIXED_LEN_BYTE_ARRAY
+                && self.descr.logical_type() == Some(LogicalType::Float16));
+
         // update the column index
         let null_page =
             (self.page_metrics.num_buffered_rows as u64) == self.page_metrics.num_page_nulls;
@@ -793,7 +791,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             } else {
                 None
             };
-            
+
             self.column_index_builder.append(
                 null_page,
                 vec![],
@@ -840,7 +838,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                     } else {
                         None
                     };
-                    
+
                     if self.can_truncate_value() {
                         self.column_index_builder.append(
                             null_page,
@@ -1433,7 +1431,7 @@ fn update_stat<T: ParquetValueType, F>(
 fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) -> bool {
     use crate::util::ieee754;
     use std::cmp::Ordering;
-    
+
     match T::PHYSICAL_TYPE {
         Type::FLOAT => {
             // Use IEEE 754 total order for float comparisons
@@ -1526,7 +1524,7 @@ fn compare_greater_unsigned_int<T: ParquetValueType>(a: &T, b: &T) -> bool {
 fn compare_greater_f16(a: &[u8], b: &[u8]) -> bool {
     use crate::util::ieee754;
     use std::cmp::Ordering;
-    
+
     let a = f16::from_le_bytes(a.try_into().unwrap());
     let b = f16::from_le_bytes(b.try_into().unwrap());
     ieee754::compare_f16(a, b) == Ordering::Greater
@@ -2687,11 +2685,11 @@ mod tests {
         let pos_one = 1.0_f32;
         let pos_inf = f32::INFINITY;
         let pos_nan = f32::from_bits(0x7fc00000);
-        
+
         let values = vec![
-            pos_nan, neg_zero, pos_inf, neg_one, neg_nan, pos_one, neg_inf, pos_zero
+            pos_nan, neg_zero, pos_inf, neg_one, neg_nan, pos_one, neg_inf, pos_zero,
         ];
-        
+
         let stats = statistics_roundtrip::<FloatType>(&values);
         if let Statistics::Float(stats) = stats {
             // With IEEE 754 total order, min should be -NaN, max should be +NaN
@@ -2715,11 +2713,11 @@ mod tests {
         let pos_one = 1.0_f64;
         let pos_inf = f64::INFINITY;
         let pos_nan = f64::from_bits(0x7ff8000000000000);
-        
+
         let values = vec![
-            pos_nan, neg_zero, pos_inf, neg_one, neg_nan, pos_one, neg_inf, pos_zero
+            pos_nan, neg_zero, pos_inf, neg_one, neg_nan, pos_one, neg_inf, pos_zero,
         ];
-        
+
         let stats = statistics_roundtrip::<DoubleType>(&values);
         if let Statistics::Double(stats) = stats {
             // With IEEE 754 total order, and NaN filtering
@@ -2735,7 +2733,7 @@ mod tests {
     fn test_ieee754_total_order_zeros() {
         // Test that -0.0 and +0.0 are handled correctly
         let values = vec![-0.0_f32, 0.0_f32, -0.0_f32, 0.0_f32];
-        
+
         let stats = statistics_roundtrip::<FloatType>(&values);
         if let Statistics::Float(stats) = stats {
             // With IEEE 754 total order, -0.0 < +0.0

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1968,9 +1968,9 @@ mod tests {
             .build();
 
         #[cfg(not(feature = "encryption"))]
-        let base_expected_size = 2312;
+        let base_expected_size = 2376;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2648;
+        let base_expected_size = 2712;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -1998,9 +1998,9 @@ mod tests {
             .build();
 
         #[cfg(not(feature = "encryption"))]
-        let bigger_expected_size = 2816;
+        let bigger_expected_size = 2880;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3152;
+        let bigger_expected_size = 3216;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -17,7 +17,7 @@
 
 use std::{io::Read, ops::Range, sync::Arc};
 
-use crate::basic::ColumnOrder;
+use crate::basic::{ColumnOrder, SortOrder};
 #[cfg(feature = "encryption")]
 use crate::encryption::{
     decrypt::{FileDecryptionProperties, FileDecryptor},
@@ -1105,6 +1105,9 @@ impl ParquetMetaDataReader {
                                 column.physical_type(),
                             );
                             res.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
+                        }
+                        TColumnOrder::IEEE754TOTALORDER(_) => {
+                            res.push(ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED));
                         }
                     }
                 }

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -269,6 +269,11 @@ pub fn from_thrift(
                         null_count,
                         old_format,
                     )
+                    // Note: We set nan_count here even though we can't verify if this is Float16.
+                    // The spec says nan_count should only be set for Float16 logical type,
+                    // but from_thrift doesn't have access to logical type information.
+                    // Writers should only set nan_count for Float16, and readers should
+                    // handle this gracefully.
                     .with_nan_count(nan_count)
                     .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
                     .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -1226,4 +1226,30 @@ mod tests {
         // u64::MAX can't fit in i64, so it should be None
         assert_eq!(thrift_stats.nan_count, None);
     }
+
+    #[test]
+    fn test_nan_counts_in_column_index() {
+        // Test that nan_counts are properly collected in page index
+        use crate::file::metadata::ColumnIndexBuilder;
+
+        // Test for floating-point column - all pages must have Some(n)
+        let mut float_builder = ColumnIndexBuilder::new();
+        float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, Some(5));
+        float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 2, Some(3));
+        float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, Some(0));  // No NaN but still Some(0)
+        
+        let float_column_index = float_builder.build_to_thrift();
+        // Verify nan_counts field is properly set for float column
+        assert_eq!(float_column_index.nan_counts, Some(vec![5, 3, 0]));
+        
+        // Test for non-floating-point column - all pages must have None
+        let mut int_builder = ColumnIndexBuilder::new();
+        int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, None);
+        int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 2, None);
+        int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, None);
+        
+        let int_column_index = int_builder.build_to_thrift();
+        // Verify nan_counts field is None for non-float column
+        assert_eq!(int_column_index.nan_counts, None);
+    }
 }

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -141,6 +141,8 @@ pub fn from_thrift(
             let null_count = Some(null_count as u64);
             // Generic distinct count (count of distinct values occurring)
             let distinct_count = stats.distinct_count.map(|value| value as u64);
+            // Generic nan count for floating point types
+            let nan_count = stats.nan_count.map(|value| value as u64);
             // Whether or not statistics use deprecated min/max fields.
             let old_format = stats.min_value.is_none() && stats.max_value.is_none();
             // Generic min value as bytes.
@@ -224,19 +226,29 @@ pub fn from_thrift(
                     };
                     Statistics::int96(min, max, distinct_count, null_count, old_format)
                 }
-                Type::FLOAT => Statistics::float(
-                    min.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
-                    max.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
-                    distinct_count,
-                    null_count,
-                    old_format,
+                Type::FLOAT => Statistics::Float(
+                    ValueStatistics::new(
+                        min.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
+                        max.map(|data| f32::from_le_bytes(data[..4].try_into().unwrap())),
+                        distinct_count,
+                        null_count,
+                        old_format,
+                    )
+                    .with_nan_count(nan_count)
+                    .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
+                    .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),
                 ),
-                Type::DOUBLE => Statistics::double(
-                    min.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
-                    max.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
-                    distinct_count,
-                    null_count,
-                    old_format,
+                Type::DOUBLE => Statistics::Double(
+                    ValueStatistics::new(
+                        min.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
+                        max.map(|data| f64::from_le_bytes(data[..8].try_into().unwrap())),
+                        distinct_count,
+                        null_count,
+                        old_format,
+                    )
+                    .with_nan_count(nan_count)
+                    .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
+                    .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),
                 ),
                 Type::BYTE_ARRAY => Statistics::ByteArray(
                     ValueStatistics::new(
@@ -257,6 +269,7 @@ pub fn from_thrift(
                         null_count,
                         old_format,
                     )
+                    .with_nan_count(nan_count)
                     .with_max_is_exact(stats.is_max_value_exact.unwrap_or(false))
                     .with_min_is_exact(stats.is_min_value_exact.unwrap_or(false)),
                 ),
@@ -282,6 +295,11 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
         .distinct_count_opt()
         .and_then(|value| i64::try_from(value).ok());
 
+    // record nan count if it can fit in i64
+    let nan_count = stats
+        .nan_count_opt()
+        .and_then(|value| i64::try_from(value).ok());
+
     let mut thrift_stats = TStatistics {
         max: None,
         min: None,
@@ -291,6 +309,7 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
         min_value: None,
         is_max_value_exact: None,
         is_min_value_exact: None,
+        nan_count,
     };
 
     // Get min/max if set.
@@ -432,6 +451,11 @@ impl Statistics {
         statistics_enum_func![self, null_count_opt]
     }
 
+    /// Returns NaN count for floating point types, if known.
+    pub fn nan_count_opt(&self) -> Option<u64> {
+        statistics_enum_func![self, nan_count_opt]
+    }
+
     /// Returns `true` if the min value is set, and is an exact min value.
     pub fn min_is_exact(&self) -> bool {
         statistics_enum_func![self, min_is_exact]
@@ -495,6 +519,8 @@ pub struct ValueStatistics<T> {
     // Distinct count could be omitted in some cases
     distinct_count: Option<u64>,
     null_count: Option<u64>,
+    // NaN count for floating point types
+    nan_count: Option<u64>,
 
     // Whether or not the min or max values are exact, or truncated.
     is_max_value_exact: bool,
@@ -525,6 +551,7 @@ impl<T: ParquetValueType> ValueStatistics<T> {
             max,
             distinct_count,
             null_count,
+            nan_count: None,
             is_min_max_deprecated,
             is_min_max_backwards_compatible: is_min_max_deprecated,
         }
@@ -608,6 +635,16 @@ impl<T: ParquetValueType> ValueStatistics<T> {
     /// Returns null count.
     pub fn null_count_opt(&self) -> Option<u64> {
         self.null_count
+    }
+
+    /// Returns NaN count for floating point types.
+    pub fn nan_count_opt(&self) -> Option<u64> {
+        self.nan_count
+    }
+
+    /// Set the NaN count for floating point types.
+    pub fn with_nan_count(self, nan_count: Option<u64>) -> Self {
+        Self { nan_count, ..self }
     }
 
     /// Returns `true` if statistics were created using old min/max fields.
@@ -711,6 +748,7 @@ mod tests {
             min_value: None,
             is_max_value_exact: None,
             is_min_value_exact: None,
+            nan_count: None,
         };
 
         from_thrift(Type::INT32, Some(thrift_stats)).unwrap();
@@ -1074,5 +1112,113 @@ mod tests {
             null_count,
             is_min_max_deprecated,
         ))
+    }
+
+    #[test]
+    fn test_nan_count_float() {
+        // Test NaN count for f32
+        let stats = Statistics::Float(
+            ValueStatistics::new(Some(1.0_f32), Some(5.0_f32), None, Some(0), false)
+                .with_nan_count(Some(3)),
+        );
+
+        assert_eq!(stats.nan_count_opt(), Some(3));
+
+        // Verify round-trip through thrift
+        let thrift_stats = to_thrift(Some(&stats)).unwrap();
+        assert_eq!(thrift_stats.nan_count, Some(3));
+
+        let round_tripped = from_thrift(Type::FLOAT, Some(thrift_stats))
+            .unwrap()
+            .unwrap();
+        assert_eq!(round_tripped.nan_count_opt(), Some(3));
+    }
+
+    #[test]
+    fn test_nan_count_double() {
+        // Test NaN count for f64
+        let stats = Statistics::Double(
+            ValueStatistics::new(Some(1.0_f64), Some(5.0_f64), None, Some(0), false)
+                .with_nan_count(Some(5)),
+        );
+
+        assert_eq!(stats.nan_count_opt(), Some(5));
+
+        // Verify round-trip through thrift
+        let thrift_stats = to_thrift(Some(&stats)).unwrap();
+        assert_eq!(thrift_stats.nan_count, Some(5));
+
+        let round_tripped = from_thrift(Type::DOUBLE, Some(thrift_stats))
+            .unwrap()
+            .unwrap();
+        assert_eq!(round_tripped.nan_count_opt(), Some(5));
+    }
+
+    #[test]
+    fn test_nan_count_none_for_non_float() {
+        // NaN count should not be set for non-floating point types
+        let stats = Statistics::int32(Some(1), Some(100), None, Some(0), false);
+        assert_eq!(stats.nan_count_opt(), None);
+
+        let thrift_stats = to_thrift(Some(&stats)).unwrap();
+        assert_eq!(thrift_stats.nan_count, None);
+    }
+
+    #[test]
+    fn test_nan_count_backwards_compatible() {
+        // Test that missing nan_count field is handled correctly
+        let thrift_stats = TStatistics {
+            min_value: Some(vec![0, 0, 0, 0]),    // 0.0_f32 in bytes
+            max_value: Some(vec![0, 0, 128, 63]), // 1.0_f32 in bytes
+            null_count: Some(0),
+            distinct_count: None,
+            nan_count: None, // Not set
+            ..Default::default()
+        };
+
+        let stats = from_thrift(Type::FLOAT, Some(thrift_stats))
+            .unwrap()
+            .unwrap();
+
+        // nan_count should be None when not provided
+        assert_eq!(stats.nan_count_opt(), None);
+    }
+
+    #[test]
+    fn test_statistics_with_nan_min_max() {
+        // Test that when there are only NaN values, min/max should be None
+        let stats = Statistics::Float(
+            ValueStatistics::new(
+                None, // No min (all NaN)
+                None, // No max (all NaN)
+                None,
+                Some(0),
+                false,
+            )
+            .with_nan_count(Some(10)), // All values are NaN
+        );
+
+        assert_eq!(stats.min_bytes_opt(), None);
+        assert_eq!(stats.max_bytes_opt(), None);
+        assert_eq!(stats.nan_count_opt(), Some(10));
+
+        // Verify serialization handles this case
+        let thrift_stats = to_thrift(Some(&stats)).unwrap();
+        assert_eq!(thrift_stats.min_value, None);
+        assert_eq!(thrift_stats.max_value, None);
+        assert_eq!(thrift_stats.nan_count, Some(10));
+    }
+
+    #[test]
+    fn test_nan_count_too_large() {
+        // Test that nan_count larger than i64::MAX is not serialized
+        let stats = Statistics::Float(
+            ValueStatistics::new(Some(1.0_f32), Some(2.0_f32), None, Some(0), false)
+                .with_nan_count(Some(u64::MAX)),
+        );
+
+        let thrift_stats = to_thrift(Some(&stats)).unwrap();
+        // u64::MAX can't fit in i64, so it should be None
+        assert_eq!(thrift_stats.nan_count, None);
     }
 }

--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -1236,18 +1236,18 @@ mod tests {
         let mut float_builder = ColumnIndexBuilder::new();
         float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, Some(5));
         float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 2, Some(3));
-        float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, Some(0));  // No NaN but still Some(0)
-        
+        float_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, Some(0)); // No NaN but still Some(0)
+
         let float_column_index = float_builder.build_to_thrift();
         // Verify nan_counts field is properly set for float column
         assert_eq!(float_column_index.nan_counts, Some(vec![5, 3, 0]));
-        
+
         // Test for non-floating-point column - all pages must have None
         let mut int_builder = ColumnIndexBuilder::new();
         int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, None);
         int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 2, None);
         int_builder.append(false, vec![0u8; 4], vec![255u8; 4], 0, None);
-        
+
         let int_column_index = int_builder.build_to_thrift();
         // Verify nan_counts field is None for non-float column
         assert_eq!(int_column_index.nan_counts, None);

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -4998,12 +4998,50 @@ impl crate::thrift::TSerializable for TypeDefinedOrder {
 }
 
 //
+// IEEE754TotalOrder
+//
+
+/// IEEE 754 total order for floating point values
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct IEEE754TotalOrder {
+}
+
+impl IEEE754TotalOrder {
+  pub fn new() -> IEEE754TotalOrder {
+    IEEE754TotalOrder {}
+  }
+}
+
+impl crate::thrift::TSerializable for IEEE754TotalOrder {
+  fn read_from_in_protocol<T: TInputProtocol>(i_prot: &mut T) -> thrift::Result<IEEE754TotalOrder> {
+    i_prot.read_struct_begin()?;
+    loop {
+      let field_ident = i_prot.read_field_begin()?;
+      if field_ident.field_type == TType::Stop {
+        break;
+      }
+      i_prot.skip(field_ident.field_type)?;
+      i_prot.read_field_end()?;
+    }
+    i_prot.read_struct_end()?;
+    Ok(IEEE754TotalOrder {})
+  }
+  fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()> {
+    let struct_ident = TStructIdentifier::new("IEEE754TotalOrder");
+    o_prot.write_struct_begin(&struct_ident)?;
+    o_prot.write_field_stop()?;
+    o_prot.write_struct_end()
+  }
+}
+
+//
 // ColumnOrder
 //
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ColumnOrder {
   TYPEORDER(TypeDefinedOrder),
+  IEEE754TOTALORDER(IEEE754TotalOrder),
 }
 
 impl crate::thrift::TSerializable for ColumnOrder {
@@ -5022,6 +5060,13 @@ impl crate::thrift::TSerializable for ColumnOrder {
           let val = TypeDefinedOrder::read_from_in_protocol(i_prot)?;
           if ret.is_none() {
             ret = Some(ColumnOrder::TYPEORDER(val));
+          }
+          received_field_count += 1;
+        },
+        2 => {
+          let val = IEEE754TotalOrder::read_from_in_protocol(i_prot)?;
+          if ret.is_none() {
+            ret = Some(ColumnOrder::IEEE754TOTALORDER(val));
           }
           received_field_count += 1;
         },
@@ -5061,6 +5106,11 @@ impl crate::thrift::TSerializable for ColumnOrder {
     match *self {
       ColumnOrder::TYPEORDER(ref f) => {
         o_prot.write_field_begin(&TFieldIdentifier::new("TYPE_ORDER", TType::Struct, 1))?;
+        f.write_to_out_protocol(o_prot)?;
+        o_prot.write_field_end()?;
+      },
+      ColumnOrder::IEEE754TOTALORDER(ref f) => {
+        o_prot.write_field_begin(&TFieldIdentifier::new("IEEE_754_TOTAL_ORDER", TType::Struct, 2))?;
         f.write_to_out_protocol(o_prot)?;
         o_prot.write_field_end()?;
       },
@@ -5315,10 +5365,17 @@ pub struct ColumnIndex {
   /// Same as repetition_level_histograms except for definitions levels.
   /// 
   pub definition_level_histograms: Option<Vec<i64>>,
+  /// A list containing the number of NaN values for each page
+  /// Only present for columns of physical type FLOAT, DOUBLE, or logical type FLOAT16.
+  /// 
+  /// If nan_counts are not present, readers MUST NOT assume all
+  /// NaN counts are 0. Writers SHOULD write this field if the column
+  /// is of applicable type, even if no NaN values are present.
+  pub nan_counts: Option<Vec<i64>>,
 }
 
 impl ColumnIndex {
-  pub fn new<F5, F6, F7>(null_pages: Vec<bool>, min_values: Vec<Vec<u8>>, max_values: Vec<Vec<u8>>, boundary_order: BoundaryOrder, null_counts: F5, repetition_level_histograms: F6, definition_level_histograms: F7) -> ColumnIndex where F5: Into<Option<Vec<i64>>>, F6: Into<Option<Vec<i64>>>, F7: Into<Option<Vec<i64>>> {
+  pub fn new<F5, F6, F7, F8>(null_pages: Vec<bool>, min_values: Vec<Vec<u8>>, max_values: Vec<Vec<u8>>, boundary_order: BoundaryOrder, null_counts: F5, repetition_level_histograms: F6, definition_level_histograms: F7, nan_counts: F8) -> ColumnIndex where F5: Into<Option<Vec<i64>>>, F6: Into<Option<Vec<i64>>>, F7: Into<Option<Vec<i64>>>, F8: Into<Option<Vec<i64>>> {
     ColumnIndex {
       null_pages,
       min_values,
@@ -5327,6 +5384,7 @@ impl ColumnIndex {
       null_counts: null_counts.into(),
       repetition_level_histograms: repetition_level_histograms.into(),
       definition_level_histograms: definition_level_histograms.into(),
+      nan_counts: nan_counts.into(),
     }
   }
 }
@@ -5341,6 +5399,7 @@ impl crate::thrift::TSerializable for ColumnIndex {
     let mut f_5: Option<Vec<i64>> = None;
     let mut f_6: Option<Vec<i64>> = None;
     let mut f_7: Option<Vec<i64>> = None;
+    let mut f_8: Option<Vec<i64>> = None;
     loop {
       let field_ident = i_prot.read_field_begin()?;
       if field_ident.field_type == TType::Stop {
@@ -5412,6 +5471,16 @@ impl crate::thrift::TSerializable for ColumnIndex {
           i_prot.read_list_end()?;
           f_7 = Some(val);
         },
+        8 => {
+          let list_ident = i_prot.read_list_begin()?;
+          let mut val: Vec<i64> = Vec::with_capacity(list_ident.size as usize);
+          for _ in 0..list_ident.size {
+            let list_elem_18 = i_prot.read_i64()?;
+            val.push(list_elem_18);
+          }
+          i_prot.read_list_end()?;
+          f_8 = Some(val);
+        },
         _ => {
           i_prot.skip(field_ident.field_type)?;
         },
@@ -5431,6 +5500,7 @@ impl crate::thrift::TSerializable for ColumnIndex {
       null_counts: f_5,
       repetition_level_histograms: f_6,
       definition_level_histograms: f_7,
+      nan_counts: f_8,
     };
     Ok(ret)
   }
@@ -5481,6 +5551,15 @@ impl crate::thrift::TSerializable for ColumnIndex {
     }
     if let Some(ref fld_var) = self.definition_level_histograms {
       o_prot.write_field_begin(&TFieldIdentifier::new("definition_level_histograms", TType::List, 7))?;
+      o_prot.write_list_begin(&TListIdentifier::new(TType::I64, fld_var.len() as i32))?;
+      for e in fld_var {
+        o_prot.write_i64(*e)?;
+      }
+      o_prot.write_list_end()?;
+      o_prot.write_field_end()?
+    }
+    if let Some(ref fld_var) = self.nan_counts {
+      o_prot.write_field_begin(&TFieldIdentifier::new("nan_counts", TType::List, 8))?;
       o_prot.write_list_begin(&TListIdentifier::new(TType::I64, fld_var.len() as i32))?;
       for e in fld_var {
         o_prot.write_i64(*e)?;

--- a/parquet/src/format.rs
+++ b/parquet/src/format.rs
@@ -1110,10 +1110,15 @@ pub struct Statistics {
   pub is_max_value_exact: Option<bool>,
   /// If true, min_value is the actual minimum value for a column
   pub is_min_value_exact: Option<bool>,
+  /// Count of NaN values in the column.
+  /// 
+  /// This field is only set for columns with floating point type
+  /// (float, double, or Float16). NaN values are not included in min/max statistics.
+  pub nan_count: Option<i64>,
 }
 
 impl Statistics {
-  pub fn new<F1, F2, F3, F4, F5, F6, F7, F8>(max: F1, min: F2, null_count: F3, distinct_count: F4, max_value: F5, min_value: F6, is_max_value_exact: F7, is_min_value_exact: F8) -> Statistics where F1: Into<Option<Vec<u8>>>, F2: Into<Option<Vec<u8>>>, F3: Into<Option<i64>>, F4: Into<Option<i64>>, F5: Into<Option<Vec<u8>>>, F6: Into<Option<Vec<u8>>>, F7: Into<Option<bool>>, F8: Into<Option<bool>> {
+  pub fn new<F1, F2, F3, F4, F5, F6, F7, F8, F9>(max: F1, min: F2, null_count: F3, distinct_count: F4, max_value: F5, min_value: F6, is_max_value_exact: F7, is_min_value_exact: F8, nan_count: F9) -> Statistics where F1: Into<Option<Vec<u8>>>, F2: Into<Option<Vec<u8>>>, F3: Into<Option<i64>>, F4: Into<Option<i64>>, F5: Into<Option<Vec<u8>>>, F6: Into<Option<Vec<u8>>>, F7: Into<Option<bool>>, F8: Into<Option<bool>>, F9: Into<Option<i64>> {
     Statistics {
       max: max.into(),
       min: min.into(),
@@ -1123,6 +1128,7 @@ impl Statistics {
       min_value: min_value.into(),
       is_max_value_exact: is_max_value_exact.into(),
       is_min_value_exact: is_min_value_exact.into(),
+      nan_count: nan_count.into(),
     }
   }
 }
@@ -1138,6 +1144,7 @@ impl crate::thrift::TSerializable for Statistics {
     let mut f_6: Option<Vec<u8>> = None;
     let mut f_7: Option<bool> = None;
     let mut f_8: Option<bool> = None;
+    let mut f_9: Option<i64> = None;
     loop {
       let field_ident = i_prot.read_field_begin()?;
       if field_ident.field_type == TType::Stop {
@@ -1177,6 +1184,10 @@ impl crate::thrift::TSerializable for Statistics {
           let val = i_prot.read_bool()?;
           f_8 = Some(val);
         },
+        9 => {
+          let val = i_prot.read_i64()?;
+          f_9 = Some(val);
+        },
         _ => {
           i_prot.skip(field_ident.field_type)?;
         },
@@ -1193,6 +1204,7 @@ impl crate::thrift::TSerializable for Statistics {
       min_value: f_6,
       is_max_value_exact: f_7,
       is_min_value_exact: f_8,
+      nan_count: f_9,
     };
     Ok(ret)
   }
@@ -1237,6 +1249,11 @@ impl crate::thrift::TSerializable for Statistics {
     if let Some(fld_var) = self.is_min_value_exact {
       o_prot.write_field_begin(&TFieldIdentifier::new("is_min_value_exact", TType::Bool, 8))?;
       o_prot.write_bool(fld_var)?;
+      o_prot.write_field_end()?
+    }
+    if let Some(fld_var) = self.nan_count {
+      o_prot.write_field_begin(&TFieldIdentifier::new("nan_count", TType::I64, 9))?;
+      o_prot.write_i64(fld_var)?;
       o_prot.write_field_end()?
     }
     o_prot.write_field_stop()?;

--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -343,6 +343,7 @@ mod tests {
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,
+            nan_counts: None,
         };
 
         assert_eq!(&index, &expected);
@@ -364,6 +365,7 @@ mod tests {
             null_counts: None,
             repetition_level_histograms: None,
             definition_level_histograms: None,
+            nan_counts: None,
         };
 
         assert_eq!(&index, &expected);

--- a/parquet/src/util/ieee754.rs
+++ b/parquet/src/util/ieee754.rs
@@ -81,54 +81,6 @@ pub fn compare_f16(a: f16, b: f16) -> Ordering {
     total_order_f16(a).cmp(&total_order_f16(b))
 }
 
-/// Returns the minimum of two f32 values using IEEE 754 total order.
-pub fn min_f32(a: f32, b: f32) -> f32 {
-    match compare_f32(a, b) {
-        Ordering::Less | Ordering::Equal => a,
-        Ordering::Greater => b,
-    }
-}
-
-/// Returns the maximum of two f32 values using IEEE 754 total order.
-pub fn max_f32(a: f32, b: f32) -> f32 {
-    match compare_f32(a, b) {
-        Ordering::Greater | Ordering::Equal => a,
-        Ordering::Less => b,
-    }
-}
-
-/// Returns the minimum of two f64 values using IEEE 754 total order.
-pub fn min_f64(a: f64, b: f64) -> f64 {
-    match compare_f64(a, b) {
-        Ordering::Less | Ordering::Equal => a,
-        Ordering::Greater => b,
-    }
-}
-
-/// Returns the maximum of two f64 values using IEEE 754 total order.
-pub fn max_f64(a: f64, b: f64) -> f64 {
-    match compare_f64(a, b) {
-        Ordering::Greater | Ordering::Equal => a,
-        Ordering::Less => b,
-    }
-}
-
-/// Returns the minimum of two f16 values using IEEE 754 total order.
-pub fn min_f16(a: f16, b: f16) -> f16 {
-    match compare_f16(a, b) {
-        Ordering::Less | Ordering::Equal => a,
-        Ordering::Greater => b,
-    }
-}
-
-/// Returns the maximum of two f16 values using IEEE 754 total order.
-pub fn max_f16(a: f16, b: f16) -> f16 {
-    match compare_f16(a, b) {
-        Ordering::Greater | Ordering::Equal => a,
-        Ordering::Less => b,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,27 +146,5 @@ mod tests {
         assert!(compare_f16(pos_zero, pos_one) == Ordering::Less);
         assert!(compare_f16(pos_one, pos_inf) == Ordering::Less);
         assert!(compare_f16(pos_inf, pos_nan) == Ordering::Less);
-    }
-
-    #[test]
-    fn test_min_max_with_nan() {
-        // Test that NaN is handled correctly in min/max
-        let nan = f32::NAN;
-        let one = 1.0_f32;
-
-        // In total order, -NaN is less than any finite value
-        // and +NaN is greater than any finite value
-        assert!(min_f32(nan, one).is_nan() || min_f32(nan, one) == one);
-        assert!(max_f32(nan, one).is_nan() || max_f32(nan, one) == one);
-    }
-
-    #[test]
-    fn test_min_max_with_zeros() {
-        let neg_zero = -0.0_f32;
-        let pos_zero = 0.0_f32;
-
-        // -0.0 < +0.0 in total order
-        assert_eq!(min_f32(neg_zero, pos_zero).to_bits(), neg_zero.to_bits());
-        assert_eq!(max_f32(neg_zero, pos_zero).to_bits(), pos_zero.to_bits());
     }
 }

--- a/parquet/src/util/ieee754.rs
+++ b/parquet/src/util/ieee754.rs
@@ -1,0 +1,220 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! IEEE 754 total order comparison functions for floating point types.
+//!
+//! According to the IEEE 754 specification, the total order is:
+//! -NaN < -Infinity < -x < -0 < +0 < +x < +Infinity < +NaN
+//! where x represents any finite non-zero value.
+//!
+//! Within NaN values, the order is determined by the payload bits.
+
+use half::f16;
+use std::cmp::Ordering;
+
+/// Converts a float to its total order representation.
+/// This allows for bitwise comparison that respects IEEE 754 total order.
+#[inline]
+fn total_order_f32(f: f32) -> u32 {
+    let bits = f.to_bits();
+    if bits & 0x8000_0000 != 0 {
+        // Negative number: flip all bits except sign
+        !bits
+    } else {
+        // Positive number: flip only sign bit
+        bits | 0x8000_0000
+    }
+}
+
+/// Converts a double to its total order representation.
+#[inline]
+fn total_order_f64(f: f64) -> u64 {
+    let bits = f.to_bits();
+    if bits & 0x8000_0000_0000_0000 != 0 {
+        // Negative number: flip all bits except sign
+        !bits
+    } else {
+        // Positive number: flip only sign bit
+        bits | 0x8000_0000_0000_0000
+    }
+}
+
+/// Converts a f16 to its total order representation.
+#[inline]
+fn total_order_f16(f: f16) -> u16 {
+    let bits = f.to_bits();
+    if bits & 0x8000 != 0 {
+        // Negative number: flip all bits except sign
+        !bits
+    } else {
+        // Positive number: flip only sign bit
+        bits | 0x8000
+    }
+}
+
+/// Compare two f32 values using IEEE 754 total order.
+pub fn compare_f32(a: f32, b: f32) -> Ordering {
+    total_order_f32(a).cmp(&total_order_f32(b))
+}
+
+/// Compare two f64 values using IEEE 754 total order.
+pub fn compare_f64(a: f64, b: f64) -> Ordering {
+    total_order_f64(a).cmp(&total_order_f64(b))
+}
+
+/// Compare two f16 values using IEEE 754 total order.
+pub fn compare_f16(a: f16, b: f16) -> Ordering {
+    total_order_f16(a).cmp(&total_order_f16(b))
+}
+
+/// Returns the minimum of two f32 values using IEEE 754 total order.
+pub fn min_f32(a: f32, b: f32) -> f32 {
+    match compare_f32(a, b) {
+        Ordering::Less | Ordering::Equal => a,
+        Ordering::Greater => b,
+    }
+}
+
+/// Returns the maximum of two f32 values using IEEE 754 total order.
+pub fn max_f32(a: f32, b: f32) -> f32 {
+    match compare_f32(a, b) {
+        Ordering::Greater | Ordering::Equal => a,
+        Ordering::Less => b,
+    }
+}
+
+/// Returns the minimum of two f64 values using IEEE 754 total order.
+pub fn min_f64(a: f64, b: f64) -> f64 {
+    match compare_f64(a, b) {
+        Ordering::Less | Ordering::Equal => a,
+        Ordering::Greater => b,
+    }
+}
+
+/// Returns the maximum of two f64 values using IEEE 754 total order.
+pub fn max_f64(a: f64, b: f64) -> f64 {
+    match compare_f64(a, b) {
+        Ordering::Greater | Ordering::Equal => a,
+        Ordering::Less => b,
+    }
+}
+
+/// Returns the minimum of two f16 values using IEEE 754 total order.
+pub fn min_f16(a: f16, b: f16) -> f16 {
+    match compare_f16(a, b) {
+        Ordering::Less | Ordering::Equal => a,
+        Ordering::Greater => b,
+    }
+}
+
+/// Returns the maximum of two f16 values using IEEE 754 total order.
+pub fn max_f16(a: f16, b: f16) -> f16 {
+    match compare_f16(a, b) {
+        Ordering::Greater | Ordering::Equal => a,
+        Ordering::Less => b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f32_total_order() {
+        // Test the order: -NaN < -Inf < -1.0 < -0.0 < +0.0 < 1.0 < +Inf < +NaN
+        let neg_nan = f32::from_bits(0xffc00000);
+        let neg_inf = f32::NEG_INFINITY;
+        let neg_one = -1.0_f32;
+        let neg_zero = -0.0_f32;
+        let pos_zero = 0.0_f32;
+        let pos_one = 1.0_f32;
+        let pos_inf = f32::INFINITY;
+        let pos_nan = f32::from_bits(0x7fc00000);
+
+        assert!(compare_f32(neg_nan, neg_inf) == Ordering::Less);
+        assert!(compare_f32(neg_inf, neg_one) == Ordering::Less);
+        assert!(compare_f32(neg_one, neg_zero) == Ordering::Less);
+        assert!(compare_f32(neg_zero, pos_zero) == Ordering::Less);
+        assert!(compare_f32(pos_zero, pos_one) == Ordering::Less);
+        assert!(compare_f32(pos_one, pos_inf) == Ordering::Less);
+        assert!(compare_f32(pos_inf, pos_nan) == Ordering::Less);
+    }
+
+    #[test]
+    fn test_f64_total_order() {
+        // Test the order: -NaN < -Inf < -1.0 < -0.0 < +0.0 < 1.0 < +Inf < +NaN
+        let neg_nan = f64::from_bits(0xfff8000000000000);
+        let neg_inf = f64::NEG_INFINITY;
+        let neg_one = -1.0_f64;
+        let neg_zero = -0.0_f64;
+        let pos_zero = 0.0_f64;
+        let pos_one = 1.0_f64;
+        let pos_inf = f64::INFINITY;
+        let pos_nan = f64::from_bits(0x7ff8000000000000);
+
+        assert!(compare_f64(neg_nan, neg_inf) == Ordering::Less);
+        assert!(compare_f64(neg_inf, neg_one) == Ordering::Less);
+        assert!(compare_f64(neg_one, neg_zero) == Ordering::Less);
+        assert!(compare_f64(neg_zero, pos_zero) == Ordering::Less);
+        assert!(compare_f64(pos_zero, pos_one) == Ordering::Less);
+        assert!(compare_f64(pos_one, pos_inf) == Ordering::Less);
+        assert!(compare_f64(pos_inf, pos_nan) == Ordering::Less);
+    }
+
+    #[test]
+    fn test_f16_total_order() {
+        // Test the order: -NaN < -Inf < -1.0 < -0.0 < +0.0 < 1.0 < +Inf < +NaN
+        let neg_nan = f16::from_bits(0xfe00);
+        let neg_inf = f16::NEG_INFINITY;
+        let neg_one = f16::from_f32(-1.0);
+        let neg_zero = f16::NEG_ZERO;
+        let pos_zero = f16::ZERO;
+        let pos_one = f16::from_f32(1.0);
+        let pos_inf = f16::INFINITY;
+        let pos_nan = f16::from_bits(0x7e00);
+
+        assert!(compare_f16(neg_nan, neg_inf) == Ordering::Less);
+        assert!(compare_f16(neg_inf, neg_one) == Ordering::Less);
+        assert!(compare_f16(neg_one, neg_zero) == Ordering::Less);
+        assert!(compare_f16(neg_zero, pos_zero) == Ordering::Less);
+        assert!(compare_f16(pos_zero, pos_one) == Ordering::Less);
+        assert!(compare_f16(pos_one, pos_inf) == Ordering::Less);
+        assert!(compare_f16(pos_inf, pos_nan) == Ordering::Less);
+    }
+
+    #[test]
+    fn test_min_max_with_nan() {
+        // Test that NaN is handled correctly in min/max
+        let nan = f32::NAN;
+        let one = 1.0_f32;
+
+        // In total order, -NaN is less than any finite value
+        // and +NaN is greater than any finite value
+        assert!(min_f32(nan, one).is_nan() || min_f32(nan, one) == one);
+        assert!(max_f32(nan, one).is_nan() || max_f32(nan, one) == one);
+    }
+
+    #[test]
+    fn test_min_max_with_zeros() {
+        let neg_zero = -0.0_f32;
+        let pos_zero = 0.0_f32;
+
+        // -0.0 < +0.0 in total order
+        assert_eq!(min_f32(neg_zero, pos_zero).to_bits(), neg_zero.to_bits());
+        assert_eq!(max_f32(neg_zero, pos_zero).to_bits(), pos_zero.to_bits());
+    }
+}

--- a/parquet/src/util/mod.rs
+++ b/parquet/src/util/mod.rs
@@ -19,6 +19,7 @@
 pub mod bit_util;
 mod bit_pack;
 pub(crate) mod interner;
+pub mod ieee754;
 
 #[cfg(any(test, feature = "test_common"))]
 pub(crate) mod test_common;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8156

# Rationale for this change

Add NaN-count parquet for parquet

# Are these changes tested?

Yes, well tested. All cases mentioned in #8156 should have been tested. Let me know if there are something missed.

# Are there any user-facing changes?

nan-count is added in a compatible way without any API breaking changes.

One exception is `Statistics::new` in the `format.rs`, but I think it's not part of the API surface.


---

**This PR was primarily authored with Claude Code using Opus 4.1 and then hand-reviewed by me. I aimed to keep it aligned with our goals, though I may have missed minor issues. I am responsible for every change made in this PR. Please flag anything that feels off, I’ll fix it quickly.**