### PR TITLE
Enable parallel writing across row groups when writing encrypted parquet

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -403,15 +403,12 @@ impl<W: Write + Send> ArrowWriter<W> {
         self.finish()
     }
 
-    pub fn get_column_writers(&mut self) -> Result<&ArrowRowGroupWriter> {
-        let in_progress = match &mut self.in_progress {
-            Some(in_progress) => in_progress,
-            x => x.insert(
-                self.row_group_writer_factory
-                    .create_row_group_writer(self.writer.flushed_row_groups().len())?,
-            ),
-        };
-        Ok(in_progress)
+    pub fn get_column_writers(&mut self) -> Result<Vec<ArrowColumnWriter>> {
+        let _ = self.flush();
+        let in_progress = self
+            .row_group_writer_factory
+            .create_row_group_writer(self.writer.flushed_row_groups().len())?;
+        Ok(in_progress.writers)
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -418,7 +418,7 @@ impl<W: Write + Send> ArrowWriter<W> {
         for chunk in chunks {
             chunk.append_to_row_group(&mut row_group_writer)?;
         }
-        let _ = row_group_writer.close();
+        row_group_writer.close()?;
         Ok(())
     }
 }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -179,7 +179,7 @@ pub struct ArrowWriter<W: Write> {
     arrow_schema: SchemaRef,
 
     /// Creates new [`ArrowRowGroupWriter`] instances as required
-    row_group_writer_factory: ArrowRowGroupWriterFactory,
+    pub row_group_writer_factory: ArrowRowGroupWriterFactory,
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
@@ -793,8 +793,9 @@ impl ArrowColumnWriter {
 }
 
 /// Encodes [`RecordBatch`] to a parquet row group
-struct ArrowRowGroupWriter {
-    writers: Vec<ArrowColumnWriter>,
+pub struct ArrowRowGroupWriter {
+    /// [`ArrowColumnWriter`] for each column in a row group
+    pub writers: Vec<ArrowColumnWriter>,
     schema: SchemaRef,
     buffered_rows: usize,
 }
@@ -827,44 +828,54 @@ impl ArrowRowGroupWriter {
     }
 }
 
-struct ArrowRowGroupWriterFactory {
+/// Factory for creating [`ArrowRowGroupWriter`] instances.
+/// This is used by [`ArrowWriter`] to create row group writers, but can be used
+/// directly for lower level API.
+pub struct ArrowRowGroupWriterFactory {
     #[cfg(feature = "encryption")]
     file_encryptor: Option<Arc<FileEncryptor>>,
 }
 
 impl ArrowRowGroupWriterFactory {
+    /// Creates a new [`ArrowRowGroupWriterFactory`] using provided [`SerializedFileWriter`].
     #[cfg(feature = "encryption")]
-    fn new<W: Write + Send>(file_writer: &SerializedFileWriter<W>) -> Self {
+    pub fn new<W: Write + Send>(file_writer: &SerializedFileWriter<W>) -> Self {
         Self {
             file_encryptor: file_writer.file_encryptor(),
         }
     }
 
     #[cfg(not(feature = "encryption"))]
-    fn new<W: Write + Send>(_file_writer: &SerializedFileWriter<W>) -> Self {
+    pub fn new<W: Write + Send>(_file_writer: &SerializedFileWriter<W>) -> Self {
         Self {}
     }
 
+    /// Creates a new [`ArrowRowGroupWriter`] for the given parquet schema and writer properties.
     #[cfg(feature = "encryption")]
-    fn create_row_group_writer(
+    pub fn create_row_group_writer(
         &self,
         parquet: &SchemaDescriptor,
         props: &WriterPropertiesPtr,
         arrow: &SchemaRef,
         row_group_index: usize,
     ) -> Result<ArrowRowGroupWriter> {
-        let writers = get_column_writers_with_encryptor(
-            parquet,
-            props,
-            arrow,
-            self.file_encryptor.clone(),
-            row_group_index,
-        )?;
+        let mut writers = Vec::with_capacity(arrow.fields.len());
+        let mut leaves = parquet.columns().iter();
+        let column_factory = ArrowColumnWriterFactory::new()
+            .with_file_encryptor(row_group_index, self.file_encryptor.clone());
+        for field in &arrow.fields {
+            column_factory.get_arrow_column_writer(
+                field.data_type(),
+                props,
+                &mut leaves,
+                &mut writers,
+            )?;
+        }
         Ok(ArrowRowGroupWriter::new(writers, arrow))
     }
 
     #[cfg(not(feature = "encryption"))]
-    fn create_row_group_writer(
+    pub fn create_row_group_writer(
         &self,
         parquet: &SchemaDescriptor,
         props: &WriterPropertiesPtr,
@@ -898,7 +909,7 @@ pub fn get_column_writers(
 
 /// Returns the [`ArrowColumnWriter`] for a given schema and supports columnar encryption
 #[cfg(feature = "encryption")]
-fn get_column_writers_with_encryptor(
+pub fn get_column_writers_with_encryptor(
     parquet: &SchemaDescriptor,
     props: &WriterPropertiesPtr,
     arrow: &SchemaRef,
@@ -921,14 +932,21 @@ fn get_column_writers_with_encryptor(
 }
 
 /// Gets [`ArrowColumnWriter`] instances for different data types
-struct ArrowColumnWriterFactory {
+pub struct ArrowColumnWriterFactory {
     #[cfg(feature = "encryption")]
     row_group_index: usize,
     #[cfg(feature = "encryption")]
     file_encryptor: Option<Arc<FileEncryptor>>,
 }
 
+impl Default for ArrowColumnWriterFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ArrowColumnWriterFactory {
+    /// Create a new [`ArrowColumnWriterFactory`]
     pub fn new() -> Self {
         Self {
             #[cfg(feature = "encryption")]
@@ -939,7 +957,7 @@ impl ArrowColumnWriterFactory {
     }
 
     #[cfg(feature = "encryption")]
-    pub fn with_file_encryptor(
+    fn with_file_encryptor(
         mut self,
         row_group_index: usize,
         file_encryptor: Option<Arc<FileEncryptor>>,
@@ -977,7 +995,7 @@ impl ArrowColumnWriterFactory {
     }
 
     /// Gets the [`ArrowColumnWriter`] for the given `data_type`
-    fn get_arrow_column_writer(
+    pub fn get_arrow_column_writer(
         &self,
         data_type: &ArrowDataType,
         props: &WriterPropertiesPtr,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -405,7 +405,7 @@ impl<W: Write + Send> ArrowWriter<W> {
 
     /// Create a new row group writer and return its column writers.
     pub fn get_column_writers(&mut self) -> Result<Vec<ArrowColumnWriter>> {
-        let _ = self.flush();
+        self.flush()?;
         let in_progress = self
             .row_group_writer_factory
             .create_row_group_writer(self.writer.flushed_row_groups().len())?;

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -955,14 +955,7 @@ struct ArrowColumnWriterFactory {
     file_encryptor: Option<Arc<FileEncryptor>>,
 }
 
-impl Default for ArrowColumnWriterFactory {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ArrowColumnWriterFactory {
-    /// Create a new [`ArrowColumnWriterFactory`]
     pub fn new() -> Self {
         Self {
             #[cfg(feature = "encryption")]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -402,6 +402,17 @@ impl<W: Write + Send> ArrowWriter<W> {
     pub fn close(mut self) -> Result<crate::format::FileMetaData> {
         self.finish()
     }
+
+    pub fn get_column_writers(&mut self) -> Result<&ArrowRowGroupWriter> {
+        let in_progress = match &mut self.in_progress {
+            Some(in_progress) => in_progress,
+            x => x.insert(
+                self.row_group_writer_factory
+                    .create_row_group_writer(self.writer.flushed_row_groups().len())?,
+            ),
+        };
+        Ok(in_progress)
+    }
 }
 
 impl<W: Write + Send> RecordBatchWriter for ArrowWriter<W> {
@@ -827,8 +838,8 @@ impl ArrowRowGroupWriter {
     }
 
     /// Get [`ArrowColumnWriter`]s for all columns in a row group
-    pub fn into_column_writers(self) -> Vec<ArrowColumnWriter> {
-        self.writers
+    pub fn get_column_writers(&self) -> &Vec<ArrowColumnWriter> {
+        &self.writers
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -179,7 +179,7 @@ pub struct ArrowWriter<W: Write> {
     arrow_schema: SchemaRef,
 
     /// Creates new [`ArrowRowGroupWriter`] instances as required
-    pub row_group_writer_factory: ArrowRowGroupWriterFactory,
+    row_group_writer_factory: ArrowRowGroupWriterFactory,
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
@@ -237,9 +237,14 @@ impl<W: Write + Send> ArrowWriter<W> {
         let max_row_group_size = props.max_row_group_size();
 
         let file_writer =
-            SerializedFileWriter::new(writer, schema.root_schema_ptr(), Arc::new(props))?;
+            SerializedFileWriter::new(writer, schema.root_schema_ptr(), Arc::new(props.clone()))?;
 
-        let row_group_writer_factory = ArrowRowGroupWriterFactory::new(&file_writer);
+        let row_group_writer_factory = ArrowRowGroupWriterFactory::new(
+            &file_writer,
+            schema,
+            arrow_schema.clone(),
+            props.into(),
+        );
 
         Ok(Self {
             writer: file_writer,
@@ -310,12 +315,10 @@ impl<W: Write + Send> ArrowWriter<W> {
 
         let in_progress = match &mut self.in_progress {
             Some(in_progress) => in_progress,
-            x => x.insert(self.row_group_writer_factory.create_row_group_writer(
-                self.writer.schema_descr(),
-                self.writer.properties(),
-                &self.arrow_schema,
-                self.writer.flushed_row_groups().len(),
-            )?),
+            x => x.insert(
+                self.row_group_writer_factory
+                    .create_row_group_writer(self.writer.flushed_row_groups().len())?,
+            ),
         };
 
         // If would exceed max_row_group_size, split batch
@@ -832,6 +835,9 @@ impl ArrowRowGroupWriter {
 /// This is used by [`ArrowWriter`] to create row group writers, but can be used
 /// directly for lower level API.
 pub struct ArrowRowGroupWriterFactory {
+    schema: SchemaDescriptor,
+    arrow_schema: SchemaRef,
+    props: WriterPropertiesPtr,
     #[cfg(feature = "encryption")]
     file_encryptor: Option<Arc<FileEncryptor>>,
 }
@@ -839,51 +845,51 @@ pub struct ArrowRowGroupWriterFactory {
 impl ArrowRowGroupWriterFactory {
     /// Creates a new [`ArrowRowGroupWriterFactory`] using provided [`SerializedFileWriter`].
     #[cfg(feature = "encryption")]
-    pub fn new<W: Write + Send>(file_writer: &SerializedFileWriter<W>) -> Self {
+    pub fn new<W: Write + Send>(
+        file_writer: &SerializedFileWriter<W>,
+        schema: SchemaDescriptor,
+        arrow_schema: SchemaRef,
+        props: WriterPropertiesPtr,
+    ) -> Self {
         Self {
+            schema,
+            arrow_schema,
+            props,
             file_encryptor: file_writer.file_encryptor(),
         }
     }
 
     #[cfg(not(feature = "encryption"))]
-    pub fn new<W: Write + Send>(_file_writer: &SerializedFileWriter<W>) -> Self {
-        Self {}
+    pub fn new<W: Write + Send>(
+        _file_writer: &SerializedFileWriter<W>,
+        schema: SchemaDescriptor,
+        arrow_schema: SchemaRef,
+        props: WriterPropertiesPtr,
+    ) -> Self {
+        Self {
+            schema,
+            arrow_schema,
+            props,
+        }
     }
 
     /// Creates a new [`ArrowRowGroupWriter`] for the given parquet schema and writer properties.
     #[cfg(feature = "encryption")]
-    pub fn create_row_group_writer(
-        &self,
-        parquet: &SchemaDescriptor,
-        props: &WriterPropertiesPtr,
-        arrow: &SchemaRef,
-        row_group_index: usize,
-    ) -> Result<ArrowRowGroupWriter> {
-        let mut writers = Vec::with_capacity(arrow.fields.len());
-        let mut leaves = parquet.columns().iter();
-        let column_factory = ArrowColumnWriterFactory::new()
-            .with_file_encryptor(row_group_index, self.file_encryptor.clone());
-        for field in &arrow.fields {
-            column_factory.get_arrow_column_writer(
-                field.data_type(),
-                props,
-                &mut leaves,
-                &mut writers,
-            )?;
-        }
-        Ok(ArrowRowGroupWriter::new(writers, arrow))
+    pub fn create_row_group_writer(&self, row_group_index: usize) -> Result<ArrowRowGroupWriter> {
+        let writers = get_column_writers_with_encryptor(
+            &self.schema,
+            &self.props,
+            &self.arrow_schema,
+            self.file_encryptor.clone(),
+            row_group_index,
+        )?;
+        Ok(ArrowRowGroupWriter::new(writers, &self.arrow_schema))
     }
 
     #[cfg(not(feature = "encryption"))]
-    pub fn create_row_group_writer(
-        &self,
-        parquet: &SchemaDescriptor,
-        props: &WriterPropertiesPtr,
-        arrow: &SchemaRef,
-        _row_group_index: usize,
-    ) -> Result<ArrowRowGroupWriter> {
-        let writers = get_column_writers(parquet, props, arrow)?;
-        Ok(ArrowRowGroupWriter::new(writers, arrow))
+    pub fn create_row_group_writer(&self, _row_group_index: usize) -> Result<ArrowRowGroupWriter> {
+        let writers = get_column_writers(&self.schema, &self.props, &self.arrow_schema)?;
+        Ok(ArrowRowGroupWriter::new(writers, &self.arrow_schema))
     }
 }
 
@@ -909,7 +915,7 @@ pub fn get_column_writers(
 
 /// Returns the [`ArrowColumnWriter`] for a given schema and supports columnar encryption
 #[cfg(feature = "encryption")]
-pub fn get_column_writers_with_encryptor(
+fn get_column_writers_with_encryptor(
     parquet: &SchemaDescriptor,
     props: &WriterPropertiesPtr,
     arrow: &SchemaRef,
@@ -932,7 +938,7 @@ pub fn get_column_writers_with_encryptor(
 }
 
 /// Gets [`ArrowColumnWriter`] instances for different data types
-pub struct ArrowColumnWriterFactory {
+struct ArrowColumnWriterFactory {
     #[cfg(feature = "encryption")]
     row_group_index: usize,
     #[cfg(feature = "encryption")]
@@ -957,7 +963,7 @@ impl ArrowColumnWriterFactory {
     }
 
     #[cfg(feature = "encryption")]
-    fn with_file_encryptor(
+    pub fn with_file_encryptor(
         mut self,
         row_group_index: usize,
         file_encryptor: Option<Arc<FileEncryptor>>,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -412,8 +412,8 @@ impl<W: Write + Send> ArrowWriter<W> {
         Ok(in_progress.writers)
     }
 
-    /// Append the given column chunks to the current row group.
-    pub fn append_to_row_groups(&mut self, chunks: Vec<ArrowColumnChunk>) -> Result<()> {
+    /// Append the given column chunks to the file as a new row group.
+    pub fn append_row_group(&mut self, chunks: Vec<ArrowColumnChunk>) -> Result<()> {
         let mut row_group_writer = self.writer.next_row_group()?;
         for chunk in chunks {
             chunk.append_to_row_group(&mut row_group_writer)?;

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -183,6 +183,7 @@ pub struct ArrowWriter<W: Write> {
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
+    all_progress: std::collections::BTreeMap<usize, ArrowRowGroupWriter>,
 }
 
 impl<W: Write + Send> std::fmt::Debug for ArrowWriter<W> {
@@ -404,12 +405,13 @@ impl<W: Write + Send> ArrowWriter<W> {
     }
 
     /// Create a new row group writer and return its column writers.
-    pub fn get_column_writers(&mut self) -> Result<Vec<ArrowColumnWriter>> {
+    pub fn get_column_writers(&mut self) -> Result<(usize, Vec<ArrowColumnWriter>)> {
         self.flush()?;
-        let in_progress = self
-            .row_group_writer_factory
-            .create_row_group_writer(self.writer.flushed_row_groups().len())?;
-        Ok(in_progress.writers)
+        let row_group_factory = &self.row_group_writer_factory;
+        let row_group_index = self.writer.flushed_row_groups().len();
+        let in_progress = row_group_factory.create_row_group_writer(row_group_index)?;
+        self.all_progress.insert(row_group_index, in_progress);
+        Ok((row_group_index, self.all_progress.get(&row_group_index).unwrap().writers))
     }
 
     /// Append the given column chunks to the file as a new row group.

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -168,7 +168,7 @@ mod levels;
 /// ```
 pub struct ArrowWriter<W: Write> {
     /// Underlying Parquet writer
-    writer: SerializedFileWriter<W>,
+    pub writer: SerializedFileWriter<W>,
 
     /// The in-progress row group if any
     in_progress: Option<ArrowRowGroupWriter>,

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -183,7 +183,6 @@ pub struct ArrowWriter<W: Write> {
 
     /// The length of arrays to write to each row group
     max_row_group_size: usize,
-    all_progress: std::collections::BTreeMap<usize, ArrowRowGroupWriter>,
 }
 
 impl<W: Write + Send> std::fmt::Debug for ArrowWriter<W> {
@@ -405,18 +404,25 @@ impl<W: Write + Send> ArrowWriter<W> {
     }
 
     /// Create a new row group writer and return its column writers.
-    pub fn get_column_writers(&mut self) -> Result<(usize, Vec<ArrowColumnWriter>)> {
+    pub fn get_column_writers(&mut self) -> Result<(usize, Vec<ArrowColumnWriter>, SerializedRowGroupWriter<W>)> {
         self.flush()?;
         let row_group_factory = &self.row_group_writer_factory;
         let row_group_index = self.writer.flushed_row_groups().len();
         let in_progress = row_group_factory.create_row_group_writer(row_group_index)?;
-        self.all_progress.insert(row_group_index, in_progress);
-        Ok((row_group_index, self.all_progress.get(&row_group_index).unwrap().writers))
+        let serialized_row_group_writer = self.writer.next_row_group()?;
+        Ok((row_group_index, in_progress.writers, serialized_row_group_writer))
+    }
+
+    /// Returns the ArrowRowGroupWriterFactory used bt this ArrowWriter.
+    pub fn get_row_group_writer_factory(self) -> ArrowRowGroupWriterFactory {
+        self.row_group_writer_factory
     }
 
     /// Append the given column chunks to the file as a new row group.
-    pub fn append_row_group(&mut self, chunks: Vec<ArrowColumnChunk>) -> Result<()> {
-        let mut row_group_writer = self.writer.next_row_group()?;
+    pub fn append_row_group(
+        chunks: Vec<ArrowColumnChunk>,
+        mut row_group_writer: SerializedRowGroupWriter<W>,
+    ) -> Result<()> {
         for chunk in chunks {
             chunk.append_to_row_group(&mut row_group_writer)?;
         }
@@ -848,7 +854,9 @@ impl ArrowRowGroupWriter {
     }
 }
 
-struct ArrowRowGroupWriterFactory {
+/// ArrowRowGroupWriterFactory can be used for creating new [`ArrowRowGroupWriter`] instances
+/// for each row group in the Parquet file.
+pub struct ArrowRowGroupWriterFactory {
     schema: SchemaDescriptor,
     arrow_schema: SchemaRef,
     props: WriterPropertiesPtr,
@@ -887,7 +895,7 @@ impl ArrowRowGroupWriterFactory {
     }
 
     #[cfg(feature = "encryption")]
-    fn create_row_group_writer(&self, row_group_index: usize) -> Result<ArrowRowGroupWriter> {
+    pub fn create_row_group_writer(&self, row_group_index: usize) -> Result<ArrowRowGroupWriter> {
         let writers = get_column_writers_with_encryptor(
             &self.schema,
             &self.props,
@@ -902,6 +910,13 @@ impl ArrowRowGroupWriterFactory {
     fn create_row_group_writer(&self, _row_group_index: usize) -> Result<ArrowRowGroupWriter> {
         let writers = get_column_writers(&self.schema, &self.props, &self.arrow_schema)?;
         Ok(ArrowRowGroupWriter::new(writers, &self.arrow_schema))
+    }
+
+    /// Create a new row group writer and return its column writers.
+    pub fn get_column_writers(&mut self, row_group_index: usize) -> Result<Vec<ArrowColumnWriter>> {
+        // let row_group_index = self.writer.flushed_row_groups().len();
+        let in_progress = self.create_row_group_writer(row_group_index)?;
+        Ok(in_progress.writers)
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -413,7 +413,7 @@ impl<W: Write + Send> ArrowWriter<W> {
         Ok((row_group_index, in_progress.writers, serialized_row_group_writer))
     }
 
-    /// Returns the ArrowRowGroupWriterFactory used bt this ArrowWriter.
+    /// Returns the ArrowRowGroupWriterFactory used by this ArrowWriter.
     pub fn get_row_group_writer_factory(self) -> ArrowRowGroupWriterFactory {
         self.row_group_writer_factory
     }
@@ -429,6 +429,14 @@ impl<W: Write + Send> ArrowWriter<W> {
         row_group_writer.close()?;
         Ok(())
     }
+    // pub fn append_row_group(&mut self, chunks: Vec<ArrowColumnChunk>) -> Result<()> {
+    //     let mut row_group_writer = self.writer.next_row_group()?;
+    //     for chunk in chunks {
+    //         chunk.append_to_row_group(&mut row_group_writer)?;
+    //     }
+    //     row_group_writer.close()?;
+    //     Ok(())
+    // }
 }
 
 impl<W: Write + Send> RecordBatchWriter for ArrowWriter<W> {

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -288,14 +288,14 @@ impl EncryptionPropertiesBuilder {
 
 #[derive(Debug)]
 /// The encryption configuration for a single Parquet file
-pub(crate) struct FileEncryptor {
+pub struct FileEncryptor {
     properties: FileEncryptionProperties,
     aad_file_unique: Vec<u8>,
     file_aad: Vec<u8>,
 }
 
 impl FileEncryptor {
-    pub(crate) fn new(properties: FileEncryptionProperties) -> Result<Self> {
+    pub fn new(properties: FileEncryptionProperties) -> Result<Self> {
         // Generate unique AAD for file
         let rng = SystemRandom::new();
         let mut aad_file_unique = vec![0u8; 8];

--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -288,14 +288,14 @@ impl EncryptionPropertiesBuilder {
 
 #[derive(Debug)]
 /// The encryption configuration for a single Parquet file
-pub struct FileEncryptor {
+pub(crate) struct FileEncryptor {
     properties: FileEncryptionProperties,
     aad_file_unique: Vec<u8>,
     file_aad: Vec<u8>,
 }
 
 impl FileEncryptor {
-    pub fn new(properties: FileEncryptionProperties) -> Result<Self> {
+    pub(crate) fn new(properties: FileEncryptionProperties) -> Result<Self> {
         // Generate unique AAD for file
         let rng = SystemRandom::new();
         let mut aad_file_unique = vec![0u8; 8];

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -457,7 +457,7 @@ pub struct WriterPropertiesBuilder {
 
 impl WriterPropertiesBuilder {
     /// Returns default state of the builder.
-    fn with_defaults() -> Self {
+    pub fn with_defaults() -> Self {
         Self {
             data_page_size_limit: DEFAULT_PAGE_SIZE,
             data_page_row_count_limit: DEFAULT_DATA_PAGE_ROW_COUNT_LIMIT,

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -190,7 +190,7 @@ impl WriterProperties {
     /// Returns a new default [`WriterPropertiesBuilder`] for creating writer
     /// properties.
     pub fn builder() -> WriterPropertiesBuilder {
-        WriterPropertiesBuilder::with_defaults()
+        WriterPropertiesBuilder::default()
     }
 
     /// Returns data page size limit.
@@ -455,9 +455,9 @@ pub struct WriterPropertiesBuilder {
     file_encryption_properties: Option<FileEncryptionProperties>,
 }
 
-impl WriterPropertiesBuilder {
+impl Default for WriterPropertiesBuilder {
     /// Returns default state of the builder.
-    pub fn with_defaults() -> Self {
+    fn default() -> Self {
         Self {
             data_page_size_limit: DEFAULT_PAGE_SIZE,
             data_page_row_count_limit: DEFAULT_DATA_PAGE_ROW_COUNT_LIMIT,
@@ -478,7 +478,9 @@ impl WriterPropertiesBuilder {
             file_encryption_properties: None,
         }
     }
+}
 
+impl WriterPropertiesBuilder {
     /// Finalizes the configuration and returns immutable writer properties struct.
     pub fn build(self) -> WriterProperties {
         WriterProperties {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -433,7 +433,7 @@ impl<W: Write + Send> SerializedFileWriter<W> {
 
     /// Get the file encryptor used by this instance to encrypt data
     #[cfg(feature = "encryption")]
-    pub fn file_encryptor(&self) -> Option<Arc<FileEncryptor>> {
+    pub(crate) fn file_encryptor(&self) -> Option<Arc<FileEncryptor>> {
         self.file_encryptor.clone()
     }
 }

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -433,7 +433,7 @@ impl<W: Write + Send> SerializedFileWriter<W> {
 
     /// Get the file encryptor used by this instance to encrypt data
     #[cfg(feature = "encryption")]
-    pub(crate) fn file_encryptor(&self) -> Option<Arc<FileEncryptor>> {
+    pub fn file_encryptor(&self) -> Option<Arc<FileEncryptor>> {
         self.file_encryptor.clone()
     }
 }

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -486,7 +486,7 @@ fn write_bloom_filters<W: Write + Send>(
 ///   more columns are available to write.
 /// - Once done writing a column, close column writer with `close`
 /// - Once all columns have been written, close row group writer with `close`
-///   method. THe close method will return row group metadata and is no-op
+///   method. The close method will return row group metadata and is no-op
 ///   on already closed row group.
 pub struct SerializedRowGroupWriter<'a, W: Write> {
     descr: SchemaDescPtr,

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -1153,9 +1153,14 @@ async fn test_multi_threaded_encrypted_writing() {
     let mut file_writer =
         SerializedFileWriter::new(&temp_file, root_schema.clone(), props.clone()).unwrap();
 
-    let arrow_row_group_writer_factory = ArrowRowGroupWriterFactory::new(&file_writer);
+    let arrow_row_group_writer_factory = ArrowRowGroupWriterFactory::new(
+        &file_writer,
+        parquet_schema,
+        schema.clone(),
+        props.clone(),
+    );
     let arrow_row_group_writer = arrow_row_group_writer_factory
-        .create_row_group_writer(&parquet_schema, &props, &schema, 0)
+        .create_row_group_writer(0)
         .unwrap();
 
     // Get column writers with encryptor from ArrowRowGroupWriter

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -1155,7 +1155,7 @@ async fn test_multi_threaded_encrypted_writing() {
 
     let arrow_row_group_writer_factory = ArrowRowGroupWriterFactory::new(&file_writer);
     let arrow_row_group_writer = arrow_row_group_writer_factory
-        .create_row_group_writer(&parquet_schema, &props.clone(), &schema, 0)
+        .create_row_group_writer(&parquet_schema, &props, &schema, 0)
         .unwrap();
 
     // Get column writers with encryptor from ArrowRowGroupWriter

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -1186,6 +1186,9 @@ async fn test_multi_threaded_encrypted_writing() {
     assert_eq!(metadata.num_rows, 0);
     assert_eq!(metadata.schema, metadata.schema);
 
+    // TODO: Test inserting via high-level API and low-level API in the same
+    // file writer, and check that data and the footer are written correctly.
+
     // Check that the file was written correctly
     let (read_record_batches, read_metadata) =
         read_encrypted_file(&path, decryption_properties.clone()).unwrap();

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -18,7 +18,8 @@
 //! This module contains tests for reading encrypted Parquet files with the Arrow API
 
 use crate::encryption_util::{
-    verify_column_indexes, verify_encryption_test_data, TestKeyRetriever,
+    read_and_roundtrip_to_encrypted_file, verify_column_indexes, verify_encryption_test_file_read,
+    TestKeyRetriever,
 };
 use arrow::array::*;
 use arrow::error::Result as ArrowResult;
@@ -28,14 +29,13 @@ use parquet::arrow::arrow_reader::{
     ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder, RowSelection,
     RowSelector,
 };
-use parquet::arrow::arrow_writer::{compute_leaves, ArrowLeafColumn};
 use parquet::arrow::ArrowWriter;
 use parquet::data_type::{ByteArray, ByteArrayType};
 use parquet::encryption::decrypt::FileDecryptionProperties;
 use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::errors::ParquetError;
 use parquet::file::metadata::ParquetMetaData;
-use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
+use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::parser::parse_message_type;
 use std::fs::File;
@@ -376,21 +376,6 @@ fn test_uniform_encryption_with_key_retriever() {
             .unwrap();
 
     verify_encryption_test_file_read(file, decryption_properties);
-}
-
-fn verify_encryption_test_file_read(file: File, decryption_properties: FileDecryptionProperties) {
-    let options =
-        ArrowReaderOptions::default().with_file_decryption_properties(decryption_properties);
-    let reader_metadata = ArrowReaderMetadata::load(&file, options.clone()).unwrap();
-    let metadata = reader_metadata.metadata();
-
-    let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(file, options).unwrap();
-    let record_reader = builder.build().unwrap();
-    let record_batches = record_reader
-        .map(|x| x.unwrap())
-        .collect::<Vec<RecordBatch>>();
-
-    verify_encryption_test_data(record_batches, metadata);
 }
 
 fn row_group_sizes(metadata: &ParquetMetaData) -> Vec<i64> {
@@ -1063,218 +1048,4 @@ fn test_decrypt_page_index(
     verify_column_indexes(arrow_metadata.metadata());
 
     Ok(())
-}
-
-fn read_encrypted_file(
-    file: &File,
-    decryption_properties: FileDecryptionProperties,
-) -> Result<(Vec<RecordBatch>, ArrowReaderMetadata), ParquetError> {
-    let options = ArrowReaderOptions::default()
-        .with_file_decryption_properties(decryption_properties.clone());
-    let metadata = ArrowReaderMetadata::load(file, options.clone())?;
-
-    let builder =
-        ParquetRecordBatchReaderBuilder::try_new_with_options(file.try_clone().unwrap(), options)?;
-    let batch_reader = builder.build()?;
-    let batches = batch_reader.collect::<parquet::errors::Result<Vec<RecordBatch>, _>>()?;
-    Ok((batches, metadata))
-}
-
-fn read_and_roundtrip_to_encrypted_file(
-    file: &File,
-    decryption_properties: FileDecryptionProperties,
-    encryption_properties: FileEncryptionProperties,
-) {
-    // read example data
-    let (batches, metadata) = read_encrypted_file(file, decryption_properties.clone()).unwrap();
-
-    // write example data to a temporary file
-    let temp_file = tempfile::tempfile().unwrap();
-    let props = WriterProperties::builder()
-        .with_file_encryption_properties(encryption_properties)
-        .build();
-
-    let mut writer = ArrowWriter::try_new(
-        temp_file.try_clone().unwrap(),
-        metadata.schema().clone(),
-        Some(props),
-    )
-    .unwrap();
-    for batch in batches {
-        writer.write(&batch).unwrap();
-    }
-
-    writer.close().unwrap();
-
-    // check re-written example data
-    verify_encryption_test_file_read(temp_file, decryption_properties);
-}
-
-#[tokio::test]
-async fn test_multi_threaded_encrypted_writing() {
-    // Read example data and set up encryption/decryption properties
-    let testdata = arrow::util::test_util::parquet_test_data();
-    let path = format!("{testdata}/encrypt_columns_and_footer.parquet.encrypted");
-    let file = File::open(path).unwrap();
-
-    let file_encryption_properties = FileEncryptionProperties::builder(b"0123456789012345".into())
-        .with_column_key("double_field", b"1234567890123450".into())
-        .with_column_key("float_field", b"1234567890123451".into())
-        .build()
-        .unwrap();
-    let decryption_properties = FileDecryptionProperties::builder(b"0123456789012345".into())
-        .with_column_key("double_field", b"1234567890123450".into())
-        .with_column_key("float_field", b"1234567890123451".into())
-        .build()
-        .unwrap();
-
-    let (record_batches, metadata) =
-        read_encrypted_file(&file, decryption_properties.clone()).unwrap();
-    let to_write: Vec<_> = record_batches
-        .iter()
-        .flat_map(|rb| rb.columns().to_vec())
-        .collect();
-    let schema = metadata.schema().clone();
-
-    let props = Some(
-        WriterPropertiesBuilder::default()
-            .with_file_encryption_properties(file_encryption_properties)
-            .build(),
-    );
-
-    // Create a temporary file to write the encrypted data
-    let temp_file = tempfile::tempfile().unwrap();
-    let mut writer = ArrowWriter::try_new(&temp_file, metadata.schema().clone(), props).unwrap();
-
-    // LOW-LEVEL API: Use low level API to write into a file using multiple threads
-
-    // Get column writers
-    let col_writers = writer.get_column_writers().unwrap();
-    let num_columns = col_writers.len();
-
-    // Create a channel for each column writer to send ArrowLeafColumn data to
-    let mut col_writer_tasks = Vec::with_capacity(num_columns);
-    let mut col_array_channels = Vec::with_capacity(num_columns);
-    for mut col_writer in col_writers.into_iter() {
-        let (send_array, mut receive_array) = tokio::sync::mpsc::channel::<ArrowLeafColumn>(100);
-        col_array_channels.push(send_array);
-        let handle = tokio::spawn(async move {
-            while let Some(col) = receive_array.recv().await {
-                col_writer.write(&col).unwrap();
-            }
-            col_writer.close().unwrap()
-        });
-        col_writer_tasks.push(handle);
-    }
-
-    // Send the ArrowLeafColumn data to the respective column writer channels
-    let mut worker_iter = col_array_channels.iter_mut();
-    for (array, field) in to_write.iter().zip(schema.fields()) {
-        for leaves in compute_leaves(field, array).unwrap() {
-            worker_iter.next().unwrap().send(leaves).await.unwrap();
-        }
-    }
-    drop(col_array_channels);
-
-    // Wait for all column writers to finish writing
-    let mut finalized_rg = Vec::with_capacity(num_columns);
-    for task in col_writer_tasks.into_iter() {
-        finalized_rg.push(task.await.unwrap());
-    }
-
-    // Append the finalized row group to the SerializedFileWriter
-    assert!(writer.append_row_group(finalized_rg).is_ok());
-
-    // HIGH-LEVEL API: Write RecordBatches into the file using ArrowWriter
-
-    // Write individual RecordBatches into the file
-    for rb in record_batches {
-        writer.write(&rb).unwrap()
-    }
-    assert!(writer.flush().is_ok());
-
-    // Close the file writer which writes the footer
-    let metadata = writer.finish().unwrap();
-    assert_eq!(metadata.num_rows, 100);
-    assert_eq!(metadata.schema, metadata.schema);
-
-    // Check that the file was written correctly
-    let (read_record_batches, read_metadata) =
-        read_encrypted_file(&temp_file, decryption_properties.clone()).unwrap();
-
-    let file_metadata = read_metadata.metadata().file_metadata();
-    assert_eq!(file_metadata.num_rows(), 100);
-    assert_eq!(file_metadata.schema_descr().num_columns(), 8);
-
-    read_metadata.metadata().row_groups().iter().for_each(|rg| {
-        assert_eq!(rg.num_columns(), 8);
-        assert_eq!(rg.num_rows(), 50);
-    });
-
-    let mut row_count = 0;
-    let wrap_at = 50;
-    for batch in read_record_batches {
-        let batch = batch;
-        row_count += batch.num_rows();
-
-        let bool_col = batch.column(0).as_boolean();
-        let time_col = batch
-            .column(1)
-            .as_primitive::<types::Time32MillisecondType>();
-        let list_col = batch.column(2).as_list::<i32>();
-        let timestamp_col = batch
-            .column(3)
-            .as_primitive::<types::TimestampNanosecondType>();
-        let f32_col = batch.column(4).as_primitive::<types::Float32Type>();
-        let f64_col = batch.column(5).as_primitive::<types::Float64Type>();
-        let binary_col = batch.column(6).as_binary::<i32>();
-        let fixed_size_binary_col = batch.column(7).as_fixed_size_binary();
-
-        for (i, x) in bool_col.iter().enumerate() {
-            assert_eq!(x.unwrap(), i % 2 == 0);
-        }
-        for (i, x) in time_col.iter().enumerate() {
-            assert_eq!(x.unwrap(), (i % wrap_at) as i32);
-        }
-        for (i, list_item) in list_col.iter().enumerate() {
-            let list_item = list_item.unwrap();
-            let list_item = list_item.as_primitive::<types::Int64Type>();
-            assert_eq!(list_item.len(), 2);
-            assert_eq!(
-                list_item.value(0),
-                (((i % wrap_at) * 2) * 1000000000000) as i64
-            );
-            assert_eq!(
-                list_item.value(1),
-                (((i % wrap_at) * 2 + 1) * 1000000000000) as i64
-            );
-        }
-        for x in timestamp_col.iter() {
-            assert!(x.is_some());
-        }
-        for (i, x) in f32_col.iter().enumerate() {
-            assert_eq!(x.unwrap(), (i % wrap_at) as f32 * 1.1f32);
-        }
-        for (i, x) in f64_col.iter().enumerate() {
-            assert_eq!(x.unwrap(), (i % wrap_at) as f64 * 1.1111111f64);
-        }
-        for (i, x) in binary_col.iter().enumerate() {
-            assert_eq!(x.is_some(), i % 2 == 0);
-            if let Some(x) = x {
-                assert_eq!(&x[0..7], b"parquet");
-            }
-        }
-        for (i, x) in fixed_size_binary_col.iter().enumerate() {
-            assert_eq!(x.unwrap(), &[(i % wrap_at) as u8; 10]);
-        }
-    }
-
-    assert_eq!(row_count, file_metadata.num_rows() as usize);
-
-    // Check that file was encrypted
-    let result = ArrowReaderMetadata::load(&temp_file, ArrowReaderOptions::default());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "Parquet error: Parquet file has an encrypted footer but decryption properties were not provided"
-    );
 }

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -1136,7 +1136,7 @@ async fn test_multi_threaded_encrypted_writing() {
     let schema = metadata.schema().clone();
 
     let props = Some(
-        WriterPropertiesBuilder::with_defaults()
+        WriterPropertiesBuilder::default()
             .with_file_encryption_properties(file_encryption_properties)
             .build(),
     );

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -532,7 +532,7 @@ async fn test_multi_threaded_encrypted_writing() {
     // LOW-LEVEL API: Use low level API to write into a file using multiple threads
 
     // Get column writers
-    let col_writers = writer.get_column_writers().unwrap();
+    let (_row_group_index, col_writers) = writer.get_column_writers().unwrap();
     let num_columns = col_writers.len();
 
     // Create a channel for each column writer to send ArrowLeafColumn data to

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -20,7 +20,6 @@
 use crate::encryption_util::{
     verify_column_indexes, verify_encryption_test_data, TestKeyRetriever,
 };
-use arrow_array::RecordBatch;
 use futures::TryStreamExt;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::arrow_writer::ArrowWriterOptions;
@@ -437,13 +436,14 @@ async fn test_decrypt_page_index(
     Ok(())
 }
 
-async fn read_encrypted_file_async(
+async fn verify_encryption_test_file_read_async(
     file: &mut tokio::fs::File,
     decryption_properties: FileDecryptionProperties,
-) -> Result<(Vec<RecordBatch>, ArrowReaderMetadata), ParquetError> {
+) -> Result<(), ParquetError> {
     let options = ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties);
 
     let arrow_metadata = ArrowReaderMetadata::load_async(file, options).await?;
+    let metadata = arrow_metadata.metadata();
 
     let record_reader = ParquetRecordBatchStreamBuilder::new_with_metadata(
         file.try_clone().await?,
@@ -451,15 +451,8 @@ async fn read_encrypted_file_async(
     )
     .build()?;
     let record_batches = record_reader.try_collect::<Vec<_>>().await?;
-    Ok((record_batches, arrow_metadata.clone()))
-}
 
-async fn verify_encryption_test_file_read_async(
-    file: &mut tokio::fs::File,
-    decryption_properties: FileDecryptionProperties,
-) -> Result<(), ParquetError> {
-    let (record_batches, metadata) = read_encrypted_file_async(file, decryption_properties).await?;
-    verify_encryption_test_data(record_batches, metadata.metadata());
+    verify_encryption_test_data(record_batches, metadata);
     Ok(())
 }
 
@@ -471,8 +464,15 @@ async fn read_and_roundtrip_to_encrypted_file_async(
     let temp_file = tempfile::tempfile().unwrap();
     let mut file = File::open(&path).await.unwrap();
 
-    let (record_batches, arrow_metadata) =
-        read_encrypted_file_async(&mut file, decryption_properties.clone()).await?;
+    let options =
+        ArrowReaderOptions::new().with_file_decryption_properties(decryption_properties.clone());
+    let arrow_metadata = ArrowReaderMetadata::load_async(&mut file, options).await?;
+    let record_reader = ParquetRecordBatchStreamBuilder::new_with_metadata(
+        file.try_clone().await?,
+        arrow_metadata.clone(),
+    )
+    .build()?;
+    let record_batches = record_reader.try_collect::<Vec<_>>().await?;
 
     let props = WriterProperties::builder()
         .with_file_encryption_properties(encryption_properties)

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -18,17 +18,18 @@
 //! This module contains tests for reading encrypted Parquet files with the async Arrow API
 
 use crate::encryption_util::{
-    verify_column_indexes, verify_encryption_test_data, TestKeyRetriever,
+    read_encrypted_file, verify_column_indexes, verify_encryption_double_test_data,
+    verify_encryption_test_data, TestKeyRetriever,
 };
 use futures::TryStreamExt;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
-use parquet::arrow::arrow_writer::ArrowWriterOptions;
-use parquet::arrow::AsyncArrowWriter;
+use parquet::arrow::arrow_writer::{compute_leaves, ArrowLeafColumn, ArrowWriterOptions};
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::{ArrowWriter, AsyncArrowWriter};
 use parquet::encryption::decrypt::FileDecryptionProperties;
 use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::errors::ParquetError;
-use parquet::file::properties::WriterProperties;
+use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use std::sync::Arc;
 use tokio::fs::File;
 
@@ -490,4 +491,105 @@ async fn read_and_roundtrip_to_encrypted_file_async(
 
     let mut file = tokio::fs::File::from_std(temp_file.try_clone().unwrap());
     verify_encryption_test_file_read_async(&mut file, decryption_properties).await
+}
+
+#[tokio::test]
+async fn test_multi_threaded_encrypted_writing() {
+    // Read example data and set up encryption/decryption properties
+    let testdata = arrow::util::test_util::parquet_test_data();
+    let path = format!("{testdata}/encrypt_columns_and_footer.parquet.encrypted");
+    let file = std::fs::File::open(path).unwrap();
+
+    let file_encryption_properties = FileEncryptionProperties::builder(b"0123456789012345".into())
+        .with_column_key("double_field", b"1234567890123450".into())
+        .with_column_key("float_field", b"1234567890123451".into())
+        .build()
+        .unwrap();
+    let decryption_properties = FileDecryptionProperties::builder(b"0123456789012345".into())
+        .with_column_key("double_field", b"1234567890123450".into())
+        .with_column_key("float_field", b"1234567890123451".into())
+        .build()
+        .unwrap();
+
+    let (record_batches, metadata) =
+        read_encrypted_file(&file, decryption_properties.clone()).unwrap();
+    let to_write: Vec<_> = record_batches
+        .iter()
+        .flat_map(|rb| rb.columns().to_vec())
+        .collect();
+    let schema = metadata.schema().clone();
+
+    let props = Some(
+        WriterPropertiesBuilder::default()
+            .with_file_encryption_properties(file_encryption_properties)
+            .build(),
+    );
+
+    // Create a temporary file to write the encrypted data
+    let temp_file = tempfile::tempfile().unwrap();
+    let mut writer = ArrowWriter::try_new(&temp_file, metadata.schema().clone(), props).unwrap();
+
+    // LOW-LEVEL API: Use low level API to write into a file using multiple threads
+
+    // Get column writers
+    let col_writers = writer.get_column_writers().unwrap();
+    let num_columns = col_writers.len();
+
+    // Create a channel for each column writer to send ArrowLeafColumn data to
+    let mut col_writer_tasks = Vec::with_capacity(num_columns);
+    let mut col_array_channels = Vec::with_capacity(num_columns);
+    for mut col_writer in col_writers.into_iter() {
+        let (send_array, mut receive_array) = tokio::sync::mpsc::channel::<ArrowLeafColumn>(100);
+        col_array_channels.push(send_array);
+        let handle = tokio::spawn(async move {
+            while let Some(col) = receive_array.recv().await {
+                col_writer.write(&col).unwrap();
+            }
+            col_writer.close().unwrap()
+        });
+        col_writer_tasks.push(handle);
+    }
+
+    // Send the ArrowLeafColumn data to the respective column writer channels
+    let mut worker_iter = col_array_channels.iter_mut();
+    for (array, field) in to_write.iter().zip(schema.fields()) {
+        for leaves in compute_leaves(field, array).unwrap() {
+            worker_iter.next().unwrap().send(leaves).await.unwrap();
+        }
+    }
+    drop(col_array_channels);
+
+    // Wait for all column writers to finish writing
+    let mut finalized_rg = Vec::with_capacity(num_columns);
+    for task in col_writer_tasks.into_iter() {
+        finalized_rg.push(task.await.unwrap());
+    }
+
+    // Append the finalized row group to the SerializedFileWriter
+    assert!(writer.append_row_group(finalized_rg).is_ok());
+
+    // HIGH-LEVEL API: Write RecordBatches into the file using ArrowWriter
+
+    // Write individual RecordBatches into the file
+    for rb in record_batches {
+        writer.write(&rb).unwrap()
+    }
+    assert!(writer.flush().is_ok());
+
+    // Close the file writer which writes the footer
+    let metadata = writer.finish().unwrap();
+    assert_eq!(metadata.num_rows, 100);
+    assert_eq!(metadata.schema, metadata.schema);
+
+    // Check that the file was written correctly
+    let (read_record_batches, read_metadata) =
+        read_encrypted_file(&temp_file, decryption_properties.clone()).unwrap();
+    verify_encryption_double_test_data(read_record_batches, read_metadata.metadata());
+
+    // Check that file was encrypted
+    let result = ArrowReaderMetadata::load(&temp_file, ArrowReaderOptions::default());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Parquet error: Parquet file has an encrypted footer but decryption properties were not provided"
+    );
 }

--- a/parquet/tests/encryption/encryption_util.rs
+++ b/parquet/tests/encryption/encryption_util.rs
@@ -17,14 +17,98 @@
 
 use arrow_array::cast::AsArray;
 use arrow_array::{types, RecordBatch};
-use parquet::encryption::decrypt::KeyRetriever;
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
+};
+use parquet::arrow::ArrowWriter;
+use parquet::encryption::decrypt::{FileDecryptionProperties, KeyRetriever};
+use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::errors::{ParquetError, Result};
 use parquet::file::metadata::ParquetMetaData;
+use parquet::file::properties::WriterProperties;
 use std::collections::HashMap;
+use std::fs::File;
 use std::sync::Mutex;
 
+pub(crate) fn verify_encryption_double_test_data(
+    record_batches: Vec<RecordBatch>,
+    metadata: &ParquetMetaData,
+) {
+    let file_metadata = metadata.file_metadata();
+    assert_eq!(file_metadata.num_rows(), 100);
+    assert_eq!(file_metadata.schema_descr().num_columns(), 8);
+
+    metadata.row_groups().iter().for_each(|rg| {
+        assert_eq!(rg.num_columns(), 8);
+        assert_eq!(rg.num_rows(), 50);
+    });
+
+    let mut row_count = 0;
+    let wrap_at = 50;
+    for batch in record_batches {
+        let batch = batch;
+        row_count += batch.num_rows();
+
+        let bool_col = batch.column(0).as_boolean();
+        let time_col = batch
+            .column(1)
+            .as_primitive::<types::Time32MillisecondType>();
+        let list_col = batch.column(2).as_list::<i32>();
+        let timestamp_col = batch
+            .column(3)
+            .as_primitive::<types::TimestampNanosecondType>();
+        let f32_col = batch.column(4).as_primitive::<types::Float32Type>();
+        let f64_col = batch.column(5).as_primitive::<types::Float64Type>();
+        let binary_col = batch.column(6).as_binary::<i32>();
+        let fixed_size_binary_col = batch.column(7).as_fixed_size_binary();
+
+        for (i, x) in bool_col.iter().enumerate() {
+            assert_eq!(x.unwrap(), i % 2 == 0);
+        }
+        for (i, x) in time_col.iter().enumerate() {
+            assert_eq!(x.unwrap(), (i % wrap_at) as i32);
+        }
+        for (i, list_item) in list_col.iter().enumerate() {
+            let list_item = list_item.unwrap();
+            let list_item = list_item.as_primitive::<types::Int64Type>();
+            assert_eq!(list_item.len(), 2);
+            assert_eq!(
+                list_item.value(0),
+                (((i % wrap_at) * 2) * 1000000000000) as i64
+            );
+            assert_eq!(
+                list_item.value(1),
+                (((i % wrap_at) * 2 + 1) * 1000000000000) as i64
+            );
+        }
+        for x in timestamp_col.iter() {
+            assert!(x.is_some());
+        }
+        for (i, x) in f32_col.iter().enumerate() {
+            assert_eq!(x.unwrap(), (i % wrap_at) as f32 * 1.1f32);
+        }
+        for (i, x) in f64_col.iter().enumerate() {
+            assert_eq!(x.unwrap(), (i % wrap_at) as f64 * 1.1111111f64);
+        }
+        for (i, x) in binary_col.iter().enumerate() {
+            assert_eq!(x.is_some(), i % 2 == 0);
+            if let Some(x) = x {
+                assert_eq!(&x[0..7], b"parquet");
+            }
+        }
+        for (i, x) in fixed_size_binary_col.iter().enumerate() {
+            assert_eq!(x.unwrap(), &[(i % wrap_at) as u8; 10]);
+        }
+    }
+
+    assert_eq!(row_count, file_metadata.num_rows() as usize);
+}
+
 /// Verifies data read from an encrypted file from the parquet-testing repository
-pub fn verify_encryption_test_data(record_batches: Vec<RecordBatch>, metadata: &ParquetMetaData) {
+pub(crate) fn verify_encryption_test_data(
+    record_batches: Vec<RecordBatch>,
+    metadata: &ParquetMetaData,
+) {
     let file_metadata = metadata.file_metadata();
     assert_eq!(file_metadata.num_rows(), 50);
     assert_eq!(file_metadata.schema_descr().num_columns(), 8);
@@ -90,7 +174,7 @@ pub fn verify_encryption_test_data(record_batches: Vec<RecordBatch>, metadata: &
 
 /// Verifies that the column and offset indexes were successfully read from an
 /// encrypted test file.
-pub fn verify_column_indexes(metadata: &ParquetMetaData) {
+pub(crate) fn verify_column_indexes(metadata: &ParquetMetaData) {
     let offset_index = metadata.offset_index().unwrap();
     // 1 row group, 8 columns
     assert_eq!(offset_index.len(), 1);
@@ -118,6 +202,69 @@ pub fn verify_column_indexes(metadata: &ParquetMetaData) {
             panic!("Expected a float column index for column {float_col_idx}");
         }
     };
+}
+
+pub(crate) fn read_encrypted_file(
+    file: &File,
+    decryption_properties: FileDecryptionProperties,
+) -> std::result::Result<(Vec<RecordBatch>, ArrowReaderMetadata), ParquetError> {
+    let options = ArrowReaderOptions::default()
+        .with_file_decryption_properties(decryption_properties.clone());
+    let metadata = ArrowReaderMetadata::load(file, options.clone())?;
+
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new_with_options(file.try_clone().unwrap(), options)?;
+    let batch_reader = builder.build()?;
+    let batches = batch_reader.collect::<Result<Vec<RecordBatch>, _>>()?;
+    Ok((batches, metadata))
+}
+
+pub(crate) fn read_and_roundtrip_to_encrypted_file(
+    file: &File,
+    decryption_properties: FileDecryptionProperties,
+    encryption_properties: FileEncryptionProperties,
+) {
+    // read example data
+    let (batches, metadata) = read_encrypted_file(file, decryption_properties.clone()).unwrap();
+
+    // write example data to a temporary file
+    let temp_file = tempfile::tempfile().unwrap();
+    let props = WriterProperties::builder()
+        .with_file_encryption_properties(encryption_properties)
+        .build();
+
+    let mut writer = ArrowWriter::try_new(
+        temp_file.try_clone().unwrap(),
+        metadata.schema().clone(),
+        Some(props),
+    )
+    .unwrap();
+    for batch in batches {
+        writer.write(&batch).unwrap();
+    }
+
+    writer.close().unwrap();
+
+    // check re-written example data
+    verify_encryption_test_file_read(temp_file, decryption_properties);
+}
+
+pub(crate) fn verify_encryption_test_file_read(
+    file: File,
+    decryption_properties: FileDecryptionProperties,
+) {
+    let options =
+        ArrowReaderOptions::default().with_file_decryption_properties(decryption_properties);
+    let reader_metadata = ArrowReaderMetadata::load(&file, options.clone()).unwrap();
+    let metadata = reader_metadata.metadata();
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(file, options).unwrap();
+    let record_reader = builder.build().unwrap();
+    let record_batches = record_reader
+        .map(|x| x.unwrap())
+        .collect::<Vec<RecordBatch>>();
+
+    verify_encryption_test_data(record_batches, metadata);
 }
 
 /// A KeyRetriever to use in Parquet encryption tests,


### PR DESCRIPTION
- Closes #8115.

# Rationale for this change

See #8115.

# What changes are included in this PR?

TBD.

# Are these changes tested?

This includes a datafusion inspired test for concurrent writting accross columns and row groups.

# Are there any user-facing changes?

TBD.