### PR TITLE
[Variant] Object builder detects duplicate fields immediately

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -929,13 +929,10 @@ impl ParentState<'_> {
 /// use parquet_variant::VariantBuilder;
 ///
 /// let mut builder = VariantBuilder::new().with_validate_unique_fields(true);
-/// let mut obj = builder.new_object();
-///
-/// obj.insert("a", 1);
-/// obj.insert("a", 2); // duplicate field
-///
-/// // When validation is enabled, finish will return an error
-/// let result = obj.finish(); // returns Err
+/// let result = builder
+///     .new_object();
+///     .with_field("a", 1)
+///     .try_with_field("a", 2); // duplicate field
 /// assert!(result.is_err());
 /// ```
 ///


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/8171
- Related to https://github.com/apache/arrow-rs/issues/8170

# Rationale for this change

It's cleaner to report duplicate field names immediately, rather than doing extra work to collect them and wait for `finish` before reporting the error.

# What changes are included in this PR?

Remove the duplicate field set from the object builder and report the error directly instead.

NOTE: This does _not_ fix the existing bug that sub-list and sub-object builders did not even attempt to check for duplicates. Upcoming changes to harmonize builder rollback will fix that as a side effect.

# Are these changes tested?

Yes, updated unit tests show the new behavior (and expose the pre-existing bug that will be fixed later)

# Are there any user-facing changes?

`ObjectBuilder::try_insert` and `ObjectBuilder::try_with_field` now return errors on duplicate (they were already fallible methods). Their infallible counterparts will now panic in case of a duplicate.