### PR TITLE
Pin nightly rust version to fix failing MIRI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,10 +42,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true
-      - name: Install python dev
-        run: |
-          apt update
-          apt install -y libpython3.11-dev
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - name: Install Nightly Rust


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/8181

# Rationale for this change

I am trying to get CI clean on main in preparation for a release, but sadly the MIRI job started failing with an internal (rust) compiler error

I believe this is due to the fact we are using bleeding edge rust (nightly)

# What changes are included in this PR?

Temporarily pin the MIRI job to use nightly from last night rather than now

# Are these changes tested?

Yes by CI

# Are there any user-facing changes?

No