### PR TITLE
[thrift-remodel] Add custom `PageLocation` decoder to speed up decoding of page indexes

### DIFF
--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -22,7 +22,7 @@ use crate::data_type::Int96;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::ColumnChunkMetaData;
 use crate::file::page_index::index::{Index, NativeIndex};
-use crate::file::page_index::offset_index::{read_offset_index, OffsetIndexMetaData};
+use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use crate::file::reader::ChunkReader;
 use crate::parquet_thrift::{FieldType, ThriftCompactInputProtocol};
 use crate::thrift_struct;
@@ -132,9 +132,9 @@ pub fn read_offset_indexes<R: ChunkReader>(
 pub(crate) fn decode_offset_index(data: &[u8]) -> Result<OffsetIndexMetaData, ParquetError> {
     let mut prot = ThriftCompactInputProtocol::new(data);
 
-    // Try to read fast-path index first. If that fails, fall back to slower but more robust
-    // reader
-    match read_offset_index(&mut prot) {
+    // Try to read fast-path first. If that fails, fall back to slower but more robust
+    // decoder.
+    match OffsetIndexMetaData::try_from_fast(&mut prot) {
         Ok(offset_index) => Ok(offset_index),
         Err(_) => {
             prot = ThriftCompactInputProtocol::new(data);

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -22,7 +22,7 @@ use crate::data_type::Int96;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::ColumnChunkMetaData;
 use crate::file::page_index::index::{Index, NativeIndex};
-use crate::file::page_index::offset_index::OffsetIndexMetaData;
+use crate::file::page_index::offset_index::{read_offset_index, OffsetIndexMetaData};
 use crate::file::reader::ChunkReader;
 use crate::parquet_thrift::{FieldType, ThriftCompactInputProtocol};
 use crate::thrift_struct;
@@ -131,7 +131,16 @@ pub fn read_offset_indexes<R: ChunkReader>(
 
 pub(crate) fn decode_offset_index(data: &[u8]) -> Result<OffsetIndexMetaData, ParquetError> {
     let mut prot = ThriftCompactInputProtocol::new(data);
-    OffsetIndexMetaData::try_from(&mut prot)
+
+    // Try to read fast-path index first. If that fails, fall back to slower but more robust
+    // reader
+    match read_offset_index(&mut prot) {
+        Ok(offset_index) => Ok(offset_index),
+        Err(_) => {
+            prot = ThriftCompactInputProtocol::new(data);
+            OffsetIndexMetaData::try_from(&mut prot)
+        }
+    }
 }
 
 thrift_struct!(

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -25,7 +25,7 @@ use crate::{
     thrift_struct,
 };
 
-thrift_struct!(
+/*thrift_struct!(
 /// Page location information for [`OffsetIndexMetaData`]
 pub struct PageLocation {
   /// Offset of the page in the file
@@ -37,7 +37,67 @@ pub struct PageLocation {
   /// (repetition_level = 0).
   3: required i64 first_row_index
 }
-);
+);*/
+
+// hand coding this one because it is very time critical
+
+/// Page location information for [`OffsetIndexMetaData`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PageLocation {
+    /// Offset of the page in the file
+    pub offset: i64,
+    /// Size of the page, including header. Sum of compressed_page_size and header
+    pub compressed_page_size: i32,
+    /// Index within the RowGroup of the first row of the page. When an
+    /// OffsetIndex is present, pages must begin on row boundaries
+    /// (repetition_level = 0).
+    pub first_row_index: i64,
+}
+
+// Note: this will fail if the fields are either out of order, or if a suboptimal
+// encoder doesn't use field deltas. If that ever occurs, remove this code and
+// revert to the commented out thrift_struct!() implementation above.
+impl<'a> TryFrom<&mut ThriftCompactInputProtocol<'a>> for PageLocation {
+    type Error = ParquetError;
+    fn try_from(prot: &mut ThriftCompactInputProtocol<'a>) -> Result<Self> {
+        // there are 3 fields, all mandatory, so all field deltas should be 1
+        let (field_type, delta) = prot.read_field_header()?;
+        if delta != 1 || field_type != FieldType::I64 as u8 {
+            return Err(general_err!("error reading PageLocation::offset"));
+        }
+        let offset = prot.read_i64()?;
+
+        let (field_type, delta) = prot.read_field_header()?;
+        if delta != 1 || field_type != FieldType::I32 as u8 {
+            return Err(general_err!(
+                "error reading PageLocation::compressed_page_size"
+            ));
+        }
+        let compressed_page_size = prot.read_i32()?;
+
+        let (field_type, delta) = prot.read_field_header()?;
+        if delta != 1 || field_type != FieldType::I64 as u8 {
+            return Err(general_err!("error reading PageLocation::first_row_index"));
+        }
+        let first_row_index = prot.read_i64()?;
+
+        // This loop slows things down a bit, but it's an acceptible price to allow
+        // forwards compatibility. We could instead assert the next field is Stop.
+        loop {
+            let (field_type, _) = prot.read_field_header()?;
+            if field_type == FieldType::Stop as u8 {
+                break;
+            }
+            prot.skip(FieldType::try_from(field_type)?)?;
+        }
+
+        Ok(Self {
+            offset,
+            compressed_page_size,
+            first_row_index,
+        })
+    }
+}
 
 impl From<&crate::format::PageLocation> for PageLocation {
     fn from(value: &crate::format::PageLocation) -> Self {

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -117,6 +117,8 @@ impl OffsetIndexMetaData {
         if delta != 1 || field_type != FieldType::List as u8 {
             return Err(general_err!("error reading OffsetIndex::page_locations"));
         }
+
+        // we have to do this manually because we want to use the fast PageLocation decoder
         let list_ident = prot.read_list_begin()?;
         let mut page_locations = Vec::with_capacity(list_ident.size as usize);
         for _ in 0..list_ident.size {
@@ -133,11 +135,7 @@ impl OffsetIndexMetaData {
                     "encountered unknown field while reading OffsetIndex"
                 ));
             }
-            let list_ident = prot.read_list_begin()?;
-            let mut vec = Vec::with_capacity(list_ident.size as usize);
-            for _ in 0..list_ident.size {
-                vec.push(prot.read_i64()?);
-            }
+            let vec = Vec::<i64>::try_from(&mut *prot)?;
             unencoded_byte_array_data_bytes = Some(vec);
 
             // this one should be Stop

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -104,6 +104,57 @@ impl OffsetIndexMetaData {
             self.unencoded_byte_array_data_bytes.clone(),
         )
     }
+
+    // Fast-path read of offset index. This works because we expect all field deltas to be 1,
+    // and there's no nesting beyond PageLocation, so no need to save the last field id. Like
+    // read_page_locations(), this will fail if absolute field id's are used.
+    pub(super) fn try_from_fast<'a>(prot: &mut ThriftCompactInputProtocol<'a>) -> Result<Self> {
+        // Offset index is a struct with 2 fields. First field is an array of PageLocations,
+        // the second an optional array of i64.
+
+        // read field 1 header, then list header, then vec of PageLocations
+        let (field_type, delta) = prot.read_field_header()?;
+        if delta != 1 || field_type != FieldType::List as u8 {
+            return Err(general_err!("error reading OffsetIndex::page_locations"));
+        }
+        let list_ident = prot.read_list_begin()?;
+        let mut page_locations = Vec::with_capacity(list_ident.size as usize);
+        for _ in 0..list_ident.size {
+            page_locations.push(read_page_location(prot)?);
+        }
+
+        let mut unencoded_byte_array_data_bytes: Option<Vec<i64>> = None;
+
+        // read second field...if it's Stop we're done
+        let (mut field_type, delta) = prot.read_field_header()?;
+        if field_type == FieldType::List as u8 {
+            if delta != 1 {
+                return Err(general_err!(
+                    "encountered unknown field while reading OffsetIndex"
+                ));
+            }
+            let list_ident = prot.read_list_begin()?;
+            let mut vec = Vec::with_capacity(list_ident.size as usize);
+            for _ in 0..list_ident.size {
+                vec.push(prot.read_i64()?);
+            }
+            unencoded_byte_array_data_bytes = Some(vec);
+
+            // this one should be Stop
+            (field_type, _) = prot.read_field_header()?;
+        }
+
+        if field_type != FieldType::Stop as u8 {
+            return Err(general_err!(
+                "encountered unknown field while reading OffsetIndex"
+            ));
+        }
+
+        Ok(Self {
+            page_locations,
+            unencoded_byte_array_data_bytes,
+        })
+    }
 }
 
 // hand coding this one because it is very time critical
@@ -142,58 +193,5 @@ fn read_page_location<'a>(prot: &mut ThriftCompactInputProtocol<'a>) -> Result<P
         offset,
         compressed_page_size,
         first_row_index,
-    })
-}
-
-// Fast-path read of offset index. this all works because we expect all field deltas to be 1,
-// and there's no nesting beyond PageLocation, so no need to save the last field id. Like
-// read_page_locations(), this will fail if absolute field id's are used.
-pub(super) fn read_offset_index<'a>(
-    prot: &mut ThriftCompactInputProtocol<'a>,
-) -> Result<OffsetIndexMetaData> {
-    // Offset index is a struct with 2 fields. First field is an array of PageLocations,
-    // the second an optional array of i64.
-
-    // read field 1 header, then list header, then vec of PageLocations
-    let (field_type, delta) = prot.read_field_header()?;
-    if delta != 1 || field_type != FieldType::List as u8 {
-        return Err(general_err!("error reading OffsetIndex::page_locations"));
-    }
-    let list_ident = prot.read_list_begin()?;
-    let mut page_locations = Vec::with_capacity(list_ident.size as usize);
-    for _ in 0..list_ident.size {
-        page_locations.push(read_page_location(prot)?);
-    }
-
-    let mut unencoded_byte_array_data_bytes: Option<Vec<i64>> = None;
-
-    // read second field...if it's Stop we're done
-    let (mut field_type, delta) = prot.read_field_header()?;
-    if field_type == FieldType::List as u8 {
-        if delta != 1 {
-            return Err(general_err!(
-                "encountered unknown field while reading OffsetIndex"
-            ));
-        }
-        let list_ident = prot.read_list_begin()?;
-        let mut vec = Vec::with_capacity(list_ident.size as usize);
-        for _ in 0..list_ident.size {
-            vec.push(prot.read_i64()?);
-        }
-        unencoded_byte_array_data_bytes = Some(vec);
-
-        // this one should be Stop
-        (field_type, _) = prot.read_field_header()?;
-    }
-
-    if field_type != FieldType::Stop as u8 {
-        return Err(general_err!(
-            "encountered unknown field while reading OffsetIndex"
-        ));
-    }
-
-    Ok(OffsetIndexMetaData {
-        page_locations,
-        unencoded_byte_array_data_bytes,
     })
 }

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -49,7 +49,6 @@ use parquet::data_type::AsBytes;
 use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader, ParquetOffsetIndex};
 use parquet::file::properties::WriterProperties;
 use parquet::file::FOOTER_SIZE;
-use parquet::format::PageLocation;
 use parquet::schema::types::SchemaDescriptor;
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -257,7 +256,7 @@ struct TestColumnChunk {
     dictionary_page_location: Option<i64>,
 
     /// The location of the data pages in the file
-    page_locations: Vec<PageLocation>,
+    page_locations: Vec<parquet::format::PageLocation>,
 }
 
 /// Information about the pages in a single row group
@@ -295,6 +294,11 @@ impl TestRowGroups {
                         let (start_offset, length) = col_meta.byte_range();
                         let start_offset = start_offset as usize;
                         let end_offset = start_offset + length as usize;
+
+                        let page_locations = page_locations
+                            .iter()
+                            .map(|loc| parquet::format::PageLocation::from(loc))
+                            .collect();
 
                         TestColumnChunk {
                             name: column_name.clone(),

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -297,7 +297,7 @@ impl TestRowGroups {
 
                         let page_locations = page_locations
                             .iter()
-                            .map(|loc| parquet::format::PageLocation::from(loc))
+                            .map(parquet::format::PageLocation::from)
                             .collect();
 
                         TestColumnChunk {


### PR DESCRIPTION
# Which issue does this PR close?
**Note: this targets a feature branch, not main**

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Part of #5854.

# Rationale for this change

Add a custom parser for `PageLocation` as the decoding of this struct is one of several hot spots.

# What changes are included in this PR?

This adds a faster means of obtaining the struct field ids to `ThriftCompactInputProtocol`. For a small struct (3 fields) with all of them required, we can save a good bit of time bypassing `ThriftCompactInputProtocol::read_field_begin` which is very general and can handle out-of-order fields, among other things. By adding a new function `read_field_header`, we can avoid the costly branching that occurs when calculating the new field id (as well as special handling needed for boolean fields). Field validation is then handled on the consuming side while decoding the `PageLocation` struct.

Note that to obtain the speed up seen, we need to assume the fields will always be in order, and the field ids will all be encoded as field deltas. This is probably a fairly safe assumption, but there does exist the possibility of custom thrift writers that use absolute field ids. If we encounter such a writer in the wild, this change will need to be reverted.

# Are these changes tested?

These changes should be covered by existing changes.

# Are there any user-facing changes?

None beyond the changes in this branch.
