### PR TITLE
Enhance the variant fuzzy test to cover time/timestamp/uuid primitive type

### DIFF
--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -34,7 +34,7 @@ rust-version = { workspace = true }
 arrow-schema = { workspace = true }
 chrono = { workspace = true }
 indexmap = "2.10.0"
-uuid = { version = "1.18.0"}
+uuid = { version = "1.18.0", features = ["v4"]}
 
 simdutf8 = { workspace = true , optional = true }
 

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -1328,6 +1328,12 @@ impl From<NaiveTime> for Variant<'_, '_> {
     }
 }
 
+impl From<Uuid> for Variant<'_, '_> {
+    fn from(value: Uuid) -> Self {
+        Variant::Uuid(value)
+    }
+}
+
 impl<'v> From<&'v str> for Variant<'_, 'v> {
     fn from(value: &'v str) -> Self {
         if value.len() > MAX_SHORT_STRING_BYTES {

--- a/parquet-variant/tests/variant_interop.rs
+++ b/parquet-variant/tests/variant_interop.rs
@@ -21,7 +21,7 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use chrono::{NaiveDate, NaiveTime};
+use chrono::{DateTime, NaiveDate, NaiveTime};
 use parquet_variant::{
     ShortString, Variant, VariantBuilder, VariantDecimal16, VariantDecimal4, VariantDecimal8,
 };
@@ -323,7 +323,7 @@ fn generate_random_value(rng: &mut StdRng, builder: &mut VariantBuilder, max_dep
         return;
     }
 
-    match rng.random_range(0..15) {
+    match rng.random_range(0..18) {
         0 => builder.append_value(()),
         1 => builder.append_value(rng.random::<bool>()),
         2 => builder.append_value(rng.random::<i8>()),
@@ -333,11 +333,13 @@ fn generate_random_value(rng: &mut StdRng, builder: &mut VariantBuilder, max_dep
         6 => builder.append_value(rng.random::<f32>()),
         7 => builder.append_value(rng.random::<f64>()),
         8 => {
+            // String
             let len = rng.random_range(0..50);
             let s: String = (0..len).map(|_| rng.random::<char>()).collect();
             builder.append_value(s.as_str());
         }
         9 => {
+            // Binary
             let len = rng.random_range(0..50);
             let bytes: Vec<u8> = (0..len).map(|_| rng.random()).collect();
             builder.append_value(bytes.as_slice());
@@ -383,6 +385,34 @@ fn generate_random_value(rng: &mut StdRng, builder: &mut VariantBuilder, max_dep
                 object_builder.insert(&key, rng.random::<i32>());
             }
             object_builder.finish().unwrap();
+        }
+        15 => {
+            // Time
+            builder.append_value(
+                NaiveTime::from_num_seconds_from_midnight_opt(
+                    // make the argument always valid
+                    rng.random_range(0..86_400),
+                    rng.random_range(0..1_000_000_000),
+                )
+                .unwrap(),
+            )
+        }
+        16 => {
+            let data_time = DateTime::from_timestamp(
+                // make the argument always valid
+                rng.random_range(0..86_400),
+                rng.random_range(0..1_000_000_000),
+            )
+            .unwrap();
+
+            // timestamp w/o timezone
+            builder.append_value(data_time.naive_local());
+
+            // timestamp with timezone
+            builder.append_value(data_time.naive_utc().and_utc());
+        }
+        17 => {
+            builder.append_value(Uuid::new_v4());
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8199.

# Rationale for this change

Add logic for the fuzzy test to cover time/timestampnanos/uuid.

# What changes are included in this PR?

- Add more cases in Variant Fuzzy Testing to cover the time/TimestampNanos/UUID

# Are these changes tested?

Covered by the existing test

# Are there any user-facing changes?

No