### PR TITLE
[Variant] Support read-only metadata builders

### DIFF
--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -20,8 +20,8 @@
 use crate::VariantArray;
 use arrow::array::{ArrayRef, BinaryViewArray, BinaryViewBuilder, NullBufferBuilder, StructArray};
 use arrow_schema::{ArrowError, DataType, Field, Fields};
-use parquet_variant::{BasicMetadataBuilder, ParentState, ValueBuilder};
 use parquet_variant::{ListBuilder, ObjectBuilder, Variant, VariantBuilderExt};
+use parquet_variant::{ParentState, ValueBuilder, WritableMetadataBuilder};
 use std::sync::Arc;
 
 /// A builder for [`VariantArray`]
@@ -74,7 +74,7 @@ pub struct VariantArrayBuilder {
     /// Nulls
     nulls: NullBufferBuilder,
     /// builder for all the metadata
-    metadata_builder: BasicMetadataBuilder,
+    metadata_builder: WritableMetadataBuilder,
     /// ending offset for each serialized metadata dictionary in the buffer
     metadata_offsets: Vec<usize>,
     /// builder for values
@@ -96,7 +96,7 @@ impl VariantArrayBuilder {
 
         Self {
             nulls: NullBufferBuilder::new(row_capacity),
-            metadata_builder: BasicMetadataBuilder::default(),
+            metadata_builder: WritableMetadataBuilder::default(),
             metadata_offsets: Vec::with_capacity(row_capacity),
             value_builder: ValueBuilder::new(),
             value_offsets: Vec::with_capacity(row_capacity),

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -500,7 +500,7 @@ impl MetadataBuilder for ReadOnlyMetadataBuilder<'_> {
         let Some((field_id, field_name)) = self.metadata.get_entry(field_name) else {
             return Err(ArrowError::InvalidArgumentError(format!(
                 "Field name '{field_name}' not found in metadata dictionary"
-            )))
+            )));
         };
 
         self.known_field_names.insert(field_name, field_id);

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -497,11 +497,11 @@ impl MetadataBuilder for ReadOnlyMetadataBuilder<'_> {
             return Ok(*field_id);
         }
 
-        let (field_id, field_name) = self.metadata.get_entry(field_name).ok_or_else(|| {
-            ArrowError::InvalidArgumentError(format!(
+        let Some((field_id, field_name)) = self.metadata.get_entry(field_name) else {
+            return Err(ArrowError::InvalidArgumentError(format!(
                 "Field name '{field_name}' not found in metadata dictionary"
-            ))
-        })?;
+            )))
+        };
 
         self.known_field_names.insert(field_name, field_id);
         Ok(field_id)
@@ -3360,6 +3360,7 @@ mod tests {
         {
             let state = ParentState::variant(&mut value_builder, &mut metadata_builder);
             let mut obj = ObjectBuilder::new(state, false);
+
             // These should succeed because the fields exist in the metadata
             obj.insert("name", "Alice");
             obj.insert("age", 30i8);

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -18,6 +18,7 @@ use std::{array::TryFromSliceError, ops::Range, str};
 
 use arrow_schema::ArrowError;
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::slice::SliceIndex;
 
@@ -115,23 +116,20 @@ pub(crate) fn string_from_slice(
 /// * `Some(Ok(index))` - Element found at the given index
 /// * `Some(Err(index))` - Element not found, but would be inserted at the given index
 /// * `None` - Key extraction failed
-pub(crate) fn try_binary_search_range_by<K, F>(
+pub(crate) fn try_binary_search_range_by<F>(
     range: Range<usize>,
-    target: &K,
-    key_extractor: F,
+    cmp: F,
 ) -> Option<Result<usize, usize>>
 where
-    K: Ord,
-    F: Fn(usize) -> Option<K>,
+    F: Fn(usize) -> Option<Ordering>,
 {
     let Range { mut start, mut end } = range;
     while start < end {
         let mid = start + (end - start) / 2;
-        let key = key_extractor(mid)?;
-        match key.cmp(target) {
-            std::cmp::Ordering::Equal => return Some(Ok(mid)),
-            std::cmp::Ordering::Greater => end = mid,
-            std::cmp::Ordering::Less => start = mid + 1,
+        match cmp(mid)? {
+            Ordering::Equal => return Some(Ok(mid)),
+            Ordering::Greater => end = mid,
+            Ordering::Less => start = mid + 1,
         }
     }
 

--- a/parquet-variant/src/variant/metadata.rs
+++ b/parquet-variant/src/variant/metadata.rs
@@ -16,7 +16,10 @@
 // under the License.
 
 use crate::decoder::{map_bytes_to_offsets, OffsetSizeBytes};
-use crate::utils::{first_byte_from_slice, overflow_error, slice_from_slice, string_from_slice};
+use crate::utils::{
+    first_byte_from_slice, overflow_error, slice_from_slice, string_from_slice,
+    try_binary_search_range_by,
+};
 
 use arrow_schema::ArrowError;
 
@@ -315,6 +318,32 @@ impl<'m> VariantMetadata<'m> {
         string_from_slice(self.bytes, self.first_value_byte as _, byte_range)
     }
 
+    // Helper method used by our `impl Index` and also by `get_entry`. Panics if the underlying
+    // bytes are invalid. Needed because the `Index` trait forces the returned result to have the
+    // lifetime of `self` instead of the string's own (longer) lifetime `'m`.
+    fn get_impl(&self, i: usize) -> &'m str {
+        self.get(i).expect("Invalid metadata dictionary entry")
+    }
+
+    /// Attempts to retrieve a dictionary entry and its field id, returning None if the requested field
+    /// name is not present. The search cost is logarithmic if [`Self::is_sorted`] and linear
+    /// otherwise.
+    ///
+    /// WARNING: This method panics if the underlying bytes are [invalid].
+    ///
+    /// [invalid]: Self#Validation
+    pub fn get_entry(&self, field_name: &str) -> Option<(u32, &'m str)> {
+        let field_id = if self.is_sorted() && self.len() > 10 {
+            // Binary search is faster for a not-tiny sorted metadata dictionary
+            let cmp = |i| Some(self.get_impl(i).cmp(field_name));
+            try_binary_search_range_by(0..self.len(), cmp)?.ok()?
+        } else {
+            // Fall back to Linear search for tiny or unsorted dictionary
+            (0..self.len()).find(|i| self.get_impl(*i) == field_name)?
+        };
+        Some((field_id as u32, self.get_impl(field_id)))
+    }
+
     /// Returns an iterator that attempts to visit all dictionary entries, producing `Err` if the
     /// iterator encounters [invalid] data.
     ///
@@ -341,7 +370,7 @@ impl std::ops::Index<usize> for VariantMetadata<'_> {
     type Output = str;
 
     fn index(&self, i: usize) -> &str {
-        self.get(i).expect("Invalid metadata dictionary entry")
+        self.get_impl(i)
     }
 }
 

--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -397,8 +397,8 @@ impl<'m, 'v> VariantObject<'m, 'v> {
         // NOTE: This does not require a sorted metadata dictionary, because the variant spec
         // requires object field ids to be lexically sorted by their corresponding string values,
         // and probing the dictionary for a field id is always O(1) work.
-        let i = try_binary_search_range_by(0..self.len(), &name, |i| self.field_name(i))?.ok()?;
-
+        let cmp = |i| Some(self.field_name(i)?.cmp(name));
+        let i = try_binary_search_range_by(0..self.len(), cmp)?.ok()?;
         self.field(i)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8152

# Rationale for this change

When manipulating existing variant values (unshredding, removing fields, etc), the metadata column is already defined and already contains all necessary field ids. In fact, defining new/different field ids would require rewriting the bytes of those already-encoded variant values. We need a way to build variant values that rely on an existing metadata dictionary.

# What changes are included in this PR?

* `MetadataBuilder` is now a trait, and most methods that work with metadata builders now take `&mut dyn MetadataBuilder` instead of `&mut MetadataBuilder`.
* The old `MetadataBuilder` struct is now `BasicMetadataBuilder` that implements `MetadataBuilder`
* Define a `ReadOnlyMetadataBuilder` that wraps a `VariantMetadata` and which also implements `MetadataBuilder`
* Update the `try_binary_search_range_by` helper method to be more general, so we can define an efficient `VariantMetadata::get_entry` that returns the field id for a given field name.

# Are these changes tested?

Existing tests cover the basic metadata builder. New tests added to cover the read-only metadata builder.

# Are there any user-facing changes?

The renamed `BasicMetadataBuilder` (breaking), the new `MetadataBuilder` trait (breaking), and the new `ReadOnlyMetadataBuilder`.
