### PR TITLE
Restore accidentally removed method Block::to_ne_bytes

### DIFF
--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -121,6 +121,13 @@ impl Block {
 
     #[inline]
     #[cfg(not(target_endian = "little"))]
+    fn to_ne_bytes(self) -> [u8; 32] {
+        // SAFETY: [u32; 8] and [u8; 32] have the same size and neither has invalid bit patterns.
+        unsafe { std::mem::transmute(self.0) }
+    }
+
+    #[inline]
+    #[cfg(not(target_endian = "little"))]
     fn to_le_bytes(self) -> [u8; 32] {
         self.swap_bytes().to_ne_bytes()
     }


### PR DESCRIPTION
This method was removed in #7824, which introduced an optimized code path for writing bloom filters on little-endian architectures. The method was however still used in the big-endian code-path. Due to the use of `#[cfg(target_endian)]` this went unnoticed in CI.

Fixes #8207