### PR TITLE
Fix error condition in doc comment of `Field::try_canonical_extension_type`

### DIFF
--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -547,7 +547,7 @@ impl Field {
     /// # Error
     ///
     /// Returns an error if
-    /// - this field does have a canonical extension type (mismatch or missing)
+    /// - this field does not have a canonical extension type (mismatch or missing)
     /// - the canonical extension is not supported
     /// - the construction of the extension type fails
     #[cfg(feature = "canonical_extension_types")]


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

I noticed an error in the doc comment about error conditions of `Field::try_canonical_extension_type`.

# What changes are included in this PR?

Fixed the doc comment.

# Are these changes tested?

No.

# Are there any user-facing changes?

No.