### PR TITLE
Added arrow-avro schema resolution value skipping

### DIFF
--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -955,7 +955,7 @@ impl<'a> Maker<'a> {
         // Prepare outputs
         let mut reader_fields: Vec<AvroField> = Vec::with_capacity(reader_record.fields.len());
         let mut writer_to_reader: Vec<Option<usize>> = vec![None; writer_record.fields.len()];
-        //let mut skip_fields: Vec<Option<AvroDataType>> = vec![None; writer_record.fields.len()];
+        let mut skip_fields: Vec<Option<AvroDataType>> = vec![None; writer_record.fields.len()];
         //let mut default_fields: Vec<usize> = Vec::new();
         // Build reader fields and mapping
         for (reader_idx, r_field) in reader_record.fields.iter().enumerate() {
@@ -975,6 +975,14 @@ impl<'a> Maker<'a> {
                 ));
             }
         }
+        // Any writer fields not mapped should be skipped
+        for (writer_idx, writer_field) in writer_record.fields.iter().enumerate() {
+            if writer_to_reader[writer_idx].is_none() {
+                // Parse writer field type to know how to skip data
+                let w_dt = self.parse_type(&writer_field.r#type, writer_ns)?;
+                skip_fields[writer_idx] = Some(w_dt);
+            }
+        }
         // Implement writer-only fields to skip in Follow-up PR here
         // Build resolved record AvroDataType
         let resolved = AvroDataType::new_with_resolution(
@@ -984,7 +992,7 @@ impl<'a> Maker<'a> {
             Some(ResolutionInfo::Record(ResolvedRecord {
                 writer_to_reader: Arc::from(writer_to_reader),
                 default_fields: Arc::default(),
-                skip_fields: Arc::default(),
+                skip_fields: Arc::from(skip_fields),
             })),
         );
         // Register a resolved record by reader name+namespace for potential named type refs

--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -70,6 +70,15 @@ pub(crate) struct RecordDecoder {
     schema: SchemaRef,
     fields: Vec<Decoder>,
     use_utf8view: bool,
+    resolved: Option<ResolvedRuntime>,
+}
+
+#[derive(Debug)]
+struct ResolvedRuntime {
+    /// writer field index -> reader field index (or None if writer-only)
+    writer_to_reader: Arc<[Option<usize>]>,
+    /// per-writer-field skipper (Some only when writer-only)
+    skip_decoders: Vec<Option<Skipper>>,
 }
 
 impl RecordDecoder {
@@ -101,14 +110,35 @@ impl RecordDecoder {
         data_type: &AvroDataType,
         use_utf8view: bool,
     ) -> Result<Self, ArrowError> {
-        match Decoder::try_new(data_type)? {
-            Decoder::Record(fields, encodings) => Ok(Self {
-                schema: Arc::new(ArrowSchema::new(fields)),
-                fields: encodings,
-                use_utf8view,
-            }),
-            encoding => Err(ArrowError::ParseError(format!(
-                "Expected record got {encoding:?}"
+        match data_type.codec() {
+            Codec::Struct(reader_fields) => {
+                // Build Arrow schema fields and per-child decoders
+                let mut arrow_fields = Vec::with_capacity(reader_fields.len());
+                let mut encodings = Vec::with_capacity(reader_fields.len());
+                for avro_field in reader_fields.iter() {
+                    arrow_fields.push(avro_field.field());
+                    encodings.push(Decoder::try_new(avro_field.data_type())?);
+                }
+                // If this record carries resolution metadata, prepare top-level runtime helpers
+                let resolved = match data_type.resolution.as_ref() {
+                    Some(ResolutionInfo::Record(rec)) => {
+                        let skip_decoders = build_skip_decoders(&rec.skip_fields)?;
+                        Some(ResolvedRuntime {
+                            writer_to_reader: rec.writer_to_reader.clone(),
+                            skip_decoders,
+                        })
+                    }
+                    _ => None,
+                };
+                Ok(Self {
+                    schema: Arc::new(ArrowSchema::new(arrow_fields)),
+                    fields: encodings,
+                    use_utf8view,
+                    resolved,
+                })
+            }
+            other => Err(ArrowError::ParseError(format!(
+                "Expected record got {other:?}"
             ))),
         }
     }
@@ -121,6 +151,19 @@ impl RecordDecoder {
     /// Decode `count` records from `buf`
     pub(crate) fn decode(&mut self, buf: &[u8], count: usize) -> Result<usize, ArrowError> {
         let mut cursor = AvroCursor::new(buf);
+        if let Some(runtime) = self.resolved.as_mut() {
+            // Top-level resolved record: read writer fields in writer order,
+            // project into reader fields, and skip writer-only fields
+            for _ in 0..count {
+                decode_with_resolution(
+                    &mut cursor,
+                    &mut self.fields,
+                    &runtime.writer_to_reader,
+                    &mut runtime.skip_decoders,
+                )?;
+            }
+            return Ok(cursor.position());
+        }
         for _ in 0..count {
             for field in &mut self.fields {
                 field.decode(&mut cursor)?;
@@ -139,6 +182,28 @@ impl RecordDecoder {
 
         RecordBatch::try_new(self.schema.clone(), arrays)
     }
+}
+
+#[inline]
+fn decode_with_resolution(
+    buf: &mut AvroCursor<'_>,
+    encodings: &mut [Decoder],
+    writer_to_reader: &[Option<usize>],
+    skippers: &mut [Option<Skipper>],
+) -> Result<(), ArrowError> {
+    for (w_idx, target) in writer_to_reader.iter().enumerate() {
+        if let Some(r_idx) = target {
+            encodings[*r_idx].decode(buf)?;
+        } else if let Some(sk) = skippers.get_mut(w_idx).and_then(|o| o.as_mut()) {
+            sk.skip(buf)?;
+        } else {
+            return Err(ArrowError::SchemaError(format!(
+                "No skipper available for writer-only field at index {}",
+                w_idx
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -183,6 +248,13 @@ enum Decoder {
     Decimal128(usize, Option<usize>, Option<usize>, Decimal128Builder),
     Decimal256(usize, Option<usize>, Option<usize>, Decimal256Builder),
     Nullable(Nullability, NullBufferBuilder, Box<Decoder>),
+    /// Resolved record that needs writer->reader projection and skipping writer-only fields
+    RecordResolved {
+        fields: Fields,
+        encodings: Vec<Decoder>,
+        writer_to_reader: Arc<[Option<usize>]>,
+        skip_decoders: Vec<Option<Skipper>>,
+    },
 }
 
 impl Decoder {
@@ -307,7 +379,17 @@ impl Decoder {
                     arrow_fields.push(avro_field.field());
                     encodings.push(encoding);
                 }
-                Self::Record(arrow_fields.into(), encodings)
+                if let Some(ResolutionInfo::Record(rec)) = data_type.resolution.as_ref() {
+                    let skip_decoders = build_skip_decoders(&rec.skip_fields)?;
+                    Self::RecordResolved {
+                        fields: arrow_fields.into(),
+                        encodings,
+                        writer_to_reader: rec.writer_to_reader.clone(),
+                        skip_decoders,
+                    }
+                } else {
+                    Self::Record(arrow_fields.into(), encodings)
+                }
             }
             (Codec::Map(child), _) => {
                 let val_field = child.field_with_name("value").with_nullable(true);
@@ -383,6 +465,9 @@ impl Decoder {
             Self::Nullable(_, null_buffer, inner) => {
                 null_buffer.append(false);
                 inner.append_null();
+            }
+            Self::RecordResolved { encodings, .. } => {
+                encodings.iter_mut().for_each(|e| e.append_null());
             }
         }
     }
@@ -492,6 +577,14 @@ impl Decoder {
                     encoding.append_null();
                     nb.append(false);
                 }
+            }
+            Self::RecordResolved {
+                encodings,
+                writer_to_reader,
+                skip_decoders,
+                ..
+            } => {
+                decode_with_resolution(buf, encodings, writer_to_reader, skip_decoders)?;
             }
         }
         Ok(())
@@ -641,8 +734,36 @@ impl Decoder {
                     .map_err(|e| ArrowError::ParseError(e.to_string()))?;
                 Arc::new(vals)
             }
+            Self::RecordResolved {
+                fields, encodings, ..
+            } => {
+                let arrays = encodings
+                    .iter_mut()
+                    .map(|x| x.flush(None))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Arc::new(StructArray::new(fields.clone(), arrays, nulls))
+            }
         })
     }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum NegativeBlockBehavior {
+    ProcessItems,
+    SkipBySize,
+}
+
+#[inline]
+fn skip_blocks(
+    buf: &mut AvroCursor<'_>,
+    mut skip_item: impl FnMut(&mut AvroCursor<'_>) -> Result<(), ArrowError>,
+    _skip_negative_block_by_size: bool,
+) -> Result<usize, ArrowError> {
+    process_blockwise(
+        buf,
+        move |c| skip_item(c),
+        NegativeBlockBehavior::SkipBySize,
+    )
 }
 
 #[inline]
@@ -650,41 +771,42 @@ fn read_blocks(
     buf: &mut AvroCursor,
     decode_entry: impl FnMut(&mut AvroCursor) -> Result<(), ArrowError>,
 ) -> Result<usize, ArrowError> {
-    read_blockwise_items(buf, true, decode_entry)
+    process_blockwise(buf, decode_entry, NegativeBlockBehavior::ProcessItems)
 }
 
 #[inline]
-fn read_blockwise_items(
-    buf: &mut AvroCursor,
-    read_size_after_negative: bool,
-    mut decode_fn: impl FnMut(&mut AvroCursor) -> Result<(), ArrowError>,
+fn process_blockwise(
+    buf: &mut AvroCursor<'_>,
+    mut on_item: impl FnMut(&mut AvroCursor<'_>) -> Result<(), ArrowError>,
+    negative_behavior: NegativeBlockBehavior,
 ) -> Result<usize, ArrowError> {
     let mut total = 0usize;
     loop {
-        // Read the block count
-        //  positive = that many items
-        //  negative = that many items + read block size
-        //  See: https://avro.apache.org/docs/1.11.1/specification/#maps
         let block_count = buf.get_long()?;
         match block_count.cmp(&0) {
             Ordering::Equal => break,
             Ordering::Less => {
-                // If block_count is negative, read the absolute value of count,
-                // then read the block size as a long and discard
                 let count = (-block_count) as usize;
-                if read_size_after_negative {
-                    let _size_in_bytes = buf.get_long()?;
-                }
-                for _ in 0..count {
-                    decode_fn(buf)?;
+                // A negative count is followed by a long of the size in bytes
+                let size_in_bytes = buf.get_long()? as usize;
+                match negative_behavior {
+                    NegativeBlockBehavior::ProcessItems => {
+                        // Process items one-by-one after reading size
+                        for _ in 0..count {
+                            on_item(buf)?;
+                        }
+                    }
+                    NegativeBlockBehavior::SkipBySize => {
+                        // Skip the entire block payload at once
+                        let _ = buf.get_fixed(size_in_bytes)?;
+                    }
                 }
                 total += count;
             }
             Ordering::Greater => {
-                // If block_count is positive, decode that many items
                 let count = block_count as usize;
-                for _i in 0..count {
-                    decode_fn(buf)?;
+                for _ in 0..count {
+                    on_item(buf)?;
                 }
                 total += count;
             }
@@ -734,6 +856,172 @@ fn sign_extend_to<const N: usize>(raw: &[u8]) -> Result<[u8; N], ArrowError> {
     arr[..pad_len].fill(extension_byte);
     arr[pad_len..].copy_from_slice(raw);
     Ok(arr)
+}
+
+/// Lightweight skipping decoder for writer-only fields
+#[derive(Debug)]
+enum Skipper {
+    Null,
+    Boolean,
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    Bytes,
+    String,
+    Date32,
+    TimeMillis,
+    TimeMicros,
+    TimestampMillis,
+    TimestampMicros,
+    Fixed(usize),
+    Decimal(Option<usize>),
+    UuidString,
+    Enum,
+    DurationFixed12,
+    List(Box<Skipper>),
+    Map(Box<Skipper>),
+    Struct(Vec<Skipper>),
+    Nullable(Nullability, Box<Skipper>),
+}
+
+impl Skipper {
+    fn from_avro(dt: &AvroDataType) -> Result<Self, ArrowError> {
+        let mut base = match dt.codec() {
+            Codec::Null => Self::Null,
+            Codec::Boolean => Self::Boolean,
+            Codec::Int32 | Codec::Date32 | Codec::TimeMillis => Self::Int32,
+            Codec::Int64 => Self::Int64,
+            Codec::TimeMicros => Self::TimeMicros,
+            Codec::TimestampMillis(_) => Self::TimestampMillis,
+            Codec::TimestampMicros(_) => Self::TimestampMicros,
+            Codec::Float32 => Self::Float32,
+            Codec::Float64 => Self::Float64,
+            Codec::Binary => Self::Bytes,
+            Codec::Utf8 | Codec::Utf8View => Self::String,
+            Codec::Fixed(sz) => Self::Fixed(*sz as usize),
+            Codec::Decimal(_, _, size) => Self::Decimal(*size),
+            Codec::Uuid => Self::UuidString, // encoded as string
+            Codec::Enum(_) => Self::Enum,
+            Codec::List(item) => Self::List(Box::new(Skipper::from_avro(item)?)),
+            Codec::Struct(fields) => {
+                let mut inner = Vec::with_capacity(fields.len());
+                for f in fields.iter() {
+                    inner.push(Skipper::from_avro(f.data_type())?);
+                }
+                Self::Struct(inner)
+            }
+            Codec::Map(values) => Self::Map(Box::new(Skipper::from_avro(values)?)),
+            Codec::Interval => Self::DurationFixed12,
+            _ => {
+                return Err(ArrowError::NotYetImplemented(format!(
+                    "Skipper not implemented for codec {:?}",
+                    dt.codec()
+                )));
+            }
+        };
+        if let Some(n) = dt.nullability() {
+            base = Self::Nullable(n, Box::new(base));
+        }
+        Ok(base)
+    }
+
+    fn skip(&mut self, buf: &mut AvroCursor<'_>) -> Result<(), ArrowError> {
+        match self {
+            Self::Null => Ok(()),
+            Self::Boolean => {
+                let _ = buf.get_bool()?;
+                Ok(())
+            }
+            Self::Int32 | Self::Date32 | Self::TimeMillis => {
+                let _ = buf.get_int()?;
+                Ok(())
+            }
+            Self::Int64 | Self::TimeMicros | Self::TimestampMillis | Self::TimestampMicros => {
+                let _ = buf.get_long()?;
+                Ok(())
+            }
+            Self::Float32 => {
+                let _ = buf.get_float()?;
+                Ok(())
+            }
+            Self::Float64 => {
+                let _ = buf.get_double()?;
+                Ok(())
+            }
+            Self::Bytes | Self::String | Self::UuidString => {
+                let _ = buf.get_bytes()?;
+                Ok(())
+            }
+            Self::Fixed(sz) => {
+                let _ = buf.get_fixed(*sz)?;
+                Ok(())
+            }
+            Self::Decimal(size) => {
+                let _ = if let Some(s) = size {
+                    buf.get_fixed(*s)
+                } else {
+                    buf.get_bytes()
+                }?;
+                Ok(())
+            }
+            Self::Enum => {
+                let _ = buf.get_int()?;
+                Ok(())
+            }
+            Self::DurationFixed12 => {
+                let _ = buf.get_fixed(12)?;
+                Ok(())
+            }
+            Self::List(item) => {
+                let _ = skip_blocks(buf, |c| item.skip(c), true)?;
+                Ok(())
+            }
+            Self::Map(value) => {
+                let _ = skip_blocks(
+                    buf,
+                    |c| {
+                        let _ = c.get_bytes()?; // key
+                        value.skip(c)
+                    },
+                    true,
+                )?;
+                Ok(())
+            }
+            Self::Struct(fields) => {
+                for f in fields.iter_mut() {
+                    f.skip(buf)?
+                }
+                Ok(())
+            }
+            Self::Nullable(order, inner) => {
+                let branch = buf.read_vlq()?;
+                let is_not_null = match *order {
+                    Nullability::NullFirst => branch != 0,
+                    Nullability::NullSecond => branch == 0,
+                };
+                if is_not_null {
+                    inner.skip(buf)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[inline]
+fn build_skip_decoders(
+    skip_fields: &[Option<AvroDataType>],
+) -> Result<Vec<Option<Skipper>>, ArrowError> {
+    let mut v = Vec::with_capacity(skip_fields.len());
+    for opt in skip_fields.iter() {
+        if let Some(dt) = opt {
+            v.push(Some(Skipper::from_avro(dt)?));
+        } else {
+            v.push(None);
+        }
+    }
+    Ok(v)
 }
 
 #[cfg(test)]
@@ -1470,5 +1758,197 @@ mod tests {
         let int_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
         assert!(int_array.is_null(0)); // row1 is null
         assert_eq!(int_array.value(1), 42); // row3 value is 42
+    }
+
+    fn make_record_resolved_decoder(
+        reader_fields: &[(&str, DataType, bool)],
+        writer_to_reader: Vec<Option<usize>>,
+        mut skip_decoders: Vec<Option<super::Skipper>>,
+    ) -> Decoder {
+        let mut field_refs: Vec<FieldRef> = Vec::with_capacity(reader_fields.len());
+        let mut encodings: Vec<Decoder> = Vec::with_capacity(reader_fields.len());
+        for (name, dt, nullable) in reader_fields {
+            field_refs.push(Arc::new(ArrowField::new(*name, dt.clone(), *nullable)));
+            let enc = match dt {
+                DataType::Int32 => Decoder::Int32(Vec::new()),
+                DataType::Int64 => Decoder::Int64(Vec::new()),
+                DataType::Utf8 => {
+                    Decoder::String(OffsetBufferBuilder::new(DEFAULT_CAPACITY), Vec::new())
+                }
+                other => panic!("Unsupported test reader field type: {other:?}"),
+            };
+            encodings.push(enc);
+        }
+        let fields: Fields = field_refs.into();
+        Decoder::RecordResolved {
+            fields,
+            encodings,
+            writer_to_reader: Arc::from(writer_to_reader),
+            skip_decoders,
+        }
+    }
+
+    #[test]
+    fn test_skip_writer_trailing_field_int32() {
+        let mut dec = make_record_resolved_decoder(
+            &[("id", arrow_schema::DataType::Int32, false)],
+            vec![Some(0), None],
+            vec![None, Some(super::Skipper::Int32)],
+        );
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_int(7));
+        data.extend_from_slice(&encode_avro_int(999));
+        let mut cur = AvroCursor::new(&data);
+        dec.decode(&mut cur).unwrap();
+        assert_eq!(cur.position(), data.len());
+        let arr = dec.flush(None).unwrap();
+        let struct_arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(struct_arr.len(), 1);
+        let id = struct_arr
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id.value(0), 7);
+    }
+
+    #[test]
+    fn test_skip_writer_middle_field_string() {
+        let mut dec = make_record_resolved_decoder(
+            &[
+                ("id", DataType::Int32, false),
+                ("score", DataType::Int64, false),
+            ],
+            vec![Some(0), None, Some(1)],
+            vec![None, Some(Skipper::String), None],
+        );
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_int(42));
+        data.extend_from_slice(&encode_avro_bytes(b"abcdef"));
+        data.extend_from_slice(&encode_avro_long(1000));
+        let mut cur = AvroCursor::new(&data);
+        dec.decode(&mut cur).unwrap();
+        assert_eq!(cur.position(), data.len());
+        let arr = dec.flush(None).unwrap();
+        let s = arr.as_any().downcast_ref::<StructArray>().unwrap();
+        let id = s
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let score = s
+            .column_by_name("score")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id.value(0), 42);
+        assert_eq!(score.value(0), 1000);
+    }
+
+    #[test]
+    fn test_skip_writer_array_with_negative_block_count_fast() {
+        let mut dec = make_record_resolved_decoder(
+            &[("id", DataType::Int32, false)],
+            vec![None, Some(0)],
+            vec![Some(super::Skipper::List(Box::new(Skipper::Int32))), None],
+        );
+        let mut array_payload = Vec::new();
+        array_payload.extend_from_slice(&encode_avro_int(1));
+        array_payload.extend_from_slice(&encode_avro_int(2));
+        array_payload.extend_from_slice(&encode_avro_int(3));
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_long(-3));
+        data.extend_from_slice(&encode_avro_long(array_payload.len() as i64));
+        data.extend_from_slice(&array_payload);
+        data.extend_from_slice(&encode_avro_long(0));
+        data.extend_from_slice(&encode_avro_int(5));
+        let mut cur = AvroCursor::new(&data);
+        dec.decode(&mut cur).unwrap();
+        assert_eq!(cur.position(), data.len());
+        let arr = dec.flush(None).unwrap();
+        let s = arr.as_any().downcast_ref::<StructArray>().unwrap();
+        let id = s
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id.len(), 1);
+        assert_eq!(id.value(0), 5);
+    }
+
+    #[test]
+    fn test_skip_writer_map_with_negative_block_count_fast() {
+        let mut dec = make_record_resolved_decoder(
+            &[("id", DataType::Int32, false)],
+            vec![None, Some(0)],
+            vec![Some(Skipper::Map(Box::new(Skipper::Int32))), None],
+        );
+        let mut entries = Vec::new();
+        entries.extend_from_slice(&encode_avro_bytes(b"k1"));
+        entries.extend_from_slice(&encode_avro_int(10));
+        entries.extend_from_slice(&encode_avro_bytes(b"k2"));
+        entries.extend_from_slice(&encode_avro_int(20));
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_avro_long(-2));
+        data.extend_from_slice(&encode_avro_long(entries.len() as i64));
+        data.extend_from_slice(&entries);
+        data.extend_from_slice(&encode_avro_long(0));
+        data.extend_from_slice(&encode_avro_int(123));
+        let mut cur = AvroCursor::new(&data);
+        dec.decode(&mut cur).unwrap();
+        assert_eq!(cur.position(), data.len());
+        let arr = dec.flush(None).unwrap();
+        let s = arr.as_any().downcast_ref::<StructArray>().unwrap();
+        let id = s
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id.len(), 1);
+        assert_eq!(id.value(0), 123);
+    }
+
+    #[test]
+    fn test_skip_writer_nullable_field_union_nullfirst() {
+        let mut dec = make_record_resolved_decoder(
+            &[("id", DataType::Int32, false)],
+            vec![None, Some(0)],
+            vec![
+                Some(super::Skipper::Nullable(
+                    Nullability::NullFirst,
+                    Box::new(super::Skipper::Int32),
+                )),
+                None,
+            ],
+        );
+        let mut row1 = Vec::new();
+        row1.extend_from_slice(&encode_avro_long(0));
+        row1.extend_from_slice(&encode_avro_int(5));
+        let mut row2 = Vec::new();
+        row2.extend_from_slice(&encode_avro_long(1));
+        row2.extend_from_slice(&encode_avro_int(123));
+        row2.extend_from_slice(&encode_avro_int(7));
+        let mut cur1 = AvroCursor::new(&row1);
+        let mut cur2 = AvroCursor::new(&row2);
+        dec.decode(&mut cur1).unwrap();
+        dec.decode(&mut cur2).unwrap();
+        assert_eq!(cur1.position(), row1.len());
+        assert_eq!(cur2.position(), row2.len());
+        let arr = dec.flush(None).unwrap();
+        let s = arr.as_any().downcast_ref::<StructArray>().unwrap();
+        let id = s
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id.len(), 2);
+        assert_eq!(id.value(0), 5);
+        assert_eq!(id.value(1), 7);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/4886
- Follows up on https://github.com/apache/arrow-rs/pull/8047

# Rationale for this change

When reading Avro into Arrow with a projection or a reader schema that omits some writer fields, we were still decoding those writer‑only fields item‑by‑item. This is unnecessary work and can dominate CPU time for large arrays/maps or deeply nested records.

Avro’s binary format explicitly allows fast skipping for arrays/maps by encoding data in blocks: when the count is negative, the next `long` gives the byte size of the block, enabling O(1) skipping of that block without decoding each item. This PR teaches the record reader to recognize and leverage that, and to avoid constructing decoders for fields we will skip altogether.

# What changes are included in this PR?

**Reader / decoding architecture**
- **Abstracted skip logic**: Centralized the common logic previously duplicated across `skip_blocks_fast` and `read_blockwise_items` into reusable helpers. This reduces code duplication and clarifies the control flow for arrays/maps.
- **Skip-aware record decoding**:
  - At construction time, we now precompute per-record **skip decoders** for writer fields that the reader will ignore.
  - Introduced a resolved-record path (`RecordResolved`) that carries:
    - `writer_to_reader` mapping for field alignment,
    - a prebuilt list of **skip decoders** for fields not present in the reader,
    - the set of active per-field decoders for the projected fields.
- **Codec builder enhancements**: In `arrow-avro/src/codec.rs`, record construction now:
  - Builds Arrow `Field`s and their decoders only for fields that are read,
  - Builds `skip_decoders` (via `build_skip_decoders`) for fields to ignore.
- **Error handling and consistency**: Kept existing strict-mode behavior; improved internal branching to avoid inconsistent states during partial decodes.

**Tests**
- **Unit tests (in `arrow-avro/src/reader/record.rs`)**
  - Added focused tests that exercise the new skip logic:
    - Skipping writer‑only fields inside **arrays** and **maps** (including negative‑count block skipping and mixed multi‑block payloads).
    - Skipping nested structures within records to ensure offsets and lengths remain correct for the fields that are read.
    - Ensured nullability and union handling remain correct when adjacent fields are skipped.
- **Integration tests (in `arrow-avro/src/reader/mod.rs`)**
  - Added end‑to‑end test using `avro/alltypes_plain.avro` to validate that projecting a subset of fields (reader schema omits some writer fields) both:
    - Produces the correct Arrow arrays for the selected fields, and
    - Avoids decoding skipped fields (validated indirectly via behavior and block boundaries).
  - The test covers compressed and uncompressed variants already present in the suite to ensure behavior is consistent across codecs.

# Are these changes tested?

- **New unit tests** cover:
  - Fast skipping for arrays/maps using negative block counts and block sizes (per Avro spec).
  - Nested and nullable scenarios to ensure correct offsets, validity bitmaps, and flush behavior when adjacent fields are skipped.
- **New integration test** in `reader/mod.rs`:
  - Reads `avro/alltypes_plain.avro` with a reader schema that omits several writer fields and asserts the resulting `RecordBatch` matches the expected arrays while exercising the skip path.
- Existing promotion, enum, decimal, fixed, and union tests continue to pass, ensuring no regressions in unrelated areas.

# Are there any user-facing changes?

N/A since `arrow-avro` is not public yet.
