### PR TITLE
WIP: Initial Parquet native geometry type support

### DIFF
--- a/arrow-schema/src/extension/canonical/geometry.rs
+++ b/arrow-schema/src/extension/canonical/geometry.rs
@@ -1,0 +1,136 @@
+use crate::extension::ExtensionType;
+use crate::ArrowError;
+
+/// Geospatial features in the WKB format with linear/planar edges interpolation
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct Geometry {
+    crs: Option<String>,
+}
+
+impl Geometry {
+    /// Create a new Geometry extension type with an optional CRS.
+    pub fn new(crs: Option<String>) -> Self {
+        Self { crs }
+    }
+
+    /// Get the CRS of the Geometry type, if any.
+    pub fn crs(&self) -> Option<&str> {
+        self.crs.as_deref()
+    }
+}
+
+impl ExtensionType for Geometry {
+    const NAME: &'static str = "geoarrow.wkb";
+
+    type Metadata = ();
+
+    fn metadata(&self) -> &Self::Metadata {
+        &()
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        None
+    }
+
+    fn deserialize_metadata(_metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Ok(())
+    }
+
+    fn supports_data_type(&self, data_type: &crate::DataType) -> Result<(), ArrowError> {
+        match data_type {
+            crate::DataType::Binary
+            | crate::DataType::LargeBinary
+            | crate::DataType::BinaryView => Ok(()),
+            data_type => Err(ArrowError::InvalidArgumentError(format!(
+                "Geometry data type mismatch, expected one of Binary, LargeBinary, BinaryView, found {data_type}"
+            ))),
+        }
+    }
+
+    fn try_new(data_type: &crate::DataType, _metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        // TODO: fix
+        let geo = Self { crs: None };
+        geo.supports_data_type(data_type)?;
+        Ok(geo)
+    }
+}
+
+/// Edge interpolation algorithm for Geography logical type
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum GeographyAlgorithm {
+    /// Edges are interpolated as geodesics on a sphere.
+    SPHERICAL,
+
+    /// <https://en.wikipedia.org/wiki/Vincenty%27s_formulae>
+    VINCENTY,
+
+    /// Thomas, Paul D. Spheroidal geodesics, reference systems, & local geometry. US Naval Oceanographic Office, 1970
+    THOMAS,
+
+    /// Thomas, Paul D. Mathematical models for navigation systems. US Naval Oceanographic Office, 1965.
+    ANDOYER,
+
+    /// Karney, Charles FF. "Algorithms for geodesics." Journal of Geodesy 87 (2013): 43-55
+    KARNEY,
+}
+
+/// Geospatial features in the [WKB format](https://libgeos.org/specifications/wkb/) with an
+/// explicit (non-linear/non-planar) edges interpolation algorithm.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct Geography {
+    crs: Option<String>,
+    algorithm: Option<GeographyAlgorithm>,
+}
+
+impl Geography {
+    /// Create a new Geography extension type with an optional CRS and algorithm.
+    pub fn new(crs: Option<String>, algorithm: Option<GeographyAlgorithm>) -> Self {
+        Self { crs, algorithm }
+    }
+
+    /// Get the CRS of the Geography type, if any.
+    pub fn crs(&self) -> Option<&str> {
+        self.crs.as_deref()
+    }
+
+    /// Get the edge interpolation algorithm of the Geography type, if any.
+    pub fn algorithm(&self) -> Option<&GeographyAlgorithm> {
+        self.algorithm.as_ref()
+    }
+}
+
+impl ExtensionType for Geography {
+    const NAME: &'static str = "geoarrow.wkb";
+
+    type Metadata = ();
+
+    fn metadata(&self) -> &Self::Metadata {
+        &()
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        None
+    }
+
+    fn deserialize_metadata(_metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Ok(())
+    }
+
+    fn supports_data_type(&self, data_type: &crate::DataType) -> Result<(), ArrowError> {
+        match data_type {
+            crate::DataType::Binary
+            | crate::DataType::LargeBinary
+            | crate::DataType::BinaryView => Ok(()),
+            data_type => Err(ArrowError::InvalidArgumentError(format!(
+                "Geography data type mismatch, expected one of Binary, LargeBinary, BinaryView, found {data_type}"
+            ))),
+        }
+    }
+
+    fn try_new(data_type: &crate::DataType, _metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        // TODO: fix
+        let geo = Self::default();
+        geo.supports_data_type(data_type)?;
+        Ok(geo)
+    }
+}

--- a/arrow-schema/src/extension/canonical/mod.rs
+++ b/arrow-schema/src/extension/canonical/mod.rs
@@ -37,6 +37,8 @@ mod uuid;
 pub use uuid::Uuid;
 mod variable_shape_tensor;
 pub use variable_shape_tensor::{VariableShapeTensor, VariableShapeTensorMetadata};
+mod geometry;
+pub use geometry::{Geography, GeographyAlgorithm, Geometry};
 
 use crate::{ArrowError, Field};
 

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -327,8 +327,8 @@ fn print_logical_and_converted(
             LogicalType::Map => "MAP".to_string(),
             LogicalType::Float16 => "FLOAT16".to_string(),
             LogicalType::Variant => "VARIANT".to_string(),
-            LogicalType::Geometry => "GEOMETRY".to_string(),
-            LogicalType::Geography => "GEOGRAPHY".to_string(),
+            LogicalType::Geometry { .. } => "GEOMETRY".to_string(),
+            LogicalType::Geography { .. } => "GEOGRAPHY".to_string(),
             LogicalType::Unknown => "UNKNOWN".to_string(),
         },
         None => {


### PR DESCRIPTION
This is a pretty early draft to start discussion. It is not ready to merge.

# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/7240, 
- closes https://github.com/apache/arrow-rs/issues/7799.

# Rationale for this change

Bare-bones support for reading and writing Parquet geometry/geography data.

# What changes are included in this PR?

This is lightly modeled after https://github.com/apache/arrow-rs/pull/7404, but that was an early draft of variant support. It looks like progress has gone on in `parquet-variant`, but it's hard to understand how that crate is intended to be used.

- **Breaking**: changes `parquet::basic::LogicalType` because we need to maintain the type-level information of `Geometry`/`Geography` that exists on [`parquet::format::LogicalType`](https://docs.rs/parquet/latest/parquet/format/enum.LogicalType.html#variant.GEOMETRY).
- Defines new `Geometry` and `Geography` arrow logical types, which each implement `arrow_schema::extension::ExtensionType`. This PR currently puts those in `arrow-schema`, but it's not clear that they should live there. If we created a new `parquet-geometry` crate, then at first glance I'd put `Geometry` and `Geography` there, but that's an issue assuming that `parquet` won't depend on `parquet-geometry`.
- Should there be two new logical types? Or should there be just one on the Arrow side?
- Those `Geometry` and `Geography` arrow logical types are currently feature-gated behind `arrow_canonical_extension_types`, while these types aren't actually canonical yet. Should we create a new `geometry` feature flag for the `parquet` crate?

Perhaps we'll create a separate `parquet-geometry` crate for the builders that maintain a bounding box when writing geometry data.

# Are these changes tested?

Not yet, I first want to put the PR up to get some initial discussion.

# Are there any user-facing changes?

> If there are any breaking changes to public APIs, please call them out.

Unfortunately, I think this _requires_ a breaking change to `parquet::basic::LogicalType` because we need to maintain the type-level information of `Geometry`/`Geography` that exists on [`parquet::format::LogicalType`](https://docs.rs/parquet/latest/parquet/format/enum.LogicalType.html#variant.GEOMETRY).
