### PR TITLE
[Variant]add strict mode to cast_to_variant

### DIFF
--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -46,5 +46,6 @@ pub mod variant_get;
 pub use variant_array::{ShreddingState, VariantArray};
 pub use variant_array_builder::{VariantArrayBuilder, VariantArrayVariantBuilder};
 
+pub use cast_to_variant::{cast_to_variant, cast_to_variant_with_options};
 pub use from_json::json_to_variant;
 pub use to_json::variant_to_json;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8155 .

# Rationale for this change

cast_to_variant will panic for values of Date64 / Timestamp that can not be converted to NaiveDate

# What changes are included in this PR?

add new api :
  `pub fn cast_to_variant_with_options(input: &dyn Array, strict: bool) -> Result<VariantArray, ArrowError>`
  - strict = true: Returns errors on conversion failures (default behavior)
  - strict = false: Returns null values for failed conversions 
add some tests to test non-strict mode.
# Are these changes tested?

Yes.

# Are there any user-facing changes?

no.