### PR TITLE
[Variant] Refactor `cast_to_variant`

### DIFF
--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -660,140 +660,8 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_to_variant_timestamp() {
-        let run_array_tests =
-            |microseconds: i64, array_ntz: Arc<dyn Array>, array_tz: Arc<dyn Array>| {
-                let timestamp = DateTime::from_timestamp_nanos(microseconds * 1000);
-                run_test(
-                    array_tz,
-                    vec![Some(Variant::TimestampMicros(timestamp)), None],
-                );
-                run_test(
-                    array_ntz,
-                    vec![
-                        Some(Variant::TimestampNtzMicros(timestamp.naive_utc())),
-                        None,
-                    ],
-                );
-            };
-
-        let nanosecond = 1234567890;
-        let microsecond = 1234567;
-        let millisecond = 1234;
-        let second = 1;
-
-        let second_array = TimestampSecondArray::from(vec![Some(second), None]);
-        run_array_tests(
-            second * 1000 * 1000,
-            Arc::new(second_array.clone()),
-            Arc::new(second_array.with_timezone("+01:00".to_string())),
-        );
-
-        let millisecond_array = TimestampMillisecondArray::from(vec![Some(millisecond), None]);
-        run_array_tests(
-            millisecond * 1000,
-            Arc::new(millisecond_array.clone()),
-            Arc::new(millisecond_array.with_timezone("+01:00".to_string())),
-        );
-
-        let microsecond_array = TimestampMicrosecondArray::from(vec![Some(microsecond), None]);
-        run_array_tests(
-            microsecond,
-            Arc::new(microsecond_array.clone()),
-            Arc::new(microsecond_array.with_timezone("+01:00".to_string())),
-        );
-
-        let timestamp = DateTime::from_timestamp_nanos(nanosecond);
-        let nanosecond_array = TimestampNanosecondArray::from(vec![Some(nanosecond), None]);
-        run_test(
-            Arc::new(nanosecond_array.clone()),
-            vec![
-                Some(Variant::TimestampNtzNanos(timestamp.naive_utc())),
-                None,
-            ],
-        );
-        run_test(
-            Arc::new(nanosecond_array.with_timezone("+01:00".to_string())),
-            vec![Some(Variant::TimestampNanos(timestamp)), None],
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_fixed_size_binary() {
-        let v1 = vec![1, 2];
-        let v2 = vec![3, 4];
-        let v3 = vec![5, 6];
-
-        let mut builder = FixedSizeBinaryBuilder::new(2);
-        builder.append_value(&v1).unwrap();
-        builder.append_value(&v2).unwrap();
-        builder.append_null();
-        builder.append_value(&v3).unwrap();
-        let array = builder.finish();
-
-        run_test(
-            Arc::new(array),
-            vec![
-                Some(Variant::Binary(&v1)),
-                Some(Variant::Binary(&v2)),
-                None,
-                Some(Variant::Binary(&v3)),
-            ],
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_binary() {
-        // BinaryType
-        let mut builder = GenericByteBuilder::<BinaryType>::new();
-        builder.append_value(b"hello");
-        builder.append_value(b"");
-        builder.append_null();
-        builder.append_value(b"world");
-        let binary_array = builder.finish();
-        run_test(
-            Arc::new(binary_array),
-            vec![
-                Some(Variant::Binary(b"hello")),
-                Some(Variant::Binary(b"")),
-                None,
-                Some(Variant::Binary(b"world")),
-            ],
-        );
-
-        // LargeBinaryType
-        let mut builder = GenericByteBuilder::<LargeBinaryType>::new();
-        builder.append_value(b"hello");
-        builder.append_value(b"");
-        builder.append_null();
-        builder.append_value(b"world");
-        let large_binary_array = builder.finish();
-        run_test(
-            Arc::new(large_binary_array),
-            vec![
-                Some(Variant::Binary(b"hello")),
-                Some(Variant::Binary(b"")),
-                None,
-                Some(Variant::Binary(b"world")),
-            ],
-        );
-
-        // BinaryViewType
-        let mut builder = GenericByteViewBuilder::<BinaryViewType>::new();
-        builder.append_value(b"hello");
-        builder.append_value(b"");
-        builder.append_null();
-        builder.append_value(b"world");
-        let byte_view_array = builder.finish();
-        run_test(
-            Arc::new(byte_view_array),
-            vec![
-                Some(Variant::Binary(b"hello")),
-                Some(Variant::Binary(b"")),
-                None,
-                Some(Variant::Binary(b"world")),
-            ],
-        );
+    fn test_cast_to_variant_null() {
+        run_test(Arc::new(NullArray::new(2)), vec![None, None])
     }
 
     #[test]
@@ -1035,62 +903,6 @@ mod tests {
                 Some(Variant::Double(f64::MAX)),
             ],
         )
-    }
-
-    #[test]
-    fn test_cast_to_variant_duration_or_interval_errors() {
-        let arrays: Vec<Box<dyn Array>> = vec![
-            // Duration types
-            Box::new(DurationSecondArray::from(vec![Some(10), None, Some(-5)])),
-            Box::new(DurationMillisecondArray::from(vec![
-                Some(10),
-                None,
-                Some(-5),
-            ])),
-            Box::new(DurationMicrosecondArray::from(vec![
-                Some(10),
-                None,
-                Some(-5),
-            ])),
-            Box::new(DurationNanosecondArray::from(vec![
-                Some(10),
-                None,
-                Some(-5),
-            ])),
-            // Interval types
-            Box::new(IntervalYearMonthArray::from(vec![Some(12), None, Some(-6)])),
-            Box::new(IntervalDayTimeArray::from(vec![
-                Some(IntervalDayTime::new(12, 0)),
-                None,
-                Some(IntervalDayTime::new(-6, 0)),
-            ])),
-            Box::new(IntervalMonthDayNanoArray::from(vec![
-                Some(IntervalMonthDayNano::new(12, 0, 0)),
-                None,
-                Some(IntervalMonthDayNano::new(-6, 0, 0)),
-            ])),
-        ];
-
-        for array in arrays {
-            let result = cast_to_variant(array.as_ref());
-            assert!(result.is_err());
-            match result.unwrap_err() {
-                ArrowError::InvalidArgumentError(msg) => {
-                    assert!(
-                        msg.contains("Casting duration/interval types to Variant is not supported")
-                    );
-                    assert!(
-                        msg.contains("The Variant format does not define duration/interval types")
-                    );
-                }
-                _ => panic!("Expected InvalidArgumentError"),
-            }
-        }
-    }
-
-    #[test]
-    fn test_cast_to_variant_null() {
-        run_test(Arc::new(NullArray::new(2)), vec![None, None])
     }
 
     #[test]
@@ -1486,7 +1298,105 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_time32_second_to_variant_time() {
+    fn test_cast_to_variant_timestamp() {
+        let run_array_tests =
+            |microseconds: i64, array_ntz: Arc<dyn Array>, array_tz: Arc<dyn Array>| {
+                let timestamp = DateTime::from_timestamp_nanos(microseconds * 1000);
+                run_test(
+                    array_tz,
+                    vec![Some(Variant::TimestampMicros(timestamp)), None],
+                );
+                run_test(
+                    array_ntz,
+                    vec![
+                        Some(Variant::TimestampNtzMicros(timestamp.naive_utc())),
+                        None,
+                    ],
+                );
+            };
+
+        let nanosecond = 1234567890;
+        let microsecond = 1234567;
+        let millisecond = 1234;
+        let second = 1;
+
+        let second_array = TimestampSecondArray::from(vec![Some(second), None]);
+        run_array_tests(
+            second * 1000 * 1000,
+            Arc::new(second_array.clone()),
+            Arc::new(second_array.with_timezone("+01:00".to_string())),
+        );
+
+        let millisecond_array = TimestampMillisecondArray::from(vec![Some(millisecond), None]);
+        run_array_tests(
+            millisecond * 1000,
+            Arc::new(millisecond_array.clone()),
+            Arc::new(millisecond_array.with_timezone("+01:00".to_string())),
+        );
+
+        let microsecond_array = TimestampMicrosecondArray::from(vec![Some(microsecond), None]);
+        run_array_tests(
+            microsecond,
+            Arc::new(microsecond_array.clone()),
+            Arc::new(microsecond_array.with_timezone("+01:00".to_string())),
+        );
+
+        let timestamp = DateTime::from_timestamp_nanos(nanosecond);
+        let nanosecond_array = TimestampNanosecondArray::from(vec![Some(nanosecond), None]);
+        run_test(
+            Arc::new(nanosecond_array.clone()),
+            vec![
+                Some(Variant::TimestampNtzNanos(timestamp.naive_utc())),
+                None,
+            ],
+        );
+        run_test(
+            Arc::new(nanosecond_array.with_timezone("+01:00".to_string())),
+            vec![Some(Variant::TimestampNanos(timestamp)), None],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_date() {
+        // Date32Array
+        run_test(
+            Arc::new(Date32Array::from(vec![
+                Some(Date32Type::from_naive_date(NaiveDate::MIN)),
+                None,
+                Some(Date32Type::from_naive_date(
+                    NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
+                )),
+                Some(Date32Type::from_naive_date(NaiveDate::MAX)),
+            ])),
+            vec![
+                Some(Variant::Date(NaiveDate::MIN)),
+                None,
+                Some(Variant::Date(NaiveDate::from_ymd_opt(2025, 8, 1).unwrap())),
+                Some(Variant::Date(NaiveDate::MAX)),
+            ],
+        );
+
+        // Date64Array
+        run_test(
+            Arc::new(Date64Array::from(vec![
+                Some(Date64Type::from_naive_date(NaiveDate::MIN)),
+                None,
+                Some(Date64Type::from_naive_date(
+                    NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
+                )),
+                Some(Date64Type::from_naive_date(NaiveDate::MAX)),
+            ])),
+            vec![
+                Some(Variant::Date(NaiveDate::MIN)),
+                None,
+                Some(Variant::Date(NaiveDate::from_ymd_opt(2025, 8, 1).unwrap())),
+                Some(Variant::Date(NaiveDate::MAX)),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_time32_second() {
         let array: Time32SecondArray = vec![Some(1), Some(86_399), None].into();
         let values = Arc::new(array);
         run_test(
@@ -1504,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_time32_millisecond_to_variant_time() {
+    fn test_cast_to_variant_time32_millisecond() {
         let array: Time32MillisecondArray = vec![Some(123_456), Some(456_000), None].into();
         let values = Arc::new(array);
         run_test(
@@ -1522,7 +1432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_time64_micro_to_variant_time() {
+    fn test_cast_to_variant_time64_micro() {
         let array: Time64MicrosecondArray = vec![Some(1), Some(123_456_789), None].into();
         let values = Arc::new(array);
         run_test(
@@ -1540,7 +1450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_time64_nano_to_variant_time() {
+    fn test_cast_to_variant_time64_nano() {
         let array: Time64NanosecondArray =
             vec![Some(1), Some(1001), Some(123_456_789_012), None].into();
         run_test(
@@ -1559,6 +1469,135 @@ mod tests {
                 None,
             ],
         )
+    }
+
+    #[test]
+    fn test_cast_to_variant_duration_or_interval_errors() {
+        let arrays: Vec<Box<dyn Array>> = vec![
+            // Duration types
+            Box::new(DurationSecondArray::from(vec![Some(10), None, Some(-5)])),
+            Box::new(DurationMillisecondArray::from(vec![
+                Some(10),
+                None,
+                Some(-5),
+            ])),
+            Box::new(DurationMicrosecondArray::from(vec![
+                Some(10),
+                None,
+                Some(-5),
+            ])),
+            Box::new(DurationNanosecondArray::from(vec![
+                Some(10),
+                None,
+                Some(-5),
+            ])),
+            // Interval types
+            Box::new(IntervalYearMonthArray::from(vec![Some(12), None, Some(-6)])),
+            Box::new(IntervalDayTimeArray::from(vec![
+                Some(IntervalDayTime::new(12, 0)),
+                None,
+                Some(IntervalDayTime::new(-6, 0)),
+            ])),
+            Box::new(IntervalMonthDayNanoArray::from(vec![
+                Some(IntervalMonthDayNano::new(12, 0, 0)),
+                None,
+                Some(IntervalMonthDayNano::new(-6, 0, 0)),
+            ])),
+        ];
+
+        for array in arrays {
+            let result = cast_to_variant(array.as_ref());
+            assert!(result.is_err());
+            match result.unwrap_err() {
+                ArrowError::InvalidArgumentError(msg) => {
+                    assert!(
+                        msg.contains("Casting duration/interval types to Variant is not supported")
+                    );
+                    assert!(
+                        msg.contains("The Variant format does not define duration/interval types")
+                    );
+                }
+                _ => panic!("Expected InvalidArgumentError"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_cast_to_variant_binary() {
+        // BinaryType
+        let mut builder = GenericByteBuilder::<BinaryType>::new();
+        builder.append_value(b"hello");
+        builder.append_value(b"");
+        builder.append_null();
+        builder.append_value(b"world");
+        let binary_array = builder.finish();
+        run_test(
+            Arc::new(binary_array),
+            vec![
+                Some(Variant::Binary(b"hello")),
+                Some(Variant::Binary(b"")),
+                None,
+                Some(Variant::Binary(b"world")),
+            ],
+        );
+
+        // LargeBinaryType
+        let mut builder = GenericByteBuilder::<LargeBinaryType>::new();
+        builder.append_value(b"hello");
+        builder.append_value(b"");
+        builder.append_null();
+        builder.append_value(b"world");
+        let large_binary_array = builder.finish();
+        run_test(
+            Arc::new(large_binary_array),
+            vec![
+                Some(Variant::Binary(b"hello")),
+                Some(Variant::Binary(b"")),
+                None,
+                Some(Variant::Binary(b"world")),
+            ],
+        );
+
+        // BinaryViewType
+        let mut builder = GenericByteViewBuilder::<BinaryViewType>::new();
+        builder.append_value(b"hello");
+        builder.append_value(b"");
+        builder.append_null();
+        builder.append_value(b"world");
+        let byte_view_array = builder.finish();
+        run_test(
+            Arc::new(byte_view_array),
+            vec![
+                Some(Variant::Binary(b"hello")),
+                Some(Variant::Binary(b"")),
+                None,
+                Some(Variant::Binary(b"world")),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_fixed_size_binary() {
+        let v1 = vec![1, 2];
+        let v2 = vec![3, 4];
+        let v3 = vec![5, 6];
+
+        let mut builder = FixedSizeBinaryBuilder::new(2);
+        builder.append_value(&v1).unwrap();
+        builder.append_value(&v2).unwrap();
+        builder.append_null();
+        builder.append_value(&v3).unwrap();
+        let array = builder.finish();
+
+        run_test(
+            Arc::new(array),
+            vec![
+                Some(Variant::Binary(&v1)),
+                Some(Variant::Binary(&v2)),
+                None,
+                Some(Variant::Binary(&v3)),
+            ],
+        );
     }
 
     #[test]
@@ -1656,6 +1695,101 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_to_variant_list() {
+        // List Array
+        let data = vec![Some(vec![Some(0), Some(1), Some(2)]), None];
+        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(data);
+
+        // Expected value
+        let (metadata, value) = {
+            let mut builder = VariantBuilder::new();
+            let mut list = builder.new_list();
+            list.append_value(0);
+            list.append_value(1);
+            list.append_value(2);
+            list.finish();
+            builder.finish()
+        };
+        let variant = Variant::new(&metadata, &value);
+
+        run_test(Arc::new(list_array), vec![Some(variant), None]);
+    }
+
+    #[test]
+    fn test_cast_to_variant_sliced_list() {
+        // List Array
+        let data = vec![
+            Some(vec![Some(0), Some(1), Some(2)]),
+            Some(vec![Some(3), Some(4), Some(5)]),
+            None,
+        ];
+        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(data);
+
+        // Expected value
+        let (metadata, value) = {
+            let mut builder = VariantBuilder::new();
+            let mut list = builder.new_list();
+            list.append_value(3);
+            list.append_value(4);
+            list.append_value(5);
+            list.finish();
+            builder.finish()
+        };
+        let variant = Variant::new(&metadata, &value);
+
+        run_test(Arc::new(list_array.slice(1, 2)), vec![Some(variant), None]);
+    }
+
+    #[test]
+    fn test_cast_to_variant_large_list() {
+        // Large List Array
+        let data = vec![Some(vec![Some(0), Some(1), Some(2)]), None];
+        let large_list_array = LargeListArray::from_iter_primitive::<Int64Type, _, _>(data);
+
+        // Expected value
+        let (metadata, value) = {
+            let mut builder = VariantBuilder::new();
+            let mut list = builder.new_list();
+            list.append_value(0i64);
+            list.append_value(1i64);
+            list.append_value(2i64);
+            list.finish();
+            builder.finish()
+        };
+        let variant = Variant::new(&metadata, &value);
+
+        run_test(Arc::new(large_list_array), vec![Some(variant), None]);
+    }
+
+    #[test]
+    fn test_cast_to_variant_sliced_large_list() {
+        // List Array
+        let data = vec![
+            Some(vec![Some(0), Some(1), Some(2)]),
+            Some(vec![Some(3), Some(4), Some(5)]),
+            None,
+        ];
+        let large_list_array = ListArray::from_iter_primitive::<Int64Type, _, _>(data);
+
+        // Expected value
+        let (metadata, value) = {
+            let mut builder = VariantBuilder::new();
+            let mut list = builder.new_list();
+            list.append_value(3i64);
+            list.append_value(4i64);
+            list.append_value(5i64);
+            list.finish();
+            builder.finish()
+        };
+        let variant = Variant::new(&metadata, &value);
+
+        run_test(
+            Arc::new(large_list_array.slice(1, 2)),
+            vec![Some(variant), None],
+        );
+    }
+
+    #[test]
     fn test_cast_to_variant_struct() {
         // Test a simple struct with two fields: id (int64) and age (int32)
         let id_array = Int64Array::from(vec![Some(1001), Some(1002), None, Some(1003)]);
@@ -1698,97 +1832,6 @@ mod tests {
         let obj4 = variant4.as_object().unwrap();
         assert_eq!(obj4.get("id"), Some(Variant::from(1003i64)));
         assert_eq!(obj4.get("age"), None);
-    }
-
-    #[test]
-    fn test_cast_to_variant_union_sparse() {
-        // Create a sparse union array with mixed types (int, float, string)
-        let int_array = Int32Array::from(vec![Some(1), None, None, None, Some(34), None]);
-        let float_array = Float64Array::from(vec![None, Some(3.2), None, Some(32.5), None, None]);
-        let string_array = StringArray::from(vec![None, None, Some("hello"), None, None, None]);
-        let type_ids = [0, 1, 2, 1, 0, 0].into_iter().collect::<ScalarBuffer<i8>>();
-
-        let union_fields = UnionFields::new(
-            vec![0, 1, 2],
-            vec![
-                Field::new("int_field", DataType::Int32, false),
-                Field::new("float_field", DataType::Float64, false),
-                Field::new("string_field", DataType::Utf8, false),
-            ],
-        );
-
-        let children: Vec<Arc<dyn Array>> = vec![
-            Arc::new(int_array),
-            Arc::new(float_array),
-            Arc::new(string_array),
-        ];
-
-        let union_array = UnionArray::try_new(
-            union_fields,
-            type_ids,
-            None, // Sparse union
-            children,
-        )
-        .unwrap();
-
-        run_test(
-            Arc::new(union_array),
-            vec![
-                Some(Variant::Int32(1)),
-                Some(Variant::Double(3.2)),
-                Some(Variant::from("hello")),
-                Some(Variant::Double(32.5)),
-                Some(Variant::Int32(34)),
-                None,
-            ],
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_union_dense() {
-        // Create a dense union array with mixed types (int, float, string)
-        let int_array = Int32Array::from(vec![Some(1), Some(34), None]);
-        let float_array = Float64Array::from(vec![3.2, 32.5]);
-        let string_array = StringArray::from(vec!["hello"]);
-        let type_ids = [0, 1, 2, 1, 0, 0].into_iter().collect::<ScalarBuffer<i8>>();
-        let offsets = [0, 0, 0, 1, 1, 2]
-            .into_iter()
-            .collect::<ScalarBuffer<i32>>();
-
-        let union_fields = UnionFields::new(
-            vec![0, 1, 2],
-            vec![
-                Field::new("int_field", DataType::Int32, false),
-                Field::new("float_field", DataType::Float64, false),
-                Field::new("string_field", DataType::Utf8, false),
-            ],
-        );
-
-        let children: Vec<Arc<dyn Array>> = vec![
-            Arc::new(int_array),
-            Arc::new(float_array),
-            Arc::new(string_array),
-        ];
-
-        let union_array = UnionArray::try_new(
-            union_fields,
-            type_ids,
-            Some(offsets), // Dense union
-            children,
-        )
-        .unwrap();
-
-        run_test(
-            Arc::new(union_array),
-            vec![
-                Some(Variant::Int32(1)),
-                Some(Variant::Double(3.2)),
-                Some(Variant::from("hello")),
-                Some(Variant::Double(32.5)),
-                Some(Variant::Int32(34)),
-                None,
-            ],
-        );
     }
 
     #[test]
@@ -2027,40 +2070,226 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_to_variant_date() {
-        // Date32Array
-        run_test(
-            Arc::new(Date32Array::from(vec![
-                Some(Date32Type::from_naive_date(NaiveDate::MIN)),
-                None,
-                Some(Date32Type::from_naive_date(
-                    NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
-                )),
-                Some(Date32Type::from_naive_date(NaiveDate::MAX)),
-            ])),
+    fn test_cast_to_variant_map() {
+        let keys = vec!["key1", "key2", "key3"];
+        let values_data = Int32Array::from(vec![1, 2, 3]);
+        let entry_offsets = vec![0, 1, 3];
+        let map_array =
+            MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets)
+                .unwrap();
+
+        let result = cast_to_variant(&map_array).unwrap();
+        // [{"key1":1}]
+        let variant1 = result.value(0);
+        assert_eq!(
+            variant1.as_object().unwrap().get("key1").unwrap(),
+            Variant::from(1)
+        );
+
+        // [{"key2":2},{"key3":3}]
+        let variant2 = result.value(1);
+        assert_eq!(
+            variant2.as_object().unwrap().get("key2").unwrap(),
+            Variant::from(2)
+        );
+        assert_eq!(
+            variant2.as_object().unwrap().get("key3").unwrap(),
+            Variant::from(3)
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_map_with_nulls() {
+        let keys = vec!["key1", "key2", "key3"];
+        let values_data = Int32Array::from(vec![1, 2, 3]);
+        let entry_offsets = vec![0, 1, 1, 3];
+        let map_array =
+            MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets)
+                .unwrap();
+
+        let result = cast_to_variant(&map_array).unwrap();
+        // [{"key1":1}]
+        let variant1 = result.value(0);
+        assert_eq!(
+            variant1.as_object().unwrap().get("key1").unwrap(),
+            Variant::from(1)
+        );
+
+        // None
+        assert!(result.is_null(1));
+
+        // [{"key2":2},{"key3":3}]
+        let variant2 = result.value(2);
+        assert_eq!(
+            variant2.as_object().unwrap().get("key2").unwrap(),
+            Variant::from(2)
+        );
+        assert_eq!(
+            variant2.as_object().unwrap().get("key3").unwrap(),
+            Variant::from(3)
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_map_with_non_string_keys() {
+        let offsets = OffsetBuffer::new(vec![0, 1, 3].into());
+        let fields = Fields::from(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Int32, false),
+        ]);
+        let columns = vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
+        ];
+
+        let entries = StructArray::new(fields.clone(), columns, None);
+        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+
+        let map_array = MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
+
+        let result = cast_to_variant(&map_array).unwrap();
+
+        let variant1 = result.value(0);
+        assert_eq!(
+            variant1.as_object().unwrap().get("1").unwrap(),
+            Variant::from(1)
+        );
+
+        let variant2 = result.value(1);
+        assert_eq!(
+            variant2.as_object().unwrap().get("2").unwrap(),
+            Variant::from(2)
+        );
+        assert_eq!(
+            variant2.as_object().unwrap().get("3").unwrap(),
+            Variant::from(3)
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_union_sparse() {
+        // Create a sparse union array with mixed types (int, float, string)
+        let int_array = Int32Array::from(vec![Some(1), None, None, None, Some(34), None]);
+        let float_array = Float64Array::from(vec![None, Some(3.2), None, Some(32.5), None, None]);
+        let string_array = StringArray::from(vec![None, None, Some("hello"), None, None, None]);
+        let type_ids = [0, 1, 2, 1, 0, 0].into_iter().collect::<ScalarBuffer<i8>>();
+
+        let union_fields = UnionFields::new(
+            vec![0, 1, 2],
             vec![
-                Some(Variant::Date(NaiveDate::MIN)),
-                None,
-                Some(Variant::Date(NaiveDate::from_ymd_opt(2025, 8, 1).unwrap())),
-                Some(Variant::Date(NaiveDate::MAX)),
+                Field::new("int_field", DataType::Int32, false),
+                Field::new("float_field", DataType::Float64, false),
+                Field::new("string_field", DataType::Utf8, false),
             ],
         );
 
-        // Date64Array
+        let children: Vec<Arc<dyn Array>> = vec![
+            Arc::new(int_array),
+            Arc::new(float_array),
+            Arc::new(string_array),
+        ];
+
+        let union_array = UnionArray::try_new(
+            union_fields,
+            type_ids,
+            None, // Sparse union
+            children,
+        )
+        .unwrap();
+
         run_test(
-            Arc::new(Date64Array::from(vec![
-                Some(Date64Type::from_naive_date(NaiveDate::MIN)),
-                None,
-                Some(Date64Type::from_naive_date(
-                    NaiveDate::from_ymd_opt(2025, 8, 1).unwrap(),
-                )),
-                Some(Date64Type::from_naive_date(NaiveDate::MAX)),
-            ])),
+            Arc::new(union_array),
             vec![
-                Some(Variant::Date(NaiveDate::MIN)),
+                Some(Variant::Int32(1)),
+                Some(Variant::Double(3.2)),
+                Some(Variant::from("hello")),
+                Some(Variant::Double(32.5)),
+                Some(Variant::Int32(34)),
                 None,
-                Some(Variant::Date(NaiveDate::from_ymd_opt(2025, 8, 1).unwrap())),
-                Some(Variant::Date(NaiveDate::MAX)),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_union_dense() {
+        // Create a dense union array with mixed types (int, float, string)
+        let int_array = Int32Array::from(vec![Some(1), Some(34), None]);
+        let float_array = Float64Array::from(vec![3.2, 32.5]);
+        let string_array = StringArray::from(vec!["hello"]);
+        let type_ids = [0, 1, 2, 1, 0, 0].into_iter().collect::<ScalarBuffer<i8>>();
+        let offsets = [0, 0, 0, 1, 1, 2]
+            .into_iter()
+            .collect::<ScalarBuffer<i32>>();
+
+        let union_fields = UnionFields::new(
+            vec![0, 1, 2],
+            vec![
+                Field::new("int_field", DataType::Int32, false),
+                Field::new("float_field", DataType::Float64, false),
+                Field::new("string_field", DataType::Utf8, false),
+            ],
+        );
+
+        let children: Vec<Arc<dyn Array>> = vec![
+            Arc::new(int_array),
+            Arc::new(float_array),
+            Arc::new(string_array),
+        ];
+
+        let union_array = UnionArray::try_new(
+            union_fields,
+            type_ids,
+            Some(offsets), // Dense union
+            children,
+        )
+        .unwrap();
+
+        run_test(
+            Arc::new(union_array),
+            vec![
+                Some(Variant::Int32(1)),
+                Some(Variant::Double(3.2)),
+                Some(Variant::from("hello")),
+                Some(Variant::Double(32.5)),
+                Some(Variant::Int32(34)),
+                None,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_dictionary() {
+        let values = StringArray::from(vec!["apple", "banana", "cherry", "date"]);
+        let keys = Int32Array::from(vec![Some(0), Some(1), None, Some(2), Some(0), Some(3)]);
+        let dict_array = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).unwrap();
+
+        run_test(
+            Arc::new(dict_array),
+            vec![
+                Some(Variant::from("apple")),
+                Some(Variant::from("banana")),
+                None,
+                Some(Variant::from("cherry")),
+                Some(Variant::from("apple")),
+                Some(Variant::from("date")),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_cast_to_variant_dictionary_with_nulls() {
+        // Test dictionary with null values in the values array
+        let values = StringArray::from(vec![Some("a"), None, Some("c")]);
+        let keys = Int8Array::from(vec![Some(0), Some(1), Some(2), Some(0)]);
+        let dict_array = DictionaryArray::<Int8Type>::try_new(keys, Arc::new(values)).unwrap();
+
+        run_test(
+            Arc::new(dict_array),
+            vec![
+                Some(Variant::from("a")),
+                None, // key 1 points to null value
+                Some(Variant::from("c")),
+                Some(Variant::from("a")),
             ],
         );
     }
@@ -2114,235 +2343,6 @@ mod tests {
                 None,
                 None,
             ],
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_dictionary() {
-        let values = StringArray::from(vec!["apple", "banana", "cherry", "date"]);
-        let keys = Int32Array::from(vec![Some(0), Some(1), None, Some(2), Some(0), Some(3)]);
-        let dict_array = DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).unwrap();
-
-        run_test(
-            Arc::new(dict_array),
-            vec![
-                Some(Variant::from("apple")),
-                Some(Variant::from("banana")),
-                None,
-                Some(Variant::from("cherry")),
-                Some(Variant::from("apple")),
-                Some(Variant::from("date")),
-            ],
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_dictionary_with_nulls() {
-        // Test dictionary with null values in the values array
-        let values = StringArray::from(vec![Some("a"), None, Some("c")]);
-        let keys = Int8Array::from(vec![Some(0), Some(1), Some(2), Some(0)]);
-        let dict_array = DictionaryArray::<Int8Type>::try_new(keys, Arc::new(values)).unwrap();
-
-        run_test(
-            Arc::new(dict_array),
-            vec![
-                Some(Variant::from("a")),
-                None, // key 1 points to null value
-                Some(Variant::from("c")),
-                Some(Variant::from("a")),
-            ],
-        );
-    }
-
-    #[test]
-    fn test_cast_map_to_variant_object() {
-        let keys = vec!["key1", "key2", "key3"];
-        let values_data = Int32Array::from(vec![1, 2, 3]);
-        let entry_offsets = vec![0, 1, 3];
-        let map_array =
-            MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets)
-                .unwrap();
-
-        let result = cast_to_variant(&map_array).unwrap();
-        // [{"key1":1}]
-        let variant1 = result.value(0);
-        assert_eq!(
-            variant1.as_object().unwrap().get("key1").unwrap(),
-            Variant::from(1)
-        );
-
-        // [{"key2":2},{"key3":3}]
-        let variant2 = result.value(1);
-        assert_eq!(
-            variant2.as_object().unwrap().get("key2").unwrap(),
-            Variant::from(2)
-        );
-        assert_eq!(
-            variant2.as_object().unwrap().get("key3").unwrap(),
-            Variant::from(3)
-        );
-    }
-
-    #[test]
-    fn test_cast_map_to_variant_object_with_nulls() {
-        let keys = vec!["key1", "key2", "key3"];
-        let values_data = Int32Array::from(vec![1, 2, 3]);
-        let entry_offsets = vec![0, 1, 1, 3];
-        let map_array =
-            MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets)
-                .unwrap();
-
-        let result = cast_to_variant(&map_array).unwrap();
-        // [{"key1":1}]
-        let variant1 = result.value(0);
-        assert_eq!(
-            variant1.as_object().unwrap().get("key1").unwrap(),
-            Variant::from(1)
-        );
-
-        // None
-        assert!(result.is_null(1));
-
-        // [{"key2":2},{"key3":3}]
-        let variant2 = result.value(2);
-        assert_eq!(
-            variant2.as_object().unwrap().get("key2").unwrap(),
-            Variant::from(2)
-        );
-        assert_eq!(
-            variant2.as_object().unwrap().get("key3").unwrap(),
-            Variant::from(3)
-        );
-    }
-
-    #[test]
-    fn test_cast_map_with_non_string_keys_to_variant_object() {
-        let offsets = OffsetBuffer::new(vec![0, 1, 3].into());
-        let fields = Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Int32, false),
-        ]);
-        let columns = vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
-            Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
-        ];
-
-        let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
-
-        let map_array = MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
-
-        let result = cast_to_variant(&map_array).unwrap();
-
-        let variant1 = result.value(0);
-        assert_eq!(
-            variant1.as_object().unwrap().get("1").unwrap(),
-            Variant::from(1)
-        );
-
-        let variant2 = result.value(1);
-        assert_eq!(
-            variant2.as_object().unwrap().get("2").unwrap(),
-            Variant::from(2)
-        );
-        assert_eq!(
-            variant2.as_object().unwrap().get("3").unwrap(),
-            Variant::from(3)
-        );
-    }
-
-    #[test]
-    fn test_cast_to_variant_list() {
-        // List Array
-        let data = vec![Some(vec![Some(0), Some(1), Some(2)]), None];
-        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(data);
-
-        // Expected value
-        let (metadata, value) = {
-            let mut builder = VariantBuilder::new();
-            let mut list = builder.new_list();
-            list.append_value(0);
-            list.append_value(1);
-            list.append_value(2);
-            list.finish();
-            builder.finish()
-        };
-        let variant = Variant::new(&metadata, &value);
-
-        run_test(Arc::new(list_array), vec![Some(variant), None]);
-    }
-
-    #[test]
-    fn test_cast_to_variant_sliced_list() {
-        // List Array
-        let data = vec![
-            Some(vec![Some(0), Some(1), Some(2)]),
-            Some(vec![Some(3), Some(4), Some(5)]),
-            None,
-        ];
-        let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(data);
-
-        // Expected value
-        let (metadata, value) = {
-            let mut builder = VariantBuilder::new();
-            let mut list = builder.new_list();
-            list.append_value(3);
-            list.append_value(4);
-            list.append_value(5);
-            list.finish();
-            builder.finish()
-        };
-        let variant = Variant::new(&metadata, &value);
-
-        run_test(Arc::new(list_array.slice(1, 2)), vec![Some(variant), None]);
-    }
-
-    #[test]
-    fn test_cast_to_variant_large_list() {
-        // Large List Array
-        let data = vec![Some(vec![Some(0), Some(1), Some(2)]), None];
-        let large_list_array = LargeListArray::from_iter_primitive::<Int64Type, _, _>(data);
-
-        // Expected value
-        let (metadata, value) = {
-            let mut builder = VariantBuilder::new();
-            let mut list = builder.new_list();
-            list.append_value(0i64);
-            list.append_value(1i64);
-            list.append_value(2i64);
-            list.finish();
-            builder.finish()
-        };
-        let variant = Variant::new(&metadata, &value);
-
-        run_test(Arc::new(large_list_array), vec![Some(variant), None]);
-    }
-
-    #[test]
-    fn test_cast_to_variant_sliced_large_list() {
-        // List Array
-        let data = vec![
-            Some(vec![Some(0), Some(1), Some(2)]),
-            Some(vec![Some(3), Some(4), Some(5)]),
-            None,
-        ];
-        let large_list_array = ListArray::from_iter_primitive::<Int64Type, _, _>(data);
-
-        // Expected value
-        let (metadata, value) = {
-            let mut builder = VariantBuilder::new();
-            let mut list = builder.new_list();
-            list.append_value(3i64);
-            list.append_value(4i64);
-            list.append_value(5i64);
-            list.finish();
-            builder.finish()
-        };
-        let variant = Variant::new(&metadata, &value);
-
-        run_test(
-            Arc::new(large_list_array.slice(1, 2)),
-            vec![Some(variant), None],
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8234.

# Rationale for this change

# What changes are included in this PR?

- Grouping related data types together (e.g., numeric types, temporal types).
- Extracting large code snippets from match branches into helper functions.
- Reordering tests to align with the data type order.

# Are these changes tested?

Covered by existing tests

# Are there any user-facing changes?

N/A
