### PR TITLE
feat: `SSLKEYLOGFILE` support for flight CLI

### DIFF
--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -85,6 +85,14 @@ struct ClientArgs {
     #[clap(long)]
     tls: bool,
 
+    /// Dump TLS key log.
+    ///
+    /// The target file is specified by the `SSLKEYLOGFILE` environment variable.
+    ///
+    /// Requires `--tls`.
+    #[clap(long, requires = "tls")]
+    key_log: bool,
+
     /// Server host.
     ///
     /// Required.
@@ -357,7 +365,11 @@ async fn setup_client(args: ClientArgs) -> Result<FlightSqlServiceClient<Channel
         .keep_alive_while_idle(true);
 
     if args.tls {
-        let tls_config = ClientTlsConfig::new().with_enabled_roots();
+        let mut tls_config = ClientTlsConfig::new().with_enabled_roots();
+        if args.key_log {
+            tls_config = tls_config.use_key_log();
+        }
+
         endpoint = endpoint
             .tls_config(tls_config)
             .context("create TLS endpoint")?;


### PR DESCRIPTION
# Which issue does this PR close?
\-

# Rationale for this change
This is #4875 now that the upstream changes are available.

Allows analysis of TLS traffic with an external tool like Wireshark.

See https://wiki.wireshark.org/TLS#using-the-pre-master-secret

# What changes are included in this PR?
New flag that opts into into the standard `SSLKEYLOGFILE` handling that other libraries and browsers support.

# Are these changes tested?
Not automatic test, but I did validate that setting the flag AND the env variable emits a log file that is successfully used by Wireshark to decrypt the traffic.

# Are there any user-facing changes?
Mostly none for normal users, but might be helpful for developers.
