### PR TITLE
Adds Confluent wire format handling to arrow-avro crate

### DIFF
--- a/arrow-avro/Cargo.toml
+++ b/arrow-avro/Cargo.toml
@@ -59,6 +59,8 @@ strum_macros = "0.27"
 uuid = "1.17"
 indexmap = "2.10"
 rand = "0.9"
+md5 = "0.8.0"
+sha2 = "0.11.0-rc.0"
 
 [dev-dependencies]
 arrow-data = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/4886
- Extends work initiated in https://github.com/apache/arrow-rs/pull/8006

# Rationale for this change

This introduces support for Confluent schema registry ID handling in the arrow-avro crate, adding compatibility with Confluent's wire format.

# What changes are included in this PR?

- Adds Confluent support
- Adds initial support for SHA256 and MD5 algorithm types. Rabin remains the default.

# Are these changes tested?

Yes, existing tests are all passing, and tests for ID handling have been added. Benchmark results show no appreciable changes.

# Are there any user-facing changes?

- Confluent users need to provide the ID fingerprint when using the `set` method, unlike the `register` method which generates it from the schema on the fly. Existing API behavior has been maintained.

- SchemaStore TryFrom now accepts a `&HashMap<Fingerprint, AvroSchema>`, rather than a `&[AvroSchema]` 
