### PR TITLE
pin comfy-table to 7.1.2

### DIFF
--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -50,7 +50,8 @@ half = { version = "2.1", default-features = false }
 num = { version = "0.4", default-features = false, features = ["std"] }
 lexical-core = { version = "1.0", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
 atoi = "2.0.0"
-comfy-table = { version = "7.0", optional = true, default-features = false }
+# unpin after MSRV bump to 1.85
+comfy-table = { version = "=7.1.2", optional = true, default-features = false }
 base64 = "0.22"
 ryu = "1.0.16"
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8243 .

# What changes are included in this PR?

pin `comfy-table` to release prior to 7.2.0's MSRV bump to 1.85 - included a TODO to unpin after arrow bumps to 1.85

(context FWIW: caught in delta_kernel [MSRV CI](https://github.com/delta-io/delta-kernel-rs/actions/runs/17310376492/job/49143119497))

# Are these changes tested?
validated MSRV with cargo-msrv:
```bash
# now passes
cargo msrv --path arrow-cast/ verify --rust-version 1.84 --all-features
```
