### PR TITLE
[Minor] Backport changes to metadata benchmark

### DIFF
--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use parquet::file::metadata::ParquetMetaDataReader;
-use parquet::file::page_encoding_stats::PageEncodingStats;
 use rand::Rng;
 use thrift::protocol::TCompactOutputProtocol;
 
@@ -27,7 +26,7 @@ use parquet::file::reader::SerializedFileReader;
 use parquet::file::serialized_reader::ReadOptionsBuilder;
 use parquet::format::{
     ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, FieldRepetitionType, FileMetaData,
-    PageType, RowGroup, SchemaElement, Type,
+    PageEncodingStats, PageType, RowGroup, SchemaElement, Type,
 };
 use parquet::thrift::TSerializable;
 
@@ -96,12 +95,12 @@ fn encoded_meta() -> Vec<u8> {
                         dictionary_page_offset: Some(rng.random()),
                         statistics: Some(stats.clone()),
                         encoding_stats: Some(vec![
-                            parquet::format::PageEncodingStats {
+                            PageEncodingStats {
                                 page_type: PageType::DICTIONARY_PAGE,
                                 encoding: Encoding::PLAIN,
                                 count: 1,
                             },
-                            parquet::format::PageEncodingStats {
+                            PageEncodingStats {
                                 page_type: PageType::DATA_PAGE,
                                 encoding: Encoding::RLE_DICTIONARY,
                                 count: 10,

--- a/parquet/benches/metadata.rs
+++ b/parquet/benches/metadata.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use parquet::file::metadata::ParquetMetaDataReader;
+use parquet::file::page_encoding_stats::PageEncodingStats;
 use rand::Rng;
 use thrift::protocol::TCompactOutputProtocol;
 
@@ -26,7 +27,7 @@ use parquet::file::reader::SerializedFileReader;
 use parquet::file::serialized_reader::ReadOptionsBuilder;
 use parquet::format::{
     ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, FieldRepetitionType, FileMetaData,
-    RowGroup, SchemaElement, Type,
+    PageType, RowGroup, SchemaElement, Type,
 };
 use parquet::thrift::TSerializable;
 
@@ -94,7 +95,18 @@ fn encoded_meta() -> Vec<u8> {
                         index_page_offset: Some(rng.random()),
                         dictionary_page_offset: Some(rng.random()),
                         statistics: Some(stats.clone()),
-                        encoding_stats: None,
+                        encoding_stats: Some(vec![
+                            parquet::format::PageEncodingStats {
+                                page_type: PageType::DICTIONARY_PAGE,
+                                encoding: Encoding::PLAIN,
+                                count: 1,
+                            },
+                            parquet::format::PageEncodingStats {
+                                page_type: PageType::DATA_PAGE,
+                                encoding: Encoding::RLE_DICTIONARY,
+                                count: 10,
+                            },
+                        ]),
                         bloom_filter_offset: None,
                         bloom_filter_length: None,
                         size_statistics: None,

--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -33,13 +33,15 @@ pub trait TSerializable: Sized {
     fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()>;
 }
 
-/// Public function to aid benchmarking. Reads Parquet `FileMetaData` encoded in `bytes`.
+// Public function to aid benchmarking. Reads Parquet `FileMetaData` encoded in `bytes`.
+#[doc(hidden)]
 pub fn bench_file_metadata(bytes: &bytes::Bytes) {
     let mut input = TCompactSliceInputProtocol::new(bytes);
     crate::format::FileMetaData::read_from_in_protocol(&mut input).unwrap();
 }
 
-/// Public function to aid benchmarking. Reads Parquet `PageHeader` encoded in `bytes`.
+// Public function to aid benchmarking. Reads Parquet `PageHeader` encoded in `bytes`.
+#[doc(hidden)]
 pub fn bench_page_header(bytes: &bytes::Bytes) {
     let mut prot = TCompactSliceInputProtocol::new(bytes);
     crate::format::PageHeader::read_from_in_protocol(&mut prot).unwrap();

--- a/parquet/src/thrift.rs
+++ b/parquet/src/thrift.rs
@@ -33,10 +33,16 @@ pub trait TSerializable: Sized {
     fn write_to_out_protocol<T: TOutputProtocol>(&self, o_prot: &mut T) -> thrift::Result<()>;
 }
 
-/// Public function to aid benchmarking.
+/// Public function to aid benchmarking. Reads Parquet `FileMetaData` encoded in `bytes`.
 pub fn bench_file_metadata(bytes: &bytes::Bytes) {
     let mut input = TCompactSliceInputProtocol::new(bytes);
     crate::format::FileMetaData::read_from_in_protocol(&mut input).unwrap();
+}
+
+/// Public function to aid benchmarking. Reads Parquet `PageHeader` encoded in `bytes`.
+pub fn bench_page_header(bytes: &bytes::Bytes) {
+    let mut prot = TCompactSliceInputProtocol::new(bytes);
+    crate::format::PageHeader::read_from_in_protocol(&mut prot).unwrap();
 }
 
 /// A more performant implementation of [`TCompactInputProtocol`] that reads a slice


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #5854.

# Rationale for this change
Backport changes to allow apples-to-apples comparison of thrift decoding

# What changes are included in this PR?

Adds a page header benchmark and updates bench names to match those in feature branch.

# Are these changes tested?

No tests needed...only changes to benchmark

# Are there any user-facing changes?

No
