### PR TITLE
Parquet: change default type for parquet v2 from delta to delta-length-byte-array

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -130,7 +130,7 @@ impl FallbackEncoder {
                 .encoding(descr.path())
                 .unwrap_or_else(|| match props.writer_version() {
                     WriterVersion::PARQUET_1_0 => Encoding::PLAIN,
-                    WriterVersion::PARQUET_2_0 => Encoding::DELTA_BYTE_ARRAY,
+                    WriterVersion::PARQUET_2_0 => Encoding::DELTA_LENGTH_BYTE_ARRAY,
                 });
 
         let encoder = match encoding {


### PR DESCRIPTION
# Which issue does this PR close?

Previously, v2 uses "delta" to encoding values, however it's too expansive for non-delta. Can we shift it to delta length byte array?

# Rationale for this change

Change the parquet-v2 default encoding to delta-length-byte-array

# What changes are included in this PR?

Change the parquet-v2 default encoding to delta-length-byte-array

# Are these changes tested?

Covered by existing

# Are there any user-facing changes?

No