### PR TITLE
[Parquet] expose ArrowRowGroupWriter

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -876,6 +876,11 @@ impl ArrowRowGroupWriter {
             .map(|writer| writer.close())
             .collect()
     }
+
+    /// Return writer for fine control on column writing
+    pub fn into_writers(self) -> Vec<ArrowColumnWriter> {
+        self.writers
+    }
 }
 
 struct ArrowRowGroupWriterFactory {


### PR DESCRIPTION
# Which issue does this PR close?



- Closes #8259.

# Rationale for this change

Use ArrowRowGroupWriter helper class  for write row group when you use API get_column_writers / append_row_group in ArrowWriter implemented in issue 

# What changes are included in this PR?

Set public ArrowRowGroupWriter and move memory_size, get_estimated_total_bytes and rows_count from ArrowWriter

# Are these changes tested?

Yes

# Are there any user-facing changes?

Yes add function in ArrowRowGroupWriter and expose it
