### PR TITLE
Update docstring comment for Writer::write() in writer.rs

### DIFF
--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -102,7 +102,7 @@ impl<W: Write> Writer<W> {
         WriterBuilder::new().with_delimiter(delimiter).build(writer)
     }
 
-    /// Write a vector of record batches to a writable object
+    /// Write an arrow RecordBatch to a writable object
     pub fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         let num_columns = batch.num_columns();
         if self.beginning {


### PR DESCRIPTION
# Rationale for this change

Update the docstring from function write() in struct Writer to reflect that we write only one RecordBatch at a time as opposed to a vector of record batches.

# What changes are included in this PR?

Just the comment doc string as above

# Are these changes tested?

yes

# Are there any user-facing changes?

No
