### PR TITLE
[Avro] Preserve value metadata of map

### DIFF
--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -1484,13 +1484,13 @@ mod tests {
         // Define enum symbols and metadata key
         let symbols = ["A", "B", "C"];
         let meta_key = "avro.enum.symbols".to_string();
-        let mut md = HashMap::new();
-        md.insert(meta_key.clone(), serde_json::to_string(&symbols).unwrap());
+        let mut metadata = HashMap::new();
+        metadata.insert(meta_key.clone(), serde_json::to_string(&symbols).unwrap());
 
         let symbols_arc: Arc<[String]> = symbols.iter().map(|s| (*s).to_string()).collect();
-        let value_type_with_md = AvroDataType::new(Codec::Enum(symbols_arc), md, None);
+        let enum_value_type = AvroDataType::new(Codec::Enum(symbols_arc), metadata, None);
         let map_type = AvroDataType::new(
-            Codec::Map(Arc::new(value_type_with_md)),
+            Codec::Map(Arc::new(enum_value_type)),
             Default::default(),
             None,
         );


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8270.

# Rationale for this change

This PR preserves the metadata that value contains when arrow-avro decoder flushes.
It is required to support value type `enum` which stores the enum definition as a json string in the field metadata.

# What changes are included in this PR?

This PR fixes decoder flush logic to preserve the metadata of the `value` of map field.

# Are these changes tested?

Added a unit test

# Are there any user-facing changes?

N/A