### PR TITLE
Add into_builder method for WriterProperties

### DIFF
--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -20,7 +20,7 @@ use crate::basic::{Compression, Encoding};
 use crate::compression::{CodecOptions, CodecOptionsBuilder};
 #[cfg(feature = "encryption")]
 use crate::encryption::encrypt::FileEncryptionProperties;
-use crate::file::metadata::KeyValue;
+use crate::file::metadata::{KeyValue, RowGroupMetaData, RowGroupMetaDataBuilder};
 use crate::format::SortingColumn;
 use crate::schema::types::ColumnPath;
 use std::str::FromStr;
@@ -192,6 +192,30 @@ impl WriterProperties {
     pub fn builder() -> WriterPropertiesBuilder {
         WriterPropertiesBuilder::default()
     }
+
+    /// Converts this [`RowGroupMetaData`] into a [`RowGroupMetaDataBuilder`]
+    pub fn into_builder(self) -> WriterPropertiesBuilder {
+        WriterPropertiesBuilder {
+            data_page_size_limit: self.data_page_size_limit,
+            data_page_row_count_limit: self.data_page_row_count_limit,
+            write_batch_size: self.write_batch_size,
+            max_row_group_size: self.max_row_group_size,
+            bloom_filter_position: self.bloom_filter_position,
+            writer_version: self.writer_version,
+            created_by: self.created_by,
+            offset_index_disabled: self.offset_index_disabled,
+            key_value_metadata: self.key_value_metadata,
+            default_column_properties: self.default_column_properties,
+            column_properties: self.column_properties,
+            sorting_columns: self.sorting_columns,
+            column_index_truncate_length: self.column_index_truncate_length,
+            statistics_truncate_length: self.statistics_truncate_length,
+            coerce_types: self.coerce_types,
+            #[cfg(feature = "encryption")]
+            file_encryption_properties: self.file_encryption_properties,
+        }
+    }
+
 
     /// Returns data page size limit.
     ///


### PR DESCRIPTION
# Which issue does this PR close?

TODO: Create associated issue.

- Closes #NNN.

# Rationale for this change

When working with the library using encryption, we have sometimes found it necessary to modify an existing set of `WriterProperties` on a per-file basis to set specific encryption properties. More generally, others may need to use an existing set of `WriterProperties` as a template and modify the properties. I have implemented this feature by adding an `into_builder` method, which appears to be the standard approach in other parts of the library.


# Are these changes tested?

Yes, `test_writer_properties_builder` has been updated to add a round-trip test for `into_builder`.

# Are there any user-facing changes?

Yes. `WriterProperties` now has a new `into_builder` method.