### PR TITLE
Use apache/arrow-dotnet for integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,7 @@ jobs:
       ARROW_INTEGRATION_CPP: ON
       ARROW_INTEGRATION_CSHARP: ON
       ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS: "rust"
+      ARCHERY_INTEGRATION_WITH_DOTNET: "1"
       ARCHERY_INTEGRATION_WITH_GO: "1"
       ARCHERY_INTEGRATION_WITH_JAVA: "1"
       ARCHERY_INTEGRATION_WITH_JS: "1"
@@ -98,6 +99,11 @@ jobs:
         with:
           path: rust
           fetch-depth: 0
+      - name: Checkout Arrow .NET
+        uses: actions/checkout@v5
+        with:
+          repository: apache/arrow-dotnet
+          path: dotnet
       - name: Checkout Arrow Go
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8294.

# Rationale for this change

The .NET implementation is extracted to apache/arrow-dotnet from apache/arrow. apache/arrow will remove `csharp/` eventually. So we should use apache/arrow-dotnet for integration test.

# What changes are included in this PR?

* Set `ARCHERY_INTEGRATION_WITH_DOTNET=1` to use the .NET implementation
* Checkout apache/arrow-dotnet

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.