### PR TITLE
Support leaf-to-index for parquet rust schema descriptor

### DIFF
--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -1008,7 +1008,7 @@ pub struct SchemaDescriptor {
     leaf_to_base: Vec<usize>,
 
     /// Mapping between the column dotstring path to the leaf index.
-    leaf_to_idx: HashMap<String, usize>,
+    leaf_to_idx: HashMap<ColumnPath, usize>,
 }
 
 impl fmt::Debug for SchemaDescriptor {
@@ -1078,8 +1078,10 @@ impl SchemaDescriptor {
     }
 
     /// Gets the index of a column its dotstring path, or -1 if not found.
-    pub fn column_index(&self, node_path: &str) -> i64 {
-        self.leaf_to_idx.get(node_path).map_or(-1, |value| *value as i64)
+    pub fn column_index(&self, node_path: &ColumnPath) -> i64 {
+        self.leaf_to_idx
+            .get(node_path)
+            .map_or(-1, |value| *value as i64)
     }
 
     /// Returns column root [`Type`] for a leaf position.
@@ -1129,6 +1131,7 @@ impl SchemaDescriptor {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_tree<'a>(
     tp: &'a TypePtr,
     root_idx: usize,
@@ -1136,7 +1139,7 @@ fn build_tree<'a>(
     mut max_def_level: i16,
     leaves: &mut Vec<ColumnDescPtr>,
     leaf_to_base: &mut Vec<usize>,
-    leaf_to_idx: &mut HashMap<String, usize>,
+    leaf_to_idx: &mut HashMap<ColumnPath, usize>,
     path_so_far: &mut Vec<&'a str>,
 ) {
     assert!(tp.get_basic_info().has_repetition());
@@ -1157,12 +1160,13 @@ fn build_tree<'a>(
         Type::PrimitiveType { .. } => {
             let mut path: Vec<String> = vec![];
             path.extend(path_so_far.iter().copied().map(String::from));
-            leaf_to_idx.insert(path.join("."), leaves.len());
+            let column_path = ColumnPath::new(path);
+            leaf_to_idx.insert(column_path.clone(), leaves.len());
             leaves.push(Arc::new(ColumnDescriptor::new(
                 tp.clone(),
                 max_def_level,
                 max_rep_level,
-                ColumnPath::new(path),
+                column_path,
             )));
             leaf_to_base.push(root_idx);
         }
@@ -1914,16 +1918,28 @@ mod tests {
         assert_eq!(descr.column(4).path().string(), "bag.records.item2");
         assert_eq!(descr.column(5).path().string(), "bag.records.item3");
 
-        assert_eq!(descr.column_index("a"), 0);
-        assert_eq!(descr.column_index("b"), 1);
-        assert_eq!(descr.column_index("c"), 2);
-        assert_eq!(descr.column_index("bag.records.item1"), 3);
-        assert_eq!(descr.column_index("bag.records.item2"), 4);
-        assert_eq!(descr.column_index("bag.records.item3"), 5);
-        assert_eq!(descr.column_index("d"), -1);
-        assert_eq!(descr.column_index("bag"), -1);
-        assert_eq!(descr.column_index("bag.records"), -1);
-        assert_eq!(descr.column_index("bag.records.item4"), -1);
+        assert_eq!(descr.column_index(&ColumnPath::from("a")), 0);
+        assert_eq!(descr.column_index(&ColumnPath::from("b")), 1);
+        assert_eq!(descr.column_index(&ColumnPath::from("c")), 2);
+        assert_eq!(
+            descr.column_index(&ColumnPath::from("bag.records.item1")),
+            3
+        );
+        assert_eq!(
+            descr.column_index(&ColumnPath::from("bag.records.item2")),
+            4
+        );
+        assert_eq!(
+            descr.column_index(&ColumnPath::from("bag.records.item3")),
+            5
+        );
+        assert_eq!(descr.column_index(&ColumnPath::from("d")), -1);
+        assert_eq!(descr.column_index(&ColumnPath::from("bag")), -1);
+        assert_eq!(descr.column_index(&ColumnPath::from("bag.records")), -1);
+        assert_eq!(
+            descr.column_index(&ColumnPath::from("bag.records.item4")),
+            -1
+        );
 
         assert_eq!(descr.get_column_root(0).name(), "a");
         assert_eq!(descr.get_column_root(3).name(), "bag");


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8311 

# Rationale for this change

This helps Rust match the C++ Library.

# What changes are included in this PR?

Includes the leaf-to-index map with tests.

# Are these changes tested?

Tests included. 

# Are there any user-facing changes?
None.
