### PR TITLE
[Variant] Remove boilerplate from make_shredding_row_builder

### DIFF
--- a/parquet-variant-compute/src/variant_get/output/row_builder.rs
+++ b/parquet-variant-compute/src/variant_get/output/row_builder.rs
@@ -37,7 +37,7 @@ pub(crate) fn make_shredding_row_builder<'a>(
     };
 
     let builder = match data_type {
-        // If no data type was requested, build a VariantArray that preserves existing shredding.
+        // If no data type was requested, build an unshredded VariantArray.
         None => VariantArrayShreddingRowBuilder::new(16).with_path(path),
         Some(datatypes::DataType::Int8) => {
             PrimitiveVariantShreddingRowBuilder::<Int8Type>::new(cast_options).with_path(path)


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Closes #NNN.

# Rationale for this change

The type handling code is replicated twice in `make_shredding_row_builder` -- for empty and non-empty paths, respectively. The code is virtually identical in both cases, and constructing any one row builder will always need two branches: (1) check for empty path; and (2) dispatch on the correct type. It also uses a macro to reduce boilerplate a bit.

# What changes are included in this PR?

Replace the macro with a new extension trait, and swap the control flow: (1) dispatch on the correct type; and (2) check for empty path. This cuts the affected code to 1/3 its original size.

# Are these changes tested?

Existing unit tests cover it.

# Are there any user-facing changes?

No.