### PR TITLE
Minor: avoid an `Arc::clone` in CacheOptions for Parquet PredicateCache

### DIFF
--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -44,12 +44,12 @@ pub struct CacheOptionsBuilder<'a> {
     /// Projection mask to apply to the cache
     pub projection_mask: &'a ProjectionMask,
     /// Cache to use for storing row groups
-    pub cache: Arc<Mutex<RowGroupCache>>,
+    pub cache: &'a Arc<Mutex<RowGroupCache>>,
 }
 
 impl<'a> CacheOptionsBuilder<'a> {
     /// create a new cache options builder
-    pub fn new(projection_mask: &'a ProjectionMask, cache: Arc<Mutex<RowGroupCache>>) -> Self {
+    pub fn new(projection_mask: &'a ProjectionMask, cache: &'a Arc<Mutex<RowGroupCache>>) -> Self {
         Self {
             projection_mask,
             cache,
@@ -79,7 +79,7 @@ impl<'a> CacheOptionsBuilder<'a> {
 #[derive(Clone)]
 pub struct CacheOptions<'a> {
     pub projection_mask: &'a ProjectionMask,
-    pub cache: Arc<Mutex<RowGroupCache>>,
+    pub cache: &'a Arc<Mutex<RowGroupCache>>,
     pub role: CacheRole,
 }
 
@@ -144,7 +144,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                 if cache_options.projection_mask.leaf_included(col_idx) {
                     Ok(Some(Box::new(CachedArrayReader::new(
                         reader,
-                        Arc::clone(&cache_options.cache),
+                        Arc::clone(cache_options.cache),
                         col_idx,
                         cache_options.role,
                         self.metrics.clone(), // cheap clone

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -619,8 +619,7 @@ where
             metadata: self.metadata.as_ref(),
         };
 
-        let cache_options_builder =
-            CacheOptionsBuilder::new(&cache_projection, row_group_cache.clone());
+        let cache_options_builder = CacheOptionsBuilder::new(&cache_projection, &row_group_cache);
 
         let filter = self.filter.as_mut();
         let mut plan_builder = ReadPlanBuilder::new(batch_size).with_selection(selection);


### PR DESCRIPTION
# Which issue does this PR close?



# Rationale for this change

I found this while working on https://github.com/apache/arrow-rs/pull/7997

Basically, the fact that the CacheOptionsBuilder had both owned and non owned fields made it a bit akward to work with -- if it is going to be zero copy (references) we pay the price of tracking lifetimes already. We may as well just do so for the Arc as well

I don't expect this to make any measurable different in performance. I am mostly treating it as a cleanup

# What changes are included in this PR?

Remove one Arc::clone

# Are these changes tested?

By existing CI
If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
