### PR TITLE
[Variant] Implement new VariantValueArrayBuilder

### DIFF
--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -46,7 +46,7 @@ pub mod variant_get;
 mod variant_to_arrow;
 
 pub use variant_array::{ShreddingState, VariantArray};
-pub use variant_array_builder::VariantArrayBuilder;
+pub use variant_array_builder::{VariantArrayBuilder, VariantValueArrayBuilder};
 
 pub use cast_to_variant::{cast_to_variant, cast_to_variant_with_options};
 pub use from_json::json_to_variant;

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -236,14 +236,12 @@ impl VariantBuilderExt for VariantArrayBuilder {
 /// assert_eq!(value_array.len(), 3);
 /// ```
 #[derive(Debug)]
-#[allow(unused)]
 pub struct VariantValueArrayBuilder {
     value_builder: ValueBuilder,
     value_offsets: Vec<usize>,
     nulls: NullBufferBuilder,
 }
 
-#[allow(unused)]
 impl VariantValueArrayBuilder {
     /// Create a new `VariantValueArrayBuilder` with the specified row capacity
     pub fn new(row_capacity: usize) -> Self {

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -220,19 +220,19 @@ impl VariantBuilderExt for VariantArrayBuilder {
 /// # Example:
 /// ```
 /// # use arrow::array::Array;
-/// # use parquet_variant::{Variant, EMPTY_VARIANT_METADATA};
+/// # use parquet_variant::{Variant};
 /// # use parquet_variant_compute::VariantValueArrayBuilder;
 /// // Create a variant value builder for 10 rows
 /// let mut builder = VariantValueArrayBuilder::new(10);
 ///
 /// // Append some values with their corresponding metadata
-/// // In practice, you should use the existing metadata you have access to.
-/// builder.append_value(Variant::from(42), EMPTY_VARIANT_METADATA).unwrap();
+/// // In practice, some of the variant values would be objects with internal metadata.
+/// builder.append_value(Variant::from(42));
 /// builder.append_null();
-/// builder.append_value(Variant::from("hello"), EMPTY_VARIANT_METADATA).unwrap();
+/// builder.append_value(Variant::from("hello"));
 ///
 /// // Build the final value array
-/// let value_array = builder.build();
+/// let value_array = builder.build().unwrap();
 /// assert_eq!(value_array.len(), 3);
 /// ```
 #[derive(Debug)]
@@ -289,10 +289,10 @@ impl VariantValueArrayBuilder {
     ///
     /// # Example
     /// ```
-    /// # use parquet_variant::{Variant, EMPTY_VARIANT_METADATA};
+    /// # use parquet_variant::Variant;
     /// # use parquet_variant_compute::VariantValueArrayBuilder;
     /// let mut builder = VariantValueArrayBuilder::new(10);
-    /// builder.append_value(Variant::from(42), EMPTY_VARIANT_METADATA).unwrap();
+    /// builder.append_value(Variant::from(42));
     /// ```
     pub fn append_value(&mut self, value: Variant<'_, '_>) {
         let metadata = value.metadata().cloned().unwrap_or(EMPTY_VARIANT_METADATA);

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -224,8 +224,7 @@ impl VariantBuilderExt for VariantArrayBuilder {
 /// // Create a variant value builder for 10 rows
 /// let mut builder = VariantValueArrayBuilder::new(10);
 ///
-/// // Append some values with their corresponding metadata. In practice, some of the variant
-/// // values would be objects with internal references to pre-existing metadata, which the
+/// // Append some values with their corresponding metadata, which the
 /// // builder takes advantage of to avoid creating new metadata.
 /// builder.append_value(Variant::from(42));
 /// builder.append_null();

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -302,7 +302,30 @@ impl VariantValueArrayBuilder {
         ValueBuilder::append_variant_bytes(self.parent_state(&mut metadata_builder), value);
     }
 
-    /// Creates a builder-specific parent state
+    /// Creates a builder-specific parent state.
+    ///
+    /// For example, this can be useful for code that wants to copy a subset of fields from an
+    /// object `value` as a new row of `value_array_builder`:
+    ///
+    /// ```no_run
+    /// # use parquet_variant::{ObjectBuilder, ReadOnlyMetadataBuilder, Variant};
+    /// # use parquet_variant_compute::VariantValueArrayBuilder;
+    /// # let value = Variant::Null;
+    /// # let mut value_array_builder = VariantValueArrayBuilder::new(0);
+    /// # fn should_keep(field_name: &str) -> bool { todo!() };
+    /// let Variant::Object(obj) = value else {
+    ///     panic!("Not a variant object");
+    /// };
+    /// let mut metadata_builder = ReadOnlyMetadataBuilder::new(obj.metadata.clone());
+    /// let state = value_array_builder.parent_state(&mut metadata_builder);
+    /// let mut object_builder = ObjectBuilder::new(state, false);
+    /// for (field_name, field_value) in obj.iter() {
+    ///     if should_keep(field_name) {
+    ///         object_builder.insert_bytes(field_name, field_value);
+    ///     }
+    /// }
+    ///  object_builder.finish(); // appends the new object
+    /// ```
     pub fn parent_state<'a>(
         &'a mut self,
         metadata_builder: &'a mut dyn MetadataBuilder,

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -135,8 +135,13 @@ fn shredded_get_path(
     let shred_basic_variant =
         |target: VariantArray, path: VariantPath<'_>, as_field: Option<&Field>| {
             let as_type = as_field.map(|f| f.data_type());
-            let mut builder =
-                make_variant_to_arrow_row_builder(path, as_type, cast_options, target.len())?;
+            let mut builder = make_variant_to_arrow_row_builder(
+                target.metadata_field(),
+                path,
+                as_type,
+                cast_options,
+                target.len(),
+            )?;
             for i in 0..target.len() {
                 if target.is_null(i) {
                     builder.append_null()?;

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -562,7 +562,7 @@ pub struct WritableMetadataBuilder {
 
 impl WritableMetadataBuilder {
     /// Upsert field name to dictionary, return its ID
-    fn upsert_field_name(&mut self, field_name: &str) -> u32 {
+    pub fn upsert_field_name(&mut self, field_name: &str) -> u32 {
         let (id, new_entry) = self.field_names.insert_full(field_name.to_string());
 
         if new_entry {

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -1320,14 +1320,12 @@ impl<'m, 'v> Variant<'m, 'v> {
         }
     }
 
-    /// Return the metadata associated with this variant, if any.
-    ///
-    /// Returns `Some(&VariantMetadata)` for object and list variants,
-    pub fn metadata(&self) -> Option<&VariantMetadata<'m>> {
+    /// Return the metadata dictionary associated with this variant value.
+    pub fn metadata(&self) -> &VariantMetadata<'m> {
         match self {
             Variant::Object(VariantObject { metadata, .. })
-            | Variant::List(VariantList { metadata, .. }) => Some(metadata),
-            _ => None,
+            | Variant::List(VariantList { metadata, .. }) => metadata,
+            _ => &EMPTY_VARIANT_METADATA,
         }
     }
 

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -17,7 +17,7 @@
 
 pub use self::decimal::{VariantDecimal16, VariantDecimal4, VariantDecimal8};
 pub use self::list::VariantList;
-pub use self::metadata::VariantMetadata;
+pub use self::metadata::{VariantMetadata, EMPTY_VARIANT_METADATA, EMPTY_VARIANT_METADATA_BYTES};
 pub use self::object::VariantObject;
 use crate::decoder::{
     self, get_basic_type, get_primitive_type, VariantBasicType, VariantPrimitiveType,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -1320,7 +1320,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// Return the metadata associated with this variant, if any.
     ///
     /// Returns `Some(&VariantMetadata)` for object and list variants,
-    pub fn metadata(&self) -> Option<&'m VariantMetadata<'_>> {
+    pub fn metadata(&self) -> Option<&VariantMetadata<'m>> {
         match self {
             Variant::Object(VariantObject { metadata, .. })
             | Variant::List(VariantList { metadata, .. }) => Some(metadata),

--- a/parquet-variant/src/variant/metadata.rs
+++ b/parquet-variant/src/variant/metadata.rs
@@ -141,6 +141,39 @@ pub struct VariantMetadata<'m> {
 // could increase the size of Variant. All those size increases could hurt performance.
 const _: () = crate::utils::expect_size_of::<VariantMetadata>(32);
 
+/// The canonical byte slice corresponding to an empty metadata dictionary.
+///
+/// ```
+/// # use parquet_variant::{EMPTY_VARIANT_METADATA_BYTES, VariantMetadata, WritableMetadataBuilder};
+/// let mut metadata_builder = WritableMetadataBuilder::default();
+/// metadata_builder.finish();
+/// let metadata_bytes = metadata_builder.into_inner();
+/// assert_eq!(&metadata_bytes, EMPTY_VARIANT_METADATA_BYTES);
+/// ```
+pub const EMPTY_VARIANT_METADATA_BYTES: &[u8] = &[1, 0, 0];
+
+/// The empty metadata dictionary.
+///
+/// ```
+/// # use parquet_variant::{EMPTY_VARIANT_METADATA, VariantMetadata, WritableMetadataBuilder};
+/// let mut metadata_builder = WritableMetadataBuilder::default();
+/// metadata_builder.finish();
+/// let metadata_bytes = metadata_builder.into_inner();
+/// let empty_metadata = VariantMetadata::try_new(&metadata_bytes).unwrap();
+/// assert_eq!(empty_metadata, EMPTY_VARIANT_METADATA);
+/// ```
+pub static EMPTY_VARIANT_METADATA: VariantMetadata = VariantMetadata {
+    bytes: EMPTY_VARIANT_METADATA_BYTES,
+    header: VariantMetadataHeader {
+        version: CORRECT_VERSION_VALUE,
+        is_sorted: false,
+        offset_size: OffsetSizeBytes::One,
+    },
+    dictionary_size: 0,
+    first_value_byte: 3,
+    validated: true,
+};
+
 impl<'m> VariantMetadata<'m> {
     /// Attempts to interpret `bytes` as a variant metadata instance, with full [validation] of all
     /// dictionary entries.

--- a/parquet-variant/src/variant/metadata.rs
+++ b/parquet-variant/src/variant/metadata.rs
@@ -162,7 +162,7 @@ pub const EMPTY_VARIANT_METADATA_BYTES: &[u8] = &[1, 0, 0];
 /// let empty_metadata = VariantMetadata::try_new(&metadata_bytes).unwrap();
 /// assert_eq!(empty_metadata, EMPTY_VARIANT_METADATA);
 /// ```
-pub static EMPTY_VARIANT_METADATA: VariantMetadata = VariantMetadata {
+pub const EMPTY_VARIANT_METADATA: VariantMetadata = VariantMetadata {
     bytes: EMPTY_VARIANT_METADATA_BYTES,
     header: VariantMetadataHeader {
         version: CORRECT_VERSION_VALUE,

--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -848,8 +848,8 @@ mod tests {
 
         let v2 = Variant::try_new(&m, &v).unwrap();
 
-        let m1 = v1.metadata().unwrap();
-        let m2 = v2.metadata().unwrap();
+        let m1 = v1.metadata();
+        let m2 = v2.metadata();
 
         // metadata would be equal since they contain the same keys
         assert_eq!(m1, m2);
@@ -900,7 +900,7 @@ mod tests {
         let (m, v) = b.finish();
 
         let v1 = Variant::try_new(&m, &v).unwrap();
-        assert!(!v1.metadata().unwrap().is_sorted());
+        assert!(!v1.metadata().is_sorted());
 
         // create another object pre-filled with field names, b and a
         // but insert the fields in the order of a, b
@@ -917,7 +917,7 @@ mod tests {
         let v2 = Variant::try_new(&m, &v).unwrap();
 
         // v2 should also have a unsorted dictionary
-        assert!(!v2.metadata().unwrap().is_sorted());
+        assert!(!v2.metadata().is_sorted());
 
         assert_eq!(v1, v2);
     }
@@ -936,7 +936,7 @@ mod tests {
 
         let v1 = Variant::try_new(&meta1, &value1).unwrap();
         // v1 is sorted
-        assert!(v1.metadata().unwrap().is_sorted());
+        assert!(v1.metadata().is_sorted());
 
         // create a second object with different insertion order
         let mut b = VariantBuilder::new().with_field_names(["d", "c", "b", "a"]);
@@ -951,7 +951,7 @@ mod tests {
 
         let v2 = Variant::try_new(&meta2, &value2).unwrap();
         // v2 is not sorted
-        assert!(!v2.metadata().unwrap().is_sorted());
+        assert!(!v2.metadata().is_sorted());
 
         // object metadata are not the same
         assert_ne!(v1.metadata(), v2.metadata());


### PR DESCRIPTION
# Which issue does this PR close?

- Pre-work for https://github.com/apache/arrow-rs/issues/8361

# Rationale for this change

There is currently no good way to populate a new variant array with variant values that reference an existing metadata, but that functionality is needed when transforming existing variant data (e.g. for shredding and unshredding operations).

# What changes are included in this PR?

Add a new `VariantValueArrayBuilder` that does not try to create new metadata; instead, it wraps a `ReadOnlyMetadata` around the `VariantMetadata` instance of the `Variant` value being inserted. This takes advantage of the new generic `ParentState` capability.

NOTE: The new array builder does _not_ impl `VariantBuilderExt` because it does not have a `MetadataBuilder` instance -- the instance is created on demand as part of the insertion itself. Instead, callers can directly invoke `VariantValueArrayBuilder::parent_state()`. This approach avoids the considerable complexity of keeping an internal metadata column index in sync with whatever external indexing might produce the variant value to be appended. It also doesn't seem to matter -- I did some pathfinding of variant shredding (going from binary to shredded variant based on some target schema), and the `VariantBuilderExt` does not seem especially helpful for that code.

# Are these changes tested?

New unit tests.

# Are there any user-facing changes?

New class.