### PR TITLE
Follow-up Improvements to Avro union handling 

### DIFF
--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -1846,7 +1846,7 @@ mod tests {
         Schema::Union(branches)
     }
 
-    fn mk_record_name(name: &'_ str) -> Schema<'_> {
+    fn mk_record_name(name: &str) -> Schema<'_> {
         Schema::Complex(ComplexType::Record(Record {
             name,
             namespace: None,

--- a/arrow-avro/src/schema.rs
+++ b/arrow-avro/src/schema.rs
@@ -984,17 +984,10 @@ fn wrap_nullable(inner: Value, null_order: Nullability) -> Value {
         Value::Array(mut union) => {
             union.retain(|v| !is_avro_json_null(v));
             match null_order {
-                Nullability::NullFirst => {
-                    let mut out = Vec::with_capacity(union.len() + 1);
-                    out.push(null);
-                    out.extend(union);
-                    Value::Array(out)
-                }
-                Nullability::NullSecond => {
-                    union.push(null);
-                    Value::Array(union)
-                }
+                Nullability::NullFirst => union.insert(0, null),
+                Nullability::NullSecond => union.push(null),
             }
+            Value::Array(union)
         }
         other => match null_order {
             Nullability::NullFirst => Value::Array(vec![null, other]),
@@ -1012,7 +1005,11 @@ fn union_branch_signature(branch: &Value) -> Result<String, ArrowError> {
             })?;
             match t {
                 "record" | "enum" | "fixed" => {
-                    let name = map.get("name").and_then(|v| v.as_str()).unwrap_or_default();
+                    let name = map.get("name").and_then(|v| v.as_str()).ok_or_else(|| {
+                        ArrowError::SchemaError(format!(
+                            "Union branch '{t}' missing required 'name'"
+                        ))
+                    })?;
                     Ok(format!("N:{t}:{name}"))
                 }
                 "array" | "map" => Ok(format!("C:{t}")),
@@ -2303,5 +2300,27 @@ mod tests {
         let a = AvroSchema::try_from(&arrow_schema).unwrap().json_string;
         let b = AvroSchema::from_arrow_with_options(&arrow_schema, None);
         assert_eq!(a, b.unwrap().json_string);
+    }
+
+    #[test]
+    fn test_union_branch_missing_name_errors() {
+        for t in ["record", "enum", "fixed"] {
+            let branch = json!({ "type": t });
+            let err = union_branch_signature(&branch).unwrap_err().to_string();
+            assert!(
+                err.contains(&format!("Union branch '{t}' missing required 'name'")),
+                "expected missing-name error for {t}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_union_branch_named_type_signature_includes_name() {
+        let rec = json!({ "type": "record", "name": "Foo" });
+        assert_eq!(union_branch_signature(&rec).unwrap(), "N:record:Foo");
+        let en = json!({ "type": "enum", "name": "Color", "symbols": ["R", "G", "B"] });
+        assert_eq!(union_branch_signature(&en).unwrap(), "N:enum:Color");
+        let fx = json!({ "type": "fixed", "name": "Bytes16", "size": 16 });
+        assert_eq!(union_branch_signature(&fx).unwrap(), "N:fixed:Bytes16");
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

This work continues arrow-avro schema resolution support and aligns behavior with the Avro spec.

- **Related to**: #4886 (“Add Avro Support”): ongoing work to round out the reader/decoder, including schema resolution and type promotion.
- **Follow-ups/Context**: #8348 (Add arrow-avro Reader support for Dense Union and Union resolution (Part 1))

# Rationale for this change

@scovich left a really solid [review](https://github.com/apache/arrow-rs/pull/8348#pullrequestreview-3237862269) on #8348 that wasn't completed until after the PR was merged in. This PR is for addressing the suggestions and improving the code. 

# What changes are included in this PR?

* Code quality improvements to `codec.rs`
* Improvements to `schema.rs` including spec compliant named type errors.

# Are these changes tested?

1. No functionality was added / modified in `codec.rs` and all existing tests are passing without changes.
2. Two new unit tests were added to `schema.rs` to cover the spec compliant named type changes.

# Are there any user-facing changes?

N/A
