### PR TITLE
Expose ReadPlan and ReadPlanBuilder

### DIFF
--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -29,7 +29,7 @@ use std::collections::VecDeque;
 
 /// A builder for [`ReadPlan`]
 #[derive(Clone)]
-pub(crate) struct ReadPlanBuilder {
+pub struct ReadPlanBuilder {
     batch_size: usize,
     /// Current to apply, includes all filters
     selection: Option<RowSelection>,
@@ -37,7 +37,7 @@ pub(crate) struct ReadPlanBuilder {
 
 impl ReadPlanBuilder {
     /// Create a `ReadPlanBuilder` with the given batch size
-    pub(crate) fn new(batch_size: usize) -> Self {
+    pub fn new(batch_size: usize) -> Self {
         Self {
             batch_size,
             selection: None,
@@ -45,14 +45,14 @@ impl ReadPlanBuilder {
     }
 
     /// Set the current selection to the given value
-    pub(crate) fn with_selection(mut self, selection: Option<RowSelection>) -> Self {
+    pub fn with_selection(mut self, selection: Option<RowSelection>) -> Self {
         self.selection = selection;
         self
     }
 
     /// Returns the current selection, if any
     #[cfg(feature = "async")]
-    pub(crate) fn selection(&self) -> Option<&RowSelection> {
+    pub fn selection(&self) -> Option<&RowSelection> {
         self.selection.as_ref()
     }
 
@@ -68,7 +68,7 @@ impl ReadPlanBuilder {
     }
 
     /// Returns true if the current plan selects any rows
-    pub(crate) fn selects_any(&self) -> bool {
+    pub fn selects_any(&self) -> bool {
         self.selection
             .as_ref()
             .map(|s| s.selects_any())
@@ -77,7 +77,7 @@ impl ReadPlanBuilder {
 
     /// Returns the number of rows selected, or `None` if all rows are selected.
     #[cfg(feature = "async")]
-    pub(crate) fn num_rows_selected(&self) -> Option<usize> {
+    pub fn num_rows_selected(&self) -> Option<usize> {
         self.selection.as_ref().map(|s| s.row_count())
     }
 
@@ -90,7 +90,7 @@ impl ReadPlanBuilder {
     /// Note: pre-existing selections may come from evaluating a previous predicate
     /// or if the [`ParquetRecordBatchReader`] specified an explicit
     /// [`RowSelection`] in addition to one or more predicates.
-    pub(crate) fn with_predicate(
+    pub fn with_predicate(
         mut self,
         array_reader: Box<dyn ArrayReader>,
         predicate: &mut dyn ArrowPredicate,
@@ -123,7 +123,7 @@ impl ReadPlanBuilder {
     }
 
     /// Create a final `ReadPlan` the read plan for the scan
-    pub(crate) fn build(mut self) -> ReadPlan {
+    pub fn build(mut self) -> ReadPlan {
         // If selection is empty, truncate
         if !self.selects_any() {
             self.selection = Some(RowSelection::from(vec![]));
@@ -230,7 +230,7 @@ impl LimitedReadPlanBuilder {
 /// A plan reading specific rows from a Parquet Row Group.
 ///
 /// See [`ReadPlanBuilder`] to create `ReadPlan`s
-pub(crate) struct ReadPlan {
+pub struct ReadPlan {
     /// The number of rows to read in each batch
     batch_size: usize,
     /// Row ranges to be selected from the data source
@@ -239,7 +239,7 @@ pub(crate) struct ReadPlan {
 
 impl ReadPlan {
     /// Returns a mutable reference to the selection, if any
-    pub(crate) fn selection_mut(&mut self) -> Option<&mut VecDeque<RowSelector>> {
+    pub fn selection_mut(&mut self) -> Option<&mut VecDeque<RowSelector>> {
         self.selection.as_mut()
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Closes #8347 .

# Rationale for this change

Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

# What changes are included in this PR?

Expose relevant structs and methods for `ReadPlan` and `ReadPlanBuilder` which can be used to build customized reader.

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

Yes. Now `ReadPlanBuilder`, `ReadPlan` and relevant methods are exposed.
