### PR TITLE
[Variant][Shredding] Support typed_access for timestamp_micro/timestamp_nano

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -23,7 +23,7 @@ use arrow::buffer::NullBuffer;
 use arrow::compute::cast;
 use arrow::datatypes::{
     Date32Type, Float16Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
-    TimestampMicrosecondType, TimestampNanosecondType
+    TimestampMicrosecondType, TimestampNanosecondType,
 };
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, TimeUnit};

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -839,51 +839,42 @@ fn typed_value_to_variant<'a>(
         DataType::Float64 => {
             primitive_conversion_single_value!(Float64Type, typed_value, index)
         }
-        DataType::Timestamp(timeunit, tz) => {
-            match (timeunit, tz) {
-                (TimeUnit::Microsecond, Some(_)) => {
-                    generic_conversion_single_value!(
-                        TimestampMicrosecondType,
-                        as_primitive,
-                        |v| DateTime::from_timestamp_micros(v).unwrap(),
-                        typed_value,
-                        index
-                    )
-                }
-                (TimeUnit::Microsecond, None) => {
-                    generic_conversion_single_value!(
-                        TimestampMicrosecondType,
-                        as_primitive,
-                        |v| DateTime::from_timestamp_micros(v).unwrap().naive_utc(),
-                        typed_value,
-                        index
-                    )
-                }
-                (TimeUnit::Nanosecond, Some(_)) => {
-                    generic_conversion_single_value!(
-                        TimestampNanosecondType,
-                        as_primitive,
-                        DateTime::from_timestamp_nanos,
-                        typed_value,
-                        index
-                    )
-                }
-                (TimeUnit::Nanosecond, None) => {
-                    generic_conversion_single_value!(
-                        TimestampNanosecondType,
-                        as_primitive,
-                        |v| DateTime::from_timestamp_nanos(v).naive_utc(),
-                        typed_value,
-                        index
-                    )
-                }
-                // Variant timestamp only support time unit with microsecond or nanosecond precision
-                _ => panic!(
-                    "Variant only support timestamp with microsecond or nanosecond precision"
-                ),
-            }
+        DataType::Timestamp(TimeUnit::Microsecond, Some(_)) => {
+            generic_conversion_single_value!(
+                TimestampMicrosecondType,
+                as_primitive,
+                |v| DateTime::from_timestamp_micros(v).unwrap(),
+                typed_value,
+                index
+            )
         }
-
+        DataType::Timestamp(TimeUnit::Microsecond, None) => {
+            generic_conversion_single_value!(
+                TimestampMicrosecondType,
+                as_primitive,
+                |v| DateTime::from_timestamp_micros(v).unwrap().naive_utc(),
+                typed_value,
+                index
+            )
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, Some(_)) => {
+            generic_conversion_single_value!(
+                TimestampNanosecondType,
+                as_primitive,
+                DateTime::from_timestamp_nanos,
+                typed_value,
+                index
+            )
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, None) => {
+            generic_conversion_single_value!(
+                TimestampNanosecondType,
+                as_primitive,
+                |v| DateTime::from_timestamp_nanos(v).naive_utc(),
+                typed_value,
+                index
+            )
+        }
         // todo other types here (note this is very similar to cast_to_variant.rs)
         // so it would be great to figure out how to share this code
         _ => {

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -297,12 +297,6 @@ mod test {
     use std::sync::Arc;
 
     use arrow::array::{
-        Array, ArrayRef, AsArray, BinaryViewArray, Date32Array, Float32Array,
-        Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, StringArray, StructArray
-    };
-    use std::sync::Arc;
-
-    use arrow::array::{
         Array, ArrayRef, AsArray, BinaryViewArray, Date32Array,
         Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
         StringArray, StructArray
@@ -317,7 +311,6 @@ mod test {
     use arrow_schema::{DataType, Field, FieldRef, Fields};
     use chrono::DateTime;
     use parquet_variant::{Variant, VariantPath, EMPTY_VARIANT_METADATA_BYTES};
-    use std::sync::Arc;
 
     fn single_variant_get_test(input_json: &str, path: VariantPath, expected_json: &str) {
         // Create input array from JSON string
@@ -990,7 +983,7 @@ mod test {
                 None, // row 2 is a string, so no typed value
                 Some(<$primitive_type>::try_from(100u8).unwrap()), // row 3 is shredded, so it has a value
             ]));
-        }
+        };
     }
 
     macro_rules! partially_shredded_variant_array_gen {
@@ -1079,14 +1072,14 @@ mod test {
         ])
     });
 
-    partially_shredded_variant_array_gen!(partially_shredded_utf8_variant_array, ||
+    partially_shredded_variant_array_gen!(partially_shredded_utf8_variant_array, || {
         StringArray::from(vec![
             Some("hello"), // row 0 is shredded
             None,          // row 1 is null
             None,          // row 2 is a string
             Some("world"), // row 3 is shredded
         ])
-    );
+    });
 
     partially_shredded_variant_array_gen!(partially_shredded_date32_variant_array, || {
         Date32Array::from(vec![
@@ -1096,50 +1089,6 @@ mod test {
             Some(20340), // row 3 is shredded, 2025-09-09
         ])
     });
-    // /// Return a VariantArray that represents a partially "shredded" variant for Date32
-    // fn partially_shredded_date32_variant_array() -> ArrayRef {
-    //     let (metadata, string_value) = {
-    //         let mut builder = parquet_variant::VariantBuilder::new();
-    //         builder.append_value("n/a");
-    //         builder.finish()
-    //     };
-    //
-    //     // Create the null buffer for the overall array
-    //     let nulls = NullBuffer::from(vec![
-    //         true,  // row 0 non null
-    //         false, // row 1 is null
-    //         true,  // row 2 non null
-    //         true,  // row 3 non null
-    //     ]);
-    //
-    //     // metadata is the same for all rows
-    //     let metadata = BinaryViewArray::from_iter_values(std::iter::repeat_n(&metadata, 4));
-    //
-    //     // See https://docs.google.com/document/d/1pw0AWoMQY3SjD7R4LgbPvMjG_xSCtXp3rZHkVp9jpZ4/edit?disco=AAABml8WQrY
-    //     // about why row1 is an empty but non null, value.
-    //     let values = BinaryViewArray::from(vec![
-    //         None,                // row 0 is shredded, so no value
-    //         Some(b"" as &[u8]),  // row 1 is null, so empty value
-    //         Some(&string_value), // copy the string value "N/A"
-    //         None,                // row 3 is shredded, so no value
-    //     ]);
-    //
-    //     let typed_value = Date32Array::from(vec![
-    //         Some(20348), // row 0 is shredded, 2025-09-17
-    //         None,        // row 1 is null
-    //         None,        // row 2 is a string, not a date
-    //         Some(20340), // row 3 is shredded, 2025-09-09
-    //     ]);
-    //
-    //     let struct_array = StructArrayBuilder::new()
-    //         .with_field("metadata", Arc::new(metadata), false)
-    //         .with_field("typed_value", Arc::new(typed_value), true)
-    //         .with_field("value", Arc::new(values), true)
-    //         .with_nulls(nulls)
-    //         .build();
-    //
-    //     Arc::new(struct_array)
-    // }
 
     /// Return a VariantArray that represents an "all null" variant
     /// for the following example (3 null values):

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -296,15 +296,14 @@ impl<'a> GetOptions<'a> {
 mod test {
     use std::sync::Arc;
 
-    use arrow::array::{
-        Array, ArrayRef, AsArray, BinaryViewArray, Date32Array,
-        Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-        StringArray, StructArray
-    };
     use super::{variant_get, GetOptions};
     use crate::json_to_variant;
     use crate::variant_array::{ShreddedVariantFieldArray, StructArrayBuilder};
     use crate::VariantArray;
+    use arrow::array::{
+        Array, ArrayRef, AsArray, BinaryViewArray, Date32Array, Float32Array, Float64Array,
+        Int16Array, Int32Array, Int64Array, Int8Array, StringArray, StructArray,
+    };
     use arrow::buffer::NullBuffer;
     use arrow::compute::CastOptions;
     use arrow::datatypes::DataType::{Int16, Int32, Int64};

--- a/parquet/tests/variant_integration.rs
+++ b/parquet/tests/variant_integration.rs
@@ -104,6 +104,7 @@ variant_test_case!(28, "Unsupported typed_value type: Decimal128(38, 9)");
 variant_test_case!(29, "Unsupported typed_value type: Decimal128(38, 9)");
 variant_test_case!(30);
 variant_test_case!(31);
+// https://github.com/apache/arrow-rs/issues/8334
 variant_test_case!(32, "Unsupported typed_value type: Time64(µs)");
 variant_test_case!(33);
 variant_test_case!(34);

--- a/parquet/tests/variant_integration.rs
+++ b/parquet/tests/variant_integration.rs
@@ -91,11 +91,10 @@ variant_test_case!(16);
 variant_test_case!(17);
 variant_test_case!(18);
 variant_test_case!(19);
-// https://github.com/apache/arrow-rs/issues/8331
-variant_test_case!(20, "Unsupported typed_value type: Timestamp(µs, \"UTC\")");
-variant_test_case!(21, "Unsupported typed_value type: Timestamp(µs, \"UTC\")");
-variant_test_case!(22, "Unsupported typed_value type: Timestamp(µs)");
-variant_test_case!(23, "Unsupported typed_value type: Timestamp(µs)");
+variant_test_case!(20);
+variant_test_case!(21);
+variant_test_case!(22);
+variant_test_case!(23);
 // https://github.com/apache/arrow-rs/issues/8332
 variant_test_case!(24, "Unsupported typed_value type: Decimal128(9, 4)");
 variant_test_case!(25, "Unsupported typed_value type: Decimal128(9, 4)");
@@ -105,13 +104,11 @@ variant_test_case!(28, "Unsupported typed_value type: Decimal128(38, 9)");
 variant_test_case!(29, "Unsupported typed_value type: Decimal128(38, 9)");
 variant_test_case!(30);
 variant_test_case!(31);
-// https://github.com/apache/arrow-rs/issues/8334
 variant_test_case!(32, "Unsupported typed_value type: Time64(µs)");
-// https://github.com/apache/arrow-rs/issues/8331
-variant_test_case!(33, "Unsupported typed_value type: Timestamp(ns, \"UTC\")");
-variant_test_case!(34, "Unsupported typed_value type: Timestamp(ns, \"UTC\")");
-variant_test_case!(35, "Unsupported typed_value type: Timestamp(ns)");
-variant_test_case!(36, "Unsupported typed_value type: Timestamp(ns)");
+variant_test_case!(33);
+variant_test_case!(34);
+variant_test_case!(35);
+variant_test_case!(36);
 variant_test_case!(37);
 // https://github.com/apache/arrow-rs/issues/8336
 variant_test_case!(38, "Unsupported typed_value type: Struct(");


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8331 .

# Rationale for this change

- Add typed_access for `Timestamp(Micro, _)` and `Timestamp(Nano, -)`

# What changes are included in this PR?

- Extract some data gen logic in tests to simplify the test logic (commit  93090d56717a6804e4862c23a0f85030b9f6406d), but it based on some old code(before #8392), rebase the master in the last commit
- Add typed_access for `Timestamp(Micro, _)` and `Timestamp(Nano, _)`
- Add test for typed_access for `Timestamp(Micro, _)` and `Timestamp(Nano, _)`

# Are these changes tested?

Covered by existing and added tests

# Are there any user-facing changes?

No