### PR TITLE
Respect `CastOptions.safe` when casting `BinaryView` → `Utf8View` (return `null` for invalid UTF‑8)

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -6401,10 +6401,7 @@ mod tests {
             cast_with_options(&binary_view_array, &DataType::Utf8View, &safe_options).unwrap();
         assert_eq!(string_view_array.data_type(), &DataType::Utf8View);
 
-        let values: Vec<_> = string_view_array
-            .as_any()
-            .downcast_ref::<StringViewArray>()
-            .unwrap()
+        let values: Vec<_> = string_view_array.as_string_view()
             .iter()
             .collect();
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -6401,9 +6401,7 @@ mod tests {
             cast_with_options(&binary_view_array, &DataType::Utf8View, &safe_options).unwrap();
         assert_eq!(string_view_array.data_type(), &DataType::Utf8View);
 
-        let values: Vec<_> = string_view_array.as_string_view()
-            .iter()
-            .collect();
+        let values: Vec<_> = string_view_array.as_string_view().iter().collect();
 
         assert_eq!(values, vec![Some("valid"), None, Some("utf8"), None]);
     }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -6383,15 +6383,19 @@ mod tests {
             None,
         ]);
 
-        let mut strict_options = CastOptions::default();
-        strict_options.safe = false;
+        let strict_options = CastOptions {
+            safe: false,
+            ..Default::default()
+        };
 
         assert!(
             cast_with_options(&binary_view_array, &DataType::Utf8View, &strict_options).is_err()
         );
 
-        let mut safe_options = CastOptions::default();
-        safe_options.safe = true;
+        let safe_options = CastOptions {
+            safe: true,
+            ..Default::default()
+        };
 
         let string_view_array =
             cast_with_options(&binary_view_array, &DataType::Utf8View, &safe_options).unwrap();

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -378,18 +378,16 @@ pub(crate) fn cast_binary_view_to_string_view(
 ) -> Result<ArrayRef, ArrowError> {
     let array = array.as_binary_view();
 
-    if cast_options.safe {
-        // When safe=true, skip the fast path to avoid double UTF-8 validation
-        // and go directly to the fallback that handles invalid UTF-8 gracefully
-        let mut builder = StringViewBuilder::with_capacity(array.len());
-        extend_valid_utf8(&mut builder, array.iter());
-        Ok(Arc::new(builder.finish()))
-    } else {
-        // When safe=false, use the fast path and let it fail on invalid UTF-8
-        array
-            .clone()
-            .to_string_view()
-            .map(|result| Arc::new(result) as ArrayRef)
+    match array.clone().to_string_view() {
+        Ok(result) => Ok(Arc::new(result)),
+        Err(error) => match cast_options.safe {
+            true => {
+                let mut builder = StringViewBuilder::with_capacity(array.len());
+                extend_valid_utf8(&mut builder, array.iter());
+                Ok(Arc::new(builder.finish()))
+            }
+            false => Err(error),
+        },
     }
 }
 

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -339,6 +339,14 @@ where
 
 /// A specified helper to cast from `GenericBinaryArray` to `GenericStringArray` when they have same
 /// offset size so re-encoding offset is unnecessary.
+fn extend_valid_utf8<'a, B, I>(builder: &mut B, iter: I)
+where
+    B: Extend<Option<&'a str>>,
+    I: Iterator<Item = Option<&'a [u8]>>,
+{
+    builder.extend(iter.map(|value| value.and_then(|bytes| std::str::from_utf8(bytes).ok())));
+}
+
 pub(crate) fn cast_binary_to_string<O: OffsetSizeTrait>(
     array: &dyn Array,
     cast_options: &CastOptions,
@@ -356,14 +364,29 @@ pub(crate) fn cast_binary_to_string<O: OffsetSizeTrait>(
                 let mut builder =
                     GenericStringBuilder::<O>::with_capacity(array.len(), array.value_data().len());
 
-                let iter = array
-                    .iter()
-                    .map(|v| v.and_then(|v| std::str::from_utf8(v).ok()));
-
-                builder.extend(iter);
+                extend_valid_utf8(&mut builder, array.iter());
                 Ok(Arc::new(builder.finish()))
             }
             false => Err(e),
+        },
+    }
+}
+
+pub(crate) fn cast_binary_view_to_string_view(
+    array: &dyn Array,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef, ArrowError> {
+    let array = array.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+
+    match array.clone().to_string_view() {
+        Ok(result) => Ok(Arc::new(result)),
+        Err(error) => match cast_options.safe {
+            true => {
+                let mut builder = StringViewBuilder::with_capacity(array.len());
+                extend_valid_utf8(&mut builder, array.iter());
+                Ok(Arc::new(builder.finish()))
+            }
+            false => Err(error),
         },
     }
 }

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -376,7 +376,7 @@ pub(crate) fn cast_binary_view_to_string_view(
     array: &dyn Array,
     cast_options: &CastOptions,
 ) -> Result<ArrayRef, ArrowError> {
-    let array = array.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+    let array = array.as_binary_view();
 
     match array.clone().to_string_view() {
         Ok(result) => Ok(Arc::new(result)),


### PR DESCRIPTION

# Which issue does this PR close?

Closes #8403.

---

# Rationale for this change

Casting from `BinaryView` to `Utf8View` currently attempts a direct conversion using `to_string_view()` which returns an error if any value contains invalid UTF‑8. This behavior is inconsistent with other binary array types in Arrow, which honor `CastOptions.safe = true` by replacing invalid UTF‑8 sequences with `NULL` values rather than failing the entire cast operation.

This PR makes `BinaryView`'s casting behavior consistent with other binary types and with user expectations: when `CastOptions.safe` is `true`, invalid UTF‑8 bytes are replaced by `NULL` in the resulting `StringViewArray`; when `CastOptions.safe` is `false`, the cast retains the existing failure behavior.

---

# What changes are included in this PR?

* Change `cast_with_options` to delegate the `BinaryView -> Utf8View` branch to a new helper function `cast_binary_view_to_string_view(array, cast_options)` instead of directly calling `to_string_view()` and erroring.

* Add `extend_valid_utf8` helper to centralize the logic of mapping `Option<&[u8]>` to `Option<&str>` (using `std::str::from_utf8(...).ok()`), and reuse it for both `GenericStringBuilder` and `StringViewBuilder` flows.

* Implement `cast_binary_view_to_string_view` which:

  * Attempts `array.clone().to_string_view()` (fast, zero-copy path) and returns it when `Ok`.
  * On `Err`, checks `cast_options.safe`:

    * If `true`, builds a `StringViewArray` by filtering invalid UTF‑8 to `NULL` using `extend_valid_utf8` and returns that array.
    * If `false`, propagates the original error (existing behavior).

* Add a unit test `test_binary_view_to_string_view_with_invalid_utf8` covering both `safe=false` (expect error) and `safe=true` (expect `NULL` where invalid UTF‑8 occurred).

Files changed (high level):

* `arrow-cast/src/cast/mod.rs`: route `BinaryView -> Utf8View` case to the new helper.
* `arrow-cast/src/cast/string.rs`: add `extend_valid_utf8` and `cast_binary_view_to_string_view`, and use `extend_valid_utf8` from an existing cast path.

---

# Are there any user-facing changes?

Yes — this changes the observable behavior of casting `BinaryView` to `Utf8View`:

* With `CastOptions.safe = true` (the safe mode), invalid UTF‑8 in `BinaryView` elements will be converted to `NULL` in the resulting `Utf8View` array instead of causing the entire cast to fail.
* With `CastOptions.safe = false`, an invalid UTF‑8 still causes the cast to fail as before.

This is a bug fix aligning `BinaryView` with the semantics of other binary types and with documented expectations for `CastOptions.safe`.

No public API surface is changed beyond the fixed behavior; the new helpers are crate-private.

