### PR TITLE
Use more compact Debug formatting of Field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ __blobstorage__
 *.bak2
 # OS-specific .gitignores
 
+# cargo insta temp files
+*.pending-snap
+
 # Mac .gitignore
 # General
 .DS_Store

--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -53,6 +53,7 @@ all-features = true
 [dev-dependencies]
 bincode = { version = "1.3.3", default-features = false }
 criterion = { version = "0.5", default-features = false }
+insta = "1.43.1"
 
 [[bench]]
 name = "ffi"

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -1180,14 +1180,12 @@ mod tests {
     #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
     fn test_debug_format_field() {
         // Make sure the `Debug` formatting of `DataType` is readable and not too long
-        insta::assert_debug_snapshot!(DataType::new_list(DataType::Int8, false), @r#"
+        insta::assert_debug_snapshot!(DataType::new_list(DataType::Int8, false), @r"
         List(
             Field {
-                name: "item",
                 data_type: Int8,
-                nullable: false,
             },
         )
-        "#);
+        ");
     }
 }

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -1175,4 +1175,19 @@ mod tests {
         let data_type: DataType = "UInt64".parse().unwrap();
         assert_eq!(data_type, DataType::UInt64);
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
+    fn test_debug_format_field() {
+        // Make sure the `Debug` formatting of `DataType` is readable and not too long
+        insta::assert_debug_snapshot!(DataType::new_list(DataType::Int8, false), @r#"
+        List(
+            Field {
+                name: "item",
+                data_type: Int8,
+                nullable: false,
+            },
+        )
+        "#);
+    }
 }

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -73,10 +73,17 @@ impl std::fmt::Debug for Field {
         } = self;
 
         let mut s = f.debug_struct("Field");
-        let s = s
-            .field("name", name)
-            .field("data_type", data_type)
-            .field("nullable", nullable);
+
+        if name != "item" {
+            // Keep it short when debug-formatting `DataType::List`
+            s.field("name", name);
+        }
+
+        s.field("data_type", data_type);
+
+        if *nullable {
+            s.field("nullable", nullable);
+        }
 
         if *dict_id != 0 {
             s.field("dict_id", dict_id);
@@ -951,13 +958,11 @@ mod test {
     #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
     fn test_debug_format_field() {
         // Make sure the `Debug` formatting of `Field` is readable and not too long
-        insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, false), @r#"
+        insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, false), @r"
         Field {
-            name: "item",
             data_type: UInt8,
-            nullable: false,
         }
-        "#);
+        ");
         insta::assert_debug_snapshot!(Field::new("column", DataType::LargeUtf8, true), @r#"
         Field {
             name: "column",

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -948,19 +948,20 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
     fn test_debug_format_field() {
-        insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, true), @r#"
-        Field {
-            name: "item",
-            data_type: UInt8,
-            nullable: true,
-        }
-        "#);
         insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, false), @r#"
         Field {
             name: "item",
             data_type: UInt8,
             nullable: false,
+        }
+        "#);
+        insta::assert_debug_snapshot!(Field::new("column", DataType::LargeUtf8, true), @r#"
+        Field {
+            name: "column",
+            data_type: LargeUtf8,
+            nullable: true,
         }
         "#);
     }

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -950,6 +950,7 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
     fn test_debug_format_field() {
+        // Make sure the `Debug` formatting of `Field` is readable and not too long
         insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, false), @r#"
         Field {
             name: "item",


### PR DESCRIPTION
# Rationale for this change
Despite us having `Display` implementations for `DataType`, a lot of error messages still use `Debug`. See for instance:

* https://github.com/apache/datafusion/pull/17565
* https://github.com/apache/arrow-rs/pull/8290

Therefor I want to make sure the `Debug` formatting of `Field` (and, by extension, `DataType`) is not _utterly horrible_. This PR makes things… slightly better.

# What changes are included in this PR?
Omits fields of `Field` that have their "default" values.

# Are these changes tested?
Yes, there are new tests.

# Are there any user-facing changes?
Though this changes the `Debug` formatting, I would NOT consider this a breaking change, because nobody should rely on consistent `Debug` formatting. See for instance https://doc.rust-lang.org/std/fmt/trait.Debug.html#stability