### PR TITLE
Fix clippy

### DIFF
--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -178,7 +178,7 @@ impl ToPyArrow for DataType {
         let module = py.import("pyarrow")?;
         let class = module.getattr("DataType")?;
         let dtype = class.call_method1("_import_from_c", (c_schema_ptr as Py_uintptr_t,))?;
-        Ok(dtype.into())
+        Ok(dtype)
     }
 }
 
@@ -214,7 +214,7 @@ impl ToPyArrow for Field {
         let module = py.import("pyarrow")?;
         let class = module.getattr("Field")?;
         let dtype = class.call_method1("_import_from_c", (c_schema_ptr as Py_uintptr_t,))?;
-        Ok(dtype.into())
+        Ok(dtype)
     }
 }
 
@@ -250,7 +250,7 @@ impl ToPyArrow for Schema {
         let module = py.import("pyarrow")?;
         let class = module.getattr("Schema")?;
         let schema = class.call_method1("_import_from_c", (c_schema_ptr as Py_uintptr_t,))?;
-        Ok(schema.into())
+        Ok(schema)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?
- related to https://github.com/apache/arrow-rs/pull/8286


# Rationale for this change
Ci is failing on main after this PR is merged
- https://github.com/apache/arrow-rs/pull/8286

<img width="1464" height="714" alt="Screenshot 2025-09-23 at 2 22 46 PM" src="https://github.com/user-attachments/assets/83725d32-baac-48a7-b6e8-3620ae3cde98" />


Here is an example failure: https://github.com/apache/arrow-rs/actions/runs/17952764906/job/51056301800
```
error: useless conversion to the same type: `pyo3::Bound<'_, pyo3::PyAny>`
   --> arrow-pyarrow/src/lib.rs:181:12
    |
181 |         Ok(dtype.into())
    |            ^^^^^^^^^^^^ help: consider removing `.into()`: `dtype`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`

error: useless conversion to the same type: `pyo3::Bound<'_, pyo3::PyAny>`
   --> arrow-pyarrow/src/lib.rs:217:12
    |
217 |         Ok(dtype.into())
    |            ^^^^^^^^^^^^ help: consider removing `.into()`: `dtype`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

error: useless conversion to the same type: `pyo3::Bound<'_, pyo3::PyAny>`
   --> arrow-pyarrow/src/lib.rs:253:12
    |
253 |         Ok(schema.into())
    |            ^^^^^^^^^^^^^ help: consider removing `.into()`: `schema`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

error: could not compile `arrow-pyarrow` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

I think it is a logical conflict

# What changes are included in this PR?

Fix clippy

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
