### PR TITLE
Bump MSRV to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ include = [
     "NOTICE.txt",
 ]
 edition = "2021"
-rust-version = "1.84"
+rust-version = "1.85"
 
 [workspace.dependencies]
 arrow = { version = "56.2.0", path = "./arrow", default-features = false }

--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -420,13 +420,13 @@ native_type_float_op!(
     1.,
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.85.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(-1_i32)
     },
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.85.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(i32::MAX)
     }
@@ -437,13 +437,13 @@ native_type_float_op!(
     1.,
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.85.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(-1_i64)
     },
     unsafe {
         // Need to allow in clippy because
-        // current MSRV (Minimum Supported Rust Version) is `1.84.0` but this item is stable since `1.87.0`
+        // current MSRV (Minimum Supported Rust Version) is `1.85.0` but this item is stable since `1.87.0`
         #[allow(unnecessary_transmutes)]
         std::mem::transmute(i64::MAX)
     }

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow"]
 edition = "2021"
-rust-version = "1.84"
+rust-version = "1.85"
 publish = false
 
 [lib]

--- a/arrow-pyarrow-testing/Cargo.toml
+++ b/arrow-pyarrow-testing/Cargo.toml
@@ -40,7 +40,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = ["arrow"]
 edition = "2021"
-rust-version = "1.84"
+rust-version = "1.85"
 publish = false
 
 


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Following https://github.com/apache/arrow-rs?tab=readme-ov-file#rust-version-compatibility-policy.

# What changes are included in this PR?

- Bump MSRV to 1.85

# Are these changes tested?

CI.

# Are there any user-facing changes?

Yes