### PR TITLE
Update `UnionArray` wording to 'non-negative'

### DIFF
--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -1877,7 +1877,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Invalid argument error: Offsets must be positive and within the length of the Array"
+            "Invalid argument error: Offsets must be non-negative and within the length of the Array"
         );
 
         let offsets = Some(vec![0, 1].into());


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-rs/issues/8418

# Rationale for this change

The "Safety" section mentions that `type_ids` are used to index into arrays, this means that values of 0 are also valid as this is the first element.

The same is also true for `offsets`. There is a check within the `UnionArray::try_new` that is validating that `offset` is not less than 0 (the value is not negative), otherwise an [error is returned](https://github.com/apache/arrow-rs/blob/f7ea0aa815d24ab1cf66bfebe92c4c85f891e4d1/arrow-array/src/array/union_array.rs#L230-L235).

# What changes are included in this PR?

Documentation/wording changes

# Are these changes tested?

N/A, documentation only.

# Are there any user-facing changes?

N/A
