### PR TITLE
Expose `fields` in `StructBuilder`

### DIFF
--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -201,6 +201,11 @@ impl StructBuilder {
         self.field_builders.len()
     }
 
+    /// Returns the fields for the struct this builder is building.
+    pub fn fields(&self) -> &Fields {
+        &self.fields
+    }
+
     /// Appends an element (either null or non-null) to the struct. The actual elements
     /// should be appended for each child sub-array in a consistent way.
     #[inline]


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change

Field data type is useful when we try to downcast field builder.

# What changes are included in this PR?

Add `fields` getter method in `StructBuilder`.

# Are these changes tested?

CI.

# Are there any user-facing changes?

No.
