### PR TITLE
Migrate `arrow-csv` to Rust 2024

### DIFF
--- a/arrow-csv/Cargo.toml
+++ b/arrow-csv/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [lib]

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -27,9 +27,9 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::infer_schema_from_files;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
+pub use self::reader::infer_schema_from_files;
 pub use self::writer::Writer;
 pub use self::writer::WriterBuilder;
 use arrow_schema::ArrowError;

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -128,7 +128,7 @@ mod records;
 use arrow_array::builder::{NullBuilder, PrimitiveBuilder};
 use arrow_array::types::*;
 use arrow_array::*;
-use arrow_cast::parse::{parse_decimal, string_to_datetime, Parser};
+use arrow_cast::parse::{Parser, parse_decimal, string_to_datetime};
 use arrow_schema::*;
 use chrono::{TimeZone, Utc};
 use csv::StringRecord;
@@ -1853,7 +1853,10 @@ mod tests {
         let file_name = "test/data/various_invalid_types/invalid_float.csv";
 
         let error = invalid_csv_helper(file_name);
-        assert_eq!("Parser error: Error while parsing value '4.x4' as type 'Float32' for column 1 at line 4. Row data: '[4,4.x4,,false]'", error);
+        assert_eq!(
+            "Parser error: Error while parsing value '4.x4' as type 'Float32' for column 1 at line 4. Row data: '[4,4.x4,,false]'",
+            error
+        );
     }
 
     #[test]
@@ -1861,7 +1864,10 @@ mod tests {
         let file_name = "test/data/various_invalid_types/invalid_int.csv";
 
         let error = invalid_csv_helper(file_name);
-        assert_eq!("Parser error: Error while parsing value '2.3' as type 'UInt64' for column 0 at line 2. Row data: '[2.3,2.2,2.22,false]'", error);
+        assert_eq!(
+            "Parser error: Error while parsing value '2.3' as type 'UInt64' for column 0 at line 2. Row data: '[2.3,2.2,2.22,false]'",
+            error
+        );
     }
 
     #[test]
@@ -1869,7 +1875,10 @@ mod tests {
         let file_name = "test/data/various_invalid_types/invalid_bool.csv";
 
         let error = invalid_csv_helper(file_name);
-        assert_eq!("Parser error: Error while parsing value 'none' as type 'Boolean' for column 3 at line 2. Row data: '[2,2.2,2.22,none]'", error);
+        assert_eq!(
+            "Parser error: Error while parsing value 'none' as type 'Boolean' for column 3 at line 2. Row data: '[2,2.2,2.22,none]'",
+            error
+        );
     }
 
     /// Infer the data type of a record
@@ -2697,7 +2706,10 @@ mod tests {
             .infer_schema(&mut read, None);
         assert!(result.is_err());
         // Include line number in the error message to help locate and fix the issue
-        assert_eq!(result.err().unwrap().to_string(), "Csv error: Encountered unequal lengths between records on CSV file. Expected 3 records, found 2 records at line 3");
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Csv error: Encountered unequal lengths between records on CSV file. Expected 3 records, found 2 records at line 3"
+        );
     }
 
     #[test]

--- a/arrow-csv/src/writer.rs
+++ b/arrow-csv/src/writer.rs
@@ -418,7 +418,7 @@ mod tests {
 
     use crate::ReaderBuilder;
     use arrow_array::builder::{
-        BinaryBuilder, Decimal128Builder, Decimal256Builder, Decimal32Builder, Decimal64Builder,
+        BinaryBuilder, Decimal32Builder, Decimal64Builder, Decimal128Builder, Decimal256Builder,
         FixedSizeBinaryBuilder, LargeBinaryBuilder,
     };
     use arrow_array::types::*;
@@ -717,7 +717,10 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555,23:46:03,foo
 
         for batch in batches {
             let err = writer.write(batch).unwrap_err().to_string();
-            assert_eq!(err, "Csv error: Error processing row 2, col 2: Cast error: Failed to convert 1926632005177685347 to temporal for Date64")
+            assert_eq!(
+                err,
+                "Csv error: Error processing row 2, col 2: Cast error: Failed to convert 1926632005177685347 to temporal for Date64"
+            )
         }
         drop(writer);
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-csv` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes