### PR TITLE
Migrate `arrow-flight` to Rust 2024

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -19,7 +19,7 @@
 name = "arrow-flight"
 description = "Apache Arrow Flight"
 version = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_flight::sql::server::PeekableFlightDataStream;
 use arrow_flight::sql::DoPutPreparedStatementResult;
-use base64::prelude::BASE64_STANDARD;
+use arrow_flight::sql::server::PeekableFlightDataStream;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use core::str;
-use futures::{stream, Stream, TryStreamExt};
+use futures::{Stream, TryStreamExt, stream};
 use once_cell::sync::Lazy;
 use prost::Message;
 use std::collections::HashSet;
@@ -39,23 +39,23 @@ use arrow_flight::sql::metadata::{
     SqlInfoData, SqlInfoDataBuilder, XdbcTypeInfo, XdbcTypeInfoData, XdbcTypeInfoDataBuilder,
 };
 use arrow_flight::sql::{
-    server::FlightSqlService, ActionBeginSavepointRequest, ActionBeginSavepointResult,
-    ActionBeginTransactionRequest, ActionBeginTransactionResult, ActionCancelQueryRequest,
-    ActionCancelQueryResult, ActionClosePreparedStatementRequest,
-    ActionCreatePreparedStatementRequest, ActionCreatePreparedStatementResult,
-    ActionCreatePreparedSubstraitPlanRequest, ActionEndSavepointRequest,
-    ActionEndTransactionRequest, Any, CommandGetCatalogs, CommandGetCrossReference,
-    CommandGetDbSchemas, CommandGetExportedKeys, CommandGetImportedKeys, CommandGetPrimaryKeys,
-    CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables, CommandGetXdbcTypeInfo,
-    CommandPreparedStatementQuery, CommandPreparedStatementUpdate, CommandStatementIngest,
-    CommandStatementQuery, CommandStatementSubstraitPlan, CommandStatementUpdate, Nullable,
-    ProstMessageExt, Searchable, SqlInfo, TicketStatementQuery, XdbcDataType,
+    ActionBeginSavepointRequest, ActionBeginSavepointResult, ActionBeginTransactionRequest,
+    ActionBeginTransactionResult, ActionCancelQueryRequest, ActionCancelQueryResult,
+    ActionClosePreparedStatementRequest, ActionCreatePreparedStatementRequest,
+    ActionCreatePreparedStatementResult, ActionCreatePreparedSubstraitPlanRequest,
+    ActionEndSavepointRequest, ActionEndTransactionRequest, Any, CommandGetCatalogs,
+    CommandGetCrossReference, CommandGetDbSchemas, CommandGetExportedKeys, CommandGetImportedKeys,
+    CommandGetPrimaryKeys, CommandGetSqlInfo, CommandGetTableTypes, CommandGetTables,
+    CommandGetXdbcTypeInfo, CommandPreparedStatementQuery, CommandPreparedStatementUpdate,
+    CommandStatementIngest, CommandStatementQuery, CommandStatementSubstraitPlan,
+    CommandStatementUpdate, Nullable, ProstMessageExt, Searchable, SqlInfo, TicketStatementQuery,
+    XdbcDataType, server::FlightSqlService,
 };
 use arrow_flight::utils::batches_to_flight_data;
 use arrow_flight::{
-    flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
-    FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse,
-    IpcMessage, SchemaAsIpc, Ticket,
+    Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
+    HandshakeResponse, IpcMessage, SchemaAsIpc, Ticket, flight_service_server::FlightService,
+    flight_service_server::FlightServiceServer,
 };
 use arrow_ipc::writer::IpcWriteOptions;
 use arrow_schema::{ArrowError, DataType, Field, Schema};

--- a/arrow-flight/examples/server.rs
+++ b/arrow-flight/examples/server.rs
@@ -20,9 +20,9 @@ use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 
 use arrow_flight::{
-    flight_service_server::FlightService, flight_service_server::FlightServiceServer, Action,
-    ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest,
-    HandshakeResponse, PollInfo, PutResult, SchemaResult, Ticket,
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PollInfo, PutResult, SchemaResult, Ticket,
+    flight_service_server::FlightService, flight_service_server::FlightServiceServer,
 };
 
 #[derive(Clone)]

--- a/arrow-flight/src/bin/flight_sql_client.rs
+++ b/arrow-flight/src/bin/flight_sql_client.rs
@@ -17,13 +17,13 @@
 
 use std::{sync::Arc, time::Duration};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use arrow_array::{ArrayRef, Datum, RecordBatch, StringArray};
-use arrow_cast::{cast_with_options, pretty::pretty_format_batches, CastOptions};
+use arrow_cast::{CastOptions, cast_with_options, pretty::pretty_format_batches};
 use arrow_flight::{
-    flight_service_client::FlightServiceClient,
-    sql::{client::FlightSqlServiceClient, CommandGetDbSchemas, CommandGetTables},
     FlightInfo,
+    flight_service_client::FlightServiceClient,
+    sql::{CommandGetDbSchemas, CommandGetTables, client::FlightSqlServiceClient},
 };
 use arrow_schema::Schema;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -378,7 +378,7 @@ fn construct_record_batch_from_params(
 }
 
 fn setup_logging(args: LoggingArgs) -> Result<()> {
-    use tracing_subscriber::{util::SubscriberInitExt, EnvFilter, FmtSubscriber};
+    use tracing_subscriber::{EnvFilter, FmtSubscriber, util::SubscriberInitExt};
 
     tracing_log::LogTracer::init().context("tracing log init")?;
 

--- a/arrow-flight/src/client.rs
+++ b/arrow-flight/src/client.rs
@@ -16,19 +16,19 @@
 // under the License.
 
 use crate::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
+    HandshakeRequest, PollInfo, PutResult, Ticket,
     decode::FlightRecordBatchStream,
     flight_service_client::FlightServiceClient,
     r#gen::{CancelFlightInfoRequest, CancelFlightInfoResult, RenewFlightEndpointRequest},
     trailers::extract_lazy_trailers,
-    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
-    HandshakeRequest, PollInfo, PutResult, Ticket,
 };
 use arrow_schema::Schema;
 use bytes::Bytes;
 use futures::{
+    Stream, StreamExt, TryStreamExt,
     future::ready,
     stream::{self, BoxStream},
-    Stream, StreamExt, TryStreamExt,
 };
 use prost::Message;
 use tonic::{metadata::MetadataMap, transport::Channel};

--- a/arrow-flight/src/client.rs
+++ b/arrow-flight/src/client.rs
@@ -18,7 +18,7 @@
 use crate::{
     decode::FlightRecordBatchStream,
     flight_service_client::FlightServiceClient,
-    gen::{CancelFlightInfoRequest, CancelFlightInfoResult, RenewFlightEndpointRequest},
+    r#gen::{CancelFlightInfoRequest, CancelFlightInfoResult, RenewFlightEndpointRequest},
     trailers::extract_lazy_trailers,
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
     HandshakeRequest, PollInfo, PutResult, Ticket,

--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{trailers::LazyTrailers, utils::flight_data_to_arrow_batch, FlightData};
+use crate::{FlightData, trailers::LazyTrailers, utils::flight_data_to_arrow_batch};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_buffer::Buffer;
 use arrow_schema::{Schema, SchemaRef};
 use bytes::Bytes;
-use futures::{ready, stream::BoxStream, Stream, StreamExt};
+use futures::{Stream, StreamExt, ready, stream::BoxStream};
 use std::{collections::HashMap, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 use tonic::metadata::MetadataMap;
 

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -17,14 +17,14 @@
 
 use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 
-use crate::{error::Result, FlightData, FlightDescriptor, SchemaAsIpc};
+use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
 use arrow_array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, UnionArray};
 use arrow_ipc::writer::{CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 
 use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef, UnionMode};
 use bytes::Bytes;
-use futures::{ready, stream::BoxStream, Stream, StreamExt};
+use futures::{Stream, StreamExt, ready, stream::BoxStream};
 
 /// Creates a [`Stream`] of [`FlightData`]s from a
 /// `Stream` of [`Result`]<[`RecordBatch`], [`FlightError`]>.

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -51,8 +51,8 @@ use arrow_ipc::{convert, writer, writer::EncodedData, writer::IpcWriteOptions};
 use arrow_schema::{ArrowError, Schema};
 
 use arrow_ipc::convert::try_schema_from_ipc_buffer;
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use bytes::Bytes;
 use prost_types::Timestamp;
 use std::{fmt, ops::Deref};

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -60,7 +60,7 @@ use std::{fmt, ops::Deref};
 type ArrowResult<T> = std::result::Result<T, ArrowError>;
 
 #[allow(clippy::all)]
-mod gen {
+mod r#gen {
     // Since this file is auto-generated, we suppress all warnings
     #![allow(missing_docs)]
     include!("arrow.flight.protocol.rs");
@@ -68,22 +68,22 @@ mod gen {
 
 /// Defines a `Flight` for generation or retrieval.
 pub mod flight_descriptor {
-    use super::gen;
-    pub use gen::flight_descriptor::DescriptorType;
+    use super::r#gen;
+    pub use r#gen::flight_descriptor::DescriptorType;
 }
 
 /// Low Level [tonic] [`FlightServiceClient`](gen::flight_service_client::FlightServiceClient).
 pub mod flight_service_client {
-    use super::gen;
-    pub use gen::flight_service_client::FlightServiceClient;
+    use super::r#gen;
+    pub use r#gen::flight_service_client::FlightServiceClient;
 }
 
 /// Low Level [tonic] [`FlightServiceServer`](gen::flight_service_server::FlightServiceServer)
 /// and [`FlightService`](gen::flight_service_server::FlightService).
 pub mod flight_service_server {
-    use super::gen;
-    pub use gen::flight_service_server::FlightService;
-    pub use gen::flight_service_server::FlightServiceServer;
+    use super::r#gen;
+    pub use r#gen::flight_service_server::FlightService;
+    pub use r#gen::flight_service_server::FlightServiceServer;
 }
 
 /// Mid Level [`FlightClient`]
@@ -101,27 +101,27 @@ pub mod encode;
 /// Common error types
 pub mod error;
 
-pub use gen::Action;
-pub use gen::ActionType;
-pub use gen::BasicAuth;
-pub use gen::CancelFlightInfoRequest;
-pub use gen::CancelFlightInfoResult;
-pub use gen::CancelStatus;
-pub use gen::Criteria;
-pub use gen::Empty;
-pub use gen::FlightData;
-pub use gen::FlightDescriptor;
-pub use gen::FlightEndpoint;
-pub use gen::FlightInfo;
-pub use gen::HandshakeRequest;
-pub use gen::HandshakeResponse;
-pub use gen::Location;
-pub use gen::PollInfo;
-pub use gen::PutResult;
-pub use gen::RenewFlightEndpointRequest;
-pub use gen::Result;
-pub use gen::SchemaResult;
-pub use gen::Ticket;
+pub use r#gen::Action;
+pub use r#gen::ActionType;
+pub use r#gen::BasicAuth;
+pub use r#gen::CancelFlightInfoRequest;
+pub use r#gen::CancelFlightInfoResult;
+pub use r#gen::CancelStatus;
+pub use r#gen::Criteria;
+pub use r#gen::Empty;
+pub use r#gen::FlightData;
+pub use r#gen::FlightDescriptor;
+pub use r#gen::FlightEndpoint;
+pub use r#gen::FlightInfo;
+pub use r#gen::HandshakeRequest;
+pub use r#gen::HandshakeResponse;
+pub use r#gen::Location;
+pub use r#gen::PollInfo;
+pub use r#gen::PutResult;
+pub use r#gen::RenewFlightEndpointRequest;
+pub use r#gen::Result;
+pub use r#gen::SchemaResult;
+pub use r#gen::Ticket;
 
 /// Helper to extract HTTP/gRPC trailers from a tonic stream.
 mod trailers;

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -28,7 +28,7 @@ use crate::decode::FlightRecordBatchStream;
 use crate::encode::FlightDataEncoderBuilder;
 use crate::error::FlightError;
 use crate::flight_service_client::FlightServiceClient;
-use crate::sql::gen::action_end_transaction_request::EndTransaction;
+use crate::sql::r#gen::action_end_transaction_request::EndTransaction;
 use crate::sql::server::{
     BEGIN_TRANSACTION, CLOSE_PREPARED_STATEMENT, CREATE_PREPARED_STATEMENT, END_TRANSACTION,
 };

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -17,8 +17,8 @@
 
 //! A FlightSQL Client [`FlightSqlServiceClient`]
 
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -52,9 +52,9 @@ use arrow_array::RecordBatch;
 use arrow_buffer::Buffer;
 use arrow_ipc::convert::fb_to_schema;
 use arrow_ipc::reader::read_record_batch;
-use arrow_ipc::{root_as_message, MessageHeader};
+use arrow_ipc::{MessageHeader, root_as_message};
 use arrow_schema::{ArrowError, Schema, SchemaRef};
-use futures::{stream, Stream, TryStreamExt};
+use futures::{Stream, TryStreamExt, stream};
 use prost::Message;
 use tonic::transport::Channel;
 use tonic::{IntoRequest, IntoStreamingRequest, Streaming};

--- a/arrow-flight/src/sql/metadata/db_schemas.rs
+++ b/arrow-flight/src/sql/metadata/db_schemas.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use arrow_arith::boolean::and;
-use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch, StringArray};
+use arrow_array::{ArrayRef, RecordBatch, StringArray, builder::StringBuilder};
 use arrow_ord::cmp::eq;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::{filter::filter_record_batch, take::take};

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use arrow_arith::boolean::or;
 use arrow_array::array::{Array, UInt32Array, UnionArray};
 use arrow_array::builder::{
-    ArrayBuilder, BooleanBuilder, Int32Builder, Int64Builder, Int8Builder, ListBuilder, MapBuilder,
+    ArrayBuilder, BooleanBuilder, Int8Builder, Int32Builder, Int64Builder, ListBuilder, MapBuilder,
     StringBuilder, UInt32Builder,
 };
 use arrow_array::{RecordBatch, Scalar};

--- a/arrow-flight/src/sql/metadata/table_types.rs
+++ b/arrow-flight/src/sql/metadata/table_types.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::{builder::StringBuilder, ArrayRef, RecordBatch};
+use arrow_array::{ArrayRef, RecordBatch, builder::StringBuilder};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::take::take;
 use once_cell::sync::Lazy;

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -44,70 +44,70 @@ use paste::paste;
 use prost::Message;
 
 #[allow(clippy::all)]
-mod gen {
+mod r#gen {
     // Since this file is auto-generated, we suppress all warnings
     #![allow(missing_docs)]
     include!("arrow.flight.protocol.sql.rs");
 }
 
-pub use gen::action_end_transaction_request::EndTransaction;
-pub use gen::command_statement_ingest::table_definition_options::{
+pub use r#gen::action_end_transaction_request::EndTransaction;
+pub use r#gen::command_statement_ingest::table_definition_options::{
     TableExistsOption, TableNotExistOption,
 };
-pub use gen::command_statement_ingest::TableDefinitionOptions;
-pub use gen::ActionBeginSavepointRequest;
-pub use gen::ActionBeginSavepointResult;
-pub use gen::ActionBeginTransactionRequest;
-pub use gen::ActionBeginTransactionResult;
-pub use gen::ActionCancelQueryRequest;
-pub use gen::ActionCancelQueryResult;
-pub use gen::ActionClosePreparedStatementRequest;
-pub use gen::ActionCreatePreparedStatementRequest;
-pub use gen::ActionCreatePreparedStatementResult;
-pub use gen::ActionCreatePreparedSubstraitPlanRequest;
-pub use gen::ActionEndSavepointRequest;
-pub use gen::ActionEndTransactionRequest;
-pub use gen::CommandGetCatalogs;
-pub use gen::CommandGetCrossReference;
-pub use gen::CommandGetDbSchemas;
-pub use gen::CommandGetExportedKeys;
-pub use gen::CommandGetImportedKeys;
-pub use gen::CommandGetPrimaryKeys;
-pub use gen::CommandGetSqlInfo;
-pub use gen::CommandGetTableTypes;
-pub use gen::CommandGetTables;
-pub use gen::CommandGetXdbcTypeInfo;
-pub use gen::CommandPreparedStatementQuery;
-pub use gen::CommandPreparedStatementUpdate;
-pub use gen::CommandStatementIngest;
-pub use gen::CommandStatementQuery;
-pub use gen::CommandStatementSubstraitPlan;
-pub use gen::CommandStatementUpdate;
-pub use gen::DoPutPreparedStatementResult;
-pub use gen::DoPutUpdateResult;
-pub use gen::Nullable;
-pub use gen::Searchable;
-pub use gen::SqlInfo;
-pub use gen::SqlNullOrdering;
-pub use gen::SqlOuterJoinsSupportLevel;
-pub use gen::SqlSupportedCaseSensitivity;
-pub use gen::SqlSupportedElementActions;
-pub use gen::SqlSupportedGroupBy;
-pub use gen::SqlSupportedPositionedCommands;
-pub use gen::SqlSupportedResultSetConcurrency;
-pub use gen::SqlSupportedResultSetType;
-pub use gen::SqlSupportedSubqueries;
-pub use gen::SqlSupportedTransaction;
-pub use gen::SqlSupportedTransactions;
-pub use gen::SqlSupportedUnions;
-pub use gen::SqlSupportsConvert;
-pub use gen::SqlTransactionIsolationLevel;
-pub use gen::SubstraitPlan;
-pub use gen::SupportedSqlGrammar;
-pub use gen::TicketStatementQuery;
-pub use gen::UpdateDeleteRules;
-pub use gen::XdbcDataType;
-pub use gen::XdbcDatetimeSubcode;
+pub use r#gen::command_statement_ingest::TableDefinitionOptions;
+pub use r#gen::ActionBeginSavepointRequest;
+pub use r#gen::ActionBeginSavepointResult;
+pub use r#gen::ActionBeginTransactionRequest;
+pub use r#gen::ActionBeginTransactionResult;
+pub use r#gen::ActionCancelQueryRequest;
+pub use r#gen::ActionCancelQueryResult;
+pub use r#gen::ActionClosePreparedStatementRequest;
+pub use r#gen::ActionCreatePreparedStatementRequest;
+pub use r#gen::ActionCreatePreparedStatementResult;
+pub use r#gen::ActionCreatePreparedSubstraitPlanRequest;
+pub use r#gen::ActionEndSavepointRequest;
+pub use r#gen::ActionEndTransactionRequest;
+pub use r#gen::CommandGetCatalogs;
+pub use r#gen::CommandGetCrossReference;
+pub use r#gen::CommandGetDbSchemas;
+pub use r#gen::CommandGetExportedKeys;
+pub use r#gen::CommandGetImportedKeys;
+pub use r#gen::CommandGetPrimaryKeys;
+pub use r#gen::CommandGetSqlInfo;
+pub use r#gen::CommandGetTableTypes;
+pub use r#gen::CommandGetTables;
+pub use r#gen::CommandGetXdbcTypeInfo;
+pub use r#gen::CommandPreparedStatementQuery;
+pub use r#gen::CommandPreparedStatementUpdate;
+pub use r#gen::CommandStatementIngest;
+pub use r#gen::CommandStatementQuery;
+pub use r#gen::CommandStatementSubstraitPlan;
+pub use r#gen::CommandStatementUpdate;
+pub use r#gen::DoPutPreparedStatementResult;
+pub use r#gen::DoPutUpdateResult;
+pub use r#gen::Nullable;
+pub use r#gen::Searchable;
+pub use r#gen::SqlInfo;
+pub use r#gen::SqlNullOrdering;
+pub use r#gen::SqlOuterJoinsSupportLevel;
+pub use r#gen::SqlSupportedCaseSensitivity;
+pub use r#gen::SqlSupportedElementActions;
+pub use r#gen::SqlSupportedGroupBy;
+pub use r#gen::SqlSupportedPositionedCommands;
+pub use r#gen::SqlSupportedResultSetConcurrency;
+pub use r#gen::SqlSupportedResultSetType;
+pub use r#gen::SqlSupportedSubqueries;
+pub use r#gen::SqlSupportedTransaction;
+pub use r#gen::SqlSupportedTransactions;
+pub use r#gen::SqlSupportedUnions;
+pub use r#gen::SqlSupportsConvert;
+pub use r#gen::SqlTransactionIsolationLevel;
+pub use r#gen::SubstraitPlan;
+pub use r#gen::SupportedSqlGrammar;
+pub use r#gen::TicketStatementQuery;
+pub use r#gen::UpdateDeleteRules;
+pub use r#gen::XdbcDataType;
+pub use r#gen::XdbcDatetimeSubcode;
 
 pub mod client;
 pub mod metadata;

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -50,11 +50,6 @@ mod r#gen {
     include!("arrow.flight.protocol.sql.rs");
 }
 
-pub use r#gen::action_end_transaction_request::EndTransaction;
-pub use r#gen::command_statement_ingest::table_definition_options::{
-    TableExistsOption, TableNotExistOption,
-};
-pub use r#gen::command_statement_ingest::TableDefinitionOptions;
 pub use r#gen::ActionBeginSavepointRequest;
 pub use r#gen::ActionBeginSavepointResult;
 pub use r#gen::ActionBeginTransactionRequest;
@@ -108,6 +103,11 @@ pub use r#gen::TicketStatementQuery;
 pub use r#gen::UpdateDeleteRules;
 pub use r#gen::XdbcDataType;
 pub use r#gen::XdbcDatetimeSubcode;
+pub use r#gen::action_end_transaction_request::EndTransaction;
+pub use r#gen::command_statement_ingest::TableDefinitionOptions;
+pub use r#gen::command_statement_ingest::table_definition_options::{
+    TableExistsOption, TableNotExistOption,
+};
 
 pub mod client;
 pub mod metadata;

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -34,7 +34,7 @@ use super::{
     SqlInfo, TicketStatementQuery,
 };
 use crate::{
-    flight_service_server::FlightService, gen::PollInfo, Action, ActionType, Criteria, Empty,
+    flight_service_server::FlightService, r#gen::PollInfo, Action, ActionType, Criteria, Empty,
     FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult,
     SchemaResult, Ticket,
 };
@@ -628,7 +628,7 @@ where
                 self.get_flight_info_catalogs(token, request).await
             }
             Command::CommandGetDbSchemas(token) => {
-                return self.get_flight_info_schemas(token, request).await
+                return self.get_flight_info_schemas(token, request).await;
             }
             Command::CommandGetTables(token) => self.get_flight_info_tables(token, request).await,
             Command::CommandGetTableTypes(token) => {
@@ -879,7 +879,7 @@ where
             let stmt = self
                 .do_action_create_prepared_statement(cmd, request)
                 .await?;
-            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+            let output = futures::stream::iter(vec![Ok(super::super::r#gen::Result {
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
@@ -921,7 +921,7 @@ where
                 Status::invalid_argument("Unable to unpack ActionBeginTransactionRequest.")
             })?;
             let stmt = self.do_action_begin_transaction(cmd, request).await?;
-            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+            let output = futures::stream::iter(vec![Ok(super::super::r#gen::Result {
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
@@ -946,7 +946,7 @@ where
                     Status::invalid_argument("Unable to unpack ActionBeginSavepointRequest.")
                 })?;
             let stmt = self.do_action_begin_savepoint(cmd, request).await?;
-            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+            let output = futures::stream::iter(vec![Ok(super::super::r#gen::Result {
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));
@@ -971,7 +971,7 @@ where
                     Status::invalid_argument("Unable to unpack ActionCancelQueryRequest.")
                 })?;
             let stmt = self.do_action_cancel_query(cmd, request).await?;
-            let output = futures::stream::iter(vec![Ok(super::super::gen::Result {
+            let output = futures::stream::iter(vec![Ok(super::super::r#gen::Result {
                 body: stmt.as_any().encode_to_vec().into(),
             })]);
             return Ok(Response::new(Box::pin(output)));

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -34,11 +34,11 @@ use super::{
     SqlInfo, TicketStatementQuery,
 };
 use crate::{
-    flight_service_server::FlightService, r#gen::PollInfo, Action, ActionType, Criteria, Empty,
-    FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult,
-    SchemaResult, Ticket,
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
+    flight_service_server::FlightService, r#gen::PollInfo,
 };
-use futures::{stream::Peekable, Stream, StreamExt};
+use futures::{Stream, StreamExt, stream::Peekable};
 use prost::Message;
 use tonic::{Request, Response, Status, Streaming};
 

--- a/arrow-flight/src/streams.rs
+++ b/arrow-flight/src/streams.rs
@@ -19,11 +19,11 @@
 
 use crate::error::FlightError;
 use futures::{
-    channel::oneshot::{Receiver, Sender},
     FutureExt, Stream, StreamExt,
+    channel::oneshot::{Receiver, Sender},
 };
 use std::pin::Pin;
-use std::task::{ready, Poll};
+use std::task::{Poll, ready};
 
 /// Wrapper around a fallible stream (one that returns errors) that makes it infallible.
 ///

--- a/arrow-flight/src/trailers.rs
+++ b/arrow-flight/src/trailers.rs
@@ -21,8 +21,8 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{ready, FutureExt, Stream, StreamExt};
-use tonic::{metadata::MetadataMap, Status, Streaming};
+use futures::{FutureExt, Stream, StreamExt, ready};
+use tonic::{Status, Streaming, metadata::MetadataMap};
 
 /// Extract [`LazyTrailers`] from [`Streaming`] [tonic] response.
 ///

--- a/arrow-flight/tests/client.rs
+++ b/arrow-flight/tests/client.rs
@@ -22,10 +22,10 @@ mod common;
 use crate::common::fixture::TestFixture;
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_flight::{
-    decode::FlightRecordBatchStream, encode::FlightDataEncoderBuilder, error::FlightError, Action,
-    ActionType, CancelFlightInfoRequest, CancelFlightInfoResult, CancelStatus, Criteria, Empty,
-    FlightClient, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
-    HandshakeResponse, PollInfo, PutResult, RenewFlightEndpointRequest, Ticket,
+    Action, ActionType, CancelFlightInfoRequest, CancelFlightInfoResult, CancelStatus, Criteria,
+    Empty, FlightClient, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PollInfo, PutResult, RenewFlightEndpointRequest, Ticket,
+    decode::FlightRecordBatchStream, encode::FlightDataEncoderBuilder, error::FlightError,
 };
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;

--- a/arrow-flight/tests/common/server.rs
+++ b/arrow-flight/tests/common/server.rs
@@ -19,14 +19,14 @@ use std::sync::{Arc, Mutex};
 
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
-use tonic::{metadata::MetadataMap, Request, Response, Status, Streaming};
+use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use tonic::{Request, Response, Status, Streaming, metadata::MetadataMap};
 
 use arrow_flight::{
-    encode::FlightDataEncoderBuilder,
-    flight_service_server::{FlightService, FlightServiceServer},
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PollInfo, PutResult, SchemaAsIpc, SchemaResult, Ticket,
+    encode::FlightDataEncoderBuilder,
+    flight_service_server::{FlightService, FlightServiceServer},
 };
 
 #[derive(Debug, Clone)]

--- a/arrow-flight/tests/common/utils.rs
+++ b/arrow-flight/tests/common/utils.rs
@@ -20,8 +20,8 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    types::Int32Type, ArrayRef, BinaryViewArray, DictionaryArray, Float64Array, RecordBatch,
-    StringViewArray, UInt8Array,
+    ArrayRef, BinaryViewArray, DictionaryArray, Float64Array, RecordBatch, StringViewArray,
+    UInt8Array, types::Int32Type,
 };
 use arrow_schema::{DataType, Field, Schema};
 

--- a/arrow-flight/tests/encode_decode.rs
+++ b/arrow-flight/tests/encode_decode.rs
@@ -21,8 +21,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_cast::pretty::pretty_format_batches;
-use arrow_flight::flight_descriptor::DescriptorType;
 use arrow_flight::FlightDescriptor;
+use arrow_flight::flight_descriptor::DescriptorType;
 use arrow_flight::{
     decode::{DecodedPayload, FlightDataDecoder, FlightRecordBatchStream},
     encode::FlightDataEncoderBuilder,

--- a/arrow-flight/tests/flight_sql_client.rs
+++ b/arrow-flight/tests/flight_sql_client.rs
@@ -64,10 +64,12 @@ pub async fn test_begin_end_transaction() {
 
     // unknown transaction id
     let transaction_id = "UnknownTransactionId".to_string().into();
-    assert!(flight_sql_client
-        .end_transaction(transaction_id, EndTransaction::Commit)
-        .await
-        .is_err());
+    assert!(
+        flight_sql_client
+            .end_transaction(transaction_id, EndTransaction::Commit)
+            .await
+            .is_err()
+    );
 }
 
 #[tokio::test]
@@ -139,9 +141,10 @@ pub async fn test_do_put_empty_stream() {
 
     // Execute a `do_put` and verify that the server error contains the expected message
     let err = flight_sql_client.do_put(request_stream).await.unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("Unhandled Error: Command is missing."),);
+    assert!(
+        err.to_string()
+            .contains("Unhandled Error: Command is missing."),
+    );
 }
 
 #[tokio::test]
@@ -172,9 +175,10 @@ pub async fn test_do_put_first_element_err() {
     // Execute a `do_put` and verify that the server error contains the expected message
     let err = flight_sql_client.do_put(request_stream).await.unwrap_err();
 
-    assert!(err
-        .to_string()
-        .contains("Unhandled Error: Command is missing."),);
+    assert!(
+        err.to_string()
+            .contains("Unhandled Error: Command is missing."),
+    );
 }
 
 #[tokio::test]
@@ -196,9 +200,10 @@ pub async fn test_do_put_missing_flight_descriptor() {
 
     // Execute a `do_put` and verify that the server error contains the expected message
     let err = flight_sql_client.do_put(request_stream).await.unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("Unhandled Error: Flight descriptor is missing."),);
+    assert!(
+        err.to_string()
+            .contains("Unhandled Error: Flight descriptor is missing."),
+    );
 }
 
 fn make_ingest_command() -> CommandStatementIngest {

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -22,19 +22,19 @@ use std::{pin::Pin, sync::Arc};
 use crate::common::fixture::TestFixture;
 use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray, TimestampNanosecondArray};
 use arrow_flight::{
+    Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
+    HandshakeResponse, IpcMessage, SchemaAsIpc, Ticket,
     decode::FlightRecordBatchStream,
     encode::FlightDataEncoderBuilder,
     flight_service_server::{FlightService, FlightServiceServer},
     sql::{
-        server::{FlightSqlService, PeekableFlightDataStream},
         ActionCreatePreparedStatementRequest, ActionCreatePreparedStatementResult, Any,
         CommandGetCatalogs, CommandGetDbSchemas, CommandGetTableTypes, CommandGetTables,
         CommandPreparedStatementQuery, CommandStatementQuery, DoPutPreparedStatementResult,
         ProstMessageExt, SqlInfo,
+        server::{FlightSqlService, PeekableFlightDataStream},
     },
     utils::batches_to_flight_data,
-    Action, FlightData, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest,
-    HandshakeResponse, IpcMessage, SchemaAsIpc, Ticket,
 };
 use arrow_ipc::writer::IpcWriteOptions;
 use arrow_schema::{ArrowError, DataType, Field, Schema, TimeUnit};


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-flight` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes