### PR TITLE
feat(parquet): add async support for wasm targets

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -89,10 +89,24 @@ lz4_flex = { version = "0.11", default-features = false, features = ["std", "fra
 zstd = { version = "0.13", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 object_store = { version = "0.12.0", default-features = false, features = ["azure", "fs"] }
 sysinfo = { version = "0.36.0", default-features = false, features = ["system"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1.0", default-features = false, features = [
+    "macros",
+    "rt-multi-thread",
+    "io-util",
+    "fs",
+] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+tokio = { version = "1.0", default-features = false, features = [
+    "macros",
+    "rt",
+    "io-util",
+] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes};
-use futures::future::{BoxFuture, FutureExt};
+use futures::future::FutureExt;
 use futures::ready;
 use futures::stream::Stream;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
@@ -56,6 +56,7 @@ use crate::file::metadata::{PageIndexPolicy, ParquetMetaData, ParquetMetaDataRea
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use crate::file::reader::{ChunkReader, Length, SerializedPageReader};
 use crate::format::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
+use crate::future::BoxedFuture;
 
 mod metadata;
 pub use metadata::*;
@@ -84,11 +85,11 @@ pub use store::*;
 /// [`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
 pub trait AsyncFileReader: Send {
     /// Retrieve the bytes in `range`
-    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>>;
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>>;
 
     /// Retrieve multiple byte ranges. The default implementation will call `get_bytes` sequentially
-    fn get_byte_ranges(&mut self, ranges: Vec<Range<u64>>) -> BoxFuture<'_, Result<Vec<Bytes>>> {
-        async move {
+    fn get_byte_ranges(&mut self, ranges: Vec<Range<u64>>) -> BoxedFuture<'_, Result<Vec<Bytes>>> {
+        Box::pin(async move {
             let mut result = Vec::with_capacity(ranges.len());
 
             for range in ranges.into_iter() {
@@ -97,8 +98,7 @@ pub trait AsyncFileReader: Send {
             }
 
             Ok(result)
-        }
-        .boxed()
+        })
     }
 
     /// Return a future which results in the [`ParquetMetaData`] for this Parquet file.
@@ -120,42 +120,41 @@ pub trait AsyncFileReader: Send {
     fn get_metadata<'a>(
         &'a mut self,
         options: Option<&'a ArrowReaderOptions>,
-    ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>>;
+    ) -> BoxedFuture<'a, Result<Arc<ParquetMetaData>>>;
 }
 
 /// This allows Box<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,
 impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
-    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>> {
         self.as_mut().get_bytes(range)
     }
 
-    fn get_byte_ranges(&mut self, ranges: Vec<Range<u64>>) -> BoxFuture<'_, Result<Vec<Bytes>>> {
+    fn get_byte_ranges(&mut self, ranges: Vec<Range<u64>>) -> BoxedFuture<'_, Result<Vec<Bytes>>> {
         self.as_mut().get_byte_ranges(ranges)
     }
 
     fn get_metadata<'a>(
         &'a mut self,
         options: Option<&'a ArrowReaderOptions>,
-    ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
+    ) -> BoxedFuture<'a, Result<Arc<ParquetMetaData>>> {
         self.as_mut().get_metadata(options)
     }
 }
 
 impl<T: AsyncFileReader + MetadataFetch + AsyncRead + AsyncSeek + Unpin> MetadataSuffixFetch for T {
-    fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
-        async move {
+    fn fetch_suffix(&mut self, suffix: usize) -> BoxedFuture<'_, Result<Bytes>> {
+        Box::pin(async move {
             self.seek(SeekFrom::End(-(suffix as i64))).await?;
             let mut buf = Vec::with_capacity(suffix);
             self.take(suffix as _).read_to_end(&mut buf).await?;
             Ok(buf.into())
-        }
-        .boxed()
+        })
     }
 }
 
 impl<T: AsyncRead + AsyncSeek + Unpin + Send> AsyncFileReader for T {
-    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
-        async move {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>> {
+        Box::pin(async move {
             self.seek(SeekFrom::Start(range.start)).await?;
 
             let to_read = range.end - range.start;
@@ -166,15 +165,14 @@ impl<T: AsyncRead + AsyncSeek + Unpin + Send> AsyncFileReader for T {
             }
 
             Ok(buffer.into())
-        }
-        .boxed()
+        })
     }
 
     fn get_metadata<'a>(
         &'a mut self,
         options: Option<&'a ArrowReaderOptions>,
-    ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
-        async move {
+    ) -> BoxedFuture<'a, Result<Arc<ParquetMetaData>>> {
+        Box::pin(async move {
             let metadata_reader = ParquetMetaDataReader::new().with_page_index_policy(
                 PageIndexPolicy::from(options.is_some_and(|o| o.page_index())),
             );
@@ -186,8 +184,7 @@ impl<T: AsyncRead + AsyncSeek + Unpin + Send> AsyncFileReader for T {
 
             let parquet_metadata = metadata_reader.load_via_suffix_and_finish(self).await?;
             Ok(Arc::new(parquet_metadata))
-        }
-        .boxed()
+        })
     }
 }
 
@@ -762,7 +759,7 @@ enum StreamState<T> {
     /// Decoding a batch
     Decoding(ParquetRecordBatchReader),
     /// Reading data from input
-    Reading(BoxFuture<'static, ReadResult<T>>),
+    Reading(BoxedFuture<'static, ReadResult<T>>),
     /// Error
     Error,
 }
@@ -930,14 +927,12 @@ where
 
                     let selection = self.selection.as_mut().map(|s| s.split_off(row_count));
 
-                    let fut = reader
-                        .read_row_group(
-                            row_group_idx,
-                            selection,
-                            self.projection.clone(),
-                            self.batch_size,
-                        )
-                        .boxed();
+                    let fut = Box::pin(reader.read_row_group(
+                        row_group_idx,
+                        selection,
+                        self.projection.clone(),
+                        self.batch_size,
+                    ));
 
                     self.state = StreamState::Reading(fut)
                 }
@@ -1246,29 +1241,32 @@ mod tests {
     }
 
     impl AsyncFileReader for TestReader {
-        fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
+        fn get_bytes(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>> {
             let range = range.clone();
             self.requests
                 .lock()
                 .unwrap()
                 .push(range.start as usize..range.end as usize);
-            futures::future::ready(Ok(self
+            Box::pin(futures::future::ready(Ok(self
                 .data
-                .slice(range.start as usize..range.end as usize)))
-            .boxed()
+                .slice(range.start as usize..range.end as usize))))
         }
 
         fn get_metadata<'a>(
             &'a mut self,
             options: Option<&'a ArrowReaderOptions>,
-        ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
+        ) -> BoxedFuture<'a, Result<Arc<ParquetMetaData>>> {
             let metadata_reader = ParquetMetaDataReader::new().with_page_index_policy(
                 PageIndexPolicy::from(options.is_some_and(|o| o.page_index())),
             );
             self.metadata = Some(Arc::new(
                 metadata_reader.parse_and_finish(&self.data).unwrap(),
             ));
-            futures::future::ready(Ok(self.metadata.clone().unwrap().clone())).boxed()
+            Box::pin(futures::future::ready(Ok(self
+                .metadata
+                .clone()
+                .unwrap()
+                .clone())))
         }
     }
 
@@ -2056,6 +2054,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn test_parquet_record_batch_stream_schema() {
         fn get_all_field_names(schema: &Schema) -> Vec<&String> {
             schema.flattened_fields().iter().map(|f| f.name()).collect()
@@ -2214,6 +2213,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn test_nested_skip() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("col_1", DataType::UInt64, false),
@@ -2461,6 +2461,7 @@ mod tests {
 
     #[tokio::test]
     #[allow(deprecated)]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn empty_offset_index_doesnt_panic_in_read_row_group() {
         use tokio::fs::File;
         let testdata = arrow::util::test_util::parquet_test_data();
@@ -2487,6 +2488,7 @@ mod tests {
 
     #[tokio::test]
     #[allow(deprecated)]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn non_empty_offset_index_doesnt_panic_in_read_row_group() {
         use tokio::fs::File;
         let testdata = arrow::util::test_util::parquet_test_data();
@@ -2512,6 +2514,7 @@ mod tests {
 
     #[tokio::test]
     #[allow(deprecated)]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn empty_offset_index_doesnt_panic_in_column_chunks() {
         use tempfile::TempDir;
         use tokio::fs::File;

--- a/parquet/src/arrow/async_writer/store.rs
+++ b/parquet/src/arrow/async_writer/store.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use bytes::Bytes;
-use futures::future::BoxFuture;
 use std::sync::Arc;
 
 use crate::arrow::async_writer::AsyncFileWriter;
@@ -93,7 +92,7 @@ impl ParquetObjectWriter {
 }
 
 impl AsyncFileWriter for ParquetObjectWriter {
-    fn write(&mut self, bs: Bytes) -> BoxFuture<'_, Result<()>> {
+    fn write(&mut self, bs: Bytes) -> BoxedFuture<'_, Result<()>> {
         Box::pin(async {
             self.w
                 .put(bs)
@@ -102,7 +101,7 @@ impl AsyncFileWriter for ParquetObjectWriter {
         })
     }
 
-    fn complete(&mut self) -> BoxFuture<'_, Result<()>> {
+    fn complete(&mut self) -> BoxedFuture<'_, Result<()>> {
         Box::pin(async {
             self.w
                 .shutdown()

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -921,8 +921,6 @@ mod async_tests {
     use arrow_array::RecordBatch;
     use arrow_schema::{Field, Schema};
     use bytes::Bytes;
-    use futures::future::BoxFuture;
-    use futures::FutureExt;
     use std::fs::File;
     use std::future::Future;
     use std::io::{Read, Seek, SeekFrom};
@@ -934,6 +932,7 @@ mod async_tests {
     use crate::arrow::ArrowWriter;
     use crate::file::properties::WriterProperties;
     use crate::file::reader::Length;
+    use crate::future::BoxedFuture;
     use crate::util::test_common::file_util::get_test_file;
 
     struct MetadataFetchFn<F>(F);
@@ -943,8 +942,8 @@ mod async_tests {
         F: FnMut(Range<u64>) -> Fut + Send,
         Fut: Future<Output = Result<Bytes>> + Send,
     {
-        fn fetch(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
-            async move { self.0(range).await }.boxed()
+        fn fetch(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>> {
+            Box::pin(async move { self.0(range).await })
         }
     }
 
@@ -956,8 +955,8 @@ mod async_tests {
         Fut: Future<Output = Result<Bytes>> + Send,
         F2: Send,
     {
-        fn fetch(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
-            async move { self.0(range).await }.boxed()
+        fn fetch(&mut self, range: Range<u64>) -> BoxedFuture<'_, Result<Bytes>> {
+            Box::pin(async move { self.0(range).await })
         }
     }
 
@@ -967,8 +966,8 @@ mod async_tests {
         F2: FnMut(usize) -> Fut + Send,
         Fut: Future<Output = Result<Bytes>> + Send,
     {
-        fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
-            async move { self.1(suffix).await }.boxed()
+        fn fetch_suffix(&mut self, suffix: usize) -> BoxedFuture<'_, Result<Bytes>> {
+            Box::pin(async move { self.1(suffix).await })
         }
     }
 

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -172,7 +172,7 @@ pub use self::encodings::{decoding, encoding};
 
 experimental!(#[macro_use] mod util);
 
-pub use util::utf8;
+pub use util::{future, utf8};
 
 #[cfg(feature = "arrow")]
 pub mod arrow;

--- a/parquet/src/util/future.rs
+++ b/parquet/src/util/future.rs
@@ -15,20 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-pub mod bit_util;
-mod bit_pack;
-pub(crate) mod interner;
+//! [`BoxedFuture`] type module
 
-pub mod push_buffers;
-#[cfg(any(test, feature = "test_common"))]
-pub(crate) mod test_common;
-pub mod utf8;
+/// BoxedFuture is the type alias of [`futures::future::BoxFuture`].
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxedFuture<'a, T> = futures::future::BoxFuture<'a, T>;
 
-#[cfg(feature = "async")]
-pub mod future;
-
-#[cfg(any(test, feature = "test_common"))]
-pub use self::test_common::page_util::{
-    DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
-};
+/// BoxedFuture is the type alias of [`futures::future::LocalBoxFuture`].
+#[cfg(target_arch = "wasm32")]
+pub type BoxedFuture<'a, T> = futures::future::LocalBoxFuture<'a, T>;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #7612.

# Rationale for this change

> Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

This PR introduces `BoxedFuture` type alias to replace `futures::future::BoxFuture`.
It helps building on WebAssembly targets (e.g. `wasm32-unknown-unknown`, `wasm32-wasip2`).

The original codes are driven from: https://github.com/apache/opendal/blob/37efe24235388788b892f46e4101d59ecd37918c/core/src/raw/futures_util.rs#L43-L58

I think it's not an ultimate solution, because the API rework is in progress.
But I think it's useful for now.

# What changes are included in this PR?

- Replace all parquet's `futures::future::BoxFuture` into `BoxedFuture` for WASM targets, which is thread-local.
- Replace all `FutureExt::boxed` calls into `Box::pin` to catch `Send` automatically

# Are these changes tested?

All build steps below are passed on my local machine:

- `cargo build --package parquet --target wasm32-unknown-unknown -p parquet --features async`
- `cargo build --package parquet --target wasm32-wasip1 -p parquet --features async`
- `cargo build --package parquet --target wasm32-wasip2 -p parquet --features async`

The tests are not passed because:

- `wasm32-unknown-unknown`: `getrandom` is not supported
- `wasm32-wasip1`, `wasm32-wasip2`: `tokio/fs` is not supported yet

# Are there any user-facing changes?

NONE