### PR TITLE
[Parquet] Minor: Remove mut ref for getting row-group bloom filter

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -4920,7 +4920,7 @@ mod tests {
     }
 
     fn test_get_row_group_column_bloom_filter(data: Bytes, with_length: bool) {
-        let mut builder = ParquetRecordBatchReaderBuilder::try_new(data.clone()).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(data.clone()).unwrap();
 
         let metadata = builder.metadata();
         assert_eq!(metadata.num_row_groups(), 1);

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -422,7 +422,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
     ///
     /// We should call this function after other forms pruning, such as projection and predicate pushdown.
     pub async fn get_row_group_column_bloom_filter(
-        &self,
+        &mut self,
         row_group_idx: usize,
         column_idx: usize,
     ) -> Result<Option<Sbbf>> {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8461 .

# Rationale for this change

See the issue 

# What changes are included in this PR?

&mut  -> &

# Are these changes tested?

Covered by existing

# Are there any user-facing changes?

No