### PR TITLE
Fix Rustfmt in arrow-cast

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -65,7 +65,7 @@ use arrow_data::ArrayData;
 use arrow_data::transform::MutableArrayData;
 use arrow_schema::*;
 use arrow_select::take::take;
-use num_traits::{cast::AsPrimitive, NumCast, ToPrimitive};
+use num_traits::{NumCast, ToPrimitive, cast::AsPrimitive};
 
 /// CastOptions provides a way to override the default cast behaviors
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Fixes failing fmt job on main (https://github.com/apache/arrow-rs/actions/runs/18039752742/job/51335266375), caused by https://github.com/apache/arrow-rs/pull/8453.