### PR TITLE
Migrate `arrow-pyarrow` to Rust 2024

### DIFF
--- a/arrow-pyarrow/Cargo.toml
+++ b/arrow-pyarrow/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [lib]

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -64,8 +64,8 @@ use arrow_array::ffi;
 use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use arrow_array::{
-    make_array, RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader,
-    StructArray,
+    RecordBatch, RecordBatchIterator, RecordBatchOptions, RecordBatchReader, StructArray,
+    make_array,
 };
 use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType, Field, Schema};


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-pyarrow` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes