### PR TITLE
Migrate `arrow-row` to Rust 2024

### DIFF
--- a/arrow-row/Cargo.toml
+++ b/arrow-row/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [lib]
@@ -47,4 +47,3 @@ half = { version = "2.1", default-features = false }
 arrow-cast = { workspace = true }
 arrow-ord = { workspace = true }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-

--- a/arrow-row/src/fixed.rs
+++ b/arrow-row/src/fixed.rs
@@ -20,8 +20,8 @@ use crate::null_sentinel;
 use arrow_array::builder::BufferBuilder;
 use arrow_array::{ArrowPrimitiveType, BooleanArray, FixedSizeBinaryArray};
 use arrow_buffer::{
-    bit_util, i256, ArrowNativeType, BooleanBuffer, Buffer, IntervalDayTime, IntervalMonthDayNano,
-    MutableBuffer, NullBuffer,
+    ArrowNativeType, BooleanBuffer, Buffer, IntervalDayTime, IntervalMonthDayNano, MutableBuffer,
+    NullBuffer, bit_util, i256,
 };
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{DataType, SortOptions};
@@ -456,7 +456,7 @@ unsafe fn decode_fixed<T: FixedLengthEncoding + ArrowNativeType>(
         .null_bit_buffer(Some(nulls));
 
     // SAFETY: Buffers correct length
-    builder.build_unchecked()
+    unsafe { builder.build_unchecked() }
 }
 
 /// Decodes a `PrimitiveArray` from rows

--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{fixed, null_sentinel, LengthTracker, RowConverter, Rows, SortField};
-use arrow_array::{new_null_array, Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait};
+use crate::{LengthTracker, RowConverter, Rows, SortField, fixed, null_sentinel};
+use arrow_array::{Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait, new_null_array};
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer};
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, SortOptions};
@@ -174,7 +174,7 @@ pub unsafe fn decode<O: OffsetSizeTrait>(
         })
         .collect();
 
-    let child = converter.convert_raw(&mut child_rows, validate_utf8)?;
+    let child = unsafe { converter.convert_raw(&mut child_rows, validate_utf8) }?;
     assert_eq!(child.len(), 1);
 
     let child_data = child[0].to_data();
@@ -279,7 +279,7 @@ pub unsafe fn decode_fixed_size_list(
         _ => {
             return Err(ArrowError::InvalidArgumentError(format!(
                 "Expected FixedSizeListArray, found: {list_type}",
-            )))
+            )));
         }
     };
 
@@ -301,7 +301,7 @@ pub unsafe fn decode_fixed_size_list(
         } else {
             for _ in 0..value_length {
                 let mut temp_child_rows = vec![&row[row_offset..]];
-                converter.convert_raw(&mut temp_child_rows, validate_utf8)?;
+                unsafe { converter.convert_raw(&mut temp_child_rows, validate_utf8) }?;
                 let decoded_bytes = row.len() - row_offset - temp_child_rows[0].len();
                 let next_offset = row_offset + decoded_bytes;
                 child_rows.push(&row[row_offset..next_offset]);
@@ -311,7 +311,7 @@ pub unsafe fn decode_fixed_size_list(
         *row = &row[row_offset..]; // Update row for the next decoder
     }
 
-    let children = converter.convert_raw(&mut child_rows, validate_utf8)?;
+    let children = unsafe { converter.convert_raw(&mut child_rows, validate_utf8) }?;
     let child_data = children.iter().map(|c| c.to_data()).collect();
     let builder = ArrayDataBuilder::new(list_type.clone())
         .len(len)
@@ -319,5 +319,7 @@ pub unsafe fn decode_fixed_size_list(
         .null_bit_buffer(Some(nulls))
         .child_data(child_data);
 
-    Ok(FixedSizeListArray::from(builder.build_unchecked()))
+    Ok(FixedSizeListArray::from(unsafe {
+        builder.build_unchecked()
+    }))
 }

--- a/arrow-row/src/run.rs
+++ b/arrow-row/src/run.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{variable, RowConverter, Rows, SortField};
+use crate::{RowConverter, Rows, SortField, variable};
 use arrow_array::types::RunEndIndexType;
 use arrow_array::{PrimitiveArray, RunArray};
 use arrow_buffer::{ArrowNativeType, ScalarBuffer};
@@ -97,7 +97,7 @@ pub unsafe fn decode<R: RunEndIndexType>(
     validate_utf8: bool,
 ) -> Result<RunArray<R>, ArrowError> {
     if rows.is_empty() {
-        let values = converter.convert_raw(&mut [], validate_utf8)?;
+        let values = unsafe { converter.convert_raw(&mut [], validate_utf8) }?;
         let run_ends_array = PrimitiveArray::<R>::try_new(ScalarBuffer::from(vec![]), None)?;
         return RunArray::<R>::try_new(&run_ends_array, &values[0]);
     }
@@ -143,9 +143,9 @@ pub unsafe fn decode<R: RunEndIndexType>(
     // Convert the unique decoded values using the row converter
     let mut unique_rows: Vec<&[u8]> = decoded_values.iter().map(|v| v.as_slice()).collect();
     let values = if unique_rows.is_empty() {
-        converter.convert_raw(&mut [], validate_utf8)?
+        unsafe { converter.convert_raw(&mut [], validate_utf8) }?
     } else {
-        converter.convert_raw(&mut unique_rows, validate_utf8)?
+        unsafe { converter.convert_raw(&mut unique_rows, validate_utf8) }?
     };
 
     // Create run ends array

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -18,8 +18,8 @@
 use crate::null_sentinel;
 use arrow_array::builder::BufferBuilder;
 use arrow_array::*;
-use arrow_buffer::bit_util::ceil;
 use arrow_buffer::MutableBuffer;
+use arrow_buffer::bit_util::ceil;
 use arrow_data::{ArrayDataBuilder, MAX_INLINE_VIEW_LEN};
 use arrow_schema::{DataType, SortOptions};
 use builder::make_view;
@@ -358,7 +358,7 @@ pub unsafe fn decode_string<I: OffsetSizeTrait>(
 
     // SAFETY:
     // Row data must have come from a valid UTF-8 array
-    GenericStringArray::from(builder.build_unchecked())
+    GenericStringArray::from(unsafe { builder.build_unchecked() })
 }
 
 /// Decodes a string view array from `rows` with the provided `options`
@@ -372,5 +372,5 @@ pub unsafe fn decode_string_view(
     validate_utf8: bool,
 ) -> StringViewArray {
     let view = decode_binary_view_inner(rows, options, validate_utf8);
-    view.to_string_view_unchecked()
+    unsafe { view.to_string_view_unchecked() }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-row` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes