### PR TITLE
Migrate `arrow-select` to Rust 2024

### DIFF
--- a/arrow-select/Cargo.toml
+++ b/arrow-select/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [lib]

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -22,7 +22,7 @@
 //! [`take`]: crate::take::take
 use crate::filter::filter_record_batch;
 use arrow_array::types::{BinaryViewType, StringViewType};
-use arrow_array::{downcast_primitive, Array, ArrayRef, BooleanArray, RecordBatch};
+use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, downcast_primitive};
 use arrow_schema::{ArrowError, DataType, SchemaRef};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -1400,13 +1400,11 @@ mod tests {
 
     /// Return a RecordBatch of 100 rows
     fn multi_column_batch(range: Range<i32>) -> RecordBatch {
-        let int64_array = Int64Array::from_iter(range.clone().map(|v| {
-            if v % 5 == 0 {
-                None
-            } else {
-                Some(v as i64)
-            }
-        }));
+        let int64_array = Int64Array::from_iter(
+            range
+                .clone()
+                .map(|v| if v % 5 == 0 { None } else { Some(v as i64) }),
+        );
         let string_view_array = StringViewArray::from_iter(range.clone().map(|v| {
             if v % 5 == 0 {
                 None

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -38,8 +38,8 @@ use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::{ArrowNativeType, BooleanBufferBuilder, NullBuffer, OffsetBuffer};
-use arrow_data::transform::{Capacities, MutableArrayData};
 use arrow_data::ArrayDataBuilder;
+use arrow_data::transform::{Capacities, MutableArrayData};
 use arrow_schema::{ArrowError, DataType, FieldRef, Fields, SchemaRef};
 use std::{collections::HashSet, ops::Add, sync::Arc};
 
@@ -549,7 +549,10 @@ mod tests {
             &PrimitiveArray::<Int32Type>::from(vec![Some(-1), Some(2), None]),
         ]);
 
-        assert_eq!(re.unwrap_err().to_string(), "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32).");
+        assert_eq!(
+            re.unwrap_err().to_string(),
+            "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32)."
+        );
     }
 
     #[test]
@@ -572,7 +575,10 @@ mod tests {
             &PrimitiveArray::<Float32Type>::from(vec![Some(1.0), Some(2.0), None]),
         ]);
 
-        assert_eq!(re.unwrap_err().to_string(), "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32).");
+        assert_eq!(
+            re.unwrap_err().to_string(),
+            "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32)."
+        );
     }
 
     #[test]
@@ -596,7 +602,10 @@ mod tests {
             &PrimitiveArray::<Float64Type>::from(vec![Some(1.0), Some(2.0), None]),
         ]);
 
-        assert_eq!(re.unwrap_err().to_string(), "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32, ...).");
+        assert_eq!(
+            re.unwrap_err().to_string(),
+            "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32, ...)."
+        );
     }
 
     #[test]
@@ -622,7 +631,10 @@ mod tests {
             &BooleanArray::from(vec![Some(true), Some(false), None]),
         ]);
 
-        assert_eq!(re.unwrap_err().to_string(), "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32, ...).");
+        assert_eq!(
+            re.unwrap_err().to_string(),
+            "Invalid argument error: It is not possible to concatenate arrays of different data types (Int64, Utf8, Int32, Int8, Int16, UInt8, UInt16, UInt32, UInt64, Float32, ...)."
+        );
     }
 
     #[test]
@@ -1154,12 +1166,14 @@ mod tests {
         // Verify pointer equality check succeeds, and therefore the
         // dictionaries are not merged. A single values buffer should be reused
         // in this case.
-        assert!(dict.values().to_data().ptr_eq(
-            &result_same_dictionary
-                .as_dictionary::<Int8Type>()
-                .values()
-                .to_data()
-        ));
+        assert!(
+            dict.values().to_data().ptr_eq(
+                &result_same_dictionary
+                    .as_dictionary::<Int8Type>()
+                    .values()
+                    .to_data()
+            )
+        );
         assert_eq!(
             result_same_dictionary
                 .as_dictionary::<Int8Type>()
@@ -1222,10 +1236,12 @@ mod tests {
         );
 
         // Should have reused the dictionary
-        assert!(array
-            .values()
-            .to_data()
-            .ptr_eq(&combined.values().to_data()));
+        assert!(
+            array
+                .values()
+                .to_data()
+                .ptr_eq(&combined.values().to_data())
+        );
         assert!(copy.values().to_data().ptr_eq(&combined.values().to_data()));
 
         let new: DictionaryArray<Int8Type> = vec!["d"].into_iter().collect();
@@ -1316,7 +1332,10 @@ mod tests {
         .unwrap();
 
         let error = concat_batches(&schema1, [&batch1, &batch2]).unwrap_err();
-        assert_eq!(error.to_string(), "Invalid argument error: It is not possible to concatenate arrays of different data types (Int32, Utf8).");
+        assert_eq!(
+            error.to_string(),
+            "Invalid argument error: It is not possible to concatenate arrays of different data types (Int32, Utf8)."
+        );
     }
 
     #[test]
@@ -1481,7 +1500,6 @@ mod tests {
         K: ArrowDictionaryKeyType,
         V: Sync + Send + 'static,
         &'a V: ArrayAccessor + IntoIterator,
-
         <&'a V as ArrayAccessor>::Item: Default + Clone + PartialEq + Debug + Ord,
         <&'a V as IntoIterator>::Item: Clone + PartialEq + Debug + Ord,
     {

--- a/arrow-select/src/dictionary.rs
+++ b/arrow-select/src/dictionary.rs
@@ -27,11 +27,11 @@ use arrow_array::types::{
     ArrowDictionaryKeyType, ArrowPrimitiveType, BinaryType, ByteArrayType, LargeBinaryType,
     LargeUtf8Type, Utf8Type,
 };
-use arrow_array::{cast::AsArray, downcast_primitive};
 use arrow_array::{
-    downcast_dictionary_array, AnyDictionaryArray, Array, ArrayRef, ArrowNativeTypeOp,
-    BooleanArray, DictionaryArray, GenericByteArray, PrimitiveArray,
+    AnyDictionaryArray, Array, ArrayRef, ArrowNativeTypeOp, BooleanArray, DictionaryArray,
+    GenericByteArray, PrimitiveArray, downcast_dictionary_array,
 };
+use arrow_array::{cast::AsArray, downcast_primitive};
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, ScalarBuffer, ToByteSlice};
 use arrow_schema::{ArrowError, DataType};
 
@@ -365,9 +365,9 @@ mod tests {
     use super::*;
 
     use arrow_array::cast::as_string_array;
-    use arrow_array::types::Int32Type;
     use arrow_array::types::Int8Type;
-    use arrow_array::{DictionaryArray, Int32Array, Int8Array, StringArray};
+    use arrow_array::types::Int32Type;
+    use arrow_array::{DictionaryArray, Int8Array, Int32Array, StringArray};
     use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
     use std::sync::Arc;
 

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -26,11 +26,11 @@ use arrow_array::types::{
     ArrowDictionaryKeyType, ArrowPrimitiveType, ByteArrayType, ByteViewType, RunEndIndexType,
 };
 use arrow_array::*;
-use arrow_buffer::{bit_util, ArrowNativeType, BooleanBuffer, NullBuffer, RunEndBuffer};
+use arrow_buffer::{ArrowNativeType, BooleanBuffer, NullBuffer, RunEndBuffer, bit_util};
 use arrow_buffer::{Buffer, MutableBuffer};
+use arrow_data::ArrayDataBuilder;
 use arrow_data::bit_iterator::{BitIndexIterator, BitSliceIterator};
 use arrow_data::transform::MutableArrayData;
-use arrow_data::ArrayDataBuilder;
 use arrow_schema::*;
 
 /// If the filter selects more than this fraction of rows, use

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -23,8 +23,8 @@ use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, MutableBuffer, NullBuffer, OffsetBuffer};
-use arrow_data::transform::MutableArrayData;
 use arrow_data::ByteView;
+use arrow_data::transform::MutableArrayData;
 use arrow_schema::{ArrowError, DataType, Fields};
 use std::sync::Arc;
 
@@ -402,8 +402,8 @@ pub fn interleave_record_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::builder::{Int32Builder, ListBuilder, PrimitiveRunBuilder};
     use arrow_array::Int32RunArray;
+    use arrow_array::builder::{Int32Builder, ListBuilder, PrimitiveRunBuilder};
     use arrow_schema::Field;
 
     #[test]

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -17,7 +17,7 @@
 
 //! Implements the `nullif` function for Arrow arrays.
 
-use arrow_array::{make_array, Array, ArrayRef, BooleanArray};
+use arrow_array::{Array, ArrayRef, BooleanArray, make_array};
 use arrow_buffer::buffer::{bitwise_bin_op_helper, bitwise_unary_op_helper};
 use arrow_buffer::{BooleanBuffer, NullBuffer};
 use arrow_schema::{ArrowError, DataType};
@@ -120,7 +120,7 @@ mod tests {
     use arrow_array::{Int32Array, NullArray, StringArray, StructArray};
     use arrow_data::ArrayData;
     use arrow_schema::{Field, Fields};
-    use rand::{rng, Rng};
+    use rand::{Rng, rng};
 
     #[test]
     fn test_nullif_int_array() {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -24,8 +24,8 @@ use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
 use arrow_buffer::{
-    bit_util, ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer,
-    ScalarBuffer,
+    ArrowNativeType, BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer,
+    bit_util,
 };
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, FieldRef, UnionMode};

--- a/arrow-select/src/union_extract.rs
+++ b/arrow-select/src/union_extract.rs
@@ -19,10 +19,10 @@
 
 use crate::take::take;
 use arrow_array::{
-    make_array, new_empty_array, new_null_array, Array, ArrayRef, BooleanArray, Int32Array, Scalar,
-    UnionArray,
+    Array, ArrayRef, BooleanArray, Int32Array, Scalar, UnionArray, make_array, new_empty_array,
+    new_null_array,
 };
-use arrow_buffer::{bit_util, BooleanBuffer, MutableBuffer, NullBuffer, ScalarBuffer};
+use arrow_buffer::{BooleanBuffer, MutableBuffer, NullBuffer, ScalarBuffer, bit_util};
 use arrow_data::layout;
 use arrow_schema::{ArrowError, DataType, UnionFields};
 use std::cmp::Ordering;
@@ -399,8 +399,8 @@ fn is_sequential_generic<const N: usize>(offsets: &[i32]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{eq_scalar_inner, is_sequential_generic, union_extract, BoolValue};
-    use arrow_array::{new_null_array, Array, Int32Array, NullArray, StringArray, UnionArray};
+    use super::{BoolValue, eq_scalar_inner, is_sequential_generic, union_extract};
+    use arrow_array::{Array, Int32Array, NullArray, StringArray, UnionArray, new_null_array};
     use arrow_buffer::{BooleanBuffer, ScalarBuffer};
     use arrow_schema::{ArrowError, DataType, Field, UnionFields, UnionMode};
     use std::sync::Arc;

--- a/arrow-select/src/window.rs
+++ b/arrow-select/src/window.rs
@@ -18,7 +18,7 @@
 //! Defines windowing functions, like `shift`ing
 
 use crate::concat::concat;
-use arrow_array::{make_array, new_null_array, Array, ArrayRef};
+use arrow_array::{Array, ArrayRef, make_array, new_null_array};
 use arrow_schema::ArrowError;
 use num_traits::abs;
 


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-select` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes