### PR TITLE
Migrate `arrow-string` to Rust 2024

### DIFF
--- a/arrow-string/Cargo.toml
+++ b/arrow-string/Cargo.toml
@@ -25,7 +25,7 @@ authors = { workspace = true }
 license = { workspace = true }
 keywords = { workspace = true }
 include = { workspace = true }
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [lib]

--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -627,11 +627,7 @@ mod tests {
         let data: Vec<Option<&str>> = (0..TOTAL)
             .map(|n| {
                 let i = n % 5;
-                if i == 3 {
-                    None
-                } else {
-                    Some(v[i as usize])
-                }
+                if i == 3 { None } else { Some(v[i as usize]) }
             })
             .collect();
 
@@ -674,11 +670,7 @@ mod tests {
         let data: Vec<Option<&str>> = (0..TOTAL)
             .map(|n| {
                 let i = n % 5;
-                if i == 3 {
-                    None
-                } else {
-                    Some(v[i as usize])
-                }
+                if i == 3 { None } else { Some(v[i as usize]) }
             })
             .collect();
 

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -727,7 +727,9 @@ mod tests {
             "arrow",
             "arrow"
         ],
-        vec!["arrow", "ar%", "%ro%", "foo", "arr", "arrow_", "arrow_", ".*"],
+        vec![
+            "arrow", "ar%", "%ro%", "foo", "arr", "arrow_", "arrow_", ".*"
+        ],
         like,
         vec![true, true, true, false, false, true, false, false]
     );
@@ -817,7 +819,9 @@ mod tests {
             "arrow",
             "arrow"
         ],
-        vec!["arrow", "ar%", "row", "foo", "arr", "arrow_", "arrow_", ".*"],
+        vec![
+            "arrow", "ar%", "row", "foo", "arr", "arrow_", "arrow_", ".*"
+        ],
         starts_with,
         vec![true, false, false, false, true, false, false, false]
     );
@@ -864,7 +868,9 @@ mod tests {
             "arrow",
             "arrow"
         ],
-        vec!["arrow", "ar%", "row", "foo", "arr", "arrow_", "arrow_", ".*"],
+        vec![
+            "arrow", "ar%", "row", "foo", "arr", "arrow_", "arrow_", ".*"
+        ],
         ends_with,
         vec![true, false, true, false, false, false, false, false]
     );
@@ -1155,7 +1161,9 @@ mod tests {
         ],
         "FFkoSS%",
         ilike,
-        vec![false, true, true, false, false, false, false, true, true, false]
+        vec![
+            false, true, true, false, false, false, false, true, true, false
+        ]
     );
 
     test_utf8_scalar!(
@@ -1174,7 +1182,9 @@ mod tests {
         ],
         "%FFkoSS",
         ilike,
-        vec![false, true, true, false, false, false, false, true, true, true]
+        vec![
+            false, true, true, false, false, false, false, true, true, true
+        ]
     );
 
     test_utf8_scalar!(
@@ -1194,7 +1204,9 @@ mod tests {
         ],
         "%FFkoSS%",
         ilike,
-        vec![false, true, true, false, false, false, false, true, true, true, true]
+        vec![
+            false, true, true, false, false, false, false, true, true, true, true
+        ]
     );
 
     // Replicates `test_utf8_array_ilike_unicode_contains` and
@@ -1219,7 +1231,9 @@ mod tests {
         ],
         "FFkoSS",
         contains,
-        vec![false, true, true, false, false, false, false, true, true, true, false]
+        vec![
+            false, true, true, false, false, false, false, true, true, true, false
+        ]
     );
 
     test_utf8_scalar!(
@@ -1239,7 +1253,9 @@ mod tests {
         ],
         "%FF__SS%",
         ilike,
-        vec![false, true, true, false, false, false, false, true, true, true, true]
+        vec![
+            false, true, true, false, false, false, false, true, true, true, true
+        ]
     );
 
     // 😈 is four bytes long.
@@ -1260,7 +1276,9 @@ mod tests {
         ],
         "%Ssh😈klF",
         like,
-        vec![false, false, false, false, false, false, false, true, true, false, false]
+        vec![
+            false, false, false, false, false, false, false, true, true, false, false
+        ]
     );
 
     test_utf8_scalar!(

--- a/arrow-string/src/substring.rs
+++ b/arrow-string/src/substring.rs
@@ -915,11 +915,7 @@ mod tests {
         let data: Vec<Option<&str>> = (0..TOTAL)
             .map(|n| {
                 let i = n % 5;
-                if i == 3 {
-                    None
-                } else {
-                    Some(v[i as usize])
-                }
+                if i == 3 { None } else { Some(v[i as usize]) }
             })
             .collect();
 


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `arrow-string` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes