### PR TITLE
Migrate `parquet_derive_test` to Rust 2024

### DIFF
--- a/parquet_derive_test/Cargo.toml
+++ b/parquet_derive_test/Cargo.toml
@@ -24,7 +24,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 keywords = [ "parquet" ]
-edition = { workspace = true }
+edition = "2024"
 publish = false
 rust-version = { workspace = true }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `parquet_derive_test` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes