### PR TITLE
Migrate `parquet-geospatial` to Rust 2024

### DIFF
--- a/parquet-geospatial/Cargo.toml
+++ b/parquet-geospatial/Cargo.toml
@@ -27,7 +27,7 @@ repository = { workspace = true }
 authors = { workspace = true }
 keywords = ["arrow", "parquet", "geometry", "geography"]
 readme = "README.md"
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/parquet-geospatial/src/bounding.rs
+++ b/parquet-geospatial/src/bounding.rs
@@ -239,7 +239,7 @@ fn visit_intervals(
         _ => {
             return Err(ArrowError::InvalidArgumentError(
                 "GeometryType not supported for dimension bounds".to_string(),
-            ))
+            ));
         }
     }
 
@@ -302,7 +302,7 @@ fn geometry_type(geom: &impl GeometryTrait<T = f64>) -> Result<i32, ArrowError> 
         Dimensions::Unknown(_) => {
             return Err(ArrowError::InvalidArgumentError(
                 "Unsupported dimensions".to_string(),
-            ))
+            ));
         }
     };
 
@@ -317,7 +317,7 @@ fn geometry_type(geom: &impl GeometryTrait<T = f64>) -> Result<i32, ArrowError> 
         _ => {
             return Err(ArrowError::InvalidArgumentError(
                 "GeometryType not supported for dimension bounds".to_string(),
-            ))
+            ));
         }
     };
 

--- a/parquet-geospatial/src/interval.rs
+++ b/parquet-geospatial/src/interval.rs
@@ -1073,8 +1073,9 @@ mod test {
 
         // Can't convert a wraparound interval that actually wraps around to an Interval
         let err = Interval::try_from(wraparound).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Can't convert wraparound interval"));
+        assert!(
+            err.to_string()
+                .contains("Can't convert wraparound interval")
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `parquet-geospatial` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes