### PR TITLE
Migrate `parquet-variant-json` to Rust 2024

### DIFF
--- a/parquet-variant-json/Cargo.toml
+++ b/parquet-variant-json/Cargo.toml
@@ -27,7 +27,7 @@ repository = { workspace = true }
 authors = { workspace = true }
 keywords = ["arrow", "parquet", "variant"]
 readme = "../parquet-variant/README.md"
-edition = { workspace = true }
+edition = "2024"
 rust-version = { workspace = true }
 
 

--- a/parquet-variant-json/src/from_json.rs
+++ b/parquet-variant-json/src/from_json.rs
@@ -135,7 +135,7 @@ mod test {
     use crate::VariantToJson;
     use arrow_schema::ArrowError;
     use parquet_variant::{
-        ShortString, Variant, VariantBuilder, VariantDecimal16, VariantDecimal4, VariantDecimal8,
+        ShortString, Variant, VariantBuilder, VariantDecimal4, VariantDecimal8, VariantDecimal16,
     };
 
     struct JsonToVariantTest<'a> {
@@ -653,7 +653,9 @@ mod test {
 
         assert_eq!(
             value,
-            &[2u8, 2u8, 0u8, 1u8, 0u8, 2u8, 6u8, 12u8, 1u8, 13u8, 0xe0u8, 0xa4u8, 0x85u8]
+            &[
+                2u8, 2u8, 0u8, 1u8, 0u8, 2u8, 6u8, 12u8, 1u8, 13u8, 0xe0u8, 0xa4u8, 0x85u8
+            ]
         );
         assert_eq!(
             metadata,

--- a/parquet-variant-json/src/to_json.rs
+++ b/parquet-variant-json/src/to_json.rs
@@ -17,7 +17,7 @@
 
 //! Module for converting Variant data to JSON format
 use arrow_schema::ArrowError;
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use chrono::Timelike;
 use parquet_variant::{Variant, VariantList, VariantObject};
 use serde_json::Value;
@@ -417,7 +417,7 @@ fn convert_array_to_json(buffer: &mut impl Write, arr: &VariantList) -> Result<(
 mod tests {
     use super::*;
     use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
-    use parquet_variant::{VariantDecimal16, VariantDecimal4, VariantDecimal8};
+    use parquet_variant::{VariantDecimal4, VariantDecimal8, VariantDecimal16};
 
     #[test]
     fn test_decimal_edge_cases() -> Result<(), ArrowError> {
@@ -1267,53 +1267,65 @@ mod tests {
         let nan_variant = Variant::Float(f32::NAN);
         let nan_result = nan_variant.to_json_value();
         assert!(nan_result.is_err());
-        assert!(nan_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid float value"));
+        assert!(
+            nan_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid float value")
+        );
 
         // Test positive infinity - should return an error since JSON doesn't support Infinity
         let pos_inf_variant = Variant::Float(f32::INFINITY);
         let pos_inf_result = pos_inf_variant.to_json_value();
         assert!(pos_inf_result.is_err());
-        assert!(pos_inf_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid float value"));
+        assert!(
+            pos_inf_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid float value")
+        );
 
         // Test negative infinity - should return an error since JSON doesn't support -Infinity
         let neg_inf_variant = Variant::Float(f32::NEG_INFINITY);
         let neg_inf_result = neg_inf_variant.to_json_value();
         assert!(neg_inf_result.is_err());
-        assert!(neg_inf_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid float value"));
+        assert!(
+            neg_inf_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid float value")
+        );
 
         // Test the same for Double variants
         let nan_double_variant = Variant::Double(f64::NAN);
         let nan_double_result = nan_double_variant.to_json_value();
         assert!(nan_double_result.is_err());
-        assert!(nan_double_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid double value"));
+        assert!(
+            nan_double_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid double value")
+        );
 
         let pos_inf_double_variant = Variant::Double(f64::INFINITY);
         let pos_inf_double_result = pos_inf_double_variant.to_json_value();
         assert!(pos_inf_double_result.is_err());
-        assert!(pos_inf_double_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid double value"));
+        assert!(
+            pos_inf_double_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid double value")
+        );
 
         let neg_inf_double_variant = Variant::Double(f64::NEG_INFINITY);
         let neg_inf_double_result = neg_inf_double_variant.to_json_value();
         assert!(neg_inf_double_result.is_err());
-        assert!(neg_inf_double_result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid double value"));
+        assert!(
+            neg_inf_double_result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid double value")
+        );
 
         // Test normal float values still work
         let normal_float = Variant::Float(std::f32::consts::PI);


### PR DESCRIPTION
# Which issue does this PR close?

- Contribute to #6827

# Rationale for this change

Splitting up #8227.

# What changes are included in this PR?

Migrate `parquet-variant-json` to Rust 2024

# Are these changes tested?

CI

# Are there any user-facing changes?

Yes