### PR TITLE
Fix some new rustdoc warnings

### DIFF
--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -29,6 +29,7 @@ pub struct MapArrayReader {
 }
 
 impl MapArrayReader {
+    #[allow(rustdoc::private_intra_doc_links)]
     /// Creates a new [`MapArrayReader`] with a `def_level`, `rep_level` and `nullable`
     /// as defined on [`ParquetField`][crate::arrow::schema::ParquetField]
     pub fn new(

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -693,7 +693,7 @@ impl ArrowReaderMetadata {
 }
 
 #[doc(hidden)]
-/// A newtype used within [`ReaderOptionsBuilder`] to distinguish sync readers from async
+// A newtype used within `ReaderOptionsBuilder` to distinguish sync readers from async
 pub struct SyncReader<T: ChunkReader>(T);
 
 impl<T: Debug + ChunkReader> Debug for SyncReader<T> {

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -205,10 +205,10 @@ impl ArrowReaderMetadata {
 }
 
 #[doc(hidden)]
-/// A newtype used within [`ReaderOptionsBuilder`] to distinguish sync readers from async
-///
-/// Allows sharing the same builder for both the sync and async versions, whilst also not
-/// breaking the pre-existing ParquetRecordBatchStreamBuilder API
+// A newtype used within `ReaderOptionsBuilder` to distinguish sync readers from async
+//
+// Allows sharing the same builder for both the sync and async versions, whilst also not
+// breaking the pre-existing ParquetRecordBatchStreamBuilder API
 pub struct AsyncReader<T>(T);
 
 /// A builder for reading parquet files from an `async` source as  [`ParquetRecordBatchStream`]


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

CI is currently failing on rustdoc as some new warnings were recently added

# What changes are included in this PR?

Two offending lines are already guarded with `#[doc(hidden)]` so they have been converted to regular comments. 

The other warning is about referencing a private struct from a private `new`. For this I've disabled the warning.

# Are these changes tested?

Docs only

# Are there any user-facing changes?

No
