### PR TITLE
Support writing GeospatialStatistics in Parquet writer

### DIFF
--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -145,8 +145,9 @@ impl<T: DataType> ColumnValueEncoderImpl<T> {
 
     fn write_slice(&mut self, slice: &[T::T]) -> Result<()> {
         if self.statistics_enabled != EnabledStatistics::None
-            // INTERVAL has undefined sort order, so don't write min/max stats for it
+            // INTERVAL, Geometry, and Geography have undefined sort order,so don't write min/max stats for them
             && self.descr.converted_type() != ConvertedType::INTERVAL
+            && !matches!(self.descr.logical_type(), Some(LogicalType::Geometry) | Some(LogicalType::Geography))
         {
             if let Some((min, max)) = self.min_max(slice, None) {
                 update_min(&self.descr, &min, &mut self.min_value);


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8523.

# Rationale for this change

One of the primary reasons the GeoParquet community was excited about first-class Parquet Geometry/Geography support was the built-in column chunk statistics (we had a workaround that involved adding a struct column, but it was difficult for non-spatial readers to use it and very difficult for non-spatial writers to write it). This PR ensures it is possible for arrow-rs to write files that include those statistics.

# What changes are included in this PR?

This PR inserts the minimum required change to enable this support (behind a feature flag).

This also fixes a "bug" (if anybody had been using it to write Geospatial types, which is unlikely)...those types must not have page min/max statistics written.

# Are these changes tested?

They will be! (Work in progress)

# Are there any user-facing changes?

No, this is behind a newly invented feature flag. In the unlikely event anybody had been writing Geometry/Geography logical types, they would continue to not have geospatial statistics written.
