### PR TITLE
support casting from null to float16

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -760,6 +760,7 @@ pub fn cast_with_options(
             | UInt8
             | Int16
             | UInt16
+            | Float16
             | Int32
             | UInt32
             | Float32
@@ -7979,6 +7980,7 @@ mod tests {
         typed_test!(UInt32Array, UInt32, UInt32Type);
         typed_test!(UInt64Array, UInt64, UInt64Type);
 
+        typed_test!(Float16Array, Float16, Float16Type);
         typed_test!(Float32Array, Float32, Float32Type);
         typed_test!(Float64Array, Float64, Float64Type);
 


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change

select arrow_cast(null, 'Float16') is not supported currently.

# What changes are included in this PR?

support casting from null to float16.

# Are these changes tested?

UT

# Are there any user-facing changes?

No