### PR TITLE
[Variant] Decimal unshredding support

### DIFF
--- a/parquet-variant-compute/src/unshred_variant.rs
+++ b/parquet-variant-compute/src/unshred_variant.rs
@@ -25,15 +25,18 @@ use arrow::array::{
 };
 use arrow::buffer::NullBuffer;
 use arrow::datatypes::{
-    ArrowPrimitiveType, DataType, Date32Type, Float32Type, Float64Type, Int16Type, Int32Type,
-    Int64Type, Int8Type, Time64MicrosecondType, TimeUnit, TimestampMicrosecondType,
-    TimestampNanosecondType,
+    ArrowPrimitiveType, DataType, Date32Type, Decimal128Type, Decimal32Type, Decimal64Type,
+    DecimalType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    Time64MicrosecondType, TimeUnit, TimestampMicrosecondType, TimestampNanosecondType,
 };
 use arrow::error::{ArrowError, Result};
 use arrow::temporal_conversions::time64us_to_time;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
-use parquet_variant::{ObjectFieldBuilder, Variant, VariantBuilderExt, VariantMetadata};
+use parquet_variant::{
+    ObjectFieldBuilder, Variant, VariantBuilderExt, VariantDecimal16, VariantDecimal4,
+    VariantDecimal8, VariantMetadata,
+};
 use uuid::Uuid;
 
 /// Removes all (nested) typed_value columns from a VariantArray by converting them back to binary
@@ -92,6 +95,9 @@ enum UnshredVariantRowBuilder<'a> {
     PrimitiveInt64(UnshredPrimitiveRowBuilder<'a, PrimitiveArray<Int64Type>>),
     PrimitiveFloat32(UnshredPrimitiveRowBuilder<'a, PrimitiveArray<Float32Type>>),
     PrimitiveFloat64(UnshredPrimitiveRowBuilder<'a, PrimitiveArray<Float64Type>>),
+    Decimal32(DecimalUnshredRowBuilder<'a, Decimal32Spec>),
+    Decimal64(DecimalUnshredRowBuilder<'a, Decimal64Spec>),
+    Decimal128(DecimalUnshredRowBuilder<'a, Decimal128Spec>),
     PrimitiveDate32(UnshredPrimitiveRowBuilder<'a, PrimitiveArray<Date32Type>>),
     PrimitiveTime64(UnshredPrimitiveRowBuilder<'a, PrimitiveArray<Time64MicrosecondType>>),
     TimestampMicrosecond(TimestampUnshredRowBuilder<'a, TimestampMicrosecondType>),
@@ -130,6 +136,9 @@ impl<'a> UnshredVariantRowBuilder<'a> {
             Self::PrimitiveInt64(b) => b.append_row(builder, metadata, index),
             Self::PrimitiveFloat32(b) => b.append_row(builder, metadata, index),
             Self::PrimitiveFloat64(b) => b.append_row(builder, metadata, index),
+            Self::Decimal32(b) => b.append_row(builder, metadata, index),
+            Self::Decimal64(b) => b.append_row(builder, metadata, index),
+            Self::Decimal128(b) => b.append_row(builder, metadata, index),
             Self::PrimitiveDate32(b) => b.append_row(builder, metadata, index),
             Self::PrimitiveTime64(b) => b.append_row(builder, metadata, index),
             Self::TimestampMicrosecond(b) => b.append_row(builder, metadata, index),
@@ -176,6 +185,26 @@ impl<'a> UnshredVariantRowBuilder<'a> {
             DataType::Int64 => primitive_builder!(PrimitiveInt64, as_primitive),
             DataType::Float32 => primitive_builder!(PrimitiveFloat32, as_primitive),
             DataType::Float64 => primitive_builder!(PrimitiveFloat64, as_primitive),
+            DataType::Decimal32(_, scale) => Self::Decimal32(DecimalUnshredRowBuilder::new(
+                value,
+                typed_value.as_primitive(),
+                *scale,
+            )),
+            DataType::Decimal64(_, scale) => Self::Decimal64(DecimalUnshredRowBuilder::new(
+                value,
+                typed_value.as_primitive(),
+                *scale,
+            )),
+            DataType::Decimal128(_, scale) => Self::Decimal128(DecimalUnshredRowBuilder::new(
+                value,
+                typed_value.as_primitive(),
+                *scale,
+            )),
+            DataType::Decimal256(_, _) => {
+                return Err(ArrowError::InvalidArgumentError(
+                    "Decimal256 is not a valid variant shredding type".to_string(),
+                ));
+            }
             DataType::Date32 => primitive_builder!(PrimitiveDate32, as_primitive),
             DataType::Time64(TimeUnit::Microsecond) => {
                 primitive_builder!(PrimitiveTime64, as_primitive)
@@ -471,6 +500,96 @@ impl<'a, T: TimestampType> TimestampUnshredRowBuilder<'a, T> {
         } else {
             builder.append_value(dt.naive_utc());
         }
+        Ok(())
+    }
+}
+
+/// Trait to unify decimal unshredding across Decimal32/64/128 types
+trait DecimalSpec {
+    type Arrow: ArrowPrimitiveType + DecimalType;
+
+    fn into_variant(
+        raw: <Self::Arrow as ArrowPrimitiveType>::Native,
+        scale: i8,
+    ) -> Result<Variant<'static, 'static>>;
+}
+
+/// Spec for Decimal32 -> VariantDecimal4
+struct Decimal32Spec;
+
+impl DecimalSpec for Decimal32Spec {
+    type Arrow = Decimal32Type;
+
+    fn into_variant(raw: i32, scale: i8) -> Result<Variant<'static, 'static>> {
+        let scale =
+            u8::try_from(scale).map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        let value = VariantDecimal4::try_new(raw, scale)
+            .map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        Ok(value.into())
+    }
+}
+
+/// Spec for Decimal64 -> VariantDecimal8
+struct Decimal64Spec;
+
+impl DecimalSpec for Decimal64Spec {
+    type Arrow = Decimal64Type;
+
+    fn into_variant(raw: i64, scale: i8) -> Result<Variant<'static, 'static>> {
+        let scale =
+            u8::try_from(scale).map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        let value = VariantDecimal8::try_new(raw, scale)
+            .map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        Ok(value.into())
+    }
+}
+
+/// Spec for Decimal128 -> VariantDecimal16
+struct Decimal128Spec;
+
+impl DecimalSpec for Decimal128Spec {
+    type Arrow = Decimal128Type;
+
+    fn into_variant(raw: i128, scale: i8) -> Result<Variant<'static, 'static>> {
+        let scale =
+            u8::try_from(scale).map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        let value = VariantDecimal16::try_new(raw, scale)
+            .map_err(|e| ArrowError::InvalidArgumentError(e.to_string()))?;
+        Ok(value.into())
+    }
+}
+
+/// Generic builder for decimal unshredding that caches scale
+struct DecimalUnshredRowBuilder<'a, S: DecimalSpec> {
+    value: Option<&'a BinaryViewArray>,
+    typed_value: &'a PrimitiveArray<S::Arrow>,
+    scale: i8,
+}
+
+impl<'a, S: DecimalSpec> DecimalUnshredRowBuilder<'a, S> {
+    fn new(
+        value: Option<&'a BinaryViewArray>,
+        typed_value: &'a PrimitiveArray<S::Arrow>,
+        scale: i8,
+    ) -> Self {
+        Self {
+            value,
+            typed_value,
+            scale,
+        }
+    }
+
+    fn append_row(
+        &mut self,
+        builder: &mut impl VariantBuilderExt,
+        metadata: &VariantMetadata,
+        index: usize,
+    ) -> Result<()> {
+        handle_unshredded_case!(self, builder, metadata, index, false);
+
+        let raw = self.typed_value.value(index);
+        let variant = S::into_variant(raw, self.scale)?;
+        builder.append_value(variant);
         Ok(())
     }
 }

--- a/parquet/tests/variant_integration.rs
+++ b/parquet/tests/variant_integration.rs
@@ -86,31 +86,12 @@ variant_test_case!(20);
 variant_test_case!(21);
 variant_test_case!(22);
 variant_test_case!(23);
-// https://github.com/apache/arrow-rs/issues/8332
-variant_test_case!(
-    24,
-    "Unshredding not yet supported for type: Decimal128(9, 4)"
-);
-variant_test_case!(
-    25,
-    "Unshredding not yet supported for type: Decimal128(9, 4)"
-);
-variant_test_case!(
-    26,
-    "Unshredding not yet supported for type: Decimal128(18, 9)"
-);
-variant_test_case!(
-    27,
-    "Unshredding not yet supported for type: Decimal128(18, 9)"
-);
-variant_test_case!(
-    28,
-    "Unshredding not yet supported for type: Decimal128(38, 9)"
-);
-variant_test_case!(
-    29,
-    "Unshredding not yet supported for type: Decimal128(38, 9)"
-);
+variant_test_case!(24);
+variant_test_case!(25);
+variant_test_case!(26);
+variant_test_case!(27);
+variant_test_case!(28);
+variant_test_case!(29);
 variant_test_case!(30);
 variant_test_case!(31);
 variant_test_case!(32);


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8332

# Rationale for this change

Missing feature

# What changes are included in this PR?

Add decimal unshredding support, which _should_ have been straightforward except:
1. The variant decimal types are not generic and do not implement any common trait that lets us generalize the logic easily. I added a custom trait in the unshredding module as a workaround, but we should probably look at something similar to arrow's `DecimalType` trait for `VariantDecimalXX` classes to implement.
2. The parquet reader seems to have a bug that forces 32- and 64-bit decimal columns to Decimal128 unless the reader specifically requests a narrower type. I think I fixed that bug, but naturally several existing parquet unit tests started to fail. I don't know yet whether those tests are simply expecting buggy behavior, or if my fix is wrong/misguided/misplaced?

<details>
<summary>Test failures caused by the parquet decimal fix</summary>

```
test arrow::array_reader::primitive_array::tests::test_primitive_array_reader_decimal_types ... FAILED
test arrow::arrow_reader::tests::test_arbitrary_decimal ... FAILED
test arrow::arrow_reader::tests::test_decimal ... FAILED
test arrow::arrow_reader::tests::test_read_decimal_file ... FAILED
test arrow::arrow_writer::tests::arrow_writer_decimal ... FAILED
test arrow::arrow_writer::tests::arrow_writer_decimal128_dictionary ... FAILED
test arrow::arrow_writer::tests::arrow_writer_decimal256_dictionary ... FAILED
test arrow::arrow_writer::tests::arrow_writer_decimal64_dictionary ... FAILED
test arrow::schema::tests::test_arrow_schema_roundtrip ... FAILED
test arrow::schema::tests::test_column_desc_to_field ... FAILED
test arrow::schema::tests::test_decimal_fields ... FAILED
test statistics::test_decimal128 ... FAILED
test statistics::test_decimal64 ... FAILED
test statistics::test_decimal_256 ... FAILED
test statistics::test_data_page_stats_with_all_null_page ... FAILED
```

For example:
```
---- arrow::arrow_reader::tests::test_decimal stdout ----

thread 'arrow::arrow_reader::tests::test_decimal' panicked at parquet/src/arrow/arrow_reader/mod.rs:4570:9:
assertion `left == right` failed
  left: Schema { fields: [Field { name: "d1", data_type: Decimal64(9, 2) }, Field { name: "d2", data_type: Decimal64(10, 2) }, Field { name: "d3", data_type: Decimal64(18, 2) }], metadata: {} }
 right: Schema { fields: [Field { name: "d1", data_type: Decimal32(9, 2) }, Field { name: "d2", data_type: Decimal64(10, 2) }, Field { name: "d3", data_type: Decimal64(18, 2) }], metadata: {} }

---- arrow::arrow_reader::tests::test_read_decimal_file stdout ----

thread 'arrow::arrow_reader::tests::test_read_decimal_file' panicked at parquet/src/arrow/arrow_reader/mod.rs:2101:81:
called `Result::unwrap()` on an `Err` value: General("invalid data type for byte array reader - Decimal32(4, 2)")

---- arrow::arrow_writer::tests::arrow_writer_decimal stdout ----

thread 'arrow::arrow_writer::tests::arrow_writer_decimal' panicked at parquet/src/arrow/arrow_writer/mod.rs:2326:9:
assertion `left == right` failed
  left: Schema { fields: [Field { name: "a", data_type: Decimal128(5, 2) }], metadata: {} }
 right: Schema { fields: [Field { name: "a", data_type: Decimal32(5, 2) }], metadata: {} }

```
or
```
--- arrow::array_reader::primitive_array::tests::test_primitive_array_reader_decimal_types stdout ----

thread 'arrow::array_reader::primitive_array::tests::test_primitive_array_reader_decimal_types' panicked at parquet/src/arrow/array_reader/primitive_array.rs:916:13:
assertion `left == right` failed
  left: Decimal32(8, 2)
 right: Decimal128(8, 2)
```
or
```
---- arrow::arrow_reader::tests::test_arbitrary_decimal stdout ----

thread 'arrow::arrow_reader::tests::test_arbitrary_decimal' panicked at parquet/src/arrow/arrow_reader/mod.rs:4473:9:
assertion `left == right` failed
  left: RecordBatch { schema: Schema { fields: [Field { name: "decimal_values_19_0", data_type: Decimal128(19, 0) }, Field { name: "decimal_values_12_0", data_type: Decimal128(12, 0) }, Field { name: "decimal_values_17_10", data_type: Decimal128(17, 10) }], metadata: {} 
}, columns: [PrimitiveArray<Decimal128(19, 0)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
], PrimitiveArray<Decimal128(12, 0)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
], PrimitiveArray<Decimal128(17, 10)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
]], row_count: 8 }
 right: RecordBatch { schema: Schema { fields: [Field { name: "decimal_values_19_0", data_type: Decimal128(19, 0) }, Field { name: "decimal_values_12_0", data_type: Decimal64(12, 0) }, Field { name: "decimal_values_17_10", data_type: Decimal64(17, 10) }], metadata: {} }, columns: [PrimitiveArray<Decimal128(19, 0)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
], PrimitiveArray<Decimal64(12, 0)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
], PrimitiveArray<Decimal64(17, 10)>
[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
]], row_count: 8 }
```
```

</details>

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
