### PR TITLE
Arrow-Parquet SBBF coercion

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -257,5 +257,10 @@ name = "row_selector"
 harness = false
 required-features = ["arrow"]
 
+[[bench]]
+name = "bloom_filter"
+harness = false
+required-features = ["arrow"]
+
 [lib]
 bench = false

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -65,14 +65,14 @@ fn setup_sbbf(array: ArrayRef, field: Field) -> Sbbf {
 fn bench_integer_types(c: &mut Criterion) {
     // Setup for Int8 benchmarks
     let test_val_i8 = 42i8;
-    let int8_array = Arc::new(Int8Array::from(vec![test_val_i8; 1000])) as ArrayRef;
+    let int8_array = Arc::new(Int8Array::from(vec![test_val_i8; 1])) as ArrayRef;
     let int8_field = Field::new("col", DataType::Int8, false);
     let sbbf_int8 = setup_sbbf(int8_array, int8_field);
     let arrow_sbbf_int8 = ArrowSbbf::new(&sbbf_int8, &DataType::Int8);
 
     // Setup for Int32 benchmarks
     let test_val_i32 = 42i32;
-    let int32_array = Arc::new(Int32Array::from(vec![test_val_i32; 1000])) as ArrayRef;
+    let int32_array = Arc::new(Int32Array::from(vec![test_val_i32; 1])) as ArrayRef;
     let int32_field = Field::new("col", DataType::Int32, false);
     let sbbf_int32 = setup_sbbf(int32_array, int32_field);
     let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32);
@@ -111,7 +111,7 @@ fn bench_decimal_types(c: &mut Criterion) {
     let test_val_dec_small = 123456i128;
     let test_bytes_dec_small = test_val_dec_small.to_le_bytes();
     let dec_small_array = Arc::new(
-        Decimal128Array::from(vec![test_val_dec_small; 1000])
+        Decimal128Array::from(vec![test_val_dec_small; 1])
             .with_precision_and_scale(5, 2)
             .unwrap(),
     ) as ArrayRef;
@@ -123,7 +123,7 @@ fn bench_decimal_types(c: &mut Criterion) {
     let test_val_dec_medium = 123456789012345i128;
     let test_bytes_dec_medium = test_val_dec_medium.to_le_bytes();
     let dec_medium_array = Arc::new(
-        Decimal128Array::from(vec![test_val_dec_medium; 1000])
+        Decimal128Array::from(vec![test_val_dec_medium; 1])
             .with_precision_and_scale(15, 2)
             .unwrap(),
     ) as ArrayRef;
@@ -135,7 +135,7 @@ fn bench_decimal_types(c: &mut Criterion) {
     let test_val_dec_large = 123456789012345678901234567890i128;
     let test_bytes_dec_large = test_val_dec_large.to_le_bytes();
     let dec_large_array = Arc::new(
-        Decimal128Array::from(vec![test_val_dec_large; 1000])
+        Decimal128Array::from(vec![test_val_dec_large; 1])
             .with_precision_and_scale(30, 2)
             .unwrap(),
     ) as ArrayRef;

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -77,9 +77,9 @@ fn bench_integer_types(c: &mut Criterion) {
     let sbbf_int32 = setup_sbbf(int32_array, int32_field);
     let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32);
 
-    c.bench_function("Sbbf::check i32", |b| {
+    c.bench_function("Sbbf::check i8", |b| {
         b.iter(|| {
-            let result = sbbf_int8.check(&test_val_i32);
+            let result = sbbf_int8.check(&test_val_i8);
             hint::black_box(result);
         })
     });
@@ -87,6 +87,13 @@ fn bench_integer_types(c: &mut Criterion) {
     c.bench_function("ArrowSbbf::check i8 (coerce to i32)", |b| {
         b.iter(|| {
             let result = arrow_sbbf_int8.check(&test_val_i8);
+            hint::black_box(result);
+        })
+    });
+
+    c.bench_function("Sbbf::check i32", |b| {
+        b.iter(|| {
+            let result = sbbf_int32.check(&test_val_i32);
             hint::black_box(result);
         })
     });
@@ -133,6 +140,14 @@ fn bench_decimal_types(c: &mut Criterion) {
     let sbbf_dec_large = setup_sbbf(dec_large_array, dec_large_field);
     let arrow_sbbf_dec_large = ArrowSbbf::new(&sbbf_dec_large, &DataType::Decimal128(30, 2));
 
+    c.bench_function("Sbbf::check Decimal128(5,2)", |b| {
+        b.iter(|| {
+            let i32_val = test_val_dec_small as i32;
+            let result = sbbf_dec_small.check(&i32_val);
+            hint::black_box(result);
+        })
+    });
+
     c.bench_function("ArrowSbbf::check Decimal128(5,2) (coerce to i32)", |b| {
         b.iter(|| {
             let test_bytes = test_val_dec_small.to_le_bytes();
@@ -141,10 +156,26 @@ fn bench_decimal_types(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("Sbbf::check Decimal128(15,2)", |b| {
+        b.iter(|| {
+            let i64_val = test_val_dec_medium as i64;
+            let result = sbbf_dec_medium.check(&i64_val);
+            hint::black_box(result);
+        })
+    });
+
     c.bench_function("ArrowSbbf::check Decimal128(15,2) (coerce to i64)", |b| {
         b.iter(|| {
             let test_bytes = test_val_dec_medium.to_le_bytes();
             let result = arrow_sbbf_dec_medium.check(&test_bytes[..]);
+            hint::black_box(result);
+        })
+    });
+
+    c.bench_function("Sbbf::check Decimal128(30,2)", |b| {
+        b.iter(|| {
+            let test_bytes = test_val_dec_large.to_le_bytes();
+            let result = sbbf_dec_large.check(&test_bytes[..]);
             hint::black_box(result);
         })
     });

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -158,6 +158,20 @@ fn bench_decimal_types(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches_int, bench_integer_types);
-criterion_group!(benches_decimal, bench_decimal_types);
+fn config() -> Criterion {
+    Criterion::default().noise_threshold(0.05)
+}
+
+criterion_group! {
+    name = benches_int;
+    config = config();
+    targets = bench_integer_types
+}
+
+criterion_group! {
+    name = benches_decimal;
+    config = config();
+    targets = bench_decimal_types
+}
+
 criterion_main!(benches_int, benches_decimal);

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -63,21 +63,20 @@ fn setup_sbbf(array: ArrayRef, field: Field) -> Sbbf {
 }
 
 fn bench_integer_types(c: &mut Criterion) {
-    // Setup for Int8 benchmarks (requires coercion to i32)
-    let int8_array = Arc::new(Int8Array::from(vec![42i8; 1000])) as ArrayRef;
+    // Setup for Int8 benchmarks
+    let test_val_i8 = 42i8;
+    let int8_array = Arc::new(Int8Array::from(vec![test_val_i8; 1000])) as ArrayRef;
     let int8_field = Field::new("col", DataType::Int8, false);
     let sbbf_int8 = setup_sbbf(int8_array, int8_field);
     let arrow_sbbf_int8 = ArrowSbbf::new(&sbbf_int8, &DataType::Int8);
-    let test_val_i32 = 42i32;
-    let test_val_i8 = 42i8;
 
-    // Setup for Int32 benchmarks (no coercion needed)
-    let int32_array = Arc::new(Int32Array::from(vec![42i32; 1000])) as ArrayRef;
+    // Setup for Int32 benchmarks
+    let test_val_i32 = 42i32;
+    let int32_array = Arc::new(Int32Array::from(vec![test_val_i32; 1000])) as ArrayRef;
     let int32_field = Field::new("col", DataType::Int32, false);
     let sbbf_int32 = setup_sbbf(int32_array, int32_field);
     let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32);
 
-    // Benchmark 1: Direct Sbbf::check with i32 (baseline)
     c.bench_function("Sbbf::check i32", |b| {
         b.iter(|| {
             let result = sbbf_int8.check(&test_val_i32);
@@ -85,7 +84,6 @@ fn bench_integer_types(c: &mut Criterion) {
         })
     });
 
-    // Benchmark 2: ArrowSbbf::check with i8 (requires coercion to i32)
     c.bench_function("ArrowSbbf::check i8 (coerce to i32)", |b| {
         b.iter(|| {
             let result = arrow_sbbf_int8.check(&test_val_i8);
@@ -93,7 +91,6 @@ fn bench_integer_types(c: &mut Criterion) {
         })
     });
 
-    // Benchmark 3: ArrowSbbf::check with i32 (no coercion, passthrough)
     c.bench_function("ArrowSbbf::check i32 (no coercion)", |b| {
         b.iter(|| {
             let result = arrow_sbbf_int32.check(&test_val_i32);
@@ -103,40 +100,39 @@ fn bench_integer_types(c: &mut Criterion) {
 }
 
 fn bench_decimal_types(c: &mut Criterion) {
-    // Setup for Decimal128 small precision (coerces to i32)
+    // Setup for Decimal128 small precision
+    let test_val_dec_small = 123456i128;
     let dec_small_array = Arc::new(
-        Decimal128Array::from(vec![123456i128; 1000])
+        Decimal128Array::from(vec![test_val_dec_small; 1000])
             .with_precision_and_scale(5, 2)
             .unwrap(),
     ) as ArrayRef;
     let dec_small_field = Field::new("col", DataType::Decimal128(5, 2), false);
     let sbbf_dec_small = setup_sbbf(dec_small_array, dec_small_field);
     let arrow_sbbf_dec_small = ArrowSbbf::new(&sbbf_dec_small, &DataType::Decimal128(5, 2));
-    let test_val_dec_small = 123456i128;
 
-    // Setup for Decimal128 medium precision (coerces to i64)
+    // Setup for Decimal128 medium precision
+    let test_val_dec_medium = 123456789012345i128;
     let dec_medium_array = Arc::new(
-        Decimal128Array::from(vec![123456789012345i128; 1000])
+        Decimal128Array::from(vec![test_val_dec_medium; 1000])
             .with_precision_and_scale(15, 2)
             .unwrap(),
     ) as ArrayRef;
     let dec_medium_field = Field::new("col", DataType::Decimal128(15, 2), false);
     let sbbf_dec_medium = setup_sbbf(dec_medium_array, dec_medium_field);
     let arrow_sbbf_dec_medium = ArrowSbbf::new(&sbbf_dec_medium, &DataType::Decimal128(15, 2));
-    let test_val_dec_medium = 123456789012345i128;
 
-    // Setup for Decimal128 large precision (no coercion)
+    // Setup for Decimal128 large precision
+    let test_val_dec_large = 123456789012345678901234567890i128;
     let dec_large_array = Arc::new(
-        Decimal128Array::from(vec![123456789012345678901234567890i128; 1000])
+        Decimal128Array::from(vec![test_val_dec_large; 1000])
             .with_precision_and_scale(30, 2)
             .unwrap(),
     ) as ArrayRef;
     let dec_large_field = Field::new("col", DataType::Decimal128(30, 2), false);
     let sbbf_dec_large = setup_sbbf(dec_large_array, dec_large_field);
     let arrow_sbbf_dec_large = ArrowSbbf::new(&sbbf_dec_large, &DataType::Decimal128(30, 2));
-    let test_val_dec_large = 123456789012345678901234567890i128;
 
-    // Benchmark 1: ArrowSbbf::check with Decimal128 small (coerce to i32)
     c.bench_function("ArrowSbbf::check Decimal128(5,2) (coerce to i32)", |b| {
         b.iter(|| {
             let test_bytes = test_val_dec_small.to_le_bytes();
@@ -145,7 +141,6 @@ fn bench_decimal_types(c: &mut Criterion) {
         })
     });
 
-    // Benchmark 2: ArrowSbbf::check with Decimal128 medium (coerce to i64)
     c.bench_function("ArrowSbbf::check Decimal128(15,2) (coerce to i64)", |b| {
         b.iter(|| {
             let test_bytes = test_val_dec_medium.to_le_bytes();
@@ -154,7 +149,6 @@ fn bench_decimal_types(c: &mut Criterion) {
         })
     });
 
-    // Benchmark 3: ArrowSbbf::check with Decimal128 large (no coercion)
     c.bench_function("ArrowSbbf::check Decimal128(30,2) (no coercion)", |b| {
         b.iter(|| {
             let test_bytes = test_val_dec_large.to_le_bytes();

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -20,6 +20,7 @@ use arrow_schema::{DataType, Field, Schema};
 use criterion::*;
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::arrow::bloom_filter::ArrowSbbf;
+use parquet::basic::Type as ParquetType;
 use parquet::bloom_filter::Sbbf;
 use parquet::file::properties::{ReaderProperties, WriterProperties};
 use parquet::file::reader::{FileReader, SerializedFileReader};
@@ -31,8 +32,8 @@ use tempfile::tempfile;
 /// Helper function to create an Sbbf from an array for benchmarking
 ///
 /// Writes the given array to a Parquet file with bloom filters enabled,
-/// then reads it back and returns the bloom filter for the first column.
-fn setup_sbbf(array: ArrayRef, field: Field) -> Sbbf {
+/// then reads it back and returns the bloom filter and physical type for the first column.
+fn setup_sbbf(array: ArrayRef, field: Field) -> (Sbbf, ParquetType) {
     let schema = Arc::new(Schema::new(vec![field.clone()]));
     let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
 
@@ -55,27 +56,32 @@ fn setup_sbbf(array: ArrayRef, field: Field) -> Sbbf {
         .build();
     let reader = SerializedFileReader::new_with_options(file, options).unwrap();
     let row_group_reader = reader.get_row_group(0).unwrap();
+    let metadata = row_group_reader.metadata();
+    let column_chunk = metadata.column(0);
+    let parquet_type = column_chunk.column_type();
 
-    row_group_reader
+    let sbbf = row_group_reader
         .get_column_bloom_filter(0)
         .expect("Bloom filter should exist")
-        .clone()
+        .clone();
+
+    (sbbf, parquet_type)
 }
 
 fn bench_integer_types(c: &mut Criterion) {
     // Setup for Int8 benchmarks (requires coercion to i32)
     let int8_array = Arc::new(Int8Array::from(vec![42i8; 1000])) as ArrayRef;
     let int8_field = Field::new("col", DataType::Int8, false);
-    let sbbf_int8 = setup_sbbf(int8_array, int8_field);
-    let arrow_sbbf_int8 = ArrowSbbf::new(&sbbf_int8, &DataType::Int8);
+    let (sbbf_int8, physical_type_int8) = setup_sbbf(int8_array, int8_field);
+    let arrow_sbbf_int8 = ArrowSbbf::new(&sbbf_int8, &DataType::Int8, physical_type_int8);
     let test_val_i32 = 42i32;
     let test_val_i8 = 42i8;
 
     // Setup for Int32 benchmarks (no coercion needed)
     let int32_array = Arc::new(Int32Array::from(vec![42i32; 1000])) as ArrayRef;
     let int32_field = Field::new("col", DataType::Int32, false);
-    let sbbf_int32 = setup_sbbf(int32_array, int32_field);
-    let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32);
+    let (sbbf_int32, physical_type_int32) = setup_sbbf(int32_array, int32_field);
+    let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32, physical_type_int32);
 
     // Benchmark 1: Direct Sbbf::check with i32 (baseline)
     c.bench_function("Sbbf::check i32", |b| {
@@ -110,8 +116,8 @@ fn bench_decimal_types(c: &mut Criterion) {
             .unwrap(),
     ) as ArrayRef;
     let dec_small_field = Field::new("col", DataType::Decimal128(5, 2), false);
-    let sbbf_dec_small = setup_sbbf(dec_small_array, dec_small_field);
-    let arrow_sbbf_dec_small = ArrowSbbf::new(&sbbf_dec_small, &DataType::Decimal128(5, 2));
+    let (sbbf_dec_small, physical_type_dec_small) = setup_sbbf(dec_small_array, dec_small_field);
+    let arrow_sbbf_dec_small = ArrowSbbf::new(&sbbf_dec_small, &DataType::Decimal128(5, 2), physical_type_dec_small);
     let test_val_dec_small = 123456i128;
 
     // Setup for Decimal128 medium precision (coerces to i64)
@@ -121,8 +127,8 @@ fn bench_decimal_types(c: &mut Criterion) {
             .unwrap(),
     ) as ArrayRef;
     let dec_medium_field = Field::new("col", DataType::Decimal128(15, 2), false);
-    let sbbf_dec_medium = setup_sbbf(dec_medium_array, dec_medium_field);
-    let arrow_sbbf_dec_medium = ArrowSbbf::new(&sbbf_dec_medium, &DataType::Decimal128(15, 2));
+    let (sbbf_dec_medium, physical_type_dec_medium) = setup_sbbf(dec_medium_array, dec_medium_field);
+    let arrow_sbbf_dec_medium = ArrowSbbf::new(&sbbf_dec_medium, &DataType::Decimal128(15, 2), physical_type_dec_medium);
     let test_val_dec_medium = 123456789012345i128;
 
     // Setup for Decimal128 large precision (no coercion)
@@ -132,8 +138,8 @@ fn bench_decimal_types(c: &mut Criterion) {
             .unwrap(),
     ) as ArrayRef;
     let dec_large_field = Field::new("col", DataType::Decimal128(30, 2), false);
-    let sbbf_dec_large = setup_sbbf(dec_large_array, dec_large_field);
-    let arrow_sbbf_dec_large = ArrowSbbf::new(&sbbf_dec_large, &DataType::Decimal128(30, 2));
+    let (sbbf_dec_large, physical_type_dec_large) = setup_sbbf(dec_large_array, dec_large_field);
+    let arrow_sbbf_dec_large = ArrowSbbf::new(&sbbf_dec_large, &DataType::Decimal128(30, 2), physical_type_dec_large);
     let test_val_dec_large = 123456789012345678901234567890i128;
 
     // Benchmark 1: ArrowSbbf::check with Decimal128 small (coerce to i32)

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::{ArrayRef, Decimal128Array, Int32Array, Int8Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::*;
+use parquet::arrow::arrow_writer::ArrowWriter;
+use parquet::arrow::bloom_filter::ArrowSbbf;
+use parquet::bloom_filter::Sbbf;
+use parquet::file::properties::{ReaderProperties, WriterProperties};
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::file::serialized_reader::ReadOptionsBuilder;
+use std::hint;
+use std::sync::Arc;
+use tempfile::tempfile;
+
+/// Helper function to create an Sbbf from an array for benchmarking
+///
+/// Writes the given array to a Parquet file with bloom filters enabled,
+/// then reads it back and returns the bloom filter for the first column.
+fn setup_sbbf(array: ArrayRef, field: Field) -> Sbbf {
+    let schema = Arc::new(Schema::new(vec![field.clone()]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+
+    // Write to parquet with bloom filter
+    let mut file = tempfile().unwrap();
+    let props = WriterProperties::builder()
+        .set_bloom_filter_enabled(true)
+        .build();
+    let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    // Read bloom filter back
+    let options = ReadOptionsBuilder::new()
+        .with_reader_properties(
+            ReaderProperties::builder()
+                .set_read_bloom_filter(true)
+                .build(),
+        )
+        .build();
+    let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+    let row_group_reader = reader.get_row_group(0).unwrap();
+
+    row_group_reader
+        .get_column_bloom_filter(0)
+        .expect("Bloom filter should exist")
+        .clone()
+}
+
+fn bench_integer_types(c: &mut Criterion) {
+    // Setup for Int8 benchmarks (requires coercion to i32)
+    let int8_array = Arc::new(Int8Array::from(vec![42i8; 1000])) as ArrayRef;
+    let int8_field = Field::new("col", DataType::Int8, false);
+    let sbbf_int8 = setup_sbbf(int8_array, int8_field);
+    let arrow_sbbf_int8 = ArrowSbbf::new(&sbbf_int8, &DataType::Int8);
+    let test_val_i32 = 42i32;
+    let test_val_i8 = 42i8;
+
+    // Setup for Int32 benchmarks (no coercion needed)
+    let int32_array = Arc::new(Int32Array::from(vec![42i32; 1000])) as ArrayRef;
+    let int32_field = Field::new("col", DataType::Int32, false);
+    let sbbf_int32 = setup_sbbf(int32_array, int32_field);
+    let arrow_sbbf_int32 = ArrowSbbf::new(&sbbf_int32, &DataType::Int32);
+
+    // Benchmark 1: Direct Sbbf::check with i32 (baseline)
+    c.bench_function("Sbbf::check i32", |b| {
+        b.iter(|| {
+            let result = sbbf_int8.check(&test_val_i32);
+            hint::black_box(result);
+        })
+    });
+
+    // Benchmark 2: ArrowSbbf::check with i8 (requires coercion to i32)
+    c.bench_function("ArrowSbbf::check i8 (coerce to i32)", |b| {
+        b.iter(|| {
+            let result = arrow_sbbf_int8.check(&test_val_i8);
+            hint::black_box(result);
+        })
+    });
+
+    // Benchmark 3: ArrowSbbf::check with i32 (no coercion, passthrough)
+    c.bench_function("ArrowSbbf::check i32 (no coercion)", |b| {
+        b.iter(|| {
+            let result = arrow_sbbf_int32.check(&test_val_i32);
+            hint::black_box(result);
+        })
+    });
+}
+
+fn bench_decimal_types(c: &mut Criterion) {
+    // Setup for Decimal128 small precision (coerces to i32)
+    let dec_small_array = Arc::new(
+        Decimal128Array::from(vec![123456i128; 1000])
+            .with_precision_and_scale(5, 2)
+            .unwrap(),
+    ) as ArrayRef;
+    let dec_small_field = Field::new("col", DataType::Decimal128(5, 2), false);
+    let sbbf_dec_small = setup_sbbf(dec_small_array, dec_small_field);
+    let arrow_sbbf_dec_small = ArrowSbbf::new(&sbbf_dec_small, &DataType::Decimal128(5, 2));
+    let test_val_dec_small = 123456i128;
+
+    // Setup for Decimal128 medium precision (coerces to i64)
+    let dec_medium_array = Arc::new(
+        Decimal128Array::from(vec![123456789012345i128; 1000])
+            .with_precision_and_scale(15, 2)
+            .unwrap(),
+    ) as ArrayRef;
+    let dec_medium_field = Field::new("col", DataType::Decimal128(15, 2), false);
+    let sbbf_dec_medium = setup_sbbf(dec_medium_array, dec_medium_field);
+    let arrow_sbbf_dec_medium = ArrowSbbf::new(&sbbf_dec_medium, &DataType::Decimal128(15, 2));
+    let test_val_dec_medium = 123456789012345i128;
+
+    // Setup for Decimal128 large precision (no coercion)
+    let dec_large_array = Arc::new(
+        Decimal128Array::from(vec![123456789012345678901234567890i128; 1000])
+            .with_precision_and_scale(30, 2)
+            .unwrap(),
+    ) as ArrayRef;
+    let dec_large_field = Field::new("col", DataType::Decimal128(30, 2), false);
+    let sbbf_dec_large = setup_sbbf(dec_large_array, dec_large_field);
+    let arrow_sbbf_dec_large = ArrowSbbf::new(&sbbf_dec_large, &DataType::Decimal128(30, 2));
+    let test_val_dec_large = 123456789012345678901234567890i128;
+
+    // Benchmark 1: ArrowSbbf::check with Decimal128 small (coerce to i32)
+    c.bench_function("ArrowSbbf::check Decimal128(5,2) (coerce to i32)", |b| {
+        b.iter(|| {
+            let test_bytes = test_val_dec_small.to_le_bytes();
+            let result = arrow_sbbf_dec_small.check(&test_bytes[..]);
+            hint::black_box(result);
+        })
+    });
+
+    // Benchmark 2: ArrowSbbf::check with Decimal128 medium (coerce to i64)
+    c.bench_function("ArrowSbbf::check Decimal128(15,2) (coerce to i64)", |b| {
+        b.iter(|| {
+            let test_bytes = test_val_dec_medium.to_le_bytes();
+            let result = arrow_sbbf_dec_medium.check(&test_bytes[..]);
+            hint::black_box(result);
+        })
+    });
+
+    // Benchmark 3: ArrowSbbf::check with Decimal128 large (no coercion)
+    c.bench_function("ArrowSbbf::check Decimal128(30,2) (no coercion)", |b| {
+        b.iter(|| {
+            let test_bytes = test_val_dec_large.to_le_bytes();
+            let result = arrow_sbbf_dec_large.check(&test_bytes[..]);
+            hint::black_box(result);
+        })
+    });
+}
+
+criterion_group!(benches_int, bench_integer_types);
+criterion_group!(benches_decimal, bench_decimal_types);
+criterion_main!(benches_int, benches_decimal);

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -109,6 +109,7 @@ fn bench_integer_types(c: &mut Criterion) {
 fn bench_decimal_types(c: &mut Criterion) {
     // Setup for Decimal128 small precision
     let test_val_dec_small = 123456i128;
+    let test_bytes_dec_small = test_val_dec_small.to_le_bytes();
     let dec_small_array = Arc::new(
         Decimal128Array::from(vec![test_val_dec_small; 1000])
             .with_precision_and_scale(5, 2)
@@ -120,6 +121,7 @@ fn bench_decimal_types(c: &mut Criterion) {
 
     // Setup for Decimal128 medium precision
     let test_val_dec_medium = 123456789012345i128;
+    let test_bytes_dec_medium = test_val_dec_medium.to_le_bytes();
     let dec_medium_array = Arc::new(
         Decimal128Array::from(vec![test_val_dec_medium; 1000])
             .with_precision_and_scale(15, 2)
@@ -131,6 +133,7 @@ fn bench_decimal_types(c: &mut Criterion) {
 
     // Setup for Decimal128 large precision
     let test_val_dec_large = 123456789012345678901234567890i128;
+    let test_bytes_dec_large = test_val_dec_large.to_le_bytes();
     let dec_large_array = Arc::new(
         Decimal128Array::from(vec![test_val_dec_large; 1000])
             .with_precision_and_scale(30, 2)
@@ -142,48 +145,42 @@ fn bench_decimal_types(c: &mut Criterion) {
 
     c.bench_function("Sbbf::check Decimal128(5,2)", |b| {
         b.iter(|| {
-            let i32_val = test_val_dec_small as i32;
-            let result = sbbf_dec_small.check(&i32_val);
+            let result = sbbf_dec_small.check(&test_bytes_dec_small[..]);
             hint::black_box(result);
         })
     });
 
     c.bench_function("ArrowSbbf::check Decimal128(5,2) (coerce to i32)", |b| {
         b.iter(|| {
-            let test_bytes = test_val_dec_small.to_le_bytes();
-            let result = arrow_sbbf_dec_small.check(&test_bytes[..]);
+            let result = arrow_sbbf_dec_small.check(&test_bytes_dec_small[..]);
             hint::black_box(result);
         })
     });
 
     c.bench_function("Sbbf::check Decimal128(15,2)", |b| {
         b.iter(|| {
-            let i64_val = test_val_dec_medium as i64;
-            let result = sbbf_dec_medium.check(&i64_val);
+            let result = sbbf_dec_medium.check(&test_bytes_dec_medium[..]);
             hint::black_box(result);
         })
     });
 
     c.bench_function("ArrowSbbf::check Decimal128(15,2) (coerce to i64)", |b| {
         b.iter(|| {
-            let test_bytes = test_val_dec_medium.to_le_bytes();
-            let result = arrow_sbbf_dec_medium.check(&test_bytes[..]);
+            let result = arrow_sbbf_dec_medium.check(&test_bytes_dec_medium[..]);
             hint::black_box(result);
         })
     });
 
     c.bench_function("Sbbf::check Decimal128(30,2)", |b| {
         b.iter(|| {
-            let test_bytes = test_val_dec_large.to_le_bytes();
-            let result = sbbf_dec_large.check(&test_bytes[..]);
+            let result = sbbf_dec_large.check(&test_bytes_dec_large[..]);
             hint::black_box(result);
         })
     });
 
     c.bench_function("ArrowSbbf::check Decimal128(30,2) (no coercion)", |b| {
         b.iter(|| {
-            let test_bytes = test_val_dec_large.to_le_bytes();
-            let result = arrow_sbbf_dec_large.check(&test_bytes[..]);
+            let result = arrow_sbbf_dec_large.check(&test_bytes_dec_large[..]);
             hint::black_box(result);
         })
     });

--- a/parquet/src/arrow/bloom_filter.rs
+++ b/parquet/src/arrow/bloom_filter.rs
@@ -31,7 +31,7 @@
 //! - `UInt8` → `INT32` (u8 → u32 → i32)
 //! - `UInt16` → `INT32` (u16 → u32 → i32)
 //!
-//! [`ArrowSbbf`] wraps an [`Sbbf`] and an Arrow [`DataType`], automatically coercing
+//! [`ArrowSbbf`] wraps an [`Sbbf`] and an Arrow [`arrow_schema::DataType`], automatically coercing
 //! values to their Parquet representation before checking the bloom filter.
 //!
 //! # Example

--- a/parquet/src/arrow/bloom_filter.rs
+++ b/parquet/src/arrow/bloom_filter.rs
@@ -1,0 +1,727 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Arrow-aware bloom filter
+//!
+//! This module provides [`ArrowSbbf`], a wrapper around [`Sbbf`] that handles
+//! Arrow-to-Parquet type coercion when checking bloom filters.
+//!
+//! # Overview
+//!
+//! Arrow supports types like `Int8` and `Int16` that have no corresponding Parquet type.
+//! Data of these types must be coerced to the appropriate Parquet type when writing.
+//!
+//! For example, Arrow small integer types are coerced writing to Parquet:
+//! - `Int8` → `INT32` (i8 → i32)
+//! - `Int16` → `INT32` (i16 → i32)
+//! - `UInt8` → `INT32` (u8 → u32 → i32)
+//! - `UInt16` → `INT32` (u16 → u32 → i32)
+//!
+//! Decimal types with small precision are also coerced:
+//! - `Decimal32/64/128/256(precision 1-9)` → `INT32` (truncated via `as i32`)
+//! - `Decimal64/128/256(precision 10-18)` → `INT64` (truncated via `as i64`)
+//!
+//! In these situations, bloom filters store hashes of the *physical* Parquet values, but Arrow users
+//! will often need to check using the *logical* Arrow values.
+//!
+//! [`ArrowSbbf`] wraps an [`Sbbf`] and an Arrow [`DataType`], automatically coercing
+//! values to their Parquet representation before checking the bloom filter.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use arrow_schema::DataType;
+//! use parquet::arrow::bloom_filter::ArrowSbbf;
+//!
+//! // Get bloom filter from row group reader
+//! let sbbf = row_group_reader.get_column_bloom_filter(0)?;
+//! let arrow_sbbf = ArrowSbbf::new(&sbbf, &DataType::Int8);
+//!
+//! // Check with i8 value - automatically coerced to i32
+//! let value: i8 = 42;
+//! if arrow_sbbf.check(&value) {
+//!     println!("Value might be present");
+//! }
+//! ```
+//!
+//! # Known Limitations
+//!
+//! **Date64 with coerce_types=true**: When [`WriterProperties::set_coerce_types`] is enabled,
+//! `Date64` values (i64 milliseconds) are coerced to `Date32` (i32 days). Currently,
+//! [`ArrowSbbf`] cannot detect this case and will produce false negatives when checking
+//! `Date64` values against bloom filters created with `coerce_types=true`.
+//!
+//! Workaround: Manually convert milliseconds to days before checking:
+//! ```ignore
+//! let ms = 864_000_000_i64; // 10 days in milliseconds
+//! let days = (ms / 86_400_000) as i32;
+//! arrow_sbbf.check(&days); // Check with i32 days instead
+//! ```
+//!
+//! [`WriterProperties::set_coerce_types`]: crate::file::properties::WriterPropertiesBuilder::set_coerce_types
+
+use crate::bloom_filter::Sbbf;
+use crate::data_type::AsBytes;
+use arrow_schema::DataType;
+
+/// Wraps an [`Sbbf`] and provides automatic type coercion based on Arrow schema.
+/// Ensures that checking bloom filters works correctly for Arrow types that require
+/// coercion to Parquet physical types (e.g., Int8 → INT32).
+#[derive(Debug, Clone)]
+pub struct ArrowSbbf<'a> {
+    sbbf: &'a Sbbf,
+    arrow_type: &'a DataType,
+}
+
+impl<'a> ArrowSbbf<'a> {
+    /// Create a new Arrow-aware bloom filter wrapper
+    /// * `sbbf` - Parquet bloom filter for the column
+    /// * `arrow_type` - Arrow data type for the column
+    pub fn new(sbbf: &'a Sbbf, arrow_type: &'a DataType) -> Self {
+        Self { sbbf, arrow_type }
+    }
+
+    /// Check if a value might be present in the bloom filter
+    /// Automatically handles type coercion based on the Arrow data type.
+    ///
+    /// Returns `true` if the value might be present (may have false positives),
+    /// or `false` if the value is definitely not present.
+    pub fn check<T: AsBytes + ?Sized>(&self, value: &T) -> bool {
+        match self.arrow_type {
+            DataType::Int8 => {
+                // Arrow Int8 -> Parquet INT32
+                let bytes = value.as_bytes();
+                if bytes.len() == 1 {
+                    let i8_val = i8::from_le_bytes([bytes[0]]);
+                    let i32_val = i8_val as i32;
+                    self.sbbf.check(&i32_val)
+                } else {
+                    // Unexpected size, fall back to direct check
+                    self.sbbf.check(value)
+                }
+            }
+            DataType::Int16 => {
+                // Arrow Int16 -> Parquet INT32
+                let bytes = value.as_bytes();
+                if bytes.len() == 2 {
+                    let i16_val = i16::from_le_bytes([bytes[0], bytes[1]]);
+                    let i32_val = i16_val as i32;
+                    self.sbbf.check(&i32_val)
+                } else {
+                    // Unexpected size, fall back to direct check
+                    self.sbbf.check(value)
+                }
+            }
+            DataType::UInt8 => {
+                // Arrow UInt8 -> Parquet INT32
+                let bytes = value.as_bytes();
+                if bytes.len() == 1 {
+                    let u8_val = bytes[0];
+                    let u32_val = u8_val as u32;
+                    let i32_val = u32_val as i32;
+                    self.sbbf.check(&i32_val)
+                } else {
+                    // Unexpected size, fall back to direct check
+                    self.sbbf.check(value)
+                }
+            }
+            DataType::UInt16 => {
+                // Arrow UInt16 -> Parquet INT32
+                let bytes = value.as_bytes();
+                if bytes.len() == 2 {
+                    let u16_val = u16::from_le_bytes([bytes[0], bytes[1]]);
+                    let u32_val = u16_val as u32;
+                    let i32_val = u32_val as i32;
+                    self.sbbf.check(&i32_val)
+                } else {
+                    // Unexpected size, fall back to direct check
+                    self.sbbf.check(value)
+                }
+            }
+            DataType::Decimal32(precision, _)
+            | DataType::Decimal64(precision, _)
+            | DataType::Decimal128(precision, _)
+            | DataType::Decimal256(precision, _)
+                if *precision >= 1 && *precision <= 9 =>
+            {
+                // Decimal with precision 1-9 -> Parquet INT32
+                // Writer truncates via `as i32`
+                let bytes = value.as_bytes();
+                match bytes.len() {
+                    4 => {
+                        // Decimal32: i32 value, directly reinterpret
+                        let i32_val = i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                        self.sbbf.check(&i32_val)
+                    }
+                    8 => {
+                        // Decimal64: i64 value, truncate to i32
+                        let i64_val = i64::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7],
+                        ]);
+                        let i32_val = i64_val as i32;
+                        self.sbbf.check(&i32_val)
+                    }
+                    16 => {
+                        // Decimal128: i128 value, truncate to i32
+                        let i128_val = i128::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12],
+                            bytes[13], bytes[14], bytes[15],
+                        ]);
+                        let i32_val = i128_val as i32;
+                        self.sbbf.check(&i32_val)
+                    }
+                    32 => {
+                        // Decimal256: i256 stored as 32 bytes, truncate to i32
+                        // Read first 16 bytes as i128, then truncate
+                        let i128_val = i128::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12],
+                            bytes[13], bytes[14], bytes[15],
+                        ]);
+                        let i32_val = i128_val as i32;
+                        self.sbbf.check(&i32_val)
+                    }
+                    _ => self.sbbf.check(value),
+                }
+            }
+            DataType::Decimal64(precision, _)
+            | DataType::Decimal128(precision, _)
+            | DataType::Decimal256(precision, _)
+                if *precision >= 10 && *precision <= 18 =>
+            {
+                // Decimal with precision 10-18 -> Parquet INT64
+                // Writer truncates via `as i64`
+                let bytes = value.as_bytes();
+                match bytes.len() {
+                    8 => {
+                        // Decimal64: i64 value, directly use
+                        let i64_val = i64::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7],
+                        ]);
+                        self.sbbf.check(&i64_val)
+                    }
+                    16 => {
+                        // Decimal128: i128 value, truncate to i64
+                        let i128_val = i128::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12],
+                            bytes[13], bytes[14], bytes[15],
+                        ]);
+                        let i64_val = i128_val as i64;
+                        self.sbbf.check(&i64_val)
+                    }
+                    32 => {
+                        // Decimal256: i256 stored as 32 bytes, truncate to i64
+                        // Read first 16 bytes as i128, then truncate
+                        let i128_val = i128::from_le_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12],
+                            bytes[13], bytes[14], bytes[15],
+                        ]);
+                        let i64_val = i128_val as i64;
+                        self.sbbf.check(&i64_val)
+                    }
+                    _ => self.sbbf.check(value),
+                }
+            }
+            // No coercion needed
+            _ => self.sbbf.check(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::ArrowWriter;
+    use crate::file::properties::{ReaderProperties, WriterProperties};
+    use crate::file::reader::{FileReader, SerializedFileReader};
+    use crate::file::serialized_reader::ReadOptionsBuilder;
+    use arrow_array::{
+        ArrayRef, Date64Array, Decimal128Array, Decimal32Array, Float16Array, Int16Array,
+        Int8Array, RecordBatch, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    };
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+    use tempfile::tempfile;
+
+    /// Helper function to build a bloom filter for testing
+    ///
+    /// Writes the given array to a Parquet file with bloom filters enabled,
+    /// then reads it back and returns the bloom filter for the first column.
+    fn build_sbbf(array: ArrayRef, field: Field) -> Sbbf {
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+
+        // Write with bloom filter enabled
+        let mut file = tempfile().unwrap();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .build();
+
+        let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back with bloom filters enabled
+        let options = ReadOptionsBuilder::new()
+            .with_reader_properties(
+                ReaderProperties::builder()
+                    .set_read_bloom_filter(true)
+                    .build(),
+            )
+            .build();
+        let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+
+        // Get and return the bloom filter
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        row_group_reader
+            .get_column_bloom_filter(0)
+            .expect("Bloom filter should exist")
+            .clone()
+    }
+
+    #[test]
+    fn test_int8_coercion() {
+        // Int8 -> Parquet INT32 (sign extension changes bytes)
+        let test_value = 3_i8;
+        let array = Arc::new(Int8Array::from(vec![1_i8, 2, test_value, 4, 5]));
+        let field = Field::new("col", DataType::Int8, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should fail (bloom filter has i32)
+        assert!(!sbbf.check(&test_value), "Direct check should fail");
+
+        // ArrowSbbf check should succeed (coerces i8 to i32)
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_int16_coercion() {
+        // Int16 -> Parquet INT32 (sign extension changes bytes)
+        let test_value = 300_i16;
+        let array = Arc::new(Int16Array::from(vec![100_i16, 200, test_value, 400, 500]));
+        let field = Field::new("col", DataType::Int16, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should fail (bloom filter has i32)
+        assert!(!sbbf.check(&test_value), "Direct check should fail");
+
+        // ArrowSbbf check should succeed (coerces i16 to i32)
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_uint8_coercion() {
+        // UInt8 -> Parquet INT32 (zero extension changes bytes)
+        let test_value = 30_u8;
+        let array = Arc::new(UInt8Array::from(vec![10_u8, 20, test_value, 40, 50]));
+        let field = Field::new("col", DataType::UInt8, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should fail (bloom filter has i32)
+        assert!(!sbbf.check(&test_value), "Direct check should fail");
+
+        // ArrowSbbf check should succeed (coerces u8 to i32)
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_uint16_coercion() {
+        // UInt16 -> Parquet INT32 (zero extension changes bytes)
+        let test_value = 3000_u16;
+        let array = Arc::new(UInt16Array::from(vec![
+            1000_u16, 2000, test_value, 4000, 5000,
+        ]));
+        let field = Field::new("col", DataType::UInt16, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should fail (bloom filter has i32)
+        assert!(!sbbf.check(&test_value), "Direct check should fail");
+
+        // ArrowSbbf check should succeed (coerces u16 to i32)
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_uint32_no_coercion() {
+        // UInt32 -> Parquet INT32 (reinterpret cast preserves bit pattern)
+        let test_value = 3_000_000_000_u32; // > i32::MAX
+        let array = Arc::new(UInt32Array::from(vec![
+            100_u32,
+            test_value,
+            4_000_000_000_u32,
+        ]));
+        let field = Field::new("col", DataType::UInt32, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should succeed (bit pattern preserved)
+        assert!(sbbf.check(&test_value), "Direct check should succeed");
+
+        // ArrowSbbf check should also succeed
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_uint64_no_coercion() {
+        // UInt64 -> Parquet INT64 (reinterpret cast preserves bit pattern)
+        let test_value = 10_000_000_000_000_000_000_u64; // > i64::MAX
+        let array = Arc::new(UInt64Array::from(vec![
+            100_u64,
+            test_value,
+            15_000_000_000_000_000_000_u64,
+        ]));
+        let field = Field::new("col", DataType::UInt64, false);
+        let sbbf = build_sbbf(array, field.clone());
+
+        // Direct check should succeed (bit pattern preserved)
+        assert!(sbbf.check(&test_value), "Direct check should succeed");
+
+        // ArrowSbbf check should also succeed
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_decimal128_small_coercion() {
+        // Decimal128(5, 2) -> Parquet INT32 (precision 1-9, truncation changes bytes)
+        let test_value = 20075_i128;
+        let array = Decimal128Array::from(vec![10050_i128, test_value, 30099_i128])
+            .with_precision_and_scale(5, 2)
+            .unwrap();
+        let field = Field::new("col", DataType::Decimal128(5, 2), false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        // Write with bloom filter
+        let mut file = tempfile().unwrap();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .build();
+        let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back
+        let options = ReadOptionsBuilder::new()
+            .with_reader_properties(
+                ReaderProperties::builder()
+                    .set_read_bloom_filter(true)
+                    .build(),
+            )
+            .build();
+        let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        let bloom_filter = row_group_reader
+            .get_column_bloom_filter(0)
+            .expect("Bloom filter should exist");
+
+        // Test 1: Direct check with i128 bytes should fail (bloom filter has i32)
+        let test_bytes = test_value.to_le_bytes();
+        let direct_result = bloom_filter.check(&test_bytes[..]);
+        println!(
+            "Decimal128(5,2): Direct Sbbf check with i128 bytes = {}",
+            direct_result
+        );
+        assert!(
+            !direct_result,
+            "Direct check with i128 bytes should fail (bloom filter has i32)"
+        );
+
+        // Test 2: ArrowSbbf check should succeed (coerces i128 to i32)
+        let arrow_sbbf = ArrowSbbf::new(&bloom_filter, field.data_type());
+        let arrow_result = arrow_sbbf.check(&test_bytes[..]);
+        println!(
+            "Decimal128(5,2): ArrowSbbf check with i128 bytes = {}",
+            arrow_result
+        );
+        assert!(
+            arrow_result,
+            "ArrowSbbf check should succeed (coerces to i32)"
+        );
+    }
+
+    #[test]
+    fn test_decimal128_medium_coercion() {
+        // Decimal128(15, 2) -> Parquet INT64 (precision 10-18, truncation changes bytes)
+        // Direct Sbbf check: false (bug - checking i128 but filter has i64)
+        // ArrowSbbf check: true (fix - coerces i128 to i64)
+        let test_value = 9876543210987_i128;
+        let array = Decimal128Array::from(vec![1234567890123_i128, test_value, 5555555555555_i128])
+            .with_precision_and_scale(15, 2)
+            .unwrap();
+        let field = Field::new("col", DataType::Decimal128(15, 2), false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        // Write with bloom filter
+        let mut file = tempfile().unwrap();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .build();
+        let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back
+        let options = ReadOptionsBuilder::new()
+            .with_reader_properties(
+                ReaderProperties::builder()
+                    .set_read_bloom_filter(true)
+                    .build(),
+            )
+            .build();
+        let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        let bloom_filter = row_group_reader
+            .get_column_bloom_filter(0)
+            .expect("Bloom filter should exist");
+
+        // Test 1: Direct check with i128 bytes should fail (bloom filter has i64)
+        let test_bytes = test_value.to_le_bytes();
+        let direct_result = bloom_filter.check(&test_bytes[..]);
+        println!(
+            "Decimal128(15,2): Direct Sbbf check with i128 bytes = {}",
+            direct_result
+        );
+        assert!(
+            !direct_result,
+            "Direct check with i128 bytes should fail (bloom filter has i64)"
+        );
+
+        // Test 2: ArrowSbbf check should succeed (coerces i128 to i64)
+        let arrow_sbbf = ArrowSbbf::new(&bloom_filter, field.data_type());
+        let arrow_result = arrow_sbbf.check(&test_bytes[..]);
+        println!(
+            "Decimal128(15,2): ArrowSbbf check with i128 bytes = {}",
+            arrow_result
+        );
+        assert!(
+            arrow_result,
+            "ArrowSbbf check should succeed (coerces to i64)"
+        );
+    }
+
+    #[test]
+    fn test_decimal32_no_coercion() {
+        // Decimal32(5, 2) -> Parquet INT32 (reinterpret cast preserves bit pattern for small precision)
+        // Direct Sbbf check: true (works without ArrowSbbf for Decimal32)
+        // ArrowSbbf check: true (wrapper doesn't hurt)
+        // Note: Decimal32 stores i32 natively, so no truncation occurs
+        let test_value = 20075_i32;
+        let array = Decimal32Array::from(vec![10050_i32, test_value, 30099_i32])
+            .with_precision_and_scale(5, 2)
+            .unwrap();
+        let field = Field::new("col", DataType::Decimal32(5, 2), false);
+        let sbbf = build_sbbf(Arc::new(array), field.clone());
+
+        // Direct check should succeed (bit pattern preserved)
+        assert!(sbbf.check(&test_value), "Direct check should succeed");
+
+        // ArrowSbbf check should also succeed
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_float16_no_coercion() {
+        // Float16 -> Parquet FIXED_LEN_BYTE_ARRAY(2) (stored as-is)
+        // Direct Sbbf check: true (bit pattern preserved)
+        // ArrowSbbf check: true (wrapper doesn't hurt)
+        use half::f16;
+        let test_value = f16::from_f32(2.5);
+        let array = Float16Array::from(vec![f16::from_f32(1.5), test_value, f16::from_f32(3.5)]);
+        let field = Field::new("col", DataType::Float16, false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        // Write with bloom filter
+        let mut file = tempfile().unwrap();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .build();
+        let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back
+        let options = ReadOptionsBuilder::new()
+            .with_reader_properties(
+                ReaderProperties::builder()
+                    .set_read_bloom_filter(true)
+                    .build(),
+            )
+            .build();
+        let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        let bloom_filter = row_group_reader
+            .get_column_bloom_filter(0)
+            .expect("Bloom filter should exist");
+
+        // Test 1: Direct check with f16 bytes should work (bit pattern preserved)
+        let test_bytes = test_value.to_le_bytes();
+        let direct_result = bloom_filter.check(&test_bytes[..]);
+        println!("Float16: Direct Sbbf check with bytes = {}", direct_result);
+        assert!(direct_result, "Direct check with bytes should succeed");
+
+        // Test 2: ArrowSbbf check should also work
+        let arrow_sbbf = ArrowSbbf::new(&bloom_filter, field.data_type());
+        let arrow_result = arrow_sbbf.check(&test_bytes[..]);
+        println!("Float16: ArrowSbbf check with bytes = {}", arrow_result);
+        assert!(arrow_result, "ArrowSbbf check should succeed");
+    }
+
+    #[test]
+    fn test_date64_no_coercion_by_default() {
+        // Date64 -> Parquet INT64 (stored as-is when coerce_types=false, which is default)
+        // Direct Sbbf check: true (no coercion by default)
+        // ArrowSbbf check: true (wrapper doesn't hurt)
+        // Note: Date64 CAN be coerced to Date32/INT32 with coerce_types=true,
+        // but that's not the default behavior, so bloom filters work correctly by default
+        let test_value = 2_000_000_000_i64;
+        let array = Date64Array::from(vec![1_000_000_000_i64, test_value, 3_000_000_000_i64]);
+        let field = Field::new("col", DataType::Date64, false);
+        let sbbf = build_sbbf(Arc::new(array), field.clone());
+
+        // Direct check should succeed (no coercion by default)
+        assert!(sbbf.check(&test_value), "Direct check should succeed");
+
+        // ArrowSbbf check should also succeed
+        let arrow_sbbf = ArrowSbbf::new(&sbbf, field.data_type());
+        assert!(
+            arrow_sbbf.check(&test_value),
+            "ArrowSbbf check should succeed"
+        );
+    }
+
+    #[test]
+    fn test_date64_with_coerce_types() {
+        // This test documents a KNOWN LIMITATION of ArrowSbbf.
+        //
+        // When WriterProperties::set_coerce_types(true) is used:
+        // - Date64 (i64 milliseconds) -> Date32 (i32 days) -> Parquet INT32
+        // - Conversion: milliseconds / 86_400_000 = days
+        //
+        // ArrowSbbf cannot currently detect this case because it only has access to
+        // the Arrow DataType, not the Parquet schema or coerce_types setting.
+        //
+        // Potential solutions (not implemented):
+        // 1. Double-check both i64 and i32 representations (increases false positive rate ~2x)
+        // 2. Change ArrowSbbf API to accept Parquet column descriptor (breaking change)
+        // 3. Require users to manually convert ms -> days when using coerce_types
+        //
+        // We chose option 3 (documented limitation) because:
+        // - coerce_types=true is not the default
+        // - Date64 + bloom filters + coerce_types is a rare combination
+        // - Can wait for user feedback before adding complexity
+
+        const MS_PER_DAY: i64 = 86_400_000;
+        let test_value_ms = 10 * MS_PER_DAY; // 10 days in milliseconds
+        let array = Date64Array::from(vec![5 * MS_PER_DAY, test_value_ms, 15 * MS_PER_DAY]);
+        let field = Field::new("col", DataType::Date64, false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        // Write with bloom filter AND coerce_types enabled
+        let mut file = tempfile().unwrap();
+        let props = WriterProperties::builder()
+            .set_bloom_filter_enabled(true)
+            .set_coerce_types(true) // This causes Date64 -> Date32 (INT32)
+            .build();
+        let mut writer = ArrowWriter::try_new(&mut file, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back
+        let options = ReadOptionsBuilder::new()
+            .with_reader_properties(
+                ReaderProperties::builder()
+                    .set_read_bloom_filter(true)
+                    .build(),
+            )
+            .build();
+        let reader = SerializedFileReader::new_with_options(file, options).unwrap();
+        let row_group_reader = reader.get_row_group(0).unwrap();
+        let bloom_filter = row_group_reader
+            .get_column_bloom_filter(0)
+            .expect("Bloom filter should exist");
+
+        // Test 1: Direct check with i64 milliseconds fails (bloom filter has i32 days)
+        let direct_result = bloom_filter.check(&test_value_ms);
+        println!(
+            "Date64 (coerce_types=true): Direct Sbbf check with i64 ms = {}",
+            direct_result
+        );
+        assert!(
+            !direct_result,
+            "Direct check with i64 ms should fail (bloom filter has i32 days)"
+        );
+
+        // Test 2: ArrowSbbf also fails (KNOWN LIMITATION - not yet implemented)
+        let arrow_sbbf = ArrowSbbf::new(&bloom_filter, field.data_type());
+        let arrow_result = arrow_sbbf.check(&test_value_ms);
+        println!(
+            "Date64 (coerce_types=true): ArrowSbbf check with i64 ms = {}",
+            arrow_result
+        );
+        assert!(
+            !arrow_result,
+            "ArrowSbbf cannot handle Date64 coercion (documented limitation)"
+        );
+
+        // Workaround: Manually convert to days before checking
+        let days = (test_value_ms / MS_PER_DAY) as i32;
+        let workaround_result = bloom_filter.check(&days);
+        println!(
+            "Date64 (coerce_types=true): Manual conversion to i32 days = {}",
+            workaround_result
+        );
+        assert!(
+            workaround_result,
+            "Workaround: checking with i32 days should succeed"
+        );
+    }
+}

--- a/parquet/src/arrow/bloom_filter.rs
+++ b/parquet/src/arrow/bloom_filter.rs
@@ -251,12 +251,7 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 16 {
-                    let i128_val = i128::from_le_bytes([
-                        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
-                        bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13],
-                        bytes[14], bytes[15],
-                    ]);
-                    let i32_val = i128_val as i32;
+                    let i32_val = i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                     self.sbbf.check(&i32_val)
                 } else {
                     true // Unexpected byte length, return false positive
@@ -274,13 +269,7 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 32 {
-                    // Read first 16 bytes as i128, then truncate to i32
-                    let i128_val = i128::from_le_bytes([
-                        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
-                        bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13],
-                        bytes[14], bytes[15],
-                    ]);
-                    let i32_val = i128_val as i32;
+                    let i32_val = i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                     self.sbbf.check(&i32_val)
                 } else {
                     true // Unexpected byte length, return false positive
@@ -319,13 +308,10 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 16 {
-                    // Read first 16 bytes as i128, then truncate to i64
-                    let i128_val = i128::from_le_bytes([
+                    let i64_val = i64::from_le_bytes([
                         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
-                        bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13],
-                        bytes[14], bytes[15],
+                        bytes[7],
                     ]);
-                    let i64_val = i128_val as i64;
                     self.sbbf.check(&i64_val)
                 } else {
                     true // Unexpected byte length, return false positive
@@ -343,13 +329,10 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 32 {
-                    // Read first 16 bytes as i128, then truncate to i64
-                    let i128_val = i128::from_le_bytes([
+                    let i64_val = i64::from_le_bytes([
                         bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
-                        bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13],
-                        bytes[14], bytes[15],
+                        bytes[7],
                     ]);
-                    let i64_val = i128_val as i64;
                     self.sbbf.check(&i64_val)
                 } else {
                     true // Unexpected byte length, return false positive

--- a/parquet/src/arrow/bloom_filter.rs
+++ b/parquet/src/arrow/bloom_filter.rs
@@ -172,9 +172,7 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 1 {
-                    let u8_val = bytes[0];
-                    let u32_val = u8_val as u32;
-                    let i32_val = u32_val as i32;
+                    let i32_val = bytes[0] as i32;
                     self.sbbf.check(&i32_val)
                 } else {
                     true // Unexpected byte length, return false positive
@@ -192,8 +190,7 @@ impl<'a> ArrowSbbf<'a> {
 
                 if bytes.len() == 2 {
                     let u16_val = u16::from_le_bytes([bytes[0], bytes[1]]);
-                    let u32_val = u16_val as u32;
-                    let i32_val = u32_val as i32;
+                    let i32_val = u16_val as i32;
                     self.sbbf.check(&i32_val)
                 } else {
                     true // Unexpected byte length, return false positive
@@ -211,11 +208,7 @@ impl<'a> ArrowSbbf<'a> {
                 );
 
                 if bytes.len() == 8 {
-                    let i64_val = i64::from_le_bytes([
-                        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
-                        bytes[7],
-                    ]);
-                    let i32_val = i64_val as i32;
+                    let i32_val = i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                     self.sbbf.check(&i32_val)
                 } else {
                     true // Unexpected byte length, return false positive

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -182,6 +182,7 @@
 experimental!(mod array_reader);
 pub mod arrow_reader;
 pub mod arrow_writer;
+pub mod bloom_filter;
 mod buffer;
 mod decoder;
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -387,7 +387,7 @@ impl Sbbf {
     }
 
     /// Check if an [AsBytes] value is probably present or definitely absent in the filter
-    pub fn check<T: AsBytes>(&self, value: &T) -> bool {
+    pub fn check<T: AsBytes + ?Sized>(&self, value: &T) -> bool {
         self.check_hash(hash_as_bytes(value))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #5550.

# Rationale for this change

Parquet types are a subset of Arrow types, so the Arrow writer must coerce to Parquet types. In some cases, this changes the physical representation. Therefore, passing Arrow data directly to `Sbbf::check` will produce false negatives. Correctness is only guaranteed when checking with the coerced Parquet value.

This issue affects some integer and decimal types. It can also affect `Date64`.

# What changes are included in this PR?

Introduces `ArrowSbbf` as an Arrow-aware interface to the Parquet `Sbbf`. This coerces incoming data if necessary and calls `Sbbf::check`.

Currently, `Date64` types can be written as either `INT32` (days since epoch) or `INT64` (milliseconds since epoch), depending on Arrow writer properties (`coerce_types`). Instead of requiring additional information to handle this special (non-default) case, this implementation instructs users to coerce `Date64` to `Date32` if the Parquet column type is `INT32`. I'm open to feedback on this decision.

# Are these changes tested?

There are tests for integer, float, decimal, and date types. Not exhaustive but covering all cases where coercion is necessary.

# Are there any user-facing changes?

There is a new `ArrowSbbf` struct that most Arrow users should prefer over using `Sbbf` directly. Also, the `Sized` constraint was relaxed on the `Sbbf::check` function to support slices. This is consistent with `Sbbf::insert`.