### PR TITLE
minor(parquet): Fix test_not_found on Windows

### DIFF
--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -292,10 +292,7 @@ mod tests {
             Ok(_) => panic!("expected failure"),
             Err(e) => {
                 let err = e.to_string();
-                assert!(
-                    err.contains("not found: No such file or directory (os error 2)"),
-                    "{err}",
-                );
+                assert!(err.contains("I don't exist.parquet not found:"), "{err}",);
             }
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

- N/A.

# Rationale for this change

The `parquet` `test_not_found` unit test was checking the error message using the Unix-specific output. This PR uses only the generic error message so it can work on Windows as well.

# What changes are included in this PR?

- Updated the `test_not_found` unit test.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.