### PR TITLE
fix: use default field name when name is None in Field conversion

### DIFF
--- a/arrow-ipc/src/convert.rs
+++ b/arrow-ipc/src/convert.rs
@@ -165,7 +165,7 @@ impl From<crate::Field<'_>> for Field {
         let arrow_field = if let Some(dictionary) = field.dictionary() {
             #[allow(deprecated)]
             Field::new_dict(
-                field.name().unwrap(),
+                field.name().unwrap_or_default(),
                 get_data_type(field, true),
                 field.nullable(),
                 dictionary.id(),
@@ -173,7 +173,7 @@ impl From<crate::Field<'_>> for Field {
             )
         } else {
             Field::new(
-                field.name().unwrap(),
+                field.name().unwrap_or_default(),
                 get_data_type(field, true),
                 field.nullable(),
             )


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #6415

# Rationale for this change


# What changes are included in this PR?


# Are these changes tested?

# Are there any user-facing changes?
No
