### PR TITLE
8543 follow up

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -498,7 +498,7 @@ impl BooleanArray {
     ///
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length. Note that this is a stronger
-    /// guarantee that `ExactSizeIterator` provides which could still report a wrong length.
+    /// guarantee than `ExactSizeIterator` provides, which could still report a wrong length.
     ///
     /// # Panics
     ///

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1458,14 +1458,21 @@ impl<T: ArrowPrimitiveType, Ptr: Into<NativeAdapter<T>>> FromIterator<Ptr> for P
 
 impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Creates a [`PrimitiveArray`] from an iterator of trusted length.
+    ///
     /// # Safety
+    ///
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
-    /// I.e. that `size_hint().1` correctly reports its length.
+    /// I.e. that `size_hint().1` correctly reports its length. Note that this is a stronger
+    /// guarantee than `ExactSizeIterator` provides, which could still report a wrong length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the iterator does not report an upper bound on `size_hint()`.
     #[inline]
     pub unsafe fn from_trusted_len_iter<I, P>(iter: I) -> Self
     where
         P: std::borrow::Borrow<Option<<T as ArrowPrimitiveType>::Native>>,
-        I: IntoIterator<Item = P>,
+        I: ExactSizeIterator<Item = P>,
     {
         let iterator = iter.into_iter();
         let (_, upper) = iterator.size_hint();

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -87,7 +87,7 @@ pub(crate) fn parse_string_view<P: Parser>(
 fn parse_string_iter<
     'a,
     P: Parser,
-    I: Iterator<Item = Option<&'a str>>,
+    I: ExactSizeIterator<Item = Option<&'a str>>,
     F: FnOnce() -> Option<NullBuffer>,
 >(
     iter: I,
@@ -156,7 +156,7 @@ pub(crate) fn cast_view_to_timestamp<T: ArrowTimestampType>(
 
 fn cast_string_to_timestamp_impl<
     'a,
-    I: Iterator<Item = Option<&'a str>>,
+    I: ExactSizeIterator<Item = Option<&'a str>>,
     T: ArrowTimestampType,
     Tz: TimeZone,
 >(
@@ -310,7 +310,7 @@ fn cast_string_to_interval_impl<'a, I, ArrowType, F>(
     parse_function: F,
 ) -> Result<ArrayRef, ArrowError>
 where
-    I: Iterator<Item = Option<&'a str>>,
+    I: ExactSizeIterator<Item = Option<&'a str>>,
     ArrowType: ArrowPrimitiveType,
     F: Fn(&str) -> Result<ArrowType::Native, ArrowError> + Copy,
 {
@@ -331,7 +331,7 @@ where
         //     20% performance improvement
         // Soundness:
         //     The iterator is trustedLen because it comes from an `StringArray`.
-        unsafe { PrimitiveArray::<ArrowType>::from_trusted_len_iter(vec) }
+        unsafe { PrimitiveArray::<ArrowType>::from_trusted_len_iter(vec.into_iter()) }
     };
     Ok(Arc::new(interval_array) as ArrayRef)
 }


### PR DESCRIPTION
# Which issue does this PR close?

This is a follow-up to #8543 . There we discussed two outstanding issues that this PR tries to address.

# Rationale for this change

Address the points from the PR.

# What changes are included in this PR?

1. Improve benchmarks (use a dynamically dispatched compiler to avoid `Vec`-specific optimizations)
2. Also use `ExactSizeIterator` for the `PrimitiveArray`

# Are these changes tested?

Existing test for `PrimitiveArray`

# Are there any user-facing changes?

Yes, `PrimitiveArray::from_trusted_len_iter` is more restrictive.
