### PR TITLE
Fix doctests of parquet push decoded without default features

### DIFF
--- a/parquet/src/file/metadata/push_decoder.rs
+++ b/parquet/src/file/metadata/push_decoder.rs
@@ -158,7 +158,7 @@ decoder.push_ranges(vec![0..file_len], vec![prefetched_bytes]).unwrap();
         other => { panic!("expected DecodeResult::Data, got: {other:?}") }
     }
 # }
-/// ```
+```
 "##
 )]
 ///


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Make sure `cargo test -p parquet --doc --no-default-features` works.

# What changes are included in this PR?

Feature gate some doc tests on the `arrow` feature in the parquet crate.

# Are these changes tested?

`cargo test -p parquet --doc --no-default-features`

# Are there any user-facing changes?

No