### PR TITLE
chore: replace paste with pastey

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -43,7 +43,7 @@ base64 = { version = "0.22", default-features = false, features = ["std"] }
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 once_cell = { version = "1", optional = true }
-paste = { version = "1.0" , optional = true }
+pastey = { version = "0.1" , optional = true }
 prost = { version = "0.14.1", default-features = false, features = ["derive"] }
 # For Timestamp type
 prost-types = { version = "0.14.1", default-features = false }
@@ -62,7 +62,7 @@ all-features = true
 
 [features]
 default = []
-flight-sql = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
+flight-sql = ["dep:arrow-arith", "dep:arrow-data", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:pastey"]
 # TODO: Remove in the next release
 flight-sql-experimental = ["flight-sql"]
 tls-aws-lc= ["tonic/tls-aws-lc"]

--- a/arrow-flight/src/sql/mod.rs
+++ b/arrow-flight/src/sql/mod.rs
@@ -40,7 +40,7 @@
 //! [`metadata`]: crate::sql::metadata
 use arrow_schema::ArrowError;
 use bytes::Bytes;
-use paste::paste;
+use pastey::paste;
 use prost::Message;
 
 #[allow(clippy::all)]

--- a/parquet-variant/Cargo.toml
+++ b/parquet-variant/Cargo.toml
@@ -44,7 +44,7 @@ name = "parquet_variant"
 bench = false
 
 [dev-dependencies]
-paste = { version = "1.0" }
+pastey = { version = "0.1" }
 criterion = { version = "0.6", default-features = false }
 rand = { version = "0.9", default-features = false, features = [
     "std",

--- a/parquet-variant/src/decoder.rs
+++ b/parquet-variant/src/decoder.rs
@@ -367,7 +367,7 @@ pub(crate) fn decode_short_string(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::paste;
+    use pastey::paste;
 
     macro_rules! test_decoder_bounds {
         ($test_name:ident, $data:expr, $decode_fn:ident, $expected:expr) => {

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -73,7 +73,7 @@ futures = { version = "0.3", default-features = false, features = ["std"], optio
 tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
 hashbrown = { version = "0.16", default-features = false }
 twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"] }
-paste = { version = "1.0" }
+pastey = { version = "0.1" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 crc32fast = { version = "1.4.2", optional = true, default-features = false }
 simdutf8 = { workspace = true , optional = true }

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -43,7 +43,7 @@ use arrow_array::{
 use arrow_buffer::i256;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use half::f16;
-use paste::paste;
+use pastey::paste;
 use std::sync::Arc;
 
 // Convert the bytes array to i32.

--- a/parquet/tests/variant_integration.rs
+++ b/parquet/tests/variant_integration.rs
@@ -41,7 +41,7 @@ type Result<T> = std::result::Result<T, String>;
 /// Note the index is zero-based, while the case number is one-based
 macro_rules! variant_test_case {
     ($case_num:literal $(, $expected_error:literal )? ) => {
-        paste::paste! {
+        pastey::paste! {
             #[test]
             $( #[should_panic(expected = $expected_error)] )?
             fn [<test_variant_integration_case_ $case_num>]() {


### PR DESCRIPTION
• # Which issue does this PR close?

  - Closes https://github.com/apache/arrow-rs/issues/7598

  # Rationale for this change

  cargo deny flags the unmaintained paste crate, so advisory checks fail until we remove it. Switching to the maintained drop-in replacement keeps the dependency tree healthy and restores the advisory gate.

  # What changes are included in this PR?

  - Replace all paste dependencies with pastey across Arrow Flight, Parquet, and Parquet Variant crates.
  - Update source files to import pastey::paste instead of paste::paste.
  - Refresh Cargo.lock so it pulls in pastey.

  # Are these changes tested?

  - cargo check -p parquet
  - cargo deny check advisories

  # Are there any user-facing changes?

  No user-facing changes or API adjustments.