### PR TITLE
feat: Improve DataType display for `RunEndEncoded`

### DIFF
--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -497,7 +497,8 @@ mod tests {
             )),
         );
         let complex_dict_data_type_string = complex_dict_data_type.to_string();
-        let expected_complex_string = "Dictionary(Int16, Struct(\"a\": Int32, \"b\": nullable Utf8))";
+        let expected_complex_string =
+            "Dictionary(Int16, Struct(\"a\": Int32, \"b\": nullable Utf8))";
         assert_eq!(complex_dict_data_type_string, expected_complex_string);
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #8351

## Rationale for this change


## What changes are included in this PR?

This PR refactors and improves the `Display` formatting for `DataType` by:

- **Improving Union type display** - now shows field information with parentheses for clarity: `Union(Sparse, 0: ('a': Int32), 1: ('b': nullable Utf8))`
- **Improving RunEndEncoded type display** - now properly formats both run_ends and values fields: `RunEndEncoded('run_ends': UInt32, 'values': nullable Int32)`


## Are these changes tested?
Yes

## Are there any user-facing changes?

