### PR TITLE
Remove experimental warning from `extension` module

### DIFF
--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -16,8 +16,6 @@
 // under the License.
 
 //! Extension types.
-//!
-//! <div class="warning">This module is experimental. There might be breaking changes between minor releases.</div>
 
 #[cfg(feature = "canonical_extension_types")]
 mod canonical;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8030

# Rationale for this change

There is no agreement yet on the what to do with extension types when modifying `Field` data types (#8350), but I think we agree on removing the experimental warning from the `extension` module. Opening this PR so we can include it in 57.0.0.

# What changes are included in this PR?

The warning removal from #8350.

# Are these changes tested?

Not required.

# Are there any user-facing changes?

Yes, extension types no longer marked experimental.