### PR TITLE
Check int96 min/max instead of panicking

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -1098,7 +1098,7 @@ mod tests {
     fn test_int96_invalid_statistics() {
         let mut thrift_stats = PageStatistics {
             max: None,
-            min: Some(vec![1, 2, 3]),
+            min: Some((0..13).collect()),
             null_count: Some(0),
             distinct_count: None,
             max_value: None,
@@ -1114,7 +1114,7 @@ mod tests {
         );
 
         thrift_stats.min = None;
-        thrift_stats.max = Some(vec![1, 2, 3]);
+        thrift_stats.max = Some((0..13).collect());
         let err = from_thrift_page_stats(Type::INT96, Some(thrift_stats)).unwrap_err();
         assert_eq!(
             err.to_string(),


### PR DESCRIPTION
# Rationale for this change
Fixes #8614 
Part of #7806 

We currently panic if the size of an int96 isn't 12. Instead, we should return an error message to avoid a panic.

# What changes are included in this PR?

Error message instead of panic.

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
Test included, existing tests should still pass.

# Are there any user-facing changes?
None.
