### PR TITLE
[Variant] Impl `Extend` for `VariantArrayBuilder`

### DIFF
--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 /// # use arrow::array::Array;
 /// # use parquet_variant::{Variant, VariantBuilder, VariantBuilderExt};
 /// # use parquet_variant_compute::VariantArrayBuilder;
+/// # use parquet_variant::ShortString;
 /// // Create a new VariantArrayBuilder with a capacity of 100 rows
 /// let mut builder = VariantArrayBuilder::new(100);
 /// // append variant values
@@ -56,9 +57,13 @@ use std::sync::Arc;
 ///   .with_field("foo", "bar")
 ///   .finish();
 ///
+/// // bulk insert a list of values
+/// // `Option::None` is a null value
+/// builder.extend([None, Some(Variant::from("norm"))]);
+///
 /// // create the final VariantArray
 /// let variant_array = builder.build();
-/// assert_eq!(variant_array.len(), 3);
+/// assert_eq!(variant_array.len(), 5);
 /// // // Access the values
 /// // row 1 is not null and is an integer
 /// assert!(!variant_array.is_null(0));
@@ -70,6 +75,12 @@ use std::sync::Arc;
 /// let value = variant_array.value(2);
 /// let obj = value.as_object().expect("expected object");
 /// assert_eq!(obj.get("foo"), Some(Variant::from("bar")));
+/// // row 3 is null
+/// assert!(variant_array.is_null(3));
+/// // row 4 is not null and is a short string
+/// assert!(!variant_array.is_null(4));
+/// let value = variant_array.value(4);
+/// assert_eq!(value, Variant::ShortString(ShortString::try_new("norm").unwrap()));
 /// ```
 #[derive(Debug)]
 pub struct VariantArrayBuilder {
@@ -455,8 +466,12 @@ mod test {
     #[test]
     fn test_variant_array_builder_non_nullable() {
         let mut builder = VariantArrayBuilder::new(10);
-        builder.append_null(); // should not panic
-        builder.append_variant(Variant::from(42i32));
+
+        builder.extend([
+            None, // should not panic
+            Some(Variant::from(42_i32)),
+        ]);
+
         let variant_array = builder.build();
 
         assert_eq!(variant_array.len(), 2);


### PR DESCRIPTION
# Rationale for this change

This PR adds support for bulk insertion of `Option<Variant>` values into a `VariantArray`

[Similar to other builders such as `GenericByteViewBuilder`](https://docs.rs/arrow/latest/arrow/array/builder/struct.GenericByteViewBuilder.html#impl-Extend%3COption%3CV%3E%3E-for-GenericByteViewBuilder%3CT%3E), it now implements the `Extend` trait

For example:

```rs
let mut b = VariantArrayBuilder::new(2);
b.extend([None, Some(Variant::Null)];
let v = b.build();
```
