### PR TITLE
Update publishing instructions to publish arrow-avro as part of 57

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -255,6 +255,7 @@ Rust Arrow Crates:
 (cd arrow-row && cargo publish)
 (cd arrow-pyarrow && cargo publish)
 (cd arrow && cargo publish)
+(cd arrow-avro && cargo publish)
 (cd arrow-flight && cargo publish)
 (cd parquet-variant && cargo publish)
 (cd parquet-variant-json && cargo publish)


### PR DESCRIPTION
- Part of https://github.com/apache/arrow-rs/issues/4886
- Part of #7835 


I believe the crate is set to be published with Arrow 57 so let's add it to the publishing instructions
