### PR TITLE
[Variant] Remove ceremony from iterator of variants into VariantArray

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -442,7 +442,9 @@ impl From<VariantArray> for ArrayRef {
 
 impl<'m, 'v> FromIterator<Option<Variant<'m, 'v>>> for VariantArray {
     fn from_iter<T: IntoIterator<Item = Option<Variant<'m, 'v>>>>(iter: T) -> Self {
-        let mut b = VariantArrayBuilder::new(0);
+        let iter = iter.into_iter();
+
+        let mut b = VariantArrayBuilder::new(iter.size_hint().0);
         b.extend(iter);
         b.build()
     }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8606

# Rationale for this change

Mapping from an iterator of `Variant`s into a `VariantArray` currently requires a lot of ceremony. This PR abstracts over this. 
