### PR TITLE
Use `Arc<FileEncryptionProperties>` everywhere to be be consistent with `FileDecryptionProperties`

### DIFF
--- a/parquet/src/encryption/encrypt.rs
+++ b/parquet/src/encryption/encrypt.rs
@@ -275,14 +275,14 @@ impl EncryptionPropertiesBuilder {
     }
 
     /// Build the encryption properties
-    pub fn build(self) -> Result<FileEncryptionProperties> {
-        Ok(FileEncryptionProperties {
+    pub fn build(self) -> Result<Arc<FileEncryptionProperties>> {
+        Ok(Arc::new(FileEncryptionProperties {
             encrypt_footer: self.encrypt_footer,
             footer_key: self.footer_key,
             column_keys: self.column_keys,
             aad_prefix: self.aad_prefix,
             store_aad_prefix: self.store_aad_prefix,
-        })
+        }))
     }
 }
 
@@ -314,7 +314,7 @@ impl FileEncryptor {
     }
 
     /// Get the encryptor's file encryption properties
-    pub fn properties(&self) -> &FileEncryptionProperties {
+    pub fn properties(&self) -> &Arc<FileEncryptionProperties> {
         &self.properties
     }
 
@@ -416,7 +416,7 @@ pub(crate) fn encrypt_thrift_object_to_vec<T: WriteThrift>(
 
 /// Get the crypto metadata for a column from the file encryption properties
 pub(crate) fn get_column_crypto_metadata(
-    properties: &FileEncryptionProperties,
+    properties: &Arc<FileEncryptionProperties>,
     column: &ColumnDescPtr,
 ) -> Option<ColumnCryptoMetaData> {
     if properties.column_keys.is_empty() {

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -458,7 +458,7 @@ pub struct WriterPropertiesBuilder {
     statistics_truncate_length: Option<usize>,
     coerce_types: bool,
     #[cfg(feature = "encryption")]
-    file_encryption_properties: Option<FileEncryptionProperties>,
+    file_encryption_properties: Option<Arc<FileEncryptionProperties>>,
 }
 
 impl Default for WriterPropertiesBuilder {
@@ -506,7 +506,7 @@ impl WriterPropertiesBuilder {
             statistics_truncate_length: self.statistics_truncate_length,
             coerce_types: self.coerce_types,
             #[cfg(feature = "encryption")]
-            file_encryption_properties: self.file_encryption_properties.map(Arc::new),
+            file_encryption_properties: self.file_encryption_properties,
         }
     }
 
@@ -709,7 +709,7 @@ impl WriterPropertiesBuilder {
     #[cfg(feature = "encryption")]
     pub fn with_file_encryption_properties(
         mut self,
-        file_encryption_properties: FileEncryptionProperties,
+        file_encryption_properties: Arc<FileEncryptionProperties>,
     ) -> Self {
         self.file_encryption_properties = Some(file_encryption_properties);
         self
@@ -965,7 +965,7 @@ impl From<WriterProperties> for WriterPropertiesBuilder {
             statistics_truncate_length: props.statistics_truncate_length,
             coerce_types: props.coerce_types,
             #[cfg(feature = "encryption")]
-            file_encryption_properties: props.file_encryption_properties.map(Arc::unwrap_or_clone),
+            file_encryption_properties: props.file_encryption_properties,
         }
     }
 }

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -318,7 +318,7 @@ impl<W: Write + Send> SerializedFileWriter<W> {
     /// Writes magic bytes at the beginning of the file.
     #[cfg(feature = "encryption")]
     fn start_file(properties: &WriterPropertiesPtr, buf: &mut TrackedWrite<W>) -> Result<()> {
-        let magic = get_file_magic(properties.file_encryption_properties.as_deref());
+        let magic = get_file_magic(properties.file_encryption_properties.as_ref());
 
         buf.write_all(magic)?;
         Ok(())
@@ -1020,7 +1020,7 @@ impl<W: Write + Send> PageWriter for SerializedPageWriter<'_, W> {
 /// as a Parquet file.
 #[cfg(feature = "encryption")]
 pub(crate) fn get_file_magic(
-    file_encryption_properties: Option<&FileEncryptionProperties>,
+    file_encryption_properties: Option<&Arc<FileEncryptionProperties>>,
 ) -> &'static [u8; 4] {
     match file_encryption_properties.as_ref() {
         Some(encryption_properties) if encryption_properties.encrypt_footer() => {

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -471,7 +471,7 @@ async fn verify_encryption_test_file_read_async(
 async fn read_and_roundtrip_to_encrypted_file_async(
     path: &str,
     decryption_properties: Arc<FileDecryptionProperties>,
-    encryption_properties: FileEncryptionProperties,
+    encryption_properties: Arc<FileEncryptionProperties>,
 ) -> Result<(), ParquetError> {
     let temp_file = tempfile::tempfile().unwrap();
     let mut file = File::open(&path).await.unwrap();

--- a/parquet/tests/encryption/encryption_util.rs
+++ b/parquet/tests/encryption/encryption_util.rs
@@ -235,7 +235,7 @@ pub(crate) fn read_encrypted_file(
 pub(crate) fn read_and_roundtrip_to_encrypted_file(
     file: &File,
     decryption_properties: Arc<FileDecryptionProperties>,
-    encryption_properties: FileEncryptionProperties,
+    encryption_properties: Arc<FileEncryptionProperties>,
 ) {
     // read example data
     let (batches, metadata) =


### PR DESCRIPTION


# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/7835
- Follow on to https://github.com/apache/arrow-rs/pull/8470

# Rationale for this change

While [testing arrow 57](https://github.com/apache/datafusion/pull/17888) with DataFusion, I found there was a disconnect
in the builders that the `FileDecryptionProperties` builder builds Arc and the `FileEncryptionProperties` builder builds the struct directly

Let's make the APIs consistent

This also allows encryption properties to be shared and cloned cheaply (I am not sure how often this is needed, but it seems like a reasonable thing to do)

# What changes are included in this PR?

See above

# Are these changes tested?

Yes, by existing tests

# Are there any user-facing changes?

This is an API change, started in https://github.com/apache/arrow-rs/pull/8470