### PR TITLE
[Variant] impl `PartialEq` and `FromIterator<Option<..>>` for `VariantArray`

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1479,13 +1479,7 @@ mod test {
         }
 
         {
-            let v_iter_reversed = {
-                let mut v = v_iter.clone();
-                v.reverse();
-
-                v
-            };
-
+            let v_iter_reversed = v_iter.iter().cloned().rev();
             let v_reversed = VariantArray::from_iter(v_iter_reversed);
 
             assert_ne!(v, v_reversed);


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8610

# Rationale for this change

Since the fields of `VariantArray` impl `PartialEq`, this PR simply derives `PartialEq` for `VariantArray`
out.

Based off of https://github.com/apache/arrow-rs/pull/8625
