### PR TITLE
(TESTING, NOT FOR MERGE) Skip decoding statistics

### DIFF
--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -457,6 +457,7 @@ fn read_column_metadata<'a>(
             11 => {
                 column.dictionary_page_offset = Some(i64::read_thrift(&mut *prot)?);
             }
+            /*
             12 => {
                 column.statistics =
                     convert_stats(column_descr, Some(Statistics::read_thrift(&mut *prot)?))?;
@@ -466,12 +467,14 @@ fn read_column_metadata<'a>(
                     read_thrift_vec::<PageEncodingStats, ThriftSliceInputProtocol>(&mut *prot)?;
                 column.encoding_stats = Some(val);
             }
+             */
             14 => {
                 column.bloom_filter_offset = Some(i64::read_thrift(&mut *prot)?);
             }
             15 => {
                 column.bloom_filter_length = Some(i32::read_thrift(&mut *prot)?);
             }
+            /*
             16 => {
                 let val = SizeStatistics::read_thrift(&mut *prot)?;
                 column.unencoded_byte_array_data_bytes = val.unencoded_byte_array_data_bytes;
@@ -484,6 +487,7 @@ fn read_column_metadata<'a>(
                 let val = GeospatialStatistics::read_thrift(&mut *prot)?;
                 column.geo_statistics = convert_geo_stats(Some(val));
             }
+             */
             _ => {
                 prot.skip(field_ident.field_type)?;
             }
@@ -537,6 +541,7 @@ fn read_column_chunk<'a>(
             3 => {
                 col_meta_mask = read_column_metadata(&mut *prot, &mut col)?;
             }
+            /**
             4 => {
                 col.offset_index_offset = Some(i64::read_thrift(&mut *prot)?);
             }
@@ -549,6 +554,7 @@ fn read_column_chunk<'a>(
             7 => {
                 col.column_index_length = Some(i32::read_thrift(&mut *prot)?);
             }
+            **/
             #[cfg(feature = "encryption")]
             8 => {
                 let val = ColumnCryptoMetaData::read_thrift(&mut *prot)?;


### PR DESCRIPTION
Successor to https://github.com/alamb/arrow-rs/pull/54

- Related to https://github.com/apache/arrow-rs/issues/8441
- Related to https://github.com/apache/arrow-rs/issues/5855

## Rationale
This PR is part of testing how much faster Parquet thrift decoding would be if/when we extended the APIs to skip parsing the portions that are not needed for query, specifically various statistics from the parquet footer metadata (aka column stats and encoding stats)

I do not intend to propose merging this (ever)

## Changes:
Comment out decoding of statistics in metadata, to mimic the effect of actually implementing
- https://github.com/apache/arrow-rs/issues/5855