### PR TITLE
perf: add optimized zip implementation for scalars

### DIFF
--- a/arrow-select/src/zip.rs
+++ b/arrow-select/src/zip.rs
@@ -149,7 +149,6 @@ fn zip_impl(
     falsy: &ArrayData,
     falsy_is_scalar: bool,
 ) -> Result<ArrayRef, ArrowError> {
-    let mask_buffer = maybe_prep_null_mask_filter(mask);
     let mut mutable = MutableArrayData::new(vec![truthy, falsy], false, truthy.len());
 
     // the SlicesIterator slices only the true values. So the gaps left by this iterator we need to
@@ -158,6 +157,7 @@ fn zip_impl(
     // keep track of how much is filled
     let mut filled = 0;
 
+    let mask_buffer = maybe_prep_null_mask_filter(mask);
     SlicesIterator::from(&mask_buffer).for_each(|(start, end)| {
         // the gap needs to be filled with falsy values
         if start > filled {
@@ -768,34 +768,6 @@ mod test {
     }
 
     #[test]
-    fn test_zip_kernel_primitive_scalar_with_boolean_array_mask_with_nulls_should_be_treated_as_false()
-     {
-        let scalar_truthy = Scalar::new(Int32Array::from_value(42, 1));
-        let scalar_falsy = Scalar::new(Int32Array::from_value(123, 1));
-
-        let mask = {
-            let booleans = BooleanBuffer::from(vec![true, true, false, true, false, false]);
-            let nulls = NullBuffer::from(vec![
-                true, true, true,
-                false, // null treated as false even though in the original mask it was true
-                true, true,
-            ]);
-            BooleanArray::new(booleans, Some(nulls))
-        };
-        let out = zip(&mask, &scalar_truthy, &scalar_falsy).unwrap();
-        let actual = out.as_any().downcast_ref::<Int32Array>().unwrap();
-        let expected = Int32Array::from(vec![
-            Some(42),
-            Some(42),
-            Some(123),
-            Some(123), // true in mask but null
-            Some(123),
-            Some(123),
-        ]);
-        assert_eq!(actual, &expected);
-    }
-
-    #[test]
     fn test_zip_kernel_primitive_scalar_none_1() {
         let scalar_truthy = Scalar::new(Int32Array::from_value(42, 1));
         let scalar_falsy = Scalar::new(Int32Array::new_null(1));
@@ -828,6 +800,84 @@ mod test {
         let out = zip(&mask, &scalar_truthy, &scalar_falsy).unwrap();
         let actual = out.as_any().downcast_ref::<Int32Array>().unwrap();
         let expected = Int32Array::from(vec![None, None, None, None, None]);
+        assert_eq!(actual, &expected);
+    }
+
+    #[test]
+    fn test_zip_primitive_array_with_nulls_is_mask_should_be_treated_as_false() {
+        let truthy = Int32Array::from_iter_values(vec![1, 2, 3, 4, 5, 6]);
+        let falsy = Int32Array::from_iter_values(vec![7, 8, 9, 10, 11, 12]);
+
+        let mask = {
+            let booleans = BooleanBuffer::from(vec![true, true, false, true, false, false]);
+            let nulls = NullBuffer::from(vec![
+                true, true, true,
+                false, // null treated as false even though in the original mask it was true
+                true, true,
+            ]);
+            BooleanArray::new(booleans, Some(nulls))
+        };
+        let out = zip(&mask, &truthy, &falsy).unwrap();
+        let actual = out.as_any().downcast_ref::<Int32Array>().unwrap();
+        let expected = Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(9),
+            Some(10), // true in mask but null
+            Some(11),
+            Some(12),
+        ]);
+        assert_eq!(actual, &expected);
+    }
+
+    #[test]
+    fn test_zip_kernel_primitive_scalar_with_boolean_array_mask_with_nulls_should_be_treated_as_false()
+     {
+        let scalar_truthy = Scalar::new(Int32Array::from_value(42, 1));
+        let scalar_falsy = Scalar::new(Int32Array::from_value(123, 1));
+
+        let mask = {
+            let booleans = BooleanBuffer::from(vec![true, true, false, true, false, false]);
+            let nulls = NullBuffer::from(vec![
+                true, true, true,
+                false, // null treated as false even though in the original mask it was true
+                true, true,
+            ]);
+            BooleanArray::new(booleans, Some(nulls))
+        };
+        let out = zip(&mask, &scalar_truthy, &scalar_falsy).unwrap();
+        let actual = out.as_any().downcast_ref::<Int32Array>().unwrap();
+        let expected = Int32Array::from(vec![
+            Some(42),
+            Some(42),
+            Some(123),
+            Some(123), // true in mask but null
+            Some(123),
+            Some(123),
+        ]);
+        assert_eq!(actual, &expected);
+    }
+
+    #[test]
+    fn test_zip_string_array_with_nulls_is_mask_should_be_treated_as_false() {
+        let truthy = StringArray::from_iter_values(vec!["1", "2", "3", "4", "5", "6"]);
+        let falsy = StringArray::from_iter_values(vec!["7", "8", "9", "10", "11", "12"]);
+
+        let mask = {
+            let booleans = BooleanBuffer::from(vec![true, true, false, true, false, false]);
+            let nulls = NullBuffer::from(vec![
+                true, true, true,
+                false, // null treated as false even though in the original mask it was true
+                true, true,
+            ]);
+            BooleanArray::new(booleans, Some(nulls))
+        };
+        let out = zip(&mask, &truthy, &falsy).unwrap();
+        let actual = out.as_string::<i32>();
+        let expected = StringArray::from_iter_values(vec![
+            "1", "2", "9", "10", // true in mask but null
+            "11", "12",
+        ]);
         assert_eq!(actual, &expected);
     }
 


### PR DESCRIPTION
Waiting for the PRs below to be merged first:
- [x] https://github.com/apache/arrow-rs/pull/8654 - zip benchmarks

**This PR include the following other PRs (unless merged)** to make the review easier, so please make sure to review them first
- [x] https://github.com/apache/arrow-rs/pull/8658 - extracted from this
- [x] https://github.com/apache/arrow-rs/pull/8656 - extracted from this


# Which issue does this PR close?

N/A

# Rationale for this change

Making zip really fast for scalars

This is useful for `IF <expr> THEN <literal> ELSE <literal> END`

# What changes are included in this PR?

Created couple of implementation for zipping scalar, for primitive, bytes and fallback

# Are these changes tested?

existing tests

# Are there any user-facing changes?

new struct `ScalarZipper`

TODO:
- [x] Need to add comments if missing
- [x] Add tests for decimal and timestamp to make sure the type is kept