### PR TITLE
feat: add `new_repeated` to `ByteArray`

### DIFF
--- a/arrow-array/src/array/byte_array.rs
+++ b/arrow-array/src/array/byte_array.rs
@@ -688,4 +688,28 @@ mod tests {
         assert_eq!(arr.value(0), "world");
         assert_eq!(arr.value(1), "world");
     }
+
+    #[test]
+    #[should_panic(expected = "usize overflow")]
+    fn create_repeated_usize_overflow_1() {
+        let _arr = BinaryArray::new_repeated(b"hello", (usize::MAX / "hello".len()) + 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "usize overflow")]
+    fn create_repeated_usize_overflow_2() {
+        let _arr = BinaryArray::new_repeated(b"hello", usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "offset overflow")]
+    fn create_repeated_i32_offset_overflow_1() {
+        let _arr = BinaryArray::new_repeated(b"hello", usize::MAX / "hello".len());
+    }
+
+    #[test]
+    #[should_panic(expected = "offset overflow")]
+    fn create_repeated_i32_offset_overflow_2() {
+        let _arr = BinaryArray::new_repeated(b"hello", ((i32::MAX as usize) / "hello".len()) + 1);
+    }
 }


### PR DESCRIPTION

**This PR include the following PRs changes** please make sure to review them first
- [x] #8658 
- [x] #8656 

# Which issue does this PR close?

N/A

# Rationale for this change

This will make scalar to array in DataFusion faster

# What changes are included in this PR?

Include the changes of:
- #8658 
- #8656 

# Are these changes tested?

yes

# Are there any user-facing changes?

yes