### PR TITLE
chore: update `OffsetBuffer::from_lengths(std::iter::repeat_n(<val>, <repeat>));` with `OffsetBuffer::from_repeated_length(<val>, <repeat>);`

### DIFF
--- a/arrow-cast/src/cast/list.rs
+++ b/arrow-cast/src/cast/list.rs
@@ -24,7 +24,7 @@ pub(crate) fn cast_values_to_list<O: OffsetSizeTrait>(
     cast_options: &CastOptions,
 ) -> Result<ArrayRef, ArrowError> {
     let values = cast_with_options(array, to.data_type(), cast_options)?;
-    let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(1, values.len()));
+    let offsets = OffsetBuffer::from_repeated_length(1, values.len());
     let list = GenericListArray::<O>::try_new(to.clone(), offsets, values, None)?;
     Ok(Arc::new(list))
 }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2381,7 +2381,7 @@ fn cast_numeric_to_binary<FROM: ArrowPrimitiveType, O: OffsetSizeTrait>(
 ) -> Result<ArrayRef, ArrowError> {
     let array = array.as_primitive::<FROM>();
     let size = std::mem::size_of::<FROM::Native>();
-    let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(size, array.len()));
+    let offsets = OffsetBuffer::from_repeated_length(size, array.len());
     Ok(Arc::new(GenericBinaryArray::<O>::try_new(
         offsets,
         array.values().inner().clone(),


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Use the dedicated faster function for creating offset with the same length

# What changes are included in this PR?

replace
```rust
OffsetBuffer::from_lengths(std::iter::repeat_n(<val>, <repeat>));
```

with
```rust
OffsetBuffer::from_repeated_length(<val>, <repeat>);
```

# Are these changes tested?

Existing tests

# Are there any user-facing changes?

Nope

----

Related to:
- #8656 