### PR TITLE
[Variant] Preserve `Field` throughout Variant shredding flow

### DIFF
--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -90,10 +90,11 @@ pub fn shred_variant(array: &VariantArray, as_type: &DataType) -> Result<Variant
         }
     }
     let (value, typed_value, nulls) = builder.finish()?;
+
     Ok(VariantArray::from_parts(
         array.metadata_field().clone(),
         Some(value),
-        Some(typed_value),
+        Some(typed_value.into()),
         nulls,
     ))
 }
@@ -334,8 +335,8 @@ impl<'a> VariantToShreddedObjectVariantRowBuilder<'a> {
         for (field_name, typed_value_builder) in self.typed_value_builders {
             let (value, typed_value, nulls) = typed_value_builder.finish()?;
             let array =
-                ShreddedVariantFieldArray::from_parts(Some(value), Some(typed_value), nulls);
-            builder = builder.with_field(field_name, ArrayRef::from(array), false);
+                ShreddedVariantFieldArray::from_parts(Some(value), Some(typed_value.into()), nulls);
+            builder = builder.with_column_name(field_name, ArrayRef::from(array), false);
         }
         if let Some(nulls) = self.typed_value_nulls.finish() {
             builder = builder.with_nulls(nulls);
@@ -368,7 +369,7 @@ mod tests {
         let typed_value = Arc::new(Int64Array::from(vec![42])) as ArrayRef;
 
         let shredded_array =
-            VariantArray::from_parts(metadata, Some(value), Some(typed_value), None);
+            VariantArray::from_parts(metadata, Some(value), Some(typed_value.into()), None);
 
         let result = shred_variant(&shredded_array, &DataType::Int64);
         assert!(matches!(
@@ -443,6 +444,7 @@ mod tests {
         let uuids = variant_array
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<FixedSizeBinaryArray>()
             .unwrap();
@@ -483,6 +485,7 @@ mod tests {
         let typed_value_field = result
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -542,6 +545,7 @@ mod tests {
         let typed_value_int32 = result_int32
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<arrow::array::Int32Array>()
             .unwrap();
@@ -554,6 +558,7 @@ mod tests {
         let typed_value_float64 = result_float64
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
@@ -687,6 +692,7 @@ mod tests {
         let typed_value = result
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<arrow::array::StructArray>()
             .unwrap();
@@ -707,6 +713,7 @@ mod tests {
         let score_typed_value = score_field
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
@@ -719,6 +726,7 @@ mod tests {
         let age_typed_value = age_field
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -1079,6 +1087,7 @@ mod tests {
         let typed_value = result
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<arrow::array::StructArray>()
             .unwrap();
@@ -1099,6 +1108,7 @@ mod tests {
         let id_typed_value = id_field
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<FixedSizeBinaryArray>()
             .unwrap();
@@ -1111,6 +1121,7 @@ mod tests {
         let session_id_typed_value = session_id_field
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<FixedSizeBinaryArray>()
             .unwrap();
@@ -1227,6 +1238,7 @@ mod tests {
         let typed_value_field = result
             .typed_value_field()
             .unwrap()
+            .inner()
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/issues/8420
- Related to https://github.com/apache/arrow-rs/issues/8665

# Rationale for this change

This PR preserves the `typed_value`'s `Field` metadata. This way, we can check for extension types. 
