### PR TITLE
perf: zero-copy path in `RowConverter::from_binary`

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -2479,6 +2479,19 @@ mod tests {
     }
 
     #[test]
+    fn test_from_binary_shared_buffer() {
+        let converter = RowConverter::new(vec![SortField::new(DataType::Binary)]).unwrap();
+        let array = Arc::new(BinaryArray::from_iter_values([&[0xFF]])) as _;
+        let rows = converter.convert_columns(&[array]).unwrap();
+        let binary_rows = rows.try_into_binary().expect("known-small rows");
+        let _binary_rows_shared_buffer = binary_rows.clone();
+
+        let parsed = converter.from_binary(binary_rows);
+
+        converter.convert_rows(parsed.iter()).unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "Encountered non UTF-8 data")]
     fn test_invalid_utf8() {
         let converter = RowConverter::new(vec![SortField::new(DataType::Binary)]).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8685.

# What changes are included in this PR?

In the implementation of `RowConverter::from_binary`, the `BinaryArray` is broken into parts and an attempt is made to convert the data buffer into `Vec` at no copying cost with `Buffer::into_vec`. Only if this fails, the data is copied out for a newly allocated `Vec`.

# Are these changes tested?

Passes existing tests using `RowConverter::from_binary`, which all convert a non-shared buffer taking advantage of the optimization.
Another test is added to cover the copying path.

# Are there any user-facing changes?

No