### PR TITLE
Fix byte_range to not panic on parquet

### DIFF
--- a/parquet/examples/read_with_rowgroup.rs
+++ b/parquet/examples/read_with_rowgroup.rs
@@ -165,7 +165,7 @@ impl InMemoryRowGroup {
         let mut vs = std::mem::take(&mut self.column_chunks);
         for (leaf_idx, meta) in self.metadata.columns().iter().enumerate() {
             if self.mask.leaf_included(leaf_idx) {
-                let (start, len) = meta.byte_range();
+                let (start, len) = meta.byte_range()?;
                 let data = reader.get_bytes(start..(start + len)).await?;
 
                 vs[leaf_idx] = Some(Arc::new(ColumnChunkData {

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1018,17 +1018,18 @@ impl ColumnChunkMetaData {
     }
 
     /// Returns the offset and length in bytes of the column chunk within the file
-    pub fn byte_range(&self) -> (u64, u64) {
+    pub fn byte_range(&self) -> Result<(u64, u64)> {
         let col_start = match self.dictionary_page_offset() {
             Some(dictionary_page_offset) => dictionary_page_offset,
             None => self.data_page_offset(),
         };
         let col_len = self.compressed_size();
-        assert!(
-            col_start >= 0 && col_len >= 0,
-            "column start and length should not be negative"
-        );
-        (col_start as u64, col_len as u64)
+        if col_start < 0 || col_len < 0 {
+            return Err(general_err!(
+                "column start and length should not be negative"
+            ));
+        }
+        Ok((col_start as u64, col_len as u64))
     }
 
     /// Returns statistics that are set for this column chunk,

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -581,7 +581,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
         props: ReaderPropertiesPtr,
     ) -> Result<Self> {
         let decompressor = create_codec(meta.compression(), props.codec_options())?;
-        let (start, len) = meta.byte_range();
+        let (start, len) = meta.byte_range()?;
 
         let state = match page_locations {
             Some(locations) => {

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -291,7 +291,7 @@ impl TestRowGroups {
                         let dictionary_page_location = col_meta.dictionary_page_offset();
 
                         // We can find the byte range of the entire column chunk
-                        let (start_offset, length) = col_meta.byte_range();
+                        let (start_offset, length) = col_meta.byte_range().unwrap();
                         let start_offset = start_offset as usize;
                         let end_offset = start_offset + length as usize;
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7806 

# Rationale for this change

The `byte_range()` method on `ColumnChunkMetaData` previously panicked if the column start or length were negative. This is undesirable in a library, as it can lead to unrecoverable errors in consumer applications.

This change modifies `byte_range()` to return a `Result<(u64, u64)>` instead, allowing callers to handle invalid byte ranges gracefully.

# What changes are included in this PR?

- The `byte_range()` method in `parquet/src/file/metadata/mod.rs` now returns a `Result`.
- Call sites of `byte_range()` have been updated to handle the `Result` using the `?` operator or `unwrap()` in tests. This affects:
  - `parquet/examples/read_with_rowgroup.rs`
  - `parquet/src/arrow/async_reader/mod.rs`
  - `parquet/src/file/serialized_reader.rs`

# Are these changes tested?

The changes are covered by existing tests. The modifications in the test files (`parquet/src/arrow/async_reader/mod.rs`) now use `unwrap()` on the `byte_range()` call, which maintains the existing test behavior of panicking on error.

# Are there any user-facing changes?

Yes, the signature of `parquet::file::metadata::ColumnChunkMetaData::byte_range()` has changed from `-> (u64, u64)` to `-> Result<(u64, u64)>`. This is a breaking change for users who call this method directly.
