### PR TITLE
check bit width to avoid panic in DeltaBitPackDecoder

### DIFF
--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -2137,16 +2137,20 @@ mod tests {
         let mut read_buffer = vec![0; 32];
         let err = decoder.get(&mut read_buffer).unwrap_err();
         assert!(
-            err.to_string().contains("Invalid delta bit width 33 which is larger than expected 32"),
-            "{}", err
+            err.to_string()
+                .contains("Invalid delta bit width 33 which is larger than expected 32"),
+            "{}",
+            err
         );
 
         let mut decoder = DeltaBitPackDecoder::<Int32Type>::new();
         decoder.set_data(corrupted_buffer, 32).unwrap();
         let err = decoder.skip(32).unwrap_err();
         assert!(
-            err.to_string().contains("Invalid delta bit width 33 which is larger than expected 32"),
-            "{}", err
+            err.to_string()
+                .contains("Invalid delta bit width 33 which is larger than expected 32"),
+            "{}",
+            err
         );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Part of #7806 
# Rationale for this change

The `DeltaBitPackDecoder` can panic if it encounters a bit width in the encoded data that is larger than the bit width of the data type being decoded. 

