### PR TITLE
Fix: ViewType gc on huge batch would produce bad output

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -541,7 +541,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
                 }
             }
 
-            let mut groups = Vec::with_capacity(total_large / (i32::MAX as usize) + 1);
+            let mut groups = Vec::new();
             let mut current_length = 0;
             let mut current_elements = 0;
 
@@ -589,7 +589,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
             (views_buf, data_blocks)
         };
 
-        // 5) Wrap up buffers
+        // 5) Wrap up views buffer
         let views_scalar = ScalarBuffer::from(views_buf);
 
         // SAFETY: views_scalar, data_blocks, and nulls are correctly aligned and sized


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8681.

# Rationale for this change

Previously, `gc()` will produce a single buffer. However, for buffer size greater than 2GiB, it would be buggy, since buffer-offset it's a 4-byte signed integer.

# What changes are included in this PR?

Add a GcCopyGroup type, and do gc for it.

# Are these changes tested?

Yes

# Are there any user-facing changes?

gc would produce more buffers
