### PR TITLE
Update `arrow-avro` `README.md` version to 57

### DIFF
--- a/arrow-avro/README.md
+++ b/arrow-avro/README.md
@@ -51,7 +51,7 @@ Disable defaults and pick only what you need (see **Feature Flags**):
 
 ```toml
 [dependencies]
-arrow-avro = { version = "57", default-features = false, features = ["deflate", "snappy"] }
+arrow-avro = { version = "57.0.0", default-features = false, features = ["deflate", "snappy"] }
 ```
 
 ---


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8691

# Rationale for this change

The `README.md` file in `arrow-avro` instructs users to install version 56. This is invalid and should be changed to version 57.

# What changes are included in this PR?

Updated the `README.md` file to reference version 57.

# Are these changes tested?

N/A since this a small `README.md` file change.

# Are there any user-facing changes?

The `README.md` file in `arrow-avro` now instructs users to install version 57.
