### PR TITLE
[Minor]: Document visibility for enums produced by Thrift macros

### DIFF
--- a/parquet/THRIFT.md
+++ b/parquet/THRIFT.md
@@ -57,7 +57,7 @@ The `thrift_enum` macro can be used in this instance.
 
 ```rust
 thrift_enum!(
-    enum Type {
+enum Type {
   BOOLEAN = 0;
   INT32 = 1;
   INT64 = 2;
@@ -84,6 +84,8 @@ pub enum Type {
   FIXED_LEN_BYTE_ARRAY,
 }
 ```
+
+All Rust `enum`s produced with this macro will have `pub` visibility.
 
 ### Unions
 
@@ -174,6 +176,9 @@ pub enum ColumnCryptoMetaData {
     ENCRYPTION_WITH_COLUMN_KEY(EncryptionWithColumnKey),
 }
 ```
+
+All Rust `enum`s produced with either macro will have `pub` visibility. `thrift_union` also allows
+for lifetime annotations, but this capability is not currently utilized.
 
 ### Structs
 

--- a/parquet/src/parquet_macros.rs
+++ b/parquet/src/parquet_macros.rs
@@ -36,7 +36,9 @@
 #[allow(clippy::crate_in_macro_def)]
 /// Macro used to generate rust enums from a Thrift `enum` definition.
 ///
-/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+/// Note:
+///  - All enums generated with this macro will have `pub` visibility.
+///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 macro_rules! thrift_enum {
     ($(#[$($def_attrs:tt)*])* enum $identifier:ident { $($(#[$($field_attrs:tt)*])* $field_name:ident = $field_value:literal;)* }) => {
         $(#[$($def_attrs)*])*
@@ -91,7 +93,9 @@ macro_rules! thrift_enum {
 ///
 /// The resulting Rust enum will have all unit variants.
 ///
-/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+/// Note:
+///  - All enums generated with this macro will have `pub` visibility.
+///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
@@ -162,9 +166,10 @@ macro_rules! thrift_union_all_empty {
 /// non-empty type, the typename must be contained within parens (e.g. `1: MyType Var1;` becomes
 /// `1: (MyType) Var1;`).
 ///
-/// This macro allows for specifying lifetime annotations for the resulting `enum` and its fields.
-///
-/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+/// Note:
+///  - All enums generated with this macro will have `pub` visibility.
+///  - This macro allows for specifying lifetime annotations for the resulting `enum` and its fields.
+///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
@@ -228,9 +233,11 @@ macro_rules! thrift_union {
 
 /// Macro used to generate Rust structs from a Thrift `struct` definition.
 ///
-/// This macro allows for specifying lifetime annotations for the resulting `struct` and its fields.
-///
-/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+/// Note:
+///  - This macro allows for specifying the visibility of the resulting `struct` and its fields.
+///    + The `struct` and all fields will have the same visibility.
+///  - This macro allows for specifying lifetime annotations for the resulting `struct` and its fields.
+///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! thrift_struct {


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

It is not obvious that the thrift macros produce public enums only (e.g. see https://github.com/apache/arrow-rs/pull/8680#discussion_r2460381795). This should be made clear in the documentation.

# What changes are included in this PR?

Add said clarification.

# Are these changes tested?

Documentation only, so no tests required.

# Are there any user-facing changes?

No, only changes to private documentation
