### PR TITLE
feat: Parquet-layout add Index and Footer info

### DIFF
--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -561,6 +561,12 @@ impl ParquetMetaDataReader {
         self.decode_footer_metadata(bytes, file_size, footer)
     }
 
+    /// Size of the serialized thrift metadata plus the 8 byte footer. Only set if
+    /// `self.parse_metadata` is called.
+    pub fn metadata_size(&self) -> Option<usize> {
+        self.metadata_size
+    }
+
     /// Return the number of bytes to read in the initial pass. If `prefetch_size` has
     /// been provided, then return that value if it is larger than the size of the Parquet
     /// file footer (8 bytes). Otherwise returns `8`.


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8682 .

# Rationale for this change

Add Index and Footer info in parquet-layout

# What changes are included in this PR?

1. Add Index and Footer info in parquet-layout
2. Expose metadata_size

# Are these changes tested?

It was testing by hand.

# Are there any user-facing changes?

No
