### PR TITLE
[Variant] Fix the index of an item in VariantArray in a unit test

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1506,7 +1506,7 @@ mod test {
         assert!(!variant_array.is_null(1));
         assert_eq!(variant_array.value(1), Variant::BooleanFalse);
 
-        assert!(!variant_array.is_null(3));
+        assert!(!variant_array.is_null(2));
         assert_eq!(
             variant_array.value(2),
             Variant::ShortString(ShortString::try_new("norm").unwrap())


### PR DESCRIPTION

# Which issue does this PR close?

Related-to: #8625 

# Rationale for this change

https://github.com/apache/arrow-rs/commit/63fe99a826c6861d9398850671ab88f1571a092d introduced the new unit test.
I believe the index=3 is a typo. It should be =2.

# What changes are included in this PR?

Fixed the array index.

# Are these changes tested?

The fix is in a unit test.


# Are there any user-facing changes?

No.