### PR TITLE
docs: Update Parquet readme implementation status

### DIFF
--- a/parquet/README.md
+++ b/parquet/README.md
@@ -73,10 +73,10 @@ The `parquet` crate provides the following features which may be enabled in your
 
 ## Parquet Feature Status
 
-Please see the [Implementation Status Page] on the [Apache Parquet] website for 
+Please see the [Implementation Status Page] on the [Apache Parquet] website for
 information on the status of this implementation.
 
-[Implementation Status Page]: https://parquet.apache.org/docs/file-format/implementationstatus/
+[implementation status page]: https://parquet.apache.org/docs/file-format/implementationstatus/
 
 ## License
 


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change

We now have a nice centralized location for parquet implementation status on the Apache Parquet site, so let's direct users there rather than maintain a separate copy here
- https://parquet.apache.org/docs/file-format/implementationstatus/

# What changes are included in this PR?

1. Remove existing implementation status
2. Add link to the parquet site

# Are these changes tested?

We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
