### PR TITLE
Use partition's BooleanBuffer in cast_to_run_end_encoded

### DIFF
--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -67,6 +67,11 @@ impl Partitions {
     pub fn is_empty(&self) -> bool {
         self.0.is_none()
     }
+
+    /// Returns the inner [`BooleanBuffer`]
+    pub fn into_inner(self) -> BooleanBuffer {
+        self.0.expect("Partitions is empty")
+    }
 }
 
 /// Given a list of lexicographically sorted columns, computes the [`Partitions`],


### PR DESCRIPTION
An attempt at improving performance of `cast_to_run_end_encoded` (see #8707) by exposing `Partition`'s inner BooleanBuffer and passing it to `filter`.

# Rationale for this change
Attempt at improving performance (need to see benchmark results to see if that's the case).

# What changes are included in this PR?
Add `partitions.into_inner`.

# Are these changes tested?
Covered by existing tests.

# Are there any user-facing changes?
No