### PR TITLE
Remove link to internal `arrow-integration-test` crate from main `arrow` crate

### DIFF
--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -330,7 +330,6 @@
 //! Some functionality is also distributed independently of this crate:
 //!
 //! * [`arrow-flight`] - support for [Arrow Flight RPC]
-//! * [`arrow-integration-test`] - support for [Arrow JSON Test Format]
 //! * [`parquet`](https://docs.rs/parquet/latest/parquet/) - support for [Apache Parquet]
 //!
 //! # Safety and Security
@@ -358,7 +357,6 @@
 //! [`Buffer`]: buffer::Buffer
 //! [`RecordBatch`]: record_batch::RecordBatch
 //! [`arrow-flight`]: https://docs.rs/arrow-flight/latest/arrow_flight/
-//! [`arrow-integration-test`]: https://docs.rs/arrow-integration-test/latest/arrow_integration_test/
 //! [`parquet`]: https://docs.rs/parquet/latest/parquet/
 //! [Arrow Flight RPC]: https://arrow.apache.org/docs/format/Flight.html
 //! [Arrow JSON Test Format]: https://github.com/apache/arrow/blob/master/docs/source/format/Integration.rst#json-test-data-format


### PR DESCRIPTION
# Which issue does this PR close?
- Closes https://github.com/apache/arrow-rs/issues/8739

# Rationale for this change

According to https://github.com/apache/arrow-rs/issues/8684#issuecomment-3433193158, the crate is only intended for use within the Arrow project itself. So we should not link to it from the user-facing docs.

# What changes are included in this PR?

remove the link from the list

# Are these changes tested?

doc-only change 

# Are there any user-facing changes?

yes, we no longer recommend an incomplete, internal crate to users