### PR TITLE
PROTOTYPE: manually unroll vlq decoder loop

### DIFF
--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -337,7 +337,6 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
             return Ok(in_progress);
         }
 
-
         // todo: it shouldn't  be possible to read more than 10 bytes
         // TODO real error
         panic!("Thrift VLQ encoding should not be more than 10 bytes long");


### PR DESCRIPTION
# Which issue does this PR close?


- Follow on to https://github.com/apache/arrow-rs/pull/8742 from @etseidl 

# Rationale for this change

Per https://github.com/apache/arrow-rs/pull/8742#pullrequestreview-3400812414 let's get crazy and see if manually unrolling the vlq decoder (hot loop) will help performance

# What changes are included in this PR?

Manually unroll the loop

# Are these changes tested?

CI passes . I am running benchmarks

# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
