### PR TITLE
feat: Ensure consistent metadata display for data types

### DIFF
--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -190,7 +190,7 @@ impl fmt::Display for FormatMetadata<'_> {
             let mut entries: Vec<(&String, &String)> = metadata.iter().collect();
             entries.sort_by(|a, b| a.0.cmp(b.0));
             write!(f, ", metadata: ")?;
-            f.debug_map().entries(entries.into_iter()).finish()
+            f.debug_map().entries(entries).finish()
         }
     }
 }


### PR DESCRIPTION
Where a datatype has associated metadata format that metadata consistently in lexical order by key.

# Which issue does this PR close?

- closes https://github.com/apache/arrow-rs/issues/8761
- helps with #8351.

# Rationale for this change


# What changes are included in this PR?

A consistent formatter for the metadata hash tables embedded in DataType.

# Are these changes tested?

Yes, I have enhanced an existing test that would have shown the issue.

# Are there any user-facing changes?


No
