### PR TITLE
[Parquet] Minor: Update comments in page decompressor

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -396,7 +396,7 @@ pub(crate) fn decode_page(
             let decompressed_size = uncompressed_page_size - offset;
             let mut decompressed = Vec::with_capacity(uncompressed_page_size);
             decompressed.extend_from_slice(&buffer[..offset]);
-            // decompressed size of zero corresponds to a page with only null values
+            // decompressed size of zero corresponds to a page with no non-null values
             // see https://github.com/apache/parquet-format/blob/master/README.md#data-pages
             if decompressed_size > 0 {
                 let compressed = &buffer[offset..];


### PR DESCRIPTION
# Which issue does this PR close?

- follow on to https://github.com/apache/arrow-rs/pull/8756

# Rationale for this change

@etseidl  comments: https://github.com/apache/arrow-rs/pull/8756#discussion_r2481506257

> Not relevant to this PR, but I think this TODO has largely been addressed by https://github.com/apache/arrow-rs/pull/8376 which enabled skipping the decoding of the page statistics.

While I was in here, I also wanted to capture the learning based on @mapleFU 's comment https://github.com/apache/arrow-rs/pull/8756#discussion_r2482281406

> The code looks good to me but the I don't know if the comment "not compressed" can be replaced, if decompress_buffer is called and decompressed_size == 0 , seems that it generally means something like "this page only have levels, but not have non-null values"? ( Point me out if I'm wrong)

# What changes are included in this PR?

Include some comments
# Are these changes tested?

No (there are no code changes)

# Are there any user-facing changes?

No, this is internal comments only. No code / behavior changes