### PR TITLE
 feat: parse `DataType::Union`, `DataType::Map`, `DataType::RunEndEncoded`

### DIFF
--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -139,8 +139,9 @@ impl fmt::Display for DataType {
                 Ok(())
             }
             Self::Union(union_fields, union_mode) => {
-                write!(f, "Union({union_mode:?}, ")?;
+                write!(f, "Union({union_mode:?}")?;
                 if !union_fields.is_empty() {
+                    write!(f, ", ")?;
                     let fields_str = union_fields
                         .iter()
                         .map(|v| {

--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -450,16 +450,15 @@ impl<'a> Parser<'a> {
         let mut type_ids = vec![];
         let mut fields = vec![];
         loop {
-            let (type_id, field) = match self.next_token()? {
-                Token::RParen => break,
-                Token::Comma => self.parse_union_field()?,
-                tok => {
-                    return Err(make_error(
-                        self.val,
-                        &format!("Expected a comma for a union field; got {tok:?}"),
-                    ));
-                }
-            };
+            if self
+                .tokenizer
+                .next_if(|next| matches!(next, Ok(Token::RParen)))
+                .is_some()
+            {
+                break;
+            }
+            self.expect_token(Token::Comma)?;
+            let (type_id, field) = self.parse_union_field()?;
             type_ids.push(type_id);
             fields.push(field);
         }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8648

# Rationale for this change

Parse `DataType::Union`, `DataType::Map` and `DataType::RunEndEncoded`.

# What changes are included in this PR?

- Add `parse_union`, `parse_map`, and `parse_run_encoded`.
- Refactor `parse_list_field_name` -> `parse_list_field` to remove duplicated codes.

# Are these changes tested?

Yes, new test added.

# Are there any user-facing changes?

Yes. Relate to #8351