### PR TITLE
Update docs for zero copy conversion of ScalarBuffer

### DIFF
--- a/arrow-buffer/src/buffer/scalar.rs
+++ b/arrow-buffer/src/buffer/scalar.rs
@@ -34,6 +34,8 @@ use std::ops::Deref;
 /// See [`Buffer`] for more low-level memory management details.
 ///
 /// # Example: Convert to/from Vec (without copies)
+///
+/// (See [`Buffer::from_vec`] and [`Buffer::into_vec`] for a lower level API)
 /// ```
 /// # use arrow_buffer::ScalarBuffer;
 /// // Zero-copy conversion from Vec
@@ -42,6 +44,7 @@ use std::ops::Deref;
 /// // convert the buffer back to Vec without copy assuming:
 /// // 1. the inner buffer is not sliced
 /// // 2. the inner buffer uses standard allocation
+/// // 3. there are no other references to the inner buffer
 /// let vec: Vec<i32> = buffer.into();
 /// assert_eq!(&vec, &[1, 2, 3]);
 /// ```


### PR DESCRIPTION
# Which issue does this PR close?

- Similar to https://github.com/apache/arrow-rs/pull/8771

# Rationale for this change

As people write more arrow kernels, let's make it easier to understand how to go back/forth to Vec without copying

# What changes are included in this PR?

Add some additional information and examples about converting ScalarBuffer back/forth to Vec

# Are these changes tested?

Yes by CI

# Are there any user-facing changes?

Docs only. No functional change