### PR TITLE
perf: override `ArrayIter` default impl for `nth`, `nth_back`, `last` and `count`

### DIFF
--- a/arrow-array/src/iterator.rs
+++ b/arrow-array/src/iterator.rs
@@ -103,6 +103,7 @@ impl<T: ArrayAccessor> Iterator for ArrayIter<T> {
         )
     }
 
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         // Check if we can advance to the desired offset
         match self.current.checked_add(n) {
@@ -121,10 +122,12 @@ impl<T: ArrayAccessor> Iterator for ArrayIter<T> {
         self.next()
     }
 
+    #[inline]
     fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
+    #[inline]
     fn count(self) -> usize
     where
         Self: Sized,
@@ -152,6 +155,7 @@ impl<T: ArrayAccessor> DoubleEndedIterator for ArrayIter<T> {
         }
     }
 
+    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         // Check if we advance to the one before the desired offset
         match self.current_end.checked_sub(n) {


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
The default implementations iterate over the iterator to get the value, while we can do that in constant time

# What changes are included in this PR?
override `nth`, `nth_back`, `last` and `count`

# Are these changes tested?
existing tests in this file that I added in previous pr

# Are there any user-facing changes?
Nope


-----

Extracted from the following PR as I probably close it as it is not faster locally in some cases:
- #8697