### PR TITLE
Remove unused `azure` feature of object_store dev-dependency

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -93,7 +93,7 @@ serde_json = { version = "1.0", features = ["std"], default-features = false }
 arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-object_store = { version = "0.12.0", default-features = false, features = ["azure", "fs"] }
+object_store = { version = "0.12.0", default-features = false, features = ["fs"] }
 sysinfo = { version = "0.37.1", default-features = false, features = ["system"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change

The development dependency enabled the `azure` feature of `object_store`, which pulls in several additional dependencies and increases compile times. It seems this feature is not actually used, the only reference to `azure` is in a doc test which is already marked as `no_run`.

# What changes are included in this PR?

Removes an unused dependency.

# Are these changes tested?

If it compiles in CI then this should be good to go.

# Are there any user-facing changes?

This should not be a breaking change since it is a dev-only dependency. The regular dependency without default features is kept.