### PR TITLE
Add `VariantPath::is_empty`

### DIFF
--- a/parquet-variant/src/path.rs
+++ b/parquet-variant/src/path.rs
@@ -87,6 +87,11 @@ impl<'a> VariantPath<'a> {
     pub fn push(&mut self, element: impl Into<VariantPathElement<'a>>) {
         self.0.push(element.into());
     }
+
+    /// Returns whether [`VariantPath`] has no path elements
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<'a> From<Vec<VariantPathElement<'a>>> for VariantPath<'a> {
@@ -180,5 +185,23 @@ impl<'a> From<&'a String> for VariantPathElement<'a> {
 impl<'a> From<usize> for VariantPathElement<'a> {
     fn from(index: usize) -> Self {
         VariantPathElement::index(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_variant_path_empty() {
+        let path = VariantPath::from_iter([]);
+        assert!(path.is_empty());
+    }
+
+    #[test]
+    fn test_variant_path_non_empty() {
+        let p = VariantPathElement::from("a");
+        let path = VariantPath::from_iter([p]);
+        assert!(!path.is_empty());
     }
 }


### PR DESCRIPTION
# Rationale for this change

This PR adds `VariantPath::is_empty` which checks whether `VariantPath` contains an empty list of `VariantPathElement`s. 

I found this API to be helpful when validating a `VariantPath`, since a `VariantPath` is only meaningful if it holds a nonempty list of `VariantPathElement`s
