### PR TITLE
WIP: special case bitwise ops when buffers are u64 aligned

### DIFF
--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -223,7 +223,8 @@ impl<'a> BitChunks<'a> {
     pub fn new(buffer: &'a [u8], offset: usize, len: usize) -> Self {
         assert!(
             ceil(offset + len, 8) <= buffer.len(),
-            "offset + len out of bounds"
+            "offset + len out of bounds. Buffer length in bits: {}, requested offset: {offset}, len: {len}",
+            buffer.len(),
         );
 
         let byte_offset = offset / 8;


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/8806
- Follow on to https://github.com/apache/arrow-rs/pull/8793
- Follow on to https://github.com/apache/arrow-rs/pull/8619
- related to https://github.com/apache/arrow-rs/issues/8561

# Rationale for this change

While messing around with other bitwise operations, I am pretty sure we can optimize these operations more

Let's try using aligned u64 operations when possible

# What changes are included in this PR?

Special case bitwise operations when the data is already aligned to u64 (a reasonably common special case)

# Are these changes tested?

Yes by CI 

# Are there any user-facing changes?

No just faster performance