### PR TITLE
Parquet-concat: supports page index and bloom filter

### DIFF
--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -333,7 +333,7 @@ impl Sbbf {
     }
 
     /// Read a new bloom filter from the given offset in the given reader.
-    pub(crate) fn read_from_column_chunk<R: ChunkReader>(
+    pub fn read_from_column_chunk<R: ChunkReader>(
         column_metadata: &ColumnChunkMetaData,
         reader: &R,
     ) -> Result<Option<Self>, ParquetError> {


### PR DESCRIPTION
# Which issue does this PR close?

Supports page index and bloom filter in parquet-concat

- Closes #8804 .

# Rationale for this change

Supports page index and bloom filter in parquet-concat

# What changes are included in this PR?

* Supports page index and bloom filter in parquet-concat
* Expose a Sbbf read api

# Are these changes tested?

Test by commands

# Are there any user-facing changes?

Might change parquet-concat behavior