### PR TITLE
remove T: ParquetValueType bound on ValueStatistics

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -1129,7 +1129,7 @@ mod tests {
     fn generic_statistics_handler<T: std::fmt::Display>(stats: ValueStatistics<T>) -> String {
         match stats.min_opt() {
             Some(s) => format!("min: {}", s),
-            None => format!("min: NA"),
+            None => "min: NA".to_string(),
         }
     }
 


### PR DESCRIPTION
The old bound was T: ParquetValueType which isn't public, so it was impossible to call the methods on ValueStatistics from a generic function in another crate, forcing the use of macros. Split out a few functions that require T: AsBytes into a separate impl.

# Which issue does this PR close?
Closes #8823 

# Rationale for this change
See issue for more details

# Are these changes tested?
Added a test that call the `ValueStatistics::min_opt` method from a generic function without a bound to a private trait.

# Are there any user-facing changes?
The methods were already public and documented, they just couldn't actually be called from external crates.
