### PR TITLE
Allow reading of improperly constructed empty lists in Parquet metadata

### DIFF
--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -61,7 +61,7 @@ impl From<ThriftProtocolError> for ParquetError {
                 general_err!("Unexpected struct field type {}", value)
             }
             ThriftProtocolError::InvalidElementType(value) => {
-                general_err!("Unexpected list/set element type{}", value)
+                general_err!("Unexpected list/set element type {}", value)
             }
             ThriftProtocolError::FieldDeltaOverflow {
                 field_delta,
@@ -302,6 +302,14 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
     /// Read the [`ListIdentifier`] for a Thrift encoded list.
     fn read_list_begin(&mut self) -> ThriftProtocolResult<ListIdentifier> {
         let header = self.read_byte()?;
+        // some parquet writers will have an element_type of 0 for an empty list.
+        // account for that and return a bogus but valid element_type.
+        if header == 0 {
+            return Ok(ListIdentifier {
+                element_type: ElementType::Byte,
+                size: 0,
+            });
+        }
         let element_type = ElementType::try_from(header & 0x0f)?;
 
         let possible_element_count = (header & 0xF0) >> 4;
@@ -1088,5 +1096,14 @@ pub(crate) mod tests {
         test_roundtrip(TimeUnit::MILLIS);
         test_roundtrip(TimeUnit::MICROS);
         test_roundtrip(TimeUnit::NANOS);
+    }
+
+    #[test]
+    fn test_decode_empty_list() {
+        let data = vec![0u8; 1];
+        let mut prot = ThriftSliceInputProtocol::new(&data);
+        let header = prot.read_list_begin().expect("error reading list header");
+        assert_eq!(header.size, 0);
+        assert_eq!(header.element_type, ElementType::Byte);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8826.

# Rationale for this change

As reported in the issue, some writers will use an element type of 0 for an empty list. This is not thrift compact protocol spec compliant, but many readers (including this crate prior to 57.0.0) tolerate this.

# What changes are included in this PR?
Adds a special case to `read_list_begin` for a 0 length list with a type of 0.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No, internal change only
