### PR TITLE
Deprecate `set_bits` in favor of `apply_bitwise_binary_op`

### DIFF
--- a/arrow-buffer/src/util/bit_util.rs
+++ b/arrow-buffer/src/util/bit_util.rs
@@ -226,7 +226,7 @@ pub fn apply_bitwise_binary_op<F>(
             let right_byte_offset = right_offset_in_bits / 8;
 
             // Read the same amount of bits from the right buffer
-            let right_first_byte: u8 = crate::util::bit_util::read_up_to_byte_from_offset(
+            let right_first_byte: u8 = read_up_to_byte_from_offset(
                 &right.as_ref()[right_byte_offset..],
                 bits_to_next_byte,
                 // Right bit offset

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -86,8 +86,6 @@ unsafe extern "C" fn release_array(array: *mut FFI_ArrowArray) {
 }
 
 /// Aligns the provided `nulls` to the provided `data_offset`
-///
-/// This is a temporary measure until offset is removed from ArrayData (#1799)
 fn align_nulls(data_offset: usize, nulls: Option<&NullBuffer>) -> Option<Buffer> {
     let nulls = nulls?;
     if data_offset == nulls.offset() {


### PR DESCRIPTION
WIP: I am verifying this PR is faster via benchmarks and if so I will polish is up and mark it ready for review

# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/8806



# Rationale for this change


- Following the changes in https://github.com/apache/arrow-rs/pull/8619, it appears that `apply_bitwise_binary_op` is faster and more general than `set_bits`, so let's deprecate set_bits in favor of it.

This is part of a broader goal to consolidate the bitwise operations in DataFusion so that we can focus additional optimization energy on them (aka bithacks for the win)

`set_bits` was introduced by @kazuyukitanimura  in 
- #6288


# What changes are included in this PR?

- [ ] Deprecate `set_bits` with a note to use apply_bitwise_binary_op instead. 
- [ ] Update any internal uses of set_bits to use apply_bitwise_binary_op instead.
- [x] Update `set_bits` to use `apply_bitwise_binary_op` internally

# Are these changes tested?
Covered by existing tests

I will also performance test 
# Are there any user-facing changes?

If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
