### PR TITLE
Add support for `Union` types in `RowConverter`

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1891,12 +1891,8 @@ unsafe fn decode_column(
             let mut rows_by_field: Vec<Vec<(usize, &[u8])>> = vec![Vec::new(); converters.len()];
 
             for (idx, row) in rows.iter_mut().enumerate() {
-                let mut cursor = 0;
-
                 let type_id_byte = {
-                    let id = row[cursor];
-                    cursor += 1;
-
+                    let id = row[0];
                     if options.descending { !id } else { id }
                 };
 
@@ -1905,7 +1901,7 @@ unsafe fn decode_column(
 
                 let field_idx = type_id as usize;
 
-                let child_row = &row[cursor..];
+                let child_row = &row[1..];
                 rows_by_field[field_idx].push((idx, child_row));
 
                 *row = &row[row.len()..];


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8828

# Rationale for this change

This PR implements row format conversion for Union types (both sparse and dense modes) in the row kernel. Union types can now be encoded into the row format for sorting and comparison ops

It handles both sparse and dense union modes by encoding each row as a null sentinel byte, followed by the type id byte, and then the encoded child row data. During decoding, rows are grouped by their type id and routed to the appropriate child converter