### PR TITLE
docs: Add example for creating a `MutableBuffer` from `Buffer`

### DIFF
--- a/arrow-buffer/benches/mutable_buffer_repeat_slice.rs
+++ b/arrow-buffer/benches/mutable_buffer_repeat_slice.rs
@@ -47,9 +47,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
                         mutable_buffer.repeat_slice_n_times(slice_to_repeat, repeat_count);
 
-                        let buffer: Buffer = mutable_buffer.into();
-
-                        buffer
+                        Buffer::from(mutable_buffer)
                     })
                 },
             );
@@ -66,9 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             mutable_buffer.extend_from_slice(slice_to_repeat);
                         }
 
-                        let buffer: Buffer = mutable_buffer.into();
-
-                        buffer
+                        Buffer::from(mutable_buffer)
                     })
                 },
             );

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -377,7 +377,7 @@ impl Buffer {
     ///    }
     /// };
     /// mutable_buffer.push(5u8);
-    /// let buffer: Buffer = mutable_buffer.into();
+    /// let buffer = Buffer::from(mutable_buffer);
     /// assert_eq!(buffer.as_slice(), &[1u8, 2, 3, 4, 5])
     /// ```
     ///

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -72,7 +72,7 @@ use super::Buffer;
 ///    }
 /// };
 /// mutable_buffer.push(5u8);
-/// let buffer: Buffer = mutable_buffer.into();
+/// let buffer = Buffer::from(mutable_buffer);
 /// assert_eq!(buffer.as_slice(), &[1u8, 2, 3, 4, 5])
 /// ```
 #[derive(Debug)]


### PR DESCRIPTION
# Which issue does this PR close?

- Similar to https://github.com/apache/arrow-rs/pull/8852

# Rationale for this change

It my not be clear how to convert to a MutableBuffer, so let's add some doc examples

# What changes are included in this PR?

Add doc examples
# Are these changes tested?

Yes by CI

# Are there any user-facing changes?
More docs, no functional change
