### PR TITLE
#8806 Consolidate bitwise operations and make `nullif` respect ArrayData bitmap layout contract

### DIFF
--- a/arrow-arith/Cargo.toml
+++ b/arrow-arith/Cargo.toml
@@ -42,3 +42,6 @@ arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
 chrono = { workspace = true }
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }

--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -18,8 +18,7 @@
 use crate::bit_chunk_iterator::BitChunks;
 use crate::bit_iterator::{BitIndexIterator, BitIndexU32Iterator, BitIterator, BitSliceIterator};
 use crate::{
-    BooleanBufferBuilder, Buffer, MutableBuffer, bit_util, buffer_bin_and, buffer_bin_or,
-    buffer_bin_xor, buffer_unary_not,
+    BooleanBufferBuilder, Buffer, MutableBuffer, bit_util,
 };
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
@@ -224,7 +223,7 @@ impl Not for &BooleanBuffer {
 
     fn not(self) -> Self::Output {
         BooleanBuffer {
-            buffer: buffer_unary_not(&self.buffer, self.offset, self.len),
+            buffer: self.buffer.bitwise_unary(self.offset, self.len, |a| !a),
             offset: 0,
             len: self.len,
         }
@@ -237,7 +236,7 @@ impl BitAnd<&BooleanBuffer> for &BooleanBuffer {
     fn bitand(self, rhs: &BooleanBuffer) -> Self::Output {
         assert_eq!(self.len, rhs.len);
         BooleanBuffer {
-            buffer: buffer_bin_and(&self.buffer, self.offset, &rhs.buffer, rhs.offset, self.len),
+            buffer: self.buffer.bitwise_binary(&rhs.buffer, self.offset, rhs.offset, self.len, |a, b| a & b),
             offset: 0,
             len: self.len,
         }
@@ -250,7 +249,7 @@ impl BitOr<&BooleanBuffer> for &BooleanBuffer {
     fn bitor(self, rhs: &BooleanBuffer) -> Self::Output {
         assert_eq!(self.len, rhs.len);
         BooleanBuffer {
-            buffer: buffer_bin_or(&self.buffer, self.offset, &rhs.buffer, rhs.offset, self.len),
+            buffer: self.buffer.bitwise_binary(&rhs.buffer, self.offset, rhs.offset, self.len, |a, b| a | b),
             offset: 0,
             len: self.len,
         }
@@ -263,7 +262,7 @@ impl BitXor<&BooleanBuffer> for &BooleanBuffer {
     fn bitxor(self, rhs: &BooleanBuffer) -> Self::Output {
         assert_eq!(self.len, rhs.len);
         BooleanBuffer {
-            buffer: buffer_bin_xor(&self.buffer, self.offset, &rhs.buffer, rhs.offset, self.len),
+            buffer: self.buffer.bitwise_binary(&rhs.buffer, self.offset, rhs.offset, self.len, |a, b| a ^ b),
             offset: 0,
             len: self.len,
         }

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -23,7 +23,7 @@ use crate::alloc::{ALIGNMENT, Deallocation};
 use crate::{
     bytes::Bytes,
     native::{ArrowNativeType, ToByteSlice},
-    util::bit_util,
+    util::bit_util::{self, apply_bitwise_binary_op, apply_bitwise_unary_op},
 };
 
 #[cfg(feature = "pool")]
@@ -596,6 +596,40 @@ impl MutableBuffer {
     pub fn claim(&self, pool: &dyn MemoryPool) {
         *self.reservation.lock().unwrap() = Some(pool.reserve(self.capacity()));
     }
+
+    /// Apply a bitwise unary operation in place to this buffer.
+    ///
+    /// The operation is applied to `len` bits starting at `offset` bits.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - The bit offset to start the operation.
+    /// * `len` - The number of bits to process.
+    /// * `op` - The unary operation to apply.
+    pub fn bitwise_unary_inplace<F>(&mut self, offset: usize, len: usize, op: F)
+    where
+        F: Fn(u64) -> u64,
+    {
+        apply_bitwise_unary_op(self.as_slice_mut(), offset, len, op)
+    }
+
+    /// Apply a bitwise binary operation in place between this buffer and another.
+    ///
+    /// The operation is applied to `len` bits starting at `self_offset` in self and `other_offset` in other.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The other buffer.
+    /// * `self_offset` - The bit offset in self.
+    /// * `other_offset` - The bit offset in other.
+    /// * `len` - The number of bits to process.
+    /// * `op` - The binary operation to apply.
+    pub fn bitwise_binary_inplace<F>(&mut self, other: &Buffer, self_offset: usize, other_offset: usize, len: usize, op: F)
+    where
+        F: Fn(u64, u64) -> u64,
+    {
+        apply_bitwise_binary_op(self.as_slice_mut(), self_offset, other.as_slice(), other_offset, len, op)
+    }
 }
 
 /// Creates a non-null pointer with alignment of [`ALIGNMENT`]
@@ -931,6 +965,7 @@ impl<T: ArrowNativeType> std::iter::FromIterator<T> for MutableBuffer {
 
 #[cfg(test)]
 mod tests {
+    use rand::{Rng, SeedableRng};
     use super::*;
 
     #[test]
@@ -1381,5 +1416,180 @@ mod tests {
 
         let data_1000: Vec<i32> = (0..1000).collect();
         test_repeat_count(repeat_count, &data_1000);
+    }
+
+    #[test]
+    fn test_mutable_buffer_bitwise_inplace() {
+        let initial = vec![0b10101010u8, 0b01010101u8];
+        let other = Buffer::from(vec![0b11110000u8, 0b00001111u8]);
+
+        // Test in-place and vs allocating
+        let mut mutable = MutableBuffer::from(initial.clone());
+        mutable.bitwise_binary_inplace(&other, 0, 0, 16, |a, b| a & b);
+        let inplace_result = Buffer::from(mutable);
+
+        let allocating_result = Buffer::from(initial.clone()).bitwise_binary(&other, 0, 0, 16, |a, b| a & b);
+
+        assert_eq!(inplace_result, allocating_result);
+
+        // Test with offsets
+        let mut mutable = MutableBuffer::from(initial.clone());
+        mutable.bitwise_binary_inplace(&other, 1, 1, 7, |a, b| a | b);
+        let inplace_result = Buffer::from(mutable);
+
+        let allocating_result = Buffer::from(initial.clone()).bitwise_binary(&other, 1, 1, 7, |a, b| a | b);
+
+        // Extract the operated bits: bits 1 to 7 from inplace_result (all in byte 0)
+        let operated_value = ((inplace_result.as_slice()[0] >> 1) & 0x7F) as u8;
+        assert_eq!(operated_value, allocating_result.as_slice()[0]);
+
+        // Test unary in-place
+        let mut mutable = MutableBuffer::from(initial.clone());
+        mutable.bitwise_unary_inplace(0, 16, |a| !a);
+        let inplace_result = Buffer::from(mutable);
+
+        let allocating_result = Buffer::from(initial).bitwise_unary(0, 16, |a| !a);
+
+        assert_eq!(inplace_result, allocating_result);
+    }
+
+    #[test]
+    fn test_mutable_buffer_bitwise_inplace_random_equivalence() {
+        // Use a fixed seed for reproducible tests
+        let mut rng = rand::rngs::StdRng::from_seed([44u8; 32]);
+
+        let buffer_sizes = [8, 16, 32, 64];
+        let offsets = [0, 1, 3, 7, 8, 13];
+        let lengths = [1, 2, 7, 8, 9, 15, 16];
+
+        for &size in &buffer_sizes {
+            for _ in 0..5 { // Generate 5 random pairs per size
+                let initial_vec: Vec<u8> = (0..size).map(|_| rng.random::<u8>()).collect();
+                let other_vec: Vec<u8> = (0..size).map(|_| rng.random::<u8>()).collect();
+                let other = Buffer::from(other_vec);
+                let buffer_bits = initial_vec.len() * 8;
+
+                for &offset in &offsets {
+                    if offset >= buffer_bits { continue; }
+                    for &len in &lengths {
+                        if offset + len > buffer_bits { continue; }
+
+                        // Test binary AND in-place
+                        let mut mutable = MutableBuffer::from(initial_vec.clone());
+                        mutable.bitwise_binary_inplace(&other, offset, offset, len, |a, b| a & b);
+                        let inplace_result = Buffer::from(mutable);
+
+                        let allocating_result = Buffer::from(initial_vec.clone()).bitwise_binary(&other, offset, offset, len, |a, b| a & b);
+
+                        // Compare bit by bit
+                        for i in 0..len {
+                            let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                            let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                            assert_eq!(inplace_bit, expected_bit, "AND bit {} mismatch for offset={}, len={}", i, offset, len);
+                        }
+
+                        // Test binary OR in-place
+                        let mut mutable = MutableBuffer::from(initial_vec.clone());
+                        mutable.bitwise_binary_inplace(&other, offset, offset, len, |a, b| a | b);
+                        let inplace_result = Buffer::from(mutable);
+
+                        let allocating_result = Buffer::from(initial_vec.clone()).bitwise_binary(&other, offset, offset, len, |a, b| a | b);
+
+                        // Compare bit by bit
+                        for i in 0..len {
+                            let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                            let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                            assert_eq!(inplace_bit, expected_bit, "OR bit {} mismatch for offset={}, len={}", i, offset, len);
+                        }
+
+                        // Test unary NOT in-place
+                        let mut mutable = MutableBuffer::from(initial_vec.clone());
+                        mutable.bitwise_unary_inplace(offset, len, |a| !a);
+                        let inplace_result = Buffer::from(mutable);
+
+                        let allocating_result = Buffer::from(initial_vec.clone()).bitwise_unary(offset, len, |a| !a);
+
+                        // Compare bit by bit
+                        for i in 0..len {
+                            let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                            let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                            assert_eq!(inplace_bit, expected_bit, "NOT bit {} mismatch for offset={}, len={}", i, offset, len);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_mutable_buffer_bitwise_inplace_boundaries() {
+        // Use a fixed seed for reproducible tests
+        let mut rng = rand::rngs::StdRng::from_seed([47u8; 32]);
+
+        // Create large buffers: 1024 bytes
+        let data: Vec<u8> = (0..1024).map(|_| rng.random::<u8>()).collect();
+        let other_data: Vec<u8> = (0..1024).map(|_| rng.random::<u8>()).collect();
+        let other = Buffer::from(other_data);
+        let total_bits = data.len() * 8;
+
+        // Boundary configurations
+        let boundary_configs = vec![
+            (0, 0), // zero length
+            (0, total_bits), // full length
+            (1, total_bits - 1), // offset 1, to end
+            (7, total_bits - 7), // offset 7, crosses byte
+            (8, total_bits - 8), // offset at byte boundary
+            (total_bits - 1, 1), // last bit
+            (total_bits - 8, 8), // last byte
+            (total_bits - 9, 9), // last byte plus one
+        ];
+
+        for (offset, len) in boundary_configs {
+            if offset + len > total_bits {
+                continue; // skip invalid
+            }
+
+            // Test unary in-place
+            let mut mutable = MutableBuffer::from(data.clone());
+            mutable.bitwise_unary_inplace(offset, len, |a| !a);
+            let inplace_result = Buffer::from(mutable);
+
+            let allocating_result = Buffer::from(data.clone()).bitwise_unary(offset, len, |a| !a);
+
+            // Compare bit by bit
+            for i in 0..len {
+                let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                assert_eq!(inplace_bit, expected_bit, "Unary bit {} mismatch for offset={}, len={}", i, offset, len);
+            }
+
+            // Test binary in-place AND
+            let mut mutable = MutableBuffer::from(data.clone());
+            mutable.bitwise_binary_inplace(&other, offset, offset, len, |a, b| a & b);
+            let inplace_result = Buffer::from(mutable);
+
+            let allocating_result = Buffer::from(data.clone()).bitwise_binary(&other, offset, offset, len, |a, b| a & b);
+
+            // Compare bit by bit
+            for i in 0..len {
+                let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                assert_eq!(inplace_bit, expected_bit, "Binary AND bit {} mismatch for offset={}, len={}", i, offset, len);
+            }
+
+            // Test binary in-place OR
+            let mut mutable = MutableBuffer::from(data.clone());
+            mutable.bitwise_binary_inplace(&other, offset, offset, len, |a, b| a | b);
+            let inplace_result = Buffer::from(mutable);
+
+            let allocating_result = Buffer::from(data.clone()).bitwise_binary(&other, offset, offset, len, |a, b| a | b);
+
+            // Compare bit by bit
+            for i in 0..len {
+                let inplace_bit = crate::bit_util::get_bit(inplace_result.as_slice(), offset + i);
+                let expected_bit = crate::bit_util::get_bit(allocating_result.as_slice(), i);
+                assert_eq!(inplace_bit, expected_bit, "Binary OR bit {} mismatch for offset={}, len={}", i, offset, len);
+            }
+        }
     }
 }

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -17,10 +17,49 @@
 
 //! Implements the `nullif` function for Arrow arrays.
 
+/*
+ * NULLIF Implementation Contract
+ *
+ * For any ArrayData:
+ * len = data.len()            // logical elements
+ * offset = data.offset()      // logical starting index into buffers
+ *
+ * Validity bitmap (if present) is a Buffer B.
+ * Invariant:
+ *   Logical index i in [0, len) is valid iff get_bit(B, offset + i) == true.
+ *
+ * For the result of nullif:
+ * We will build a fresh ArrayData with offset = 0.
+ * For that result:
+ *   Logical index i is valid iff get_bit(result_validity, i) == true.
+ *   Values buffer is laid out so element 0 is first result value, etc.
+ *
+ * For nullif semantics:
+ * Let V(i) = left is valid at i
+ *     C(i) = condition "nullify at i" is true (depends on left, right, type)
+ * Then:
+ *   result_valid(i) = V(i) & !C(i)
+ *   result_value(i) = left_value(i)    // when result_valid(i) == true
+ *
+ * This contract is the law. All nullif implementations must follow it.
+ * See docs/arraydata_bitmap_layout_contract.md for full details.
+ */
+
 use arrow_array::{Array, ArrayRef, BooleanArray, make_array};
-use arrow_buffer::buffer::{bitwise_bin_op_helper, bitwise_unary_op_helper};
-use arrow_buffer::{BooleanBuffer, NullBuffer};
+use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer};
+use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};
+
+fn get_element_size(data_type: &DataType) -> usize {
+    match data_type {
+        DataType::Boolean => 1,
+        DataType::Int8 | DataType::UInt8 => 1,
+        DataType::Int16 | DataType::UInt16 => 2,
+        DataType::Int32 | DataType::UInt32 | DataType::Float32 => 4,
+        DataType::Int64 | DataType::UInt64 | DataType::Float64 => 8,
+        _ => panic!("unsupported"),
+    }
+}
 
 /// Returns a new array with the same values and the validity bit to false where
 /// the corresponding element of`right` is true.
@@ -55,65 +94,164 @@ pub fn nullif(left: &dyn Array, right: &BooleanArray) -> Result<ArrayRef, ArrowE
         return Ok(make_array(left_data));
     }
 
-    // left=0 (null)   right=null       output bitmap=null
-    // left=0          right=1          output bitmap=null
-    // left=1 (set)    right=null       output bitmap=set   (passthrough)
-    // left=1          right=1 & comp=true    output bitmap=null
-    // left=1          right=1 & comp=false   output bitmap=set
-    //
-    // Thus: result = left null bitmap & (!right_values | !right_bitmap)
-    //              OR left null bitmap & !(right_values & right_bitmap)
-
-    // Compute right_values & right_bitmap
-    let right = match right.nulls() {
+    let cond_mask = match right.nulls() {
         Some(nulls) => right.values() & nulls.inner(),
         None => right.values().clone(),
     };
+    let cond_offset = cond_mask.offset();
 
-    // Compute left null bitmap & !right
-
-    let (combined, null_count) = match left_data.nulls() {
-        Some(left) => {
-            let mut valid_count = 0;
-            let b = bitwise_bin_op_helper(
-                left.buffer(),
-                left.offset(),
-                right.inner(),
-                right.offset(),
-                len,
-                |l, r| {
-                    let t = l & !r;
-                    valid_count += t.count_ones() as usize;
-                    t
-                },
-            );
-            (b, len - valid_count)
+    let validity = if let Some(left_nulls) = left_data.nulls() {
+        let left_valid = left_nulls.inner().inner();
+        let left_bit_offset = left_nulls.inner().offset();
+        compute_nullif_validity(&left_valid, left_bit_offset, &cond_mask.inner(), cond_offset, len)
+    } else {
+        // left is all valid
+        let left_valid_len = (len + 7) / 8;
+        let mut left_valid_data = vec![255u8; left_valid_len];
+        if len % 8 != 0 {
+            let mask = (1u8 << (len % 8)) - 1;
+            left_valid_data[left_valid_len - 1] = mask;
         }
-        None => {
-            let mut null_count = 0;
-            let buffer = bitwise_unary_op_helper(right.inner(), right.offset(), len, |b| {
-                let t = !b;
-                null_count += t.count_zeros() as usize;
-                t
-            });
-            (buffer, null_count)
-        }
+        let left_valid = Buffer::from(left_valid_data);
+        let left_bit_offset = 0;
+        compute_nullif_validity(&left_valid, left_bit_offset, &cond_mask.inner(), cond_offset, len)
     };
 
-    let combined = BooleanBuffer::new(combined, 0, len);
-    // Safety:
-    // Counted nulls whilst computing
-    let nulls = unsafe { NullBuffer::new_unchecked(combined, null_count) };
-    let data = left_data.into_builder().nulls(Some(nulls));
+    let (null_buffer, _) = compute_null_buffer(&validity, len);
+    let nulls = NullBuffer::new(null_buffer);
 
-    // SAFETY:
-    // Only altered null mask
-    Ok(make_array(unsafe { data.build_unchecked() }))
+    let data_without_nulls = copy_array_data_with_offset_zero(&left_data)?;
+    let data = ArrayDataBuilder::new(left_data.data_type().clone())
+        .len(len)
+        .nulls(Some(nulls))
+        .offset(0)
+        .buffers(data_without_nulls.buffers().to_vec())
+        .child_data(data_without_nulls.child_data().to_vec())
+        .build()
+        .unwrap();
+
+    Ok(make_array(data))
+}
+
+/// Computes the null buffer and null count from the validity buffer.
+///
+/// The null buffer has bits set where validity is 1 (not null).
+/// The null count is computed as len - number of set bits in validity.
+fn compute_null_buffer(validity: &Buffer, len: usize) -> (BooleanBuffer, usize) {
+    let null_buffer = BooleanBuffer::new(validity.clone(), 0, len);
+    let null_count = len - validity.count_set_bits_offset(0, len);
+    (null_buffer, null_count)
+}
+
+/// Computes the NULLIF validity bitmap from left validity and condition mask.
+///
+/// For each logical index `i` in `0..len`:
+/// - `left_bit = bit(left_valid, left_offset + i)`
+/// - `cond_bit = bit(cond_mask, cond_offset + i)`
+/// - `result_bit = left_bit & !cond_bit`
+///
+/// This implements the core bitmap logic for NULLIF, isolating it from array-level concerns.
+fn compute_nullif_validity(
+    left_valid: &Buffer,
+    left_offset: usize,
+    cond_mask: &Buffer,
+    cond_offset: usize,
+    len: usize,
+) -> Buffer {
+    left_valid.bitwise_binary(cond_mask, left_offset, cond_offset, len, |l, c| l & !c)
+}
+
+/// Creates a new ArrayData with offset=0 by slicing the buffers from the given ArrayData.
+/// This ensures the result ArrayData has offset=0 as per the nullif contract.
+fn copy_array_data_with_offset_zero(left_data: &ArrayData) -> Result<ArrayData, ArrowError> {
+    let len = left_data.len();
+    let offset = left_data.offset();
+    let data_type = left_data.data_type();
+    let mut buffers = Vec::new();
+    let mut child_data = Vec::new();
+
+    match data_type {
+        DataType::Boolean => {
+            let values = left_data.buffers()[0].bitwise_unary(offset, len, |b| b);
+            buffers.push(values);
+        }
+        DataType::Int8 | DataType::UInt8 | DataType::Int16 | DataType::UInt16 |
+        DataType::Int32 | DataType::UInt32 | DataType::Float32 |
+        DataType::Int64 | DataType::UInt64 | DataType::Float64 => {
+            let element_size = get_element_size(data_type);
+            let start = offset * element_size;
+            let end = start + len * element_size;
+            let values = Buffer::from(&left_data.buffers()[0].as_slice()[start..end]);
+            buffers.push(values);
+        }
+        DataType::Utf8 => {
+            let offsets_buf = &left_data.buffers()[0];
+            let data_buf = &left_data.buffers()[1];
+            let offsets_start = offset;
+            let offsets_end = offset + len + 1;
+            let offsets_slice = &offsets_buf.as_slice()[offsets_start * 4..offsets_end * 4];
+            let base_offset = i32::from_le_bytes(offsets_slice[0..4].try_into().unwrap()) as usize;
+            let data_end = i32::from_le_bytes(offsets_slice[offsets_slice.len() - 4..].try_into().unwrap()) as usize;
+            let data_slice = &data_buf.as_slice()[base_offset..data_end];
+            let mut new_offsets = Vec::with_capacity(len + 1);
+            for i in 0..=len {
+                let old_offset = i32::from_le_bytes(offsets_slice[i * 4..(i + 1) * 4].try_into().unwrap()) as usize;
+                new_offsets.push((old_offset - base_offset) as i32);
+            }
+            let new_offsets_buf = Buffer::from(new_offsets.into_iter().flat_map(|x| x.to_le_bytes()).collect::<Vec<u8>>());
+            buffers.push(new_offsets_buf);
+            buffers.push(Buffer::from(data_slice));
+        }
+        DataType::LargeUtf8 => {
+            let offsets_buf = &left_data.buffers()[0];
+            let data_buf = &left_data.buffers()[1];
+            let offsets_start = offset;
+            let offsets_end = offset + len + 1;
+            let offsets_slice = &offsets_buf.as_slice()[offsets_start * 8..offsets_end * 8];
+            let base_offset = i64::from_le_bytes(offsets_slice[0..8].try_into().unwrap()) as usize;
+            let data_end = i64::from_le_bytes(offsets_slice[offsets_slice.len() - 8..].try_into().unwrap()) as usize;
+            let data_slice = &data_buf.as_slice()[base_offset..data_end];
+            let mut new_offsets = Vec::with_capacity(len + 1);
+            for i in 0..=len {
+                let old_offset = i64::from_le_bytes(offsets_slice[i * 8..(i + 1) * 8].try_into().unwrap()) as usize;
+                new_offsets.push((old_offset - base_offset) as i64);
+            }
+            let new_offsets_buf = Buffer::from(new_offsets.into_iter().flat_map(|x| x.to_le_bytes()).collect::<Vec<u8>>());
+            buffers.push(new_offsets_buf);
+            buffers.push(Buffer::from(data_slice));
+        }
+        DataType::Struct(_) => {
+            // No buffers for struct
+            child_data = left_data.child_data().iter()
+                .map(|child| copy_array_data_with_offset_zero(child))
+                .collect::<Result<Vec<_>, _>>()?;
+        }
+        _ => {
+            // For other types, copy buffers as is and keep offset (for now, to avoid breaking)
+            // TODO: implement slicing for other types like List, Binary, etc.
+            buffers = left_data.buffers().to_vec();
+            child_data = left_data.child_data().to_vec();
+            return Ok(ArrayDataBuilder::new(data_type.clone())
+                .len(len)
+                .offset(offset)
+                .buffers(buffers)
+                .child_data(child_data)
+                .build()?);
+        }
+    }
+
+    Ok(ArrayDataBuilder::new(data_type.clone())
+        .len(len)
+        .offset(0)
+        .buffers(buffers)
+        .child_data(child_data)
+        .build()?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_buffer::bit_util::get_bit;
     use arrow_array::builder::{BooleanBuilder, Int32Builder, StructBuilder};
     use arrow_array::cast::AsArray;
     use arrow_array::types::Int32Type;
@@ -523,6 +661,232 @@ mod tests {
 
                     test_nullif(&a, &b);
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn test_nullif_with_offsets_and_nulls() {
+        // Build arrays using builder to ensure correct null count
+        let array = Int32Array::from(vec![Some(15), None, Some(8), Some(1), Some(9)]);
+
+        let condition = BooleanArray::from(vec![Some(false), None, Some(true), Some(false), None]);
+
+        // Test on full arrays
+        let result_full = nullif(&array, &condition).unwrap();
+        let expected_full = Int32Array::from(vec![
+            Some(15), // false -> keep
+            None,     // null condition -> keep (was null)
+            None,     // true -> null
+            Some(1),  // false -> keep
+            Some(9),  // null condition -> keep
+        ]);
+        assert_eq!(result_full.as_primitive::<Int32Type>(), &expected_full);
+
+        // Test on sliced arrays
+        let array_sliced = array.slice(1, 3); // None, Some(8), Some(1)
+        let condition_sliced = condition.slice(1, 3); // None, Some(true), Some(false)
+        let result_sliced = nullif(&array_sliced, &condition_sliced).unwrap();
+
+        let expected_sliced = Int32Array::from(vec![
+            None,    // null condition -> keep (was null)
+            None,    // true -> null
+            Some(1), // false -> keep
+        ]);
+        assert_eq!(result_sliced.as_primitive::<Int32Type>(), &expected_sliced);
+
+        // Test with different condition
+        let array2 = Int32Array::from(vec![Some(10), None, Some(20), Some(30), None]);
+
+        let condition2 = BooleanArray::from(vec![Some(false), Some(true), Some(false), Some(true), Some(false)]);
+
+        let result = nullif(&array2, &condition2).unwrap();
+        let expected = Int32Array::from(vec![
+            Some(10), // false -> keep
+            None,     // true -> null (was null)
+            Some(20), // false -> keep
+            None,     // true -> null
+            None,     // false -> keep (was null)
+        ]);
+        assert_eq!(result.as_primitive::<Int32Type>(), &expected);
+    }
+
+    #[test]
+    fn test_nullif_null_count_and_offsets_regressions() {
+        // Construct a small Int32Array with nulls
+        let values = Int32Array::from(vec![Some(1), None, Some(2), Some(1), None, Some(3)]);
+        // Construct a "condition" array (equals values for nullif)
+        let equals = BooleanArray::from(vec![Some(true), Some(false), None, Some(true), Some(false), None]);
+
+        // Helper to build expected Vec<Option<i32>>
+        fn build_expected(values: &[Option<i32>], equals: &[Option<bool>]) -> Vec<Option<i32>> {
+            values.iter().zip(equals.iter()).map(|(&v, &e)| {
+                if v.is_none() {
+                    None
+                } else if e == Some(true) {
+                    None
+                } else {
+                    v
+                }
+            }).collect()
+        }
+
+        // Test full arrays
+        let result_full = nullif(&values, &equals).unwrap();
+        assert_eq!(result_full.len(), values.len());
+        let actual_nulls: Vec<Option<i32>> = result_full.as_primitive::<Int32Type>().iter().collect();
+        let expected_full = build_expected(&[Some(1), None, Some(2), Some(1), None, Some(3)], &[Some(true), Some(false), None, Some(true), Some(false), None]);
+        assert_eq!(actual_nulls, expected_full);
+        assert_eq!(result_full.null_count(), actual_nulls.iter().filter(|x| x.is_none()).count());
+
+        // Test sliced arrays: values.slice(1, 4) and equals.slice(1, 4)
+        // values[1..5]: None, Some(2), Some(1), None
+        // equals[1..5]: Some(false), None, Some(true), Some(false)
+        let values_slice1 = values.slice(1, 4);
+        let equals_slice1 = equals.slice(1, 4);
+        let result_slice1 = nullif(&values_slice1, &equals_slice1).unwrap();
+        assert_eq!(result_slice1.len(), 4);
+        let actual_slice1: Vec<Option<i32>> = result_slice1.as_primitive::<Int32Type>().iter().collect();
+        let expected_slice1 = build_expected(&[None, Some(2), Some(1), None], &[Some(false), None, Some(true), Some(false)]);
+        assert_eq!(actual_slice1, expected_slice1);
+        assert_eq!(result_slice1.null_count(), actual_slice1.iter().filter(|x| x.is_none()).count());
+
+        // Test another slice: values.slice(2, 3) and equals.slice(2, 3)
+        // values[2..5]: Some(2), Some(1), None
+        // equals[2..5]: None, Some(true), Some(false)
+        let values_slice2 = values.slice(2, 3);
+        let equals_slice2 = equals.slice(2, 3);
+        let result_slice2 = nullif(&values_slice2, &equals_slice2).unwrap();
+        assert_eq!(result_slice2.len(), 3);
+        let actual_slice2: Vec<Option<i32>> = result_slice2.as_primitive::<Int32Type>().iter().collect();
+        let expected_slice2 = build_expected(&[Some(2), Some(1), None], &[None, Some(true), Some(false)]);
+        assert_eq!(actual_slice2, expected_slice2);
+        assert_eq!(result_slice2.null_count(), actual_slice2.iter().filter(|x| x.is_none()).count());
+    }
+
+    #[test]
+    fn test_nullif_boolean_offsets_regression() {
+        // Use BooleanArray to reproduce BooleanBuffer slicing issues
+        let values = BooleanArray::from(vec![Some(true), None, Some(false), Some(true), None, Some(false), Some(true), Some(false)]);
+        let equals = BooleanArray::from(vec![Some(false), Some(true), None, Some(true), Some(false), None, Some(true), Some(false)]);
+
+        // Helper to build expected Vec<Option<bool>>
+        fn build_expected_bool(values: &[Option<bool>], equals: &[Option<bool>]) -> Vec<Option<bool>> {
+            values.iter().zip(equals.iter()).map(|(&v, &e)| {
+                if v.is_none() {
+                    None
+                } else if e == Some(true) {
+                    None
+                } else {
+                    v
+                }
+            }).collect()
+        }
+
+        // Test slices that cross byte boundaries (e.g., offset=1,len=5; offset=3,len=5; offset=7,len=1)
+        // Slice 1: offset=1, len=5 (values[1..6]: None, Some(false), Some(true), None, Some(false))
+        // equals[1..6]: Some(true), None, Some(true), Some(false), None
+        let values_slice1 = values.slice(1, 5);
+        let equals_slice1 = equals.slice(1, 5);
+        let result_slice1 = nullif(&values_slice1, &equals_slice1).unwrap();
+        assert_eq!(result_slice1.len(), 5);
+        let actual_slice1: Vec<Option<bool>> = result_slice1.as_boolean().iter().collect();
+        let expected_slice1 = build_expected_bool(&[None, Some(false), Some(true), None, Some(false)], &[Some(true), None, Some(true), Some(false), None]);
+        assert_eq!(actual_slice1, expected_slice1);
+        assert_eq!(result_slice1.null_count(), actual_slice1.iter().filter(|x| x.is_none()).count());
+
+        // Slice 2: offset=3, len=5 (values[3..8]: Some(true), None, Some(false), Some(true), Some(false))
+        // equals[3..8]: Some(true), Some(false), None, Some(true), Some(false)
+        let values_slice2 = values.slice(3, 5);
+        let equals_slice2 = equals.slice(3, 5);
+        let result_slice2 = nullif(&values_slice2, &equals_slice2).unwrap();
+        assert_eq!(result_slice2.len(), 5);
+        let actual_slice2: Vec<Option<bool>> = result_slice2.as_boolean().iter().collect();
+        let expected_slice2 = build_expected_bool(&[Some(true), None, Some(false), Some(true), Some(false)], &[Some(true), Some(false), None, Some(true), Some(false)]);
+        assert_eq!(actual_slice2, expected_slice2);
+        assert_eq!(result_slice2.null_count(), actual_slice2.iter().filter(|x| x.is_none()).count());
+
+        // Slice 3: offset=7, len=1 (values[7..8]: Some(false))
+        // equals[7..8]: Some(false)
+        let values_slice3 = values.slice(7, 1);
+        let equals_slice3 = equals.slice(7, 1);
+        let result_slice3 = nullif(&values_slice3, &equals_slice3).unwrap();
+        assert_eq!(result_slice3.len(), 1);
+        let actual_slice3: Vec<Option<bool>> = result_slice3.as_boolean().iter().collect();
+        let expected_slice3 = build_expected_bool(&[Some(false)], &[Some(false)]);
+        assert_eq!(actual_slice3, expected_slice3);
+        assert_eq!(result_slice3.null_count(), actual_slice3.iter().filter(|x| x.is_none()).count());
+    }
+
+    #[test]
+    fn test_nullif_all_null_and_empty() {
+        // Test all-null input
+        let all_null = Int32Array::from(vec![None, None, None]);
+        let condition = BooleanArray::from(vec![Some(true), Some(false), None]);
+        let result = nullif(&all_null, &condition).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.null_count(), 3);
+        let actual: Vec<Option<i32>> = result.as_primitive::<Int32Type>().iter().collect();
+        assert_eq!(actual, vec![None, None, None]);
+
+        // Test no-null input
+        let no_null = Int32Array::from(vec![Some(1), Some(2), Some(3)]);
+        let condition = BooleanArray::from(vec![Some(false), Some(true), Some(false)]);
+        let result = nullif(&no_null, &condition).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.null_count(), 1);
+        let actual: Vec<Option<i32>> = result.as_primitive::<Int32Type>().iter().collect();
+        assert_eq!(actual, vec![Some(1), None, Some(3)]);
+
+        // Test empty arrays
+        let empty_values = Int32Array::from(Vec::<Option<i32>>::new());
+        let empty_condition = BooleanArray::from(Vec::<Option<bool>>::new());
+        let result = nullif(&empty_values, &empty_condition).unwrap();
+        assert_eq!(result.len(), 0);
+        assert_eq!(result.null_count(), 0);
+    }
+
+    #[test]
+    fn test_compute_nullif_validity_basic_and_offsets() {
+        // left:  0b11110000, 0b00001111
+        // cond:  0b10101010, 0b01010101
+        let left = Buffer::from(vec![0b11110000u8, 0b00001111u8]);
+        let cond = Buffer::from(vec![0b10101010u8, 0b01010101u8]);
+
+        // Cases: (left_offset, cond_offset, len, expected_bits as Vec<bool>)
+        let cases = vec![
+            // No offset, 8 bits
+            (0, 0, 8, vec![
+                // left bits: 0 0 0 0 1 1 1 1
+                // cond bits: 0 1 0 1 0 1 0 1
+                // result: 0&!0=0, 0&!1=0, 0&!0=0, 0&!1=0, 1&!0=1, 1&!1=0, 1&!0=1, 1&!1=0
+                // => 0,0,0,0,1,0,1,0
+                false, false, false, false, true, false, true, false
+            ]),
+            // Offsets that make (offset+len)%8==0
+            (1, 1, 7, vec![
+                // left_offset=1, left bits 1-7: 0,0,0,1,1,1,1
+                // cond_offset=1, cond bits 1-7: 1,0,1,0,1,0,1
+                // result: 0&!1=0, 0&!0=0, 0&!1=0, 1&!0=1, 1&!1=0, 1&!0=1, 1&!1=0
+                // => 0,0,0,1,0,1,0
+                false, false, false, true, false, true, false
+            ]),
+            // A cross-byte case
+            (3, 3, 5, vec![
+                // left_offset=3, left bits 3-7: 0,1,1,1,1
+                // cond_offset=3, cond bits 3-7: 1,0,1,0,1
+                // result: 0&!1=0, 1&!0=1, 1&!1=0, 1&!0=1, 1&!1=0
+                // => 0,1,0,1,0
+                false, true, false, true, false
+            ]),
+        ];
+
+        for (loff, coff, len, expected) in cases {
+            let mask = compute_nullif_validity(&left, loff, &cond, coff, len);
+            // Check each bit in the resulting Buffer against expected
+            for i in 0..len {
+                let bit = get_bit(mask.as_slice(), i);
+                assert_eq!(bit, expected[i], "mismatch at bit {} for offsets ({}, {})", i, loff, coff);
             }
         }
     }

--- a/docs/arraydata_bitmap_layout_contract.md
+++ b/docs/arraydata_bitmap_layout_contract.md
@@ -1,0 +1,76 @@
+# ArrayData + Bitmap Layout Contract
+
+This document specifies the invariants for `ArrayData`, offsets, and bitmap buffers (validity and condition bitmaps) in Arrow-rs. These rules are derived from the actual implementation and must be treated as ground truth for bitwise and null-handling operations like `nullif`.
+
+## 1. Basics
+
+- **Bit Numbering**: Bits are numbered starting from 0 as the least significant bit (LSB) of byte 0, then bit 1 as the next LSB, and so on, across bytes in little-endian order.
+- **Validity Bitmap Invariant**:
+  > For an `ArrayData` with `len = L`, `offset = O` (in elements), and validity bitmap buffer `B`:
+  > Logical index `i` in `[0, L)` is valid iff `get_bit(B, O + i) == true`.
+- **Null Count**: If `null_count` is set, it MUST equal the count of `false` bits in the validity bitmap over the logical range `[0, L)`.
+
+## 2. Slicing
+
+- **Slice Operation**: `array.slice(offset', len')` produces a new `ArrayData` with:
+  - `len = len'`,
+  - `offset = O + offset'`,
+  - Shared underlying buffers (no copying).
+- **Sliced Validity Invariant**:
+  > For the sliced `ArrayData` with `len = L'`, `offset = O'`, and the same validity bitmap buffer `B`:
+  > Logical index `i` in `[0, L')` is valid iff `get_bit(B, O' + i) == true`.
+
+## 3. Constructing New ArrayData with a Fresh Validity Buffer
+
+- **Case 1: Offset = 0 and New Validity Bitmap**:
+  - Bit `i` in the validity bitmap `B'` corresponds directly to logical index `i` for `i` in `[0, L)`.
+  - `null_count` MUST equal the number of `false` bits in `B'` over `[0, L)`, or be left unset for Arrow to compute.
+- **Case 2: Reusing Existing Null Buffer with Offset**:
+  - When reusing a `NullBuffer` from an existing array, the `offset` in the new `ArrayData` adjusts the logical-to-physical bit mapping as per the basic invariant.
+  - Ensure the reused buffer's bits align with the new `len` and `offset`; `null_count` must reflect the new logical range.
+
+## 4. `nullif`-Specific Contract
+
+- **Condition Bitmap**: A condition bitmap `C` indicates elements to nullify: logical index `i` should be nulled if `C[i] == true`.
+- **Validity Computation Rule**:
+  > Given left validity `V` and condition `C` (both in logical index space):
+  > `result_valid(i) = V(i) & !C(i)`.
+- **Buffer Mapping**:
+  - For left array with `offset_left`, bit index for `V(i)` is `offset_left + i`.
+  - For condition array with `offset_cond`, bit index for `C(i)` is `offset_cond + i`.
+  - The result validity bitmap should be constructed with `offset = 0` and bits computed as above.
+
+## 5. Do/Don't Guidelines
+
+- **DO**: Centralize bitmap math in helpers that take `(buffer, bit_offset, len)` and return a new bitmap with `offset = 0`.
+- **DO**: Ensure `null_count` matches the validity bitmap or leave it unset for automatic computation.
+- **DON'T**: Manually slice buffers and add offsets (avoid double-compensation); use the slicing semantics instead.
+
+## 6. Nullif Implementation Contract
+
+For any ArrayData:
+
+len = data.len()            // logical elements
+offset = data.offset()      // logical starting index into buffers
+
+Validity bitmap (if present) is a Buffer B.
+
+Invariant:
+  Logical index i in [0, len) is valid iff get_bit(B, offset + i) == true.
+
+For the result of nullif:
+
+We will build a fresh ArrayData with offset = 0.
+
+For that result:
+  Logical index i is valid iff get_bit(result_validity, i) == true.
+  Values buffer is laid out so element 0 is first result value, etc.
+
+For nullif semantics:
+
+Let V(i) = left is valid at i
+    C(i) = condition "nullify at i" is true (depends on left, right, type)
+
+Then:
+  result_valid(i) = V(i) & !C(i)
+  result_value(i) = left_value(i)    // when result_valid(i) == true


### PR DESCRIPTION
Here’s a version that fits their template and avoids mentioning Python:

---

# Which issue does this PR close?

* Closes #8806.

# Rationale for this change

The bitwise operations used across `arrow-buffer`, `arrow-arith`, and `arrow-select` were spread across several overlapping helpers, which made it difficult to:

* Know which APIs were the “canonical” bitwise primitives, and
* Reason about and fix bugs involving offsets and null bitmaps, especially in `nullif`.

While working on bitwise kernels, we also found that `nullif` in `arrow-select` was fragile around sliced arrays, offsets, and null-count handling. This PR centralizes the bitwise logic and makes `nullif` explicitly respect the `ArrayData` bitmap layout invariants (length, offset, validity mapping).

# What changes are included in this PR?

High-level:

* **Documented the bitmap layout contract**

  * Added a documentation file (`docs/arraydata_bitmap_layout_contract.md`) that spells out:

    * How `len` and `offset` relate to validity bits,
    * How new arrays should be constructed (`offset = 0`),
    * And the `nullif` validity rule: `result_valid(i) = V(i) & !C(i)`.

* **Strengthened core bitwise testing in `arrow-buffer` / `arrow-arith`**

  * Added/extended tests that:

    * Compare new `Buffer`/`MutableBuffer` bitwise APIs against existing helpers across random data,
    * Exercise offsets and tail bits (including `(offset + len)` boundary cases),
    * Check that in-place (`MutableBuffer`) operations produce the same bits as allocating versions.
  * Added `rand` as a **dev-dependency** of `arrow-arith` to support reproducible randomized tests.

* **Refactored `nullif` to follow the layout contract**

  * Introduced a helper:

    ```rust
    fn compute_nullif_validity(
        left_valid: &Buffer,
        left_offset: usize,
        cond_mask: &Buffer,
        cond_offset: usize,
        len: usize,
    ) -> Buffer
    ```

    which implements the core `V(i) & !C(i)` validity logic over buffers and bit offsets.

  * Updated `nullif` to:

    * Derive correct bit offsets from `ArrayData` for the left validity and condition mask,
    * Always build new result `ArrayData` with `offset = 0`,
    * Slice value/offset buffers so element 0 in the result corresponds to logical index 0 for:

      * Primitive arrays,
      * Boolean arrays,
      * Utf8 / LargeUtf8 arrays,
      * Struct arrays (with correct top-level validity propagation).

* **Nullif-focused tests**

  * Added a focused unit test for `compute_nullif_validity` that exercises:

    * No-offset cases,
    * `(offset + len) % 8 == 0` boundaries,
    * Cross-byte bit ranges.
  * Verified and fixed behavior so that the existing `nullif` tests all pass, including:

    * Offset regressions for ints and booleans,
    * String and struct slice tests,
    * `null_count` regression tests,
    * The existing `nullif_fuzz` test.

Net effect: `nullif` is now a thin consumer of the documented bitmap layout contract and the consolidated bitwise APIs.

# Are these changes tested?

Yes.

The following were run locally:

```bash
# Core buffer + arithmetic crates
cargo test -p arrow-buffer --lib
cargo test -p arrow-arith --lib

# Select crate, including all nullif tests
cargo test -p arrow-select --lib
cargo test -p arrow-select --lib nullif -- --nocapture
```

All of the above pass, including the previously failing `nullif` regression and fuzz tests.

# Are there any user-facing changes?

There are **no breaking changes** to public APIs.

User-visible effects:

* `nullif` behavior is now strictly aligned with the documented bitmap layout contract for:

  * Sliced arrays,
  * Offsets,
  * Null masks,
  * Strings and structs.
* This should only be observable as **bug fixes** in corner cases (e.g., nulls at specific offsets, struct/string slices), not API changes.

No new configuration or feature flags are introduced; this is primarily a correctness and maintainability improvement around existing behavior.
