### PR TITLE
Make ArrayFormatterFactory Send + Sync and add a test

### DIFF
--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -352,7 +352,7 @@ impl<'a> FormatOptions<'a> {
 ///        &FormatOptions::new().with_formatter_factory(Some(&MyFormatters {}))
 /// );
 /// ```
-pub trait ArrayFormatterFactory: Debug {
+pub trait ArrayFormatterFactory: Debug + Send + Sync {
     /// Creates a new [`ArrayFormatter`] for the given [`Array`] and an optional [`Field`]. If the
     /// default implementation should be used, return [`None`].
     ///
@@ -1338,6 +1338,19 @@ mod tests {
     #[test]
     fn test_const_options() {
         assert_eq!(TEST_CONST_OPTIONS.date_format, Some("foo"));
+    }
+
+    /// See https://github.com/apache/arrow-rs/issues/8875
+    #[test]
+    fn test_options_send_sync() {
+        fn assert_send_sync<T>()
+        where
+            T: Send + Sync,
+        {
+            // nothing – the compiler does the work
+        }
+
+        assert_send_sync::<FormatOptions<'static>>();
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8875 .

Ping @alamb 

# Rationale for this change

`FormatOptions` is no longer `Send` and `Sync`.

# What changes are included in this PR?

- Require `Send` + `Sync` for `ArrayFormatterFactory`
- Assertion that `FormatOptions` is `Send` + `Sync`

# Are these changes tested?

- Yes

# Are there any user-facing changes?

Yes, should fix the compiler error. I could compile DataFusion with the following patch adapted from the issue:

```
## Temporary arrow-rs patch until 57.1.0 is released

[patch.crates-io]
arrow = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-array = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-buffer = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-cast = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-data = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-ipc = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-schema = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-select = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-string = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-ord = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
arrow-flight = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
parquet = { git = "https://github.com/tobixdev/arrow-rs.git", branch = "custom-formatters" }
```