### PR TITLE
Add UnionArray::fields

### DIFF
--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -311,6 +311,14 @@ impl UnionArray {
         }
     }
 
+    /// Returns the [`UnionFields`] for the union.
+    pub fn fields(&self) -> &UnionFields {
+        match self.data_type() {
+            DataType::Union(fields, _) => fields,
+            _ => unreachable!("Union array's data type is not a union!"),
+        }
+    }
+
     /// Returns whether the `UnionArray` is dense (or sparse if `false`).
     pub fn is_dense(&self) -> bool {
         match self.data_type() {


### PR DESCRIPTION
# Which issue does this PR close?

This PR adds another method on the `UnionArray` api that returns a list of `FieldRef`s associated with the union type

See: https://github.com/apache/arrow-rs/pull/8838#discussion_r2543160023
