### PR TITLE
Page index column semantics

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1119,7 +1119,7 @@ impl<T: ChunkReader + 'static> ReaderPageIterator<T> {
         // To avoid `i[rg_idx][self.column_idx`] panic, we need to filter out empty `i[rg_idx]`.
         let page_locations = offset_index
             .filter(|i| !i[rg_idx].is_empty())
-            .map(|i| i[rg_idx][self.column_idx].page_locations.clone());
+            .map(|i| i[rg_idx][self.column_idx].as_ref().unwrap().page_locations.clone());
         let total_rows = rg.num_rows() as usize;
         let reader = self.reader.clone();
 
@@ -4562,7 +4562,7 @@ pub(crate) mod tests {
                 ArrowReaderOptions::new().with_page_index(true),
             )
             .unwrap();
-            assert!(!builder.metadata().offset_index().unwrap()[0].is_empty());
+            assert!(!builder.metadata().offset_index().expect("offset index should be present when page index is enabled")[0].is_empty());
             let reader = builder.build().unwrap();
             let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
             assert_eq!(batches.len(), 8);

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -254,12 +254,16 @@ impl RowSelection {
     fn selection_skips_any_page(
         &self,
         projection: &ProjectionMask,
-        columns: &[OffsetIndexMetaData],
+        columns: &[Option<OffsetIndexMetaData>],
     ) -> bool {
         columns.iter().enumerate().any(|(leaf_idx, column)| {
             if !projection.leaf_included(leaf_idx) {
                 return false;
             }
+
+            let Some(column) = column else {
+                return false;
+            };
 
             let locations = column.page_locations();
             if locations.is_empty() {
@@ -275,7 +279,7 @@ impl RowSelection {
     pub(crate) fn should_force_selectors(
         &self,
         projection: &ProjectionMask,
-        offset_index: Option<&[OffsetIndexMetaData]>,
+        offset_index: Option<&[Option<OffsetIndexMetaData>]>,
     ) -> bool {
         match offset_index {
             Some(columns) => self.selection_skips_any_page(projection, columns),

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -600,14 +600,14 @@ macro_rules! make_data_page_stats_iterator {
     ($iterator_type: ident, $func: ident, $stat_value_type: ty) => {
         struct $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             iter: I,
         }
 
         impl<'a, I> $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             fn new(iter: I) -> Self {
                 Self { iter }
@@ -616,7 +616,7 @@ macro_rules! make_data_page_stats_iterator {
 
         impl<'a, I> Iterator for $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             type Item = Vec<Option<$stat_value_type>>;
 
@@ -630,8 +630,8 @@ macro_rules! make_data_page_stats_iterator {
                         // create an arrow null-array with the length
                         // corresponding to the number of entries in
                         // `ParquetOffsetIndex` per row group per column.
-                        ColumnIndexMetaData::NONE => Some(vec![None; len]),
-                        _ => Some(<$stat_value_type>::$func(&index).collect::<Vec<_>>()),
+                        None => Some(vec![None; len]),
+                        Some(index) => Some(<$stat_value_type>::$func(index).collect::<Vec<_>>()),
                     },
                     _ => None,
                 }
@@ -690,14 +690,14 @@ macro_rules! get_decimal_page_stats_iterator {
     ($iterator_type: ident, $func: ident, $stat_value_type: ident, $convert_func: ident) => {
         struct $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             iter: I,
         }
 
         impl<'a, I> $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             fn new(iter: I) -> Self {
                 Self { iter }
@@ -706,7 +706,7 @@ macro_rules! get_decimal_page_stats_iterator {
 
         impl<'a, I> Iterator for $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             type Item = Vec<Option<$stat_value_type>>;
 
@@ -715,25 +715,26 @@ macro_rules! get_decimal_page_stats_iterator {
                 let next = self.iter.next();
                 match next {
                     Some((len, index)) => match index {
-                        ColumnIndexMetaData::INT32(native_index) => Some(
+                        None => Some(vec![None; len]),
+                        Some(ColumnIndexMetaData::INT32(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $stat_value_type::from(*x)))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::INT64(native_index) => Some(
+                        Some(ColumnIndexMetaData::INT64(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $stat_value_type::try_from(*x).unwrap()))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::BYTE_ARRAY(native_index) => Some(
+                        Some(ColumnIndexMetaData::BYTE_ARRAY(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $convert_func(x)))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(native_index) => Some(
+                        Some(ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $convert_func(x)))
@@ -1116,7 +1117,7 @@ pub(crate) fn min_page_statistics<'a, I>(
     physical_type: Option<PhysicalType>,
 ) -> Result<ArrayRef>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     get_data_page_statistics!(Min, data_type, iterator, physical_type)
 }
@@ -1129,7 +1130,7 @@ pub(crate) fn max_page_statistics<'a, I>(
     physical_type: Option<PhysicalType>,
 ) -> Result<ArrayRef>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     get_data_page_statistics!(Max, data_type, iterator, physical_type)
 }
@@ -1140,11 +1141,11 @@ where
 /// The returned Array is an [`UInt64Array`]
 pub(crate) fn null_counts_page_statistics<'a, I>(iterator: I) -> Result<UInt64Array>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     let iter = iterator.flat_map(|(len, index)| match index {
-        ColumnIndexMetaData::NONE => vec![None; len],
-        column_index => column_index.null_counts().map_or(vec![None; len], |v| {
+        None | Some(ColumnIndexMetaData::NONE) => vec![None; len],
+        Some(column_index) => column_index.null_counts().map_or(vec![None; len], |v| {
             v.iter().map(|i| Some(*i as u64)).collect::<Vec<_>>()
         }),
     });
@@ -1533,11 +1534,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
 
         min_page_statistics(data_type, iter, self.physical_type)
@@ -1564,11 +1569,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
 
         max_page_statistics(data_type, iter, self.physical_type)
@@ -1597,11 +1606,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
         null_counts_page_statistics(iter)
     }
@@ -1641,22 +1654,25 @@ impl<'a> StatisticsConverter<'a> {
 
         let mut row_count_total = Vec::new();
         for rg_idx in row_group_indices {
-            let page_locations = &column_offset_index[*rg_idx][parquet_index].page_locations();
+            if let Some(oi) = &column_offset_index[*rg_idx][parquet_index] {
+                let page_locations = oi.page_locations();
 
-            let row_count_per_page = page_locations
-                .windows(2)
-                .map(|loc| Some(loc[1].first_row_index as u64 - loc[0].first_row_index as u64));
+                let row_count_per_page = page_locations
+                    .windows(2)
+                    .map(|loc| Some(loc[1].first_row_index as u64 - loc[0].first_row_index as u64));
 
-            // append the last page row count
-            let num_rows_in_row_group = &row_group_metadatas[*rg_idx].num_rows();
-            let row_count_per_page = row_count_per_page
-                .chain(std::iter::once(Some(
-                    *num_rows_in_row_group as u64
-                        - page_locations.last().unwrap().first_row_index as u64,
-                )))
-                .collect::<Vec<_>>();
+                // append the last page row count
+                let num_rows_in_row_group = &row_group_metadatas[*rg_idx].num_rows();
+                let row_count_per_page = row_count_per_page
+                    .chain(std::iter::once(Some(
+                        *num_rows_in_row_group as u64
+                            - page_locations.last().unwrap().first_row_index as u64,
+                    )))
+                    .collect::<Vec<_>>();
 
-            row_count_total.extend(row_count_per_page);
+                row_count_total.extend(row_count_per_page);
+            }
+            // else skip
         }
 
         Ok(Some(UInt64Array::from_iter(row_count_total)))

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -1144,7 +1144,7 @@ where
     I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     let iter = iterator.flat_map(|(len, index)| match index {
-        None | Some(ColumnIndexMetaData::NONE) => vec![None; len],
+        None => vec![None; len],
         Some(column_index) => column_index.null_counts().map_or(vec![None; len], |v| {
             v.iter().map(|i| Some(*i as u64)).collect::<Vec<_>>()
         }),

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2244,9 +2244,9 @@ mod tests {
         );
 
         assert!(reader.metadata().offset_index().is_some());
-        let offset_indexes = &reader.metadata().offset_index().unwrap()[0];
+        let offset_indexes = &reader.metadata().offset_index().expect("offset index should be present when page index is enabled")[0];
 
-        let page_locations = offset_indexes[0].page_locations.clone();
+        let page_locations = offset_indexes[0].as_ref().expect("offset index should be present for column 0").page_locations.clone();
 
         // We should fallback to PLAIN encoding after the first row and our max page size is 1 bytes
         // so we expect one dictionary encoded page and then a page per row thereafter.
@@ -3971,12 +3971,12 @@ mod tests {
         let bytes = Bytes::from(buf);
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(bytes, options).unwrap();
-        let index = reader.metadata().offset_index().unwrap();
+        let index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
 
         assert_eq!(index.len(), 1);
         assert_eq!(index[0].len(), 2); // 2 columns
-        assert_eq!(index[0][0].page_locations().len(), 1); // 1 page
-        assert_eq!(index[0][1].page_locations().len(), 1); // 1 page
+        assert_eq!(index[0][0].as_ref().expect("offset index should be present for column 0").page_locations().len(), 1); // 1 page
+        assert_eq!(index[0][1].as_ref().expect("offset index should be present for column 1").page_locations().len(), 1); // 1 page
     }
 
     #[test]
@@ -4037,21 +4037,21 @@ mod tests {
         // The column chunk for column "b" shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let offset_index = reader.metadata().offset_index().unwrap();
+        let offset_index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
         assert_eq!(offset_index.len(), 1); // 1 row group
         assert_eq!(offset_index[0].len(), 2); // 2 columns
 
-        let column_index = reader.metadata().column_index().unwrap();
+        let column_index = reader.metadata().column_index().expect("column index should be present when page index is enabled");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 
         let a_idx = &column_index[0][0];
         assert!(
-            matches!(a_idx, ColumnIndexMetaData::BYTE_ARRAY(_)),
+            matches!(a_idx, Some(ColumnIndexMetaData::BYTE_ARRAY(_))),
             "{a_idx:?}"
         );
         let b_idx = &column_index[0][1];
-        assert!(matches!(b_idx, ColumnIndexMetaData::NONE), "{b_idx:?}");
+        assert!(matches!(b_idx, None), "{b_idx:?}");
     }
 
     #[test]
@@ -4112,14 +4112,14 @@ mod tests {
         // The column chunk for column "b"  shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let column_index = reader.metadata().column_index().unwrap();
+        let column_index = reader.metadata().column_index().expect("column index should be present");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 
         let a_idx = &column_index[0][0];
-        assert!(matches!(a_idx, ColumnIndexMetaData::NONE), "{a_idx:?}");
+        assert!(matches!(a_idx, None), "{a_idx:?}");
         let b_idx = &column_index[0][1];
-        assert!(matches!(b_idx, ColumnIndexMetaData::NONE), "{b_idx:?}");
+        assert!(matches!(b_idx, None), "{b_idx:?}");
     }
 
     #[test]

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -963,8 +963,8 @@ mod tests {
         assert_eq!(metadata_with_index.num_row_groups(), 1);
 
         // Check offset indexes are present for all columns
-        let offset_index = metadata_with_index.offset_index().unwrap();
-        let column_index = metadata_with_index.column_index().unwrap();
+        let offset_index = metadata_with_index.offset_index().expect("offset index should be present when page index is enabled");
+        let column_index = metadata_with_index.column_index().expect("column index should be present when page index is enabled");
 
         assert_eq!(offset_index.len(), metadata_with_index.num_row_groups());
         assert_eq!(column_index.len(), metadata_with_index.num_row_groups());

--- a/parquet/src/arrow/push_decoder/reader_builder/data.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/data.rs
@@ -224,7 +224,7 @@ impl<'a> DataRequestBuilder<'a> {
 fn get_offset_index(
     parquet_metadata: &ParquetMetaData,
     row_group_idx: usize,
-) -> Option<&[OffsetIndexMetaData]> {
+) -> Option<&[Option<OffsetIndexMetaData>]> {
     parquet_metadata
         .offset_index()
         // filter out empty offset indexes (old versions specified Some(vec![]) when no present)

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -645,7 +645,7 @@ impl RowGroupReaderBuilder {
     }
 
     /// Get the offset index for the specified row group, if any
-    fn row_group_offset_index(&self, row_group_idx: usize) -> Option<&[OffsetIndexMetaData]> {
+    fn row_group_offset_index(&self, row_group_idx: usize) -> Option<&[Option<OffsetIndexMetaData>]> {
         self.metadata
             .offset_index()
             .filter(|index| !index.is_empty())
@@ -676,7 +676,7 @@ impl RowGroupReaderBuilder {
 fn override_selector_strategy_if_needed(
     plan_builder: ReadPlanBuilder,
     projection_mask: &ProjectionMask,
-    offset_index: Option<&[OffsetIndexMetaData]>,
+    offset_index: Option<&[Option<OffsetIndexMetaData>]>,
 ) -> ReadPlanBuilder {
     // override only applies to Auto policy, If the policy is already Mask or Selectors, respect that
     let RowSelectionPolicy::Auto { .. } = plan_builder.row_selection_policy() else {

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -94,6 +94,10 @@ impl Args {
                 ParquetError::General(format!(
                     "No offset index for row group {row_group_idx} column chunk {column_idx}"
                 ))
+            })?.as_ref().ok_or_else(|| {
+                ParquetError::General(format!(
+                    "Offset index is None for row group {row_group_idx} column chunk {column_idx}"
+                ))
             })?;
 
             let row_counts =

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -146,14 +146,14 @@ pub(crate) use writer::ThriftMetadataWriter;
 ///
 /// `column_index[row_group_number][column_number]` holds the
 /// [`ColumnIndex`] corresponding to column `column_number` of row group
-/// `row_group_number`.
+/// `row_group_number`, or `None` if no index is available.
 ///
 /// For example `column_index[2][3]` holds the [`ColumnIndex`] for the fourth
-/// column in the third row group of the parquet file.
+/// column in the third row group of the parquet file, or `None`.
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`ColumnIndex`]: crate::file::page_index::column_index::ColumnIndexMetaData
-pub type ParquetColumnIndex = Vec<Vec<ColumnIndexMetaData>>;
+pub type ParquetColumnIndex = Vec<Vec<Option<ColumnIndexMetaData>>>;
 
 /// [`OffsetIndexMetaData`] for each data page of each row group of each column
 ///
@@ -162,11 +162,11 @@ pub type ParquetColumnIndex = Vec<Vec<ColumnIndexMetaData>>;
 ///
 /// `offset_index[row_group_number][column_number]` holds
 /// the [`OffsetIndexMetaData`] corresponding to column
-/// `column_number`of row group `row_group_number`.
+/// `column_number`of row group `row_group_number`, or `None` if no index is available.
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`OffsetIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-pub type ParquetOffsetIndex = Vec<Vec<OffsetIndexMetaData>>;
+pub type ParquetOffsetIndex = Vec<Vec<Option<OffsetIndexMetaData>>>;
 
 /// Parsed metadata for a single Parquet file
 ///
@@ -1908,8 +1908,8 @@ mod tests {
 
         let parquet_meta = ParquetMetaDataBuilder::new(file_metadata)
             .set_row_groups(row_group_meta)
-            .set_column_index(Some(vec![vec![ColumnIndexMetaData::BOOLEAN(native_index)]]))
-            .set_offset_index(Some(vec![vec![offset_index]]))
+            .set_column_index(Some(vec![vec![Some(ColumnIndexMetaData::BOOLEAN(native_index))]]))
+            .set_offset_index(Some(vec![vec![Some(offset_index)]]))
             .build();
 
         #[cfg(not(feature = "encryption"))]

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -149,19 +149,11 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             .is_some_and(|ci| ci.iter().all(|cii| cii.iter().all(|idx| idx.is_none())));
 
         // transform from Option<Vec<Vec<Option<ColumnIndexMetaData>>>> to
-        // Option<Vec<Vec<ColumnIndexMetaData>>>
+        // Option<Vec<Vec<Option<ColumnIndexMetaData>>>>
         let column_indexes: Option<ParquetColumnIndex> = if all_none {
             None
         } else {
-            column_indexes.map(|ovvi| {
-                ovvi.into_iter()
-                    .map(|vi| {
-                        vi.into_iter()
-                            .map(|ci| ci.unwrap_or(ColumnIndexMetaData::NONE))
-                            .collect()
-                    })
-                    .collect()
-            })
+            column_indexes
         };
 
         Ok(column_indexes)
@@ -184,12 +176,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         let offset_indexes: Option<ParquetOffsetIndex> = if all_none {
             None
         } else {
-            // FIXME(ets): this will panic if there's a missing index.
-            offset_indexes.map(|ovvi| {
-                ovvi.into_iter()
-                    .map(|vi| vi.into_iter().map(|oi| oi.unwrap()).collect())
-                    .collect()
-            })
+            offset_indexes
         };
 
         Ok(offset_indexes)
@@ -489,7 +476,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                         let column_indexes = &row_group_column_indexes[rg_idx];
                         column_indexes
                             .iter()
-                            .map(|column_index| Some(column_index.clone()))
+                            .map(|column_index| column_index.clone())
                             .collect()
                     })
                     .collect()
@@ -505,7 +492,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                         let offset_indexes = &row_group_offset_indexes[rg_idx];
                         offset_indexes
                             .iter()
-                            .map(|offset_index| Some(offset_index.clone()))
+                            .map(|offset_index| offset_index.clone())
                             .collect()
                     })
                     .collect()

--- a/parquet/src/file/page_index/column_index.rs
+++ b/parquet/src/file/page_index/column_index.rs
@@ -510,7 +510,11 @@ macro_rules! colidx_enum_func {
 pub enum ColumnIndexMetaData {
     /// Sometimes reading page index from parquet file
     /// will only return pageLocations without min_max index,
-    /// `NONE` represents this lack of index information
+    /// `NONE` represents this lack of index information.
+    ///
+    /// Note: This is a legacy marker and should not be used to represent
+    /// missing column indexes in `ParquetColumnIndex` (that is now done via
+    /// `None` on the `Option`).
     NONE,
     /// Boolean type index
     BOOLEAN(PrimitiveColumnIndex<bool>),

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -283,7 +283,7 @@ impl<R: 'static + ChunkReader> FileReader for SerializedFileReader<R> {
 pub struct SerializedRowGroupReader<'a, R: ChunkReader> {
     chunk_reader: Arc<R>,
     metadata: &'a RowGroupMetaData,
-    offset_index: Option<&'a [OffsetIndexMetaData]>,
+    offset_index: Option<&'a [Option<OffsetIndexMetaData>]>,
     props: ReaderPropertiesPtr,
     bloom_filters: Vec<Option<Sbbf>>,
 }
@@ -293,7 +293,7 @@ impl<'a, R: ChunkReader> SerializedRowGroupReader<'a, R> {
     pub fn new(
         chunk_reader: Arc<R>,
         metadata: &'a RowGroupMetaData,
-        offset_index: Option<&'a [OffsetIndexMetaData]>,
+        offset_index: Option<&'a [Option<OffsetIndexMetaData>]>,
         props: ReaderPropertiesPtr,
     ) -> Result<Self> {
         let bloom_filters = if props.read_bloom_filter() {
@@ -328,7 +328,7 @@ impl<R: 'static + ChunkReader> RowGroupReader for SerializedRowGroupReader<'_, R
     fn get_column_page_reader(&self, i: usize) -> Result<Box<dyn PageReader>> {
         let col = self.metadata.column(i);
 
-        let page_locations = self.offset_index.map(|x| x[i].page_locations.clone());
+        let page_locations = self.offset_index.and_then(|x| x[i].as_ref().map(|idx| idx.page_locations.clone()));
 
         let props = Arc::clone(&self.props);
         Ok(Box::new(SerializedPageReader::new_with_properties(
@@ -1718,7 +1718,7 @@ mod tests {
 
         let page_locations = row_group
             .offset_index
-            .map(|x| x[column].page_locations.clone());
+            .and_then(|x| x[column].as_ref().map(|idx| idx.page_locations.clone()));
 
         let props = Arc::clone(&row_group.props);
         SerializedPageReader::new_with_properties(
@@ -1919,8 +1919,8 @@ mod tests {
         let reader = SerializedFileReader::new_with_options(test_file, read_options)?;
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
-        assert_eq!(metadata.column_index().unwrap().len(), 1);
-        assert_eq!(metadata.offset_index().unwrap().len(), 1);
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 1);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 1);
 
         // true, false predicate
         let test_file = get_test_file("alltypes_tiny_pages.parquet");
@@ -2005,11 +2005,11 @@ mod tests {
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let column_index = metadata.column_index().unwrap();
+        let column_index = metadata.column_index().expect("column index should be present");
 
         // only one row group
         assert_eq!(column_index.len(), 1);
-        let index = if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][0] {
+        let index = if let ColumnIndexMetaData::BYTE_ARRAY(index) = column_index[0][0].as_ref().expect("column index should be present for column 0") {
             index
         } else {
             unreachable!()
@@ -2025,11 +2025,11 @@ mod tests {
         assert_eq!(b"Hello", min.as_bytes());
         assert_eq!(b"today", max.as_bytes());
 
-        let offset_indexes = metadata.offset_index().unwrap();
+        let offset_indexes = metadata.offset_index().expect("offset index should be present");
         // only one row group
         assert_eq!(offset_indexes.len(), 1);
         let offset_index = &offset_indexes[0];
-        let page_offset = &offset_index[0].page_locations()[0];
+        let page_offset = &offset_index[0].as_ref().expect("offset index should be present for column 0").page_locations()[0];
 
         assert_eq!(4, page_offset.offset);
         assert_eq!(152, page_offset.compressed_page_size);
@@ -2074,172 +2074,171 @@ mod tests {
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let column_index = metadata.column_index().unwrap();
-        let row_group_offset_indexes = &metadata.offset_index().unwrap()[0];
+        let column_index = metadata.column_index().expect("column index should be present");
+        let row_group_offset_indexes = &metadata.offset_index().expect("offset index should be present")[0];
 
         // only one row group
         assert_eq!(column_index.len(), 1);
         let row_group_metadata = metadata.row_group(0);
 
         //col0->id: INT32 UNCOMPRESSED DO:0 FPO:4 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 7299, num_nulls: 0]
-        assert!(!&column_index[0][0].is_sorted());
-        let boundary_order = &column_index[0][0].get_boundary_order();
+        assert!(!column_index[0][0].as_ref().expect("column index should be present for column 0").is_sorted());
+        let boundary_order = column_index[0][0].as_ref().unwrap().get_boundary_order();
         assert!(boundary_order.is_some());
         matches!(boundary_order.unwrap(), BoundaryOrder::UNORDERED);
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][0] {
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][0].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 0),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[0].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[0].as_ref().expect("offset index should be present for column 0").page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col1->bool_col:BOOLEAN UNCOMPRESSED DO:0 FPO:37329 SZ:3022/3022/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: false, max: true, num_nulls: 0]
-        assert!(&column_index[0][1].is_sorted());
-        if let ColumnIndexMetaData::BOOLEAN(index) = &column_index[0][1] {
+        assert!(column_index[0][1].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::BOOLEAN(index) = column_index[0][1].as_ref().unwrap() {
             assert_eq!(index.num_pages(), 82);
-            assert_eq!(row_group_offset_indexes[1].page_locations.len(), 82);
+            assert_eq!(row_group_offset_indexes[1].as_ref().expect("offset index should be present for column 1").page_locations.len(), 82);
         } else {
             unreachable!()
         };
         //col2->tinyint_col: INT32 UNCOMPRESSED DO:0 FPO:40351 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][2].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][2] {
+        assert!(column_index[0][2].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][2].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 2),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[2].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[2].as_ref().expect("offset index should be present for column 2").page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col4->smallint_col: INT32 UNCOMPRESSED DO:0 FPO:77676 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][3].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][3] {
+        assert!(column_index[0][3].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][3].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 3),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[3].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[3].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col5->smallint_col: INT32 UNCOMPRESSED DO:0 FPO:77676 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][4].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][4] {
+        assert!(column_index[0][4].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][4].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 4),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[4].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[4].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col6->bigint_col: INT64 UNCOMPRESSED DO:0 FPO:152326 SZ:71598/71598/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 90, num_nulls: 0]
-        assert!(!&column_index[0][5].is_sorted());
-        if let ColumnIndexMetaData::INT64(index) = &column_index[0][5] {
+        assert!(!column_index[0][5].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT64(index) = column_index[0][5].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 528,
                 get_row_group_min_max_bytes(row_group_metadata, 5),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[5].page_locations.len(), 528);
+            assert_eq!(row_group_offset_indexes[5].as_ref().unwrap().page_locations.len(), 528);
         } else {
             unreachable!()
         };
         //col7->float_col: FLOAT UNCOMPRESSED DO:0 FPO:223924 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: -0.0, max: 9.9, num_nulls: 0]
-        assert!(&column_index[0][6].is_sorted());
-        if let ColumnIndexMetaData::FLOAT(index) = &column_index[0][6] {
+        assert!(column_index[0][6].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::FLOAT(index) = column_index[0][6].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 6),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[6].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[6].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col8->double_col: DOUBLE UNCOMPRESSED DO:0 FPO:261249 SZ:71598/71598/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: -0.0, max: 90.89999999999999, num_nulls: 0]
-        assert!(!&column_index[0][7].is_sorted());
-        if let ColumnIndexMetaData::DOUBLE(index) = &column_index[0][7] {
+        assert!(!column_index[0][7].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::DOUBLE(index) = column_index[0][7].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 528,
                 get_row_group_min_max_bytes(row_group_metadata, 7),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[7].page_locations.len(), 528);
+            assert_eq!(row_group_offset_indexes[7].as_ref().unwrap().page_locations.len(), 528);
         } else {
             unreachable!()
         };
         //col9->date_string_col: BINARY UNCOMPRESSED DO:0 FPO:332847 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 01/01/09, max: 12/31/10, num_nulls: 0]
-        assert!(!&column_index[0][8].is_sorted());
-        if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][8] {
+        assert!(!&column_index[0][8].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::BYTE_ARRAY(index)) = &column_index[0][8] {
             check_byte_array_page_index(
                 index,
                 974,
                 get_row_group_min_max_bytes(row_group_metadata, 8),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[8].page_locations.len(), 974);
+            assert_eq!(row_group_offset_indexes[8].as_ref().unwrap().page_locations.len(), 974);
         } else {
             unreachable!()
         };
         //col10->string_col: BINARY UNCOMPRESSED DO:0 FPO:444795 SZ:45298/45298/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][9].is_sorted());
-        if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][9] {
+        assert!(&column_index[0][9].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::BYTE_ARRAY(index)) = &column_index[0][9] {
             check_byte_array_page_index(
                 index,
                 352,
                 get_row_group_min_max_bytes(row_group_metadata, 9),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[9].page_locations.len(), 352);
+            assert_eq!(row_group_offset_indexes[9].as_ref().unwrap().page_locations.len(), 352);
         } else {
             unreachable!()
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
         //Notice: min_max values for each page for this col not exits.
-        assert!(!&column_index[0][10].is_sorted());
-        if let ColumnIndexMetaData::NONE = &column_index[0][10] {
-            assert_eq!(row_group_offset_indexes[10].page_locations.len(), 974);
+        if column_index[0][10].is_none() {
+            assert_eq!(row_group_offset_indexes[10].as_ref().unwrap().page_locations.len(), 974);
         } else {
             unreachable!()
         };
         //col12->year: INT32 UNCOMPRESSED DO:0 FPO:602041 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 2009, max: 2010, num_nulls: 0]
-        assert!(&column_index[0][11].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][11] {
+        assert!(&column_index[0][11].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::INT32(index)) = &column_index[0][11] {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 11),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[11].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[11].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col13->month: INT32 UNCOMPRESSED DO:0 FPO:639366 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 1, max: 12, num_nulls: 0]
-        assert!(!&column_index[0][12].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][12] {
+        assert!(!&column_index[0][12].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::INT32(index)) = &column_index[0][12] {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 12),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[12].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[12].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
@@ -2502,7 +2501,7 @@ mod tests {
         let b = Bytes::from(out);
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(b, options).unwrap();
-        let index = reader.metadata().column_index().unwrap();
+        let index = reader.metadata().column_index().expect("column index should be present");
 
         // 1 row group
         assert_eq!(index.len(), 1);
@@ -2511,7 +2510,7 @@ mod tests {
         assert_eq!(c.len(), 1);
 
         match &c[0] {
-            ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v) => {
+            Some(ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v)) => {
                 assert_eq!(v.num_pages(), 1);
                 assert_eq!(v.null_count(0).unwrap(), 1);
                 assert_eq!(v.min_value(0).unwrap(), &[0; 11]);
@@ -2636,17 +2635,17 @@ mod tests {
         // check we only got the relevant page indexes
         assert!(metadata.column_index().is_some());
         assert!(metadata.offset_index().is_some());
-        assert_eq!(metadata.column_index().unwrap().len(), 1);
-        assert_eq!(metadata.offset_index().unwrap().len(), 1);
-        let col_idx = metadata.column_index().unwrap();
-        let off_idx = metadata.offset_index().unwrap();
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 1);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 1);
+        let col_idx = metadata.column_index().expect("column index should be present");
+        let off_idx = metadata.offset_index().expect("offset index should be present");
         let col_stats = metadata.row_group(0).column(0).statistics().unwrap();
         let pg_idx = &col_idx[0][0];
-        let off_idx_i = &off_idx[0][0];
+        let off_idx_i = off_idx[0][0].as_ref().expect("offset index should be present for column 0");
 
         // test that we got the index matching the row group
         match pg_idx {
-            ColumnIndexMetaData::INT32(int_idx) => {
+            Some(ColumnIndexMetaData::INT32(int_idx)) => {
                 let min = col_stats.min_bytes_opt().unwrap().get_i32_le();
                 let max = col_stats.max_bytes_opt().unwrap().get_i32_le();
                 assert_eq!(int_idx.min_value(0), Some(min).as_ref());
@@ -2679,19 +2678,19 @@ mod tests {
         // check we only got the relevant page indexes
         assert!(metadata.column_index().is_some());
         assert!(metadata.offset_index().is_some());
-        assert_eq!(metadata.column_index().unwrap().len(), 2);
-        assert_eq!(metadata.offset_index().unwrap().len(), 2);
-        let col_idx = metadata.column_index().unwrap();
-        let off_idx = metadata.offset_index().unwrap();
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 2);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 2);
+        let col_idx = metadata.column_index().expect("column index should be present");
+        let off_idx = metadata.offset_index().expect("offset index should be present");
 
         for (i, col_idx_i) in col_idx.iter().enumerate().take(metadata.num_row_groups()) {
             let col_stats = metadata.row_group(i).column(0).statistics().unwrap();
             let pg_idx = &col_idx_i[0];
-            let off_idx_i = &off_idx[i][0];
+            let off_idx_i = off_idx[i][0].as_ref().expect("offset index should be present for column 0");
 
             // test that we got the index matching the row group
             match pg_idx {
-                ColumnIndexMetaData::INT32(int_idx) => {
+                Some(ColumnIndexMetaData::INT32(int_idx)) => {
                     let min = col_stats.min_bytes_opt().unwrap().get_i32_le();
                     let max = col_stats.max_bytes_opt().unwrap().get_i32_le();
                     assert_eq!(int_idx.min_value(0), Some(min).as_ref());

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -287,7 +287,7 @@ impl TestRowGroups {
                     .enumerate()
                     .map(|(col_idx, col_meta)| {
                         let column_name = col_meta.column_descr().name().to_string();
-                        let page_locations = offset_index[rg_index][col_idx].page_locations();
+                        let page_locations = offset_index[rg_index][col_idx].as_ref().unwrap().page_locations();
                         let dictionary_page_location = col_meta.dictionary_page_offset();
 
                         // We can find the byte range of the entire column chunk

--- a/parquet/tests/arrow_reader/statistics.rs
+++ b/parquet/tests/arrow_reader/statistics.rs
@@ -49,6 +49,8 @@ use parquet::arrow::arrow_reader::{
 use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::file::statistics::{Statistics, ValueStatistics};
+use parquet::schema::types::ColumnPath;
+use parquet::file::page_index::column_index::ColumnIndexMetaData;
 use parquet::schema::types::{SchemaDescPtr, SchemaDescriptor};
 
 #[derive(Debug, Default, Clone)]
@@ -3044,5 +3046,188 @@ mod test {
             .map(|s| s.map(|s| s.to_string()))
             .collect();
         Arc::new(array)
+    }
+}
+
+#[cfg(test)]
+mod page_index_partial_tests {
+    use super::*;
+    use parquet::file::properties::EnabledStatistics;
+    use std::fs::File;
+
+    /// Test that partially missing column indexes across columns does not panic
+    /// and correctly represents None for missing indexes
+    #[test]
+    fn test_page_index_partial_column_index_presence_does_not_panic() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_partial_page_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that enable page indexes only for the first column
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that column index is present at top level
+        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+
+        // Verify structure: 1 row group
+        assert_eq!(column_index.len(), 1);
+        let rg_column_index = &column_index[0];
+
+        // Verify per-column: first column has index, second has NONE
+        assert_eq!(rg_column_index.len(), 2);
+        assert!(rg_column_index[0].is_some(), "first column should have column index");
+        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+
+        // Check that offset index follows the same pattern (both should be present)
+        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+        assert_eq!(offset_index.len(), 1);
+        let rg_offset_index = &offset_index[0];
+        assert_eq!(rg_offset_index.len(), 2);
+        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
+        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+    }
+
+    /// Test that partially missing offset indexes across columns does not panic
+    /// and correctly represents None for missing indexes
+    #[test]
+    fn test_page_index_partial_offset_index_presence_does_not_panic() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_partial_offset_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that enable page indexes only for the first column
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that offset index is present at top level
+        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+
+        // Verify structure: 1 row group
+        assert_eq!(offset_index.len(), 1);
+        let rg_offset_index = &offset_index[0];
+
+        // Verify per-column: first column has index, second does not
+        assert_eq!(rg_offset_index.len(), 2);
+        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
+        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+
+        // Check that column index follows the same pattern
+        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+        assert_eq!(column_index.len(), 1);
+        let rg_column_index = &column_index[0];
+        assert_eq!(rg_column_index.len(), 2);
+        assert!(rg_column_index[0].is_some(), "first column should have column index");
+        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+    }
+
+    /// Test regression: no page indexes for all columns should not panic
+    /// and correctly represent the absence of indexes
+    #[test]
+    fn test_page_index_no_indexes_for_all_columns_regression() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_no_page_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that disable all page indexes
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_offset_index_disabled(true)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled (should not find any)
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that no page indexes are present
+        assert!(metadata.column_index().is_none(), "column index should be None when disabled");
+        assert!(metadata.offset_index().is_none(), "offset index should be None when disabled");
     }
 }

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -81,13 +81,14 @@ fn assert_layout(file_reader: &Bytes, meta: &ParquetMetaData, layout: &Layout) {
         .row_groups()
         .iter()
         .zip(&layout.row_groups)
-        .zip(meta.offset_index().unwrap());
+        .zip(meta.offset_index().expect("offset index should be present"));
 
     for ((row_group, row_group_layout), offset_index) in iter {
         // Check against offset index
         assert_eq!(offset_index.len(), row_group_layout.columns.len());
 
         for (column_index, column_layout) in offset_index.iter().zip(&row_group_layout.columns) {
+            let column_index = column_index.as_ref().unwrap();
             assert_eq!(
                 column_index.page_locations.len(),
                 column_layout.pages.len(),

--- a/parquet/tests/encryption/encryption_util.rs
+++ b/parquet/tests/encryption/encryption_util.rs
@@ -186,20 +186,20 @@ pub(crate) fn verify_encryption_test_data(
 /// Verifies that the column and offset indexes were successfully read from an
 /// encrypted test file.
 pub(crate) fn verify_column_indexes(metadata: &ParquetMetaData) {
-    let offset_index = metadata.offset_index().unwrap();
+    let offset_index = metadata.offset_index().expect("offset index should be present");
     // 1 row group, 8 columns
     assert_eq!(offset_index.len(), 1);
     assert_eq!(offset_index[0].len(), 8);
     // Check float column, which is encrypted in the non-uniform test file
     let float_col_idx = 4;
-    let offset_index = &offset_index[0][float_col_idx];
+    let offset_index = &offset_index[0][float_col_idx].as_ref().expect("offset index should be present for column 4");
     assert_eq!(offset_index.page_locations.len(), 1);
     assert!(offset_index.page_locations[0].offset > 0);
 
-    let column_index = metadata.column_index().unwrap();
+    let column_index = metadata.column_index().expect("column index should be present");
     assert_eq!(column_index.len(), 1);
     assert_eq!(column_index[0].len(), 8);
-    let column_index = &column_index[0][float_col_idx];
+    let column_index = &column_index[0][float_col_idx].as_ref().expect("column index should be present for column 4");
 
     match column_index {
         parquet::file::page_index::column_index::ColumnIndexMetaData::FLOAT(float_index) => {


### PR DESCRIPTION
# Page index column semantics: use `None` instead of `ColumnIndexMetaData::NONE`

---

## Goal

Normalize column page index semantics so that missing column indexes are represented as `None` at the leaf of `ParquetColumnIndex`, treating `ColumnIndexMetaData::NONE` as a legacy/special marker instead of the general “no index” representation.

---

## Which issue does this PR close?

Part of [#8818](https://github.com/apache/arrow-rs/issues/8818).

---

## Rationale for this change

After introducing:
```rust
pub type ParquetColumnIndex = Vec<Vec<Option<ColumnIndexMetaData>>>;
```
there were still code paths that used `Some(ColumnIndexMetaData::NONE)` to represent *“no column index for this column chunk”*. That left us with two parallel representations for “missing”:

- `None`
- `Some(ColumnIndexMetaData::NONE)`

This is confusing for callers and undermines the advantages of modeling optionality with `Option`. The more idiomatic and type-safe approach is:

- Use `None` to express *“no index for this (row_group, column)”*
- Use `Some(ColumnIndexMetaData::...)` only when an actual index is present
- Treat `ColumnIndexMetaData::NONE` as a legacy/special-case sentinel, not the general “missing index” marker

This PR updates parsing, writing, and consumers to align with that model.

---

## What changes are included in this PR?

- ### Parser semantics for column indexes
  - `parse_column_index` now sets:
    - `ParquetColumnIndex[row_group][column] = None` when there is no column index range for that column chunk
    - `Some(ColumnIndexMetaData::...)` when column index data is present
  - This replaces the previous behavior that could return `Some(ColumnIndexMetaData::NONE)` in these cases.

- ### Writer / metadata plumbing
  - Ensure writer paths and internal builders only produce `Some(ColumnIndexMetaData::...)` when a column index actually exists.
  - When no column index is produced, the leaf is set to `None` instead of `Some(NONE)`.

- ### `ColumnIndexMetaData::NONE` documentation and usage
  - Document `ColumnIndexMetaData::NONE` as a legacy marker and clarify it must NOT be used to represent missing column indexes in `ParquetColumnIndex`; `None` on the outer `Option` should be used instead.
  - Update consumers (e.g., in `arrow_reader/statistics.rs`) to:
    - Treat `None` as “no column index for this column chunk”
    - Treat `Some(ci)` as “column index present”
    - Only special-case `ColumnIndexMetaData::NONE` where it has specific legacy meaning for page-level stats, not as the general “no index” signal.

- ### Consumers and statistics logic
  - Update iterator macros and helpers to work with `Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>` instead of the non-optional type.
  - For statistics:
    - `None` → fill with `len` `None` entries (no stats for that chunk)
    - `Some(ColumnIndexMetaData::...)` → derive min/max/null_count as before
  - This ensures:
    - Column-index-based pruning is skipped when `None` is encountered
    - The code no longer relies on `ColumnIndexMetaData::NONE` as the primary “missing” signal

- ### Tests
  - Update tests that previously expected `Some(ColumnIndexMetaData::NONE)` to now expect `None` for missing column indexes.
  - Preserve existing expectations where `ColumnIndexMetaData::NONE` has specific meaning, but not as the default representation of “no index”.

---

## Are these changes tested?

**Yes.**

- Existing parquet tests have been updated where necessary and are passing.
- Page-index-related tests (including statistics and reader tests) are updated to assert the new semantics and are passing.

Example commands:

cargo test --package parquet --lib
cargo test --package parquet --test arrow_reader -- test_page_index*   # or equivalent page-index tests


---

## Are there any user-facing changes?

**Yes, in terms of how missing column indexes are surfaced:**

- Callers that inspect `ParquetColumnIndex` should now treat:
  - `None` at the leaf as “no column index for this column chunk”
  - `Some(ColumnIndexMetaData::...)` as “column index present”
- Any downstream code relying on `Some(ColumnIndexMetaData::NONE)` as a missing-index marker will need to be updated to check for `None` instead.

The on-disk Parquet encoding remains unchanged.

Most observable differences should be:
- More consistent representation of missing column indexes
- Fewer surprises around mixed `None` / `Some(NONE)` representations
- No new panics introduced by this normalization