### PR TITLE
page-index-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ __pycache__/
 
 # Parquet file from arrow_reader_clickbench
 hits_1.parquet
+/.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@
 
 # Changelog
 
+## [58.0.0](https://github.com/apache/arrow-rs/tree/58.0.0) (2025-11-28)
+
+**Breaking changes:**
+
+- [Parquet] Changed `ParquetColumnIndex` and `ParquetOffsetIndex` aliases to `Vec<Vec<Option<...>>>` to correctly model missing indexes per column chunk. Code accessing these indexes via `metadata.column_index()` or `metadata.offset_index()` must now handle the `Option` wrapper.
+
+  Migration example:
+  ```rust
+  // Before
+  let idx: &ColumnIndexMetaData = &metadata.column_index().unwrap()[rg][col];
+
+  // After
+  let idx: &ColumnIndexMetaData = metadata.column_index().unwrap()[rg][col]
+      .as_ref()
+      .expect("index missing");
+  ```
+
 ## [57.0.0](https://github.com/apache/arrow-rs/tree/57.0.0) (2025-10-19)
 
 [Full Changelog](https://github.com/apache/arrow-rs/compare/56.2.0...57.0.0)

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -51,7 +51,7 @@ mod test_util;
 
 // Note that this crate is public under the `experimental` feature flag.
 use crate::file::metadata::RowGroupMetaData;
-pub use builder::{ArrayReaderBuilder, CacheOptions, CacheOptionsBuilder};
+pub use builder::{ArrayReaderBuilder, CacheOptionsBuilder};
 pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
 #[allow(unused_imports)] // Only used for benchmarks

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1119,7 +1119,7 @@ impl<T: ChunkReader + 'static> ReaderPageIterator<T> {
         // To avoid `i[rg_idx][self.column_idx`] panic, we need to filter out empty `i[rg_idx]`.
         let page_locations = offset_index
             .filter(|i| !i[rg_idx].is_empty())
-            .map(|i| i[rg_idx][self.column_idx].page_locations.clone());
+            .map(|i| i[rg_idx][self.column_idx].as_ref().unwrap().page_locations.clone());
         let total_rows = rg.num_rows() as usize;
         let reader = self.reader.clone();
 
@@ -4562,7 +4562,7 @@ pub(crate) mod tests {
                 ArrowReaderOptions::new().with_page_index(true),
             )
             .unwrap();
-            assert!(!builder.metadata().offset_index().unwrap()[0].is_empty());
+            assert!(!builder.metadata().offset_index().expect("offset index should be present when page index is enabled")[0].is_empty());
             let reader = builder.build().unwrap();
             let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
             assert_eq!(batches.len(), 8);

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -254,12 +254,16 @@ impl RowSelection {
     fn selection_skips_any_page(
         &self,
         projection: &ProjectionMask,
-        columns: &[OffsetIndexMetaData],
+        columns: &[Option<OffsetIndexMetaData>],
     ) -> bool {
         columns.iter().enumerate().any(|(leaf_idx, column)| {
             if !projection.leaf_included(leaf_idx) {
                 return false;
             }
+
+            let Some(column) = column else {
+                return false;
+            };
 
             let locations = column.page_locations();
             if locations.is_empty() {
@@ -275,7 +279,7 @@ impl RowSelection {
     pub(crate) fn should_force_selectors(
         &self,
         projection: &ProjectionMask,
-        offset_index: Option<&[OffsetIndexMetaData]>,
+        offset_index: Option<&[Option<OffsetIndexMetaData>]>,
     ) -> bool {
         match offset_index {
             Some(columns) => self.selection_skips_any_page(projection, columns),

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -600,14 +600,14 @@ macro_rules! make_data_page_stats_iterator {
     ($iterator_type: ident, $func: ident, $stat_value_type: ty) => {
         struct $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             iter: I,
         }
 
         impl<'a, I> $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             fn new(iter: I) -> Self {
                 Self { iter }
@@ -616,7 +616,7 @@ macro_rules! make_data_page_stats_iterator {
 
         impl<'a, I> Iterator for $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             type Item = Vec<Option<$stat_value_type>>;
 
@@ -630,8 +630,8 @@ macro_rules! make_data_page_stats_iterator {
                         // create an arrow null-array with the length
                         // corresponding to the number of entries in
                         // `ParquetOffsetIndex` per row group per column.
-                        ColumnIndexMetaData::NONE => Some(vec![None; len]),
-                        _ => Some(<$stat_value_type>::$func(&index).collect::<Vec<_>>()),
+                        None => Some(vec![None; len]),
+                        Some(index) => Some(<$stat_value_type>::$func(index).collect::<Vec<_>>()),
                     },
                     _ => None,
                 }
@@ -690,14 +690,14 @@ macro_rules! get_decimal_page_stats_iterator {
     ($iterator_type: ident, $func: ident, $stat_value_type: ident, $convert_func: ident) => {
         struct $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             iter: I,
         }
 
         impl<'a, I> $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             fn new(iter: I) -> Self {
                 Self { iter }
@@ -706,7 +706,7 @@ macro_rules! get_decimal_page_stats_iterator {
 
         impl<'a, I> Iterator for $iterator_type<'a, I>
         where
-            I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+            I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
         {
             type Item = Vec<Option<$stat_value_type>>;
 
@@ -715,25 +715,26 @@ macro_rules! get_decimal_page_stats_iterator {
                 let next = self.iter.next();
                 match next {
                     Some((len, index)) => match index {
-                        ColumnIndexMetaData::INT32(native_index) => Some(
+                        None => Some(vec![None; len]),
+                        Some(ColumnIndexMetaData::INT32(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $stat_value_type::from(*x)))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::INT64(native_index) => Some(
+                        Some(ColumnIndexMetaData::INT64(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $stat_value_type::try_from(*x).unwrap()))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::BYTE_ARRAY(native_index) => Some(
+                        Some(ColumnIndexMetaData::BYTE_ARRAY(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $convert_func(x)))
                                 .collect::<Vec<_>>(),
                         ),
-                        ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(native_index) => Some(
+                        Some(ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(native_index)) => Some(
                             native_index
                                 .$func()
                                 .map(|x| x.map(|x| $convert_func(x)))
@@ -1116,7 +1117,7 @@ pub(crate) fn min_page_statistics<'a, I>(
     physical_type: Option<PhysicalType>,
 ) -> Result<ArrayRef>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     get_data_page_statistics!(Min, data_type, iterator, physical_type)
 }
@@ -1129,7 +1130,7 @@ pub(crate) fn max_page_statistics<'a, I>(
     physical_type: Option<PhysicalType>,
 ) -> Result<ArrayRef>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     get_data_page_statistics!(Max, data_type, iterator, physical_type)
 }
@@ -1140,11 +1141,11 @@ where
 /// The returned Array is an [`UInt64Array`]
 pub(crate) fn null_counts_page_statistics<'a, I>(iterator: I) -> Result<UInt64Array>
 where
-    I: Iterator<Item = (usize, &'a ColumnIndexMetaData)>,
+    I: Iterator<Item = (usize, &'a Option<ColumnIndexMetaData>)>,
 {
     let iter = iterator.flat_map(|(len, index)| match index {
-        ColumnIndexMetaData::NONE => vec![None; len],
-        column_index => column_index.null_counts().map_or(vec![None; len], |v| {
+        None | Some(ColumnIndexMetaData::NONE) => vec![None; len],
+        Some(column_index) => column_index.null_counts().map_or(vec![None; len], |v| {
             v.iter().map(|i| Some(*i as u64)).collect::<Vec<_>>()
         }),
     });
@@ -1533,11 +1534,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
 
         min_page_statistics(data_type, iter, self.physical_type)
@@ -1564,11 +1569,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
 
         max_page_statistics(data_type, iter, self.physical_type)
@@ -1597,11 +1606,15 @@ impl<'a> StatisticsConverter<'a> {
         let iter = row_group_indices.into_iter().map(|rg_index| {
             let column_page_index_per_row_group_per_column =
                 &column_page_index[*rg_index][parquet_index];
-            let num_data_pages = &column_offset_index[*rg_index][parquet_index]
-                .page_locations()
-                .len();
+            let num_data_pages = if let Some(ci) = column_page_index_per_row_group_per_column {
+                ci.num_pages() as usize
+            } else if let Some(oi) = &column_offset_index[*rg_index][parquet_index] {
+                oi.page_locations().len()
+            } else {
+                0
+            };
 
-            (*num_data_pages, column_page_index_per_row_group_per_column)
+            (num_data_pages, column_page_index_per_row_group_per_column)
         });
         null_counts_page_statistics(iter)
     }
@@ -1641,22 +1654,25 @@ impl<'a> StatisticsConverter<'a> {
 
         let mut row_count_total = Vec::new();
         for rg_idx in row_group_indices {
-            let page_locations = &column_offset_index[*rg_idx][parquet_index].page_locations();
+            if let Some(oi) = &column_offset_index[*rg_idx][parquet_index] {
+                let page_locations = oi.page_locations();
 
-            let row_count_per_page = page_locations
-                .windows(2)
-                .map(|loc| Some(loc[1].first_row_index as u64 - loc[0].first_row_index as u64));
+                let row_count_per_page = page_locations
+                    .windows(2)
+                    .map(|loc| Some(loc[1].first_row_index as u64 - loc[0].first_row_index as u64));
 
-            // append the last page row count
-            let num_rows_in_row_group = &row_group_metadatas[*rg_idx].num_rows();
-            let row_count_per_page = row_count_per_page
-                .chain(std::iter::once(Some(
-                    *num_rows_in_row_group as u64
-                        - page_locations.last().unwrap().first_row_index as u64,
-                )))
-                .collect::<Vec<_>>();
+                // append the last page row count
+                let num_rows_in_row_group = &row_group_metadatas[*rg_idx].num_rows();
+                let row_count_per_page = row_count_per_page
+                    .chain(std::iter::once(Some(
+                        *num_rows_in_row_group as u64
+                            - page_locations.last().unwrap().first_row_index as u64,
+                    )))
+                    .collect::<Vec<_>>();
 
-            row_count_total.extend(row_count_per_page);
+                row_count_total.extend(row_count_per_page);
+            }
+            // else skip
         }
 
         Ok(Some(UInt64Array::from_iter(row_count_total)))

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2244,9 +2244,9 @@ mod tests {
         );
 
         assert!(reader.metadata().offset_index().is_some());
-        let offset_indexes = &reader.metadata().offset_index().unwrap()[0];
+        let offset_indexes = &reader.metadata().offset_index().expect("offset index should be present when page index is enabled")[0];
 
-        let page_locations = offset_indexes[0].page_locations.clone();
+        let page_locations = offset_indexes[0].as_ref().expect("offset index should be present for column 0").page_locations.clone();
 
         // We should fallback to PLAIN encoding after the first row and our max page size is 1 bytes
         // so we expect one dictionary encoded page and then a page per row thereafter.
@@ -3971,12 +3971,12 @@ mod tests {
         let bytes = Bytes::from(buf);
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(bytes, options).unwrap();
-        let index = reader.metadata().offset_index().unwrap();
+        let index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
 
         assert_eq!(index.len(), 1);
         assert_eq!(index[0].len(), 2); // 2 columns
-        assert_eq!(index[0][0].page_locations().len(), 1); // 1 page
-        assert_eq!(index[0][1].page_locations().len(), 1); // 1 page
+        assert_eq!(index[0][0].as_ref().expect("offset index should be present for column 0").page_locations().len(), 1); // 1 page
+        assert_eq!(index[0][1].as_ref().expect("offset index should be present for column 1").page_locations().len(), 1); // 1 page
     }
 
     #[test]
@@ -4037,21 +4037,21 @@ mod tests {
         // The column chunk for column "b" shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let offset_index = reader.metadata().offset_index().unwrap();
+        let offset_index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
         assert_eq!(offset_index.len(), 1); // 1 row group
         assert_eq!(offset_index[0].len(), 2); // 2 columns
 
-        let column_index = reader.metadata().column_index().unwrap();
+        let column_index = reader.metadata().column_index().expect("column index should be present when page index is enabled");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 
         let a_idx = &column_index[0][0];
         assert!(
-            matches!(a_idx, ColumnIndexMetaData::BYTE_ARRAY(_)),
+            matches!(a_idx, Some(ColumnIndexMetaData::BYTE_ARRAY(_))),
             "{a_idx:?}"
         );
         let b_idx = &column_index[0][1];
-        assert!(matches!(b_idx, ColumnIndexMetaData::NONE), "{b_idx:?}");
+        assert!(matches!(b_idx, None), "{b_idx:?}");
     }
 
     #[test]
@@ -4112,14 +4112,14 @@ mod tests {
         // The column chunk for column "b"  shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let column_index = reader.metadata().column_index().unwrap();
+        let column_index = reader.metadata().column_index().expect("column index should be present");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 
         let a_idx = &column_index[0][0];
-        assert!(matches!(a_idx, ColumnIndexMetaData::NONE), "{a_idx:?}");
+        assert!(matches!(a_idx, None), "{a_idx:?}");
         let b_idx = &column_index[0][1];
-        assert!(matches!(b_idx, ColumnIndexMetaData::NONE), "{b_idx:?}");
+        assert!(matches!(b_idx, None), "{b_idx:?}");
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2244,9 +2244,16 @@ mod tests {
         );
 
         assert!(reader.metadata().offset_index().is_some());
-        let offset_indexes = &reader.metadata().offset_index().expect("offset index should be present when page index is enabled")[0];
+        let offset_indexes = &reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present when page index is enabled")[0];
 
-        let page_locations = offset_indexes[0].as_ref().expect("offset index should be present for column 0").page_locations.clone();
+        let page_locations = offset_indexes[0]
+            .as_ref()
+            .expect("offset index should be present for column 0")
+            .page_locations
+            .clone();
 
         // We should fallback to PLAIN encoding after the first row and our max page size is 1 bytes
         // so we expect one dictionary encoded page and then a page per row thereafter.
@@ -3971,12 +3978,29 @@ mod tests {
         let bytes = Bytes::from(buf);
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(bytes, options).unwrap();
-        let index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
+        let index = reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present when page index is enabled");
 
         assert_eq!(index.len(), 1);
         assert_eq!(index[0].len(), 2); // 2 columns
-        assert_eq!(index[0][0].as_ref().expect("offset index should be present for column 0").page_locations().len(), 1); // 1 page
-        assert_eq!(index[0][1].as_ref().expect("offset index should be present for column 1").page_locations().len(), 1); // 1 page
+        assert_eq!(
+            index[0][0]
+                .as_ref()
+                .expect("offset index should be present for column 0")
+                .page_locations()
+                .len(),
+            1
+        ); // 1 page
+        assert_eq!(
+            index[0][1]
+                .as_ref()
+                .expect("offset index should be present for column 1")
+                .page_locations()
+                .len(),
+            1
+        ); // 1 page
     }
 
     #[test]
@@ -4037,11 +4061,17 @@ mod tests {
         // The column chunk for column "b" shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let offset_index = reader.metadata().offset_index().expect("offset index should be present when page index is enabled");
+        let offset_index = reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present when page index is enabled");
         assert_eq!(offset_index.len(), 1); // 1 row group
         assert_eq!(offset_index[0].len(), 2); // 2 columns
 
-        let column_index = reader.metadata().column_index().expect("column index should be present when page index is enabled");
+        let column_index = reader
+            .metadata()
+            .column_index()
+            .expect("column index should be present when page index is enabled");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 
@@ -4112,7 +4142,10 @@ mod tests {
         // The column chunk for column "b"  shouldn't have statistics
         assert!(b_col.statistics().is_none());
 
-        let column_index = reader.metadata().column_index().expect("column index should be present");
+        let column_index = reader
+            .metadata()
+            .column_index()
+            .expect("column index should be present");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 columns
 

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -963,8 +963,12 @@ mod tests {
         assert_eq!(metadata_with_index.num_row_groups(), 1);
 
         // Check offset indexes are present for all columns
-        let offset_index = metadata_with_index.offset_index().expect("offset index should be present when page index is enabled");
-        let column_index = metadata_with_index.column_index().expect("column index should be present when page index is enabled");
+        let offset_index = metadata_with_index
+            .offset_index()
+            .expect("offset index should be present when page index is enabled");
+        let column_index = metadata_with_index
+            .column_index()
+            .expect("column index should be present when page index is enabled");
 
         assert_eq!(offset_index.len(), metadata_with_index.num_row_groups());
         assert_eq!(column_index.len(), metadata_with_index.num_row_groups());

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -963,8 +963,8 @@ mod tests {
         assert_eq!(metadata_with_index.num_row_groups(), 1);
 
         // Check offset indexes are present for all columns
-        let offset_index = metadata_with_index.offset_index().unwrap();
-        let column_index = metadata_with_index.column_index().unwrap();
+        let offset_index = metadata_with_index.offset_index().expect("offset index should be present when page index is enabled");
+        let column_index = metadata_with_index.column_index().expect("column index should be present when page index is enabled");
 
         assert_eq!(offset_index.len(), metadata_with_index.num_row_groups());
         assert_eq!(column_index.len(), metadata_with_index.num_row_groups());

--- a/parquet/src/arrow/decoder/mod.rs
+++ b/parquet/src/arrow/decoder/mod.rs
@@ -20,5 +20,7 @@
 mod delta_byte_array;
 mod dictionary_index;
 
+#[allow(unused_imports)]
 pub use delta_byte_array::DeltaByteArrayDecoder;
+#[allow(unused_imports)]
 pub use dictionary_index::DictIndexDecoder;

--- a/parquet/src/arrow/decoder/mod.rs
+++ b/parquet/src/arrow/decoder/mod.rs
@@ -20,7 +20,6 @@
 mod delta_byte_array;
 mod dictionary_index;
 
-#[allow(unused_imports)]
 pub use delta_byte_array::DeltaByteArrayDecoder;
 #[allow(unused_imports)]
 pub use dictionary_index::DictIndexDecoder;

--- a/parquet/src/arrow/in_memory_row_group.rs
+++ b/parquet/src/arrow/in_memory_row_group.rs
@@ -97,10 +97,14 @@ impl InMemoryRowGroup<'_> {
                     let use_expanded = cache_mask.map(|m| m.leaf_included(idx)).unwrap_or(false);
                     if use_expanded {
                         ranges.extend(
-                            expanded_selection.scan_ranges(&offset_index[idx].as_ref().unwrap().page_locations),
+                            expanded_selection
+                                .scan_ranges(&offset_index[idx].as_ref().unwrap().page_locations),
                         );
                     } else {
-                        ranges.extend(selection.scan_ranges(&offset_index[idx].as_ref().unwrap().page_locations));
+                        ranges.extend(
+                            selection
+                                .scan_ranges(&offset_index[idx].as_ref().unwrap().page_locations),
+                        );
                     }
                     page_start_offsets.push(ranges.iter().map(|range| range.start).collect());
 

--- a/parquet/src/arrow/push_decoder/reader_builder/data.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/data.rs
@@ -224,7 +224,7 @@ impl<'a> DataRequestBuilder<'a> {
 fn get_offset_index(
     parquet_metadata: &ParquetMetaData,
     row_group_idx: usize,
-) -> Option<&[OffsetIndexMetaData]> {
+) -> Option<&[Option<OffsetIndexMetaData>]> {
     parquet_metadata
         .offset_index()
         // filter out empty offset indexes (old versions specified Some(vec![]) when no present)

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -645,7 +645,7 @@ impl RowGroupReaderBuilder {
     }
 
     /// Get the offset index for the specified row group, if any
-    fn row_group_offset_index(&self, row_group_idx: usize) -> Option<&[OffsetIndexMetaData]> {
+    fn row_group_offset_index(&self, row_group_idx: usize) -> Option<&[Option<OffsetIndexMetaData>]> {
         self.metadata
             .offset_index()
             .filter(|index| !index.is_empty())
@@ -676,7 +676,7 @@ impl RowGroupReaderBuilder {
 fn override_selector_strategy_if_needed(
     plan_builder: ReadPlanBuilder,
     projection_mask: &ProjectionMask,
-    offset_index: Option<&[OffsetIndexMetaData]>,
+    offset_index: Option<&[Option<OffsetIndexMetaData>]>,
 ) -> ReadPlanBuilder {
     // override only applies to Auto policy, If the policy is already Mask or Selectors, respect that
     let RowSelectionPolicy::Auto { .. } = plan_builder.row_selection_policy() else {

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -645,7 +645,10 @@ impl RowGroupReaderBuilder {
     }
 
     /// Get the offset index for the specified row group, if any
-    fn row_group_offset_index(&self, row_group_idx: usize) -> Option<&[Option<OffsetIndexMetaData>]> {
+    fn row_group_offset_index(
+        &self,
+        row_group_idx: usize,
+    ) -> Option<&[Option<OffsetIndexMetaData>]> {
         self.metadata
             .offset_index()
             .filter(|index| !index.is_empty())

--- a/parquet/src/arrow/schema/extension.rs
+++ b/parquet/src/arrow/schema/extension.rs
@@ -26,6 +26,7 @@
 use crate::basic::LogicalType;
 use crate::errors::ParquetError;
 use crate::schema::types::Type;
+#[cfg(feature = "variant_experimental")]
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::Field;
 
@@ -36,7 +37,7 @@ use arrow_schema::Field;
 /// Arrow DataType, and instead are represented by an Arrow ExtensionType.
 /// Extension types are attached to Arrow Fields via metadata.
 pub(crate) fn try_add_extension_type(
-    #[allow(unused_mut)] mut arrow_field: Field,
+    mut arrow_field: Field,
     parquet_type: &Type,
 ) -> Result<Field, ParquetError> {
     let Some(parquet_logical_type) = parquet_type.get_basic_info().logical_type_ref() else {

--- a/parquet/src/arrow/schema/extension.rs
+++ b/parquet/src/arrow/schema/extension.rs
@@ -26,8 +26,8 @@
 use crate::basic::LogicalType;
 use crate::errors::ParquetError;
 use crate::schema::types::Type;
-use arrow_schema::Field;
 use arrow_schema::extension::ExtensionType;
+use arrow_schema::Field;
 
 /// Adds extension type metadata, if necessary, based on the Parquet field's
 /// [`LogicalType`]
@@ -36,7 +36,7 @@ use arrow_schema::extension::ExtensionType;
 /// Arrow DataType, and instead are represented by an Arrow ExtensionType.
 /// Extension types are attached to Arrow Fields via metadata.
 pub(crate) fn try_add_extension_type(
-    mut arrow_field: Field,
+    #[allow(unused_mut)] mut arrow_field: Field,
     parquet_type: &Type,
 ) -> Result<Field, ParquetError> {
     let Some(parquet_logical_type) = parquet_type.get_basic_info().logical_type_ref() else {

--- a/parquet/src/bin/parquet-concat.rs
+++ b/parquet/src/bin/parquet-concat.rs
@@ -109,9 +109,11 @@ impl Args {
                 let mut rg_out = writer.next_row_group()?;
                 for (col_idx, column) in rg.columns().iter().enumerate() {
                     let bloom_filter = read_bloom_filter(column, &input);
-                    let column_index = rg_column_indexes.and_then(|row| row.get(col_idx)).cloned();
+                    let column_index = rg_column_indexes
+                        .and_then(|row| row.get(col_idx).and_then(|opt| opt.clone()));
 
-                    let offset_index = rg_offset_indexes.and_then(|row| row.get(col_idx)).cloned();
+                    let offset_index = rg_offset_indexes
+                        .and_then(|row| row.get(col_idx).and_then(|opt| opt.clone()));
 
                     let result = ColumnCloseResult {
                         bytes_written: column.compressed_size() as _,

--- a/parquet/src/bin/parquet-fromcsv-help.txt
+++ b/parquet/src/bin/parquet-fromcsv-help.txt
@@ -1,4 +1,3 @@
-
 Usage: parquet [OPTIONS] --schema <SCHEMA> --input-file <INPUT_FILE> --output-file <OUTPUT_FILE>
 
 Options:

--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -445,6 +445,9 @@ mod tests {
         let mut actual = String::from_utf8(buffer_vec).unwrap();
         let pos = actual.find('\n').unwrap() + 1;
         actual = actual[pos..].to_string();
+        // Normalize line endings for cross-platform compatibility
+        let expected = expected.replace("\r\n", "\n").trim_start().to_string();
+        let actual = actual.replace("\r\n", "\n").trim_start().to_string();
         assert_eq!(
             expected, actual,
             "help text not match. please update to \n---\n{actual}\n---\n"

--- a/parquet/src/bin/parquet-fromcsv.rs
+++ b/parquet/src/bin/parquet-fromcsv.rs
@@ -445,9 +445,6 @@ mod tests {
         let mut actual = String::from_utf8(buffer_vec).unwrap();
         let pos = actual.find('\n').unwrap() + 1;
         actual = actual[pos..].to_string();
-        // Normalize line endings for cross-platform compatibility
-        let expected = expected.replace("\r\n", "\n").trim_start().to_string();
-        let actual = actual.replace("\r\n", "\n").trim_start().to_string();
         assert_eq!(
             expected, actual,
             "help text not match. please update to \n---\n{actual}\n---\n"

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -94,6 +94,10 @@ impl Args {
                 ParquetError::General(format!(
                     "No offset index for row group {row_group_idx} column chunk {column_idx}"
                 ))
+            })?.as_ref().ok_or_else(|| {
+                ParquetError::General(format!(
+                    "Offset index is None for row group {row_group_idx} column chunk {column_idx}"
+                ))
             })?;
 
             let row_counts =

--- a/parquet/src/bin/parquet-index.rs
+++ b/parquet/src/bin/parquet-index.rs
@@ -103,21 +103,22 @@ impl Args {
             let row_counts =
                 compute_row_counts(offset_index.page_locations.as_slice(), row_group.num_rows());
             match &column_indices[column_idx] {
-                ColumnIndexMetaData::NONE => println!("NO INDEX"),
-                ColumnIndexMetaData::BOOLEAN(v) => {
+                Some(ColumnIndexMetaData::NONE) => println!("NO INDEX"),
+                Some(ColumnIndexMetaData::BOOLEAN(v)) => {
                     print_index::<bool>(v, offset_index, &row_counts)?
                 }
-                ColumnIndexMetaData::INT32(v) => print_index(v, offset_index, &row_counts)?,
-                ColumnIndexMetaData::INT64(v) => print_index(v, offset_index, &row_counts)?,
-                ColumnIndexMetaData::INT96(v) => print_index(v, offset_index, &row_counts)?,
-                ColumnIndexMetaData::FLOAT(v) => print_index(v, offset_index, &row_counts)?,
-                ColumnIndexMetaData::DOUBLE(v) => print_index(v, offset_index, &row_counts)?,
-                ColumnIndexMetaData::BYTE_ARRAY(v) => {
+                Some(ColumnIndexMetaData::INT32(v)) => print_index(v, offset_index, &row_counts)?,
+                Some(ColumnIndexMetaData::INT64(v)) => print_index(v, offset_index, &row_counts)?,
+                Some(ColumnIndexMetaData::INT96(v)) => print_index(v, offset_index, &row_counts)?,
+                Some(ColumnIndexMetaData::FLOAT(v)) => print_index(v, offset_index, &row_counts)?,
+                Some(ColumnIndexMetaData::DOUBLE(v)) => print_index(v, offset_index, &row_counts)?,
+                Some(ColumnIndexMetaData::BYTE_ARRAY(v)) => {
                     print_bytes_index(v, offset_index, &row_counts)?
                 }
-                ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v) => {
+                Some(ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v)) => {
                     print_bytes_index(v, offset_index, &row_counts)?
                 }
+                None => println!("NO INDEX"),
             }
         }
         Ok(())

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -146,10 +146,20 @@ pub(crate) use writer::ThriftMetadataWriter;
 ///
 /// `column_index[row_group_number][column_number]` holds the
 /// [`ColumnIndex`] corresponding to column `column_number` of row group
-/// `row_group_number`, or `None` if no index is available.
+/// `row_group_number`, or `None` if no index is available for that column chunk.
 ///
-/// For example `column_index[2][3]` holds the [`ColumnIndex`] for the fourth
-/// column in the third row group of the parquet file, or `None`.
+/// Note: `None` at the leaf level means "no index for this (row_group, column)".
+///
+/// # Example
+///
+/// ```rust
+/// # use parquet::file::metadata::ParquetColumnIndex;
+/// # fn example(indexes: &ParquetColumnIndex, rg: usize, col: usize) {
+/// if let Some(idx) = indexes[rg][col].as_ref() {
+///     // use idx
+/// }
+/// # }
+/// ```
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`ColumnIndex`]: crate::file::page_index::column_index::ColumnIndexMetaData
@@ -162,7 +172,21 @@ pub type ParquetColumnIndex = Vec<Vec<Option<ColumnIndexMetaData>>>;
 ///
 /// `offset_index[row_group_number][column_number]` holds
 /// the [`OffsetIndexMetaData`] corresponding to column
-/// `column_number`of row group `row_group_number`, or `None` if no index is available.
+/// `column_number`of row group `row_group_number`, or `None` if no index is available
+/// for that column chunk.
+///
+/// Note: `None` at the leaf level means "no index for this (row_group, column)".
+///
+/// # Example
+///
+/// ```rust
+/// # use parquet::file::metadata::ParquetOffsetIndex;
+/// # fn example(indexes: &ParquetOffsetIndex, rg: usize, col: usize) {
+/// if let Some(idx) = indexes[rg][col].as_ref() {
+///     // use idx
+/// }
+/// # }
+/// ```
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`OffsetIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1908,7 +1908,9 @@ mod tests {
 
         let parquet_meta = ParquetMetaDataBuilder::new(file_metadata)
             .set_row_groups(row_group_meta)
-            .set_column_index(Some(vec![vec![Some(ColumnIndexMetaData::BOOLEAN(native_index))]]))
+            .set_column_index(Some(vec![vec![Some(ColumnIndexMetaData::BOOLEAN(
+                native_index,
+            ))]]))
             .set_offset_index(Some(vec![vec![Some(offset_index)]]))
             .build();
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -146,14 +146,14 @@ pub(crate) use writer::ThriftMetadataWriter;
 ///
 /// `column_index[row_group_number][column_number]` holds the
 /// [`ColumnIndex`] corresponding to column `column_number` of row group
-/// `row_group_number`.
+/// `row_group_number`, or `None` if no index is available.
 ///
 /// For example `column_index[2][3]` holds the [`ColumnIndex`] for the fourth
-/// column in the third row group of the parquet file.
+/// column in the third row group of the parquet file, or `None`.
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`ColumnIndex`]: crate::file::page_index::column_index::ColumnIndexMetaData
-pub type ParquetColumnIndex = Vec<Vec<ColumnIndexMetaData>>;
+pub type ParquetColumnIndex = Vec<Vec<Option<ColumnIndexMetaData>>>;
 
 /// [`OffsetIndexMetaData`] for each data page of each row group of each column
 ///
@@ -162,11 +162,11 @@ pub type ParquetColumnIndex = Vec<Vec<ColumnIndexMetaData>>;
 ///
 /// `offset_index[row_group_number][column_number]` holds
 /// the [`OffsetIndexMetaData`] corresponding to column
-/// `column_number`of row group `row_group_number`.
+/// `column_number`of row group `row_group_number`, or `None` if no index is available.
 ///
 /// [PageIndex documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 /// [`OffsetIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-pub type ParquetOffsetIndex = Vec<Vec<OffsetIndexMetaData>>;
+pub type ParquetOffsetIndex = Vec<Vec<Option<OffsetIndexMetaData>>>;
 
 /// Parsed metadata for a single Parquet file
 ///
@@ -1908,8 +1908,8 @@ mod tests {
 
         let parquet_meta = ParquetMetaDataBuilder::new(file_metadata)
             .set_row_groups(row_group_meta)
-            .set_column_index(Some(vec![vec![ColumnIndexMetaData::BOOLEAN(native_index)]]))
-            .set_offset_index(Some(vec![vec![offset_index]]))
+            .set_column_index(Some(vec![vec![Some(ColumnIndexMetaData::BOOLEAN(native_index))]]))
+            .set_offset_index(Some(vec![vec![Some(offset_index)]]))
             .build();
 
         #[cfg(not(feature = "encryption"))]

--- a/parquet/src/file/metadata/parser.rs
+++ b/parquet/src/file/metadata/parser.rs
@@ -279,16 +279,6 @@ pub(crate) fn parse_column_index(
 
     metadata.set_column_index(Some(index));
 
-    if column_index_policy == PageIndexPolicy::Required {
-        for rg in metadata.column_index().unwrap() {
-            for col in rg {
-                if col.is_none() {
-                    return Err(general_err!("missing column index"));
-                }
-            }
-        }
-    }
-
     Ok(())
 }
 

--- a/parquet/src/file/metadata/parser.rs
+++ b/parquet/src/file/metadata/parser.rs
@@ -278,6 +278,17 @@ pub(crate) fn parse_column_index(
         .collect::<crate::errors::Result<Vec<_>>>()?;
 
     metadata.set_column_index(Some(index));
+
+    if column_index_policy == PageIndexPolicy::Required {
+        for rg in metadata.column_index().unwrap() {
+            for col in rg {
+                if col.is_none() {
+                    return Err(general_err!("missing column index"));
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -317,5 +328,16 @@ pub(crate) fn parse_offset_index(
         })
         .collect::<crate::errors::Result<Vec<_>>>()?;
     metadata.set_offset_index(Some(index));
+
+    if offset_index_policy == PageIndexPolicy::Required {
+        for rg in metadata.offset_index().unwrap() {
+            for col in rg {
+                if col.is_none() {
+                    return Err(general_err!("missing offset index"));
+                }
+            }
+        }
+    }
+
     Ok(())
 }

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -96,7 +96,7 @@ pub enum PageIndexPolicy {
 impl From<bool> for PageIndexPolicy {
     fn from(value: bool) -> Self {
         match value {
-            true => Self::Required,
+            true => Self::Optional,
             false => Self::Skip,
         }
     }

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -90,13 +90,16 @@ pub enum PageIndexPolicy {
     /// Read the page index if it exists, otherwise do not error.
     Optional,
     /// Require the page index to exist, and error if it does not.
+    ///
+    /// Note: Required is enforced only for the offset index. Column indexes may still be
+    /// absent for some column chunks; consumers must handle None.
     Required,
 }
 
 impl From<bool> for PageIndexPolicy {
     fn from(value: bool) -> Self {
         match value {
-            true => Self::Optional,
+            true => Self::Required,
             false => Self::Skip,
         }
     }

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -149,19 +149,11 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             .is_some_and(|ci| ci.iter().all(|cii| cii.iter().all(|idx| idx.is_none())));
 
         // transform from Option<Vec<Vec<Option<ColumnIndexMetaData>>>> to
-        // Option<Vec<Vec<ColumnIndexMetaData>>>
+        // Option<Vec<Vec<Option<ColumnIndexMetaData>>>>
         let column_indexes: Option<ParquetColumnIndex> = if all_none {
             None
         } else {
-            column_indexes.map(|ovvi| {
-                ovvi.into_iter()
-                    .map(|vi| {
-                        vi.into_iter()
-                            .map(|ci| ci.unwrap_or(ColumnIndexMetaData::NONE))
-                            .collect()
-                    })
-                    .collect()
-            })
+            column_indexes
         };
 
         Ok(column_indexes)
@@ -184,12 +176,7 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
         let offset_indexes: Option<ParquetOffsetIndex> = if all_none {
             None
         } else {
-            // FIXME(ets): this will panic if there's a missing index.
-            offset_indexes.map(|ovvi| {
-                ovvi.into_iter()
-                    .map(|vi| vi.into_iter().map(|oi| oi.unwrap()).collect())
-                    .collect()
-            })
+            offset_indexes
         };
 
         Ok(offset_indexes)
@@ -489,7 +476,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                         let column_indexes = &row_group_column_indexes[rg_idx];
                         column_indexes
                             .iter()
-                            .map(|column_index| Some(column_index.clone()))
+                            .map(|column_index| column_index.clone())
                             .collect()
                     })
                     .collect()
@@ -505,7 +492,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                         let offset_indexes = &row_group_offset_indexes[rg_idx];
                         offset_indexes
                             .iter()
-                            .map(|offset_index| Some(offset_index.clone()))
+                            .map(|offset_index| offset_index.clone())
                             .collect()
                     })
                     .collect()

--- a/parquet/src/file/metadata/writer.rs
+++ b/parquet/src/file/metadata/writer.rs
@@ -150,11 +150,8 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
 
         // transform from Option<Vec<Vec<Option<ColumnIndexMetaData>>>> to
         // Option<Vec<Vec<Option<ColumnIndexMetaData>>>>
-        let column_indexes: Option<ParquetColumnIndex> = if all_none {
-            None
-        } else {
-            column_indexes
-        };
+        let column_indexes: Option<ParquetColumnIndex> =
+            if all_none { None } else { column_indexes };
 
         Ok(column_indexes)
     }
@@ -173,11 +170,8 @@ impl<'a, W: Write> ThriftMetadataWriter<'a, W> {
             .as_ref()
             .is_some_and(|oi| oi.iter().all(|oii| oii.iter().all(|idx| idx.is_none())));
 
-        let offset_indexes: Option<ParquetOffsetIndex> = if all_none {
-            None
-        } else {
-            offset_indexes
-        };
+        let offset_indexes: Option<ParquetOffsetIndex> =
+            if all_none { None } else { offset_indexes };
 
         Ok(offset_indexes)
     }
@@ -474,10 +468,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                 (0..self.metadata.row_groups().len())
                     .map(|rg_idx| {
                         let column_indexes = &row_group_column_indexes[rg_idx];
-                        column_indexes
-                            .iter()
-                            .map(|column_index| column_index.clone())
-                            .collect()
+                        column_indexes.to_vec()
                     })
                     .collect()
             })
@@ -490,10 +481,7 @@ impl<'a, W: Write> ParquetMetaDataWriter<'a, W> {
                 (0..self.metadata.row_groups().len())
                     .map(|rg_idx| {
                         let offset_indexes = &row_group_offset_indexes[rg_idx];
-                        offset_indexes
-                            .iter()
-                            .map(|offset_index| offset_index.clone())
-                            .collect()
+                        offset_indexes.to_vec()
                     })
                     .collect()
             })

--- a/parquet/src/file/page_index/column_index.rs
+++ b/parquet/src/file/page_index/column_index.rs
@@ -510,7 +510,11 @@ macro_rules! colidx_enum_func {
 pub enum ColumnIndexMetaData {
     /// Sometimes reading page index from parquet file
     /// will only return pageLocations without min_max index,
-    /// `NONE` represents this lack of index information
+    /// `NONE` represents this lack of index information.
+    ///
+    /// Note: This is a legacy marker and should not be used to represent
+    /// missing column indexes in `ParquetColumnIndex` (that is now done via
+    /// `None` on the `Option`).
     NONE,
     /// Boolean type index
     BOOLEAN(PrimitiveColumnIndex<bool>),

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -283,7 +283,7 @@ impl<R: 'static + ChunkReader> FileReader for SerializedFileReader<R> {
 pub struct SerializedRowGroupReader<'a, R: ChunkReader> {
     chunk_reader: Arc<R>,
     metadata: &'a RowGroupMetaData,
-    offset_index: Option<&'a [OffsetIndexMetaData]>,
+    offset_index: Option<&'a [Option<OffsetIndexMetaData>]>,
     props: ReaderPropertiesPtr,
     bloom_filters: Vec<Option<Sbbf>>,
 }
@@ -293,7 +293,7 @@ impl<'a, R: ChunkReader> SerializedRowGroupReader<'a, R> {
     pub fn new(
         chunk_reader: Arc<R>,
         metadata: &'a RowGroupMetaData,
-        offset_index: Option<&'a [OffsetIndexMetaData]>,
+        offset_index: Option<&'a [Option<OffsetIndexMetaData>]>,
         props: ReaderPropertiesPtr,
     ) -> Result<Self> {
         let bloom_filters = if props.read_bloom_filter() {
@@ -328,7 +328,7 @@ impl<R: 'static + ChunkReader> RowGroupReader for SerializedRowGroupReader<'_, R
     fn get_column_page_reader(&self, i: usize) -> Result<Box<dyn PageReader>> {
         let col = self.metadata.column(i);
 
-        let page_locations = self.offset_index.map(|x| x[i].page_locations.clone());
+        let page_locations = self.offset_index.and_then(|x| x[i].as_ref().map(|idx| idx.page_locations.clone()));
 
         let props = Arc::clone(&self.props);
         Ok(Box::new(SerializedPageReader::new_with_properties(
@@ -1718,7 +1718,7 @@ mod tests {
 
         let page_locations = row_group
             .offset_index
-            .map(|x| x[column].page_locations.clone());
+            .and_then(|x| x[column].as_ref().map(|idx| idx.page_locations.clone()));
 
         let props = Arc::clone(&row_group.props);
         SerializedPageReader::new_with_properties(
@@ -1919,8 +1919,8 @@ mod tests {
         let reader = SerializedFileReader::new_with_options(test_file, read_options)?;
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
-        assert_eq!(metadata.column_index().unwrap().len(), 1);
-        assert_eq!(metadata.offset_index().unwrap().len(), 1);
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 1);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 1);
 
         // true, false predicate
         let test_file = get_test_file("alltypes_tiny_pages.parquet");
@@ -2005,11 +2005,11 @@ mod tests {
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let column_index = metadata.column_index().unwrap();
+        let column_index = metadata.column_index().expect("column index should be present");
 
         // only one row group
         assert_eq!(column_index.len(), 1);
-        let index = if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][0] {
+        let index = if let ColumnIndexMetaData::BYTE_ARRAY(index) = column_index[0][0].as_ref().expect("column index should be present for column 0") {
             index
         } else {
             unreachable!()
@@ -2025,11 +2025,11 @@ mod tests {
         assert_eq!(b"Hello", min.as_bytes());
         assert_eq!(b"today", max.as_bytes());
 
-        let offset_indexes = metadata.offset_index().unwrap();
+        let offset_indexes = metadata.offset_index().expect("offset index should be present");
         // only one row group
         assert_eq!(offset_indexes.len(), 1);
         let offset_index = &offset_indexes[0];
-        let page_offset = &offset_index[0].page_locations()[0];
+        let page_offset = &offset_index[0].as_ref().expect("offset index should be present for column 0").page_locations()[0];
 
         assert_eq!(4, page_offset.offset);
         assert_eq!(152, page_offset.compressed_page_size);
@@ -2074,172 +2074,171 @@ mod tests {
         let metadata = reader.metadata();
         assert_eq!(metadata.num_row_groups(), 1);
 
-        let column_index = metadata.column_index().unwrap();
-        let row_group_offset_indexes = &metadata.offset_index().unwrap()[0];
+        let column_index = metadata.column_index().expect("column index should be present");
+        let row_group_offset_indexes = &metadata.offset_index().expect("offset index should be present")[0];
 
         // only one row group
         assert_eq!(column_index.len(), 1);
         let row_group_metadata = metadata.row_group(0);
 
         //col0->id: INT32 UNCOMPRESSED DO:0 FPO:4 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 7299, num_nulls: 0]
-        assert!(!&column_index[0][0].is_sorted());
-        let boundary_order = &column_index[0][0].get_boundary_order();
+        assert!(!column_index[0][0].as_ref().expect("column index should be present for column 0").is_sorted());
+        let boundary_order = column_index[0][0].as_ref().unwrap().get_boundary_order();
         assert!(boundary_order.is_some());
         matches!(boundary_order.unwrap(), BoundaryOrder::UNORDERED);
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][0] {
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][0].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 0),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[0].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[0].as_ref().expect("offset index should be present for column 0").page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col1->bool_col:BOOLEAN UNCOMPRESSED DO:0 FPO:37329 SZ:3022/3022/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: false, max: true, num_nulls: 0]
-        assert!(&column_index[0][1].is_sorted());
-        if let ColumnIndexMetaData::BOOLEAN(index) = &column_index[0][1] {
+        assert!(column_index[0][1].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::BOOLEAN(index) = column_index[0][1].as_ref().unwrap() {
             assert_eq!(index.num_pages(), 82);
-            assert_eq!(row_group_offset_indexes[1].page_locations.len(), 82);
+            assert_eq!(row_group_offset_indexes[1].as_ref().expect("offset index should be present for column 1").page_locations.len(), 82);
         } else {
             unreachable!()
         };
         //col2->tinyint_col: INT32 UNCOMPRESSED DO:0 FPO:40351 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][2].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][2] {
+        assert!(column_index[0][2].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][2].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 2),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[2].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[2].as_ref().expect("offset index should be present for column 2").page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col4->smallint_col: INT32 UNCOMPRESSED DO:0 FPO:77676 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][3].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][3] {
+        assert!(column_index[0][3].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][3].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 3),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[3].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[3].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col5->smallint_col: INT32 UNCOMPRESSED DO:0 FPO:77676 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][4].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][4] {
+        assert!(column_index[0][4].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT32(index) = column_index[0][4].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 4),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[4].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[4].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col6->bigint_col: INT64 UNCOMPRESSED DO:0 FPO:152326 SZ:71598/71598/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 90, num_nulls: 0]
-        assert!(!&column_index[0][5].is_sorted());
-        if let ColumnIndexMetaData::INT64(index) = &column_index[0][5] {
+        assert!(!column_index[0][5].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::INT64(index) = column_index[0][5].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 528,
                 get_row_group_min_max_bytes(row_group_metadata, 5),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[5].page_locations.len(), 528);
+            assert_eq!(row_group_offset_indexes[5].as_ref().unwrap().page_locations.len(), 528);
         } else {
             unreachable!()
         };
         //col7->float_col: FLOAT UNCOMPRESSED DO:0 FPO:223924 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: -0.0, max: 9.9, num_nulls: 0]
-        assert!(&column_index[0][6].is_sorted());
-        if let ColumnIndexMetaData::FLOAT(index) = &column_index[0][6] {
+        assert!(column_index[0][6].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::FLOAT(index) = column_index[0][6].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 6),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[6].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[6].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col8->double_col: DOUBLE UNCOMPRESSED DO:0 FPO:261249 SZ:71598/71598/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: -0.0, max: 90.89999999999999, num_nulls: 0]
-        assert!(!&column_index[0][7].is_sorted());
-        if let ColumnIndexMetaData::DOUBLE(index) = &column_index[0][7] {
+        assert!(!column_index[0][7].as_ref().unwrap().is_sorted());
+        if let ColumnIndexMetaData::DOUBLE(index) = column_index[0][7].as_ref().unwrap() {
             check_native_page_index(
                 index,
                 528,
                 get_row_group_min_max_bytes(row_group_metadata, 7),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[7].page_locations.len(), 528);
+            assert_eq!(row_group_offset_indexes[7].as_ref().unwrap().page_locations.len(), 528);
         } else {
             unreachable!()
         };
         //col9->date_string_col: BINARY UNCOMPRESSED DO:0 FPO:332847 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 01/01/09, max: 12/31/10, num_nulls: 0]
-        assert!(!&column_index[0][8].is_sorted());
-        if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][8] {
+        assert!(!&column_index[0][8].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::BYTE_ARRAY(index)) = &column_index[0][8] {
             check_byte_array_page_index(
                 index,
                 974,
                 get_row_group_min_max_bytes(row_group_metadata, 8),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[8].page_locations.len(), 974);
+            assert_eq!(row_group_offset_indexes[8].as_ref().unwrap().page_locations.len(), 974);
         } else {
             unreachable!()
         };
         //col10->string_col: BINARY UNCOMPRESSED DO:0 FPO:444795 SZ:45298/45298/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 0, max: 9, num_nulls: 0]
-        assert!(&column_index[0][9].is_sorted());
-        if let ColumnIndexMetaData::BYTE_ARRAY(index) = &column_index[0][9] {
+        assert!(&column_index[0][9].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::BYTE_ARRAY(index)) = &column_index[0][9] {
             check_byte_array_page_index(
                 index,
                 352,
                 get_row_group_min_max_bytes(row_group_metadata, 9),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[9].page_locations.len(), 352);
+            assert_eq!(row_group_offset_indexes[9].as_ref().unwrap().page_locations.len(), 352);
         } else {
             unreachable!()
         };
         //col11->timestamp_col: INT96 UNCOMPRESSED DO:0 FPO:490093 SZ:111948/111948/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[num_nulls: 0, min/max not defined]
         //Notice: min_max values for each page for this col not exits.
-        assert!(!&column_index[0][10].is_sorted());
-        if let ColumnIndexMetaData::NONE = &column_index[0][10] {
-            assert_eq!(row_group_offset_indexes[10].page_locations.len(), 974);
+        if column_index[0][10].is_none() {
+            assert_eq!(row_group_offset_indexes[10].as_ref().unwrap().page_locations.len(), 974);
         } else {
             unreachable!()
         };
         //col12->year: INT32 UNCOMPRESSED DO:0 FPO:602041 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 2009, max: 2010, num_nulls: 0]
-        assert!(&column_index[0][11].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][11] {
+        assert!(&column_index[0][11].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::INT32(index)) = &column_index[0][11] {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 11),
                 BoundaryOrder::ASCENDING,
             );
-            assert_eq!(row_group_offset_indexes[11].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[11].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
         //col13->month: INT32 UNCOMPRESSED DO:0 FPO:639366 SZ:37325/37325/1.00 VC:7300 ENC:BIT_PACKED,RLE,PLAIN ST:[min: 1, max: 12, num_nulls: 0]
-        assert!(!&column_index[0][12].is_sorted());
-        if let ColumnIndexMetaData::INT32(index) = &column_index[0][12] {
+        assert!(!&column_index[0][12].as_ref().unwrap().is_sorted());
+        if let Some(ColumnIndexMetaData::INT32(index)) = &column_index[0][12] {
             check_native_page_index(
                 index,
                 325,
                 get_row_group_min_max_bytes(row_group_metadata, 12),
                 BoundaryOrder::UNORDERED,
             );
-            assert_eq!(row_group_offset_indexes[12].page_locations.len(), 325);
+            assert_eq!(row_group_offset_indexes[12].as_ref().unwrap().page_locations.len(), 325);
         } else {
             unreachable!()
         };
@@ -2502,7 +2501,7 @@ mod tests {
         let b = Bytes::from(out);
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(b, options).unwrap();
-        let index = reader.metadata().column_index().unwrap();
+        let index = reader.metadata().column_index().expect("column index should be present");
 
         // 1 row group
         assert_eq!(index.len(), 1);
@@ -2511,7 +2510,7 @@ mod tests {
         assert_eq!(c.len(), 1);
 
         match &c[0] {
-            ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v) => {
+            Some(ColumnIndexMetaData::FIXED_LEN_BYTE_ARRAY(v)) => {
                 assert_eq!(v.num_pages(), 1);
                 assert_eq!(v.null_count(0).unwrap(), 1);
                 assert_eq!(v.min_value(0).unwrap(), &[0; 11]);
@@ -2636,17 +2635,17 @@ mod tests {
         // check we only got the relevant page indexes
         assert!(metadata.column_index().is_some());
         assert!(metadata.offset_index().is_some());
-        assert_eq!(metadata.column_index().unwrap().len(), 1);
-        assert_eq!(metadata.offset_index().unwrap().len(), 1);
-        let col_idx = metadata.column_index().unwrap();
-        let off_idx = metadata.offset_index().unwrap();
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 1);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 1);
+        let col_idx = metadata.column_index().expect("column index should be present");
+        let off_idx = metadata.offset_index().expect("offset index should be present");
         let col_stats = metadata.row_group(0).column(0).statistics().unwrap();
         let pg_idx = &col_idx[0][0];
-        let off_idx_i = &off_idx[0][0];
+        let off_idx_i = off_idx[0][0].as_ref().expect("offset index should be present for column 0");
 
         // test that we got the index matching the row group
         match pg_idx {
-            ColumnIndexMetaData::INT32(int_idx) => {
+            Some(ColumnIndexMetaData::INT32(int_idx)) => {
                 let min = col_stats.min_bytes_opt().unwrap().get_i32_le();
                 let max = col_stats.max_bytes_opt().unwrap().get_i32_le();
                 assert_eq!(int_idx.min_value(0), Some(min).as_ref());
@@ -2679,19 +2678,19 @@ mod tests {
         // check we only got the relevant page indexes
         assert!(metadata.column_index().is_some());
         assert!(metadata.offset_index().is_some());
-        assert_eq!(metadata.column_index().unwrap().len(), 2);
-        assert_eq!(metadata.offset_index().unwrap().len(), 2);
-        let col_idx = metadata.column_index().unwrap();
-        let off_idx = metadata.offset_index().unwrap();
+        assert_eq!(metadata.column_index().expect("column index should be present").len(), 2);
+        assert_eq!(metadata.offset_index().expect("offset index should be present").len(), 2);
+        let col_idx = metadata.column_index().expect("column index should be present");
+        let off_idx = metadata.offset_index().expect("offset index should be present");
 
         for (i, col_idx_i) in col_idx.iter().enumerate().take(metadata.num_row_groups()) {
             let col_stats = metadata.row_group(i).column(0).statistics().unwrap();
             let pg_idx = &col_idx_i[0];
-            let off_idx_i = &off_idx[i][0];
+            let off_idx_i = off_idx[i][0].as_ref().expect("offset index should be present for column 0");
 
             // test that we got the index matching the row group
             match pg_idx {
-                ColumnIndexMetaData::INT32(int_idx) => {
+                Some(ColumnIndexMetaData::INT32(int_idx)) => {
                     let min = col_stats.min_bytes_opt().unwrap().get_i32_le();
                     let max = col_stats.max_bytes_opt().unwrap().get_i32_le();
                     assert_eq!(int_idx.min_value(0), Some(min).as_ref());

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -2071,11 +2071,17 @@ mod tests {
         let options = ReadOptionsBuilder::new().with_page_index().build();
         let reader = SerializedFileReader::new_with_options(Bytes::from(file), options).unwrap();
 
-        let offset_index = reader.metadata().offset_index().expect("offset index should be present");
+        let offset_index = reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present");
         assert_eq!(offset_index.len(), 1); // 1 row group
         assert_eq!(offset_index[0].len(), 2); // 2 columns
 
-        let column_index = reader.metadata().column_index().expect("column index should be present");
+        let column_index = reader
+            .metadata()
+            .column_index()
+            .expect("column index should be present");
         assert_eq!(column_index.len(), 1); // 1 row group
         assert_eq!(column_index[0].len(), 2); // 2 column
 
@@ -2159,10 +2165,16 @@ mod tests {
 
         // check histogram in column index as well
         assert!(reader.metadata().column_index().is_some());
-        let column_index = reader.metadata().column_index().expect("column index should be present");
+        let column_index = reader
+            .metadata()
+            .column_index()
+            .expect("column index should be present");
         assert_eq!(column_index.len(), 1);
         assert_eq!(column_index[0].len(), 1);
-        let col_idx = if let ColumnIndexMetaData::BYTE_ARRAY(index) = column_index[0][0].as_ref().expect("column index should be present for column 0") {
+        let col_idx = if let ColumnIndexMetaData::BYTE_ARRAY(index) = column_index[0][0]
+            .as_ref()
+            .expect("column index should be present for column 0")
+        {
             assert_eq!(index.num_pages(), 1);
             index
         } else {
@@ -2174,10 +2186,19 @@ mod tests {
         check_def_hist(col_idx.definition_level_histogram(0).unwrap());
 
         assert!(reader.metadata().offset_index().is_some());
-        let offset_index = reader.metadata().offset_index().expect("offset index should be present");
+        let offset_index = reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present");
         assert_eq!(offset_index.len(), 1);
         assert_eq!(offset_index[0].len(), 1);
-        assert!(offset_index[0][0].as_ref().expect("offset index should be present for column 0").unencoded_byte_array_data_bytes.is_some());
+        assert!(
+            offset_index[0][0]
+                .as_ref()
+                .expect("offset index should be present for column 0")
+                .unencoded_byte_array_data_bytes
+                .is_some()
+        );
         let page_sizes = offset_index[0][0]
             .as_ref()
             .expect("offset index should be present for column 0")
@@ -2312,10 +2333,16 @@ mod tests {
 
         // check histogram in column index as well
         assert!(reader.metadata().column_index().is_some());
-        let column_index = reader.metadata().column_index().expect("column index should be present");
+        let column_index = reader
+            .metadata()
+            .column_index()
+            .expect("column index should be present");
         assert_eq!(column_index.len(), 1);
         assert_eq!(column_index[0].len(), 1);
-        let col_idx = if let ColumnIndexMetaData::INT32(index) = column_index[0][0].as_ref().expect("column index should be present for column 0") {
+        let col_idx = if let ColumnIndexMetaData::INT32(index) = column_index[0][0]
+            .as_ref()
+            .expect("column index should be present for column 0")
+        {
             assert_eq!(index.num_pages(), 1);
             index
         } else {
@@ -2326,10 +2353,19 @@ mod tests {
         check_rep_hist(col_idx.repetition_level_histogram(0).unwrap());
 
         assert!(reader.metadata().offset_index().is_some());
-        let offset_index = reader.metadata().offset_index().expect("offset index should be present");
+        let offset_index = reader
+            .metadata()
+            .offset_index()
+            .expect("offset index should be present");
         assert_eq!(offset_index.len(), 1);
         assert_eq!(offset_index[0].len(), 1);
-        assert!(offset_index[0][0].as_ref().expect("offset index should be present for column 0").unencoded_byte_array_data_bytes.is_none());
+        assert!(
+            offset_index[0][0]
+                .as_ref()
+                .expect("offset index should be present for column 0")
+                .unencoded_byte_array_data_bytes
+                .is_none()
+        );
     }
 
     #[test]
@@ -2499,8 +2535,12 @@ mod tests {
             let rg_offset_indexes = offset_indexes.and_then(|oi| oi.get(rg_idx));
             let mut rg_out = writer.next_row_group().unwrap();
             for (col_idx, column) in rg.columns().iter().enumerate() {
-                let column_index = rg_column_indexes.and_then(|row| row.get(col_idx)).and_then(|opt| opt.clone());
-                let offset_index = rg_offset_indexes.and_then(|row| row.get(col_idx)).and_then(|opt| opt.clone());
+                let column_index = rg_column_indexes
+                    .and_then(|row| row.get(col_idx))
+                    .and_then(|opt| opt.clone());
+                let offset_index = rg_offset_indexes
+                    .and_then(|row| row.get(col_idx))
+                    .and_then(|opt| opt.clone());
                 let result = ColumnCloseResult {
                     bytes_written: column.compressed_size() as _,
                     rows_written: rg.num_rows() as _,

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -287,7 +287,10 @@ impl TestRowGroups {
                     .enumerate()
                     .map(|(col_idx, col_meta)| {
                         let column_name = col_meta.column_descr().name().to_string();
-                        let page_locations = offset_index[rg_index][col_idx].as_ref().unwrap().page_locations();
+                        let page_locations = offset_index[rg_index][col_idx]
+                            .as_ref()
+                            .unwrap()
+                            .page_locations();
                         let dictionary_page_location = col_meta.dictionary_page_offset();
 
                         // We can find the byte range of the entire column chunk

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -287,7 +287,7 @@ impl TestRowGroups {
                     .enumerate()
                     .map(|(col_idx, col_meta)| {
                         let column_name = col_meta.column_descr().name().to_string();
-                        let page_locations = offset_index[rg_index][col_idx].page_locations();
+                        let page_locations = offset_index[rg_index][col_idx].as_ref().unwrap().page_locations();
                         let dictionary_page_location = col_meta.dictionary_page_offset();
 
                         // We can find the byte range of the entire column chunk

--- a/parquet/tests/arrow_reader/statistics.rs
+++ b/parquet/tests/arrow_reader/statistics.rs
@@ -47,10 +47,10 @@ use parquet::arrow::arrow_reader::{
     ArrowReaderBuilder, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
 };
 use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
+use parquet::file::page_index::column_index::ColumnIndexMetaData;
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::file::statistics::{Statistics, ValueStatistics};
 use parquet::schema::types::ColumnPath;
-use parquet::file::page_index::column_index::ColumnIndexMetaData;
 use parquet::schema::types::{SchemaDescPtr, SchemaDescriptor};
 
 #[derive(Debug, Default, Clone)]
@@ -3074,7 +3074,10 @@ mod page_index_partial_tests {
         // Create writer properties that enable page indexes only for the first column
         let props = WriterProperties::builder()
             .set_statistics_enabled(EnabledStatistics::None)
-            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .set_column_statistics_enabled(
+                ColumnPath::new(vec!["col1".to_string()]),
+                EnabledStatistics::Page,
+            )
             .build();
 
         // Create test data
@@ -3084,7 +3087,8 @@ mod page_index_partial_tests {
                 Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
                 Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
         writer.write(&batch).expect("writing batch");
@@ -3099,7 +3103,9 @@ mod page_index_partial_tests {
         let metadata = reader.metadata();
 
         // Check that column index is present at top level
-        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+        let column_index = metadata
+            .column_index()
+            .expect("column index should be present when page index is enabled");
 
         // Verify structure: 1 row group
         assert_eq!(column_index.len(), 1);
@@ -3107,16 +3113,30 @@ mod page_index_partial_tests {
 
         // Verify per-column: first column has index, second has NONE
         assert_eq!(rg_column_index.len(), 2);
-        assert!(rg_column_index[0].is_some(), "first column should have column index");
-        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+        assert!(
+            rg_column_index[0].is_some(),
+            "first column should have column index"
+        );
+        assert!(
+            rg_column_index[1].is_none(),
+            "second column should have None column index"
+        );
 
         // Check that offset index follows the same pattern (both should be present)
-        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+        let offset_index = metadata
+            .offset_index()
+            .expect("offset index should be present when page index is enabled");
         assert_eq!(offset_index.len(), 1);
         let rg_offset_index = &offset_index[0];
         assert_eq!(rg_offset_index.len(), 2);
-        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
-        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+        assert!(
+            rg_offset_index[0].is_some(),
+            "first column should have offset index"
+        );
+        assert!(
+            rg_offset_index[1].is_some(),
+            "second column should have offset index"
+        );
     }
 
     /// Test that partially missing offset indexes across columns does not panic
@@ -3138,7 +3158,10 @@ mod page_index_partial_tests {
         // Create writer properties that enable page indexes only for the first column
         let props = WriterProperties::builder()
             .set_statistics_enabled(EnabledStatistics::None)
-            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .set_column_statistics_enabled(
+                ColumnPath::new(vec!["col1".to_string()]),
+                EnabledStatistics::Page,
+            )
             .build();
 
         // Create test data
@@ -3148,7 +3171,8 @@ mod page_index_partial_tests {
                 Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
                 Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
         writer.write(&batch).expect("writing batch");
@@ -3163,7 +3187,9 @@ mod page_index_partial_tests {
         let metadata = reader.metadata();
 
         // Check that offset index is present at top level
-        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+        let offset_index = metadata
+            .offset_index()
+            .expect("offset index should be present when page index is enabled");
 
         // Verify structure: 1 row group
         assert_eq!(offset_index.len(), 1);
@@ -3171,16 +3197,30 @@ mod page_index_partial_tests {
 
         // Verify per-column: first column has index, second does not
         assert_eq!(rg_offset_index.len(), 2);
-        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
-        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+        assert!(
+            rg_offset_index[0].is_some(),
+            "first column should have offset index"
+        );
+        assert!(
+            rg_offset_index[1].is_some(),
+            "second column should have offset index"
+        );
 
         // Check that column index follows the same pattern
-        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+        let column_index = metadata
+            .column_index()
+            .expect("column index should be present when page index is enabled");
         assert_eq!(column_index.len(), 1);
         let rg_column_index = &column_index[0];
         assert_eq!(rg_column_index.len(), 2);
-        assert!(rg_column_index[0].is_some(), "first column should have column index");
-        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+        assert!(
+            rg_column_index[0].is_some(),
+            "first column should have column index"
+        );
+        assert!(
+            rg_column_index[1].is_none(),
+            "second column should have None column index"
+        );
     }
 
     /// Test regression: no page indexes for all columns should not panic
@@ -3212,7 +3252,8 @@ mod page_index_partial_tests {
                 Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
                 Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
         writer.write(&batch).expect("writing batch");
@@ -3227,7 +3268,13 @@ mod page_index_partial_tests {
         let metadata = reader.metadata();
 
         // Check that no page indexes are present
-        assert!(metadata.column_index().is_none(), "column index should be None when disabled");
-        assert!(metadata.offset_index().is_none(), "offset index should be None when disabled");
+        assert!(
+            metadata.column_index().is_none(),
+            "column index should be None when disabled"
+        );
+        assert!(
+            metadata.offset_index().is_none(),
+            "offset index should be None when disabled"
+        );
     }
 }

--- a/parquet/tests/arrow_reader/statistics.rs
+++ b/parquet/tests/arrow_reader/statistics.rs
@@ -49,6 +49,8 @@ use parquet::arrow::arrow_reader::{
 use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::file::statistics::{Statistics, ValueStatistics};
+use parquet::schema::types::ColumnPath;
+use parquet::file::page_index::column_index::ColumnIndexMetaData;
 use parquet::schema::types::{SchemaDescPtr, SchemaDescriptor};
 
 #[derive(Debug, Default, Clone)]
@@ -3044,5 +3046,188 @@ mod test {
             .map(|s| s.map(|s| s.to_string()))
             .collect();
         Arc::new(array)
+    }
+}
+
+#[cfg(test)]
+mod page_index_partial_tests {
+    use super::*;
+    use parquet::file::properties::EnabledStatistics;
+    use std::fs::File;
+
+    /// Test that partially missing column indexes across columns does not panic
+    /// and correctly represents None for missing indexes
+    #[test]
+    fn test_page_index_partial_column_index_presence_does_not_panic() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_partial_page_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that enable page indexes only for the first column
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that column index is present at top level
+        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+
+        // Verify structure: 1 row group
+        assert_eq!(column_index.len(), 1);
+        let rg_column_index = &column_index[0];
+
+        // Verify per-column: first column has index, second has NONE
+        assert_eq!(rg_column_index.len(), 2);
+        assert!(rg_column_index[0].is_some(), "first column should have column index");
+        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+
+        // Check that offset index follows the same pattern (both should be present)
+        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+        assert_eq!(offset_index.len(), 1);
+        let rg_offset_index = &offset_index[0];
+        assert_eq!(rg_offset_index.len(), 2);
+        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
+        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+    }
+
+    /// Test that partially missing offset indexes across columns does not panic
+    /// and correctly represents None for missing indexes
+    #[test]
+    fn test_page_index_partial_offset_index_presence_does_not_panic() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_partial_offset_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that enable page indexes only for the first column
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_column_statistics_enabled(ColumnPath::new(vec!["col1".to_string()]), EnabledStatistics::Page)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that offset index is present at top level
+        let offset_index = metadata.offset_index().expect("offset index should be present when page index is enabled");
+
+        // Verify structure: 1 row group
+        assert_eq!(offset_index.len(), 1);
+        let rg_offset_index = &offset_index[0];
+
+        // Verify per-column: first column has index, second does not
+        assert_eq!(rg_offset_index.len(), 2);
+        assert!(rg_offset_index[0].is_some(), "first column should have offset index");
+        assert!(rg_offset_index[1].is_some(), "second column should have offset index");
+
+        // Check that column index follows the same pattern
+        let column_index = metadata.column_index().expect("column index should be present when page index is enabled");
+        assert_eq!(column_index.len(), 1);
+        let rg_column_index = &column_index[0];
+        assert_eq!(rg_column_index.len(), 2);
+        assert!(rg_column_index[0].is_some(), "first column should have column index");
+        assert!(rg_column_index[1].is_none(), "second column should have None column index");
+    }
+
+    /// Test regression: no page indexes for all columns should not panic
+    /// and correctly represent the absence of indexes
+    #[test]
+    fn test_page_index_no_indexes_for_all_columns_regression() {
+        let mut output_file = tempfile::Builder::new()
+            .prefix("parquet_no_page_index")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        // Create a schema with two columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("col1", DataType::Int32, false),
+            Field::new("col2", DataType::Int32, false),
+        ]));
+
+        // Create writer properties that disable all page indexes
+        let props = WriterProperties::builder()
+            .set_statistics_enabled(EnabledStatistics::None)
+            .set_offset_index_disabled(true)
+            .build();
+
+        // Create test data
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10])),
+            ],
+        ).unwrap();
+
+        let mut writer = ArrowWriter::try_new(&mut output_file, schema, Some(props)).unwrap();
+        writer.write(&batch).expect("writing batch");
+        writer.close().unwrap();
+
+        // Read the file with page index enabled (should not find any)
+        let file = output_file.reopen().unwrap();
+        let options = ArrowReaderOptions::new().with_page_index(true);
+        let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
+
+        // Verify metadata reading does not panic
+        let metadata = reader.metadata();
+
+        // Check that no page indexes are present
+        assert!(metadata.column_index().is_none(), "column index should be None when disabled");
+        assert!(metadata.offset_index().is_none(), "offset index should be None when disabled");
     }
 }

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -81,13 +81,14 @@ fn assert_layout(file_reader: &Bytes, meta: &ParquetMetaData, layout: &Layout) {
         .row_groups()
         .iter()
         .zip(&layout.row_groups)
-        .zip(meta.offset_index().unwrap());
+        .zip(meta.offset_index().expect("offset index should be present"));
 
     for ((row_group, row_group_layout), offset_index) in iter {
         // Check against offset index
         assert_eq!(offset_index.len(), row_group_layout.columns.len());
 
         for (column_index, column_layout) in offset_index.iter().zip(&row_group_layout.columns) {
+            let column_index = column_index.as_ref().unwrap();
             assert_eq!(
                 column_index.page_locations.len(),
                 column_layout.pages.len(),

--- a/parquet/tests/encryption/encryption_util.rs
+++ b/parquet/tests/encryption/encryption_util.rs
@@ -186,20 +186,20 @@ pub(crate) fn verify_encryption_test_data(
 /// Verifies that the column and offset indexes were successfully read from an
 /// encrypted test file.
 pub(crate) fn verify_column_indexes(metadata: &ParquetMetaData) {
-    let offset_index = metadata.offset_index().unwrap();
+    let offset_index = metadata.offset_index().expect("offset index should be present");
     // 1 row group, 8 columns
     assert_eq!(offset_index.len(), 1);
     assert_eq!(offset_index[0].len(), 8);
     // Check float column, which is encrypted in the non-uniform test file
     let float_col_idx = 4;
-    let offset_index = &offset_index[0][float_col_idx];
+    let offset_index = &offset_index[0][float_col_idx].as_ref().expect("offset index should be present for column 4");
     assert_eq!(offset_index.page_locations.len(), 1);
     assert!(offset_index.page_locations[0].offset > 0);
 
-    let column_index = metadata.column_index().unwrap();
+    let column_index = metadata.column_index().expect("column index should be present");
     assert_eq!(column_index.len(), 1);
     assert_eq!(column_index[0].len(), 8);
-    let column_index = &column_index[0][float_col_idx];
+    let column_index = &column_index[0][float_col_idx].as_ref().expect("column index should be present for column 4");
 
     match column_index {
         parquet::file::page_index::column_index::ColumnIndexMetaData::FLOAT(float_index) => {

--- a/parquet/tests/encryption/encryption_util.rs
+++ b/parquet/tests/encryption/encryption_util.rs
@@ -186,20 +186,28 @@ pub(crate) fn verify_encryption_test_data(
 /// Verifies that the column and offset indexes were successfully read from an
 /// encrypted test file.
 pub(crate) fn verify_column_indexes(metadata: &ParquetMetaData) {
-    let offset_index = metadata.offset_index().expect("offset index should be present");
+    let offset_index = metadata
+        .offset_index()
+        .expect("offset index should be present");
     // 1 row group, 8 columns
     assert_eq!(offset_index.len(), 1);
     assert_eq!(offset_index[0].len(), 8);
     // Check float column, which is encrypted in the non-uniform test file
     let float_col_idx = 4;
-    let offset_index = &offset_index[0][float_col_idx].as_ref().expect("offset index should be present for column 4");
+    let offset_index = &offset_index[0][float_col_idx]
+        .as_ref()
+        .expect("offset index should be present for column 4");
     assert_eq!(offset_index.page_locations.len(), 1);
     assert!(offset_index.page_locations[0].offset > 0);
 
-    let column_index = metadata.column_index().expect("column index should be present");
+    let column_index = metadata
+        .column_index()
+        .expect("column index should be present");
     assert_eq!(column_index.len(), 1);
     assert_eq!(column_index[0].len(), 8);
-    let column_index = &column_index[0][float_col_idx].as_ref().expect("column index should be present for column 4");
+    let column_index = &column_index[0][float_col_idx]
+        .as_ref()
+        .expect("column index should be present for column 4");
 
     match column_index {
         parquet::file::page_index::column_index::ColumnIndexMetaData::FLOAT(float_index) => {


### PR DESCRIPTION
Goal
Introduce `Vec<Vec<Option<...>>>` for column and offset page indexes and update the parquet crate so it compiles and existing behavior continues to work, while keeping semantics changes as small and explicit as possible.

Which issue does this PR close?
Part of #8818.

Rationale for this change
The Parquet format allows page indexes (column index and offset index) to be optional per column chunk. The existing Rust types:

- `pub type ParquetColumnIndex = Vec<Vec<ColumnIndexMetaData>>`
- `pub type ParquetOffsetIndex = Vec<Vec<OffsetIndexMetaData>>`

implicitly assume that once page indexes are loaded, every column chunk has an index. This makes it awkward (and sometimes impossible) to represent partially missing indexes and encourages `unwrap()`-based code paths.

This PR introduces an `Option` at the leaf of these containers so we can explicitly represent “no index for this (row_group, column)” and prepare the codebase for safer semantics in follow-up PRs.

What changes are included in this PR?
- Type alias changes

  - Change the page index aliases to:

    ```rust
    pub type ParquetColumnIndex = Vec<Vec<Option<ColumnIndexMetaData>>>;
    pub type ParquetOffsetIndex = Vec<Vec<Option<OffsetIndexMetaData>>>;
    ```

  - Clarify the documentation comments for these aliases to mention `None` at the leaf as “no index for this column chunk”.

- Minimal plumbing to keep existing code compiling

  - Update internal metadata builders and writers to construct `ParquetColumnIndex` and `ParquetOffsetIndex` with `Some(...)` where indexes are currently generated.
  - Update call sites that indexed into `[row_group][column]` and previously saw a bare `ColumnIndexMetaData` or `OffsetIndexMetaData` to accept an `Option<...>`. In this PR we mostly:
    - Wrap existing values in `Some(...)`, and
    - Where behavior previously assumed an index was always present, use `as_ref().expect(...)` to preserve the invariant and make the assumptions explicit in error messages.

- No behavioral logic changes yet

  - This PR intentionally avoids changing how missing indices are *interpreted* (for example, `ColumnIndexMetaData::NONE` is preserved where it was used before).
  - More nuanced handling of `None` vs `ColumnIndexMetaData::NONE`, and graceful behavior for partially missing indices, is left for later PRs.

## Are these changes tested?

Yes.

- Existing parquet tests pass with the new types and plumbing in place:
  ```bash
  cargo test --package parquet --lib
  ```
- No new behavior-focused tests are introduced in this PR; the intent is to introduce the new in-memory representation with minimal semantic changes and rely on existing tests to confirm that behavior is preserved.

---

## Are there any user-facing changes?

Yes, at the type level.

- **Public aliases:**
  - `ParquetColumnIndex` is now `Vec<Vec<Option<ColumnIndexMetaData>>>`
  - `ParquetOffsetIndex` is now `Vec<Vec<Option<OffsetIndexMetaData>>>`

- **Downstream code** that accessed these aliases as `indexes[row_group][column]` will need to handle `Option`, for example:

  ```rust
  if let Some(idx) = indexes[rg][col].as_ref() {
      // use idx
  }
  ```

- The Parquet on-disk format and footer encoding are **unchanged**.

Semantically, the goal of this PR is “same behavior, new types”; more meaningful changes in how missing indexes are represented and handled are done in follow-up PRs.
