### PR TITLE
Allocate a zeroed buffer for FixedSizeBinaryArray::null

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -119,10 +119,10 @@ impl FixedSizeBinaryArray {
     /// * `size < 0`
     /// * `size * len` would overflow `usize`
     pub fn new_null(size: i32, len: usize) -> Self {
-        let capacity = size.to_usize().unwrap().checked_mul(len).unwrap();
+        let capacity_in_bytes = size.to_usize().unwrap().checked_mul(len).unwrap();
         Self {
             data_type: DataType::FixedSizeBinary(size),
-            value_data: MutableBuffer::new(capacity).into(),
+            value_data: MutableBuffer::new_null(capacity_in_bytes * 8).into(),
             nulls: Some(NullBuffer::new_null(len)),
             value_length: size,
             len,
@@ -982,6 +982,10 @@ mod tests {
 
         let nulls = NullBuffer::new_null(5);
         FixedSizeBinaryArray::new(2, buffer.clone(), Some(nulls));
+
+        let null_array = FixedSizeBinaryArray::new_null(4, 3);
+        assert_eq!(null_array.len(), 3);
+        assert_eq!(null_array.values().len(), 12);
 
         let a = FixedSizeBinaryArray::new(3, buffer.clone(), None);
         assert_eq!(a.len(), 3);


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8900 .

# Rationale for this change

This causes the values buffer to have the expected length after creating the null array.

# What changes are included in this PR?

Use `MutableBuffer::new_null` instead of `MutableBuffer::new`

# Are these changes tested?

Yes, additional constructor test

# Are there any user-facing changes?

Yes, the buffer will now be correctly initialized when calling `FixedSizeBinaryArray::new_null`