### PR TITLE
WIP: Boolean mask backed RowSelection

### DIFF
--- a/arrow-buffer/src/buffer/boolean.rs
+++ b/arrow-buffer/src/buffer/boolean.rs
@@ -162,7 +162,10 @@ impl BooleanBuffer {
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         assert!(
             offset.saturating_add(len) <= self.len,
-            "the length + offset of the sliced BooleanBuffer cannot exceed the existing length"
+            "the length ({}) + offset ({}) of the sliced BooleanBuffer cannot exceed the existing length ({})",
+            len,
+            offset,
+            self.len
         );
         Self {
             buffer: self.buffer.clone(),

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -58,8 +58,19 @@ impl ReadPlanBuilder {
     /// Configure the policy to use when materialising the [`RowSelection`]
     ///
     /// Defaults to [`RowSelectionPolicy::Auto`]
+    ///
+    /// If a particular policy is specified, this guarantees that the resulting
+    /// `ReadPlan` will use the specified strategy
     pub fn with_row_selection_policy(mut self, policy: RowSelectionPolicy) -> Self {
         self.row_selection_policy = policy;
+        // force the selection to be in the correct format
+        self.selection = self
+            .selection
+            .take()
+            .map(|s| match self.resolve_selection_strategy() {
+                RowSelectionStrategy::Mask => s.to_mask(),
+                RowSelectionStrategy::Selectors => s.to_selectors(),
+            });
         self
     }
 

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -174,6 +174,7 @@ impl ReadPlanBuilder {
                 _ => filters.push(prep_null_mask_filter(&filter)),
             };
         }
+        
 
         let raw = RowSelection::from_filters(&filters);
         self.selection = match self.selection.take() {

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -193,6 +193,8 @@ impl Default for RowSelection {
 impl RowSelection {
     /// Creates a [`RowSelection`] from a slice of [`BooleanArray`]
     ///
+    /// This always creates a `BitmaskSelection`.
+    ///
     /// # Panic
     ///
     /// Panics if any of the [`BooleanArray`] contain nulls
@@ -209,6 +211,24 @@ impl RowSelection {
     pub fn from_selectors(selectors: Vec<RowSelector>) -> Self {
         Self::Selectors(RowSelectorSelection::from_selectors(selectors))
     }
+
+    /// Creates a [`RowSelection`] from a slice of [`BooleanArray`] given the specified
+    /// strategy
+    ///
+    /// # Panic
+    ///
+    /// Panics if any of the [`BooleanArray`] contain nulls
+    pub fn from_filters_with_strategy(filters: &[BooleanArray], strategy: RowSelectionStrategy) -> Self {
+        match strategy{
+            RowSelectionStrategy::Mask => {
+                 Self::Mask(BitmaskSelection::from_filters(filters))
+            },
+            RowSelectionStrategy::Selectors => {
+                 Self::Selectors(RowSelectorSelection::from_filters(filters))
+            },
+        }
+    }
+
 
 
     /// Creates a [`RowSelection`] from an iterator of consecutive ranges to keep

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -349,9 +349,7 @@ impl RowSelection {
     pub(crate) fn trim(self) -> Self {
         match self {
             Self::Selectors(selection) => Self::Selectors(selection.trim()),
-            Self::Mask(_mask) => {
-                todo!()
-            }
+            Self::Mask(mask) => Self::Mask(mask.trim()),
         }
     }
 
@@ -2112,31 +2110,43 @@ mod tests {
 
     #[test]
     fn test_trim() {
-        let selection = RowSelectorSelection::from(vec![
-            RowSelector::skip(34),
-            RowSelector::select(12),
-            RowSelector::skip(3),
-            RowSelector::select(35),
-        ]);
+        test_selection(
+            || {
+                RowSelection::from(vec![
+                    RowSelector::skip(34),
+                    RowSelector::select(12),
+                    RowSelector::skip(3),
+                    RowSelector::select(35),
+                ])
+            },
+            |selection| {
+                let expected = vec![
+                    RowSelector::skip(34),
+                    RowSelector::select(12),
+                    RowSelector::skip(3),
+                    RowSelector::select(35),
+                ];
 
-        let expected = vec![
-            RowSelector::skip(34),
-            RowSelector::select(12),
-            RowSelector::skip(3),
-            RowSelector::select(35),
-        ];
+                let trimmed = selection.clone().trim();
+                assert_eq!(into_selectors(&trimmed), expected);
+            },
+        );
 
-        assert_eq!(selection.trim().selectors, expected);
+        test_selection(
+            || {
+                RowSelection::from(vec![
+                    RowSelector::skip(34),
+                    RowSelector::select(12),
+                    RowSelector::skip(3),
+                ])
+            },
+            |selection| {
+                let trimmed = selection.clone().trim();
+                let expected = vec![RowSelector::skip(34), RowSelector::select(12)];
 
-        let selection = RowSelectorSelection::from(vec![
-            RowSelector::skip(34),
-            RowSelector::select(12),
-            RowSelector::skip(3),
-        ]);
-
-        let expected = vec![RowSelector::skip(34), RowSelector::select(12)];
-
-        assert_eq!(selection.trim().selectors, expected);
+                assert_eq!(into_selectors(&trimmed), expected);
+            },
+        );
     }
 
     /// Runs `verify_fn(s1)` with both Mask and Selector backed cursors

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -416,7 +416,7 @@ impl RowSelection {
                 Self::Selectors(selection.expand_to_batch_boundaries(batch_size, total_rows))
             }
             Self::Mask(mask) => {
-                todo!()
+                Self::Mask(mask.expand_to_batch_boundaries(batch_size, total_rows))
             }
         }
     }
@@ -1258,6 +1258,7 @@ fn page_location_range(page: &PageLocation) -> Range<u64> {
 mod tests {
     use super::*;
     use rand::{Rng, rng};
+    use crate::record::Row;
 
     #[test]
     fn test_from_filters() {
@@ -1737,6 +1738,7 @@ mod tests {
         }
     }
 
+
     #[test]
     fn test_iter() {
         // use the iter() API to show it does what is expected and
@@ -2141,6 +2143,66 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_expand_to_batch_boundaries() {
+        test_selection(|| {
+            // selection goes up to row 28, total 30 rows
+            RowSelection::from(vec![
+                // select 1 row in range 0..8
+                RowSelector::skip(5),
+                RowSelector::select(1),
+                RowSelector::skip(2),
+                // select no rows in range 8..16
+                RowSelector::skip(8),
+                // select 7 rows in range 16..24
+                RowSelector::skip(1),
+                RowSelector::select(7),
+                // select 1 rows in range 24..30
+                RowSelector::skip(4),
+                RowSelector::select(1),
+                RowSelector::skip(1)
+            ])
+        }, |selection| {
+            let expanded = selection.expand_to_batch_boundaries(8, 30);
+            let expected = vec![
+                RowSelector::select(8),
+                RowSelector::skip(8),
+                RowSelector::select(14),
+            ];
+
+            assert_eq!(into_selectors(&expanded), expected);
+        });
+
+        // test when there is no selected rows at the end
+        test_selection(|| {
+            RowSelection::from(vec![
+                // select now rows in range 0..8
+                RowSelector::skip(8),
+                // select 6 rows in range 8..16
+                RowSelector::skip(1),
+                RowSelector::select(6),
+                RowSelector::skip(1),
+                // select a row in range 16..24
+                RowSelector::skip(4),
+                RowSelector::select(2),
+                RowSelector::skip(2),
+                // no rows in range 24..30
+                RowSelector::skip(6)
+            ])
+        }, |selection| {
+            let expanded = selection.expand_to_batch_boundaries(8, 30);
+            let expected = vec![
+                RowSelector::skip(8),
+                RowSelector::select(16),
+                RowSelector::skip(6),
+            ];
+
+            assert_eq!(into_selectors(&expanded), expected);
+        })
+
+    }
+
+
     /// Runs `verify_fn(s1)` with both Mask and Selector backed cursors
     ///
     /// This is used to ensuring both cursor types behave identically
@@ -2256,4 +2318,6 @@ mod tests {
     fn into_selectors(selection: &RowSelection) -> Vec<RowSelector> {
         selection.clone().into()
     }
+
+
 }

--- a/parquet/src/arrow/arrow_reader/selection.rs
+++ b/parquet/src/arrow/arrow_reader/selection.rs
@@ -15,13 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod and_then;
+pub(crate) mod conversion;
+pub(crate) mod mask;
+
 use crate::arrow::ProjectionMask;
+use crate::arrow::arrow_reader::selection::conversion::consecutive_ranges_to_row_selectors;
+use crate::arrow::arrow_reader::selection::mask::BitmaskSelection;
 use crate::errors::ParquetError;
 use crate::file::page_index::offset_index::{OffsetIndexMetaData, PageLocation};
 use arrow_array::{Array, BooleanArray};
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
 use arrow_select::filter::SlicesIterator;
-use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::ops::Range;
 
@@ -60,8 +65,12 @@ pub(crate) enum RowSelectionStrategy {
     Mask,
 }
 
-/// [`RowSelection`] is a collection of [`RowSelector`] used to skip rows when
-/// scanning a parquet file
+/// Select or skip some number of contiguous rows.
+///
+/// This is similar to a run-length encoding of selected rows, compared to
+/// a boolean mask which explicitly represents each row.
+///
+/// See [`RowSelection`] for representing a full selection of rows.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RowSelector {
     /// The number of rows
@@ -89,8 +98,10 @@ impl RowSelector {
     }
 }
 
-/// [`RowSelection`] allows selecting or skipping a provided number of rows
-/// when scanning the parquet file.
+// TODO: maybe call this `Selection` and typedef to RowSelection for backwards compatibility?
+
+/// [`RowSelection`] represents the rows that should be selected (decoded)
+/// when reading parquet data.
 ///
 /// This is applied prior to reading column data, and can therefore
 /// be used to skip IO to fetch data into memory
@@ -98,10 +109,15 @@ impl RowSelector {
 /// A typical use-case would be using the [`PageIndex`] to filter out rows
 /// that don't satisfy a predicate
 ///
-/// # Example
-/// ```
-/// use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+/// Internally it adaptively switches between two possible representations, each
+/// better for different patterns of rows that are selected:
+/// * A list of [`RowSelector`] (ranges) values (more efficient for large contiguous
+///   selections or skips)
+/// * A boolean mask (more efficient for sparse selections
 ///
+/// # Example: Create with [`RowSelector`]s
+/// ```
+/// # use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
 /// let selectors = vec![
 ///     RowSelector::skip(5),
 ///     RowSelector::select(5),
@@ -120,27 +136,384 @@ impl RowSelector {
 ///
 /// let actual: Vec<RowSelector> = selection.into();
 /// assert_eq!(actual, expected);
-///
-/// // you can also create a selection from consecutive ranges
-/// let ranges = vec![5..10, 10..15];
-/// let selection =
-///   RowSelection::from_consecutive_ranges(ranges.into_iter(), 20);
-/// let actual: Vec<RowSelector> = selection.into();
-/// assert_eq!(actual, expected);
 /// ```
 ///
-/// A [`RowSelection`] maintains the following invariants:
+/// # Example: Create with ranges
+/// ```
+/// # use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+/// // you can also create a selection from consecutive ranges
+/// let ranges = vec![5..10, 10..15];
+/// let selection = RowSelection::from_consecutive_ranges(ranges.into_iter(), 20);
+/// let actual: Vec<RowSelector> = selection.into();
+/// assert_eq!(actual,
+///   vec![
+///     RowSelector::skip(5),
+///     RowSelector::select(10),
+///     RowSelector::skip(5)
+///   ]);
+/// ```
+///
+/// # Example converting `RowSelection` to/from `Vec<RowSelector>`
+/// ```
+/// # use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+/// let selectors = vec![
+///    RowSelector::skip(5),
+///    RowSelector::select(10),
+/// ];
+/// let selection = RowSelection::from(selectors);
+/// let back: Vec<RowSelector> = selection.into();
+/// assert_eq!(back, vec![
+///   RowSelector::skip(5),
+///   RowSelector::select(10),
+/// ]);
+/// ```
+///
+/// # Example converting `RowSelection` to/from to `BooleanArray`
+/// ```
+/// # use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+/// # use arrow_array::BooleanArray;
+/// let mask = BooleanArray::from(vec![false, false, false, true, true, false]);
+/// let selection = RowSelection::from(mask.clone());
+/// let back: BooleanArray = selection.into();
+/// assert_eq!(back, mask);
+/// ```
+///
+/// [`PageIndex`]: crate::file::page_index::column_index::ColumnIndexMetaData
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RowSelection {
+    /// Selection based on a list of [`RowSelector`]s
+    Selectors(RowSelectorSelection),
+    /// Selection based on a boolean mask
+    Mask(BitmaskSelection),
+}
+impl Default for RowSelection {
+    fn default() -> Self {
+        Self::Selectors(RowSelectorSelection::default())
+    }
+}
+
+impl RowSelection {
+    /// Creates a [`RowSelection`] from a slice of [`BooleanArray`]
+    ///
+    /// # Panic
+    ///
+    /// Panics if any of the [`BooleanArray`] contain nulls
+    pub fn from_filters(filters: &[BooleanArray]) -> Self {
+        // TODO decide how to do this based on density or something??
+        Self::Mask(BitmaskSelection::from_filters(filters))
+        //Self::Selectors(RowSelectorSelection::from_filters(filters))
+    }
+
+    /// Creates a [`RowSelection`] from an iterator of consecutive ranges to keep
+    pub fn from_consecutive_ranges<I: Iterator<Item = Range<usize>>>(
+        ranges: I,
+        total_rows: usize,
+    ) -> Self {
+        // todo should this be decided based on density or something??
+        Self::Selectors(RowSelectorSelection::from_consecutive_ranges(
+            ranges, total_rows,
+        ))
+    }
+
+    /// Given an offset index, return the byte ranges for all data pages selected by `self`
+    ///
+    /// This is useful for determining what byte ranges to fetch from underlying storage
+    ///
+    /// Note: this method does not make any effort to combine consecutive ranges, nor coalesce
+    /// ranges that are close together. This is instead delegated to the IO subsystem to optimise,
+    /// e.g. [`ObjectStore::get_ranges`](object_store::ObjectStore::get_ranges)
+    pub fn scan_ranges(&self, page_locations: &[PageLocation]) -> Vec<Range<u64>> {
+        match self {
+            Self::Selectors(selection) => selection.scan_ranges(page_locations),
+            Self::Mask(_mask) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Returns true if selectors should be forced, preventing mask materialisation
+    pub(crate) fn should_force_selectors(
+        &self,
+        projection: &ProjectionMask,
+        offset_index: Option<&[OffsetIndexMetaData]>,
+    ) -> bool {
+        match self {
+            Self::Selectors(selectors) => {
+                selectors.should_force_selectors(projection, offset_index)
+            }
+            Self::Mask(_) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Splits off the first `row_count` from this [`RowSelection`]
+    ///
+    /// If the row_count exceeds the total number of rows in this selection,
+    /// the entire selection is returned and this selection becomes empty.
+    pub fn split_off(&mut self, row_count: usize) -> Self {
+        match self {
+            Self::Selectors(selection) => Self::Selectors(selection.split_off(row_count)),
+            Self::Mask(mask) => Self::Mask(mask.split_off(row_count)),
+        }
+    }
+
+    /// returns a [`RowSelection`] representing rows that are selected in both
+    /// input [`RowSelection`]s.
+    ///
+    /// This is equivalent to the logical `AND` / conjunction of the two
+    /// selections.
+    ///
+    /// # Example
+    /// If `N` means the row is not selected, and `Y` means it is
+    /// selected:
+    ///
+    /// ```text
+    /// self:     NNNNNNNNNNNNYYYYYYYYYYYYYYYYYYYYYYNNNYYYYY
+    /// other:                YYYYYNNNNYYYYYYYYYYYYY   YYNNN
+    ///
+    /// returned: NNNNNNNNNNNNYYYYYNNNNYYYYYYYYYYYYYNNNYYNNN
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `other` does not have a length equal to the number of rows selected
+    /// by this RowSelection
+    ///
+    pub fn and_then(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Selectors(left), Self::Selectors(right)) => {
+                Self::Selectors(left.and_then(right))
+            }
+            (Self::Mask(left), Self::Mask(right)) => Self::Mask(left.and_then(right)),
+            // need to convert one to the other
+            // todo figure out some heuristic here
+            (Self::Selectors(left), Self::Mask(right)) => {
+                let left_mask = BitmaskSelection::from_row_selectors(&left.selectors);
+                Self::Mask(left_mask.and_then(right))
+            }
+            (Self::Mask(left), Self::Selectors(right)) => {
+                let right_mask = BitmaskSelection::from_row_selectors(&right.selectors);
+                Self::Mask(left.and_then(&right_mask))
+            }
+        }
+    }
+
+    /// Compute the intersection of two [`RowSelection`]
+    /// For example:
+    /// self:      NNYYYYNNYYNYN
+    /// other:     NYNNNNNNY
+    ///
+    /// returned:  NNNNNNNNYYNYN
+    pub fn intersection(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Selectors(left), Self::Selectors(right)) => {
+                Self::Selectors(intersect_row_selections(&left.selectors, &right.selectors))
+            }
+            (Self::Mask(left), Self::Mask(right)) => Self::Mask(left.intersection(right)),
+            // need to convert one to the other
+            _ => {
+                todo!()
+            }
+        }
+    }
+
+    /// Compute the union of two [`RowSelection`]
+    /// For example:
+    /// self:      NNYYYYNNYYNYN
+    /// other:     NYNNNNNNN
+    ///
+    /// returned:  NYYYYYNNYYNYN
+    pub fn union(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Selectors(left), Self::Selectors(right)) => {
+                Self::Selectors(union_row_selections(&left.selectors, &right.selectors))
+            }
+            (Self::Mask(left), Self::Mask(right)) => Self::Mask(left.union(right)),
+            // need to convert one to the other
+            _ => {
+                todo!()
+            }
+        }
+    }
+
+    /// Returns `true` if this [`RowSelection`] selects any rows
+    pub fn selects_any(&self) -> bool {
+        match self {
+            Self::Selectors(selection) => selection.selects_any(),
+            Self::Mask(mask) => mask.selects_any(),
+        }
+    }
+
+    /// Trims this [`RowSelection`] removing any trailing skips
+    pub(crate) fn trim(self) -> Self {
+        match self {
+            Self::Selectors(selection) => Self::Selectors(selection.trim()),
+            Self::Mask(_mask) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Applies an offset to this [`RowSelection`], skipping the first `offset` selected rows
+    pub(crate) fn offset(self, offset: usize) -> Self {
+        match self {
+            Self::Selectors(selection) => Self::Selectors(selection.offset(offset)),
+            Self::Mask(mask) => Self::Mask(mask.offset(offset)),
+        }
+    }
+
+    /// Limit this [`RowSelection`] to only select `limit` rows
+    pub(crate) fn limit(self, limit: usize) -> Self {
+        match self {
+            Self::Selectors(selection) => Self::Selectors(selection.limit(limit)),
+            Self::Mask(_mask) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Returns an iterator over the [`RowSelector`]s for this
+    /// [`RowSelection`].
+    pub fn iter(&self) -> impl Iterator<Item = &RowSelector> {
+        match self {
+            Self::Selectors(selection) => selection.iter(),
+            Self::Mask(_mask) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Returns the number of selected rows
+    pub fn row_count(&self) -> usize {
+        match self {
+            Self::Selectors(selection) => selection.row_count(),
+            Self::Mask(mask) => mask.row_count(),
+        }
+    }
+
+    /// Returns the number of de-selected rows
+    pub fn skipped_row_count(&self) -> usize {
+        match self {
+            Self::Selectors(selection) => selection.skipped_row_count(),
+            Self::Mask(mask) => {
+                todo!()
+            }
+        }
+    }
+
+    /// Expands the selection to align with batch boundaries.
+    /// This is needed when using cached array readers to ensure that
+    /// the cached data covers full batches.
+    pub(crate) fn expand_to_batch_boundaries(&self, batch_size: usize, total_rows: usize) -> Self {
+        match self {
+            Self::Selectors(selection) => {
+                Self::Selectors(selection.expand_to_batch_boundaries(batch_size, total_rows))
+            }
+            Self::Mask(mask) => {
+                todo!()
+            }
+        }
+    }
+}
+
+impl From<Vec<RowSelector>> for RowSelection {
+    fn from(selectors: Vec<RowSelector>) -> Self {
+        Self::Selectors(selectors.into_iter().collect())
+    }
+}
+
+impl FromIterator<RowSelector> for RowSelection {
+    fn from_iter<T: IntoIterator<Item = RowSelector>>(iter: T) -> Self {
+        Self::Selectors(iter.into_iter().collect())
+    }
+}
+
+impl From<RowSelection> for Vec<RowSelector> {
+    fn from(r: RowSelection) -> Self {
+        match r {
+            RowSelection::Selectors(selection) => selection.into(),
+            RowSelection::Mask(selection) => selection.into(),
+        }
+    }
+}
+
+impl From<RowSelection> for VecDeque<RowSelector> {
+    fn from(r: RowSelection) -> Self {
+        Vec::<RowSelector>::from(r).into()
+    }
+}
+
+impl From<RowSelectorSelection> for RowSelection {
+    fn from(r: RowSelectorSelection) -> Self {
+        Self::Selectors(r)
+    }
+}
+
+impl From<BitmaskSelection> for RowSelection {
+    fn from(r: BitmaskSelection) -> Self {
+        Self::Mask(r)
+    }
+}
+
+impl From<BooleanArray> for RowSelection {
+    fn from(array: BooleanArray) -> Self {
+        Self::from_filters(&[array])
+    }
+}
+
+impl From<RowSelection> for BooleanArray {
+    fn from(selection: RowSelection) -> Self {
+        match selection {
+            RowSelection::Selectors(selectors) => {
+                BitmaskSelection::from_row_selectors(&selectors.selectors).into()
+            }
+            RowSelection::Mask(mask) => mask.into(),
+        }
+    }
+}
+
+// TODO move to its own module
+/// One possible backing of [`RowSelection`], based on Vec<RowSelector>
+///
+/// It is similar to the "Range Index" described in
+/// [Predicate Caching: Query-Driven Secondary Indexing for Cloud Data Warehouses]
+///
+/// Represents the result of a filter evaluation as a series of ranges (a type
+/// of run length encoding). It is more efficient for large contiguous
+/// selections or skips.
+///
+/// For example, the selection:
+/// ```text
+/// skip 5
+/// select 10
+/// skip 5
+/// ```
+///
+/// Represents evaluating a filter over 20 rows where the first 5 and last 5
+/// rows are filtered out, and the middle 10 rows are retained.
+///
+/// A [`RowSelectorSelection`] maintains the following invariants:
 ///
 /// * It contains no [`RowSelector`] of 0 rows
 /// * Consecutive [`RowSelector`]s alternate skipping or selecting rows
 ///
-/// [`PageIndex`]: crate::file::page_index::column_index::ColumnIndexMetaData
+///
+/// [Predicate Caching: Query-Driven Secondary Indexing for Cloud Data Warehouses]: https://dl.acm.org/doi/10.1145/3626246.3653395
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct RowSelection {
+struct RowSelectorSelection {
     selectors: Vec<RowSelector>,
 }
 
-impl RowSelection {
+impl RowSelectorSelection {
+    /// Create a [`RowSelection`] from a Vec of [`RowSelector`]
+    ///
+    /// Note this will filter any selectors with row_count == 0 and combining consecutive selectors
+    pub fn from_selectors(selectors: Vec<RowSelector>) -> Self {
+        // processing / simplification happens in from_iter
+        selectors.into_iter().collect()
+    }
+
     /// Creates a [`RowSelection`] from a slice of [`BooleanArray`]
     ///
     /// # Panic
@@ -165,33 +538,9 @@ impl RowSelection {
         ranges: I,
         total_rows: usize,
     ) -> Self {
-        let mut selectors: Vec<RowSelector> = Vec::with_capacity(ranges.size_hint().0);
-        let mut last_end = 0;
-        for range in ranges {
-            let len = range.end - range.start;
-            if len == 0 {
-                continue;
-            }
-
-            match range.start.cmp(&last_end) {
-                Ordering::Equal => match selectors.last_mut() {
-                    Some(last) => last.row_count = last.row_count.checked_add(len).unwrap(),
-                    None => selectors.push(RowSelector::select(len)),
-                },
-                Ordering::Greater => {
-                    selectors.push(RowSelector::skip(range.start - last_end));
-                    selectors.push(RowSelector::select(len))
-                }
-                Ordering::Less => panic!("out of order"),
-            }
-            last_end = range.end;
+        Self {
+            selectors: consecutive_ranges_to_row_selectors(ranges, total_rows),
         }
-
-        if last_end != total_rows {
-            selectors.push(RowSelector::skip(total_rows - last_end))
-        }
-
-        Self { selectors }
     }
 
     /// Given an offset index, return the byte ranges for all data pages selected by `self`
@@ -567,13 +916,15 @@ impl RowSelection {
     }
 }
 
-impl From<Vec<RowSelector>> for RowSelection {
+impl From<Vec<RowSelector>> for RowSelectorSelection {
     fn from(selectors: Vec<RowSelector>) -> Self {
-        selectors.into_iter().collect()
+        RowSelectorSelection::from_selectors(selectors)
     }
 }
 
-impl FromIterator<RowSelector> for RowSelection {
+/// Create a RowSelectorRowSelection from an iterator of RowSelectors
+/// filtering out any selectors with row_count == 0 and combining consecutive selectors
+impl FromIterator<RowSelector> for RowSelectorSelection {
     fn from_iter<T: IntoIterator<Item = RowSelector>>(iter: T) -> Self {
         let iter = iter.into_iter();
 
@@ -603,14 +954,14 @@ impl FromIterator<RowSelector> for RowSelection {
     }
 }
 
-impl From<RowSelection> for Vec<RowSelector> {
-    fn from(r: RowSelection) -> Self {
+impl From<RowSelectorSelection> for Vec<RowSelector> {
+    fn from(r: RowSelectorSelection) -> Self {
         r.selectors
     }
 }
 
-impl From<RowSelection> for VecDeque<RowSelector> {
-    fn from(r: RowSelection) -> Self {
+impl From<RowSelectorSelection> for VecDeque<RowSelector> {
+    fn from(r: RowSelectorSelection) -> Self {
         r.selectors.into()
     }
 }
@@ -621,7 +972,7 @@ impl From<RowSelection> for VecDeque<RowSelector> {
 /// other:     NYNNNNNNY
 ///
 /// returned:  NNNNNNNNYYNYN
-fn intersect_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowSelection {
+fn intersect_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowSelectorSelection {
     let mut l_iter = left.iter().copied().peekable();
     let mut r_iter = right.iter().copied().peekable();
 
@@ -683,7 +1034,7 @@ fn intersect_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowS
 /// returned:  NYYYYYNNYYNYN
 ///
 /// This can be removed from here once RowSelection::union is in parquet::arrow
-fn union_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowSelection {
+fn union_row_selections(left: &[RowSelector], right: &[RowSelector]) -> RowSelectorSelection {
     let mut l_iter = left.iter().copied().peekable();
     let mut r_iter = right.iter().copied().peekable();
 
@@ -946,199 +1297,239 @@ mod tests {
             BooleanArray::from(Vec::<bool>::new()),
         ];
 
-        let selection = RowSelection::from_filters(&filters[..1]);
-        assert!(selection.selects_any());
-        assert_eq!(
-            selection.selectors,
-            vec![RowSelector::skip(3), RowSelector::select(4)]
+        test_selection(
+            || RowSelection::from_filters(&filters[..1]),
+            |selection| {
+                assert!(selection.selects_any());
+                assert_eq!(
+                    into_selectors(selection),
+                    vec![RowSelector::skip(3), RowSelector::select(4)]
+                );
+            },
+        );
+        test_selection(
+            || RowSelection::from_filters(&filters[..2]),
+            |selection| {
+                assert!(selection.selects_any());
+                assert_eq!(
+                    into_selectors(selection),
+                    vec![
+                        RowSelector::skip(3),
+                        RowSelector::select(6),
+                        RowSelector::skip(2),
+                        RowSelector::select(3)
+                    ]
+                );
+            },
+        );
+        test_selection(
+            || RowSelection::from_filters(&filters),
+            |selection| {
+                assert!(selection.selects_any());
+                assert_eq!(
+                    into_selectors(selection),
+                    vec![
+                        RowSelector::skip(3),
+                        RowSelector::select(6),
+                        RowSelector::skip(2),
+                        RowSelector::select(3),
+                        RowSelector::skip(4)
+                    ]
+                );
+            },
         );
 
-        let selection = RowSelection::from_filters(&filters[..2]);
-        assert!(selection.selects_any());
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::skip(3),
-                RowSelector::select(6),
-                RowSelector::skip(2),
-                RowSelector::select(3)
-            ]
+        test_selection(
+            || RowSelection::from_filters(&filters[2..3]),
+            |selection| {
+                assert!(!selection.selects_any());
+                assert_eq!(into_selectors(selection), vec![RowSelector::skip(4)]);
+            },
         );
-
-        let selection = RowSelection::from_filters(&filters);
-        assert!(selection.selects_any());
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::skip(3),
-                RowSelector::select(6),
-                RowSelector::skip(2),
-                RowSelector::select(3),
-                RowSelector::skip(4)
-            ]
-        );
-
-        let selection = RowSelection::from_filters(&filters[2..3]);
-        assert!(!selection.selects_any());
-        assert_eq!(selection.selectors, vec![RowSelector::skip(4)]);
     }
 
     #[test]
     fn test_split_off() {
-        let mut selection = RowSelection::from(vec![
-            RowSelector::skip(34),
-            RowSelector::select(12),
-            RowSelector::skip(3),
-            RowSelector::select(35),
-        ]);
+        test_selection(
+            || {
+                RowSelection::from(vec![
+                    RowSelector::skip(34),
+                    RowSelector::select(12),
+                    RowSelector::skip(3),
+                    RowSelector::select(35),
+                ])
+            },
+            |selection| {
+                let mut selection = selection.clone();
+                let split = selection.split_off(34);
+                assert_eq!(into_selectors(&split), vec![RowSelector::skip(34)]);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![
+                        RowSelector::select(12),
+                        RowSelector::skip(3),
+                        RowSelector::select(35)
+                    ]
+                );
 
-        let split = selection.split_off(34);
-        assert_eq!(split.selectors, vec![RowSelector::skip(34)]);
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::select(12),
-                RowSelector::skip(3),
-                RowSelector::select(35)
-            ]
-        );
+                let split = selection.split_off(5);
+                assert_eq!(into_selectors(&split), vec![RowSelector::select(5)]);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![
+                        RowSelector::select(7),
+                        RowSelector::skip(3),
+                        RowSelector::select(35)
+                    ]
+                );
 
-        let split = selection.split_off(5);
-        assert_eq!(split.selectors, vec![RowSelector::select(5)]);
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::select(7),
-                RowSelector::skip(3),
-                RowSelector::select(35)
-            ]
-        );
+                let split = selection.split_off(8);
+                assert_eq!(
+                    into_selectors(&split),
+                    vec![RowSelector::select(7), RowSelector::skip(1)]
+                );
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![RowSelector::skip(2), RowSelector::select(35)]
+                );
 
-        let split = selection.split_off(8);
-        assert_eq!(
-            split.selectors,
-            vec![RowSelector::select(7), RowSelector::skip(1)]
+                let split = selection.split_off(200);
+                assert_eq!(
+                    into_selectors(&split),
+                    vec![RowSelector::skip(2), RowSelector::select(35)]
+                );
+                assert!(into_selectors(&selection).is_empty());
+            },
         );
-        assert_eq!(
-            selection.selectors,
-            vec![RowSelector::skip(2), RowSelector::select(35)]
-        );
-
-        let split = selection.split_off(200);
-        assert_eq!(
-            split.selectors,
-            vec![RowSelector::skip(2), RowSelector::select(35)]
-        );
-        assert!(selection.selectors.is_empty());
     }
 
     #[test]
     fn test_offset() {
-        let selection = RowSelection::from(vec![
-            RowSelector::select(5),
-            RowSelector::skip(23),
-            RowSelector::select(7),
-            RowSelector::skip(33),
-            RowSelector::select(6),
-        ]);
+        test_selection(
+            || {
+                RowSelection::from(vec![
+                    RowSelector::select(5),
+                    RowSelector::skip(23),
+                    RowSelector::select(7),
+                    RowSelector::skip(33),
+                    RowSelector::select(6),
+                ])
+            },
+            |selection| {
+                let selection = selection.clone();
+                let selection = selection.offset(2);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![
+                        RowSelector::skip(2),
+                        RowSelector::select(3),
+                        RowSelector::skip(23),
+                        RowSelector::select(7),
+                        RowSelector::skip(33),
+                        RowSelector::select(6),
+                    ]
+                );
 
-        let selection = selection.offset(2);
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::skip(2),
-                RowSelector::select(3),
-                RowSelector::skip(23),
-                RowSelector::select(7),
-                RowSelector::skip(33),
-                RowSelector::select(6),
-            ]
-        );
+                let selection = selection.offset(5);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![
+                        RowSelector::skip(30),
+                        RowSelector::select(5),
+                        RowSelector::skip(33),
+                        RowSelector::select(6),
+                    ]
+                );
 
-        let selection = selection.offset(5);
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::skip(30),
-                RowSelector::select(5),
-                RowSelector::skip(33),
-                RowSelector::select(6),
-            ]
-        );
+                let selection = selection.offset(3);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![
+                        RowSelector::skip(33),
+                        RowSelector::select(2),
+                        RowSelector::skip(33),
+                        RowSelector::select(6),
+                    ]
+                );
 
-        let selection = selection.offset(3);
-        assert_eq!(
-            selection.selectors,
-            vec![
-                RowSelector::skip(33),
-                RowSelector::select(2),
-                RowSelector::skip(33),
-                RowSelector::select(6),
-            ]
-        );
+                let selection = selection.offset(2);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![RowSelector::skip(68), RowSelector::select(6),]
+                );
 
-        let selection = selection.offset(2);
-        assert_eq!(
-            selection.selectors,
-            vec![RowSelector::skip(68), RowSelector::select(6),]
-        );
-
-        let selection = selection.offset(3);
-        assert_eq!(
-            selection.selectors,
-            vec![RowSelector::skip(71), RowSelector::select(3),]
+                let selection = selection.offset(3);
+                assert_eq!(
+                    into_selectors(&selection),
+                    vec![RowSelector::skip(71), RowSelector::select(3),]
+                );
+            },
         );
     }
 
     #[test]
     fn test_and() {
-        let mut a = RowSelection::from(vec![
-            RowSelector::skip(12),
-            RowSelector::select(23),
-            RowSelector::skip(3),
-            RowSelector::select(5),
-        ]);
+        test_two_selections(
+            || {
+                let a = RowSelection::from(vec![
+                    RowSelector::skip(12),
+                    RowSelector::select(23),
+                    RowSelector::skip(3),
+                    RowSelector::select(5),
+                ]);
 
-        let b = RowSelection::from(vec![
-            RowSelector::select(5),
-            RowSelector::skip(4),
-            RowSelector::select(15),
-            RowSelector::skip(4),
-        ]);
+                let b = RowSelection::from(vec![
+                    RowSelector::select(5),
+                    RowSelector::skip(4),
+                    RowSelector::select(15),
+                    RowSelector::skip(4),
+                ]);
+                (a, b)
+            },
+            |a, b| {
+                let mut a = a.clone();
 
-        let mut expected = RowSelection::from(vec![
-            RowSelector::skip(12),
-            RowSelector::select(5),
-            RowSelector::skip(4),
-            RowSelector::select(14),
-            RowSelector::skip(3),
-            RowSelector::select(1),
-            RowSelector::skip(4),
-        ]);
+                let mut expected = RowSelection::from(vec![
+                    RowSelector::skip(12),
+                    RowSelector::select(5),
+                    RowSelector::skip(4),
+                    RowSelector::select(14),
+                    RowSelector::skip(3),
+                    RowSelector::select(1),
+                    RowSelector::skip(4),
+                ]);
 
-        assert_eq!(a.and_then(&b), expected);
+                // Convert to selectors to ensure equality
+                assert_eq!(into_selectors(&a.and_then(&b)), into_selectors(&expected));
 
-        a.split_off(7);
-        expected.split_off(7);
-        assert_eq!(a.and_then(&b), expected);
+                a.split_off(7);
+                expected.split_off(7);
+                assert_eq!(into_selectors(&a.and_then(&b)), into_selectors(&expected));
+            },
+        );
+        test_two_selections(
+            || {
+                let a = RowSelection::from(vec![RowSelector::select(5), RowSelector::skip(3)]);
 
-        let a = RowSelection::from(vec![RowSelector::select(5), RowSelector::skip(3)]);
-
-        let b = RowSelection::from(vec![
-            RowSelector::select(2),
-            RowSelector::skip(1),
-            RowSelector::select(1),
-            RowSelector::skip(1),
-        ]);
-
-        assert_eq!(
-            a.and_then(&b).selectors,
-            vec![
-                RowSelector::select(2),
-                RowSelector::skip(1),
-                RowSelector::select(1),
-                RowSelector::skip(4)
-            ]
+                let b = RowSelection::from(vec![
+                    RowSelector::select(2),
+                    RowSelector::skip(1),
+                    RowSelector::select(1),
+                    RowSelector::skip(1),
+                ]);
+                (a, b)
+            },
+            |a, b| {
+                assert_eq!(
+                    into_selectors(&a.and_then(&b)),
+                    vec![
+                        RowSelector::select(2),
+                        RowSelector::skip(1),
+                        RowSelector::select(1),
+                        RowSelector::skip(4)
+                    ]
+                );
+            },
         );
     }
 
@@ -1170,70 +1561,109 @@ mod tests {
             RowSelector::skip(0),
         ];
 
-        let expected = RowSelection::from(vec![
+        let expected = RowSelectorSelection::from(vec![
             RowSelector::skip(6),
             RowSelector::select(10),
             RowSelector::skip(4),
         ]);
 
-        assert_eq!(RowSelection::from_iter(a), expected);
-        assert_eq!(RowSelection::from_iter(b), expected);
-        assert_eq!(RowSelection::from_iter(c), expected);
+        assert_eq!(RowSelectorSelection::from_iter(a), expected);
+        assert_eq!(RowSelectorSelection::from_iter(b), expected);
+        assert_eq!(RowSelectorSelection::from_iter(c), expected);
     }
 
     #[test]
     fn test_combine_2elements() {
-        let a = vec![RowSelector::select(10), RowSelector::select(5)];
-        let a_expect = vec![RowSelector::select(15)];
-        assert_eq!(RowSelection::from_iter(a).selectors, a_expect);
+        test_selection(
+            || RowSelection::from_iter(vec![RowSelector::select(10), RowSelector::select(5)]),
+            |selection| {
+                let expected = vec![RowSelector::select(15)];
+                assert_eq!(into_selectors(selection), expected);
+            },
+        );
 
-        let b = vec![RowSelector::select(10), RowSelector::skip(5)];
-        let b_expect = vec![RowSelector::select(10), RowSelector::skip(5)];
-        assert_eq!(RowSelection::from_iter(b).selectors, b_expect);
+        test_selection(
+            || RowSelection::from_iter(vec![RowSelector::select(10), RowSelector::skip(5)]),
+            |selection| {
+                let expected = vec![RowSelector::select(10), RowSelector::skip(5)];
+                assert_eq!(into_selectors(selection), expected);
+            },
+        );
 
-        let c = vec![RowSelector::skip(10), RowSelector::select(5)];
-        let c_expect = vec![RowSelector::skip(10), RowSelector::select(5)];
-        assert_eq!(RowSelection::from_iter(c).selectors, c_expect);
+        test_selection(
+            || RowSelection::from_iter(vec![RowSelector::skip(10), RowSelector::select(5)]),
+            |selection| {
+                let expected = vec![RowSelector::skip(10), RowSelector::select(5)];
+                assert_eq!(into_selectors(selection), expected);
+            },
+        );
 
-        let d = vec![RowSelector::skip(10), RowSelector::skip(5)];
-        let d_expect = vec![RowSelector::skip(15)];
-        assert_eq!(RowSelection::from_iter(d).selectors, d_expect);
-    }
+        test_selection(
+            || RowSelection::from_iter(vec![RowSelector::skip(10), RowSelector::skip(5)]),
+            |selection| {
+                let expected = vec![RowSelector::skip(15)];
+                assert_eq!(into_selectors(selection), expected);
+            },
+        );
 
-    #[test]
-    fn test_from_one_and_empty() {
         let a = vec![RowSelector::select(10)];
-        let selection1 = RowSelection::from(a.clone());
-        assert_eq!(selection1.selectors, a);
+        test_selection(
+            || RowSelection::from_iter(a.clone()),
+            |selection| {
+                assert_eq!(&into_selectors(selection), &a);
+            },
+        );
 
         let b = vec![];
-        let selection1 = RowSelection::from(b.clone());
-        assert_eq!(selection1.selectors, b)
+        test_selection(
+            || RowSelection::from_iter(b.clone()),
+            |selection| {
+                assert_eq!(&into_selectors(selection), &b);
+            },
+        );
     }
 
     #[test]
     #[should_panic(expected = "selection exceeds the number of selected rows")]
-    fn test_and_longer() {
-        let a = RowSelection::from(vec![
-            RowSelector::select(3),
-            RowSelector::skip(33),
-            RowSelector::select(3),
-            RowSelector::skip(33),
-        ]);
-        let b = RowSelection::from(vec![RowSelector::select(36)]);
+    fn test_and_longer_selectors() {
+        let (a, b) = longer_selectors();
+        let a = force_selectors(a);
+        let b = force_selectors(b);
         a.and_then(&b);
+    }
+
+    #[test]
+    #[should_panic(expected = "The 'other' selection must have exactly as many set bits as 'self'")]
+    fn test_and_longer_mask() {
+        let (a, b) = longer_selectors();
+        let a = force_mask(a);
+        let b = force_mask(b);
+        a.and_then(&b);
+    }
+
+    /// Returns two RowSelections where the first is longer than the second
+    fn longer_selectors() -> (RowSelection, RowSelection) {
+        (
+            RowSelection::from(vec![
+                RowSelector::select(3),
+                RowSelector::skip(33),
+                RowSelector::select(3),
+                RowSelector::skip(33),
+            ]),
+            RowSelection::from(vec![RowSelector::select(36)]),
+        )
     }
 
     #[test]
     #[should_panic(expected = "selection contains less than the number of selected rows")]
     fn test_and_shorter() {
-        let a = RowSelection::from(vec![
+        let a = RowSelectorSelection::from(vec![
             RowSelector::select(3),
             RowSelector::skip(33),
             RowSelector::select(3),
             RowSelector::skip(33),
         ]);
-        let b = RowSelection::from(vec![RowSelector::select(3)]);
+        let b = RowSelectorSelection::from(vec![RowSelector::select(3)]);
         a.and_then(&b);
     }
 
@@ -1311,11 +1741,11 @@ mod tests {
         for _ in 0..100 {
             let a_len = rand.random_range(10..100);
             let a_bools: Vec<_> = (0..a_len).map(|_| rand.random_bool(0.2)).collect();
-            let a = RowSelection::from_filters(&[BooleanArray::from(a_bools.clone())]);
+            let a = RowSelectorSelection::from_filters(&[BooleanArray::from(a_bools.clone())]);
 
             let b_len: usize = a_bools.iter().map(|x| *x as usize).sum();
             let b_bools: Vec<_> = (0..b_len).map(|_| rand.random_bool(0.8)).collect();
-            let b = RowSelection::from_filters(&[BooleanArray::from(b_bools.clone())]);
+            let b = RowSelectorSelection::from_filters(&[BooleanArray::from(b_bools.clone())]);
 
             let mut expected_bools = vec![false; a_len];
 
@@ -1326,7 +1756,8 @@ mod tests {
                 }
             }
 
-            let expected = RowSelection::from_filters(&[BooleanArray::from(expected_bools)]);
+            let expected =
+                RowSelectorSelection::from_filters(&[BooleanArray::from(expected_bools)]);
 
             let total_rows: usize = expected.selectors.iter().map(|s| s.row_count).sum();
             assert_eq!(a_len, total_rows);
@@ -1345,7 +1776,7 @@ mod tests {
             RowSelector::select(4),
         ];
 
-        let round_tripped = RowSelection::from(selectors.clone())
+        let round_tripped = RowSelectorSelection::from(selectors.clone())
             .iter()
             .cloned()
             .collect::<Vec<_>>();
@@ -1355,11 +1786,15 @@ mod tests {
     #[test]
     fn test_limit() {
         // Limit to existing limit should no-op
-        let selection = RowSelection::from(vec![RowSelector::select(10), RowSelector::skip(90)]);
+        let selection =
+            RowSelectorSelection::from(vec![RowSelector::select(10), RowSelector::skip(90)]);
         let limited = selection.limit(10);
-        assert_eq!(RowSelection::from(vec![RowSelector::select(10)]), limited);
+        assert_eq!(
+            RowSelectorSelection::from(vec![RowSelector::select(10)]),
+            limited
+        );
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::select(10),
             RowSelector::skip(10),
             RowSelector::select(10),
@@ -1444,7 +1879,7 @@ mod tests {
             },
         ];
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             // Skip first page
             RowSelector::skip(10),
             // Multiple selects in same page
@@ -1467,7 +1902,7 @@ mod tests {
         // assert_eq!(mask, vec![false, true, true, false, true, true, false]);
         assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60]);
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             // Skip first page
             RowSelector::skip(10),
             // Multiple selects in same page
@@ -1491,7 +1926,7 @@ mod tests {
         // assert_eq!(mask, vec![false, true, true, false, true, true, true]);
         assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60, 60..70]);
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             // Skip first page
             RowSelector::skip(10),
             // Multiple selects in same page
@@ -1517,7 +1952,7 @@ mod tests {
         // assert_eq!(mask, vec![false, true, true, false, true, true, true]);
         assert_eq!(ranges, vec![10..20, 20..30, 40..50, 50..60, 60..70]);
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             // Skip first page
             RowSelector::skip(10),
             // Multiple selects in same page
@@ -1540,7 +1975,7 @@ mod tests {
     #[test]
     fn test_from_ranges() {
         let ranges = [1..3, 4..6, 6..6, 8..8, 9..10];
-        let selection = RowSelection::from_consecutive_ranges(ranges.into_iter(), 10);
+        let selection = RowSelectorSelection::from_consecutive_ranges(ranges.into_iter(), 10);
         assert_eq!(
             selection.selectors,
             vec![
@@ -1555,14 +1990,14 @@ mod tests {
 
         let out_of_order_ranges = [1..3, 8..10, 4..7];
         let result = std::panic::catch_unwind(|| {
-            RowSelection::from_consecutive_ranges(out_of_order_ranges.into_iter(), 10)
+            RowSelectorSelection::from_consecutive_ranges(out_of_order_ranges.into_iter(), 10)
         });
         assert!(result.is_err());
     }
 
     #[test]
     fn test_empty_selector() {
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::skip(0),
             RowSelector::select(2),
             RowSelector::skip(0),
@@ -1570,7 +2005,7 @@ mod tests {
         ]);
         assert_eq!(selection.selectors, vec![RowSelector::select(4)]);
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::select(0),
             RowSelector::skip(2),
             RowSelector::select(0),
@@ -1581,18 +2016,18 @@ mod tests {
 
     #[test]
     fn test_intersection() {
-        let selection = RowSelection::from(vec![RowSelector::select(1048576)]);
+        let selection = RowSelectorSelection::from(vec![RowSelector::select(1048576)]);
         let result = selection.intersection(&selection);
         assert_eq!(result, selection);
 
-        let a = RowSelection::from(vec![
+        let a = RowSelectorSelection::from(vec![
             RowSelector::skip(10),
             RowSelector::select(10),
             RowSelector::skip(10),
             RowSelector::select(20),
         ]);
 
-        let b = RowSelection::from(vec![
+        let b = RowSelectorSelection::from(vec![
             RowSelector::skip(20),
             RowSelector::select(20),
             RowSelector::skip(10),
@@ -1611,12 +2046,12 @@ mod tests {
 
     #[test]
     fn test_union() {
-        let selection = RowSelection::from(vec![RowSelector::select(1048576)]);
+        let selection = RowSelectorSelection::from(vec![RowSelector::select(1048576)]);
         let result = selection.union(&selection);
         assert_eq!(result, selection);
 
         // NYNYY
-        let a = RowSelection::from(vec![
+        let a = RowSelectorSelection::from(vec![
             RowSelector::skip(10),
             RowSelector::select(10),
             RowSelector::skip(10),
@@ -1624,7 +2059,7 @@ mod tests {
         ]);
 
         // NNYYNYN
-        let b = RowSelection::from(vec![
+        let b = RowSelectorSelection::from(vec![
             RowSelector::skip(20),
             RowSelector::select(20),
             RowSelector::skip(10),
@@ -1647,7 +2082,7 @@ mod tests {
 
     #[test]
     fn test_row_count() {
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::skip(34),
             RowSelector::select(12),
             RowSelector::skip(3),
@@ -1657,17 +2092,19 @@ mod tests {
         assert_eq!(selection.row_count(), 12 + 35);
         assert_eq!(selection.skipped_row_count(), 34 + 3);
 
-        let selection = RowSelection::from(vec![RowSelector::select(12), RowSelector::select(35)]);
+        let selection =
+            RowSelectorSelection::from(vec![RowSelector::select(12), RowSelector::select(35)]);
 
         assert_eq!(selection.row_count(), 12 + 35);
         assert_eq!(selection.skipped_row_count(), 0);
 
-        let selection = RowSelection::from(vec![RowSelector::skip(34), RowSelector::skip(3)]);
+        let selection =
+            RowSelectorSelection::from(vec![RowSelector::skip(34), RowSelector::skip(3)]);
 
         assert_eq!(selection.row_count(), 0);
         assert_eq!(selection.skipped_row_count(), 34 + 3);
 
-        let selection = RowSelection::from(vec![]);
+        let selection = RowSelectorSelection::from(vec![]);
 
         assert_eq!(selection.row_count(), 0);
         assert_eq!(selection.skipped_row_count(), 0);
@@ -1675,7 +2112,7 @@ mod tests {
 
     #[test]
     fn test_trim() {
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::skip(34),
             RowSelector::select(12),
             RowSelector::skip(3),
@@ -1691,7 +2128,7 @@ mod tests {
 
         assert_eq!(selection.trim().selectors, expected);
 
-        let selection = RowSelection::from(vec![
+        let selection = RowSelectorSelection::from(vec![
             RowSelector::skip(34),
             RowSelector::select(12),
             RowSelector::skip(3),
@@ -1700,5 +2137,121 @@ mod tests {
         let expected = vec![RowSelector::skip(34), RowSelector::select(12)];
 
         assert_eq!(selection.trim().selectors, expected);
+    }
+
+    /// Runs `verify_fn(s1)` with both Mask and Selector backed cursors
+    ///
+    /// This is used to ensuring both cursor types behave identically
+    /// for the same logical operations.
+    ///
+    /// Tests are written in terms of two closures:
+    /// 1. Create a `RowSelection` using the provided `create_fn`
+    /// 2. Verify the created selection using the provided `verify_fn`
+    ///
+    /// This function will invoke the `verify_fn` with both a Selector-backed and
+    /// Mask-backed `RowSelection`, ensuring both behave identically.
+    fn test_selection<C, V>(create_fn: C, verify_fn: V)
+    where
+        C: FnOnce() -> RowSelection,
+        V: Fn(&RowSelection),
+    {
+        let selection = create_fn();
+        test_two_selections(
+            move || {
+                let empty = RowSelection::from(vec![]);
+                (selection, empty)
+            },
+            |c1, _empty| {
+                verify_fn(c1);
+            },
+        );
+    }
+
+    /// Runs `verify_fn(s1, s2)` with all combinations of Mask and Selector backed
+    /// cursors
+    ///
+    /// This is used to ensuring both cursor types behave identically
+    /// for the same logical operations.
+    ///
+    /// Tests are written in terms of two closures:
+    /// 1. Create 2 `RowSelection`s using the provided `create_fn`
+    /// 2. Verify the created selection using the provided `verify_fn`
+    ///
+    /// This function will invoke the verify_fn with all combinations of Selector-backed and
+    /// Mask-backed `RowSelection`, ensuring both behave identically.
+    fn test_two_selections<C, V>(create_fn: C, verify_fn: V)
+    where
+        C: FnOnce() -> (RowSelection, RowSelection),
+        V: Fn(&RowSelection, &RowSelection),
+    {
+        let (selection1, selection2) = create_fn();
+        verify_round_trip(&selection1);
+        verify_round_trip(&selection2);
+        let combos = vec![
+            TestCombination {
+                description: "Selector-Selector",
+                selection1: force_selectors(selection1.clone()),
+                selection2: force_selectors(selection2.clone()),
+            },
+            TestCombination {
+                description: "Selector-Mask",
+                selection1: force_selectors(selection1.clone()),
+                selection2: force_mask(selection2.clone()),
+            },
+            TestCombination {
+                description: "Mask-Selector",
+                selection1: force_mask(selection1.clone()),
+                selection2: force_selectors(selection2.clone()),
+            },
+            TestCombination {
+                description: "Mask-Mask",
+                selection1: force_mask(selection1.clone()),
+                selection2: force_mask(selection2.clone()),
+            },
+        ];
+
+        for TestCombination {
+            description,
+            selection1,
+            selection2,
+        } in combos
+        {
+            println!("Verifying combination: {description}:\n\n{selection1:#?}\n\n{selection2:#?}",);
+            verify_fn(&selection1, &selection2);
+        }
+    }
+
+    struct TestCombination {
+        description: &'static str,
+        selection1: RowSelection,
+        selection2: RowSelection,
+    }
+
+    fn verify_round_trip(selection: &RowSelection) {
+        let selectors = force_selectors(selection.clone());
+        let mask = force_mask(selection.clone());
+
+        assert_eq!(force_mask(selectors.clone()), mask);
+        assert_eq!(force_selectors(mask.clone()), selectors);
+    }
+
+    fn force_selectors(selection: RowSelection) -> RowSelection {
+        let selectors: Vec<RowSelector> = selection.into();
+        let selector_selection = RowSelectorSelection::from(selectors);
+        let selection = RowSelection::from(selector_selection);
+        assert!(matches!(selection, RowSelection::Selectors(_)));
+        selection
+    }
+
+    fn force_mask(selection: RowSelection) -> RowSelection {
+        let mask: BooleanArray = selection.into();
+        let mask_selection = BitmaskSelection::from(mask);
+        let selection = RowSelection::from(mask_selection);
+        assert!(matches!(selection, RowSelection::Mask(_)));
+        selection
+    }
+
+    fn into_selectors(selection: &RowSelection) -> Vec<RowSelector> {
+        selection.clone().into()
     }
 }

--- a/parquet/src/arrow/arrow_reader/selection/and_then.rs
+++ b/parquet/src/arrow/arrow_reader/selection/and_then.rs
@@ -1,0 +1,346 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimized [`boolean_buffer_and_then`] kernel, based on code by
+//! Xiangpeng Hao in <https://github.com/apache/arrow-rs/pull/6624> and
+//! [LiquidCache's implementation](https://github.com/XiangpengHao/liquid-cache/blob/60323cdb5f17f88af633ad9acbc7d74f684f9912/src/parquet/src/utils.rs#L17)
+
+use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
+
+fn boolean_buffer_and_then_fallback(left: &BooleanBuffer, right: &BooleanBuffer) -> BooleanBuffer {
+    debug_assert_eq!(
+        left.count_set_bits(),
+        right.len(),
+        "the left selection must have the same number of set bits as the right selection"
+    );
+
+    // If left is all set bits, return right directly
+    if left.len() == right.len() {
+        debug_assert_eq!(left.count_set_bits(), left.len());
+        return right.clone();
+    }
+
+    // bits from left in a modifiable form
+    // TODO avoid this allocation when possible (reuse left)
+    let mut builder = BooleanBufferBuilder::new(left.len());
+    builder.append_buffer(&left);
+
+    let mut other_bits = right.iter();
+
+    for bit_idx in left.set_indices() {
+        let predicate = other_bits
+            .next()
+            .expect("Mismatch in set bits between self and other");
+        if !predicate {
+            builder.set_bit(bit_idx, false);
+        }
+    }
+    debug_assert!(other_bits.next().is_none(), "Mismatch in set bits"); //
+
+    builder.finish()
+}
+
+/// Combines this [`BooleanBuffer`] with another using logical AND on the selected bits.
+///
+/// Unlike intersection, the `other` [`BooleanBuffer`] must have exactly as many **set bits** as `self`,
+/// i.e., self.count_set_bits() == other.len().
+///
+/// This method will keep only the bits in `self` that are also set in `other`
+/// at the positions corresponding to `self`'s set bits.
+/// For example:
+/// left:   NNYYYNNYYNYN
+/// right:    YNY  NY N
+/// result: NNYNYNNNYNNN
+///
+/// Optimized version of `boolean_buffer_and_then` using BMI2 PDEP instructions.
+/// This function performs the same operation but uses bit manipulation instructions
+/// for better performance on supported x86_64 CPUs.
+pub(crate) fn boolean_buffer_and_then(
+    left: &BooleanBuffer,
+    right: &BooleanBuffer,
+) -> BooleanBuffer {
+    debug_assert_eq!(
+        left.count_set_bits(),
+        right.len(),
+        "the right selection must have the same number of set bits as the left selection"
+    );
+
+    if left.len() == right.len() {
+        debug_assert_eq!(left.count_set_bits(), left.len());
+        return right.clone();
+    }
+
+    // Fast path for BMI2 support on x86_64
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("bmi2") {
+            return unsafe { boolean_buffer_and_then_bmi2(left, right) };
+        }
+    }
+
+    boolean_buffer_and_then_fallback(left, right)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn load_u64_zero_padded(base_ptr: *const u8, total_bytes: usize, offset: usize) -> u64 {
+    let remaining = total_bytes.saturating_sub(offset);
+    if remaining >= 8 {
+        unsafe { core::ptr::read_unaligned(base_ptr.add(offset) as *const u64) }
+    } else if remaining > 0 {
+        let mut tmp = [0u8; 8];
+        unsafe {
+            core::ptr::copy_nonoverlapping(base_ptr.add(offset), tmp.as_mut_ptr(), remaining);
+        }
+        u64::from_le_bytes(tmp)
+    } else {
+        0
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+unsafe fn boolean_buffer_and_then_bmi2(
+    left: &BooleanBuffer,
+    right: &BooleanBuffer,
+) -> BooleanBuffer {
+    use core::arch::x86_64::_pdep_u64;
+
+    debug_assert_eq!(left.count_set_bits(), right.len());
+
+    let bit_len = left.len();
+    let byte_len = bit_len.div_ceil(8);
+    let left_ptr = left.values().as_ptr();
+    let right_bytes = right.len().div_ceil(8);
+    let right_ptr = right.values().as_ptr();
+
+    let mut out = MutableBuffer::from_len_zeroed(byte_len);
+    let out_ptr = out.as_mut_ptr();
+
+    let full_words = bit_len / 64;
+    let mut right_bit_idx = 0; // how many bits we have processed from right
+
+    for word_idx in 0..full_words {
+        let left_word =
+            unsafe { core::ptr::read_unaligned(left_ptr.add(word_idx * 8) as *const u64) };
+
+        if left_word == 0 {
+            continue;
+        }
+
+        let need = left_word.count_ones();
+
+        // Absolute byte & bit offset of the first needed bit inside `right`.
+        let rb_byte = right_bit_idx / 8;
+        let rb_bit = (right_bit_idx & 7) as u32;
+
+        let need_high = rb_bit != 0;
+        let safe16 = right_bytes.saturating_sub(16);
+        let mut r_bits;
+        if rb_byte <= safe16 {
+            let low = unsafe { core::ptr::read_unaligned(right_ptr.add(rb_byte) as *const u64) };
+            if need_high {
+                let high =
+                    unsafe { core::ptr::read_unaligned(right_ptr.add(rb_byte + 8) as *const u64) };
+                r_bits = (low >> rb_bit) | (high << (64 - rb_bit));
+            } else {
+                r_bits = low >> rb_bit;
+            }
+        } else {
+            let low = load_u64_zero_padded(right_ptr, right_bytes, rb_byte);
+            r_bits = low >> rb_bit;
+            if need_high {
+                let high = load_u64_zero_padded(right_ptr, right_bytes, rb_byte + 8);
+                r_bits |= high << (64 - rb_bit);
+            }
+        }
+
+        // Mask off the high garbage.
+        r_bits &= 1u64.unbounded_shl(need).wrapping_sub(1);
+
+        // The PDEP instruction: https://www.felixcloutier.com/x86/pdep
+        // It takes left_word as the mask, and deposit the packed bits into the sparse positions of `left_word`.
+        let result = _pdep_u64(r_bits, left_word);
+
+        unsafe {
+            core::ptr::write_unaligned(out_ptr.add(word_idx * 8) as *mut u64, result);
+        }
+
+        right_bit_idx += need as usize;
+    }
+
+    // Handle remaining bits that are less than 64 bits
+    let tail_bits = bit_len & 63;
+    if tail_bits != 0 {
+        // Build the mask from the remaining bytes in one bounded copy
+        let tail_bytes = tail_bits.div_ceil(8);
+        let base = unsafe { left_ptr.add(full_words * 8) };
+        let mut mask: u64;
+        if tail_bytes == 8 {
+            mask = unsafe { core::ptr::read_unaligned(base as *const u64) };
+        } else {
+            let mut buf = [0u8; 8];
+            unsafe {
+                core::ptr::copy_nonoverlapping(base, buf.as_mut_ptr(), tail_bytes);
+            }
+            mask = u64::from_le_bytes(buf);
+        }
+        // Clear any high bits beyond the actual tail length
+        mask &= (1u64 << tail_bits) - 1;
+
+        if mask != 0 {
+            let need = mask.count_ones();
+
+            let rb_byte = right_bit_idx / 8;
+            let rb_bit = (right_bit_idx & 7) as u32;
+
+            let need_high = rb_bit != 0;
+            let safe16 = right_bytes.saturating_sub(16);
+            let mut r_bits;
+            if rb_byte <= safe16 {
+                let low =
+                    unsafe { core::ptr::read_unaligned(right_ptr.add(rb_byte) as *const u64) };
+                if need_high {
+                    let high = unsafe {
+                        core::ptr::read_unaligned(right_ptr.add(rb_byte + 8) as *const u64)
+                    };
+                    r_bits = (low >> rb_bit) | (high << (64 - rb_bit));
+                } else {
+                    r_bits = low >> rb_bit;
+                }
+            } else {
+                let low = load_u64_zero_padded(right_ptr, right_bytes, rb_byte);
+                r_bits = low >> rb_bit;
+                if need_high {
+                    let high = load_u64_zero_padded(right_ptr, right_bytes, rb_byte + 8);
+                    r_bits |= high << (64 - rb_bit);
+                }
+            }
+
+            r_bits &= 1u64.unbounded_shl(need).wrapping_sub(1);
+
+            let result = _pdep_u64(r_bits, mask);
+
+            let tail_bytes = tail_bits.div_ceil(8);
+            let result_bytes = result.to_le_bytes();
+            let dst_off = full_words * 8;
+            unsafe {
+                let dst = core::slice::from_raw_parts_mut(out_ptr, byte_len);
+                dst[dst_off..dst_off + tail_bytes].copy_from_slice(&result_bytes[..tail_bytes]);
+            }
+        }
+    }
+
+    BooleanBuffer::new(out.into(), 0, bit_len)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_boolean_buffer_and_then_bmi2_large() {
+        use super::boolean_buffer_and_then_bmi2;
+
+        // Test with larger buffer (more than 64 bits)
+        let size = 128;
+        let mut left_builder = BooleanBufferBuilder::new(size);
+        let mut right_bits = Vec::new();
+
+        // Create a pattern where every 3rd bit is set in left
+        for i in 0..size {
+            let is_set = i.is_multiple_of(3);
+            left_builder.append(is_set);
+            if is_set {
+                // For right buffer, alternate between true/false
+                right_bits.push(right_bits.len().is_multiple_of(2));
+            }
+        }
+        let left = left_builder.finish();
+
+        let mut right_builder = BooleanBufferBuilder::new(right_bits.len());
+        for bit in right_bits {
+            right_builder.append(bit);
+        }
+        let right = right_builder.finish();
+
+        let result_bmi2 = unsafe { boolean_buffer_and_then_bmi2(&left, &right) };
+        let result_orig = boolean_buffer_and_then_fallback(&left, &right);
+
+        assert_eq!(result_bmi2.len(), result_orig.len());
+        assert_eq!(result_bmi2.len(), size);
+
+        // Verify they produce the same result
+        for i in 0..size {
+            assert_eq!(
+                result_bmi2.value(i),
+                result_orig.value(i),
+                "Mismatch at position {i}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_boolean_buffer_and_then_bmi2_edge_cases() {
+        use super::boolean_buffer_and_then_bmi2;
+
+        // Test case: all bits set in left, alternating pattern in right
+        let mut left_builder = BooleanBufferBuilder::new(16);
+        for _ in 0..16 {
+            left_builder.append(true);
+        }
+        let left = left_builder.finish();
+
+        let mut right_builder = BooleanBufferBuilder::new(16);
+        for i in 0..16 {
+            right_builder.append(i % 2 == 0);
+        }
+        let right = right_builder.finish();
+
+        let result_bmi2 = unsafe { boolean_buffer_and_then_bmi2(&left, &right) };
+        let result_orig = boolean_buffer_and_then_fallback(&left, &right);
+
+        assert_eq!(result_bmi2.len(), result_orig.len());
+        for i in 0..16 {
+            assert_eq!(
+                result_bmi2.value(i),
+                result_orig.value(i),
+                "Mismatch at position {i}"
+            );
+            // Should be true for even indices, false for odd
+            assert_eq!(result_bmi2.value(i), i.is_multiple_of(2));
+        }
+
+        // Test case: no bits set in left
+        let mut left_empty_builder = BooleanBufferBuilder::new(8);
+        for _ in 0..8 {
+            left_empty_builder.append(false);
+        }
+        let left_empty = left_empty_builder.finish();
+        let right_empty = BooleanBufferBuilder::new(0).finish();
+
+        let result_bmi2_empty = unsafe { boolean_buffer_and_then_bmi2(&left_empty, &right_empty) };
+        let result_orig_empty = boolean_buffer_and_then_fallback(&left_empty, &right_empty);
+
+        assert_eq!(result_bmi2_empty.len(), result_orig_empty.len());
+        assert_eq!(result_bmi2_empty.len(), 8);
+        for i in 0..8 {
+            assert!(!result_bmi2_empty.value(i));
+            assert!(!result_orig_empty.value(i));
+        }
+    }
+}

--- a/parquet/src/arrow/arrow_reader/selection/and_then.rs
+++ b/parquet/src/arrow/arrow_reader/selection/and_then.rs
@@ -119,6 +119,7 @@ unsafe fn boolean_buffer_and_then_bmi2(
     right: &BooleanBuffer,
 ) -> BooleanBuffer {
     use core::arch::x86_64::_pdep_u64;
+    use arrow_buffer::MutableBuffer;
 
     debug_assert_eq!(left.count_set_bits(), right.len());
 

--- a/parquet/src/arrow/arrow_reader/selection/and_then.rs
+++ b/parquet/src/arrow/arrow_reader/selection/and_then.rs
@@ -118,8 +118,8 @@ unsafe fn boolean_buffer_and_then_bmi2(
     left: &BooleanBuffer,
     right: &BooleanBuffer,
 ) -> BooleanBuffer {
-    use core::arch::x86_64::_pdep_u64;
     use arrow_buffer::MutableBuffer;
+    use core::arch::x86_64::_pdep_u64;
 
     debug_assert_eq!(left.count_set_bits(), right.len());
 

--- a/parquet/src/arrow/arrow_reader/selection/conversion.rs
+++ b/parquet/src/arrow/arrow_reader/selection/conversion.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Conversion code for [`RowSelection`] representations
+
+use crate::arrow::arrow_reader::RowSelector;
+use arrow_array::BooleanArray;
+use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
+use arrow_select::filter::SlicesIterator;
+use std::cmp::Ordering;
+use std::ops::Range;
+
+pub(crate) fn row_selectors_to_boolean_buffer(selectors: &[RowSelector]) -> BooleanBuffer {
+    let total_rows = selectors
+        .iter()
+        .filter(|s| !s.skip)
+        .map(|s| s.row_count)
+        .sum();
+    let mut builder = BooleanBufferBuilder::new(total_rows);
+
+    for selector in selectors.iter() {
+        if selector.skip {
+            builder.append_n(selector.row_count, false);
+        } else {
+            builder.append_n(selector.row_count, true);
+        }
+    }
+    builder.finish()
+}
+
+/// Converts an iterator of [`BooleanArray`] / [`BooleanBuffer`] into a
+/// Vec of [`RowSelection`].
+///
+/// Call [`prep_null_mask_filter`](arrow_select::filter::prep_null_mask_filter)
+/// beforehand to ensure there are no nulls.
+///
+/// # Panic
+///
+/// Panics if any of the [`BooleanArray`] contain nulls.
+pub(crate) fn boolean_array_to_row_selectors(filter: &BooleanArray) -> Vec<RowSelector> {
+    let total_rows = filter.len();
+
+    let iter = SlicesIterator::new(filter).map(move |(start, end)| start..end);
+
+    consecutive_ranges_to_row_selectors(iter, total_rows)
+}
+
+/// Creates a [`RowSelection`] from an iterator of consecutive ranges to keep
+pub(crate) fn consecutive_ranges_to_row_selectors<I: Iterator<Item = Range<usize>>>(
+    ranges: I,
+    total_rows: usize,
+) -> Vec<RowSelector> {
+    let mut selectors: Vec<RowSelector> = Vec::with_capacity(ranges.size_hint().0);
+    let mut last_end = 0;
+    for range in ranges {
+        let len = range.end - range.start;
+        if len == 0 {
+            continue;
+        }
+
+        match range.start.cmp(&last_end) {
+            Ordering::Equal => match selectors.last_mut() {
+                Some(last) => last.row_count = last.row_count.checked_add(len).unwrap(),
+                None => selectors.push(RowSelector::select(len)),
+            },
+            Ordering::Greater => {
+                selectors.push(RowSelector::skip(range.start - last_end));
+                selectors.push(RowSelector::select(len))
+            }
+            Ordering::Less => panic!("out of order"),
+        }
+        last_end = range.end;
+    }
+
+    if last_end != total_rows {
+        selectors.push(RowSelector::skip(total_rows - last_end))
+    }
+
+    selectors
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+
+    fn generate_random_filter(total_rows: usize, selection_ratio: f64) -> BooleanArray {
+        let mut rng = rand::rng();
+        let bools: Vec<bool> = (0..total_rows)
+            .map(|_| rng.random_bool(selection_ratio))
+            .collect();
+        BooleanArray::from(bools)
+    }
+
+    #[test]
+    fn test_boolean_row_selection_round_trip() {
+        let total_rows = 1_000;
+        for &selection_ratio in &[0.0, 0.1, 0.5, 0.9, 1.0] {
+            let filter = generate_random_filter(total_rows, selection_ratio);
+            let row_selection = boolean_array_to_row_selectors(&filter);
+            let filter_again = row_selectors_to_boolean_buffer(&row_selection);
+            assert_eq!(filter, filter_again.into());
+        }
+    }
+}

--- a/parquet/src/arrow/arrow_reader/selection/mask.rs
+++ b/parquet/src/arrow/arrow_reader/selection/mask.rs
@@ -1,0 +1,281 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::arrow::arrow_reader::RowSelector;
+use crate::arrow::arrow_reader::selection::and_then::boolean_buffer_and_then;
+use crate::arrow::arrow_reader::selection::conversion::{
+    boolean_array_to_row_selectors, row_selectors_to_boolean_buffer,
+};
+use arrow_array::{Array, BooleanArray};
+use arrow_buffer::bit_iterator::BitIndexIterator;
+use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
+use std::fmt::Debug;
+use std::ops::Range;
+
+/// [`RowSelection`] based on a [`BooleanArray`]
+///
+/// This represents the result of a filter evaluation as a bitmap. It is
+/// more efficient for sparse filter results with many small skips or selections.
+///
+/// It is similar to the "Bitmap Index" described in [Predicate Caching:
+/// Query-Driven Secondary Indexing for Cloud Data
+/// Warehouses](https://dl.acm.org/doi/10.1145/3626246.3653395)
+///
+/// [`RowSelection`]: super::RowSelection
+///
+/// Based on code from Xiangpeng Hao in <https://github.com/apache/arrow-rs/pull/6624> and
+/// [LiquidCache's implementation](https://github.com/XiangpengHao/liquid-cache/blob/60323cdb5f17f88af633ad9acbc7d74f684f9912/src/parquet/src/utils.rs#L17)
+#[derive(Clone, Eq, PartialEq)]
+pub(super) struct BitmaskSelection {
+    pub(super) mask: BooleanBuffer,
+}
+
+/// Prints out the BitMaskSelection as boolean byts
+impl Debug for BitmaskSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BitmaskSelection {{ len={}, mask: [", self.mask.len())?;
+        // print each byte as binary digits
+        for bit in self.mask.iter() {
+            write!(f, "{}", if bit { "1" } else { "0" })?;
+        }
+        write!(f, "] }}")?;
+        Ok(())
+    }
+}
+
+impl BitmaskSelection {
+    /// Create a new [`BooleanRowSelection] from a list of [`BooleanArray`].
+    ///
+    /// Note this ignores the null bits in the input arrays
+    /// TODO: should it call prepnull_mask directly?
+    pub fn from_filters(filters: &[BooleanArray]) -> Self {
+        let arrays: Vec<&dyn Array> = filters.iter().map(|x| x as &dyn Array).collect();
+        let result = arrow_select::concat::concat(&arrays).unwrap().into_data();
+        let (boolean_array, _null) = BooleanArray::from(result).into_parts();
+        BitmaskSelection {
+            mask: boolean_array,
+        }
+    }
+
+    pub fn from_row_selectors(selection: &[RowSelector]) -> Self {
+        BitmaskSelection {
+            mask: row_selectors_to_boolean_buffer(selection),
+        }
+    }
+
+    /// Convert this [`BitmaskSelection`] into a [`BooleanArray`]
+    pub fn into_filter(self) -> BooleanArray {
+        BooleanArray::new(self.mask, None)
+    }
+
+    /// Convert this [`BitmaskSelection`] into a vector of [`RowSelector`]
+    pub fn into_row_selectors(self) -> Vec<RowSelector> {
+        boolean_array_to_row_selectors(&self.into_filter())
+    }
+
+    /// Create a new [`BitmaskSelection`] with all rows unselected
+    pub fn new_unselected(row_count: usize) -> Self {
+        let buffer = BooleanBuffer::new_unset(row_count);
+        Self { mask: buffer }
+    }
+
+    /// Create a new [`BitmaskSelection`] with all rows selected
+    pub fn new_selected(row_count: usize) -> Self {
+        let buffer = BooleanBuffer::new_set(row_count);
+        Self { mask: buffer }
+    }
+
+    /// Returns a new [`BitmaskSelection`] that selects the inverse of this [`BitmaskSelection`].
+    pub fn inverted(&self) -> Self {
+        let buffer = !&self.mask;
+        Self { mask: buffer }
+    }
+
+    /// Returns the number of rows selected by this [`BitmaskSelection`].
+    pub fn row_count(&self) -> usize {
+        self.mask.count_set_bits()
+    }
+
+    /// Create a new [`BitmaskSelection`] from a list of consecutive ranges.
+    pub fn from_consecutive_ranges(
+        ranges: impl Iterator<Item = Range<usize>>,
+        total_rows: usize,
+    ) -> Self {
+        let mut buffer = BooleanBufferBuilder::new(total_rows);
+        let mut last_end = 0;
+
+        for range in ranges {
+            let len = range.end - range.start;
+            if len == 0 {
+                continue;
+            }
+
+            if range.start > last_end {
+                buffer.append_n(range.start - last_end, false);
+            }
+            buffer.append_n(len, true);
+            last_end = range.end;
+        }
+
+        if last_end != total_rows {
+            buffer.append_n(total_rows - last_end, false);
+        }
+
+        BitmaskSelection {
+            mask: buffer.finish(),
+        }
+    }
+
+    /// Compute the union of two [`BitmaskSelection`]
+    /// For example:
+    /// self:      NNYYYYNNYYNYN
+    /// other:     NYNNNNNNN
+    ///
+    /// returned:  NYYYYYNNYYNYN
+    #[must_use]
+    pub fn union(&self, other: &Self) -> Self {
+        // use arrow::compute::kernels::boolean::or;
+
+        let union_selectors = &self.mask | &other.mask;
+
+        BitmaskSelection {
+            mask: union_selectors,
+        }
+    }
+
+    /// Compute the intersection of two [`BitmaskSelection`]
+    /// For example:
+    /// self:      NNYYYYNNYYNYN
+    /// other:     NYNNNNNNY
+    ///
+    /// returned:  NNNNNNNNYYNYN
+    #[must_use]
+    pub fn intersection(&self, other: &Self) -> Self {
+        let intersection_selectors = &self.mask & &other.mask;
+
+        BitmaskSelection {
+            mask: intersection_selectors,
+        }
+    }
+
+    /// Combines this [`BitmaskSelection`] with another using logical AND on the selected bits.
+    ///
+    /// Unlike intersection, the `other` [`BitmaskSelection`] must have exactly as many set bits as `self`.
+    /// This method will keep only the bits in `self` that are also set in `other`
+    /// at the positions corresponding to `self`'s set bits.
+    pub fn and_then(&self, other: &Self) -> Self {
+        // Ensure that 'other' has exactly as many set bits as 'self'
+        debug_assert_eq!(
+            self.row_count(),
+            other.mask.len(),
+            "The 'other' selection must have exactly as many set bits as 'self'."
+        );
+
+        BitmaskSelection {
+            mask: boolean_buffer_and_then(&self.mask, &other.mask),
+        }
+    }
+
+    /// Returns an iterator over the indices of the set bits in this [`BitmaskSelection`]
+    pub fn true_iter(&self) -> BitIndexIterator<'_> {
+        self.mask.set_indices()
+    }
+
+    /// Returns `true` if this [`BitmaskSelection`] selects any rows
+    pub fn selects_any(&self) -> bool {
+        self.true_iter().next().is_some()
+    }
+
+    /// Returns a new [`BitmaskSelection`] that selects the rows in this [`BitmaskSelection`] from `offset` to `offset + len`
+    pub fn slice(&self, offset: usize, len: usize) -> BooleanArray {
+        BooleanArray::new(self.mask.slice(offset, len), None)
+    }
+
+    /// Splits off the first `row_count` rows
+    pub fn split_off(&mut self, row_count: usize) -> Self {
+        if row_count >= self.mask.len() {
+            let split_mask = self.mask.clone();
+            self.mask = BooleanBuffer::new_unset(0);
+            BitmaskSelection { mask: split_mask }
+        } else {
+            let split_mask = self.mask.slice(0, row_count);
+            self.mask = self.mask.slice(row_count, self.mask.len() - row_count);
+            BitmaskSelection { mask: split_mask }
+        }
+    }
+
+    /// Applies an offset to this [`RowSelection`], skipping the first `offset` selected rows
+    ///
+    /// Sets the fist `offset` selected rows to false
+    pub fn offset(self, offset: usize) -> Self {
+        let mut total_num_set = 0;
+
+        // iterator:
+        // * first value is the start of the range (inclusive)
+        // * second value is the end of the range (exclusive)
+        for (start, end) in self.mask.set_slices() {
+            let num_set = end - start;
+            // the offset is within this range,
+            if offset <= total_num_set + num_set {
+                let num_in_range = offset - total_num_set;
+                let slice_offset = start + num_in_range;
+                // Set all bits to false before slice_offset
+                // TODO try and avoid this allocation and update in place
+                let remaining_len = self.mask.len() - slice_offset;
+                let new_mask = {
+                    let mut builder = BooleanBufferBuilder::new(self.mask.len());
+                    builder.append_n(slice_offset, false);
+                    builder.append_buffer(&self.mask.slice(slice_offset, remaining_len));
+                    builder.finish()
+                };
+                return BitmaskSelection { mask: new_mask };
+            } else {
+                total_num_set += num_set;
+            }
+        }
+
+        // if we reach here, the offset is beyond the number of selected rows,
+        // so return an empty selection
+        BitmaskSelection {
+            mask: BooleanBuffer::new_unset(self.mask.len()),
+        }
+    }
+}
+
+impl From<Vec<RowSelector>> for BitmaskSelection {
+    fn from(selectors: Vec<RowSelector>) -> Self {
+        Self::from_row_selectors(&selectors)
+    }
+}
+
+impl From<BitmaskSelection> for Vec<RowSelector> {
+    fn from(selection: BitmaskSelection) -> Self {
+        selection.into_row_selectors()
+    }
+}
+
+impl From<BooleanArray> for BitmaskSelection {
+    fn from(filter: BooleanArray) -> Self {
+        Self::from_filters(&[filter])
+    }
+}
+
+impl From<BitmaskSelection> for BooleanArray {
+    fn from(selection: BitmaskSelection) -> Self {
+        selection.into_filter()
+    }
+}

--- a/parquet/src/arrow/arrow_reader/selection/mask.rs
+++ b/parquet/src/arrow/arrow_reader/selection/mask.rs
@@ -254,6 +254,21 @@ impl BitmaskSelection {
             mask: BooleanBuffer::new_unset(self.mask.len()),
         }
     }
+
+    /// Trims the selection so it contains no trailing unselected rows
+    pub fn trim(self) -> Self {
+        let mut new_len = self.mask.len();
+        // SAFETY: new_len is > 0 and less than len
+        unsafe {
+            while new_len > 0 && !self.mask.value_unchecked(new_len - 1) {
+                new_len -= 1;
+            }
+        }
+
+        BitmaskSelection {
+            mask: self.mask.slice(0, new_len),
+        }
+    }
 }
 
 impl From<Vec<RowSelector>> for BitmaskSelection {

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -712,6 +712,6 @@ mod tests {
     #[test]
     // Verify that the size of RowGroupDecoderState does not grow too large
     fn test_structure_size() {
-        assert_eq!(std::mem::size_of::<RowGroupDecoderState>(), 200);
+        assert_eq!(std::mem::size_of::<RowGroupDecoderState>(), 224);
     }
 }

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -706,10 +706,18 @@ fn override_selector_strategy_if_needed(
 
     // override the plan builder strategy with the resolved one
     let new_policy = match resolved_strategy {
-        RowSelectionStrategy::Mask => RowSelectionPolicy::Mask,
+        RowSelectionStrategy::Mask => {
+            RowSelectionPolicy::Mask
+        },
         RowSelectionStrategy::Selectors => RowSelectionPolicy::Selectors,
     };
 
+    if plan_builder.row_selection_policy() != &new_policy {
+        println!(
+            "WARNING: Overriding row selection strategy to {:?} based on projection and offset index",
+            resolved_strategy
+        );
+    }
     plan_builder.with_row_selection_policy(new_policy)
 }
 

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -351,7 +351,7 @@ impl RowGroupReaderBuilder {
                 let RowGroupInfo {
                     row_group_idx,
                     row_count,
-                    plan_builder,
+                    mut plan_builder,
                 } = row_group_info;
 
                 // If nothing is selected, we are done with this row group
@@ -366,6 +366,14 @@ impl RowGroupReaderBuilder {
 
                 // Make a request for the data needed to evaluate the current predicate
                 let predicate = filter_info.current();
+
+                // TODO avoid overrides
+                plan_builder = plan_builder.with_row_selection_policy(self.row_selection_policy);
+                plan_builder = override_selector_strategy_if_needed(
+                    plan_builder,
+                    &self.projection,
+                    self.row_group_offset_index(row_group_idx),
+                );
 
                 // need to fetch pages the column needs for decoding, figure
                 // that out based on the current selection and projection
@@ -521,6 +529,14 @@ impl RowGroupReaderBuilder {
                     *limit -= rows_after;
                 }
 
+                // Force to selection strategy
+                plan_builder = plan_builder.with_row_selection_policy(self.row_selection_policy);
+                plan_builder = override_selector_strategy_if_needed(
+                    plan_builder,
+                    &self.projection,
+                    self.row_group_offset_index(row_group_idx),
+                );
+
                 let data_request = DataRequestBuilder::new(
                     row_group_idx,
                     row_count,
@@ -533,14 +549,6 @@ impl RowGroupReaderBuilder {
                 // Final projection fetch shouldn't expand selection for cache
                 // so don't call with_cache_projection here
                 .build();
-
-                plan_builder = plan_builder.with_row_selection_policy(self.row_selection_policy);
-
-                plan_builder = override_selector_strategy_if_needed(
-                    plan_builder,
-                    &self.projection,
-                    self.row_group_offset_index(row_group_idx),
-                );
 
                 let row_group_info = RowGroupInfo {
                     row_group_idx,


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8844

## TODOs
- [ ] Make a PR to extract the RowSelection backed code into its own module
- [ ] Rework main tests in selection.rs to be parameterized / use different backing APIs
- [ ] Performance test with DataFusion https://github.com/apache/datafusion/pull/19301


# Rationale for this change

Make the parquet predicate evaluation faster by not converting back/forth between BooleanArray and RowSelection as much

# What changes are included in this PR?
1. Change RowSelection to have two possible backings
2. Add a BooleanArray backed implementation, based on @XiangpengHao 's code from https://github.com/apache/arrow-rs/pull/6624

# Are these changes tested?
TBD


# Are there any user-facing changes?


## Internal notes for myself
- [x] Get it compiling, not actually routing through BooleanSelection
- [x] Start routing through BooleanSelection
- [ ] Test / verify performance in benchmarks
- [ ] Test / verify performance in DataFusion

