### PR TITLE
[8910]Fixed doc test with feature prettyprint

### DIFF
--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -290,6 +290,7 @@ impl<'a> FormatOptions<'a> {
 /// this example requires the `prettyprint` feature.
 ///
 /// ```rust
+/// # #[cfg(feature = "prettyprint")]{
 /// use std::fmt::Write;
 /// use arrow_array::{cast::AsArray, Array, Int32Array};
 /// use arrow_cast::display::{ArrayFormatter, ArrayFormatterFactory, DisplayIndex, FormatOptions, FormatResult};
@@ -351,6 +352,7 @@ impl<'a> FormatOptions<'a> {
 ///        &my_batches,
 ///        &FormatOptions::new().with_formatter_factory(Some(&MyFormatters {}))
 /// );
+/// # }
 /// ```
 pub trait ArrayFormatterFactory: Debug + Send + Sync {
     /// Creates a new [`ArrayFormatter`] for the given [`Array`] and an optional [`Field`]. If the


### PR DESCRIPTION
# Which issue does this PR close?

We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.

- Closes #8910 .

# Rationale for this change

To fix the doc-test with feature-flag `prettyprint`

# What changes are included in this PR?

Enabled feature-flag `prettyprint` for specific doc-test that need this feature.

# Are these changes tested?
Yes

# Are there any user-facing changes?
No
