### PR TITLE
[minor] Name Magic Number "8" in `FixedSizeBinaryArray::new_null`

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -119,10 +119,11 @@ impl FixedSizeBinaryArray {
     /// * `size < 0`
     /// * `size * len` would overflow `usize`
     pub fn new_null(size: i32, len: usize) -> Self {
+        const BITS_IN_A_BYTE: usize = 8;
         let capacity_in_bytes = size.to_usize().unwrap().checked_mul(len).unwrap();
         Self {
             data_type: DataType::FixedSizeBinary(size),
-            value_data: MutableBuffer::new_null(capacity_in_bytes * 8).into(),
+            value_data: MutableBuffer::new_null(capacity_in_bytes * BITS_IN_A_BYTE).into(),
             nulls: Some(NullBuffer::new_null(len)),
             value_length: size,
             len,


### PR DESCRIPTION
# Which issue does this PR close?

- Follow-up on #8901 

# Rationale for this change

It's non-obvious why the number "8" appears here.

# What changes are included in this PR?

Name the number such that it's more obvious that this is a conversion from bytes to bits.

@alamb I can also include the [suggested comment](https://github.com/apache/arrow-rs/pull/8901#discussion_r2550603957) if you prefer it. I thought the constant may have a lesser risk of becoming outdated without being noticed when changes to `MutableBuffer::new_null` happen.

# Are these changes tested?

- No behavior changes

# Are there any user-facing changes?

- No
