### PR TITLE
Update `test_variant_get_error_when_cast_failure...`  tests to uses a valid `VariantArray`

### DIFF
--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -3751,18 +3751,18 @@ mod test {
         }
     }
 
-    perfectly_shredded_variant_array_fn!(perfectly_shredded_invalid_time_variant_array, || {
+    fn invalid_time_variant_array() -> ArrayRef {
+        let mut builder = VariantArrayBuilder::new(3);
         // 86401000000 is invalid for Time64Microsecond (max is 86400000000)
-        Time64MicrosecondArray::from(vec![
-            Some(86401000000),
-            Some(86401000000),
-            Some(86401000000),
-        ])
-    });
+        builder.append_variant(Variant::Int64(86401000000));
+        builder.append_variant(Variant::Int64(86401000000));
+        builder.append_variant(Variant::Int64(86401000000));
+        Arc::new(builder.build().into_inner())
+    }
 
     #[test]
     fn test_variant_get_error_when_cast_failure_and_safe_false() {
-        let variant_array = perfectly_shredded_invalid_time_variant_array();
+        let variant_array = invalid_time_variant_array();
 
         let field = Field::new("result", DataType::Time64(TimeUnit::Microsecond), true);
         let cast_options = CastOptions {
@@ -3775,14 +3775,15 @@ mod test {
         let err = variant_get(&variant_array, options).unwrap_err();
         assert!(
             err.to_string().contains(
-                "Cast error: Cast failed at index 0 (array type: Time64(µs)): Invalid microsecond from midnight: 86401000000"
-            )
+                "Cast error: Failed to extract primitive of type Time64(µs) from variant Int64(86401000000) at path VariantPath([])"
+            ),
+            "actual: {err}",
         );
     }
 
     #[test]
     fn test_variant_get_return_null_when_cast_failure_and_safe_true() {
-        let variant_array = perfectly_shredded_invalid_time_variant_array();
+        let variant_array = invalid_time_variant_array();
 
         let field = Field::new("result", DataType::Time64(TimeUnit::Microsecond), true);
         let cast_options = CastOptions {


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/pull/8887
# Rationale for this change

In this comment here: https://github.com/apache/arrow-rs/pull/8887#issuecomment-3558818347

One of the tests intended to cover the behavior of CastOptions actually contains an invalid Shredded variant (the values could not have been shredded successfully because the integer values are out of range)

My understanding is that the test is intended to illustrate that casting fails when a non-shredded variant into a shredded variant. Thus, it would not have been possible to create the incorrect shredded variant in the first place (there would have been an error during shredding)

# What changes are included in this PR?

1. Update the test to provide a valid VariantArray, and update the error message

# Are these changes tested?
Only tests
# Are there any user-facing changes?

None -- this is a test only change