### PR TITLE
Allow creating zero-sized FixedSizeBinary arrays

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -1029,13 +1029,11 @@ mod tests {
         let zero_sized_with_nulls = FixedSizeBinaryArray::new(0, Buffer::default(), Some(nulls));
         assert_eq!(zero_sized_with_nulls.len(), 3);
 
-        let zero_sized_with_non_empty_buffer = FixedSizeBinaryArray::try_new(0, buffer, None);
-        assert!(
-            matches!(
-                zero_sized_with_non_empty_buffer,
-                Err(ArrowError::InvalidArgumentError(_))
-            ),
-            "Should not be able to create a zero sized array with non-empty buffer"
+        let zero_sized_with_non_empty_buffer_err =
+            FixedSizeBinaryArray::try_new(0, buffer, None).unwrap_err();
+        assert_eq!(
+            zero_sized_with_non_empty_buffer_err.to_string(),
+            "Invalid argument error: Buffer cannot have non-zero length if the item size is zero"
         );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8926 .

Note that creating sch arrays was already possible with the builder API (see `test_fixed_size_binary_builder_with_zero_value_length`) but not directly with the Array API.

# Rationale for this change

Avoid panicking (divide by zero) in `FixedSizeBinaryArray::try_new(0, ...)`

# What changes are included in this PR?

Special case for `size == 0` in `FixedSizeBinaryArray::try_new`.

# Are these changes tested?

Yes, additional constructor tests.

# Are there any user-facing changes?

Yes, no panics and the ability to directly create FSB arrays with zero-length items.
