### PR TITLE
arrow-buffer: add i256::trailing_zeros

### DIFF
--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -590,6 +590,14 @@ impl i256 {
         }
     }
 
+    /// Returns the number of trailing zeros in the binary representation of this [`i256`].
+    pub const fn trailing_zeros(&self) -> u32 {
+        match self.low {
+            0 => u128::BITS + self.high.trailing_zeros(),
+            _ => self.low.trailing_zeros(),
+        }
+    }
+
     fn redundant_leading_sign_bits_i256(n: i256) -> u8 {
         let mask = n >> 255; // all ones or all zeros
         ((n ^ mask).leading_zeros() - 1) as u8 // we only need one sign bit
@@ -1326,5 +1334,21 @@ mod tests {
         let big_neg = i256::from_f64(-(max_f * 2.0)).unwrap_or(i256::MIN);
         let out = big_neg.to_f64().unwrap();
         assert!(out.is_finite() && out.is_sign_negative());
+    }
+
+    #[test]
+    fn test_trailing_zeros() {
+        // Without high part
+        assert_eq!(i256::from(0).trailing_zeros(), 256);
+        assert_eq!(i256::from(2).trailing_zeros(), 1);
+        assert_eq!(i256::from(16).trailing_zeros(), 4);
+        assert_eq!(i256::from(17).trailing_zeros(), 0);
+        // With high part
+        assert_eq!(i256::from_parts(0, i128::MAX).trailing_zeros(), 128);
+        assert_eq!(i256::from_parts(0, 16).trailing_zeros(), 128 + 4);
+        assert_eq!(i256::from_parts(2, i128::MAX).trailing_zeros(), 1);
+
+        assert_eq!(i256::MAX.trailing_zeros(), 0);
+        assert_eq!(i256::from(-1).trailing_zeros(), 0);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8968.

# Rationale for this change

- Add `i256::trailing_zeros` to align with other integer types - e.g. [`i128::trailing_zeros`](https://doc.rust-lang.org/std/primitive.i128.html#method.trailing_zeros)
- Add function documentation
- Add unit tests

# What changes are included in this PR?

Function, docs, unit tests

# Are these changes tested?

New unit tests

# Are there any user-facing changes?

New function in `i256` struct