### PR TITLE
feat: support casting  `Time32` to `Int64`

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -312,7 +312,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         // temporal casts
         (Int32, Date32 | Date64 | Time32(_)) => true,
         (Date32, Int32 | Int64) => true,
-        (Time32(_), Int32) => true,
+        (Time32(_), Int32 | Int64) => true,
         (Int64, Date64 | Date32 | Time64(_)) => true,
         (Date64, Int64 | Int32) => true,
         (Time64(_), Int64) => true,
@@ -12097,6 +12097,8 @@ mod tests {
         let to_type = DataType::Int64;
         let cast_options = CastOptions::default();
 
+        assert!(can_cast_types(array.data_type(), &to_type));
+
         let result = cast_with_options(&array, &to_type, &cast_options);
         assert!(
             result.is_ok(),
@@ -12118,6 +12120,8 @@ mod tests {
         let array = Arc::new(array) as Arc<dyn Array>;
         let to_type = DataType::Int64;
         let cast_options = CastOptions::default();
+
+        assert!(can_cast_types(array.data_type(), &to_type));
 
         let result = cast_with_options(&array, &to_type, &cast_options);
         assert!(
@@ -12148,6 +12152,8 @@ mod tests {
 
         // 2. Cast Time32(Second) to Int64
         let int64_type = DataType::Int64;
+        assert!(can_cast_types(time32_array.data_type(), &int64_type));
+
         let result = cast_with_options(&time32_array, &int64_type, &cast_options);
 
         assert!(


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/19036

While this issue was raised on the datafusion side, I think this is where the underlying issue exists, i.e., that arrow cannot do the cast directly.

# Rationale for this change

It should be possible to directly go from a time32 to an int64, but currently it is not.

# What changes are included in this PR?

1. Add match arms for needed cases.
2. Add test that mimics cast issue described in datafusion issue.

# Are these changes tested?

Yes, adds test to mimic the case described in the datafusion issue.

# Are there any user-facing changes?

No