### PR TITLE
arrow-data: avoid allocating in get_last_run_end

### DIFF
--- a/arrow-data/src/transform/run.rs
+++ b/arrow-data/src/transform/run.rs
@@ -25,9 +25,7 @@ fn get_last_run_end<T: ArrowNativeType>(run_ends_data: &super::MutableArrayData)
     if run_ends_data.data.len == 0 {
         T::default()
     } else {
-        // Convert buffer to typed slice and get the last element
-        let buffer = Buffer::from(run_ends_data.data.buffer1.as_slice());
-        let typed_slice: &[T] = buffer.typed_data();
+        let typed_slice: &[T] = run_ends_data.data.buffer1.typed_data();
         if typed_slice.len() >= run_ends_data.data.len {
             typed_slice[run_ends_data.data.len - 1]
         } else {


### PR DESCRIPTION
The previous code called Buffer::from to get typed_data, which allocates a new MutableBuffer.

# Which issue does this PR close?

I believe this PR is small enough to not require an issue.

# Rationale for this change

Performance. This PR reduces allocations

# What changes are included in this PR?

See commit

# Are these changes tested?

By pre-existing tests

# Are there any user-facing changes?

No
