### PR TITLE
arrow-buffer: implement num-traits numeric operations

### DIFF
--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -19,9 +19,9 @@ use crate::arith::derive_arith;
 use crate::bigint::div::div_rem;
 use num_bigint::BigInt;
 use num_traits::{
-    cast::AsPrimitive, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, FromPrimitive,
-    Num, One, Signed, ToPrimitive, WrappingAdd, WrappingMul, WrappingNeg, WrappingSub,
-    Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, FromPrimitive,
+    Num, One, Signed, ToPrimitive, WrappingAdd, WrappingMul, WrappingNeg, WrappingSub, Zero,
+    cast::AsPrimitive,
 };
 use std::cmp::Ordering;
 use std::num::ParseIntError;
@@ -994,11 +994,21 @@ impl Signed for i256 {
     }
 }
 
+impl Bounded for i256 {
+    fn min_value() -> Self {
+        i256::MIN
+    }
+
+    fn max_value() -> Self {
+        i256::MAX
+    }
+}
+
 #[cfg(all(test, not(miri)))] // llvm.x86.subborrow.64 not supported by MIRI
 mod tests {
     use super::*;
     use num_traits::Signed;
-    use rand::{rng, Rng};
+    use rand::{Rng, rng};
 
     #[test]
     fn test_signed_cmp() {
@@ -1520,6 +1530,9 @@ mod tests {
 
         assert_eq!(<i256 as One>::one(), i256::from(1));
         assert_eq!(<i256 as Zero>::zero(), i256::from(0));
+
+        assert_eq!(<i256 as Bounded>::min_value(), i256::MIN);
+        assert_eq!(<i256 as Bounded>::max_value(), i256::MAX);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8976

# Rationale for this change

`i256` doesn't implement some numeric traits. It'd be good to have it supported alongside other standard types.

# What changes are included in this PR?

- Trait implementations (checked ops, `Num`, `One`, `Zero`) using already written methods
- Unit tests

Not all traits are implemented (checked shl/shr, pow is not here yet). The main point of this PR is to provide a starting implementation.

# Are these changes tested?

Tested via new unit test

# Are there any user-facing changes?

Only new trait implementation.