### PR TITLE
[arrow-json] support deserializing JSON to variant

### DIFF
--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -35,12 +35,18 @@ bench = false
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = []
+variant_experimental = []
+
 [dependencies]
 arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-cast = { workspace = true }
 arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
+parquet-variant-compute = { workspace = true }
+parquet-variant = { workspace = true }
 half = { version = "2.1", default-features = false }
 indexmap = { version = "2.0", default-features = false, features = ["std"] }
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -46,6 +46,7 @@ impl<O: OffsetSizeTrait> ListArrayDecoder<O> {
             _ => unreachable!(),
         };
         let decoder = make_decoder(
+            Some(field.clone()),
             field.data_type().clone(),
             coerce_primitive,
             strict_mode,

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -57,6 +57,7 @@ impl MapArrayDecoder {
         };
 
         let keys = make_decoder(
+            Some(fields[0].clone()),
             fields[0].data_type().clone(),
             coerce_primitive,
             strict_mode,
@@ -64,6 +65,7 @@ impl MapArrayDecoder {
             struct_mode,
         )?;
         let values = make_decoder(
+            Some(fields[1].clone()),
             fields[1].data_type().clone(),
             coerce_primitive,
             strict_mode,

--- a/arrow-json/src/reader/struct_array.rs
+++ b/arrow-json/src/reader/struct_array.rs
@@ -46,6 +46,7 @@ impl StructArrayDecoder {
                 // it doesn't contain any nulls not masked by its parent
                 let nullable = f.is_nullable() || is_nullable;
                 make_decoder(
+                    Some(f.clone()),
                     f.data_type().clone(),
                     coerce_primitive,
                     strict_mode,

--- a/arrow-json/src/reader/variant_array.rs
+++ b/arrow-json/src/reader/variant_array.rs
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::{Array, StructArray};
+use parquet_variant::{ObjectFieldBuilder, Variant, VariantBuilder, VariantBuilderExt};
+use parquet_variant_compute::VariantArrayBuilder;
+use arrow_data::ArrayData;
+use arrow_schema::ArrowError;
+
+use crate::reader::ArrayDecoder;
+use crate::reader::tape::{Tape, TapeElement};
+
+#[derive(Default)]
+pub struct VariantArrayDecoder {}
+
+impl ArrayDecoder for VariantArrayDecoder {
+    fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayData, ArrowError> {
+        let mut array_builder = VariantArrayBuilder::new(pos.len());
+        for p in pos {
+            let mut builder = VariantBuilder::new();
+            variant_from_tape_element(&mut builder, *p, tape)?;
+            let (metadata, value) = builder.finish();
+            array_builder.append_value(Variant::new(&metadata, &value));
+        }
+        let variant_struct_array: StructArray = array_builder.build().into();
+        Ok(variant_struct_array.into_data())
+    }
+}
+
+fn variant_from_tape_element(builder: &mut impl VariantBuilderExt, mut p: u32, tape: &Tape) -> Result<u32, ArrowError> {
+    match tape.get(p) {
+        TapeElement::StartObject(end_idx) => {
+            let mut object_builder = builder.try_new_object()?;
+            p += 1;
+            while p < end_idx {
+                // Read field name
+                let field_name = match tape.get(p) {
+                    TapeElement::String(s) => tape.get_string(s),
+                    _ => return Err(tape.error(p, "field name")),
+                };
+        
+                let mut field_builder = ObjectFieldBuilder::new(field_name, &mut object_builder);
+                p = tape.next(p, "field value")?;
+                p = variant_from_tape_element(&mut field_builder, p, tape)?;
+            }
+            object_builder.finish();
+        }
+        TapeElement::EndObject(_u32) => unreachable!(),
+        TapeElement::StartList(end_idx) => {
+            let mut list_builder = builder.try_new_list()?;
+            p+= 1;
+            while p < end_idx {
+                p = variant_from_tape_element(&mut list_builder, p, tape)?;
+            }
+            list_builder.finish();
+        }
+        TapeElement::EndList(_u32) => unreachable!(),
+        TapeElement::String(idx) => builder.append_value(tape.get_string(idx)),
+        TapeElement::Number(idx) => {
+            let s = tape.get_string(idx);
+            builder.append_value(parse_number(s)?)
+        },
+        TapeElement::I64(i) => builder.append_value(i),
+        TapeElement::I32(i) => builder.append_value(i),
+        TapeElement::F64(f) => builder.append_value(f),
+        TapeElement::F32(f) => builder.append_value(f),
+        TapeElement::True => builder.append_value(true),
+        TapeElement::False => builder.append_value(false),
+        TapeElement::Null => builder.append_value(Variant::Null),
+    }
+    p += 1;
+    Ok(p)
+}
+
+fn parse_number<'a, 'b>(s: &'a str) -> Result<Variant<'a, 'b>, ArrowError> {
+    match lexical_core::parse::<i64>(s.as_bytes()) {
+        Ok(v) => Ok(Variant::from(v)),
+        Err(_) => {
+            match lexical_core::parse::<f64>(s.as_bytes()) {
+                Ok(v) => Ok(Variant::from(v)),
+                Err(_) => Err(ArrowError::JsonError(format!("failed to parse {s} as number"))),
+            }
+        }
+    }
+}

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -81,6 +81,7 @@ force_validate = ["arrow-array/force_validate", "arrow-data/force_validate"]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi", "arrow-array/ffi"]
 chrono-tz = ["arrow-array/chrono-tz"]
 canonical_extension_types = ["arrow-schema/canonical_extension_types"]
+variant_experimental = ["arrow-json?/variant_experimental"]
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/parquet-variant-compute/Cargo.toml
+++ b/parquet-variant-compute/Cargo.toml
@@ -29,8 +29,10 @@ rust-version = { workspace = true }
 
 
 [dependencies]
-arrow = { workspace = true , features = ["canonical_extension_types"]}
-arrow-schema = { workspace = true }
+arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
+arrow-cast = { workspace = true }
+arrow-schema = { workspace = true, features = ["canonical_extension_types"] }
 half = { version = "2.1", default-features = false }
 indexmap = "2.10.0"
 parquet-variant = { workspace = true }

--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -17,7 +17,7 @@
 
 use crate::arrow_to_variant::make_arrow_to_variant_row_builder;
 use crate::{CastOptions, VariantArray, VariantArrayBuilder};
-use arrow::array::Array;
+use arrow_array::Array;
 use arrow_schema::ArrowError;
 
 /// Casts a typed arrow [`Array`] to a [`VariantArray`]. This is useful when you

--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -19,7 +19,7 @@
 //! STRUCT<metadata: BINARY, value: BINARY>
 
 use crate::{VariantArray, VariantArrayBuilder};
-use arrow::array::{Array, ArrayRef, LargeStringArray, StringArray, StringViewArray};
+use arrow_array::{Array, ArrayRef, LargeStringArray, StringArray, StringViewArray};
 use arrow_schema::ArrowError;
 use parquet_variant_json::JsonToVariant;
 

--- a/parquet-variant-compute/src/to_json.rs
+++ b/parquet-variant-compute/src/to_json.rs
@@ -18,10 +18,9 @@
 //! Module for transforming a batch of Variants represented as
 //! STRUCT<metadata: BINARY, value: BINARY> into a batch of JSON strings.
 
-use arrow::array::{Array, ArrayRef, BinaryArray, BooleanBufferBuilder, StringArray, StructArray};
-use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
-use arrow::datatypes::DataType;
-use arrow_schema::ArrowError;
+use arrow_array::{Array, ArrayRef, BinaryArray, StringArray, StructArray};
+use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer, BooleanBufferBuilder};
+use arrow_schema::{ArrowError, DataType};
 use parquet_variant::Variant;
 use parquet_variant_json::VariantToJson;
 

--- a/parquet-variant-compute/src/type_conversion.rs
+++ b/parquet-variant-compute/src/type_conversion.rs
@@ -17,8 +17,8 @@
 
 //! Module for transforming a typed arrow `Array` to `VariantArray`.
 
-use arrow::compute::{DecimalCast, rescale_decimal};
-use arrow::datatypes::{
+use arrow_cast::{DecimalCast, rescale_decimal};
+use arrow_array::types::{ 
     self, ArrowPrimitiveType, ArrowTimestampType, Decimal32Type, Decimal64Type, Decimal128Type,
     DecimalType,
 };
@@ -73,24 +73,24 @@ macro_rules! impl_timestamp_from_variant {
     };
 }
 
-impl_primitive_from_variant!(datatypes::Int32Type, as_int32);
-impl_primitive_from_variant!(datatypes::Int16Type, as_int16);
-impl_primitive_from_variant!(datatypes::Int8Type, as_int8);
-impl_primitive_from_variant!(datatypes::Int64Type, as_int64);
-impl_primitive_from_variant!(datatypes::UInt8Type, as_u8);
-impl_primitive_from_variant!(datatypes::UInt16Type, as_u16);
-impl_primitive_from_variant!(datatypes::UInt32Type, as_u32);
-impl_primitive_from_variant!(datatypes::UInt64Type, as_u64);
-impl_primitive_from_variant!(datatypes::Float16Type, as_f16);
-impl_primitive_from_variant!(datatypes::Float32Type, as_f32);
-impl_primitive_from_variant!(datatypes::Float64Type, as_f64);
-impl_primitive_from_variant!(datatypes::Date32Type, as_naive_date, |v| {
-    Some(datatypes::Date32Type::from_naive_date(v))
+impl_primitive_from_variant!(types::Int32Type, as_int32);
+impl_primitive_from_variant!(types::Int16Type, as_int16);
+impl_primitive_from_variant!(types::Int8Type, as_int8);
+impl_primitive_from_variant!(types::Int64Type, as_int64);
+impl_primitive_from_variant!(types::UInt8Type, as_u8);
+impl_primitive_from_variant!(types::UInt16Type, as_u16);
+impl_primitive_from_variant!(types::UInt32Type, as_u32);
+impl_primitive_from_variant!(types::UInt64Type, as_u64);
+impl_primitive_from_variant!(types::Float16Type, as_f16);
+impl_primitive_from_variant!(types::Float32Type, as_f32);
+impl_primitive_from_variant!(types::Float64Type, as_f64);
+impl_primitive_from_variant!(types::Date32Type, as_naive_date, |v| {
+    Some(types::Date32Type::from_naive_date(v))
 });
-impl_primitive_from_variant!(datatypes::Date64Type, as_naive_date, |v| {
-    Some(datatypes::Date64Type::from_naive_date(v))
+impl_primitive_from_variant!(types::Date64Type, as_naive_date, |v| {
+    Some(types::Date64Type::from_naive_date(v))
 });
-impl_primitive_from_variant!(datatypes::Time32SecondType, as_time_utc, |v| {
+impl_primitive_from_variant!(types::Time32SecondType, as_time_utc, |v| {
     // Return None if there are leftover nanoseconds
     if v.nanosecond() != 0 {
         None
@@ -98,7 +98,7 @@ impl_primitive_from_variant!(datatypes::Time32SecondType, as_time_utc, |v| {
         Some(v.num_seconds_from_midnight() as i32)
     }
 });
-impl_primitive_from_variant!(datatypes::Time32MillisecondType, as_time_utc, |v| {
+impl_primitive_from_variant!(types::Time32MillisecondType, as_time_utc, |v| {
     // Return None if there are leftover microseconds
     if v.nanosecond() % 1_000_000 != 0 {
         None
@@ -106,15 +106,15 @@ impl_primitive_from_variant!(datatypes::Time32MillisecondType, as_time_utc, |v| 
         Some((v.num_seconds_from_midnight() * 1_000) as i32 + (v.nanosecond() / 1_000_000) as i32)
     }
 });
-impl_primitive_from_variant!(datatypes::Time64MicrosecondType, as_time_utc, |v| {
+impl_primitive_from_variant!(types::Time64MicrosecondType, as_time_utc, |v| {
     Some((v.num_seconds_from_midnight() * 1_000_000 + v.nanosecond() / 1_000) as i64)
 });
-impl_primitive_from_variant!(datatypes::Time64NanosecondType, as_time_utc, |v| {
+impl_primitive_from_variant!(types::Time64NanosecondType, as_time_utc, |v| {
     // convert micro to nano seconds
     Some(v.num_seconds_from_midnight() as i64 * 1_000_000_000 + v.nanosecond() as i64)
 });
 impl_timestamp_from_variant!(
-    datatypes::TimestampSecondType,
+    types::TimestampSecondType,
     as_timestamp_ntz_nanos,
     ntz = true,
     |timestamp| {
@@ -127,7 +127,7 @@ impl_timestamp_from_variant!(
     }
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampSecondType,
+    types::TimestampSecondType,
     as_timestamp_nanos,
     ntz = false,
     |timestamp| {
@@ -140,7 +140,7 @@ impl_timestamp_from_variant!(
     }
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampMillisecondType,
+    types::TimestampMillisecondType,
     as_timestamp_ntz_nanos,
     ntz = true,
     |timestamp| {
@@ -153,7 +153,7 @@ impl_timestamp_from_variant!(
     }
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampMillisecondType,
+    types::TimestampMillisecondType,
     as_timestamp_nanos,
     ntz = false,
     |timestamp| {
@@ -166,25 +166,25 @@ impl_timestamp_from_variant!(
     }
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampMicrosecondType,
+    types::TimestampMicrosecondType,
     as_timestamp_ntz_micros,
     ntz = true,
     Self::make_value,
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampMicrosecondType,
+    types::TimestampMicrosecondType,
     as_timestamp_micros,
     ntz = false,
     |timestamp| Self::make_value(timestamp.naive_utc())
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampNanosecondType,
+    types::TimestampNanosecondType,
     as_timestamp_ntz_nanos,
     ntz = true,
     Self::make_value
 );
 impl_timestamp_from_variant!(
-    datatypes::TimestampNanosecondType,
+    types::TimestampNanosecondType,
     as_timestamp_nanos,
     ntz = false,
     |timestamp| Self::make_value(timestamp.naive_utc())
@@ -299,7 +299,7 @@ macro_rules! generic_conversion_single_value_with_result {
             Err(e) => Err(ArrowError::CastError(format!(
                 "Cast failed at index {idx} (array type: {ty}): {e}",
                 idx = $index,
-                ty = <$t as ::arrow::datatypes::ArrowPrimitiveType>::DATA_TYPE
+                ty = <$t as ::arrow_array::types::ArrowPrimitiveType>::DATA_TYPE
             ))),
         }
     }};

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -18,7 +18,7 @@
 //! [`VariantArrayBuilder`] implementation
 
 use crate::VariantArray;
-use arrow::array::{ArrayRef, BinaryViewArray, BinaryViewBuilder, NullBufferBuilder, StructArray};
+use arrow_array::{ArrayRef, BinaryViewArray, builder::BinaryViewBuilder, builder::NullBufferBuilder, StructArray};
 use arrow_schema::{ArrowError, DataType, Field, Fields};
 use parquet_variant::{
     BuilderSpecificState, ListBuilder, MetadataBuilder, ObjectBuilder, Variant, VariantBuilderExt,

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -131,7 +131,7 @@ encryption = ["dep:ring"]
 flate2-rust_backened = ["flate2/rust_backend"]
 flate2-zlib-rs = ["flate2/zlib-rs"]
 # Enable parquet variant support
-variant_experimental = ["arrow", "parquet-variant", "parquet-variant-json", "parquet-variant-compute"]
+variant_experimental = ["arrow", "arrow/variant_experimental", "parquet-variant", "parquet-variant-json", "parquet-variant-compute"]
 # Enable geospatial support
 geospatial = ["parquet-geospatial"]
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #8987.

# What changes are included in this PR?

With this change you can provide a Variant annotated Field to the arrow-json reader and it will deserialize JSON into that column as a Variant.  

For example 
```rust
let variant_array = VariantArrayBuilder::new(0).build();

let struct_field = Schema::new(vec![
    Field::new("id", DataType::Int32, false),
    // call VariantArray::field to get the correct Field
    variant_array.field("var"),
]);

let builder = ReaderBuilder::new(Arc::new(struct_field.clone()));
let result = builder
    .with_struct_mode(StructMode::ObjectOnly)
    .build(Cursor::new(b"{\"id\": 1, \"var\": [\"mixed data\", 1]}"));
```

This is my first PR to this project, so I wanted to get this up for feedback. Some things to point out:
- I added this under an arrow-json feature `variant_experimental` which matches the feature in other crates. Does this align with expectations for how this feature would be exposed?
- `arrow-json` must include `parquet-variant-compute` so to avoid a circular dependency I had to modify `parquet-variant-compute` to include `arrow` sub crates (e.g. `arrow-schema`) instead of including through `arrow`. That makes up a decent chunk of the changes in this PR and could be pulled out as a standalone change but I was not sure if it was intentional that `parquet-variant-compute` included from `arrow` directly.
- It does not attempt to deserialize to Decimal (which aligns with the existing code in `parquet-variant-compute`), numbers are deserialized to either i64 or f64.

# Are these changes tested?

Unit test was added. Open to feedback on whether that test is adequate or more is expected.

# Are there any user-facing changes?

Yes, users can now provide Variant extensions fields to arrow-json reader. 