### PR TITLE
Fix row slice bug in Union column decoding with many columns

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -4199,7 +4199,7 @@ mod tests {
             assert_eq!(col.value(i).as_ref(), union_array.value(i).as_ref());
         }
     }
-  
+
     #[test]
     fn rows_size_should_count_for_capacity() {
         let row_converter = RowConverter::new(vec![SortField::new(DataType::UInt8)]).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8999

# Rationale for this change

This PR fixes a bug in the row-to-column conversion for Union types when multiple union columns are present in the same row converter

Previously, the row slice was being consumed from reading their data correctly. The fix tracks bytes consumed per row across all union fields, this way it properly advances row slices

