### PR TITLE
fix: integration / Archery test With other arrows container ran out of space

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,155 +78,111 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Monitor disk usage - Initial
+        run: |
+          echo "=== Initial Disk Usage ==="
+          df -h /
+          echo ""
+
+      - name: Remove unnecessary preinstalled software
+        run: |
+          echo "=== Cleaning up host disk space ==="
+          echo "Disk space before cleanup:"
+          df -h /
+
+          # Clean apt cache
+          apt-get clean || true
+
+          # Remove GitHub Actions tool cache
+          rm -rf /__t/* || true
+
+          # Remove large packages from host filesystem (mounted at /host/)
+          rm -rf /host/usr/share/dotnet || true
+          rm -rf /host/usr/local/lib/android || true
+          rm -rf /host/usr/local/.ghcup || true
+          rm -rf /host/opt/hostedtoolcache/CodeQL || true
+
+          echo ""
+          echo "Disk space after cleanup:"
+          df -h /
+          echo ""
+
       # This is necessary so that actions/checkout can find git
       - name: Export conda path
         run: echo "/opt/conda/envs/arrow/bin" >> $GITHUB_PATH
       # This is necessary so that Rust can find cargo
       - name: Export cargo path
         run: echo "/root/.cargo/bin" >> $GITHUB_PATH
-      - name: Check rustup
-        run: which rustup
-      - name: Check cmake
-        run: which cmake
+
+      # Checkout repos (using shallow clones with fetch-depth: 1)
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
           repository: apache/arrow
           submodules: true
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Checkout Arrow Rust
         uses: actions/checkout@v6
         with:
           path: rust
           submodules: true
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Checkout Arrow .NET
         uses: actions/checkout@v6
         with:
           repository: apache/arrow-dotnet
           path: dotnet
+          fetch-depth: 1
       - name: Checkout Arrow Go
         uses: actions/checkout@v6
         with:
           repository: apache/arrow-go
           path: go
+          fetch-depth: 1
       - name: Checkout Arrow Java
         uses: actions/checkout@v6
         with:
           repository: apache/arrow-java
           path: java
+          fetch-depth: 1
       - name: Checkout Arrow JavaScript
         uses: actions/checkout@v6
         with:
           repository: apache/arrow-js
           path: js
+          fetch-depth: 1
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@v6
         with:
           repository: apache/arrow-nanoarrow
           path: nanoarrow
-      - name: Monitor resources - Before build
+          fetch-depth: 1
+
+      - name: Monitor disk usage - After checkouts
         run: |
-          echo "=== INITIAL RESOURCE USAGE ==="
-          echo "--- Memory ---"
-          free -h
-          echo "--- Disk ---"
-          df -h
-          echo "--- Process count ---"
-          ps aux | wc -l
-          echo "--- Top memory consumers ---"
-          ps aux --sort=-%mem | head -10
-      - name: Patch build script to monitor JS copy
-        run: |
-          # Create a monitoring wrapper for the cp command
-          cat > /tmp/monitored_cp.sh << 'EOF'
-          #!/bin/bash
-          echo "=== BEFORE CP: Memory and Disk ==="
-          free -h
+          echo "=== After Checkouts ==="
           df -h /
-          echo "=== JS directory size ==="
-          du -sh "$1" 2>/dev/null || echo "Source not found: $1"
-          if [ -d "$1/node_modules" ]; then
-            echo "=== node_modules size ==="
-            du -sh "$1/node_modules"
-            echo "=== node_modules file count ==="
-            find "$1/node_modules" -type f | wc -l
-          fi
+          echo ""
 
-          echo "=== Starting cp -a at $(date) ==="
-          # Run the actual cp with progress monitoring
-          (
-            while kill -0 $$ 2>/dev/null; do
-              echo "--- Resources during cp at $(date) ---"
-              free -h | grep "Mem:"
-              df -h / | tail -1
-              sleep 5
-            done
-          ) &
-          MONITOR_PID=$!
-
-          # Run the copy
-          /bin/cp -a "$@"
-          CP_EXIT=$?
-
-          # Stop monitoring
-          kill $MONITOR_PID 2>/dev/null || true
-
-          echo "=== AFTER CP: Memory and Disk ==="
-          free -h
-          df -h /
-
-          exit $CP_EXIT
-          EOF
-          chmod +x /tmp/monitored_cp.sh
-
-          # Backup and patch the build script to use monitored cp
-          cp ci/scripts/integration_arrow_build.sh ci/scripts/integration_arrow_build.sh.orig
-          sed -i 's|cp -a "${arrow_dir}/js" "${build_dir}/js"|/tmp/monitored_cp.sh "${arrow_dir}/js" "${build_dir}/js"|g' ci/scripts/integration_arrow_build.sh
-          sed -i 's|cp -a "${arrow_dir}/dotnet" "${build_dir}/dotnet"|/tmp/monitored_cp.sh "${arrow_dir}/dotnet" "${build_dir}/dotnet"|g' ci/scripts/integration_arrow_build.sh
-
-          echo "=== Build script patched to monitor cp commands ==="
-          diff ci/scripts/integration_arrow_build.sh.orig ci/scripts/integration_arrow_build.sh || true
       - name: Build
-        run: |
-          # Create a wrapper script to monitor during build
-          cat > /tmp/monitor_build.sh << 'EOF'
-          #!/bin/bash
-          set -e
+        run: conda run --no-capture-output ci/scripts/integration_arrow_build.sh $PWD /build
 
-          # Start background monitoring
-          (
-            while true; do
-              echo "=== Resource snapshot at $(date) ==="
-              free -h | grep -E "Mem:|Swap:"
-              df -h / | tail -1
-              sleep 30
-            done
-          ) &
-          MONITOR_PID=$!
-
-          # Run the actual build
-          conda run --no-capture-output ci/scripts/integration_arrow_build.sh $PWD /build
-
-          # Stop monitoring
-          kill $MONITOR_PID 2>/dev/null || true
-          EOF
-          chmod +x /tmp/monitor_build.sh
-          /tmp/monitor_build.sh
-      - name: Monitor resources - After build
+      - name: Monitor disk usage - After build
         if: always()
         run: |
-          echo "=== FINAL RESOURCE USAGE ==="
-          echo "--- Memory ---"
-          free -h
-          echo "--- Disk ---"
-          df -h
-          echo "--- Build directory size ---"
-          du -sh /build/* 2>/dev/null || echo "No /build directory"
-          echo "--- Top 20 largest directories ---"
-          du -h /build 2>/dev/null | sort -rh | head -20 || echo "Cannot analyze /build"
+          echo "=== After Build ==="
+          df -h /
+          echo ""
+
       - name: Run
         run: conda run --no-capture-output ci/scripts/integration_arrow.sh $PWD /build
+
+      - name: Monitor disk usage - After tests
+        if: always()
+        run: |
+          echo "=== After Tests ==="
+          df -h /
+          echo ""
 
   # test FFI against the C-Data interface exposed by pyarrow
   pyarrow-integration-test:


### PR DESCRIPTION
# Which issue does this PR close?


- Closes #9024.

# Rationale for this change

the ci container starts with 63gb / 72gb used, the 9GB remaining disk space is barely enough for a cross build in 7 languages that leads to ci being stuck.

this is what a debug step after initialize container shows
=== CONTAINER DISK USAGE ===
Filesystem      Size  Used Avail Use% Mounted on
overlay          72G   63G  9.5G  87% /


# What changes are included in this PR?

- add resource monitoring to build process
- add a clean up step to remove unnecessary software (cuts 6GB of space)
=== Cleaning up host disk space ===
Disk space before cleanup:
Filesystem      Size  Used Avail Use% Mounted on
overlay          72G   63G  9.5G  87% /

Disk space after cleanup:
Filesystem      Size  Used Avail Use% Mounted on
overlay          72G   57G   16G  79% /
- add a small optimization to shallow clone (only clone most recent commit not full history) for github repos

optimization results we have 6.1 GB left after build

=== After Build ===
Filesystem      Size  Used Avail Use% Mounted on
overlay          72G   66G  6.1G  92% /


# Are these changes tested?

tested by github ci

# Are there any user-facing changes?

no