### PR TITLE
Switch from `ryu` -> `zmij` for float formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ simdutf8 = { version = "0.1.5", default-features = false }
 
 criterion = { version = "0.8.0", default-features = false }
 
+zmij = "0.1"
+
 # release inherited profile keeping debug information and symbols
 # for mem/cpu profiling
 [profile.profiling]

--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -53,7 +53,7 @@ lexical-core = { version = "1.0", default-features = false, features = ["write-i
 atoi = "2.0.0"
 comfy-table = { version = "7", optional = true, default-features = false }
 base64 = "0.22"
-ryu = "1.0.16"
+zmij = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, default-features = false }

--- a/arrow-cast/src/display.rs
+++ b/arrow-cast/src/display.rs
@@ -672,7 +672,7 @@ macro_rules! primitive_display_float {
         {
             fn write(&self, idx: usize, f: &mut dyn Write) -> FormatResult {
                 let value = self.value(idx);
-                let mut buffer = ryu::Buffer::new();
+                let mut buffer = zmij::Buffer::new();
                 f.write_str(buffer.format(value))?;
                 Ok(())
             }

--- a/arrow-json/Cargo.toml
+++ b/arrow-json/Cargo.toml
@@ -50,7 +50,7 @@ chrono = { workspace = true }
 lexical-core = { version = "1.0", default-features = false}
 memchr = "2.7.4"
 simdutf8 = { workspace = true }
-ryu = "1.0"
+zmij = { workspace = true }
 itoa = "1.0"
 
 [dev-dependencies]

--- a/arrow-json/src/reader/string_array.rs
+++ b/arrow-json/src/reader/string_array.rs
@@ -25,7 +25,7 @@ use crate::reader::ArrayDecoder;
 use crate::reader::tape::{Tape, TapeElement};
 
 use itoa;
-use ryu;
+use zmij;
 
 const TRUE: &str = "true";
 const FALSE: &str = "false";
@@ -88,7 +88,7 @@ impl<O: OffsetSizeTrait> ArrayDecoder for StringArrayDecoder<O> {
 
         let mut builder = GenericStringBuilder::<O>::with_capacity(pos.len(), data_capacity);
 
-        let mut float_formatter = ryu::Buffer::new();
+        let mut float_formatter = zmij::Buffer::new();
         let mut int_formatter = itoa::Buffer::new();
 
         for p in pos {


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Prior art: [`serde_json` switch to `zmij`](https://github.com/serde-rs/json/pull/1304).

# What changes are included in this PR?

`zmij` already supports f32 formatting, so switch from `ryu` to `zmij`.


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No.
