### PR TITLE
Minor: avoid some clones when reading parquet

### DIFF
--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -129,8 +129,8 @@ impl ArrayReader for StructArrayReader {
             .len(children_array_len)
             .child_data(
                 children_array
-                    .iter()
-                    .map(|x| x.to_data())
+                    .into_iter()
+                    .map(|x| x.into_data())
                     .collect::<Vec<ArrayData>>(),
             );
 


### PR DESCRIPTION
# Which issue does this PR close?

- RElated to  https://github.com/apache/datafusion/pull/19477

# Rationale for this change

While profiling   https://github.com/apache/datafusion/pull/19477 I noticed some additional clones we could avoid

<img width="1504" height="927" alt="Screenshot 2025-12-26 at 12 03 00 PM" src="https://github.com/user-attachments/assets/958f76e2-53d0-4008-b224-d9275984cd1a" />

I doubt this will be a huge deal but it does remove some allocations int he parquet read path

# What changes are included in this PR?

Use `into_data` rather than `to_data`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
