### PR TITLE
Minor: avoid clone in RunArray row decoding via buffer stealing

### DIFF
--- a/arrow-row/src/run.rs
+++ b/arrow-row/src/run.rs
@@ -134,7 +134,11 @@ pub unsafe fn decode<R: RunEndIndexType>(
                 run_ends.push(R::Native::usize_as(idx));
             }
             unique_row_indices.push(decoded_values.len());
-            decoded_values.push(decoded_data.clone());
+            let capacity = decoded_data.capacity();
+            decoded_values.push(std::mem::replace(
+                &mut decoded_data,
+                Vec::with_capacity(capacity),
+            ));
         }
     }
     // Add the final run end


### PR DESCRIPTION
# Which issue does this PR close?
its a nitpick to replace
"allocation + memcpy" with "allocation only".


# Rationale for this change
remove the value clone in decode path
`decoded_values.push(decoded_data.clone())`
and taking from decoded_data directly


# What changes are included in this PR?


# Are these changes tested?

i think the current testing suite will do 
# Are there any user-facing changes?

no
