### PR TITLE
disable array reader cache for nested fields

### DIFF
--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -152,7 +152,12 @@ impl<'a> ArrayReaderBuilder<'a> {
                     return Ok(Some(reader));
                 };
 
-                if cache_options.projection_mask.leaf_included(col_idx) {
+                // Skip caching for columns with nullable ancestors (def_level > 0)
+                // because CachedArrayReader doesn't support get_def_levels() yet.
+                // See: https://github.com/apache/arrow-rs/issues/XXXX
+                if cache_options.projection_mask.leaf_included(col_idx)
+                    && field.def_level == 0
+                {
                     Ok(Some(Box::new(CachedArrayReader::new(
                         reader,
                         Arc::clone(cache_options.cache),


### PR DESCRIPTION
I'm not sure if this is the best approach.

While working on Parquet struct filter / projection pushdown I found this limitation.
If you try to read a struct column in both a projection and filter you get a panic that traces back to:

https://github.com/apache/arrow-rs/blob/39f0aadeb6d15a9253fe4a4ca6d8a6769ccc91a5/parquet/src/arrow/array_reader/cached_array_reader.rs#L342-L344

(this causes an upstream panic because the child reader needs to know the nullability of the parent, I think)