### PR TITLE
TESTING: no code change, boolean kernel benchmark stability

### DIFF
--- a/arrow-buffer/src/buffer/ops.rs
+++ b/arrow-buffer/src/buffer/ops.rs
@@ -61,6 +61,8 @@ where
 
 /// Apply a bitwise operation `op` to two inputs and return the result as a Buffer.
 /// The inputs are treated as bitmaps, meaning that offsets and length are specified in number of bits.
+///
+/// This is a comment for testing purposes
 pub fn bitwise_bin_op_helper<F>(
     left: &Buffer,
     left_offset_in_bits: usize,


### PR DESCRIPTION
- part of https://github.com/apache/arrow-rs/pull/9022

I am trying to figure out why the boolean benchmarks are showing performance differences when I don't think they are making any changes

This PR is a baseline for boolean kernels -- I am using it to ensure the benchmark runs are stable without code changes 