### PR TITLE
TESTING: test just special case boolean code

### DIFF
--- a/arrow-buffer/src/buffer/ops.rs
+++ b/arrow-buffer/src/buffer/ops.rs
@@ -74,6 +74,30 @@ pub fn bitwise_bin_op_helper<F>(
 where
     F: FnMut(u64, u64) -> u64,
 {
+    // If the underlying buffers are aligned to u64 we can apply the operation directly on the u64 slices
+    // to improve performance.
+    if left_offset_in_bits == 0 && right_offset_in_bits == 0 {
+        unsafe {
+            let (left_prefix, left_u64s, left_suffix) = left.as_slice().align_to::<u64>();
+            let (right_prefix, right_u64s, right_suffix) = right.as_slice().align_to::<u64>();
+            // if there is no prefix or suffix, both buffers are aligned and we can do the operation directly
+            // on u64s
+            // TODO also handle non empty suffixes by processing them separately
+            if left_prefix.is_empty()
+                && right_prefix.is_empty()
+                && left_suffix.is_empty()
+                && right_suffix.is_empty()
+            {
+                let result_u64s = left_u64s
+                    .iter()
+                    .zip(right_u64s.iter())
+                    .map(|(l, r)| op(*l, *r))
+                    .collect::<Vec<u64>>();
+                return result_u64s.into();
+            }
+        }
+    }
+
     let left_chunks = left.bit_chunks(left_offset_in_bits, len_in_bits);
     let right_chunks = right.bit_chunks(right_offset_in_bits, len_in_bits);
 


### PR DESCRIPTION
- part of https://github.com/apache/arrow-rs/pull/9022

I am trying to figure out why the boolean benchmarks are showing performance differences when I don't think they are making any changes

This is the based on the baseline 
- https://github.com/apache/arrow-rs/pull/9069 

But with the special case path from
- https://github.com/apache/arrow-rs/pull/8807

I am hoping that the `slice24` benchmark does not show any changes here
