### PR TITLE
perf: improve calculating length performance for `GenericByteArray` in row conversion

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1659,8 +1659,7 @@ fn push_generic_byte_array_lengths<T: ByteArrayType>(
             array
                 .offsets()
                 .lengths()
-                .map(Some)
-                .map(variable::padded_length),
+                .map(variable::non_null_padded_length),
         )
     }
 }

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -55,11 +55,20 @@ pub fn encoded_len(a: Option<&[u8]>) -> usize {
 #[inline]
 pub fn padded_length(a: Option<usize>) -> usize {
     match a {
-        Some(a) if a <= BLOCK_SIZE => 1 + ceil(a, MINI_BLOCK_SIZE) * (MINI_BLOCK_SIZE + 1),
+        Some(a) => non_null_padded_length(a),
+        None => 1,
+    }
+}
+
+/// Returns the padded length of the encoded length of the given length
+#[inline]
+pub(crate) fn non_null_padded_length(len: usize) -> usize {
+    if len <= BLOCK_SIZE {
+        1 + ceil(len, MINI_BLOCK_SIZE) * (MINI_BLOCK_SIZE + 1)
+    } else {
         // Each miniblock ends with a 1 byte continuation, therefore add
         // `(MINI_BLOCK_COUNT - 1)` additional bytes over non-miniblock size
-        Some(a) => MINI_BLOCK_COUNT + ceil(a, BLOCK_SIZE) * (BLOCK_SIZE + 1),
-        None => 1,
+        MINI_BLOCK_COUNT + ceil(len, BLOCK_SIZE) * (BLOCK_SIZE + 1)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Making the row length calculation faster which result in faster row conversion

# What changes are included in this PR?

Instead of iterating over the items in the array and getting the length from the byte slice, we use the offsets directly and zip with nulls if necessary 

# Are these changes tested?

Existing tests

# Are there any user-facing changes?

Faster encoding

------

Split to 2 more PRs as the other 2 add a change to the public API

Related to:
- #9079
- #9080
