### PR TITLE
Add `DataType::is_decimal`

### DIFF
--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -591,6 +591,16 @@ impl DataType {
         matches!(self, UInt8 | UInt16 | UInt32 | UInt64)
     }
 
+    /// Returns true if this type is decimal: (Decimal*).
+    #[inline]
+    pub fn is_decimal(&self) -> bool {
+        use DataType::*;
+        matches!(
+            self,
+            Decimal32(..) | Decimal64(..) | Decimal128(..) | Decimal256(..)
+        )
+    }
+
     /// Returns true if this type is valid as a dictionary key
     #[inline]
     pub fn is_dictionary_key_type(&self) -> bool {
@@ -1166,6 +1176,15 @@ mod tests {
     fn test_floating() {
         assert!(DataType::is_floating(&DataType::Float16));
         assert!(!DataType::is_floating(&DataType::Int32));
+    }
+
+    #[test]
+    fn test_decimal() {
+        assert!(DataType::is_decimal(&DataType::Decimal32(4, 2)));
+        assert!(DataType::is_decimal(&DataType::Decimal64(4, 2)));
+        assert!(DataType::is_decimal(&DataType::Decimal128(4, 2)));
+        assert!(DataType::is_decimal(&DataType::Decimal256(4, 2)));
+        assert!(!DataType::is_decimal(&DataType::Float16));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #5163

# Rationale for this change

I've implemented this function at least twice in other codebases, and `arrow-rs` now has 4 variants.

# What changes are included in this PR?

New public function to test if a `DataType` is any decimal variant.

# Are these changes tested?

Yes

# Are there any user-facing changes?

New function including docs.
