### PR TITLE
chore: switch test from `bincode` to maintained `postcard` crate (RUSTSEC-2025-0141 )

### DIFF
--- a/arrow-schema/Cargo.toml
+++ b/arrow-schema/Cargo.toml
@@ -53,12 +53,9 @@ serde = ["dep:serde_core", "dep:serde"]
 all-features = true
 
 [dev-dependencies]
-bincode = { version = "2.0.1", default-features = false, features = [
-    "std",
-    "serde",
-] }
 criterion = { workspace = true, default-features = false }
 insta = "1.43.1"
+postcard = { version = "1.0.10", default-features = false, features = ["use-std"] }
 
 [[bench]]
 name = "ffi"

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -1448,10 +1448,8 @@ mod test {
 
     #[cfg(feature = "serde")]
     fn assert_binary_serde_round_trip(field: Field) {
-        let config = bincode::config::legacy();
-        let serialized = bincode::serde::encode_to_vec(&field, config).unwrap();
-        let (deserialized, _): (Field, _) =
-            bincode::serde::decode_from_slice(&serialized, config).unwrap();
+        let serialized = postcard::to_stdvec(&field).unwrap();
+        let deserialized: Field = postcard::from_bytes(&serialized).unwrap();
         assert_eq!(field, deserialized)
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes https://github.com/apache/arrow-rs/pull/9009
- Also addresses https://rustsec.org/advisories/RUSTSEC-2025-0141 -- this is only used for testing but still

# Rationale for this change

https://crates.io/crates/bincode is unmaintained

<img width="833" height="657" alt="Screenshot 2026-01-06 at 5 57 13 PM" src="https://github.com/user-attachments/assets/9e18a6e5-eb45-4470-94b7-e17b89ad558e" />

There also appears to be some sort of drama related to the maintainer

While we only use this code in tests, it would be nice to avoid issues sooner rather than later

# What changes are included in this PR?

Change to use postcard

# Are these changes tested?
by ci

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
