### PR TITLE
docs: Improve main README.md and highlight community

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ project is governed by the Apache Software Foundation's [code of
 conduct](https://www.apache.org/foundation/policies/conduct.html).
 
 We use GitHub [issues] and [pull requests] for all technical discussions, reviews,
-new features, bug fixes and release coordiation. This ensures that all communication
+new features, bug fixes and release coordination. This ensures that all communication
 is public and archived for future reference.
 
 The `dev@arrow.apache.org` mailing list is the communication channel for the overall Apache Arrow community.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

One of my new years resolutions is to try and encourage / build the arrow-rs community more. Part of doing so is to lower the barrier for new contributors with clear communication and documentation. 

Thus I would like to improve the main readme

# What changes are included in this PR?

Update the README. See rendered preview here: https://github.com/alamb/arrow-rs/blob/alamb/improved_comms_docs/README.md

1. Move community section to the top of the README file
2. Clarify that most communication happens on github

<img width="1348" height="775" alt="Screenshot 2026-01-09 at 9 33 06 AM" src="https://github.com/user-attachments/assets/fc3f6041-478d-4170-bb40-3956764a9b8d" />


# Are these changes tested?

CI
# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
