### PR TITLE
[Parquet] perf: Create Utf8/BinaryViewArray directly rather than via `ArrayData`

### DIFF
--- a/parquet/src/arrow/buffer/view_buffer.rs
+++ b/parquet/src/arrow/buffer/view_buffer.rs
@@ -71,7 +71,9 @@ impl ViewBuffer {
     pub fn into_array(self, null_buffer: Option<Buffer>, data_type: &ArrowType) -> ArrayRef {
         let len = self.views.len();
         let views = ScalarBuffer::from(self.views);
-        let nulls = null_buffer.map(|b| NullBuffer::new(BooleanBuffer::new(b, 0, len)));
+        let nulls = null_buffer
+            .map(|b| NullBuffer::new(BooleanBuffer::new(b, 0, len)))
+            .filter(|n| n.null_count() != 0);
         match data_type {
             ArrowType::Utf8View => {
                 // Safety: views were created correctly, and checked that the data is utf8 when building the buffer


### PR DESCRIPTION
# Which issue does this PR close?
- part of https://github.com/apache/arrow-rs/issues/9061
- part of - Part of https://github.com/apache/arrow-rs/issues/9128



# Rationale for this change

- similarly to https://github.com/apache/arrow-rs/pull/9120

Creating Arrays via ArrayData / `make_array` has overhead (at least 2 Vec allocations) compared to simply creating the arrays directly

ViewArrays also have an extra Vec allocation (to hold their buffers)

# What changes are included in this PR?

Update the parquet reader to create ViewArrays directly

# Are these changes tested?
By CI

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
