### PR TITLE
[Parquet] perf: Create `PrimitiveArray`s directly rather than via `ArrayData`

### DIFF
--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -633,7 +633,7 @@ impl<T: FromPyArrow> FromPyObject<'_, '_> for PyArrowType<T> {
     type Error = PyErr;
 
     fn extract(value: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
-        Ok(Self(T::from_pyarrow_bound(&*value)?))
+        Ok(Self(T::from_pyarrow_bound(&value)?))
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?
- related to https://github.com/apache/arrow-rs/issues/9061
- Part of https://github.com/apache/arrow-rs/issues/9128


# Rationale for this change

- similarly to https://github.com/apache/arrow-rs/pull/9120

Creating Arrays via ArrayData / `make_array` has overhead (at least 2 Vec allocations) compared to simply creating the arrays directly

# What changes are included in this PR?

Update the parquet reader to create `PrimitiveArray`s directly

# Are these changes tested?
By CI

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
