### PR TITLE
Fix clippy

### DIFF
--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -633,7 +633,7 @@ impl<T: FromPyArrow> FromPyObject<'_, '_> for PyArrowType<T> {
     type Error = PyErr;
 
     fn extract(value: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
-        Ok(Self(T::from_pyarrow_bound(&*value)?))
+        Ok(Self(T::from_pyarrow_bound(&value)?))
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

Clippy is failiing on main after merging https://github.com/apache/arrow-rs/commit/cfba3ccc0c9460dba65ca000c34e6491c8043abc 
- https://github.com/apache/arrow-rs/pull/8773

Example: https://github.com/apache/arrow-rs/actions/runs/20865325961/job/59954918027

```
error: deref which would be done by auto-deref
   --> arrow-pyarrow/src/lib.rs:636:39
    |
636 |         Ok(Self(T::from_pyarrow_bound(&*value)?))
    |                                       ^^^^^^^ help: try: `&value`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#explicit_auto_deref
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`
```

# What changes are included in this PR?
Apply clippy fix

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
