### PR TITLE
fix: support cast from `Null` to list view/run encoded/union types

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -104,41 +104,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
     }
 
     match (from_type, to_type) {
-        (
-            Null,
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Float16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | Timestamp(_, _)
-            | Time64(_)
-            | Duration(_)
-            | Interval(_)
-            | FixedSizeBinary(_)
-            | Binary
-            | Utf8
-            | LargeBinary
-            | LargeUtf8
-            | BinaryView
-            | Utf8View
-            | List(_)
-            | LargeList(_)
-            | FixedSizeList(_, _)
-            | Struct(_)
-            | Map(_, _)
-            | Dictionary(_, _),
-        ) => true,
+        (Null, _) => true,
         // Dictionary/List conditions should be put in front of others
         (Dictionary(_, from_value_type), Dictionary(_, to_value_type)) => {
             can_cast_types(from_value_type, to_value_type)
@@ -212,7 +178,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         ) => true,
         // signed numeric to decimal
         (
-            Null | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
+            Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
         ) => true,
         // decimal to unsigned numeric
@@ -805,41 +771,7 @@ pub fn cast_with_options(
         return Ok(make_array(array.to_data()));
     }
     match (from_type, to_type) {
-        (
-            Null,
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Float16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | Timestamp(_, _)
-            | Time64(_)
-            | Duration(_)
-            | Interval(_)
-            | FixedSizeBinary(_)
-            | Binary
-            | Utf8
-            | LargeBinary
-            | LargeUtf8
-            | BinaryView
-            | Utf8View
-            | List(_)
-            | LargeList(_)
-            | FixedSizeList(_, _)
-            | Struct(_)
-            | Map(_, _)
-            | Dictionary(_, _),
-        ) => Ok(new_null_array(to_type, array.len())),
+        (Null, _) => Ok(new_null_array(to_type, array.len())),
         (RunEndEncoded(index_type, _), _) => match index_type.data_type() {
             Int16 => run_end_encoded_cast::<Int16Type>(array, to_type, cast_options),
             Int32 => run_end_encoded_cast::<Int32Type>(array, to_type, cast_options),
@@ -8199,17 +8131,27 @@ mod tests {
         typed_test!(Date64Array, Date64, Date64Type);
     }
 
-    fn cast_from_null_to_other(data_type: &DataType) {
+    fn cast_from_null_to_other_base(data_type: &DataType, is_complex: bool) {
         // Cast from null to data_type
-        {
-            let array = new_null_array(&DataType::Null, 4);
-            assert_eq!(array.data_type(), &DataType::Null);
-            let cast_array = cast(&array, data_type).expect("cast failed");
-            assert_eq!(cast_array.data_type(), data_type);
-            for i in 0..4 {
+        let array = new_null_array(&DataType::Null, 4);
+        assert_eq!(array.data_type(), &DataType::Null);
+        let cast_array = cast(&array, data_type).expect("cast failed");
+        assert_eq!(cast_array.data_type(), data_type);
+        for i in 0..4 {
+            if is_complex {
+                assert!(cast_array.logical_nulls().unwrap().is_null(i));
+            } else {
                 assert!(cast_array.is_null(i));
             }
         }
+    }
+
+    fn cast_from_null_to_other(data_type: &DataType) {
+        cast_from_null_to_other_base(data_type, false);
+    }
+
+    fn cast_from_null_to_other_complex(data_type: &DataType) {
+        cast_from_null_to_other_base(data_type, true);
     }
 
     #[test]
@@ -8255,6 +8197,23 @@ mod tests {
         // Cast null from and to struct
         let data_type = DataType::Struct(vec![Field::new("data", DataType::Int64, false)].into());
         cast_from_null_to_other(&data_type);
+
+        let target_type = DataType::ListView(Arc::new(Field::new("item", DataType::Int32, true)));
+        cast_from_null_to_other(&target_type);
+
+        let target_type =
+            DataType::LargeListView(Arc::new(Field::new("item", DataType::Int32, true)));
+        cast_from_null_to_other(&target_type);
+
+        let fields = UnionFields::from_fields(vec![Field::new("a", DataType::Int64, false)]);
+        let target_type = DataType::Union(fields, UnionMode::Sparse);
+        cast_from_null_to_other_complex(&target_type);
+
+        let target_type = DataType::RunEndEncoded(
+            Arc::new(Field::new("item", DataType::Int32, true)),
+            Arc::new(Field::new("item", DataType::Int32, true)),
+        );
+        cast_from_null_to_other_complex(&target_type);
     }
 
     /// Print the `DictionaryArray` `array` as a vector of strings

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -698,7 +698,29 @@ impl ArrayData {
                         false,
                     )
                 }
-                d => unreachable!("{d}"),
+                // Handled by Some(width) branch above
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Timestamp(_, _)
+                | DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Duration(_)
+                | DataType::Interval(_)
+                | DataType::Decimal32(_, _)
+                | DataType::Decimal64(_, _)
+                | DataType::Decimal128(_, _)
+                | DataType::Decimal256(_, _) => unreachable!("{data_type}"),
             },
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9133

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Allow casting null arrays to all types we support. We missed (large) list view, run end encoded and union.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor from null arm to accept all target types to enable casting to large list view, list view, run end encoded and union types.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No.
