### PR TITLE
docs(variant): fix VariantObject::get documentation to reflect Option return type

### DIFF
--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -390,7 +390,7 @@ impl<'m, 'v> VariantObject<'m, 'v> {
 
     /// Returns the value of the field with the specified name, if any.
     ///
-    /// Returns `Some(Variant)` if the field exists, or `None` if the field does not exist
+    /// Returns `Some(Variant)` if the field exists, or `None` if the field does not exist.
     pub fn get(&self, name: &str) -> Option<Variant<'m, 'v>> {
         // Binary search through the field IDs of this object to find the requested field name.
         //


### PR DESCRIPTION
### Which issue does this PR close?

Closes #9105

### Rationale for this change

The documentation for `VariantObject::get` previously described `Result`-style
semantics (`Ok(None)` / `Err`), but the method actually returns
`Option<Variant>`. This mismatch could confuse users of the API.

### What changes are included in this PR?

- Update the documentation for `VariantObject::get` to correctly describe its
  `Option` return type.
- No functional or behavioral changes are included.
