### PR TITLE
Update ASF copyright year in NOTICE

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Arrow
-Copyright 2016-2019 The Apache Software Foundation
+Copyright 2016-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Closes #9131

This PR updates the Apache Software Foundation copyright year
in `arrow-rs/NOTICE.txt`, as discussed in the release verification
follow-up. No third-party entries are modified.
