### PR TITLE
feat: add null comparison handling in make_comparator

### DIFF
--- a/arrow-ord/src/ord.rs
+++ b/arrow-ord/src/ord.rs
@@ -484,6 +484,7 @@ pub fn make_comparator(
              }
         },
         (Map(_, _), Map(_, _)) => compare_map(left, right, opts),
+        (Null, Null) => Ok(Box::new(|_, _| Ordering::Equal)),
         (Union(_, _), Union(_, _)) => compare_union(left, right, opts),
         (lhs, rhs) => Err(ArrowError::InvalidArgumentError(match lhs == rhs {
             true => format!("The data type type {lhs:?} has no natural order"),
@@ -1500,5 +1501,16 @@ mod tests {
             &out,
             "Cannot compare UnionArrays with different modes: left=Dense, right=Sparse"
         );
+    }
+
+    #[test]
+    fn test_null_array_cmp() {
+        let a = NullArray::new(3);
+        let b = NullArray::new(3);
+        let cmp = make_comparator(&a, &b, SortOptions::default()).unwrap();
+
+        assert_eq!(cmp(0, 0), Ordering::Equal);
+        assert_eq!(cmp(0, 1), Ordering::Equal);
+        assert_eq!(cmp(2, 0), Ordering::Equal);
     }
 }


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

`make_comparator` currently does not support Null data type, returning an error when comparing two NullArrays. This prevents sorting or comparing arrays that contain Null type columns.



<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Add support for Null data type in `make_comparator`. Since all values in a NullArray are semantically null and indistinguishable, any comparison returns `Ordering::Equal`.



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

Yes. `make_comparator` now accepts Null type arrays instead of returning an error. This is a non-breaking enhancement.



<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
