### PR TITLE
Minor: try and avoid an allocation creating `GenericByteViewArray` from `ArrayData`

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -990,16 +990,14 @@ impl<T: ByteViewType + ?Sized> From<ArrayData> for GenericByteViewArray<T> {
     fn from(data: ArrayData) -> Self {
         let (_data_type, len, nulls, offset, buffers, _child_data) = data.into_parts();
 
-        // first buffer is views
-        let views = buffers[0].clone();
-        // remaining buffers are data buffers
-        let buffers = Arc::from_iter(buffers.into_iter().skip(1));
+        let mut buffers = buffers.into_iter();
+        // first buffer is views, remaining are data buffers
+        let views = ScalarBuffer::new(buffers.next().unwrap(), offset, len);
 
-        let views = ScalarBuffer::new(views, offset, len);
         Self {
             data_type: T::DATA_TYPE,
             views,
-            buffers,
+            buffers: Arc::from_iter(buffers),
             nulls,
             phantom: Default::default(),
         }


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/9061
- follow on https://github.com/apache/arrow-rs/pull/9114


# Rationale for this change

@scovich noted in  https://github.com/apache/arrow-rs/pull/9114#discussion_r2683051311 that calling `Vec::remove` does an extra copy and that `Vec::from` doesn't actually reuse the allocation the way I thought it did


# What changes are included in this PR?

Build the Arc for buffers directly

# Are these changes tested?

BY existing tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
