### PR TITLE
Avoid a clone when creating `BooleanArray` from ArrayData

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -389,24 +389,21 @@ impl From<Vec<Option<bool>>> for BooleanArray {
 
 impl From<ArrayData> for BooleanArray {
     fn from(data: ArrayData) -> Self {
+        let (data_type, len, nulls, offset, mut buffers, _child_data) = data.into_parts();
         assert_eq!(
-            data.data_type(),
-            &DataType::Boolean,
-            "BooleanArray expected ArrayData with type {} got {}",
+            data_type,
             DataType::Boolean,
-            data.data_type()
+            "BooleanArray expected ArrayData with type Boolean got {data_type:?}",
         );
         assert_eq!(
-            data.buffers().len(),
+            buffers.len(),
             1,
             "BooleanArray data should contain a single buffer only (values buffer)"
         );
-        let values = BooleanBuffer::new(data.buffers()[0].clone(), data.offset(), data.len());
+        let buffer = buffers.pop().expect("checked above");
+        let values = BooleanBuffer::new(buffer, offset, len);
 
-        Self {
-            values,
-            nulls: data.nulls().cloned(),
-        }
+        Self { values, nulls }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/9061
- broken out of https://github.com/apache/arrow-rs/pull/9058

# Rationale for this change

Let's make arrow-rs the fastest we can and the fewer allocations the better

# What changes are included in this PR?

Apply pattern from https://github.com/apache/arrow-rs/pull/9114 

# Are these changes tested?

Existing tests 

# Are there any user-facing changes?

No