### PR TITLE
Add lossy option to CastOptions for controlling precision loss in casts

### DIFF
--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -346,7 +346,6 @@ mod test {
     use arrow::compute::CastOptions;
     use arrow::datatypes::DataType::{Int16, Int32, Int64};
     use arrow::datatypes::i256;
-    use arrow::util::display::FormatOptions;
     use arrow_schema::DataType::{Boolean, Float32, Float64, Int8};
     use arrow_schema::{DataType, Field, FieldRef, Fields, IntervalUnit, TimeUnit};
     use chrono::DateTime;
@@ -1286,7 +1285,7 @@ mod test {
             .with_as_type(Some(FieldRef::from(field)))
             .with_cast_options(CastOptions {
                 safe: false,
-                format_options: FormatOptions::default(),
+                ..Default::default()
             });
 
         let result = variant_get(&array, options);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9172.


# What changes are included in this PR?

This PR adds `lossy` in `CastOptions`, which aims to control precision loss in casts.


Behavior matrix:

| `safe`  |  `lossy` | Behavior |
| ---     |   ---    |     ---  |
| `true`  |  `false` | Default.  Invalid casts return Null, Lossy casts(e.g., float to int) return NULL. |
 | `true`  |  `true`  | Invalid casts return Null, Lossy casts are allowed (truncation occurs).  |
| `false` |  `false` | Invalid casts return an error. Lossy casts return an error.  |
| `false` |  `true`  | Invalid casts return an error. Lossy casts are allowed (truncation occurs). |



The generated docs

<img width="1183" height="1106" alt="WeChatWorkScreenshot_511c6389-827c-4a4c-a308-551f285785e4" src="https://github.com/user-attachments/assets/8292fb84-8280-4fc5-bd21-3697f392f265" />


# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No tests, this added a new flag.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

Yes, changed the `CastOptions`
