### PR TITLE
Add decimal <-> float16 cast support

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -51,6 +51,9 @@ use crate::cast::list::*;
 use crate::cast::map::*;
 use crate::cast::run_array::*;
 use crate::cast::string::*;
+use arrow_array::types::Float16Type;
+use half::f16;
+
 
 use arrow_buffer::IntervalMonthDayNano;
 use arrow_data::ByteView;
@@ -2356,6 +2359,11 @@ where
         Int16 => cast_decimal_to_integer::<D, Int16Type>(array, base, *scale, cast_options),
         Int32 => cast_decimal_to_integer::<D, Int32Type>(array, base, *scale, cast_options),
         Int64 => cast_decimal_to_integer::<D, Int64Type>(array, base, *scale, cast_options),
+
+
+        Float16 => cast_decimal_to_float::<D, Float16Type, _>(array, |x| {
+        half::f16::from_f64(as_float(x) / 10_f64.powi(*scale as i32))
+        }),
         Float32 => cast_decimal_to_float::<D, Float32Type, _>(array, |x| {
             (as_float(x) / 10_f64.powi(*scale as i32)) as f32
         }),
@@ -2452,6 +2460,16 @@ where
             base,
             cast_options,
         ),
+
+
+         Float16 => cast_floating_point_to_decimal::<_, D>(
+            array.as_primitive::<Float16Type>(),
+            *precision,
+            *scale,
+            cast_options,
+        ),
+
+
         Float32 => cast_floating_point_to_decimal::<_, D>(
             array.as_primitive::<Float32Type>(),
             *precision,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2765,7 +2765,6 @@ mod tests {
     use half::f16;
     use std::sync::Arc;
 
-
     #[test]
     fn test_decimal128_to_float16_cast() {
         use arrow_array::{Decimal128Array, Float16Array};
@@ -2775,19 +2774,11 @@ mod tests {
             .unwrap();
 
         let result = cast(&decimal, &DataType::Float16).unwrap();
-        let float_arr = result
-            .as_any()
-            .downcast_ref::<Float16Array>()
-            .unwrap();
+        let float_arr = result.as_any().downcast_ref::<Float16Array>().unwrap();
 
         assert_eq!(float_arr.len(), 2);
         assert!(float_arr.is_null(1));
     }
-
-
-
-
-
 
     #[derive(Clone)]
     struct DecimalCastTestConfig {

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -213,19 +213,23 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         ) => true,
         // signed numeric to decimal
         (
-            Null | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
+            Null | Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
         ) => true,
+
         // decimal to unsigned numeric
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
             UInt8 | UInt16 | UInt32 | UInt64,
         ) => true,
+
         // decimal to signed numeric
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
-            Null | Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
+            Null | Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
         ) => true,
+
+        
         // decimal to string
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -183,6 +183,9 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
         ) => true,
 
+        // decimal to null
+        (Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _), Null) => true,
+
         // decimal to unsigned numeric
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2765,6 +2765,30 @@ mod tests {
     use half::f16;
     use std::sync::Arc;
 
+
+    #[test]
+    fn test_decimal128_to_float16_cast() {
+        use arrow_array::{Decimal128Array, Float16Array};
+
+        let decimal = Decimal128Array::from(vec![Some(12345), None])
+            .with_precision_and_scale(10, 2)
+            .unwrap();
+
+        let result = cast(&decimal, &DataType::Float16).unwrap();
+        let float_arr = result
+            .as_any()
+            .downcast_ref::<Float16Array>()
+            .unwrap();
+
+        assert_eq!(float_arr.len(), 2);
+        assert!(float_arr.is_null(1));
+    }
+
+
+
+
+
+
     #[derive(Clone)]
     struct DecimalCastTestConfig {
         input_prec: u8,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -179,10 +179,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         ) => true,
         // signed numeric to decimal
         (
-<<<<<<< HEAD
-            Null | Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
-            Int8 | Int16 | Int32 | Int64 | Float32 | Float64,
->>>>>>> main
+            Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
         ) => true,
 
@@ -195,10 +192,9 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         // decimal to signed numeric
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),
-            Null | Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
+            Int8 | Int16 | Int32 | Int64 | Float16 | Float32 | Float64,
         ) => true,
 
-        
         // decimal to string
         (
             Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -52,8 +52,6 @@ use crate::cast::map::*;
 use crate::cast::run_array::*;
 use crate::cast::string::*;
 use arrow_array::types::Float16Type;
-use half::f16;
-
 
 use arrow_buffer::IntervalMonthDayNano;
 use arrow_data::ByteView;
@@ -2360,9 +2358,8 @@ where
         Int32 => cast_decimal_to_integer::<D, Int32Type>(array, base, *scale, cast_options),
         Int64 => cast_decimal_to_integer::<D, Int64Type>(array, base, *scale, cast_options),
 
-
         Float16 => cast_decimal_to_float::<D, Float16Type, _>(array, |x| {
-        half::f16::from_f64(as_float(x) / 10_f64.powi(*scale as i32))
+            half::f16::from_f64(as_float(x) / 10_f64.powi(*scale as i32))
         }),
         Float32 => cast_decimal_to_float::<D, Float32Type, _>(array, |x| {
             (as_float(x) / 10_f64.powi(*scale as i32)) as f32
@@ -2461,14 +2458,12 @@ where
             cast_options,
         ),
 
-
-         Float16 => cast_floating_point_to_decimal::<_, D>(
+        Float16 => cast_floating_point_to_decimal::<_, D>(
             array.as_primitive::<Float16Type>(),
             *precision,
             *scale,
             cast_options,
         ),
-
 
         Float32 => cast_floating_point_to_decimal::<_, D>(
             array.as_primitive::<Float32Type>(),

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -567,8 +567,10 @@ impl DataType {
     /// Returns true if this type is floating: (Float*).
     #[inline]
     pub fn is_floating(&self) -> bool {
-        use DataType::*;
-        matches!(self, Float16 | Float32 | Float64)
+        matches!(
+            self,
+            DataType::Float16 | DataType::Float32 | DataType::Float64
+        )
     }
 
     /// Returns true if this type is integer: (Int*, UInt*).


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9123.

# Rationale for this change

Apache Arrow currently supports casting between decimal and float32/float64 types, but does not support float16.
This PR adds support for casting between decimal and float16 types to provide feature parity with other floating point types.

# What changes are included in this PR?

- Added Float16 → Decimal casting support  
- Added Decimal → Float16 casting support  

# Are these changes tested?

Yes. Existing cast tests pass locally:

cargo test -p arrow-cast

# Are there any user-facing changes?

Yes. Users can now cast between decimal and float16 types using the standard Arrow cast APIs.
