### PR TITLE
Deprecate `ArrowReaderOptions::with_page_index` and update API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,6 @@
 
 # Changelog
 
-## [Unreleased]
-
-**Breaking changes:**
-
-- Deprecate `ArrowReaderOptions::with_page_index` in favor of `with_page_index_policy` to support `PageIndexPolicy` enum with Skip, Optional, and Required policies. The deprecated method converts boolean to Required (true) or Skip (false). Use `with_page_index_policy`, `with_column_index_policy`, or `with_offset_index_policy` for fine-grained control.
-
 ## [57.2.0](https://github.com/apache/arrow-rs/tree/57.2.0) (2026-01-07)
 
 [Full Changelog](https://github.com/apache/arrow-rs/compare/57.1.0...57.2.0)

--- a/parquet/benches/arrow_reader_clickbench.rs
+++ b/parquet/benches/arrow_reader_clickbench.rs
@@ -42,6 +42,7 @@ use parquet::arrow::arrow_reader::{
     ParquetRecordBatchReaderBuilder, RowFilter,
 };
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::schema::types::SchemaDescriptor;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
@@ -847,7 +848,7 @@ fn column_indices(schema: &SchemaDescriptor, column_names: &Vec<&str>) -> Vec<us
 /// Loads Parquet metadata from the given path, including page indexes
 fn load_metadata(path: &Path) -> ArrowReaderMetadata {
     let file = std::fs::File::open(path).unwrap();
-    let options = ArrowReaderOptions::new().with_page_index(true);
+    let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
     let orig_metadata =
         ArrowReaderMetadata::load(&file, options.clone()).expect("parquet-metadata loading failed");
 

--- a/parquet/benches/arrow_statistics.rs
+++ b/parquet/benches/arrow_statistics.rs
@@ -24,7 +24,10 @@ use arrow_schema::{
     Field, Schema,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use parquet::{arrow::arrow_reader::ArrowReaderOptions, file::properties::WriterProperties};
+use parquet::{
+    arrow::arrow_reader::ArrowReaderOptions,
+    file::{metadata::PageIndexPolicy, properties::WriterProperties},
+};
 use parquet::{
     arrow::{ArrowWriter, arrow_reader::ArrowReaderBuilder},
     file::properties::EnabledStatistics,
@@ -195,7 +198,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         for data_page_row_count_limit in &data_page_row_count_limits {
             let file = create_parquet_file(dtype.clone(), row_groups, data_page_row_count_limit);
             let file = file.reopen().unwrap();
-            let options = ArrowReaderOptions::new().with_page_index(true);
+            let options =
+                ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
             let reader = ArrowReaderBuilder::try_new_with_options(file, options).unwrap();
             let metadata = reader.metadata();
             let row_groups = metadata.row_groups();

--- a/parquet/examples/external_metadata.rs
+++ b/parquet/examples/external_metadata.rs
@@ -189,7 +189,7 @@ async fn read_remote_parquet_file_with_metadata(
 ) -> Vec<RecordBatch> {
     let options = ArrowReaderOptions::new()
         // tell the reader to read the page index
-        .with_page_index(true);
+        .with_page_index_policy(PageIndexPolicy::from(true));
     // create a reader with pre-existing metadata
     let arrow_reader_metadata = ArrowReaderMetadata::try_new(metadata.into(), options).unwrap();
     let reader =

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -47,6 +47,7 @@ use parquet::arrow::arrow_reader::{
 use parquet::arrow::{ArrowWriter, ProjectionMask};
 use parquet::data_type::AsBytes;
 use parquet::file::FOOTER_SIZE;
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::{FooterTail, ParquetMetaData, ParquetOffsetIndex};
 use parquet::file::page_index::offset_index::PageLocation;
 use parquet::file::properties::WriterProperties;
@@ -73,7 +74,7 @@ fn test_file() -> TestParquetFile {
 ///
 /// Note these tests use the PageIndex to reduce IO
 fn test_options() -> ArrowReaderOptions {
-    ArrowReaderOptions::default().with_page_index(true)
+    ArrowReaderOptions::default().with_page_index_policy(PageIndexPolicy::from(true))
 }
 
 /// Return a row filter that evaluates "b > 575" AND "b < 625"
@@ -189,7 +190,7 @@ impl TestParquetFile {
         // Read the parquet file to determine its layout
         let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(
             bytes.clone(),
-            ArrowReaderOptions::default().with_page_index(true),
+            ArrowReaderOptions::default().with_page_index_policy(PageIndexPolicy::from(true)),
         )
         .unwrap();
 

--- a/parquet/tests/arrow_reader/io/sync_reader.rs
+++ b/parquet/tests/arrow_reader/io/sync_reader.rs
@@ -27,6 +27,7 @@ use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::{
     ArrowReaderOptions, ParquetRecordBatchReaderBuilder, RowSelection, RowSelector,
 };
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::reader::{ChunkReader, Length};
 use std::io::Read;
 use std::sync::Arc;
@@ -122,7 +123,7 @@ fn test_read_single_column() {
 #[test]
 fn test_read_single_column_no_page_index() {
     let test_file = test_file();
-    let options = test_options().with_page_index(false);
+    let options = test_options().with_page_index_policy(PageIndexPolicy::from(false));
     let builder = sync_builder(&test_file, options);
     let schema_descr = builder.metadata().file_metadata().schema_descr_ptr();
     let builder = builder.with_projection(ProjectionMask::columns(&schema_descr, ["b"]));

--- a/parquet/tests/arrow_reader/predicate_cache.rs
+++ b/parquet/tests/arrow_reader/predicate_cache.rs
@@ -33,7 +33,7 @@ use parquet::arrow::arrow_reader::{ArrowPredicateFn, ArrowReaderOptions, RowFilt
 use parquet::arrow::arrow_reader::{ArrowReaderBuilder, ParquetRecordBatchReaderBuilder};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder, ProjectionMask};
-use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData, ParquetMetaDataReader};
+use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use parquet::file::properties::WriterProperties;
 use std::ops::Range;
 use std::sync::Arc;
@@ -356,9 +356,14 @@ impl AsyncFileReader for TestReader {
         &'a mut self,
         options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
-        let metadata_reader = ParquetMetaDataReader::new().with_page_index_policy(
-            PageIndexPolicy::from(options.is_some_and(|o| o.page_index())),
-        );
+        let mut metadata_reader = ParquetMetaDataReader::new();
+
+        if let Some(options) = options {
+            metadata_reader = metadata_reader
+                .with_column_index_policy(options.column_index_policy())
+                .with_offset_index_policy(options.offset_index_policy());
+        }
+
         self.metadata = Some(Arc::new(
             metadata_reader.parse_and_finish(&self.data).unwrap(),
         ));

--- a/parquet/tests/arrow_reader/statistics.rs
+++ b/parquet/tests/arrow_reader/statistics.rs
@@ -46,6 +46,7 @@ use parquet::arrow::arrow_reader::statistics::StatisticsConverter;
 use parquet::arrow::arrow_reader::{
     ArrowReaderBuilder, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
 };
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::file::statistics::{Statistics, ValueStatistics};
@@ -145,7 +146,7 @@ fn build_parquet_file(
     let _file_meta = writer.close().unwrap();
 
     let file = output_file.reopen().unwrap();
-    let options = ArrowReaderOptions::new().with_page_index(true);
+    let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
     ArrowReaderBuilder::try_new_with_options(file, options).unwrap()
 }
 
@@ -170,7 +171,7 @@ impl TestReader {
 
         // open the file & get the reader
         let file = file.reopen().unwrap();
-        let options = ArrowReaderOptions::new().with_page_index(true);
+        let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
         ArrowReaderBuilder::try_new_with_options(file, options).unwrap()
     }
 }

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -24,6 +24,7 @@ use bytes::Bytes;
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};
 use parquet::basic::{Encoding, PageType};
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::{ReaderProperties, WriterProperties};
 use parquet::file::reader::SerializedPageReader;
@@ -68,7 +69,8 @@ fn do_test(test: LayoutTest) {
     let b = Bytes::from(buf);
 
     // Re-read file to decode column index
-    let read_options = ArrowReaderOptions::new().with_page_index(true);
+    let read_options =
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
     let reader =
         ParquetRecordBatchReaderBuilder::try_new_with_options(b.clone(), read_options).unwrap();
 

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -34,6 +34,7 @@ use parquet::data_type::{ByteArray, ByteArrayType};
 use parquet::encryption::decrypt::FileDecryptionProperties;
 use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::errors::ParquetError;
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
@@ -453,7 +454,7 @@ fn uniform_encryption_roundtrip(
 
     let options = ArrowReaderOptions::new()
         .with_file_decryption_properties(decryption_properties)
-        .with_page_index(page_index);
+        .with_page_index_policy(PageIndexPolicy::from(page_index));
 
     let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(file, options)?;
     assert_eq!(&row_group_sizes(builder.metadata()), &[50, 50, 50]);
@@ -557,7 +558,7 @@ fn uniform_encryption_page_skipping(page_index: bool) -> parquet::errors::Result
 
     let options = ArrowReaderOptions::new()
         .with_file_decryption_properties(decryption_properties)
-        .with_page_index(page_index);
+        .with_page_index_policy(PageIndexPolicy::from(page_index));
 
     let builder = ParquetRecordBatchReaderBuilder::try_new_with_options(file, options)?;
 
@@ -1041,7 +1042,7 @@ fn test_decrypt_page_index(
     let file = File::open(path)?;
     let options = ArrowReaderOptions::default()
         .with_file_decryption_properties(decryption_properties)
-        .with_page_index(true);
+        .with_page_index_policy(PageIndexPolicy::from(true));
 
     let arrow_metadata = ArrowReaderMetadata::load(&file, options)?;
 

--- a/parquet/tests/encryption/encryption_async.rs
+++ b/parquet/tests/encryption/encryption_async.rs
@@ -35,6 +35,7 @@ use parquet::arrow::{
 use parquet::encryption::decrypt::FileDecryptionProperties;
 use parquet::encryption::encrypt::FileEncryptionProperties;
 use parquet::errors::ParquetError;
+use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::ParquetMetaData;
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::file::writer::SerializedFileWriter;
@@ -439,7 +440,7 @@ async fn test_decrypt_page_index(
 
     let options = ArrowReaderOptions::new()
         .with_file_decryption_properties(decryption_properties)
-        .with_page_index(true);
+        .with_page_index_policy(PageIndexPolicy::from(true));
 
     let arrow_metadata = ArrowReaderMetadata::load_async(&mut file, options).await?;
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/9197

# Rationale for this change

This PR deprecates `ArrowReaderOptions::with_page_index(bool)` in favor of `with_page_index_policy(PageIndexPolicy)` to align with the `ParquetMetadataReader` api. The underlying implementation continues to use separate `column_index` and `offset_index` fields



# Are there any user-facing changes?

Yes, some methods are deprecated