### PR TITLE
fix: avoid panic in `RunEndBuffer::sliced_values` for empty run arrays

### DIFF
--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -642,6 +642,7 @@ mod tests {
     use super::*;
     use crate::builder::PrimitiveRunBuilder;
     use crate::cast::AsArray;
+    use crate::new_empty_array;
     use crate::types::{Int8Type, UInt32Type};
     use crate::{Int16Array, Int32Array, StringArray};
 
@@ -737,6 +738,26 @@ mod tests {
 
         let run_ends = ree_array.run_ends();
         assert_eq!(run_ends.values(), &run_ends_values);
+    }
+
+    #[test]
+    fn test_run_array_empty() {
+        let runs = new_empty_array(&DataType::Int16);
+        let runs = runs.as_primitive::<Int16Type>();
+        let values = new_empty_array(&DataType::Int64);
+        let array = RunArray::try_new(runs, &values).unwrap();
+
+        fn assertions(array: &RunArray<Int16Type>) {
+            assert!(array.is_empty());
+            assert_eq!(array.get_start_physical_index(), 0);
+            assert_eq!(array.get_end_physical_index(), 0);
+            assert!(array.get_physical_indices::<i16>(&[]).unwrap().is_empty());
+            assert!(array.run_ends().is_empty());
+            assert_eq!(array.run_ends().sliced_values().count(), 0);
+        }
+
+        assertions(&array);
+        assertions(&array.slice(0, 0));
     }
 
     #[test]

--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -199,9 +199,18 @@ where
     pub fn sliced_values(&self) -> impl Iterator<Item = E> + '_ {
         let offset = self.logical_offset;
         let len = self.logical_length;
-        let start = self.get_start_physical_index();
-        let end = self.get_end_physical_index();
-        self.run_ends[start..=end].iter().map(move |&val| {
+
+        // Doing this roundabout way since the iterator type we return must be
+        // the same (i.e. cannot use std::iter::empty())
+        let range = if self.is_empty() {
+            0..0
+        } else {
+            let start = self.get_start_physical_index();
+            let end = self.get_end_physical_index() + 1;
+            start..end
+        };
+
+        self.run_ends[range].iter().map(move |&val| {
             let val = val.as_usize().saturating_sub(offset).min(len);
             E::from_usize(val).unwrap()
         })


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- N/A

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Reviewing https://github.com/apache/arrow-rs/pull/9182 made me realize we didn't account for empty run arrays in the recent fix for accounting for sliced run arrays in kernels

- https://github.com/apache/arrow-rs/pull/9036

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix `RunEndBuffer::sliced_values` to return an empty iterator when the buffer is empty (previously panicked)

Also add some tests for empty run arrays

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No
