### PR TITLE
Support casting negative scale decimals to numeric

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -849,13 +849,14 @@ where
                     } else {
                         let v = array.value(i).mul_checked(div)?;
 
-                        let value = <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "value of {:?} is out of range {}",
-                                v,
-                                T::DATA_TYPE
-                            ))
-                        })?;
+                        let value =
+                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
+                                ArrowError::CastError(format!(
+                                    "value of {:?} is out of range {}",
+                                    v,
+                                    T::DATA_TYPE
+                                ))
+                            })?;
 
                         value_builder.append_value(value);
                     }
@@ -885,13 +886,14 @@ where
                     } else {
                         let v = array.value(i).div_checked(div)?;
 
-                        let value = <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
-                            ArrowError::CastError(format!(
-                                "value of {:?} is out of range {}",
-                                v,
-                                T::DATA_TYPE
-                            ))
-                        })?;
+                        let value =
+                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
+                                ArrowError::CastError(format!(
+                                    "value of {:?} is out of range {}",
+                                    v,
+                                    T::DATA_TYPE
+                                ))
+                            })?;
 
                         value_builder.append_value(value);
                     }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3928,7 +3928,13 @@ mod tests {
             &array,
             Int64Array,
             &DataType::Int64,
-            vec![Some(125_000), Some(225_000), Some(325_000), None, Some(525_000)]
+            vec![
+                Some(125_000),
+                Some(225_000),
+                Some(325_000),
+                None,
+                Some(525_000)
+            ]
         );
 
         let value_array: Vec<Option<i64>> = vec![Some(12), Some(34), None];
@@ -3940,8 +3946,7 @@ mod tests {
             vec![Some(120_000_000_000), Some(340_000_000_000), None]
         );
 
-        let value_array: Vec<Option<i128>> =
-            vec![Some(125), Some(225), Some(325), None, Some(525)];
+        let value_array: Vec<Option<i128>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal128_array(value_array, 38, -4).unwrap();
         generate_cast_test_case!(
             &array,


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9201 .

# Rationale for this change

Casting decimals with negative scale to integer types currently errors because the scale factor is always applied as a division. Negative scales represent powers of ten that should scale the integer value up, so the cast should multiply instead.

# What changes are included in this PR?

- Apply the scale factor using multiplication when scale < 0 in cast_decimal_to_integer.

# Are these changes tested?

Yes, the test given by issue is passed.
```
// arrow-cast/src/cast/mod.rs
    #[test]
    fn test_cast_decimal_to_numeric_negative_scale() {
        let value_array: Vec<Option<i256>> = vec![
            Some(i256::from_i128(125)),
            Some(i256::from_i128(225)),
            Some(i256::from_i128(325)),
            None,
            Some(i256::from_i128(525)),
        ];
        let array = create_decimal256_array(value_array, 38, -1).unwrap();

        generate_cast_test_case!(
            &array,
            Int64Array,
            &DataType::Int64,
            vec![Some(1_250), Some(2_250), Some(3_250), None, Some(5_250)]
        );
    }
```

# Are there any user-facing changes?

No.