### PR TITLE
Add benchmarks for reading struct arrays from parquet

### DIFF
--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -88,6 +88,12 @@ fn build_test_schema() -> SchemaDescPtr {
             OPTIONAL INT32 optional_int16_leaf (INTEGER(16, true));
             REQUIRED INT64 mandatory_uint64_leaf (INTEGER(64, false));
             OPTIONAL INT64 optional_uint64_leaf (INTEGER(64, false));
+            REQUIRED GROUP mandatory_struct_optional_int32_leaf {
+                OPTIONAL INT32 element;
+            }
+            OPTIONAL GROUP optional_struct_optional_int32_leaf {
+                OPTIONAL INT32 element;
+            }
         }
         ";
     parse_message_type(message_type)
@@ -1174,6 +1180,98 @@ fn bench_primitive<T>(
     });
 }
 
+// Benchmark reading a struct with a single primitive field.
+// No need to bench all encodings for the data, as that should already be covered by `bench_primitive`.
+// The only performance difference should be caused by the additional definition level.
+fn bench_struct_primitive<T>(
+    group: &mut BenchmarkGroup<WallTime>,
+    mandatory_column_desc: &ColumnDescPtr,
+    optional_column_desc: &ColumnDescPtr,
+    min: usize,
+    max: usize,
+) where
+    T: parquet::data_type::DataType,
+    T::T: SampleUniform + FromPrimitive + Copy,
+{
+    let mut count: usize = 0;
+
+    let data = build_encoded_primitive_page_iterator::<T>(
+        mandatory_column_desc.clone(),
+        0.0,
+        Encoding::PLAIN,
+        min,
+        max,
+    );
+    group.bench_function(
+        "plain encoded, mandatory struct, optional data, no NULLs",
+        |b| {
+            b.iter(|| {
+                let array_reader =
+                    create_primitive_array_reader(data.clone(), mandatory_column_desc.clone());
+                count = bench_array_reader(array_reader);
+            });
+            assert_eq!(count, EXPECTED_VALUE_COUNT);
+        },
+    );
+
+    let data = build_encoded_primitive_page_iterator::<T>(
+        optional_column_desc.clone(),
+        0.0,
+        Encoding::PLAIN,
+        min,
+        max,
+    );
+    group.bench_function(
+        "plain encoded, optional struct, optional data, no NULLs",
+        |b| {
+            b.iter(|| {
+                let array_reader =
+                    create_primitive_array_reader(data.clone(), optional_column_desc.clone());
+                count = bench_array_reader(array_reader);
+            });
+            assert_eq!(count, EXPECTED_VALUE_COUNT);
+        },
+    );
+
+    let data = build_encoded_primitive_page_iterator::<T>(
+        mandatory_column_desc.clone(),
+        0.5,
+        Encoding::PLAIN,
+        min,
+        max,
+    );
+    group.bench_function(
+        "plain encoded, mandatory struct, optional data, half NULLs",
+        |b| {
+            b.iter(|| {
+                let array_reader =
+                    create_primitive_array_reader(data.clone(), mandatory_column_desc.clone());
+                count = bench_array_reader(array_reader);
+            });
+            assert_eq!(count, EXPECTED_VALUE_COUNT);
+        },
+    );
+
+    let data = build_encoded_primitive_page_iterator::<T>(
+        optional_column_desc.clone(),
+        0.5,
+        Encoding::PLAIN,
+        min,
+        max,
+    );
+    group.bench_function(
+        "plain encoded, optional struct, optional data, half NULLs",
+        |b| {
+            b.iter(|| {
+                let array_reader =
+                    create_primitive_array_reader(data.clone(), optional_column_desc.clone());
+                count = bench_array_reader(array_reader);
+            });
+            assert_eq!(count, EXPECTED_VALUE_COUNT);
+        },
+    );
+}
+
 fn float16_benches(c: &mut Criterion) {
     let schema = build_test_schema();
 
@@ -1304,6 +1402,8 @@ fn add_benches(c: &mut Criterion) {
     let optional_int16_column_desc = schema.column(36);
     let mandatory_uint64_column_desc = schema.column(37);
     let optional_uint64_column_desc = schema.column(38);
+    let mandatory_struct_optional_in32_column_desc = schema.column(39);
+    let optional_struct_optional_in32_column_desc = schema.column(40);
 
     // primitive / int32 benchmarks
     // =============================
@@ -1392,6 +1492,16 @@ fn add_benches(c: &mut Criterion) {
         &mut group,
         &mandatory_uint64_column_desc,
         &optional_uint64_column_desc,
+        0,
+        1000,
+    );
+    group.finish();
+
+    let mut group = c.benchmark_group("arrow_array_reader/struct/Int32Array");
+    bench_struct_primitive::<Int32Type>(
+        &mut group,
+        &mandatory_struct_optional_in32_column_desc,
+        &optional_struct_optional_in32_column_desc,
         0,
         1000,
     );


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9209.

# Rationale for this change

Improve the performance benchmark coverage.

# What changes are included in this PR?


# Are these changes tested?

Benchmark results on my machine, without target specific optimizations:

```
arrow_array_reader/Int32Array/plain encoded, mandatory, no NULLs
                        time:   [8.5123 µs 8.5218 µs 8.5321 µs]

arrow_array_reader/Int32Array/plain encoded, optional, no NULLs
                        time:   [12.843 µs 12.863 µs 12.885 µs]

arrow_array_reader/Int32Array/plain encoded, optional, half NULLs
                        time:   [64.977 µs 65.108 µs 65.267 µs]

arrow_array_reader/struct/Int32Array/plain encoded, mandatory struct, optional data, no NULLs
                        time:   [14.456 µs 14.473 µs 14.491 µs]

arrow_array_reader/struct/Int32Array/plain encoded, optional struct, optional data, no NULLs
                        time:   [173.14 µs 173.68 µs 174.23 µs]

arrow_array_reader/struct/Int32Array/plain encoded, mandatory struct, optional data, half NULLs
                        time:   [65.636 µs 65.780 µs 65.906 µs]

arrow_array_reader/struct/Int32Array/plain encoded, optional struct, optional data, half NULLs
                        time:   [433.95 µs 434.29 µs 434.67 µs]
```

I think these show that a mandatory struct has negligible overhead compared to a non-nested primitive column. But an optional struct, even if its definition level is always valid, has a significant overhead.

# Are there any user-facing changes?

no