### PR TITLE
[Parquet] perf: reuse seeked File clone in ChunkReader::get_read()

### DIFF
--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -93,7 +93,7 @@ impl ChunkReader for File {
     fn get_read(&self, start: u64) -> Result<Self::T> {
         let mut reader = self.try_clone()?;
         reader.seek(SeekFrom::Start(start))?;
-        Ok(BufReader::new(self.try_clone()?))
+        Ok(BufReader::new(reader))
     }
 
     fn get_bytes(&self, start: u64, length: usize) -> Result<Bytes> {


### PR DESCRIPTION
# Which issue does this PR close?
N/A, it's a minor performance fix.

# Rationale for this change
While reviewing Parquet performance, I observed a duplicate `try_clone()`. I wasn't able to tell why it was required. After benchmarking and running tests, it seems there is no reason for the duplication.
`ChunkReader::get_read()` for `File` calls [`try_clone()`](https://doc.rust-lang.org/std/fs/struct.File.html#method.try_clone) twice: once to seek, then again for the `BufReader`, discarding the first clone. This might be wasteful, as each `try_clone()` duplicates the file descriptor via a system call. So, one less dup() syscall per get_read() call.

# What changes are included in this PR?
Reuse the already-seeked file clone instead of creating a new one.

# Are these changes tested?
Covered by existing tests. 
Local benchmarks using [divan](https://github.com/nvzqz/divan) show ~36% improvement for `get_read()` calls on my laptop.

# Are there any user-facing changes?
 No.
