### PR TITLE
Remove dead code to fix clippy failure on main

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -921,24 +921,6 @@ pub fn new_null_array(data_type: &DataType, length: usize) -> ArrayRef {
     make_array(ArrayData::new_null(data_type, length))
 }
 
-/// Helper function that gets offset from an [`ArrayData`]
-///
-/// # Safety
-///
-/// - ArrayData must contain a valid [`OffsetBuffer`] as its first buffer
-unsafe fn get_offsets<O: ArrowNativeType>(data: &ArrayData) -> OffsetBuffer<O> {
-    match data.is_empty() && data.buffers()[0].is_empty() {
-        true => OffsetBuffer::new_empty(),
-        false => {
-            let buffer =
-                ScalarBuffer::new(data.buffers()[0].clone(), data.offset(), data.len() + 1);
-            // Safety:
-            // ArrayData is valid
-            unsafe { OffsetBuffer::new_unchecked(buffer) }
-        }
-    }
-}
-
 /// Helper function that creates an [`OffsetBuffer`] from a buffer and array offset/ length
 ///
 /// # Safety


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change
Clippy is failing on main: https://github.com/apache/arrow-rs/actions/runs/21112104909/job/60712213339


```
error: function `get_offsets` is never used
   --> arrow-array/src/array/mod.rs:929:11
    |
929 | unsafe fn get_offsets<O: ArrowNativeType>(data: &ArrayData) -> OffsetBuffer<O> {
    |           ^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`

```

This is due to a logical conflict with some of my PRs (that migrated to use a different version of this function, and now this one is not used)

# What changes are included in this PR?

remove the unused method

# Are these changes tested?


# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
