### PR TITLE
Add additional test coverage for  `BatchCoalescer` push_batch_with_filter

### DIFF
--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -1469,11 +1469,11 @@ mod tests {
                 .into_iter()
                 .flat_map(|batch| [empty_batch.clone(), batch])
                 .collect();
-            let emtpy_filter = BooleanArray::builder(0).finish();
+            let empty_filters = BooleanArray::builder(0).finish();
             self.filters = self
                 .filters
                 .into_iter()
-                .flat_map(|filter| [emtpy_filter.clone(), filter])
+                .flat_map(|filter| [empty_filters.clone(), filter])
                 .collect();
             self.with_description("empty batches inserted")
         }
@@ -1488,6 +1488,7 @@ mod tests {
             let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
             RecordBatch::try_new_with_options(batch.schema(), new_columns, &options).unwrap()
         }
+
         fn remove_nulls_from_array(array: &ArrayRef) -> ArrayRef {
             make_array(array.to_data().into_builder().nulls(None).build().unwrap())
         }
@@ -1505,7 +1506,6 @@ mod tests {
 
                 let single_column_batches = self.input_batches.iter().map(|batch| {
                     let single_column = batch.column_by_name(column.name()).unwrap();
-
                     RecordBatch::try_new(
                         Arc::clone(&single_column_schema),
                         vec![single_column.clone()],


### PR DESCRIPTION

# Which issue does this PR close?


- part of https://github.com/apache/arrow-rs/issues/9136 from @Dandandan 

# Rationale for this change

This PR from @Dandandan adds a bunch of (very cool) special casess for filtering in the coalescer:
- https://github.com/apache/arrow-rs/pull/8951

However, these new special cases are not covered by existing tests, so let's increase the coverage


# What changes are included in this PR?

Add coverage for the following cases

// 1. non-null fast path
// 2. Empty batches
// 3. One column (from the batch)

I also added names to the tests as now each test is run in several different permutations so I wanted to assist debugging

# Are these changes tested?

All the tests pass (which is verified by CI)

I verified coverge of the special cases with 
```
cargo llvm-cov test --html -p arrow-select
```

# Are there any user-facing changes?

No, this is test change only