### PR TITLE
Json comma fix

### DIFF
--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -415,12 +415,8 @@ impl TapeDecoder {
                         break;
                     }
 
-                    let b = match iter.next_non_whitespace() {
-                        Some(b) => b,
-                        None => break,
-                    };
-
                     // Start of row
+                    let b = next_non_whitespace!(iter);
                     self.cur_row += 1;
 
                     // Detect value type and push appropriate state

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -753,9 +753,9 @@ impl Iterator for BufIter<'_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let b = self.peek();
+        let b = self.peek()?;
         self.pos += 1;
-        b
+        Some(b)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -734,44 +734,26 @@ impl<'a> BufIter<'a> {
         }
     }
 
-    // Skip to the next non-whitespace char and return a peek at it
+    // Advance to the next non-whitespace char and peek at it
     fn skip_whitespace(&mut self) -> Option<u8> {
-        let s = self.as_slice();
-        match s
-            .iter()
-            .copied()
-            .enumerate()
-            .find(|(_, b)| !json_whitespace(*b))
-        {
-            Some((x, b)) => {
-                self.advance(x);
-                Some(b)
+        for b in self.as_slice() {
+            if !json_whitespace(*b) {
+                return Some(*b);
             }
-            None => {
-                self.advance(s.len());
-                None
-            }
+            self.pos += 1;
         }
+        None
     }
 
-    // Advance to and consume the next non-whitespace char
+    // Advance to the next non-whitespace char and consume it
     fn next_non_whitespace(&mut self) -> Option<u8> {
-        let s = self.as_slice();
-        match s
-            .iter()
-            .copied()
-            .enumerate()
-            .find(|(_, b)| !json_whitespace(*b))
-        {
-            Some((x, b)) => {
-                self.advance(x + 1);
-                Some(b)
-            }
-            None => {
-                self.advance(s.len());
-                None
+        for b in self.as_slice() {
+            self.pos += 1;
+            if !json_whitespace(*b) {
+                return Some(*b);
             }
         }
+        None
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/9204

# Rationale for this change

It's not good to tolerate obviously ill-formed JSON like `[,,, 10,,, 20,,,]`

# What changes are included in this PR?

Reject leading and repeated commas while still tolerating at most one trailing comma, since that's a common and intuitive case.

While we're at it, optimize the tape decoder state machine to eliminate redundant decision-making. The performance benefits from that optimization compensate for the performance loss due to checking separately from commas.

# Are these changes tested?

Yes, new unit tests cover the expected behavior change and benchmarking shows moderate overall improvement in performance. Exception: the three `xxx_hex_json` variants are very noisy and show anything from 15% speedup to 20% slowdown from run to run. But as far as I can tell they are all tape-decoding the exact same input JSON values, and any performance differences in the tape decoder should affect them equally. This leads me to conclude that those three benchmark cases are just plain unstable.

# Are there any user-facing changes?

JSON parsing now rejects ill-formed JSON it used to accept. Not sure if this might merit a documentation change?