### PR TITLE
[Parquet] Add test for reading/writing long UTF8 StringViews

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -1810,11 +1810,16 @@ mod tests {
         let raw_string_values = vec!["foo", long.as_str(), "bar"];
         let raw_binary_values = vec![b"foo".to_vec(), long.as_bytes().to_vec(), b"bar".to_vec()];
 
-        let string_view_values = StringViewArray::from(raw_string_values);
-        let binary_view_values = BinaryViewArray::from_iter_values(raw_binary_values);
+        let string_view_values: ArrayRef = Arc::new(StringViewArray::from(raw_string_values));
+        let binary_view_values: ArrayRef =
+            Arc::new(BinaryViewArray::from_iter_values(raw_binary_values));
+
+        one_column_roundtrip(Arc::clone(&string_view_values), false);
+        one_column_roundtrip(Arc::clone(&binary_view_values), false);
+
         let batch = RecordBatch::try_new(
             Arc::new(schema),
-            vec![Arc::new(string_view_values), Arc::new(binary_view_values)],
+            vec![string_view_values, binary_view_values],
         )
         .unwrap();
 


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/arrow-rs/pull/9236


# Rationale for this change

While reviewing https://github.com/apache/arrow-rs/pull/9236 from @Dandandan I found (with codex's help) that the UTF8 validation for long strings was slightly different. 

This test shows the problem (it passes on main but fails on the current PR)

# What changes are included in this PR?

Add new test

# Are these changes tested?

yes only tests 
# Are there any user-facing changes?

No