### PR TITLE
parquet: reader datapage v2 skip decoder set up if all values are nulls

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -232,6 +232,9 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
     }
 
     fn read(&mut self, out: &mut Self::Buffer, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let decoder = self
             .decoder
             .as_mut()
@@ -241,6 +244,9 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
     }
 
     fn skip_values(&mut self, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let decoder = self
             .decoder
             .as_mut()

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -192,6 +192,9 @@ impl ColumnValueDecoder for ByteViewArrayColumnValueDecoder {
     }
 
     fn read(&mut self, out: &mut Self::Buffer, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let decoder = self
             .decoder
             .as_mut()
@@ -201,6 +204,9 @@ impl ColumnValueDecoder for ByteViewArrayColumnValueDecoder {
     }
 
     fn skip_values(&mut self, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let decoder = self
             .decoder
             .as_mut()

--- a/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
+++ b/parquet/src/arrow/array_reader/fixed_len_byte_array.rs
@@ -406,6 +406,10 @@ impl ColumnValueDecoder for ValueDecoder {
             None => out.byte_length = Some(self.byte_length),
         }
 
+        if num_values == 0 {
+            return Ok(0);
+        }
+
         match self.decoder.as_mut().unwrap() {
             Decoder::Plain { offset, buf } => {
                 let to_read =
@@ -466,6 +470,9 @@ impl ColumnValueDecoder for ValueDecoder {
     }
 
     fn skip_values(&mut self, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         match self.decoder.as_mut().unwrap() {
             Decoder::Plain { offset, buf } => {
                 let to_read = num_values.min((buf.len() - *offset) / self.byte_length);

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -527,12 +527,18 @@ where
                                 )?;
                             }
 
-                            self.values_decoder.set_data(
-                                encoding,
-                                buf.slice((rep_levels_byte_len + def_levels_byte_len) as usize..),
-                                num_values as usize,
-                                Some((num_values - num_nulls) as usize),
-                            )?;
+                            // OPTIMIZATION: only do values decoder setup for pages that is not all-null
+                            if num_nulls != num_values {
+                                self.values_decoder.set_data(
+                                    encoding,
+                                    buf.slice(
+                                        (rep_levels_byte_len + def_levels_byte_len) as usize..,
+                                    ),
+                                    num_values as usize,
+                                    Some((num_values - num_nulls) as usize),
+                                )?;
+                            }
+
                             return Ok(true);
                         }
                     };

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -229,6 +229,9 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     }
 
     fn read(&mut self, out: &mut Self::Buffer, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let encoding = self
             .current_encoding
             .expect("current_encoding should be set");
@@ -246,6 +249,9 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
     }
 
     fn skip_values(&mut self, num_values: usize) -> Result<usize> {
+        if num_values == 0 {
+            return Ok(0);
+        }
         let encoding = self
             .current_encoding
             .expect("current_encoding should be set");


### PR DESCRIPTION
# Which issue does this PR close?


- Closes #NNN.

# Rationale for this change

the Page Header of datapage v2 has num values and num nulls if all values are null we can skip setting up decoder.

# What changes are included in this PR?
- some early exits after decoder skipped


# Are these changes tested?


# Are there any user-facing changes?

no
