### PR TITLE
Implement a more generic from_nested_iter method for list arrays

### DIFF
--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -432,7 +432,6 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     /// # use arrow_array::ListArray;
     /// # use arrow_array::types::Int32Type;
     /// # use arrow_array::builder::StringDictionaryBuilder;
-    ///
     /// let data = vec![
     ///    Some(vec![Some("foo"), Some("bar"), Some("baz")]),
     ///    None,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9267.

# Rationale for this change

Implement a convenient function to create list arrays of many more types from nested iterators.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

yes, new tests added and the existing `from_iter_primitive` delegates to the new method for additional converage.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

No breaking changes. The `from_iter_primitive` could potentially get deprecated.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
