### PR TITLE
doc: change take index out of range access to be undefined behavior and not guarantee panic

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -63,7 +63,7 @@ use num_traits::{One, Zero};
 ///
 /// # Safety
 ///
-/// When `options` is not set to check bounds, taking indexes after `len` will panic.
+/// When `options` is not set to check bounds, taking indexes after `len` is *undefined behavior*.
 ///
 /// # See also
 /// * [`BatchCoalescer`]: to filter multiple [`RecordBatch`] and coalesce
@@ -132,7 +132,7 @@ pub fn take(
 ///
 /// # Safety
 ///
-/// When `options` is not set to check bounds, taking indexes after `len` will panic.
+/// When `options` is not set to check bounds, taking indexes after `len` is *undefined behavior*.
 ///
 /// # Examples
 /// ```
@@ -1007,6 +1007,9 @@ to_indices_reinterpret!(Int64Type, UInt64Type);
 /// Take rows by index from [`RecordBatch`] and returns a new [`RecordBatch`] from those indexes.
 ///
 /// This function will call [`take`] on each array of the [`RecordBatch`] and assemble a new [`RecordBatch`].
+///
+/// # Safety
+/// taking indexes after `len` is *undefined behavior*.
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

I want to add some optimizations that uses `get_unchecked` but the safety comment says that we panic on out of range access which might not be the case for `get_unchecked`.

for example this pr:
- #9277

# What changes are included in this PR?

Update safety note

# Are these changes tested?

No

# Are there any user-facing changes?

Yes, we no longer guarantee that out of range will panic and instead it can lead to undefined behavior, which the user might not be able to catch