### PR TITLE
chore: upgrade object-store 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ rusty-tags.vi
 .idea/
 .vscode
 .devcontainer
+.zed
 venv/*
 # created by doctests
 parquet/data.parquet

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -49,7 +49,7 @@ parquet-variant = { workspace = true, optional = true }
 parquet-variant-json = { workspace = true, optional = true }
 parquet-variant-compute = { workspace = true, optional = true }
 
-object_store = { version = "0.12.0", default-features = false, optional = true }
+object_store = { version = "0.13.0", default-features = false, optional = true }
 
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
@@ -93,7 +93,7 @@ arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "jso
 arrow-cast = { workspace = true }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-object_store = { version = "0.12.0", default-features = false, features = ["azure", "fs"] }
+object_store = { version = "0.13.0", default-features = false, features = ["azure", "fs"] }
 sysinfo = { version = "0.37.1", default-features = false, features = ["system"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Which issue does this PR close?

# Rationale for this change
Bump dependency.

# What changes are included in this PR?
Bumps object-store to 0.13.x

# Are these changes tested?
Normal tests.

# Are there any user-facing changes?
No.