### PR TITLE
Improve `PrimitiveArray::from_iter` perf

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1467,21 +1467,8 @@ impl<T: ArrowPrimitiveType, Ptr: Into<NativeAdapter<T>>> FromIterator<Ptr> for P
             })
             .collect();
 
-        let len = null_builder.len();
-        let maybe_nulls = null_builder.finish().map(|x| x.into_inner().into_inner());
-
-        let data = unsafe {
-            ArrayData::new_unchecked(
-                T::DATA_TYPE,
-                len,
-                None,
-                maybe_nulls,
-                0,
-                vec![buffer],
-                vec![],
-            )
-        };
-        PrimitiveArray::from(data)
+        let maybe_nulls = null_builder.finish();
+        PrimitiveArray::new(ScalarBuffer::from(buffer), maybe_nulls)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #NNN.

# Rationale for this change
Speeds up `from_iter`.

This speeds up creation for statistics if all values are present (common case):

```
Extract row group statistics for Int64/extract_statistics/Int64
                        time:   [392.26 ns 394.25 ns 397.06 ns]
                        change: [−44.865% −44.674% −44.456%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Extract data page statistics for Int64/extract_statistics/Int64
                        time:   [8.8307 µs 8.8472 µs 8.8641 µs]
                        change: [−22.701% −22.399% −22.099%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Extract row group statistics for UInt64/extract_statistics/UInt64
                        time:   [391.21 ns 393.46 ns 396.43 ns]
                        change: [−44.227% −43.085% −41.444%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

Extract data page statistics for UInt64/extract_statistics/UInt64
                        time:   [7.9090 µs 8.0075 µs 8.1958 µs]
                        change: [−48.323% −46.584% −44.593%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

Extract row group statistics for F64/extract_statistics/F64
                        time:   [395.12 ns 395.86 ns 396.64 ns]
                        change: [−58.982% −57.663% −56.236%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

Extract data page statistics for F64/extract_statistics/F64
                        time:   [8.9134 µs 8.9925 µs 9.1393 µs]
                        change: [−29.078% −25.866% −22.853%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
```

# What changes are included in this PR?

