### PR TITLE
Define Array methods for working with ArrayRef

### DIFF
--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -587,7 +587,7 @@ fn innermost_array_ref(array: Cow<'_, ArrayRef>) -> ArrayRef {
 /// This provides zero-cost downcasting when the dynamic type matches, avoiding cloning
 /// through [`ArrayData`]. Automatically handles nested `Arc<dyn Array>` wrappers.
 ///
-/// If the Arc contains nested Arc<dyn Array>, this method unwraps the innermost Arc.
+/// If the Arc contains nested `Arc<dyn Array>`, this method unwraps the innermost Arc.
 ///
 /// ```
 /// # use std::sync::Arc;

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -637,11 +637,11 @@ pub fn downcast_array_ref<T: Array + 'static>(array: ArrayRef) -> Result<Arc<T>,
     }
 
     // Both checks passed - safe to reconstruct Arc<T>
-    let concrete_ptr = Arc::into_raw(array) as *const () as *const T;
+    let ptr = Arc::into_raw(array).cast();
 
     // SAFETY: The Arc owns a T at the same address as the trait object's data pointer, so we can
     // reinterpret the Arc's dyn Array pointer to point to T instead. See above.
-    Ok(unsafe { Arc::from_raw(concrete_ptr) })
+    Ok(unsafe { Arc::from_raw(ptr) })
 }
 
 /// A generic trait for accessing the values of an [`Array`]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8794

# Rationale for this change

Two things:
1. An `&ArrayRef` can coerce to `&dyn Array`, but there is currently no way to recover the original `ArrayRef` instance afterward, because `Array::as_any()` returns the referent of the `ArrayRef`.
2. An `Arc<T: Array>` can coerce to `ArrayRef`, but there is currently no way to recover the orignal `Arc<T>` because `Array` does not (and indeed cannot) satisfy the `Any + 'static` bound that `Arc::downcast` requires.

# What changes are included in this PR?

Define a new `Array::as_array_ref()` method, with a provided implementation that returns None. `<Arc<T> as Array>::as_array_ref()` returns `Some(self)` and `<&T as Array>::as_array_ref()` delegates to its referent.

Also define a new `Array::to_array_ref()` method that attempts to recover an `ArrayRef` but which falls back to creating a new Array instance via `Array` -> `ArrayData` -> `make_array`. This provides a simple way to obtain an owned `ArrayRef` from any `&dyn Array`, optimized to a cheap Arc clone in case the trait object is already an `ArrayRef`.

Define a new freestanding `downcast_array_ref` function that attempts to recover the original `Arc<T>` from an owned `ArrayRef` -- mirroring the behavior of `Arc::downcast`, but without the restrictive type bounds.

# Are these changes tested?

Yes, new doc tests validate the code.

# Are there any user-facing changes?

New user-facing functions described above.