### PR TITLE
Remove some `unsafe` and allocations when creating PrimitiveArrays from Vec and `from_trusted_len_iter`

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -25,7 +25,9 @@ use crate::timezone::Tz;
 use crate::trusted_len::trusted_len_unzip;
 use crate::types::*;
 use crate::{Array, ArrayAccessor, ArrayRef, Scalar};
-use arrow_buffer::{ArrowNativeType, BooleanBuffer, Buffer, NullBufferBuilder, NullBuffer, ScalarBuffer, i256};
+use arrow_buffer::{
+    ArrowNativeType, BooleanBuffer, Buffer, NullBuffer, NullBufferBuilder, ScalarBuffer, i256,
+};
 use arrow_data::bit_iterator::try_for_each_valid_idx;
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType};


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/9298


# Rationale for this change

While reviewing https://github.com/apache/arrow-rs/pull/9294 from @Dandandan  I noticed some other places where we can avoid making ArrayData and thus save some allocations  (and `unsafe`)

I don't expect this to make a huge performance difference, but every little allocation helps, and I think the change is justified simply from the perspective of avoiding some more `unsafe`


# What changes are included in this PR?

Construct primitive arrays directly

# Are these changes tested?

By existing CI
# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
