### PR TITLE
Orasort based sort kernels

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,6 @@ on:
       - arrow-pyarrow/**
       - arrow-schema/**
       - arrow-select/**
-      - arrow-sort/**
       - arrow-string/**
       - arrow/**
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,8 @@ parquet-variant-compute = { version = "57.2.0", path = "./parquet-variant-comput
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 
+orasort = { version = "0.1.0" }
+
 simdutf8 = { version = "0.1.5", default-features = false }
 
 criterion = { version = "0.8.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ parquet-variant-compute = { version = "57.2.0", path = "./parquet-variant-comput
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 
-orasort = { path = "../orasort" }
+orasort = { version = "0.1.2" }
 
 simdutf8 = { version = "0.1.5", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ parquet-variant-compute = { version = "57.2.0", path = "./parquet-variant-comput
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 
-orasort = { version = "0.1.0" }
+orasort = { version = "0.1.1" }
 
 simdutf8 = { version = "0.1.5", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ parquet-variant-compute = { version = "57.2.0", path = "./parquet-variant-comput
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 
-orasort = { version = "0.1.1" }
+orasort = { path = "../orasort" }
 
 simdutf8 = { version = "0.1.5", default-features = false }
 

--- a/arrow-ord/Cargo.toml
+++ b/arrow-ord/Cargo.toml
@@ -41,7 +41,11 @@ arrow-buffer = { workspace = true }
 arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
+orasort = { workspace = true }
 
 [dev-dependencies]
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-rand = { version = "0.9", default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.9", default-features = false, features = [
+    "std",
+    "std_rng",
+] }

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -372,7 +372,7 @@ fn sort_bytes<T: ByteArrayType>(
         .iter()
         .map(|&idx| unsafe {
             let slice: &[u8] = values.value_unchecked(idx as usize).as_ref();
-            let prefix = if slice.len() >= 8 {
+            let prefix = if slice.len() >= SPLICE_PREFIX_SIZE {
                 let raw = std::ptr::read_unaligned(slice.as_ptr() as *const u64);
                 u64::from_be(raw)
             } else if slice.is_empty() {
@@ -490,7 +490,7 @@ fn sort_byte_view<T: ByteViewType>(
         .iter()
         .map(|&idx| unsafe {
             let slice: &[u8] = values.value_unchecked(idx as usize).as_ref();
-            let prefix = if slice.len() >= 8 {
+            let prefix = if slice.len() >= SPLICE_PREFIX_SIZE {
                 let raw = std::ptr::read_unaligned(slice.as_ptr() as *const u64);
                 u64::from_be(raw)
             } else if slice.is_empty() {

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -378,7 +378,7 @@ fn sort_bytes<T: ByteArrayType>(
             } else if slice.is_empty() {
                 0u64
             } else {
-                let mut buf = [0u8; 8];
+                let mut buf = [0u8; SPLICE_PREFIX_SIZE];
                 std::ptr::copy_nonoverlapping(slice.as_ptr(), buf.as_mut_ptr(), slice.len());
                 u64::from_be_bytes(buf)
             };
@@ -400,7 +400,7 @@ fn sort_bytes<T: ByteArrayType>(
         unsafe {
             let a_bytes: &[u8] = values.value_unchecked(a.0 as usize).as_ref();
             let b_bytes: &[u8] = values.value_unchecked(b.0 as usize).as_ref();
-            // If both strings are >= 8 bytes, first 8 bytes are equal (same prefix),
+            // If both strings are >= SPLICE_PREFIX_SIZE bytes, first SPLICE_PREFIX_SIZE bytes are equal (same prefix),
             // so skip them. Otherwise compare full slices (short strings may differ
             // in length despite matching zero-padded prefixes).
             if a_bytes.len() >= SPLICE_PREFIX_SIZE && b_bytes.len() >= SPLICE_PREFIX_SIZE {
@@ -496,7 +496,7 @@ fn sort_byte_view<T: ByteViewType>(
             } else if slice.is_empty() {
                 0u64
             } else {
-                let mut buf = [0u8; 8];
+                let mut buf = [0u8; SPLICE_PREFIX_SIZE];
                 std::ptr::copy_nonoverlapping(slice.as_ptr(), buf.as_mut_ptr(), slice.len());
                 u64::from_be_bytes(buf)
             };

--- a/arrow/benches/sort_kernel.rs
+++ b/arrow/benches/sort_kernel.rs
@@ -321,13 +321,18 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
     });
 
-    let arr = create_string_array_with_len::<i32>(2usize.pow(18), 0.5, 10);
-    c.bench_function("sort string[10] nulls 2^18", |b| {
+    let arr = create_string_array_with_len::<i32>(2usize.pow(19), 0.5, 10);
+    c.bench_function("sort string[10] nulls 2^19", |b| {
         b.iter(|| bench_sort_to_indices(&arr, None))
     });
 
-    let arr = create_string_array_with_len::<i32>(2usize.pow(18), 0.5, 100);
-    c.bench_function("sort string[100] nulls 2^18", |b| {
+    let arr = create_string_array_with_len::<i32>(2usize.pow(19), 0.5, 100);
+    c.bench_function("sort string[100] nulls 2^19", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    let arr = create_string_array_with_len::<i32>(2usize.pow(19), 0.5, 1000);
+    c.bench_function("sort string[1000] nulls 2^19", |b| {
         b.iter(|| bench_sort_to_indices(&arr, None))
     });
 }

--- a/arrow/benches/sort_kernel.rs
+++ b/arrow/benches/sort_kernel.rs
@@ -320,6 +320,16 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("rank string[10] nulls 2^12", |b| {
         b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
     });
+
+    let arr = create_string_array_with_len::<i32>(2usize.pow(18), 0.5, 10);
+    c.bench_function("sort string[10] nulls 2^18", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
+
+    let arr = create_string_array_with_len::<i32>(2usize.pow(18), 0.5, 100);
+    c.bench_function("sort string[100] nulls 2^18", |b| {
+        b.iter(|| bench_sort_to_indices(&arr, None))
+    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Implements Orasort sorting algorithm for sort kernels.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Orasort is spliced based on prefix and uses radix sort in spliced chunks.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Orasort sorting inclusion, adapting to prefix splices for array buffers.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, tests are already covering it.
In addition to that extra benchmarks are added to demonstrate the gain.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No.

## Bench Results (main vs this branch)
```
     Running benches/sort_kernel.rs (target/release/deps/sort_kernel-64fa6c88d50ded54)
Benchmarking sort string[10] nulls 2^19: Collecting 100 samples in estimated 5.14sort string[10] nulls 2^19
                        time:   [12.913 ms 12.964 ms 13.022 ms]
                        change: [−16.013% −15.570% −15.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking sort string[100] nulls 2^19: Collecting 100 samples in estimated 5.6sort string[100] nulls 2^19
                        time:   [11.255 ms 11.299 ms 11.351 ms]
                        change: [−16.676% −16.115% −15.551%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking sort string[1000] nulls 2^19: Collecting 100 samples in estimated 6.sort string[1000] nulls 2^19
                        time:   [15.421 ms 15.493 ms 15.573 ms]
                        change: [−21.110% −20.594% −20.048%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
  ```
  
  Orasort core implementation: https://github.com/psila-ai/orasort
  Perf defaults of the Orasort: https://github.com/psila-ai/orasort?tab=readme-ov-file#performance