### PR TITLE
[57_maintenance] fix: ensure `BufferBuilder::truncate` doesn't overset length (#9288)

### DIFF
--- a/arrow-buffer/src/builder/mod.rs
+++ b/arrow-buffer/src/builder/mod.rs
@@ -322,7 +322,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         self.buffer.truncate(len * std::mem::size_of::<T>());
-        self.len = len;
+        self.len = self.len.min(len);
     }
 
     /// # Safety
@@ -417,5 +417,17 @@ mod tests {
         assert_eq!(builder.len(), 2);
         builder.extend([3, 4]);
         assert_eq!(builder.len(), 4);
+    }
+
+    #[test]
+    fn truncate_safety() {
+        let mut builder = BufferBuilder::from(vec![40, -63, 90]);
+        assert_eq!(builder.len(), 3);
+        builder.truncate(151);
+        assert_eq!(builder.len(), 3);
+        builder.advance(219);
+        assert_eq!(builder.len(), 222);
+        let slice = builder.as_slice_mut();
+        assert_eq!(slice.len(), 222);
     }
 }


### PR DESCRIPTION
- Part of https://github.com/apache/arrow-rs/issues/9240
- Related to https://github.com/apache/arrow-rs/issues/9286

This is a backport of the following PR to the 57 line
- https://github.com/apache/arrow-rs/pull/9288 from @Jefffrey 
