### PR TITLE
Remove support for List types in bit_length kernel

### DIFF
--- a/arrow-string/src/length.rs
+++ b/arrow-string/src/length.rs
@@ -121,14 +121,6 @@ pub fn bit_length(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
     }
 
     match array.data_type() {
-        DataType::List(_) => {
-            let list = array.as_list::<i32>();
-            Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))
-        }
-        DataType::LargeList(_) => {
-            let list = array.as_list::<i64>();
-            Ok(bit_length_impl::<Int64Type>(list.offsets(), list.nulls()))
-        }
         DataType::Utf8 => {
             let list = array.as_string::<i32>();
             Ok(bit_length_impl::<Int32Type>(list.offsets(), list.nulls()))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9349 .

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
bit_length for List/LargeList multiplies element count by 8, which is semantically wrong since elements can be arbitrary types.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
 remove the existing List/LargeList support for bit_length
# Are these changes tested?
YES
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
NO