### PR TITLE
Add zstd windowLog override to WriterProperties

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -366,7 +366,9 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         page_writer: Box<dyn PageWriter + 'a>,
     ) -> Self {
         let codec = props.compression(descr.path());
-        let codec_options = CodecOptionsBuilder::default().build();
+        let codec_options = CodecOptionsBuilder::default()
+            .set_zstd_window_log_override(props.zstd_window_log_override())
+            .build();
         let compressor = create_codec(codec, &codec_options).unwrap();
         let encoder = E::try_new(&descr, props.as_ref()).unwrap();
 

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -367,7 +367,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     ) -> Self {
         let codec = props.compression(descr.path());
         let codec_options = CodecOptionsBuilder::default()
-            .set_zstd_window_log_override(props.zstd_window_log_override())
+            .set_zstd_window_log_override(props.zstd_window_log_override(descr.path()))
             .build();
         let compressor = create_codec(codec, &codec_options).unwrap();
         let encoder = E::try_new(&descr, props.as_ref()).unwrap();

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -197,7 +197,10 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
         }
         CodecType::ZSTD(level) => {
             #[cfg(any(feature = "zstd", test))]
-            return Ok(Some(Box::new(ZSTDCodec::new(level, _options.zstd_window_log_override))));
+            return Ok(Some(Box::new(ZSTDCodec::new(
+                level,
+                _options.zstd_window_log_override,
+            ))));
             Err(ParquetError::General(
                 "Disabled feature at compile time: zstd".into(),
             ))

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -79,6 +79,10 @@ pub trait Codec: Send {
 pub struct CodecOptions {
     /// Whether or not to fallback to other LZ4 older implementations on error in LZ4_HADOOP.
     backward_compatible_lz4: bool,
+    /// Optional override for the zstd window log size, which is normally derived
+    /// from the compression level by the zstd library (e.g. 21 = 2MB at levels
+    /// 3-8, 22 = 4MB at levels 9-16, up to 27 = 128MB at level 22).
+    zstd_window_log_override: Option<u32>,
 }
 
 impl Default for CodecOptions {
@@ -90,12 +94,17 @@ impl Default for CodecOptions {
 pub struct CodecOptionsBuilder {
     /// Whether or not to fallback to other LZ4 older implementations on error in LZ4_HADOOP.
     backward_compatible_lz4: bool,
+    /// Optional override for the zstd window log size, which is normally derived
+    /// from the compression level by the zstd library (e.g. 21 = 2MB at levels
+    /// 3-8, 22 = 4MB at levels 9-16, up to 27 = 128MB at level 22).
+    zstd_window_log_override: Option<u32>,
 }
 
 impl Default for CodecOptionsBuilder {
     fn default() -> Self {
         Self {
             backward_compatible_lz4: true,
+            zstd_window_log_override: None,
         }
     }
 }
@@ -114,9 +123,18 @@ impl CodecOptionsBuilder {
         self
     }
 
+    /// Overrides the zstd window log size that would normally be derived from
+    /// the compression level (e.g. 27 = 128MB window).
+    /// Pass `None` to use the zstd default for the given compression level.
+    pub fn set_zstd_window_log_override(mut self, value: Option<u32>) -> CodecOptionsBuilder {
+        self.zstd_window_log_override = value;
+        self
+    }
+
     pub fn build(self) -> CodecOptions {
         CodecOptions {
             backward_compatible_lz4: self.backward_compatible_lz4,
+            zstd_window_log_override: self.zstd_window_log_override,
         }
     }
 }
@@ -179,7 +197,7 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
         }
         CodecType::ZSTD(level) => {
             #[cfg(any(feature = "zstd", test))]
-            return Ok(Some(Box::new(ZSTDCodec::new(level))));
+            return Ok(Some(Box::new(ZSTDCodec::new(level, _options.zstd_window_log_override))));
             Err(ParquetError::General(
                 "Disabled feature at compile time: zstd".into(),
             ))
@@ -511,12 +529,13 @@ mod zstd_codec {
     /// Codec for Zstandard compression algorithm.
     pub struct ZSTDCodec {
         level: ZstdLevel,
+        window_log: Option<u32>,
     }
 
     impl ZSTDCodec {
         /// Creates new Zstandard compression codec.
-        pub(crate) fn new(level: ZstdLevel) -> Self {
-            Self { level }
+        pub(crate) fn new(level: ZstdLevel, window_log: Option<u32>) -> Self {
+            Self { level, window_log }
         }
     }
 
@@ -536,6 +555,9 @@ mod zstd_codec {
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             let mut encoder = zstd::Encoder::new(output_buf, self.level.0)?;
+            if let Some(wl) = self.window_log {
+                encoder.window_log(wl)?;
+            }
             encoder.write_all(input_buf)?;
             match encoder.finish() {
                 Ok(_) => Ok(()),
@@ -915,6 +937,25 @@ mod tests {
             test_codec_with_size(CodecType::ZSTD(level));
             test_codec_without_size(CodecType::ZSTD(level));
         }
+    }
+
+    #[test]
+    fn test_codec_zstd_with_window_log() {
+        let level = ZstdLevel::try_new(3).unwrap();
+        let options = CodecOptionsBuilder::default()
+            .set_zstd_window_log_override(Some(27))
+            .build();
+        let mut codec = create_codec(CodecType::ZSTD(level), &options)
+            .unwrap()
+            .unwrap();
+        let data = b"hello world hello world hello world";
+        let mut compressed = Vec::new();
+        codec.compress(data, &mut compressed).unwrap();
+        let mut decompressed = Vec::new();
+        codec
+            .decompress(&compressed, &mut decompressed, Some(data.len()))
+            .unwrap();
+        assert_eq!(&decompressed, data);
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -168,6 +168,7 @@ pub struct WriterProperties {
     column_index_truncate_length: Option<usize>,
     statistics_truncate_length: Option<usize>,
     coerce_types: bool,
+    zstd_window_log_override: Option<u32>,
     #[cfg(feature = "encryption")]
     pub(crate) file_encryption_properties: Option<Arc<FileEncryptionProperties>>,
 }
@@ -378,6 +379,11 @@ impl WriterProperties {
             .unwrap_or(DEFAULT_COMPRESSION)
     }
 
+    /// Returns the optional zstd window log size.
+    pub(crate) fn zstd_window_log_override(&self) -> Option<u32> {
+        self.zstd_window_log_override
+    }
+
     /// Returns `true` if dictionary encoding is enabled for a column.
     ///
     /// For more details see [`WriterPropertiesBuilder::set_dictionary_enabled`]
@@ -457,6 +463,7 @@ pub struct WriterPropertiesBuilder {
     column_index_truncate_length: Option<usize>,
     statistics_truncate_length: Option<usize>,
     coerce_types: bool,
+    zstd_window_log_override: Option<u32>,
     #[cfg(feature = "encryption")]
     file_encryption_properties: Option<Arc<FileEncryptionProperties>>,
 }
@@ -480,6 +487,7 @@ impl Default for WriterPropertiesBuilder {
             column_index_truncate_length: DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
             statistics_truncate_length: DEFAULT_STATISTICS_TRUNCATE_LENGTH,
             coerce_types: DEFAULT_COERCE_TYPES,
+            zstd_window_log_override: None,
             #[cfg(feature = "encryption")]
             file_encryption_properties: None,
         }
@@ -505,6 +513,7 @@ impl WriterPropertiesBuilder {
             column_index_truncate_length: self.column_index_truncate_length,
             statistics_truncate_length: self.statistics_truncate_length,
             coerce_types: self.coerce_types,
+            zstd_window_log_override: self.zstd_window_log_override,
             #[cfg(feature = "encryption")]
             file_encryption_properties: self.file_encryption_properties,
         }
@@ -742,6 +751,14 @@ impl WriterPropertiesBuilder {
         self
     }
 
+    /// Overrides the zstd window log size that would normally be derived from
+    /// the compression level (e.g. 27 = 128MB window).
+    /// Only applies when using [`Compression::ZSTD`].
+    pub fn set_zstd_window_log_override(mut self, value: u32) -> Self {
+        self.zstd_window_log_override = Some(value);
+        self
+    }
+
     /// Sets default flag to enable/disable dictionary encoding for all columns (defaults to `true`
     /// via [`DEFAULT_DICTIONARY_ENABLED`]).
     ///
@@ -964,6 +981,7 @@ impl From<WriterProperties> for WriterPropertiesBuilder {
             column_index_truncate_length: props.column_index_truncate_length,
             statistics_truncate_length: props.statistics_truncate_length,
             coerce_types: props.coerce_types,
+            zstd_window_log_override: props.zstd_window_log_override,
             #[cfg(feature = "encryption")]
             file_encryption_properties: props.file_encryption_properties,
         }


### PR DESCRIPTION
# Which issue does this PR close?

- Addresses #8358.

# Rationale for this change

Tuning window size with zstd is important for wider columns such as html strings. In my personal uses I saw a 32% size decrease with small performance penalty with level = 9 and windowLog = 27 (128 MB windows up from 8 MB default for level 9).

# What changes are included in this PR?

We add a `zstd_window_log_override: Option<u32>` param to `CodecOptions` to just allow the value to be set through to `zstd-safe`. Just plumbing.

# Are these changes tested?

Pass all the cargo tests, one unit test provided, just to show a usage example/guard the behaviour, doesn't necessarily test the behaviour of the underlying zstd library.

# Are there any user-facing changes?

No backwards incompatible changes, but this change adds a new param to `CodecOptionsBuilder`, and makes changes to cargo docs.

# notes

I think taking the approach of making this an override makes the most sense, for the following reasons:

1. The term override make sense, zstd levels typically set the windowLog, and then you can manually set it, so fundamentally they are overrides.
2. This makes it a natural fit in `CodecOptions` which also includes an encoder specific flag in `backward_compatible_lz4`.
3. We had to put the override flag in `WriterProperties`, which I'm not sure is entirely natural, but I couldn't think of another way to do this. We could guard this with the `zstd` flag but I'm not sure if that is consistent with the other zstd code.

Please let me know if you think of a better way to do this.
