### PR TITLE
Compact StringView buffer during sparse (<50%) take to avoid holding the original buffers alive

### DIFF
--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -186,6 +186,32 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_take(&values, &indices))
     });
 
+    // Compact path benchmarks: indices.len() < values.len() / 2
+    // Simulates high-selectivity filtering (e.g., ClickBench Q22: 46/100K rows)
+    let values = create_string_view_array(4096, 0.0);
+    let indices = create_random_index(256, 0.0); // ~6% selectivity
+    c.bench_function("take stringview compact 4096 -> 256", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(4096, 0.0);
+    let indices = create_random_index(64, 0.0); // ~1.5% selectivity
+    c.bench_function("take stringview compact 4096 -> 64", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(4096, 0.5);
+    let indices = create_random_index(256, 0.0); // null values, sparse
+    c.bench_function("take stringview compact null values 4096 -> 256", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_view_array(4096, 0.0);
+    let indices = create_random_index(256, 0.5); // null indices, sparse
+    c.bench_function("take stringview compact null indices 4096 -> 256", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
     let values = create_primitive_run_array::<Int32Type, Int32Type>(1024, 512);
     let indices = create_random_index(1024, 0.0);
     c.bench_function(


### PR DESCRIPTION
# Which issue does this PR close?

On clickbench query profiles Noticed the buffers allocated on producer thread, dropped on consumer thread. Mimalloc's deferred-free mechanism caused up to 9.26% CPU in _mi_heap_delayed_free_partial.

# Rationale for this change

The previous implementation treated take as a purely generic gather, leaving buffer compaction to the downstream coalescing step. While correct, this meant that in sparse cases we would:

1. Read and copy string data twice (once during take, again during coalescing), and
2. Keep large backing buffers alive across thread boundaries via Arc, even when only a small subset of the data was referenced.

This PR optimizes the sparse case by recognizing that compaction is effectively inevitable downstream. When take selects a small fraction of rows, we fuse gather and compaction into a single pass. This:

1. Avoids the second read/copy of string data
2. Prevents retaining large unused buffers
3. Reduces cross-thread memory retention

The dense case remains unchanged, so the existing fast path is preserved. The heuristic is intentionally conservative and only triggers when sparsity suggests compaction will be beneficial.

# What changes are included in this PR?

The optimization fuses the take and compaction into a single pass via take_byte_view_compact. It kicks in automatically when the take is sparse (indices.len() < array.len() / 2):


# Are these changes tested?

arrow select test passed

# Are there any user-facing changes?

no