### PR TITLE
fix: use explicit f16 conversion in bench utilities for newer half crate

### DIFF
--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -722,7 +722,7 @@ pub fn create_f16_array(size: usize, nan_density: f32) -> Float16Array {
             if rng.random::<f32>() < nan_density {
                 Some(f16::NAN)
             } else {
-                Some(rng.random())
+                Some(f16::from_f32(rng.random::<f32>()))
             }
         })
         .collect()

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -92,7 +92,7 @@ pub fn create_random_array(
         UInt16 => Arc::new(create_primitive_array::<UInt16Type>(size, null_density)),
         UInt32 => Arc::new(create_primitive_array::<UInt32Type>(size, null_density)),
         UInt64 => Arc::new(create_primitive_array::<UInt64Type>(size, null_density)),
-        Float16 => Arc::new(create_primitive_array::<Float16Type>(size, null_density)),
+        Float16 => Arc::new(create_f16_array(size, null_density)),
         Float32 => Arc::new(create_primitive_array::<Float32Type>(size, null_density)),
         Float64 => Arc::new(create_primitive_array::<Float64Type>(size, null_density)),
         Timestamp(unit, tz) => match unit {


### PR DESCRIPTION
The `half::f16` type no longer implements `rand::distributions::Standard`, so benchmarks using `rng.random::<f16>()` fail to compile. Use `f16::from_f32(rng.random::<f32>())` instead, and route Float16 array generation through `create_f16_array` which already handles this.

# Which issue does this PR close?

N/A

# Rationale for this change

The `half::f16` type no longer implements `rand::distributions::Standard`, so benchmarks using `rng.random::<f16>()` fail to compile. Use `f16::from_f32(rng.random::<f32>())` instead, and route Float16 array generation through `create_f16_array` which already handles this.

# What changes are included in this PR?

Some small changes to get benchmarks working

# Are these changes tested?

Yeah we can run benches

# Are there any user-facing changes?

Nope