### PR TITLE
Reproduce the issue of #9370 in a minimal, end-to-end way

### DIFF
--- a/parquet/tests/arrow_reader/row_filter/sync.rs
+++ b/parquet/tests/arrow_reader/row_filter/sync.rs
@@ -354,7 +354,7 @@ fn test_list_struct_page_boundary_desync_produces_length_mismatch() {
         for j in 0..num_elems {
             sb.field_builder::<Int32Builder>(0)
                 .unwrap()
-                .append_value(i as i32 * 10 + j as i32);
+                .append_value(i as i32 * 10 + j);
             sb.field_builder::<StringBuilder>(1)
                 .unwrap()
                 .append_value(format!("{long_prefix}_{i}_{j}"));


### PR DESCRIPTION
# Which issue does this PR close?

Related to

- https://github.com/apache/arrow-rs/pull/9374
- https://github.com/apache/arrow-rs/issues/9370

# Rationale for this change

In https://github.com/apache/arrow-rs/pull/9374, I only came up with a unit-test that didn't really throw the message "Not all children array length are the same!" error the issue #9370 is about. In this PR, tests are introduced that are able to reproduce this issue end-to-end and are expected to still panic. In test `test_list_struct_page_boundary_desync_produces_length_mismatch`, we exactly get the error message the original issue is about, while `test_row_selection_list_column_v2_page_boundary_skip` shows a slightly different error message.

# What changes are included in this PR?

Two test are introduced, which currently are expected to panic:
- test_row_selection_list_column_v2_page_boundary_skip
- test_list_struct_page_boundary_desync_produces_length_mismatch

# Are there any user-facing changes?

No