### PR TITLE
[Minor] Use per-predicate projection masks in arrow_reader_clickbench benchmark

### DIFF
--- a/parquet/benches/arrow_reader_clickbench.rs
+++ b/parquet/benches/arrow_reader_clickbench.rs
@@ -638,7 +638,6 @@ fn find_file_if_exists(mut current_dir: PathBuf, file_name: &str) -> Option<Path
     None
 }
 
-
 /// Encapsulates the test parameters for a single benchmark
 struct ReadTest {
     /// Human identifiable name


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #NNN.

# Rationale for this change

As suggested by Claude - currently it uses a projection mask for all columns, significantly slowing down queries that have multiple predicates.
This makes it more in line with consumer side (e.g. DataFusion) (so we can more accurately benchmark improvements).

It shows the perf difference in a number of (multi-filter) queries:

```
group                                             clickbench-optimizations               main
arrow_reader_clickbench/async_object_store/Q22    1.00    151.8±6.46ms        ? ?/sec    1.52    230.5±1.68ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q36    1.00     26.3±0.24ms        ? ?/sec    4.30    113.1±0.67ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q37    1.00      9.3±0.06ms        ? ?/sec    9.64     89.7±1.20ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q38    1.00     22.4±0.26ms        ? ?/sec    1.44     32.3±0.29ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q39    1.00     38.1±0.66ms        ? ?/sec    1.09     41.5±0.35ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q40    1.00     13.0±0.15ms        ? ?/sec    2.96     38.6±0.45ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q41    1.00     10.1±0.11ms        ? ?/sec    2.83     28.5±0.73ms        ? ?/sec
arrow_reader_clickbench/async_object_store/Q42    1.00      5.6±0.05ms        ? ?/sec    1.87     10.5±0.12ms        ? ?/sec
```

# What changes are included in this PR?

# Are these changes tested?


# Are there any user-facing changes?

