### PR TITLE
arrow-buffer: i256: Implement num_traits wrapping shift

### DIFF
--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -843,8 +843,8 @@ macro_rules! define_standard_shift {
     };
 }
 
-define_standard_shift!(Shl, shl, [u16, u32, u64, usize, i16, i32, i64, isize]);
-define_standard_shift!(Shr, shr, [u16, u32, u64, usize, i16, i32, i64, isize]);
+define_standard_shift!(Shl, shl, [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]);
+define_standard_shift!(Shr, shr, [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]);
 
 macro_rules! define_as_primitive {
     ($native_ty:ty) => {

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -20,8 +20,8 @@ use crate::bigint::div::div_rem;
 use num_bigint::BigInt;
 use num_traits::{
     Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, FromPrimitive,
-    Num, One, Signed, ToPrimitive, WrappingAdd, WrappingMul, WrappingNeg, WrappingSub, Zero,
-    cast::AsPrimitive,
+    Num, One, Signed, ToPrimitive, WrappingAdd, WrappingMul, WrappingNeg, WrappingShl, WrappingShr,
+    WrappingSub, Zero, cast::AsPrimitive,
 };
 use std::cmp::Ordering;
 use std::num::ParseIntError;
@@ -807,6 +807,46 @@ impl Shr<u8> for i256 {
     }
 }
 
+impl WrappingShl for i256 {
+    #[inline]
+    fn wrapping_shl(&self, rhs: u32) -> i256 {
+        (*self).shl(rhs)
+    }
+}
+
+impl WrappingShr for i256 {
+    #[inline]
+    fn wrapping_shr(&self, rhs: u32) -> i256 {
+        (*self).shr(rhs)
+    }
+}
+
+// Define Shr<T> and Shl<T> for specified integer types
+macro_rules! define_wrapping_shift {
+    // Handle multiple types
+    ($trait_name:ident, $method:ident, [$($t:ty),+]) => {
+        $(define_wrapping_shift!($trait_name, $method, $t);)+
+    };
+    // Handle single type
+    ($trait_name:ident, $method:ident, $t:ty) => {
+        impl $trait_name<$t> for i256 {
+            type Output = i256;
+
+            #[inline]
+            fn $method(self, rhs: $t) -> Self::Output {
+                // Take modulo 256
+                #[allow(clippy::suspicious_arithmetic_impl)]
+                let shift: u8 = (rhs % (256 as $t)) as u8;
+                // Use existing Shl<u8> / Shr<u8> implementation
+                <Self as $trait_name<u8>>::$method(self, shift)
+            }
+        }
+    };
+}
+
+define_wrapping_shift!(Shl, shl, [u16, u32, u64, usize, i16, i32, i64, isize]);
+define_wrapping_shift!(Shr, shr, [u16, u32, u64, usize, i16, i32, i64, isize]);
+
 macro_rules! define_as_primitive {
     ($native_ty:ty) => {
         impl AsPrimitive<i256> for $native_ty {
@@ -1190,9 +1230,19 @@ mod tests {
             let (expected, _) = i256::from_bigint_with_overflow(bl.clone() << shift);
             assert_eq!(actual.to_string(), expected.to_string());
 
+            let wrapping_actual = <i256 as WrappingShl>::wrapping_shl(&il, shift as u32);
+            assert_eq!(wrapping_actual.to_string(), expected.to_string());
+
             let actual = il >> shift;
             let (expected, _) = i256::from_bigint_with_overflow(bl.clone() >> shift);
             assert_eq!(actual.to_string(), expected.to_string());
+
+            let wrapping_actual = <i256 as WrappingShr>::wrapping_shr(&il, shift as u32);
+            assert_eq!(wrapping_actual.to_string(), expected.to_string());
+
+            // Check wrapping of the shift argument
+            let wrapping_actual = <i256 as WrappingShr>::wrapping_shr(&il, 512 + shift as u32);
+            assert_eq!(wrapping_actual.to_string(), expected.to_string());
         }
     }
 

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -823,11 +823,12 @@ impl WrappingShr for i256 {
     }
 }
 
-// Define Shr<T> and Shl<T> for specified integer types
-macro_rules! define_wrapping_shift {
+// Define Shl<T> and Shr<T> for specified integer types using
+// an existing Shl<u8> and Shr<u8> implementation
+macro_rules! define_standard_shift {
     // Handle multiple types
     ($trait_name:ident, $method:ident, [$($t:ty),+]) => {
-        $(define_wrapping_shift!($trait_name, $method, $t);)+
+        $(define_standard_shift!($trait_name, $method, $t);)+
     };
     // Handle single type
     ($trait_name:ident, $method:ident, $t:ty) => {
@@ -836,18 +837,14 @@ macro_rules! define_wrapping_shift {
 
             #[inline]
             fn $method(self, rhs: $t) -> Self::Output {
-                // Take modulo 256
-                #[allow(clippy::suspicious_arithmetic_impl)]
-                let shift: u8 = (rhs % (256 as $t)) as u8;
-                // Use existing Shl<u8> / Shr<u8> implementation
-                <Self as $trait_name<u8>>::$method(self, shift)
+                self.$method(rhs as u8)
             }
         }
     };
 }
 
-define_wrapping_shift!(Shl, shl, [u16, u32, u64, usize, i16, i32, i64, isize]);
-define_wrapping_shift!(Shr, shr, [u16, u32, u64, usize, i16, i32, i64, isize]);
+define_standard_shift!(Shl, shl, [u16, u32, u64, usize, i16, i32, i64, isize]);
+define_standard_shift!(Shr, shr, [u16, u32, u64, usize, i16, i32, i64, isize]);
 
 macro_rules! define_as_primitive {
     ($native_ty:ty) => {

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -843,8 +843,16 @@ macro_rules! define_standard_shift {
     };
 }
 
-define_standard_shift!(Shl, shl, [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]);
-define_standard_shift!(Shr, shr, [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]);
+define_standard_shift!(
+    Shl,
+    shl,
+    [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]
+);
+define_standard_shift!(
+    Shr,
+    shr,
+    [u16, u32, u64, u128, usize, i16, i32, i64, i128, isize]
+);
 
 macro_rules! define_as_primitive {
     ($native_ty:ty) => {

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -810,14 +810,16 @@ impl Shr<u8> for i256 {
 impl WrappingShl for i256 {
     #[inline]
     fn wrapping_shl(&self, rhs: u32) -> i256 {
-        (*self).shl(rhs)
+        // Mask the higher-order bits
+        (*self).shl(rhs as u8)
     }
 }
 
 impl WrappingShr for i256 {
     #[inline]
     fn wrapping_shr(&self, rhs: u32) -> i256 {
-        (*self).shr(rhs)
+        // Masks the higher-order bits
+        (*self).shr(rhs as u8)
     }
 }
 

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -837,6 +837,8 @@ macro_rules! define_standard_shift {
 
             #[inline]
             fn $method(self, rhs: $t) -> Self::Output {
+                let rhs = u8::try_from(rhs).expect("rhs overflow for shift {rhs}");
+                // Other possible overflows are handled by Shl<u8> implementation
                 self.$method(rhs as u8)
             }
         }
@@ -1592,18 +1594,12 @@ mod tests {
         assert_eq!(<i256 as Bounded>::max_value(), i256::MAX);
     }
 
+    #[should_panic]
     #[test]
-    fn test_shl_panic() {
+    fn test_shl_panic_on_arg_overflow() {
         let value = i256::from(123);
-        let rhs = std::hint::black_box(10);
+        let rhs = std::hint::black_box(500);
         let _ = value << rhs;
-    }
-
-    #[test]
-    fn test_shr_panic() {
-        let value = i256::from(123);
-        let rhs = std::hint::black_box(10);
-        let _ = value >> rhs;
     }
 
     #[test]

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -1585,6 +1585,20 @@ mod tests {
     }
 
     #[test]
+    fn test_shl_panic() {
+        let value = i256::from(123);
+        let rhs = std::hint::black_box(10);
+        let _ = value << rhs;
+    }
+
+    #[test]
+    fn test_shr_panic() {
+        let value = i256::from(123);
+        let rhs = std::hint::black_box(10);
+        let _ = value >> rhs;
+    }
+
+    #[test]
     fn test_numtraits_from_str_radix() {
         assert_eq!(
             i256::from_str_radix("123456789", 10).expect("parsed"),

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -839,7 +839,7 @@ macro_rules! define_standard_shift {
             fn $method(self, rhs: $t) -> Self::Output {
                 let rhs = u8::try_from(rhs).expect("rhs overflow for shift");
                 // Other possible overflows are handled by Shl<u8> implementation
-                self.$method(rhs as u8)
+                self.$method(rhs)
             }
         }
     };

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -810,7 +810,7 @@ impl Shr<u8> for i256 {
 impl WrappingShl for i256 {
     #[inline]
     fn wrapping_shl(&self, rhs: u32) -> i256 {
-        // Mask the higher-order bits
+        // Limit shift to 256 (max valid shift for i256)
         (*self).shl(rhs as u8)
     }
 }
@@ -818,7 +818,7 @@ impl WrappingShl for i256 {
 impl WrappingShr for i256 {
     #[inline]
     fn wrapping_shr(&self, rhs: u32) -> i256 {
-        // Masks the higher-order bits
+        // Limit shift to 256 (max valid shift for i256)
         (*self).shr(rhs as u8)
     }
 }
@@ -837,7 +837,7 @@ macro_rules! define_standard_shift {
 
             #[inline]
             fn $method(self, rhs: $t) -> Self::Output {
-                let rhs = u8::try_from(rhs).expect("rhs overflow for shift {rhs}");
+                let rhs = u8::try_from(rhs).expect("rhs overflow for shift");
                 // Other possible overflows are handled by Shl<u8> implementation
                 self.$method(rhs as u8)
             }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9417

# Rationale for this change

A follow-up to #8976

Implement some missing traits - [WrappingShl](https://docs.rs/num-traits/latest/num_traits/ops/wrapping/trait.WrappingShl.html) and [WrappingShr](https://docs.rs/num-traits/latest/num_traits/ops/wrapping/trait.WrappingShl.html) 

# What changes are included in this PR?

- num_traits' WrappingShl implementation  for `usize`
- `Shl` and `Shr` trait implementation for all scalar numeric types, not only for `u8`

# Are these changes tested?

- Unit tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
