### PR TITLE
Avoid allocating a `Vec` in `StructBuilder`

### DIFF
--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -222,7 +222,7 @@ impl StructBuilder {
     /// Appends `n` `null`s into the builder.
     #[inline]
     pub fn append_nulls(&mut self, n: usize) {
-        self.null_buffer_builder.append_slice(&vec![false; n]);
+        self.null_buffer_builder.append_n_nulls(n);
     }
 
     /// Builds the `StructArray` and reset this builder.


### PR DESCRIPTION

# Which issue does this PR close?

Resolves #9427

While going through the code, @scovich noticed that it allocates a `vec![false; n]` to be appended to the null buffer, which is not very efficent:

```
append_nulls: vec![false; n] (old) vs append_n_nulls (new)

┌─────────┬─────────────────┬──────────────────────┬─────────┐
│    n    │ old (vec alloc) │ new (append_n_nulls) │ speedup │
├─────────┼─────────────────┼──────────────────────┼─────────┤
│ 100     │ 82 ns           │ 43 ns                │ ~2x     │
├─────────┼─────────────────┼──────────────────────┼─────────┤
│ 1,000   │ 319 ns          │ 47 ns                │ ~7x     │
├─────────┼─────────────────┼──────────────────────┼─────────┤
│ 10,000  │ 2,540 ns        │ 68 ns                │ ~37x    │
├─────────┼─────────────────┼──────────────────────┼─────────┤
│ 100,000 │ 25,526 ns       │ 293 ns               │ ~87x    │
└─────────┴─────────────────┴──────────────────────┴─────────┘
```

# Rationale for this change

MOAR efficient

# What changes are included in this PR?

Avoid allocating a `Vec`.

# Are these changes tested?

Existing tests

# Are there any user-facing changes?

Less memory consumption and a happy CPU