### PR TITLE
Add `claim` method to recordbatch for memory accounting

### DIFF
--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -773,6 +773,20 @@ impl RecordBatch {
         RecordBatch::try_new(schema, columns)
     }
 
+    /// Registers all buffers in this record batch with the provided [`MemoryPool`].
+    ///
+    /// This claims memory for all columns in the batch by calling [`Array::claim`]
+    /// on each column.
+    ///
+    /// [`MemoryPool`]: arrow_buffer::MemoryPool
+    /// [`Array::claim`]: crate::Array::claim
+    #[cfg(feature = "pool")]
+    pub fn claim(&self, pool: &dyn arrow_buffer::MemoryPool) {
+        for column in self.columns() {
+            column.claim(pool);
+        }
+    }
+
     /// Returns the total number of bytes of memory occupied physically by this batch.
     ///
     /// Note that this does not always correspond to the exact memory usage of a


### PR DESCRIPTION
# Which issue does this PR close?

None specifically but aligns with some of the changes in https://github.com/apache/arrow-rs/issues/8137

# Rationale for this change

It should be easy to claim a `RecordBatch` in totality with an arrow memory pool

# What changes are included in this PR?

Adds a few methods to bubble up the `claim` to `RecordBatch` level if the `pool` feature is enabled.

# Are these changes tested?

Yes & new tests added

# Are there any user-facing changes?

If `pool` feature is added, a new `claim` method on `RecordBatch` and associated structs
