### PR TITLE
Add `SortBuilder` for `SortOptions`

### DIFF
--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -44,6 +44,57 @@ use std::ops;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 
+/// Builder for [`SortOptions`]
+///
+/// Please refer to the docs for details
+#[derive(Clone, Hash, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct SortBuilder {
+    _force_construct_with_new: (),
+}
+impl SortBuilder {
+    /// Create a new `SortBuilder` to configure `SortOptions`.
+    pub fn new() -> Self {
+        Self {
+            _force_construct_with_new: (),
+        }
+    }
+    /// Set this sort options to sort in ascending order
+    pub fn asc(self) -> SortBuilderOrd {
+        SortBuilderOrd { descending: false }
+    }
+    /// Set this sort options to sort in descending order
+    pub fn desc(self) -> SortBuilderOrd {
+        SortBuilderOrd { descending: true }
+    }
+}
+
+/// Intermediate builder state after selecting ascending/descending order.
+///
+/// Use `SortBuilder::asc()` or `SortBuilder::desc()` to obtain
+/// this state and then call `nulls_first()` or `nulls_last()` to finish
+/// constructing a `SortOptions`.
+#[derive(Clone, Hash, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct SortBuilderOrd {
+    /// Whether to sort in descending order
+    descending: bool,
+}
+impl SortBuilderOrd {
+    /// Set this sort options to sort nulls first
+    pub fn nulls_first(self) -> SortOptions {
+        SortOptions {
+            descending: self.descending,
+            nulls_first: true,
+        }
+    }
+    /// Set this sort options to sort nulls last
+    pub fn nulls_last(self) -> SortOptions {
+        SortOptions {
+            descending: self.descending,
+            nulls_first: false,
+        }
+    }
+}
+
 /// Options that define the sort order of a given column
 ///
 /// The default sorts equivalently to of `ASC NULLS FIRST` in SQL (i.e.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Prepare for https://github.com/apache/datafusion/pull/20229; later in datafusion we can reexport this `SortBuilder` and `SortOptions` for a to-be-implemented alternative of `sort()` dataframe statement.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

want to solve the obscure API problem described in https://github.com/apache/datafusion/issues/20227

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

the change added a new builder for the existing `SortOptions`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes and everything passes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

yes.

there are new struct `SortBuilder` and its pub methods introduced
