### PR TITLE
Implement comparisons for RunArray.

### DIFF
--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -643,7 +643,7 @@ fn merge_run_ends<I: types::RunEndIndexType>(
     let mut l = left.run_ends().sliced_values().enumerate().peekable();
     let mut r = right.run_ends().sliced_values().enumerate().peekable();
 
-    let max_size = left.run_ends().len() * 2; // The actual size is at least half `max_size`.
+    let max_size = left.run_ends().len() + right.run_ends().len();
     let mut all_run_ends = Vec::with_capacity(max_size);
     let mut l_idx = Vec::with_capacity(max_size);
     let mut r_idx = Vec::with_capacity(max_size);


### PR DESCRIPTION
This MR implements efficient eq, neq, distinct, not distinct, gt, lt, ... for 2 RunArrays with the same DataTypes & length.

The idea is to:

1. Compute all values indices where the comparison must be performed.

This is the union of the run-ends

For example, given 2 RunArray with run-end values:
      [3, 4, 10]
  and [2, 5, 10]

The intersection of their run-ends is
      [2, 3, 4, 5, 10]

The corresponding indices of the values array of each RunArray are:
      [0, 0, 1, 2, 2]
  and [0, 1, 1, 1, 2]

2. Use apply_op_vectored() to perform the operation on the values arrays at those indices.

3. Finally take nulls into account.

4. Build a BooleanArray from the result + the null mask.

Implementation thoughts:

A. Returning a RunArray instead of a BooleanArray would be interesting. This can be more efficient: a RunArray (with values being a BooleanBuffer) would have a length in `[1; len(input RunArray) * 2]` and can be efficiently constructed. This would require introducing new pub functions: distinct_run_array, eq_run_array, etc.

B. The operation is performed on all indices before looking at the nulls. With sparse (null-heavy) arrays this is wasteful. It might be worth skipping the computation when either side is null and then splicing results from non-null and null indices.

C. There's a bit of copy-paste for downcast_primitive_array!() usage. I could only skip that by introducing a new macro, which didn't seem desirable.

D. I find the lack of a value type for a fully typed run array annoying. `Array` and `RunArray<I>` are value types, but `TypedRunArray<'_, I, V>` is a reference type. This is frustrating. Some type contracts are only comments, and not enforced by the type system.

This feature is tracked in https://github.com/apache/arrow-rs/issues/3520.