### PR TITLE
Simplify downcast_...!() macro definitions

### DIFF
--- a/arrow-array/src/cast.rs
+++ b/arrow-array/src/cast.rs
@@ -138,20 +138,23 @@ macro_rules! downcast_integer {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_integer_array {
-    ($values:ident => $e:expr, $($tail:tt)*) => {
-        $crate::downcast_integer_array!($values => {$e} $($tail)*)
-    };
-    (($($values:ident),+) => $e:expr, $($tail:tt)*) => {
-        $crate::downcast_integer_array!(($($values),+) => {$e} $($tail)*)
-    };
-    ($($values:ident),+ => $e:block $($tail:tt)*) => {
-        $crate::downcast_integer_array!(($($values),+) => $e $($tail)*)
-    };
-    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
         $crate::downcast_integer!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
             $($p $(if $pred)? => $fallback,)*
         }
+    };
+    // Turn $e into a block.
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_integer_array!($values => {$e} $($p $(if $pred)? => $fallback,)*)
+    };
+    // Remove $values parentheses.
+    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_integer_array!($($values),+ => $e $($p $(if $pred)? => $fallback,)*)
+    };
+    // Turn $e into a block & remove $values parentheses.
+    (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_integer_array!($($values),+ => {$e} $($p $(if $pred)? => $fallback,)*)
     };
 }
 
@@ -304,20 +307,23 @@ macro_rules! downcast_temporal {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_temporal_array {
-    ($values:ident => $e:expr, $($tail:tt)*) => {
-        $crate::downcast_temporal_array!($values => {$e} $($tail)*)
-    };
-    (($($values:ident),+) => $e:expr, $($tail:tt)*) => {
-        $crate::downcast_temporal_array!(($($values),+) => {$e} $($tail)*)
-    };
-    ($($values:ident),+ => $e:block $($tail:tt)*) => {
-        $crate::downcast_temporal_array!(($($values),+) => $e $($tail)*)
-    };
-    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
         $crate::downcast_temporal!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
             $($p $(if $pred)? => $fallback,)*
         }
+    };
+    // Turn $e into a block.
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_temporal_array!($values => {$e} $($p $(if $pred)? => $fallback,)*)
+    };
+    // Remove $values parentheses.
+    (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_temporal_array!($($values),+ => $e $($p $(if $pred)? => $fallback,)*)
+    };
+    // Turn $e into a block & remove $values parentheses.
+    (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        $crate::downcast_temporal_array!($($values),+ => {$e} $($p $(if $pred)? => $fallback,)*)
     };
 }
 
@@ -450,27 +456,23 @@ macro_rules! downcast_primitive_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_primitive_array {
-    (@base $($values:ident),+ => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
         $crate::downcast_primitive!{
             $($values.data_type()),+ => ($crate::downcast_primitive_array_helper, $($values),+, $e),
             $($p $(if $pred)? => $fallback,)*
         }
     };
-    // All good.
-    ($($values:ident),+ => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
-        $crate::downcast_primitive_array!(@base $($values),+ => $e $($p $(if $pred)? => $fallback,)*)
-    };
     // Turn $e into a block.
     ($values:ident => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
-        $crate::downcast_primitive_array!(@base $values => {$e} $($p $(if $pred)? => $fallback,)*)
+        $crate::downcast_primitive_array!($values => {$e} $($p $(if $pred)? => $fallback,)*)
     };
     // Remove $values parentheses.
     (($($values:ident),+) => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
-        $crate::downcast_primitive_array!(@base ($($values),+) => $e $($p $(if $pred)? => $fallback,)*)
+        $crate::downcast_primitive_array!($($values),+ => $e $($p $(if $pred)? => $fallback,)*)
     };
-    // Turn $e into a block, remove $values parentheses.
+    // Turn $e into a block & remove $values parentheses.
     (($($values:ident),+) => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
-        $crate::downcast_primitive_array!(@base $($values),+ => {$e} $($p $(if $pred)? => $fallback,)*)
+        $crate::downcast_primitive_array!($($values),+ => {$e} $($p $(if $pred)? => $fallback,)*)
     };
 }
 
@@ -553,8 +555,8 @@ macro_rules! downcast_dictionary_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_dictionary_array {
-    ($values:ident => $e:expr, $($tail:tt)*) => {
-        downcast_dictionary_array!($values => {$e} $($tail)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        downcast_dictionary_array!($values => {$e} $($p $(if $pred)? => $fallback,)*)
     };
 
     ($values:ident => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
@@ -661,8 +663,8 @@ macro_rules! downcast_run_array_helper {
 /// [`DataType`]: arrow_schema::DataType
 #[macro_export]
 macro_rules! downcast_run_array {
-    ($values:ident => $e:expr, $($tail:tt)*) => {
-        downcast_run_array!($values => {$e} $($tail)*)
+    ($values:ident => $e:expr, $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {
+        downcast_run_array!($values => {$e} $($p $(if $pred)? => $fallback,)*)
     };
 
     ($values:ident => $e:block $($p:pat $(if $pred:expr)? => $fallback:expr $(,)?)*) => {


### PR DESCRIPTION
1. Reduce some quantifiers from `*` to `?` when 2+ occurrences would generate invalid Rust code. `$(if $pred:expr)*`
2. Clean up 4-armed recursive macros: 
  * put the base case first
  * explain the fixups
  * fix all at once, going directly to the base case, instead of possibly multiple hoops

The inital motivation was getting rust-analyzer to stop choking on such macros usage where the left-hand side was a tuple and the right-hand-side an expr.