### PR TITLE
Introduce public function `id()` on `Field`

### DIFF
--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -30,6 +30,9 @@ use crate::{
     extension::{EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY, ExtensionType},
 };
 
+/// The metadata key for the Parquet field id of a [`Field`].
+pub const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
+
 /// A reference counted [`Field`]
 pub type FieldRef = Arc<Field>;
 
@@ -502,6 +505,16 @@ impl Field {
         self.metadata()
             .get(EXTENSION_TYPE_METADATA_KEY)
             .map(String::as_ref)
+    }
+
+    /// Returns the parquet field id of this [`Field`], if set.
+    ///
+    /// This returns the value of [`PARQUET_FIELD_ID_META_KEY`] metadata key, parsed
+    /// as an `i32`. Returns `None` if the key is not present or the value
+    /// is not a valid integer.
+    pub fn id(&self) -> Option<i32> {
+        let value = self.metadata().get(PARQUET_FIELD_ID_META_KEY)?;
+        value.parse().ok()
     }
 
     /// Returns an instance of the given [`ExtensionType`] of this [`Field`],

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -224,7 +224,7 @@ pub const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 ///
 /// [`Field::metadata`]: arrow_schema::Field::metadata
 /// [`BasicTypeInfo::id`]: crate::schema::types::BasicTypeInfo::id
-pub const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
+pub use arrow_schema::PARQUET_FIELD_ID_META_KEY;
 
 /// A [`ProjectionMask`] identifies a set of columns within a potentially nested schema to project
 ///

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -543,7 +543,7 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
     } else {
         Repetition::REQUIRED
     };
-    let id = field_id(field);
+    let id = field.id();
     // create type from field
     match field.data_type() {
         DataType::Null => Type::primitive_type_builder(name, PhysicalType::INT32)
@@ -858,11 +858,6 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
             "Converting RunEndEncodedType to parquet not supported",
         )),
     }
-}
-
-fn field_id(field: &Field) -> Option<i32> {
-    let value = field.metadata().get(super::PARQUET_FIELD_ID_META_KEY)?;
-    value.parse().ok() // Fail quietly if not a valid integer
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9469.

# Rationale for this change

I want to discuss the following with the community. Today, arrow-rs supports Parquet field-IDs via a heuristic based on a special key (`PARQUET:field_id`) in the field metadata. Instead, I would suggest bumping it to a method on Field itself.

# What changes are included in this PR?

Adding a public `id()`, and removing a private `field_id(field)`.

# Are these changes tested?

Existing tests.

# Are there any user-facing changes?

A new public API.