### PR TITLE
Add PrimitiveRunBuilder::with_data_type() to customize the values' DataType

### DIFF
--- a/arrow-array/src/builder/primitive_run_builder.rs
+++ b/arrow-array/src/builder/primitive_run_builder.rs
@@ -277,9 +277,7 @@ mod tests {
 
     use crate::builder::PrimitiveRunBuilder;
     use crate::cast::AsArray;
-    use crate::types::{
-        Decimal128Type, Int16Type, TimestampMicrosecondType, UInt32Type,
-    };
+    use crate::types::{Decimal128Type, Int16Type, TimestampMicrosecondType, UInt32Type};
     use crate::{Array, Decimal128Array, TimestampMicrosecondArray, UInt32Array};
 
     #[test]


### PR DESCRIPTION
This enables setting a timezone or precision & scale on parameterized DataType values.

Note: I think the panic is unfortunate, and a try_with_data_type() would be sensible.

# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/8042.

# Are these changes tested?

Yes

# Are there any user-facing changes?

- Adds `PrimitiveRunBuilder::with_data_type`.
