### PR TITLE
Add some benchmarks for decoding delta encoded Parquet

### DIFF
--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -1214,7 +1214,7 @@ fn bench_primitive<T>(
         0,
         false,
     );
-    group.bench_function("binary skip packed single value", |b| {
+    group.bench_function("binary packed skip single value", |b| {
         b.iter(|| {
             let array_reader =
                 create_primitive_array_reader(data.clone(), mandatory_column_desc.clone());


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #9476.

# Rationale for this change

Add benchmarks to show benefit of the optimizations in #9477

# What changes are included in this PR?

Adds some benches for DELTA_BINARY_PACKED, DELTA_BYTE_ARRAY, and DELTA_LENGTH_BYTE_ARRAY. The generated data is meant to show the benefit of special casing for miniblocks with a bitwidth of 0.

# Are these changes tested?

Just benches

# Are there any user-facing changes?

No
