### PR TITLE
chore: pin comfy-table to 7.2.1 to respect our MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ include = [
     "NOTICE.txt",
 ]
 edition = "2024"
+# When this changes, please update rust-toolchain.toml to
+# ensure that CI uses the appropriate minimum version
 rust-version = "1.85"
 
 [workspace.dependencies]

--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -51,7 +51,7 @@ half = { version = "2.1", default-features = false }
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 lexical-core = { version = "1.0", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
 atoi = "2.0.0"
-comfy-table = { version = "7", optional = true, default-features = false }
+comfy-table = { version = "7.2.1", optional = true, default-features = false }
 base64 = "0.22"
 ryu = "1.0.16"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "1.91"
+channel = "1.85"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
The 7.2.2 release of comfy-table results in the build no longer being compatible with Rust 1.85. This change pins that restriction and ensures that CI is testing with our minimum version instead of the latest stable

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

cargo build

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

This broke some delta-kernel-rs builds when upgrading to 58