### PR TITLE
ci: Use rust 2024 edition's default resolver instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,6 @@ members = [
     "parquet_derive_test",
 ]
 
-# Enable the version 2 feature resolver, which avoids unifying features for targets that are not being built
-#
-# Critically this prevents dev-dependencies from enabling features even when not building a target that
-# uses dev-dependencies, e.g. the library crate. This in turn ensures that we can catch invalid feature
-# flag combinations that would otherwise only surface in dependent crates
-#
-# Reference - https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2
-#
-resolver = "2"
-
 exclude = [
     # arrow-pyarrow-testing is excluded because it requires a Python interpreter with the pyarrow package installed,
     # which makes running `cargo test --all` fail if the appropriate Python environment is not set up.


### PR DESCRIPTION


# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/pull/9501.

# Rationale for this change

We previously used `resolver=2` to enable feature unification. This functionality is now covered by the new `resolver=3`. Additionally, `resolver=3` is the default for the Rust 2024 edition and includes the valuable feature of MSRV-aware dependency resolution.

I just remove our old `resolver=2` pin so we can use the edition's default.

For more context: https://doc.rust-lang.org/nightly/cargo/reference/resolver.html#resolver-versions

# What changes are included in this PR?

cargo's resolver

# Are these changes tested?

In CI

# Are there any user-facing changes?

No