### PR TITLE
fix: first next_back() on new RowsIter panics

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1414,9 +1414,12 @@ impl DoubleEndedIterator for RowsIter<'_> {
         if self.end == self.start {
             return None;
         }
-        // Safety: We have checked that `start` is less than `end`
-        let row = unsafe { self.rows.row_unchecked(self.end - 1) };
+
         self.end -= 1;
+
+        // Safety: By construction we create `end >= start`, so if `end` is not equal to `start` it cannot be less than `start`
+        //          therefore `end - 1` is within range
+        let row = unsafe { self.rows.row_unchecked(self.end) };
         Some(row)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

it should not panic

# What changes are included in this PR?

correctly use last row in `next_back`

# Are these changes tested?

yes

# Are there any user-facing changes?

they can now use `next_back`