### PR TITLE
fix: remove incorrect debug assertion in BatchCoalescer 

### DIFF
--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -99,9 +99,8 @@ impl<B: ByteViewType> InProgressByteViewArray<B> {
     /// eagerly to avoid allocations that are not used.
     fn ensure_capacity(&mut self) {
         if self.views.capacity() == 0 {
-            self.views.reserve_exact(self.batch_size);
+            self.views.reserve(self.batch_size);
         }
-        debug_assert_eq!(self.views.capacity(), self.batch_size);
     }
 
     /// Finishes in progress buffer, if any

--- a/arrow-select/src/coalesce/primitive.rs
+++ b/arrow-select/src/coalesce/primitive.rs
@@ -56,9 +56,8 @@ impl<T: ArrowPrimitiveType> InProgressPrimitiveArray<T> {
     /// eagerly to avoid allocations that are not used.
     fn ensure_capacity(&mut self) {
         if self.current.capacity() == 0 {
-            self.current.reserve_exact(self.batch_size);
+            self.current.reserve(self.batch_size);
         }
-        debug_assert_eq!(self.current.capacity(), self.batch_size);
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

 - Closes https://github.com/apache/arrow-rs/issues/9506


# Rationale for this change

`Vec::reserve(n)` does not guarantee exact capacity, Rust's `MIN_NON_ZERO_CAP` optimization means `reserve(2)` gives capacity = 4 for most numeric types, causing `debug_assert_eq!(capacity, batch_size)` to panic in debug mode when `batch_size < 4`.
# What changes are included in this PR?

Replace `reserve` with `reserve_exact` in `ensure_capacity` in both `InProgressPrimitiveArray` and `InProgressByteViewArray`. `reserve_exact` skips the amortized growth optimization and allocates exactly the requested capacity, making the assertion correct.

# Are these changes tested?
No. This only fixes an incorrect debug assertion. 

# Are there any user-facing changes?
No
