### PR TITLE
[bench] Replace pure-Rust snap with C++ snappy library for parquet (de)compression

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -44,7 +44,7 @@ runs:
       shell: bash
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler
+        apt-get install -y protobuf-compiler g++
     - name: Disable debuginfo generation
       # Disable full debug symbol generation to speed up CI build and keep memory down
       # "1" means line tables only, which is useful for panic tracebacks.

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -44,7 +44,7 @@ runs:
       shell: bash
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler g++
+        apt-get install -y protobuf-compiler
     - name: Disable debuginfo generation
       # Disable full debug symbol generation to speed up CI build and keep memory down
       # "1" means line tables only, which is useful for panic tracebacks.

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -101,8 +101,10 @@ all-features = true
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
-# Enable snappy compression (uses C++ snappy library via snappy_src, plus snap crate for CLI framed format)
-snap = ["snappy_src", "dep:snap"]
+# Enable snappy compression using the pure-Rust snap crate
+snap = ["dep:snap"]
+# Use C++ snappy library instead of the pure-Rust snap crate (requires C++ compiler, not available on wasm32)
+snappy_cpp = ["snap", "snappy_src"]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -54,6 +54,7 @@ object_store = { version = "0.13.1", default-features = false, optional = true }
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
+snappy_src = { version = "0.2", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
 # To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backened` backends
 flate2 = { version = "1.1", default-features = false, optional = true }
@@ -81,7 +82,6 @@ ring = { version = "0.17", default-features = false, features = ["std"], optiona
 [dev-dependencies]
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 criterion = { workspace = true, default-features = false, features = ["async_futures"]  }
-snap = { version = "1.0", default-features = false }
 tempfile = { version = "3.0", default-features = false }
 insta = "1.43.1"
 brotli = { version = "8.0", default-features = false, features = ["std"] }
@@ -101,6 +101,8 @@ all-features = true
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
+# Enable snappy compression (uses C++ snappy library via snappy_src, plus snap crate for CLI framed format)
+snap = ["snappy_src", "dep:snap"]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -38,7 +38,6 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 snappy_src = { version = "0.2", default-features = false, optional = true }
 
 [dependencies]
-link-cplusplus = "1"
 arrow-array = { workspace = true, optional = true }
 arrow-buffer = { workspace = true, optional = true }
 arrow-csv = { workspace = true, optional = true }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -35,6 +35,7 @@ ring = { version = "0.17", default-features = false, features = ["wasm32_unknown
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
+snappy_src = { version = "0.2", default-features = false, optional = true }
 
 [dependencies]
 arrow-array = { workspace = true, optional = true }
@@ -54,7 +55,6 @@ object_store = { version = "0.13.1", default-features = false, optional = true }
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
-snappy_src = { version = "0.2", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
 # To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backened` backends
 flate2 = { version = "1.1", default-features = false, optional = true }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -38,6 +38,7 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 snappy_src = { version = "0.2", default-features = false, optional = true }
 
 [dependencies]
+link-cplusplus = "1"
 arrow-array = { workspace = true, optional = true }
 arrow-buffer = { workspace = true, optional = true }
 arrow-csv = { workspace = true, optional = true }

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -196,8 +196,8 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
     }
 }
 
-/// Snappy codec using C++ snappy library (non-wasm targets)
-#[cfg(all(any(feature = "snap", test), not(target_arch = "wasm32")))]
+/// Snappy codec using C++ snappy library (requires `snappy_cpp` feature, non-wasm targets only)
+#[cfg(all(feature = "snappy_cpp", not(target_arch = "wasm32")))]
 mod snappy_codec {
     use std::os::raw::c_char;
 
@@ -242,9 +242,7 @@ mod snappy_codec {
                 }
             };
             let offset = output_buf.len();
-            output_buf.reserve(len);
-            // SAFETY: we just reserved `len` bytes and snappy will write exactly `len` bytes
-            unsafe { output_buf.set_len(offset + len) };
+            output_buf.resize(offset + len, 0);
             let mut out_len = len;
             let status = unsafe {
                 snappy_uncompress(
@@ -263,11 +261,8 @@ mod snappy_codec {
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             let output_buf_len = output_buf.len();
-            let required_len =
-                unsafe { snappy_max_compressed_length(input_buf.len()) };
-            output_buf.reserve(required_len);
-            // SAFETY: we just reserved `required_len` bytes
-            unsafe { output_buf.set_len(output_buf_len + required_len) };
+            let required_len = unsafe { snappy_max_compressed_length(input_buf.len()) };
+            output_buf.resize(output_buf_len + required_len, 0);
             let mut out_len = required_len;
             let status = unsafe {
                 snappy_compress(
@@ -287,13 +282,16 @@ mod snappy_codec {
     }
 }
 
-/// Snappy codec using pure-Rust snap crate (wasm32 fallback)
-#[cfg(all(any(feature = "snap", test), target_arch = "wasm32"))]
+/// Snappy codec using pure-Rust snap crate (default, or wasm32 when snappy_cpp is enabled)
+#[cfg(all(
+    any(feature = "snap", test),
+    not(all(feature = "snappy_cpp", not(target_arch = "wasm32")))
+))]
 mod snappy_codec {
     use snap::raw::{Decoder, Encoder};
 
     use crate::compression::Codec;
-    use crate::errors::Result;
+    use crate::errors::{ParquetError, Result};
 
     pub struct SnappyCodec {
         decoder: Decoder,

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -196,7 +196,8 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
     }
 }
 
-#[cfg(any(feature = "snap", test))]
+/// Snappy codec using C++ snappy library (non-wasm targets)
+#[cfg(all(any(feature = "snap", test), not(target_arch = "wasm32")))]
 mod snappy_codec {
     use std::os::raw::c_char;
 
@@ -208,11 +209,9 @@ mod snappy_codec {
     use crate::compression::Codec;
     use crate::errors::{ParquetError, Result};
 
-    /// Codec for Snappy compression format using C++ snappy library.
     pub struct SnappyCodec;
 
     impl SnappyCodec {
-        /// Creates new Snappy compression codec.
         pub(crate) fn new() -> Self {
             Self
         }
@@ -256,7 +255,6 @@ mod snappy_codec {
                 )
             };
             if status != snappy_status_SNAPPY_OK {
-                // Reset length on failure
                 output_buf.truncate(offset);
                 return Err(general_err!("snappy: decompress error"));
             }
@@ -288,6 +286,74 @@ mod snappy_codec {
         }
     }
 }
+
+/// Snappy codec using pure-Rust snap crate (wasm32 fallback)
+#[cfg(all(any(feature = "snap", test), target_arch = "wasm32"))]
+mod snappy_codec {
+    use snap::raw::{Decoder, Encoder};
+
+    use crate::compression::Codec;
+    use crate::errors::Result;
+
+    pub struct SnappyCodec {
+        decoder: Decoder,
+        encoder: Encoder,
+    }
+
+    impl SnappyCodec {
+        pub(crate) fn new() -> Self {
+            Self {
+                decoder: Decoder::new(),
+                encoder: Encoder::new(),
+            }
+        }
+    }
+
+    impl Codec for SnappyCodec {
+        fn decompress(
+            &mut self,
+            input_buf: &[u8],
+            output_buf: &mut Vec<u8>,
+            uncompress_size: Option<usize>,
+        ) -> Result<usize> {
+            let len = uncompress_size.unwrap_or_else(|| {
+                snap::raw::decompress_len(input_buf).unwrap_or(0)
+            });
+            let offset = output_buf.len();
+            output_buf.resize(offset + len, 0);
+            match self.decoder.decompress(input_buf, &mut output_buf[offset..]) {
+                Ok(n) => {
+                    output_buf.truncate(offset + n);
+                    Ok(n)
+                }
+                Err(e) => {
+                    output_buf.truncate(offset);
+                    Err(general_err!("snappy decompress error: {}", e))
+                }
+            }
+        }
+
+        fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
+            let output_buf_len = output_buf.len();
+            let required_len = snap::raw::max_compress_len(input_buf.len());
+            output_buf.resize(output_buf_len + required_len, 0);
+            match self
+                .encoder
+                .compress(input_buf, &mut output_buf[output_buf_len..])
+            {
+                Ok(n) => {
+                    output_buf.truncate(output_buf_len + n);
+                    Ok(())
+                }
+                Err(e) => {
+                    output_buf.truncate(output_buf_len);
+                    Err(general_err!("snappy compress error: {}", e))
+                }
+            }
+        }
+    }
+}
+
 #[cfg(any(feature = "snap", test))]
 pub use snappy_codec::*;
 

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -198,24 +198,23 @@ pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<
 
 #[cfg(any(feature = "snap", test))]
 mod snappy_codec {
-    use snap::raw::{Decoder, Encoder, decompress_len, max_compress_len};
+    use std::os::raw::c_char;
+
+    use snappy_src::{
+        snappy_compress, snappy_max_compressed_length, snappy_status_SNAPPY_OK,
+        snappy_uncompress, snappy_uncompressed_length,
+    };
 
     use crate::compression::Codec;
-    use crate::errors::Result;
+    use crate::errors::{ParquetError, Result};
 
-    /// Codec for Snappy compression format.
-    pub struct SnappyCodec {
-        decoder: Decoder,
-        encoder: Encoder,
-    }
+    /// Codec for Snappy compression format using C++ snappy library.
+    pub struct SnappyCodec;
 
     impl SnappyCodec {
         /// Creates new Snappy compression codec.
         pub(crate) fn new() -> Self {
-            Self {
-                decoder: Decoder::new(),
-                encoder: Encoder::new(),
-            }
+            Self
         }
     }
 
@@ -228,23 +227,63 @@ mod snappy_codec {
         ) -> Result<usize> {
             let len = match uncompress_size {
                 Some(size) => size,
-                None => decompress_len(input_buf)?,
+                None => {
+                    let mut result: usize = 0;
+                    let status = unsafe {
+                        snappy_uncompressed_length(
+                            input_buf.as_ptr() as *const c_char,
+                            input_buf.len(),
+                            &mut result,
+                        )
+                    };
+                    if status != snappy_status_SNAPPY_OK {
+                        return Err(general_err!("snappy: unable to get uncompressed length"));
+                    }
+                    result
+                }
             };
             let offset = output_buf.len();
-            output_buf.resize(offset + len, 0);
-            self.decoder
-                .decompress(input_buf, &mut output_buf[offset..])
-                .map_err(|e| e.into())
+            output_buf.reserve(len);
+            // SAFETY: we just reserved `len` bytes and snappy will write exactly `len` bytes
+            unsafe { output_buf.set_len(offset + len) };
+            let mut out_len = len;
+            let status = unsafe {
+                snappy_uncompress(
+                    input_buf.as_ptr() as *const c_char,
+                    input_buf.len(),
+                    output_buf[offset..].as_mut_ptr() as *mut c_char,
+                    &mut out_len,
+                )
+            };
+            if status != snappy_status_SNAPPY_OK {
+                // Reset length on failure
+                output_buf.truncate(offset);
+                return Err(general_err!("snappy: decompress error"));
+            }
+            Ok(out_len)
         }
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
             let output_buf_len = output_buf.len();
-            let required_len = max_compress_len(input_buf.len());
-            output_buf.resize(output_buf_len + required_len, 0);
-            let n = self
-                .encoder
-                .compress(input_buf, &mut output_buf[output_buf_len..])?;
-            output_buf.truncate(output_buf_len + n);
+            let required_len =
+                unsafe { snappy_max_compressed_length(input_buf.len()) };
+            output_buf.reserve(required_len);
+            // SAFETY: we just reserved `required_len` bytes
+            unsafe { output_buf.set_len(output_buf_len + required_len) };
+            let mut out_len = required_len;
+            let status = unsafe {
+                snappy_compress(
+                    input_buf.as_ptr() as *const c_char,
+                    input_buf.len(),
+                    output_buf[output_buf_len..].as_mut_ptr() as *mut c_char,
+                    &mut out_len,
+                )
+            };
+            if status != snappy_status_SNAPPY_OK {
+                output_buf.truncate(output_buf_len);
+                return Err(general_err!("snappy: compress error"));
+            }
+            output_buf.truncate(output_buf_len + out_len);
             Ok(())
         }
     }

--- a/parquet/src/errors.rs
+++ b/parquet/src/errors.rs
@@ -101,13 +101,6 @@ impl From<io::Error> for ParquetError {
     }
 }
 
-#[cfg(any(feature = "snap", test))]
-impl From<snap::Error> for ParquetError {
-    fn from(e: snap::Error) -> ParquetError {
-        ParquetError::External(Box::new(e))
-    }
-}
-
 impl From<thrift::Error> for ParquetError {
     fn from(e: thrift::Error) -> ParquetError {
         ParquetError::External(Box::new(e))


### PR DESCRIPTION
https://github.com/apache/arrow-rs/issues/9530

Use snappy_src (C++ snappy bindings) for raw snappy compress/decompress instead of the pure-Rust snap crate, while keeping snap as a dependency for CLI framed format support.

Getting some good perf numbers here.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
