### PR TITLE
Make with_file_decryption_properties pub instead of pub(crate)

### DIFF
--- a/parquet/src/file/metadata/push_decoder.rs
+++ b/parquet/src/file/metadata/push_decoder.rs
@@ -308,7 +308,7 @@ impl ParquetMetaDataPushDecoder {
 
     #[cfg(feature = "encryption")]
     /// Provide decryption properties for decoding encrypted Parquet files
-    pub(crate) fn with_file_decryption_properties(
+    pub fn with_file_decryption_properties(
         mut self,
         file_decryption_properties: Option<std::sync::Arc<FileDecryptionProperties>>,
     ) -> Self {


### PR DESCRIPTION
# Which issue does this PR close?


- Closes #NNN.

# Rationale for this change
I would like to use `ParquetMetaDataPushDecoder` in arrow-datafusion, but the `with_file_decryption_properties` function is pub(crate), so I can't fully implement the encryption feature.,

# What changes are included in this PR?
Make it pub

# Are these changes tested?

Not needed

# Are there any user-facing changes?

Now pub
