### PR TITLE
feat: expose arrow schema on async avro reader

### DIFF
--- a/arrow-avro/src/reader/async_reader/mod.rs
+++ b/arrow-avro/src/reader/async_reader/mod.rs
@@ -1573,7 +1573,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_arrow_schema_from_reader_no_reader_schema() {
-        // Use a very small header size hint to force multiple fetches
         let file = arrow_test_data("avro/alltypes_plain.avro");
         let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
         let location = Path::from_filesystem_path(&file).unwrap();
@@ -1585,6 +1584,7 @@ mod tests {
             .clone()
             .with_metadata(Default::default());
 
+        // Build reader without providing reader schema - should use writer schema from file
         let reader = AsyncAvroFileReader::builder(file_reader, file_size, 1024)
             .try_build()
             .await
@@ -1600,17 +1600,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_arrow_schema_from_reader_with_reader_schema() {
-        // Use a very small header size hint to force multiple fetches
         let file = arrow_test_data("avro/alltypes_plain.avro");
         let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
         let location = Path::from_filesystem_path(&file).unwrap();
         let file_size = store.head(&location).await.unwrap().size;
 
         let file_reader = AvroObjectReader::new(store, location);
-        let schema = get_alltypes_schema();
-        let reader_schema = AvroSchema::try_from(schema.as_ref()).unwrap();
-        let expected_schema = schema.as_ref().clone().with_metadata(Default::default());
+        let schema = get_alltypes_schema()
+            .project(&[0, 1, 7])
+            .unwrap()
+            .with_metadata(Default::default());
+        let reader_schema = AvroSchema::try_from(&schema).unwrap();
+        let expected_schema = schema.clone();
 
+        // Build reader with provided reader schema - must apply the projection
         let reader = AsyncAvroFileReader::builder(file_reader, file_size, 1024)
             .with_reader_schema(reader_schema)
             .try_build()
@@ -1627,13 +1630,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_arrow_schema_from_reader_nested_records() {
-        // Use a very small header size hint to force multiple fetches
         let file = arrow_test_data("avro/nested_records.avro");
         let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
         let location = Path::from_filesystem_path(&file).unwrap();
         let file_size = store.head(&location).await.unwrap().size;
 
         let file_reader = AvroObjectReader::new(store, location);
+
+        // The schema produced by the reader should match the expected schema,
+        // attaching Avro type name metadata to fields of record and list types.
         let expected_schema = get_nested_records_schema()
             .as_ref()
             .clone()


### PR DESCRIPTION
# Rationale for this change

Exposes the Arrow schema produced by the async Avro file reader, similarly to the `schema` method on the synchronous reader.

This allows an application to prepare casting or other schema transformations with no need to fetch the first record batch to learn the produced Arrow schema. Since the async reader only parses OCF content for the moment, the schema does not change from batch to batch.

# What changes are included in this PR?

The `schema` method for `AsyncAvroFileReader` exposes the Arrow schema of record batches that are produced by the reader.

# Are these changes tested?

Added tests verifying that the returned schema matches the expected.

# Are there any user-facing changes?

Added a `schema` method to `AsyncAvroFileReader`.