### PR TITLE
fix: trim before parsing numbers

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -2830,6 +2830,16 @@ mod tests {
         // Whitespace-only strings should return None
         assert_eq!(Int32Type::parse("  "), None);
         assert_eq!(Float32Type::parse("  "), None);
+
+        // only leading
+        assert_eq!(Int8Type::parse("    63"), Some(63_i8));
+        assert_eq!(Int16Type::parse(" 87"), Some(87_i16));
+        assert_eq!(Int32Type::parse("     765"), Some(765_i32));
+
+        // only trailing
+        assert_eq!(Int8Type::parse("34 "), Some(34_i8));
+        assert_eq!(Int16Type::parse("87   "), Some(87_i16));
+        assert_eq!(Int32Type::parse("765     "), Some(765_i32));
     }
 
     #[test]

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        lexical_core::parse(string.trim().as_bytes())
+        lexical_core::parse(string.trim_ascii().as_bytes())
             .ok()
             .map(f16::from_f32)
     }
@@ -453,13 +453,13 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        lexical_core::parse(string.trim().as_bytes()).ok()
+        lexical_core::parse(string.trim_ascii().as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        lexical_core::parse(string.trim().as_bytes()).ok()
+        lexical_core::parse(string.trim_ascii().as_bytes()).ok()
     }
 }
 
@@ -467,7 +467,7 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                let string = string.trim();
+                let string = string.trim_ascii();
                 if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        lexical_core::parse(string.as_bytes())
+        lexical_core::parse(string.trim().as_bytes())
             .ok()
             .map(f16::from_f32)
     }
@@ -453,13 +453,13 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        lexical_core::parse(string.as_bytes()).ok()
+        lexical_core::parse(string.trim().as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        lexical_core::parse(string.as_bytes()).ok()
+        lexical_core::parse(string.trim().as_bytes()).ok()
     }
 }
 
@@ -467,6 +467,7 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
+                let string = string.trim();
                 if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
@@ -2801,6 +2802,34 @@ mod tests {
         assert_eq!(Float64Type::parse("+"), None);
         assert_eq!(TimestampNanosecondType::parse(""), None);
         assert_eq!(Date32Type::parse(""), None);
+    }
+
+    #[test]
+    fn test_parse_trimmed_whitespace() {
+        // Float types
+        assert_eq!(Float16Type::parse(" 1.5 "), Some(f16::from_f32(1.5)));
+        assert_eq!(Float32Type::parse(" 1.5 "), Some(1.5_f32));
+        assert_eq!(Float64Type::parse(" 1.5 "), Some(1.5_f64));
+        assert_eq!(Float32Type::parse("\t2.0\n"), Some(2.0_f32));
+        assert_eq!(Float64Type::parse("\t2.0\n"), Some(2.0_f64));
+
+        // Integer types
+        assert_eq!(Int8Type::parse(" 42 "), Some(42_i8));
+        assert_eq!(Int16Type::parse(" 42 "), Some(42_i16));
+        assert_eq!(Int32Type::parse(" 42 "), Some(42_i32));
+        assert_eq!(Int64Type::parse(" 42 "), Some(42_i64));
+        assert_eq!(UInt8Type::parse(" 42 "), Some(42_u8));
+        assert_eq!(UInt16Type::parse(" 42 "), Some(42_u16));
+        assert_eq!(UInt32Type::parse(" 42 "), Some(42_u32));
+        assert_eq!(UInt64Type::parse(" 42 "), Some(42_u64));
+
+        // Negative integers with whitespace
+        assert_eq!(Int32Type::parse(" -1 "), Some(-1_i32));
+        assert_eq!(Int64Type::parse("\t-100\n"), Some(-100_i64));
+
+        // Whitespace-only strings should return None
+        assert_eq!(Int32Type::parse("  "), None);
+        assert_eq!(Float32Type::parse("  "), None);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9538 

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The `Parser::parse` implementations for numeric types did not trim whitespace before parsing. This caused values like " 42 " or " 1.5 "  to fail parsing and return `None`, even though they represent valid numbers.



# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Added `.trim()` calls before parsing in FloatType Parser implementations.
- Added `string.trim()` at the top of the parser_primitive! macro, which covers all integer and duration types.


# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. Added test_parse_trimmed_whitespace covering:

- Float types with leading/trailing spaces and tabs/newlines
- Signed and unsigned integer types with whitespace
- Negative integers with whitespace
- Whitespace-only strings returning None

**Datafusion changes**
For the following SQL :-
```sql
 SELECT
    substring('Suite 28', 6) AS extracted,
    length(substring('Suite 28', 6)) AS extracted_length,
    CAST(substring('Suite 28', 6) AS INT) AS extracted_int,
    CAST(substring('Suite 28', 6) AS INT) + 1 AS plus_one;
```
in datafusion we used to get
| extracted | extracted_length | extracted_int | plus_one |
|----------|------------------|---------------|----------|
|  28      | 3                | null          | null     |

now after these changes, we get 
| extracted | extracted_length | extracted_int | plus_one |
|----------|------------------|---------------|----------|
|  28      | 3                | 28            | 29       |

this behaviour is now aligned with Databricks

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
Yes. Numeric parsing now accepts strings with leading/trailing whitespace. This is a relaxation of the previous behaviour (previously `None`, now `Some(value)`), so it is not a breaking change.
