### PR TITLE
arrow-select: fix MutableArrayData interleave for ListView

### DIFF
--- a/arrow-data/src/transform/list_view.rs
+++ b/arrow-data/src/transform/list_view.rs
@@ -27,21 +27,20 @@ pub(super) fn build_extend<T: ArrowNativeType + Integer + CheckedAdd>(
     let offsets = array.buffer::<T>(0);
     let sizes = array.buffer::<T>(1);
     Box::new(
-        move |mutable: &mut _MutableArrayData, _index: usize, start: usize, len: usize| {
-            let offset_buffer = &mut mutable.buffer1;
-            let sizes_buffer = &mut mutable.buffer2;
+        move |mutable: &mut _MutableArrayData, index: usize, start: usize, len: usize| {
+            let mut new_offset = T::usize_as(mutable.child_data[0].len());
 
-            for &offset in &offsets[start..start + len] {
-                offset_buffer.push(offset);
+            for i in start..start + len {
+                mutable.buffer1.push(new_offset);
+                mutable.buffer2.push(sizes[i]);
+                new_offset = new_offset.checked_add(&sizes[i]).expect("offset overflow");
+
+                let size = sizes[i].as_usize();
+                if size > 0 {
+                    let child_start = offsets[i].as_usize();
+                    mutable.child_data[0].extend(index, child_start, child_start + size);
+                }
             }
-
-            // sizes
-            for &size in &sizes[start..start + len] {
-                sizes_buffer.push(size);
-            }
-
-            // the beauty of views is that we don't need to copy child_data, we just splat
-            // the offsets and sizes.
         },
     )
 }

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -582,6 +582,7 @@ mod tests {
     use arrow_array::Int32RunArray;
     use arrow_array::builder::{GenericListBuilder, Int32Builder, PrimitiveRunBuilder};
     use arrow_array::types::Int8Type;
+    use arrow_buffer::ScalarBuffer;
     use arrow_schema::Field;
 
     #[test]
@@ -1488,5 +1489,59 @@ mod tests {
             interleave(&[&list], &indices),
             Err(ArrowError::OffsetOverflowError(_))
         ));
+    }
+
+    #[test]
+    fn test_interleave_list_view() {
+        // `interleave` for ListView falls through to `interleave_fallback`, which uses
+        // `MutableArrayData`. `list_view::build_extend` copies offsets/sizes but never
+        // extends the child array, so the result contains offsets/sizes that reference
+        // positions in the now-absent original child arrays while the child is empty.
+        //
+        // lv_a: [[1, 2], [3]]   (values=[1,2,3], offsets=[0,2], sizes=[2,1])
+        // lv_b: [[4, 5, 6]]     (values=[4,5,6], offsets=[0],   sizes=[3])
+        // interleave at [(0,0), (1,0), (0,1)] should produce [[1, 2], [4, 5, 6], [3]]
+        let field = Arc::new(Field::new_list_field(DataType::Int64, false));
+
+        let lv_a = ListViewArray::new(
+            Arc::clone(&field),
+            ScalarBuffer::from(vec![0i32, 2]),
+            ScalarBuffer::from(vec![2i32, 1]),
+            Arc::new(Int64Array::from(vec![1_i64, 2, 3])),
+            None,
+        );
+        let lv_b = ListViewArray::new(
+            field,
+            ScalarBuffer::from(vec![0i32]),
+            ScalarBuffer::from(vec![3i32]),
+            Arc::new(Int64Array::from(vec![4_i64, 5, 6])),
+            None,
+        );
+
+        let result = interleave(
+            &[&lv_a as &dyn Array, &lv_b as &dyn Array],
+            &[(0, 0), (1, 0), (0, 1)],
+        )
+        .unwrap();
+
+        result
+            .to_data()
+            .validate_full()
+            .expect("interleaved ListViewArray must be internally consistent");
+
+        let result_lv = result.as_list_view::<i32>();
+        assert_eq!(result_lv.len(), 3);
+        assert_eq!(
+            result_lv.value(0).as_primitive::<Int64Type>().values(),
+            &[1, 2]
+        );
+        assert_eq!(
+            result_lv.value(1).as_primitive::<Int64Type>().values(),
+            &[4, 5, 6]
+        );
+        assert_eq!(
+            result_lv.value(2).as_primitive::<Int64Type>().values(),
+            &[3]
+        );
     }
 }


### PR DESCRIPTION
The previous code did not extend child data buffers.

I'm preparing a PR for an optimized listview interleave, but wanted to make sure the fallback path was correct before comparing benchmarks.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9559 
- Closes https://github.com/apache/arrow-rs/pull/9562
- https://github.com/apache/arrow-rs/issues/9561

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Fix a bug

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Bugfix and test

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
ListView interleaves did not succeed previously.