### PR TITLE
fix: Used `checked_add` for bounds checks to avoid UB

### DIFF
--- a/arrow-buffer/src/util/bit_mask.rs
+++ b/arrow-buffer/src/util/bit_mask.rs
@@ -439,7 +439,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected="operation will overflow read buffer")]
+    #[should_panic(expected = "operation will overflow read buffer")]
     fn test_overflow_read_buffer_bounds() {
         // Tiny buffers so any huge computed index is out-of-bounds.
         let data = [0u8; 1];
@@ -457,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected="operation will overflow write buffer")]
+    #[should_panic(expected = "operation will overflow write buffer")]
     fn test_overflow_write_buffer_bounds() {
         // Tiny buffers so any huge computed index is out-of-bounds.
         let data = [0u8; 1];


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9543.

# Rationale for this change

See issue, but it is possible to construct arguments to `arrow_buffer::bit_util::bit_mask::set_bits` that overflow the bounds checking protecting unsafe code.

# What changes are included in this PR?
Use `checked_add` when doing the bounds checking and panic when an overflow occurs.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No
