### PR TITLE
[Variant] Add unshred_variant support for Binary and LargeBinary types

### DIFF
--- a/parquet-variant-compute/src/unshred_variant.rs
+++ b/parquet-variant-compute/src/unshred_variant.rs
@@ -683,7 +683,9 @@ impl<'a, L: ListLikeArray> ListUnshredVariantBuilder<'a, L> {
 #[cfg(test)]
 mod tests {
     use crate::VariantArray;
-    use arrow::array::{BinaryArray, BinaryViewArray, LargeBinaryArray, LargeStringArray, StringViewArray};
+    use arrow::array::{
+        BinaryArray, BinaryViewArray, LargeBinaryArray, LargeStringArray, StringViewArray,
+    };
     use parquet_variant::Variant;
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9526 

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`shred_variant` already supports Binary and LargeBinary types (#9525, #9554), but unshred_variant does not handle these types. This means shredded Binary/LargeBinary columns cannot be converted back to unshredded VariantArrays.

# What changes are included in this PR?

  Adds unshred_variant support for DataType::Binary and DataType::LargeBinary in parquet-variant-compute/src/unshred_variant.rs:
  - New enum variants PrimitiveBinary and PrimitiveLargeBinary
  - Match arms in append_row and try_new_opt
  - AppendToVariantBuilder impls for BinaryArray and LargeBinaryArray



# Are these changes tested?

Yes

# Are there any user-facing changes?

No breaking changes

