### PR TITLE
Pre-reserve output capacity in ByteView/ByteArray dictionary decoding

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -580,6 +580,9 @@ impl ByteArrayDecoderDictionary {
             return Ok(0);
         }
 
+        // Pre-reserve offsets capacity to avoid per-chunk reallocation
+        output.offsets.reserve(len);
+
         self.decoder.read(len, |keys| {
             output.extend_from_dictionary(keys, dict.offsets.as_slice(), dict.values.as_slice())
         })

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -500,6 +500,9 @@ impl ByteViewArrayDecoderDictionary {
         // then the base_buffer_idx is 5 - 2 = 3
         let base_buffer_idx = output.buffers.len() as u32 - dict.buffers.len() as u32;
 
+        // Pre-reserve output capacity to avoid per-chunk reallocation in extend
+        output.views.reserve(len);
+
         let mut error = None;
         let read = self.decoder.read(len, |keys| {
             if base_buffer_idx == 0 {


### PR DESCRIPTION
## Summary

- Reserve `output.views` capacity in `ByteViewArrayDecoderDictionary::read` before the decode loop
- Reserve `output.offsets` capacity in `ByteArrayDecoderDictionary::read` before the decode loop

This avoids per-chunk reallocation during `extend` calls inside the dictionary decode loop.

Closes #9587

## Test plan

- [ ] Existing tests pass (no functional change, only pre-allocation)
- [ ] Benchmark dictionary-encoded StringView/BinaryView/String reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)