### PR TITLE
Change occurances of `truncate(0)` to `clear`

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -1371,7 +1371,7 @@ mod tests {
             assert_eq!(pool.used(), 40);
 
             // Truncate to zero
-            buffer.truncate(0);
+            buffer.clear();
             assert_eq!(buffer.len(), 0);
             assert_eq!(pool.used(), 0);
         }

--- a/arrow-json/src/reader/value_iter.rs
+++ b/arrow-json/src/reader/value_iter.rs
@@ -73,7 +73,7 @@ impl<R: BufRead> Iterator for ValueIter<R> {
         }
 
         loop {
-            self.line_buf.truncate(0);
+            self.line_buf.clear();
             match self.reader.read_line(&mut self.line_buf) {
                 Ok(0) => {
                     // read_line returns 0 when stream reached EOF

--- a/parquet/tests/geospatial.rs
+++ b/parquet/tests/geospatial.rs
@@ -380,8 +380,8 @@ mod test {
 
         for i in 0..reader.num_row_groups() {
             let row_group = reader.get_row_group(i).unwrap();
-            values.truncate(0);
-            def_levels.truncate(0);
+            values.clear();
+            def_levels.clear();
 
             let mut row_group_out = writer.next_row_group().unwrap();
 


### PR DESCRIPTION
# Which issue does this PR close?

In response to a comment on #9494, I have searched for occurances of `truncate(0)` and replaced them with `clear` to be more idiomatic. I know it's only a minor stylistic change, but it does help with code readability.

In the process, I also noticed and fixed an inconsistency between `MutableBuffer::truncate` and `MutableBuffer::clear`. Not sure if this is a latent bug or actually benign.

# Rationale for this change

Explained above

# What changes are included in this PR?

* Replace a few instances of `truncate(0)` with `clear`
* Fix `MutableBuffer::clear` to be consistent with `MutableBuffer::truncate`

# Are these changes tested?

Yes, the existing test suite passes.

# Are there any user-facing changes?

No