### PR TITLE
[Variant]  Add unshredded `Struct` fast-path for `variant_get(..., Struct)`

### DIFF
--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -3144,8 +3144,12 @@ mod test {
 
         let result = variant_get(&variant_array_ref, options).unwrap();
         let struct_result = result.as_struct();
-        let field_a = struct_result.column(0).as_primitive::<arrow::datatypes::Int32Type>();
-        let field_b = struct_result.column(1).as_primitive::<arrow::datatypes::Int32Type>();
+        let field_a = struct_result
+            .column(0)
+            .as_primitive::<arrow::datatypes::Int32Type>();
+        let field_b = struct_result
+            .column(1)
+            .as_primitive::<arrow::datatypes::Int32Type>();
 
         // Row 0 is an object, so the struct row is valid with extracted fields.
         assert!(!struct_result.is_null(0));
@@ -3187,9 +3191,10 @@ mod test {
         };
 
         let err = variant_get(&variant_array_ref, options).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Failed to extract struct from variant"));
+        assert!(
+            err.to_string()
+                .contains("Failed to extract struct from variant")
+        );
     }
 
     /// Create comprehensive shredded variant with diverse null patterns and empty objects


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9596.

# Rationale for this change

Check issue
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Reuse `shred_basic_variant` as a fast path for unshredded `Struct` handling in `variant_get(..., Struct)`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes, added two unit tests to establish safe mode behavior.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
