### PR TITLE
fix: Stop using https://dist.apache.org/repos/dist/dev/arrow/KEYS for verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -33,23 +33,27 @@ set -o pipefail
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ARROW_DIR="$(dirname $(dirname ${SOURCE_DIR}))"
-ARROW_DIST_URL='https://dist.apache.org/repos/dist/dev/arrow'
+ARROW_RC_URL="https://dist.apache.org/repos/dist/dev/arrow"
+ARROW_KEYS_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS"
 
-download_dist_file() {
+download_file() {
   curl \
     --silent \
     --show-error \
     --fail \
     --location \
-    --remote-name $ARROW_DIST_URL/$1
+    --output "$2" \
+    "$1"
 }
 
 download_rc_file() {
-  download_dist_file apache-arrow-rs-${VERSION}-rc${RC_NUMBER}/$1
+  download_file \
+  "${ARROW_RC_URL}/apache-arrow-rs-${VERSION}-rc${RC_NUMBER}/$1" \
+  "$1"
 }
 
 import_gpg_keys() {
-  download_dist_file KEYS
+  download_file "${ARROW_KEYS_URL}" KEYS
   gpg --import KEYS
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9603 

# Rationale for this change

The release and dev KEYS files could get out of synch.
We should use the release/ version:
- Users use the release/ version not dev/ version when they verify our artifacts' signature
- https://dist.apache.org/ may reject our request when we request many times by CI

# What changes are included in this PR?

Use `https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS` to download the KEYS file and the expected `https://dist.apache.org/repos/dist/dev/arrow` for the RC artifacts.

# Are these changes tested?

Yes, I've verified 58.1.0 1 both previous to the change and after the change.

# Are there any user-facing changes?

No
