### PR TITLE
deps: fix `object_store` breakage for 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,11 +108,13 @@ parquet-variant-compute = { version = "58.1.0", path = "./parquet-variant-comput
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 
-simdutf8 = { version = "0.1.5", default-features = false }
-
 criterion = { version = "0.8.0", default-features = false }
 
 insta = { version = "1.46.3", default-features = false }
+
+object_store = { version = "0.13.2", default-features = false }
+
+simdutf8 = { version = "0.1.5", default-features = false }
 
 # release inherited profile keeping debug information and symbols
 # for mem/cpu profiling

--- a/arrow-avro/Cargo.toml
+++ b/arrow-avro/Cargo.toml
@@ -56,7 +56,7 @@ arrow-buffer = { workspace = true }
 arrow-array = { workspace = true }
 arrow-select = { workspace = true, optional = true }
 
-object_store = { version = "0.13", default-features = false, optional = true }
+object_store = { workspace = true, optional = true }
 
 bytes = { version = "1.11.0", default-features = false, features = ["std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
@@ -93,7 +93,7 @@ futures = "0.3.31"
 async-stream = "0.3.6"
 apache-avro = "0.21.0"
 num-bigint = "0.4"
-object_store = { version = "0.13", default-features = false, features = ["fs"] }
+object_store = { workspace = true, features = ["fs"] }
 once_cell = "1.21.3"
 half = { version = "2.1", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -49,7 +49,7 @@ parquet-variant = { workspace = true, optional = true }
 parquet-variant-json = { workspace = true, optional = true }
 parquet-variant-compute = { workspace = true, optional = true }
 
-object_store = { version = "0.13.1", default-features = false, optional = true }
+object_store = { workspace = true, optional = true, features = ["tokio"] }
 
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
@@ -93,7 +93,7 @@ arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "jso
 arrow-cast = { workspace = true }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
 rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-object_store = { version = "0.13.1", default-features = false, features = ["azure", "fs"] }
+object_store = { workspace = true, features = ["azure", "fs"] }
 sysinfo = { version = "0.38.1", default-features = false, features = ["system"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Rationale for this change

The `object_store` crate release 0.13.2 breaks the build of parquet because it feature-gates the `buffered` module. I have filed https://github.com/apache/arrow-rs-object-store/issues/677 about the breakage; meanwhile this fix is made in expectation that 0.13.2 will not be yanked and the feature gate will remain.

# What changes are included in this PR?

Bump the version to 0.13.2 and requesting the "tokio" feature.

# Are these changes tested?

The build should succeed in CI workflows.

# Are there any user-facing changes?

No