### PR TITLE
Fix `MutableBuffer::clear`

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -1371,7 +1371,7 @@ mod tests {
             assert_eq!(pool.used(), 40);
 
             // Truncate to zero
-            buffer.truncate(0);
+            buffer.clear();
             assert_eq!(buffer.len(), 0);
             assert_eq!(pool.used(), 0);
         }

--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -450,7 +450,13 @@ impl MutableBuffer {
 
     /// Clear all existing data from this buffer.
     pub fn clear(&mut self) {
-        self.len = 0
+        self.len = 0;
+        #[cfg(feature = "pool")]
+        {
+            if let Some(reservation) = self.reservation.lock().unwrap().as_mut() {
+                reservation.resize(self.len);
+            }
+        }
     }
 
     /// Returns the data stored in this buffer as a slice.

--- a/arrow-json/src/reader/value_iter.rs
+++ b/arrow-json/src/reader/value_iter.rs
@@ -73,7 +73,7 @@ impl<R: BufRead> Iterator for ValueIter<R> {
         }
 
         loop {
-            self.line_buf.truncate(0);
+            self.line_buf.clear();
             match self.reader.read_line(&mut self.line_buf) {
                 Ok(0) => {
                     // read_line returns 0 when stream reached EOF

--- a/parquet/tests/geospatial.rs
+++ b/parquet/tests/geospatial.rs
@@ -380,8 +380,8 @@ mod test {
 
         for i in 0..reader.num_row_groups() {
             let row_group = reader.get_row_group(i).unwrap();
-            values.truncate(0);
-            def_levels.truncate(0);
+            values.clear();
+            def_levels.clear();
 
             let mut row_group_out = writer.next_row_group().unwrap();
 


### PR DESCRIPTION
# Which issue does this PR close?

- closes https://github.com/apache/arrow-rs/pull/9593

# Rationale for this change

In a previous PR (#9593), I change instances of `truncate(0)` to `clear()`. However, this breaks the test `test_truncate_with_pool` at `arrow-buffer/src/buffer/mutable.rs:1357`, due to an inconsistency between the implementation of `truncate` and `clear`. This PR fixes that test.

# What changes are included in this PR?

This PR copies a section of code related to the `pool` feature present in `truncate` but absent in `clear`, fixing the failing unit test.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.