### PR TITLE
fix: handle missing dictionary batch for null-only columns in IPC reader

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -3283,12 +3283,10 @@ mod tests {
             // Each message is: [continuation (4 bytes)] [meta_len (4 bytes)]
             //                   [metadata (meta_len bytes)] [body (bodyLength bytes)]
             let mut header = [0u8; 4];
-            if std::io::Read::read_exact(&mut cursor, &mut header).is_err() {
+            if cursor.read_exact(&mut header).is_err() {
                 break;
             }
-            if header == CONTINUATION_MARKER
-                && std::io::Read::read_exact(&mut cursor, &mut header).is_err()
-            {
+            if header == CONTINUATION_MARKER && cursor.read_exact(&mut header).is_err() {
                 break;
             }
             let meta_len = u32::from_le_bytes(header) as usize;
@@ -3299,12 +3297,12 @@ mod tests {
                 break;
             }
             let mut meta_buf = vec![0u8; meta_len];
-            std::io::Read::read_exact(&mut cursor, &mut meta_buf).unwrap();
+            cursor.read_exact(&mut meta_buf).unwrap();
 
             let message = root_as_message(&meta_buf).unwrap();
             let body_len = message.bodyLength() as usize;
             let mut body_buf = vec![0u8; body_len];
-            std::io::Read::read_exact(&mut cursor, &mut body_buf).unwrap();
+            cursor.read_exact(&mut body_buf).unwrap();
 
             if message.header_type() == crate::MessageHeader::DictionaryBatch {
                 // Skip the dictionary batch — this is what C++ does for


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9595

# Rationale for this change

The [IPC specification](https://arrow.apache.org/docs/format/Columnar.html#format-ipc) states:

> An edge-case for interleaved dictionary and record batches occurs when the record batches contain dictionary encoded arrays that are completely null. In this case, the dictionary for the encoded column might appear after the first record batch.

Arrow C++ (v17+) relies on this and does not emit a dictionary batch when all values in a dictionary-encoded column are null.  The Rust IPC reader currently fails with `"Cannot find a dictionary batch with dict id: ..."` when reading such streams, making cross-language interop broken for this edge case.

# What changes are included in this PR?

When the IPC reader encounters a `Dictionary`-typed column whose `dict_id` has no corresponding entry in `dictionaries_by_id`, it now synthesizes an empty values array of the appropriate type (via `new_empty_array`) instead of returning an error.  This matches the spec's allowance for omitted dictionary batches on null-only columns.

# Are these changes tested?

Yes.  A new test (`test_read_null_dict_without_dictionary_batch`) writes an IPC stream with an all-null dictionary column, strips the dictionary batch message from the raw bytes to simulate C++ behavior, then verifies the Rust reader successfully decodes the stream.

# Are there any user-facing changes?

IPC streams produced by C++ (or other implementations) that omit dictionary batches for null-only dictionary columns can now be read without error.  Previously these streams caused a `ParseError`.