### PR TITLE
Add bloom filter folding to automatically size SBBF filters

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -275,5 +275,9 @@ name = "row_selection_cursor"
 harness = false
 required-features = ["arrow"]
 
+[[bench]]
+name = "bloom_filter"
+harness = false
+
 [lib]
 bench = false

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use parquet::bloom_filter::Sbbf;
 
 /// Build a bloom filter sized for `initial_ndv` at `fpp`, insert `num_values` distinct values,
@@ -39,20 +39,16 @@ fn bench_fold_to_target_fpp(c: &mut Criterion) {
         let filter = build_filter(initial_ndv, fpp, num_values);
         let num_blocks = filter.num_blocks();
         group.throughput(Throughput::Elements(num_blocks as u64));
-        group.bench_with_input(
-            BenchmarkId::new("ndv", num_values),
-            &filter,
-            |b, filter| {
-                b.iter_batched(
-                    || filter.clone(),
-                    |mut f| {
-                        f.fold_to_target_fpp(fpp);
-                        f
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("ndv", num_values), &filter, |b, filter| {
+            b.iter_batched(
+                || filter.clone(),
+                |mut f| {
+                    f.fold_to_target_fpp(fpp);
+                    f
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
     }
     group.finish();
 }

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use parquet::bloom_filter::Sbbf;
+
+/// Build a bloom filter sized for `initial_ndv` at `fpp`, insert `num_values` distinct values,
+/// and return it ready for folding.
+fn build_filter(initial_ndv: u64, fpp: f64, num_values: u64) -> Sbbf {
+    let mut sbbf = Sbbf::new_with_ndv_fpp(initial_ndv, fpp).unwrap();
+    for i in 0..num_values {
+        sbbf.insert(&i);
+    }
+    sbbf
+}
+
+fn bench_fold_to_target_fpp(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold_to_target_fpp");
+
+    // Realistic scenario: filter sized for 1M NDV, varying actual distinct values
+    let initial_ndv = 1_000_000u64;
+    let fpp = 0.05;
+
+    for num_values in [1_000u64, 10_000, 100_000] {
+        let filter = build_filter(initial_ndv, fpp, num_values);
+        let num_blocks = filter.num_blocks();
+        group.throughput(Throughput::Elements(num_blocks as u64));
+        group.bench_with_input(
+            BenchmarkId::new("ndv", num_values),
+            &filter,
+            |b, filter| {
+                b.iter_batched(
+                    || filter.clone(),
+                    |mut f| {
+                        f.fold_to_target_fpp(fpp);
+                        f
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_insert_and_fold(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert_and_fold");
+
+    let initial_ndv = 1_000_000u64;
+    let fpp = 0.05;
+
+    for num_values in [1_000u64, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(num_values));
+        group.bench_with_input(
+            BenchmarkId::new("values", num_values),
+            &num_values,
+            |b, &num_values| {
+                b.iter(|| {
+                    let mut sbbf = Sbbf::new_with_ndv_fpp(initial_ndv, fpp).unwrap();
+                    for i in 0..num_values {
+                        sbbf.insert(&i);
+                    }
+                    sbbf.fold_to_target_fpp(fpp);
+                    sbbf
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_fold_to_target_fpp, bench_insert_and_fold);
+criterion_main!(benches);

--- a/parquet/benches/bloom_filter.rs
+++ b/parquet/benches/bloom_filter.rs
@@ -79,5 +79,35 @@ fn bench_insert_and_fold(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_fold_to_target_fpp, bench_insert_and_fold);
+fn bench_insert_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert_only");
+
+    let initial_ndv = 1_000_000u64;
+    let fpp = 0.05;
+
+    for num_values in [1_000u64, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(num_values));
+        group.bench_with_input(
+            BenchmarkId::new("values", num_values),
+            &num_values,
+            |b, &num_values| {
+                b.iter(|| {
+                    let mut sbbf = Sbbf::new_with_ndv_fpp(initial_ndv, fpp).unwrap();
+                    for i in 0..num_values {
+                        sbbf.insert(&i);
+                    }
+                    sbbf
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_fold_to_target_fpp,
+    bench_insert_and_fold,
+    bench_insert_only
+);
 criterion_main!(benches);

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -16,13 +16,13 @@
 // under the License.
 
 use crate::basic::Encoding;
-use crate::bloom_filter::Sbbf;
+use crate::bloom_filter::{Sbbf, num_of_bits_from_ndv_fpp};
 use crate::column::writer::encoder::{ColumnValueEncoder, DataPageValues, DictionaryPage};
 use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
 use crate::encodings::rle::RleEncoder;
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
+use crate::file::properties::{EnabledStatistics, WriterProperties, WriterVersion, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::ColumnDescPtr;
@@ -423,6 +423,7 @@ pub struct ByteArrayEncoder {
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
     bloom_filter: Option<Sbbf>,
+    bloom_filter_target_fpp: Option<f64>,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
 }
 
@@ -430,7 +431,11 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     type T = ByteArray;
     type Values = dyn Array;
     fn flush_bloom_filter(&mut self) -> Option<Sbbf> {
-        self.bloom_filter.take()
+        let mut sbbf = self.bloom_filter.take()?;
+        if let Some(target_fpp) = self.bloom_filter_target_fpp {
+            sbbf.fold_to_target_fpp(target_fpp);
+        }
+        Some(sbbf)
     }
 
     fn try_new(descr: &ColumnDescPtr, props: &WriterProperties) -> Result<Self>
@@ -443,10 +448,30 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
         let fallback = FallbackEncoder::new(descr, props)?;
 
-        let bloom_filter = props
-            .bloom_filter_properties(descr.path())
-            .map(|props| Sbbf::new_with_ndv_fpp(props.ndv, props.fpp))
-            .transpose()?;
+        let (bloom_filter, bloom_filter_target_fpp) =
+            match props.bloom_filter_properties(descr.path()) {
+                Some(bf_props) => match bf_props.ndv {
+                    Some(ndv) => {
+                        // Fixed-size mode: size based on explicit NDV (legacy behavior)
+                        (Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?), None)
+                    }
+                    None => {
+                        // Folding mode: allocate large, fold down at flush
+                        let max_bytes = bf_props.max_bytes.unwrap_or_else(|| {
+                            let row_count = props
+                                .max_row_group_row_count()
+                                .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
+                                as u64;
+                            num_of_bits_from_ndv_fpp(row_count, bf_props.fpp) / 8
+                        });
+                        (
+                            Some(Sbbf::new_with_num_of_bytes(max_bytes)),
+                            Some(bf_props.fpp),
+                        )
+                    }
+                },
+                None => (None, None),
+            };
 
         let statistics_enabled = props.statistics_enabled(descr.path());
 
@@ -456,6 +481,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             fallback,
             statistics_enabled,
             bloom_filter,
+            bloom_filter_target_fpp,
             dict_encoder: dictionary,
             min_value: None,
             max_value: None,

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -17,7 +17,9 @@
 
 use crate::basic::Encoding;
 use crate::bloom_filter::Sbbf;
-use crate::column::writer::encoder::{ColumnValueEncoder, DataPageValues, DictionaryPage};
+use crate::column::writer::encoder::{
+    ColumnValueEncoder, DataPageValues, DictionaryPage, create_bloom_filter,
+};
 use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
 use crate::encodings::rle::RleEncoder;
@@ -423,7 +425,7 @@ pub struct ByteArrayEncoder {
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
     bloom_filter: Option<Sbbf>,
-    bloom_filter_target_fpp: Option<f64>,
+    bloom_filter_target_fpp: f64,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
 }
 
@@ -432,9 +434,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     type Values = dyn Array;
     fn flush_bloom_filter(&mut self) -> Option<Sbbf> {
         let mut sbbf = self.bloom_filter.take()?;
-        if let Some(target_fpp) = self.bloom_filter_target_fpp {
-            sbbf.fold_to_target_fpp(target_fpp);
-        }
+        sbbf.fold_to_target_fpp(self.bloom_filter_target_fpp);
         Some(sbbf)
     }
 
@@ -448,15 +448,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
         let fallback = FallbackEncoder::new(descr, props)?;
 
-        let (bloom_filter, bloom_filter_target_fpp) =
-            match props.bloom_filter_properties(descr.path()) {
-                Some(bf_props) => {
-                    let (sbbf, target_fpp) =
-                        Sbbf::from_properties(bf_props, props.max_row_group_row_count())?;
-                    (Some(sbbf), target_fpp)
-                }
-                None => (None, None),
-            };
+        let (bloom_filter, bloom_filter_target_fpp) = create_bloom_filter(props, descr)?;
 
         let statistics_enabled = props.statistics_enabled(descr.path());
 

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -16,15 +16,13 @@
 // under the License.
 
 use crate::basic::Encoding;
-use crate::bloom_filter::{Sbbf, num_of_bits_from_ndv_fpp};
+use crate::bloom_filter::Sbbf;
 use crate::column::writer::encoder::{ColumnValueEncoder, DataPageValues, DictionaryPage};
 use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
 use crate::encodings::rle::RleEncoder;
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{
-    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties, WriterVersion,
-};
+use crate::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::ColumnDescPtr;
@@ -452,26 +450,11 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
         let (bloom_filter, bloom_filter_target_fpp) =
             match props.bloom_filter_properties(descr.path()) {
-                Some(bf_props) => match bf_props.ndv {
-                    Some(ndv) => {
-                        // Fixed-size mode: size based on explicit NDV (legacy behavior)
-                        (Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?), None)
-                    }
-                    None => {
-                        // Folding mode: allocate large, fold down at flush
-                        let max_bytes = bf_props.max_bytes.unwrap_or_else(|| {
-                            let row_count = props
-                                .max_row_group_row_count()
-                                .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
-                                as u64;
-                            num_of_bits_from_ndv_fpp(row_count, bf_props.fpp) / 8
-                        });
-                        (
-                            Some(Sbbf::new_with_num_of_bytes(max_bytes)),
-                            Some(bf_props.fpp),
-                        )
-                    }
-                },
+                Some(bf_props) => {
+                    let (sbbf, target_fpp) =
+                        Sbbf::from_properties(bf_props, props.max_row_group_row_count())?;
+                    (Some(sbbf), target_fpp)
+                }
                 None => (None, None),
             };
 

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -22,7 +22,9 @@ use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
 use crate::encodings::rle::RleEncoder;
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{EnabledStatistics, WriterProperties, WriterVersion, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
+use crate::file::properties::{
+    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties, WriterVersion,
+};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::ColumnDescPtr;

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3172,7 +3172,7 @@ mod tests {
         // NDV smaller than actual distinct values — tests the underestimate path
         let mut options = RoundTripOptions::new(array, false);
         options.bloom_filter = true;
-        options.bloom_filter_ndv = Some(10);
+        options.bloom_filter_ndv = Some(3);
 
         let files = one_column_roundtrip_with_options(options);
         check_bloom_filter(

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3148,12 +3148,31 @@ mod tests {
         );
     }
 
+    /// Test that bloom filter folding produces correct results even when
+    /// the configured NDV differs significantly from actual NDV.
+    /// A large NDV means a larger initial filter that gets folded down;
+    /// a small NDV means a smaller initial filter.
     #[test]
-    fn i32_column_bloom_filter_fixed_size() {
+    fn i32_column_bloom_filter_fixed_ndv() {
         let array = Arc::new(Int32Array::from_iter(0..SMALL_SIZE as i32));
+
+        // NDV much larger than actual distinct values — tests folding a large filter down
+        let mut options = RoundTripOptions::new(array.clone(), false);
+        options.bloom_filter = true;
+        options.bloom_filter_ndv = Some(1_000_000);
+
+        let files = one_column_roundtrip_with_options(options);
+        check_bloom_filter(
+            files,
+            "col".to_string(),
+            (0..SMALL_SIZE as i32).collect(),
+            (SMALL_SIZE as i32 + 1..SMALL_SIZE as i32 + 10).collect(),
+        );
+
+        // NDV smaller than actual distinct values — tests the underestimate path
         let mut options = RoundTripOptions::new(array, false);
         options.bloom_filter = true;
-        options.bloom_filter_ndv = Some(SMALL_SIZE as u64);
+        options.bloom_filter_ndv = Some(10);
 
         let files = one_column_roundtrip_with_options(options);
         check_bloom_filter(

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2681,6 +2681,7 @@ mod tests {
         values: ArrayRef,
         schema: SchemaRef,
         bloom_filter: bool,
+        bloom_filter_ndv: Option<u64>,
         bloom_filter_position: BloomFilterPosition,
     }
 
@@ -2692,6 +2693,7 @@ mod tests {
                 values,
                 schema: Arc::new(schema),
                 bloom_filter: false,
+                bloom_filter_ndv: None,
                 bloom_filter_position: BloomFilterPosition::AfterRowGroup,
             }
         }
@@ -2712,6 +2714,7 @@ mod tests {
             values,
             schema,
             bloom_filter,
+            bloom_filter_ndv,
             bloom_filter_position,
         } = options;
 
@@ -2750,15 +2753,18 @@ mod tests {
             for encoding in &encodings {
                 for version in [WriterVersion::PARQUET_1_0, WriterVersion::PARQUET_2_0] {
                     for row_group_size in row_group_sizes {
-                        let props = WriterProperties::builder()
+                        let mut builder = WriterProperties::builder()
                             .set_writer_version(version)
                             .set_max_row_group_row_count(Some(row_group_size))
                             .set_dictionary_enabled(dictionary_size != 0)
                             .set_dictionary_page_size_limit(dictionary_size.max(1))
                             .set_encoding(*encoding)
                             .set_bloom_filter_enabled(bloom_filter)
-                            .set_bloom_filter_position(bloom_filter_position)
-                            .build();
+                            .set_bloom_filter_position(bloom_filter_position);
+                        if let Some(ndv) = bloom_filter_ndv {
+                            builder = builder.set_bloom_filter_ndv(ndv);
+                        }
+                        let props = builder.build();
 
                         files.push(roundtrip_opts(&expected_batch, props))
                     }
@@ -3132,6 +3138,22 @@ mod tests {
         let array = Arc::new(Int32Array::from_iter(0..SMALL_SIZE as i32));
         let mut options = RoundTripOptions::new(array, false);
         options.bloom_filter = true;
+
+        let files = one_column_roundtrip_with_options(options);
+        check_bloom_filter(
+            files,
+            "col".to_string(),
+            (0..SMALL_SIZE as i32).collect(),
+            (SMALL_SIZE as i32 + 1..SMALL_SIZE as i32 + 10).collect(),
+        );
+    }
+
+    #[test]
+    fn i32_column_bloom_filter_fixed_size() {
+        let array = Arc::new(Int32Array::from_iter(0..SMALL_SIZE as i32));
+        let mut options = RoundTripOptions::new(array, false);
+        options.bloom_filter = true;
+        options.bloom_filter_ndv = Some(SMALL_SIZE as u64);
 
         let files = one_column_roundtrip_with_options(options);
         check_bloom_filter(

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -498,81 +498,45 @@ impl Sbbf {
         );
         let half = len / 2;
         for i in 0..half {
+            let a = self.0[2 * i]; // Copy to avoid aliasing with self.0[i]
+            let b = self.0[2 * i + 1];
             for j in 0..8 {
-                self.0[i].0[j] = self.0[2 * i].0[j] | self.0[2 * i + 1].0[j];
+                self.0[i].0[j] = a.0[j] | b.0[j];
             }
         }
         self.0.truncate(half);
     }
 
-    /// Estimate the FPP that would result from folding once, without mutating the filter.
-    ///
-    /// Unlike standard Bloom filters where FPP depends on the global fill ratio, SBBF
-    /// membership checks are **per-block**: a query hashes to exactly one block, then checks
-    /// `k=8` bits within that block. The FPP is therefore the **average of per-block FPPs**:
-    ///
-    /// ```text
-    /// FPP = (1 / num_blocks) * sum_i (set_bits_in_block_i / 256)^8
-    /// ```
-    ///
-    /// To project the FPP after a fold, we simulate the merge of each adjacent pair `(2i, 2i+1)`
-    /// by computing `(block[2i] | block[2i+1]).count_ones()` without actually mutating the filter.
-    fn estimated_fpp_after_fold(&self) -> f64 {
-        let half = self.0.len() / 2;
-        let mut total_fpp: f64 = 0.0;
-        for i in 0..half {
-            let mut set_bits: u32 = 0;
-            for j in 0..8 {
-                set_bits += (self.0[2 * i].0[j] | self.0[2 * i + 1].0[j]).count_ones();
-            }
-            let block_fill = f64::from(set_bits) / 256.0;
-            total_fpp += block_fill.powi(8);
-        }
-        total_fpp / half as f64
-    }
-
-    /// Fold the bloom filter down to the smallest size that still meets the target FPP 
+    /// Fold the bloom filter down to the smallest size that still meets the target FPP
     /// (False Positive Percentage)
     ///
-    /// Repeatedly halves the filter by merging adjacent block pairs (see `fold_once`),
+    /// Repeatedly halves the filter by merging adjacent block pairs via bitwise OR,
     /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or
     /// when the filter reaches the minimum size of 1 block (32 bytes).
     ///
-    /// ## Background
+    /// ## How it works
     ///
-    /// Bloom filter folding is a technique for dynamically resizing filters after
-    /// construction. For a standard Bloom filter of size `m` (a power of two), an element
-    /// hashed to index `i = h(x) mod m` would map to `i' = h(x) mod (m/2)` in a filter
-    /// half the size. Since `m` is a power of two, the fold is a bitwise OR of the upper half
-    /// onto the lower half: `B_folded[j] = B[j] | B[j + m/2]`.
-    ///
-    /// ## Adaptation for SBBF
-    ///
-    /// SBBFs use multiplicative hashing for block selection rather than modular arithmetic:
+    /// SBBFs use multiplicative hashing for block selection:
     ///
     /// ```text
     /// block_index = ((hash >> 32) * num_blocks) >> 32
     /// ```
     ///
     /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`, so
-    /// blocks `2i` and `2i+1` (not `i` and `i+N/2`) map to the same position. The fold
-    /// therefore merges **adjacent** pairs:
+    /// blocks `2i` and `2i+1` map to the same position. Each fold merges **adjacent** pairs:
     ///
     /// ```text
     /// folded[i] = blocks[2*i] | blocks[2*i + 1]
     /// ```
     ///
-    /// ## FPP estimation
-    ///
-    /// SBBF membership checks are per-block (`k=8` bit checks within one 256-bit block), so
-    /// the FPP is the average of per-block false positive probabilities:
+    /// The FPP after a fold is estimated as the average per-block false positive probability:
     ///
     /// ```text
     /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
     /// ```
     ///
-    /// Before each fold, we project the post-fold FPP by simulating the block merges. Folding
-    /// stops when the next fold would exceed the target.
+    /// Each iteration computes the folded blocks and their FPP in a single pass. If the
+    /// estimated FPP would exceed the target, the fold is discarded and iteration stops.
     ///
     /// ## Correctness
     ///
@@ -580,32 +544,34 @@ impl Sbbf {
     /// filter remains set in the folded filter (via bitwise OR). The only effect is a controlled
     /// increase in FPP as set bits from different blocks are merged together.
     ///
-    /// ## Typical usage
-    ///
-    /// ```text
-    /// // 1. Allocate large (worst-case NDV = max row group rows)
-    /// let mut sbbf = Sbbf::new_with_num_of_bytes(1_048_576); // 1 MiB
-    ///
-    /// // 2. Insert all values during column writing
-    /// for value in column_values {
-    ///     sbbf.insert(&value);
-    /// }
-    ///
-    /// // 3. Fold down to target FPP before serializing
-    /// sbbf.fold_to_target_fpp(0.05);
-    /// // Filter is now optimally sized for the actual data
-    /// ```
-    ///
     /// ## References
     ///
     /// - Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
     ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
         while self.0.len() >= 2 {
-            if self.estimated_fpp_after_fold() > target_fpp {
+            // Compute the folded blocks and estimate FPP in a single pass.
+            // Using a fresh Vec avoids aliasing, enabling auto-vectorization of the
+            // inner [u32; 8] OR loop. chunks_exact(2) eliminates bounds checks.
+            let half = self.0.len() / 2;
+            let mut folded = Vec::with_capacity(half);
+            let mut total_fpp: f64 = 0.0;
+
+            for pair in self.0.chunks_exact(2) {
+                let mut block = Block::ZERO;
+                let mut set_bits: u32 = 0;
+                for j in 0..8 {
+                    block.0[j] = pair[0].0[j] | pair[1].0[j];
+                    set_bits += block.0[j].count_ones();
+                }
+                total_fpp += (f64::from(set_bits) / 256.0).powi(8);
+                folded.push(block);
+            }
+
+            if total_fpp / half as f64 > target_fpp {
                 break;
             }
-            self.fold_once();
+            self.0 = folded;
         }
     }
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -82,7 +82,6 @@ use crate::basic::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash
 use crate::data_type::AsBytes;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::ColumnChunkMetaData;
-use crate::file::properties::{BloomFilterProperties, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
 use crate::file::reader::ChunkReader;
 use crate::parquet_thrift::{
     ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol, ThriftCompactOutputProtocol,
@@ -205,14 +204,12 @@ impl std::ops::IndexMut<usize> for Block {
 /// parallel bit manipulation. When checking membership, only one block is accessed per query,
 /// eliminating the cache-miss penalty of standard Bloom filters.
 ///
-/// ## Two sizing modes
+/// ## Sizing and folding
 ///
-/// - **Fixed-size mode**: Created via [`Sbbf::new_with_ndv_fpp`] when the number of distinct
-///   values (NDV) is known. The filter is sized exactly for the given NDV and FPP.
-///
-/// - **Folding mode**: Created via [`Sbbf::new_with_num_of_bytes`] at a conservatively large
-///   size, then compacted after all values are inserted by calling [`Sbbf::fold_to_target_fpp`].
-///   This eliminates the need to know NDV upfront.
+/// Filters are initially sized for a maximum expected number of distinct values (NDV) via
+/// [`Sbbf::new_with_ndv_fpp`]. After all values are inserted, the filter is compacted by
+/// calling [`Sbbf::fold_to_target_fpp`], which folds the filter down to the smallest size
+/// that still meets the target false positive probability.
 ///
 /// The creation of this structure is based on the [`crate::file::properties::BloomFilterProperties`]
 /// struct set via [`crate::file::properties::WriterProperties`] and is thus hidden by default.
@@ -276,34 +273,6 @@ pub(crate) fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
 }
 
 impl Sbbf {
-    /// Create a bloom filter from [`BloomFilterProperties`], returning the filter and an
-    /// optional target FPP for folding mode.
-    ///
-    /// | `ndv` | `max_bytes` | Behavior |
-    /// |-------|-------------|----------|
-    /// | Set   | _           | Fixed-size filter sized for that NDV (legacy). Returns `None` for FPP. |
-    /// | None  | Set         | Filter of `max_bytes`, folded at flush via [`Sbbf::fold_to_target_fpp`]. |
-    /// | None  | None        | Filter sized for `max_distinct_items` (default: [`DEFAULT_MAX_ROW_GROUP_ROW_COUNT`]) items at the given FPP, folded at flush. |
-    pub fn from_properties(
-        props: &BloomFilterProperties,
-        max_distinct_items: Option<usize>,
-    ) -> Result<(Self, Option<f64>)> {
-        match props.ndv {
-            Some(ndv) => {
-                // Fixed-size mode: size based on explicit NDV (legacy behavior)
-                Ok((Self::new_with_ndv_fpp(ndv, props.fpp)?, None))
-            }
-            None => {
-                // Folding mode: allocate large, fold down at flush
-                let max_bytes = props.max_bytes.unwrap_or_else(|| {
-                    let ndv = max_distinct_items.unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64;
-                    num_of_bits_from_ndv_fpp(ndv, props.fpp) / 8
-                });
-                Ok((Self::new_with_num_of_bytes(max_bytes), Some(props.fpp)))
-            }
-        }
-    }
-
     /// Create a new [Sbbf] with given number of distinct values and false positive probability.
     /// Will return an error if `fpp` is greater than or equal to 1.0 or less than 0.0.
     pub fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Result<Self, ParquetError> {

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -249,7 +249,7 @@ fn optimal_num_of_bytes(num_bytes: usize) -> usize {
 // we have m = - k * n / ln(1 - fpp ^ (1 / k))
 // where k = number of hash functions, m = number of bits, n = number of distinct values
 #[inline]
-fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
+pub(crate) fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
     let num_bits = -8.0 * ndv as f64 / (1.0 - fpp.powf(1.0 / 8.0)).ln();
     num_bits as usize
 }
@@ -431,6 +431,68 @@ impl Sbbf {
         self.0.capacity() * std::mem::size_of::<Block>()
     }
 
+    /// Returns the number of blocks in this bloom filter.
+    pub fn num_blocks(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Fold the bloom filter once by merging adjacent block pairs via bitwise OR,
+    /// halving the filter size. Block[2i] and Block[2i+1] are merged into a single block
+    /// at position [i] in the folded filter. This preserves correctness because
+    /// `hash_to_block_index` maps to `floor(original_index / 2)` when `num_blocks` is halved.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the filter has fewer than 2 blocks.
+    fn fold_once(&mut self) {
+        let len = self.0.len();
+        assert!(len >= 2, "Cannot fold a bloom filter with fewer than 2 blocks");
+        let half = len / 2;
+        for i in 0..half {
+            for j in 0..8 {
+                self.0[i].0[j] = self.0[2 * i].0[j] | self.0[2 * i + 1].0[j];
+            }
+        }
+        self.0.truncate(half);
+    }
+
+    /// Estimate the FPP that would result from folding once, without mutating the filter.
+    ///
+    /// SBBF checks are per-block: a query hashes to one block, then checks 8 bits within it.
+    /// The FPP is therefore the average of per-block FPPs, not a function of global fill.
+    /// For each merged block pair (2i, 2i+1), we compute `(block_fill)^8` and average.
+    fn estimated_fpp_after_fold(&self) -> f64 {
+        let half = self.0.len() / 2;
+        let mut total_fpp = 0.0;
+        for i in 0..half {
+            let mut set_bits: u32 = 0;
+            for j in 0..8 {
+                set_bits += (self.0[2 * i].0[j] | self.0[2 * i + 1].0[j]).count_ones();
+            }
+            let block_fill = set_bits as f64 / 256.0;
+            total_fpp += block_fill.powi(8);
+        }
+        total_fpp / half as f64
+    }
+
+    /// Fold the bloom filter down until reaching the target false positive probability.
+    ///
+    /// Repeatedly halves the filter by OR-ing the upper half into the lower half, stopping
+    /// when the next fold would cause the estimated FPP to exceed `target_fpp`, or when the
+    /// filter reaches the minimum size of 1 block (32 bytes).
+    ///
+    /// This is useful when a bloom filter was allocated conservatively large and needs to be
+    /// compacted after all values have been inserted. Folding preserves all set bits, so there
+    /// are never false negatives — only a controlled increase in false positive probability.
+    pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
+        while self.0.len() >= 2 {
+            if self.estimated_fpp_after_fold() > target_fpp {
+                break;
+            }
+            self.fold_once();
+        }
+    }
+
     /// Reads a Sbff from Thrift encoded bytes
     ///
     /// # Examples
@@ -601,6 +663,83 @@ mod tests {
         ] {
             assert_eq!(*num_bits, num_of_bits_from_ndv_fpp(*ndv, *fpp) as u64);
         }
+    }
+
+    #[test]
+    fn test_fold_once_halves_block_count() {
+        let mut sbbf = Sbbf::new_with_num_of_bytes(1024); // 32 blocks
+        assert_eq!(sbbf.num_blocks(), 32);
+        sbbf.fold_once();
+        assert_eq!(sbbf.num_blocks(), 16);
+        sbbf.fold_once();
+        assert_eq!(sbbf.num_blocks(), 8);
+    }
+
+    #[test]
+    fn test_fold_preserves_inserted_values() {
+        // Create a large filter, insert values, fold, verify no false negatives
+        let mut sbbf = Sbbf::new_with_num_of_bytes(32 * 1024); // 32KB = 1024 blocks
+        let values: Vec<String> = (0..1000).map(|i| format!("value_{i}")).collect();
+        for v in &values {
+            sbbf.insert(v.as_str());
+        }
+
+        // Fold several times
+        let original_blocks = sbbf.num_blocks();
+        sbbf.fold_to_target_fpp(0.05);
+        assert!(sbbf.num_blocks() < original_blocks, "should have folded at least once");
+
+        // All inserted values must still be found (no false negatives)
+        for v in &values {
+            assert!(
+                sbbf.check(v.as_str()),
+                "Value '{}' missing after folding (false negative!)",
+                v
+            );
+        }
+    }
+
+    #[test]
+    fn test_fold_to_target_fpp_stops_before_exceeding_target() {
+        let mut sbbf = Sbbf::new_with_num_of_bytes(64 * 1024); // 64KB
+        // Insert enough values to set some bits
+        for i in 0..5000 {
+            sbbf.insert(&i);
+        }
+
+        let target_fpp = 0.01;
+        sbbf.fold_to_target_fpp(target_fpp);
+
+        // After folding, the estimated FPP should be at or below target
+        // (the current state should not exceed target — we stopped before that would happen)
+        let total_bits = (sbbf.num_blocks() * 256) as f64;
+        let set_bits: u64 = sbbf
+            .0
+            .iter()
+            .flat_map(|b| b.0.iter())
+            .map(|w| w.count_ones() as u64)
+            .sum();
+        let fill = set_bits as f64 / total_bits;
+        let current_fpp = fill.powi(8);
+        assert!(
+            current_fpp <= target_fpp,
+            "FPP {current_fpp} exceeds target {target_fpp}"
+        );
+    }
+
+    #[test]
+    fn test_fold_empty_filter_folds_to_minimum() {
+        // An empty filter has fill=0, so estimated FPP is always 0 — should fold all the way down
+        let mut sbbf = Sbbf::new_with_num_of_bytes(1024); // 32 blocks
+        sbbf.fold_to_target_fpp(0.01);
+        assert_eq!(sbbf.num_blocks(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot fold a bloom filter with fewer than 2 blocks")]
+    fn test_fold_once_panics_at_minimum_size() {
+        let mut sbbf = Sbbf::new_with_num_of_bytes(32); // 1 block (minimum)
+        sbbf.fold_once();
     }
 
     #[test]

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -303,7 +303,7 @@ fn optimal_num_of_bytes(num_bytes: usize) -> usize {
 // we have m = - k * n / ln(1 - fpp ^ (1 / k))
 // where k = number of hash functions, m = number of bits, n = number of distinct values
 #[inline]
-pub(crate) fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
+fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
     let num_bits = -8.0 * ndv as f64 / (1.0 - fpp.powf(1.0 / 8.0)).ln();
     num_bits as usize
 }
@@ -490,90 +490,8 @@ impl Sbbf {
         self.0.len()
     }
 
-    /// Fold the bloom filter once, halving its size by merging adjacent block pairs.
-    ///
-    /// This implements an elementary folding operation for Split Block Bloom
-    /// Filters. Each pair of adjacent blocks is combined via bitwise OR:
-    ///
-    /// ```text
-    /// folded[i] = blocks[2*i] | blocks[2*i + 1]    for 0 <= i < num_blocks/2
-    /// ```
-    ///
-    /// ## Why adjacent pairs (not halves)?
-    ///
-    /// SBBFs use **multiplicative** hashing for block selection:
-    ///
-    /// ```text
-    /// block_index = ((hash >> 32) * num_blocks) >> 32
-    /// ```
-    ///
-    /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`.
-    /// Therefore blocks `2i` and `2i+1` map to the same position `i` in the folded filter.
-    ///
-    /// This differs from standard Bloom filter folding, which merges the two halves
-    /// (`B[i] | B[i + m/2]`) because standard filters use modular hashing where
-    /// `h(x) mod (m/2)` maps indices `i` and `i + m/2` to the same position.
-    ///
-    /// ## References
-    ///
-    /// 1. Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
-    ///    IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
-    ///
-    /// # Panics
-    ///
-    /// Panics if the filter has fewer than 2 blocks.
-    fn fold_once(&mut self) {
-        let len = self.0.len();
-        assert!(
-            len >= 2,
-            "Cannot fold a bloom filter with fewer than 2 blocks"
-        );
-        assert_eq!(
-            len % 2,
-            0,
-            "Cannot fold a bloom filter with an odd number of blocks"
-        );
-        let half = len / 2;
-        for i in 0..half {
-            // Copy both blocks to stack locals before writing. This eliminates
-            // aliasing between self.0[i] and self.0[2*i], allowing the compiler
-            // to vectorize the OR into SIMD instructions.
-            let merged = self.0[2 * i] | self.0[2 * i + 1];
-            self.0[i] = merged;
-        }
-        self.0.truncate(half);
-    }
-
-    /// Estimate the FPP that would result from folding once, without mutating the filter.
-    ///
-    /// SBBF membership checks are per-block (`k=8` bit checks within one 256-bit block),
-    /// so FPP is the average per-block false positive probability:
-    ///
-    /// ```text
-    /// FPP = (1 / num_blocks) * sum_i (set_bits_in_block_i / 256)^8
-    /// ```
-    ///
-    /// Separating the OR from the popcount lets the compiler emit vectorized popcount
-    /// instructions (e.g., `cnt.16b` on ARM NEON) instead of per-word scalar popcount.
-    fn estimated_fpp_after_fold(&self) -> f64 {
-        assert_eq!(
-            self.0.len() % 2,
-            0,
-            "Cannot estimate fold FPP for a bloom filter with an odd number of blocks"
-        );
-        let mut total_fpp: f64 = 0.0;
-        for pair in self.0.chunks_exact(2) {
-            let merged = pair[0] | pair[1];
-            let set_bits = merged.count_ones();
-            let block_fill = f64::from(set_bits) / 256.0;
-            total_fpp += block_fill.powi(8);
-        }
-        let half = self.0.len() as f64 / 2.0;
-        total_fpp / half
-    }
-
     /// Fold the bloom filter down to the smallest size that still meets the target FPP
-    /// (False Positive Percentage)
+    /// (False Positive Percentage).
     ///
     /// Repeatedly halves the filter by merging adjacent block pairs via bitwise OR,
     /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or
@@ -594,22 +512,9 @@ impl Sbbf {
     /// folded[i] = blocks[2*i] | blocks[2*i + 1]
     /// ```
     ///
-    /// The FPP after a fold is estimated as the average per-block false positive probability:
-    ///
-    /// ```text
-    /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
-    /// ```
-    ///
-    /// ## Implementation
-    ///
-    /// Uses a two-phase approach:
-    /// 1. **Tree reduction**: Simulate merges in a scratch buffer to determine how many
-    ///    folds are safe. This reads the original data once, then works on progressively
-    ///    smaller scratch — total work O(N). At each level, the FPP is estimated via
-    ///    popcount of the merged blocks.
-    /// 2. **Single in-place fold**: Once the target fold count is known, merge groups of
-    ///    `2^num_folds` adjacent blocks in a single pass over the original data, then
-    ///    truncate. This avoids re-reading the data at each fold level.
+    /// This differs from standard Bloom filter folding, which merges the two halves
+    /// (`B[i] | B[i + m/2]`) because standard filters use modular hashing where
+    /// `h(x) mod (m/2)` maps indices `i` and `i + m/2` to the same position.
     ///
     /// ## Correctness
     ///
@@ -622,19 +527,34 @@ impl Sbbf {
     /// - Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
     ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
+        let num_folds = self.num_folds_for_target_fpp(target_fpp);
+        if num_folds > 0 {
+            self.fold_n(num_folds);
+        }
+    }
+
+    /// Determine how many folds can be applied without exceeding `target_fpp`.
+    ///
+    /// Simulates merges via a tree reduction on a scratch buffer: reads the original
+    /// data once (into pairwise-OR'd scratch), then works on progressively smaller
+    /// scratch — total work O(N).
+    ///
+    /// The FPP after a fold is estimated as the average per-block false positive probability.
+    /// SBBF membership checks perform `k=8` bit checks within one 256-bit block, so:
+    ///
+    /// ```text
+    /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
+    /// ```
+    fn num_folds_for_target_fpp(&self, target_fpp: f64) -> u32 {
         let len = self.0.len();
         if len < 2 {
-            return;
+            return 0;
         }
 
-        // Phase 1: Determine how many folds are safe by simulating merges
-        // in a scratch buffer. This reads the original data once, then works
-        // on progressively smaller scratch — total work O(N).
         let mut scratch: Vec<Block> = self.0.chunks_exact(2).map(|p| p[0] | p[1]).collect();
         let mut num_folds = 0u32;
 
         loop {
-            // Check FPP at this fold level
             let num_blocks = scratch.len() as f64;
             let mut total_fpp: f64 = 0.0;
             for block in &scratch {
@@ -649,21 +569,32 @@ impl Sbbf {
             if scratch.len() < 2 {
                 break;
             }
-            // Merge scratch pairwise for next level
             let new_len = scratch.len() / 2;
             for i in 0..new_len {
                 scratch[i] = scratch[2 * i] | scratch[2 * i + 1];
             }
             scratch.truncate(new_len);
         }
-        drop(scratch);
 
-        if num_folds == 0 {
-            return;
-        }
+        num_folds
+    }
 
-        // Phase 2: Single in-place fold to the target level.
+    /// Fold the filter `num_folds` times in a single pass.
+    ///
+    /// Merges groups of `2^num_folds` adjacent blocks via bitwise OR, producing
+    /// `len / 2^num_folds` output blocks. The original allocation is reused.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_folds` is 0 or would reduce the filter below 1 block.
+    fn fold_n(&mut self, num_folds: u32) {
+        assert!(num_folds > 0, "num_folds must be at least 1");
+        let len = self.0.len();
         let group_size = 1usize << num_folds;
+        assert!(
+            group_size <= len,
+            "Cannot fold {num_folds} times: need at least {group_size} blocks, have {len}"
+        );
         let new_len = len / group_size;
         for i in 0..new_len {
             let start = i * group_size;
@@ -849,12 +780,12 @@ mod tests {
     }
 
     #[test]
-    fn test_fold_once_halves_block_count() {
+    fn test_fold_n_halves_block_count() {
         let mut sbbf = Sbbf::new_with_num_of_bytes(1024); // 32 blocks
         assert_eq!(sbbf.num_blocks(), 32);
-        sbbf.fold_once();
+        sbbf.fold_n(1);
         assert_eq!(sbbf.num_blocks(), 16);
-        sbbf.fold_once();
+        sbbf.fold_n(1);
         assert_eq!(sbbf.num_blocks(), 8);
     }
 
@@ -922,10 +853,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot fold a bloom filter with fewer than 2 blocks")]
-    fn test_fold_once_panics_at_minimum_size() {
+    #[should_panic(expected = "Cannot fold 1 times: need at least 2 blocks, have 1")]
+    fn test_fold_n_panics_at_minimum_size() {
         let mut sbbf = Sbbf::new_with_num_of_bytes(32); // 1 block (minimum)
-        sbbf.fold_once();
+        sbbf.fold_n(1);
     }
 
     #[test]
@@ -1032,7 +963,7 @@ mod tests {
 
             // verify the actual blocks match
             let mut folded = original.clone();
-            folded.fold_once();
+            folded.fold_n(1);
             assert_eq!(folded.num_blocks(), half);
 
             let mut fresh = Sbbf::new_with_num_of_bytes(half * 32);
@@ -1062,7 +993,7 @@ mod tests {
         }
 
         for expected_blocks in [256, 128, 64, 32, 16, 8, 4, 2, 1] {
-            filter.fold_once();
+            filter.fold_n(1);
             assert_eq!(filter.num_blocks(), expected_blocks);
 
             let mut fresh = Sbbf::new_with_num_of_bytes(expected_blocks * 32);
@@ -1134,7 +1065,7 @@ mod tests {
 
         // check FPP at each fold level
         for expected_blocks in [256, 128, 64, 32, 16, 8, 4, 2, 1] {
-            folded.fold_once();
+            folded.fold_n(1);
             assert_eq!(folded.num_blocks(), expected_blocks);
 
             // build a fresh filter of the same size with the same values

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -128,15 +128,28 @@ struct Block([u32; 8]);
 impl Block {
     const ZERO: Block = Block([0; 8]);
 
-    /// takes as its argument a single unsigned 32-bit integer and returns a block in which each
-    /// word has exactly one bit set.
+    /// Produce a block where each of the 8 words has exactly one bit set.
+    ///
+    /// For each word `i` the bit position is derived from `x`:
+    ///
+    /// ```text
+    ///   y = (x wrapping* SALT[i]) >> 27   // top 5 bits → value in 0..31
+    ///   word[i] = 1 << y                  // exactly one bit set per word
+    /// ```
+    ///
+    /// Because only the top 5 bits survive the shift, each word picks one of
+    /// 32 possible bit positions. The eight SALT constants spread the choices
+    /// so different words usually light up different positions.
+    ///
+    /// Key property: the mask depends *only* on `x` (a u32) and the fixed
+    /// SALT constants — it is independent of the filter size. This is why
+    /// folding preserves bit patterns (see Lemma 2 in tests).
     fn mask(x: u32) -> Self {
         let mut result = [0_u32; 8];
         for i in 0..8 {
-            // wrapping instead of checking for overflow
-            let y = x.wrapping_mul(SALT[i]);
-            let y = y >> 27;
-            result[i] = 1 << y;
+            let y = x.wrapping_mul(SALT[i]); // spread bits via multiply
+            let y = y >> 27; // keep top 5 bits → 0..31
+            result[i] = 1 << y; // set exactly that one bit
         }
         Self(result)
     }
@@ -161,7 +174,10 @@ impl Block {
         self
     }
 
-    /// setting every bit in the block that was also set in the result from mask
+    /// OR the mask bits into this block (`block[i] |= mask[i]`).
+    ///
+    /// After insertion the 8 bits chosen by `mask(hash)` are guaranteed set;
+    /// bits previously set by other hashes are preserved.
     fn insert(&mut self, hash: u32) {
         let mask = Self::mask(hash);
         for i in 0..8 {
@@ -169,7 +185,11 @@ impl Block {
         }
     }
 
-    /// returns true when every bit that is set in the result of mask is also set in the block.
+    /// Check membership: returns `true` when *every* bit from `mask(hash)` is
+    /// already set in this block (`block[i] & mask[i] != 0` for all 8 words).
+    ///
+    /// A `true` result means "probably present" (other inserts may have set
+    /// the same bits). A `false` is definitive — the value was never inserted.
     fn check(&self, hash: u32) -> bool {
         let mask = Self::mask(hash);
         for i in 0..8 {
@@ -449,10 +469,27 @@ impl Sbbf {
         Ok(Some(Self::new(&bitset)))
     }
 
+    /// Map a 64-bit hash to a block index in `[0, num_blocks)`.
+    ///
+    /// Uses the "multiply-and-shift" trick (a fast alternative to modulo):
+    ///
+    /// ```text
+    ///   upper32 = hash >> 32           // take the top 32 bits of the hash
+    ///   index   = (upper32 * N) >> 32  // ∈ [0, N)  where N = num_blocks
+    /// ```
+    ///
+    /// Why this matters for folding (Lemma 1): when N is a power of two and
+    /// you halve it to N/2, the index also halves:
+    ///
+    /// ```text
+    ///   index_N   = (upper32 * N)   >> 32
+    ///   index_N/2 = (upper32 * N/2) >> 32 = index_N / 2  (integer division)
+    /// ```
+    ///
+    /// So the block that held hash `h` in the big filter is at `index / 2` in
+    /// the half-sized filter — exactly where `fold` ORs it.
     #[inline]
     fn hash_to_block_index(&self, hash: u64) -> usize {
-        // unchecked_mul is unstable, but in reality this is safe, we'd just use saturating mul
-        // but it will not saturate
         (((hash >> 32).saturating_mul(self.0.len() as u64)) >> 32) as usize
     }
 
@@ -567,7 +604,10 @@ impl Sbbf {
 
         // Find max folds where estimated FPP stays within target.
         // f_k = 1 - (1 - avg_fill)^(2^k), FPP_k = f_k^8
-        assert!(len.is_power_of_two(), "Number of blocks must be a power of 2 for folding");
+        assert!(
+            len.is_power_of_two(),
+            "Number of blocks must be a power of 2 for folding"
+        );
         let max_folds = len.trailing_zeros(); // log2(len) since len is power of 2
         let one_minus_f = 1.0 - avg_fill;
         let mut num_folds = 0u32;
@@ -906,29 +946,42 @@ mod tests {
         }
     }
 
-    /*
-        Ok, so the following is trying to prove in simple terms that folding an SBBF and
-        building a fresh smaller SBBF from scratch produces the exact same bits
-
-        If you insert the same values into a 512-block filter and fold it to 256 blocks,
-        you get a bit-for-bit identical result to just inserting those values into a
-        256-block filter directly. The fold doesn't lose information or scramble anything,
-        it's like you had known the right size all along
-
-        This works because of the 2 lemmas:
-        1. when you half the filter, each hash's block index divides cleanly by 2
-        so the hash that went to block `i` in the big filter goes to block `i/2` in the small one
-        which is exactly where the fold puts it
-        > this is trivial since floor(x/2) == floor(floor(x) / 2) is a basic math fact
-
-        2. the bit pattern set _within_ a block depends only on the lower 32 bits of the hash,
-        which doesn't change with filter size. So the same bits get set regardless!
-        > structually trivial, mask() takes a u32 and uses only the SALT constants.
-
-
-        When you combine it together, every hash sets the same bits in the same destination block
-        whether you fold or build fresh. Therefore the filters are bit-identical
-    */
+    /// Prove that folding an SBBF by one level produces the exact same bits
+    /// as building a fresh filter at the smaller size from scratch.
+    ///
+    /// # What is folding?
+    ///
+    /// ```text
+    ///   Original (N = 8 blocks):
+    ///   ┌───┬───┬───┬───┬───┬───┬───┬───┐
+    ///   │ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │
+    ///   └─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┴─┬─┘
+    ///     │   │   │   │   │   │   │   │
+    ///     └─OR┘   └─OR┘   └─OR┘   └─OR┘    pair-wise OR
+    ///       │       │       │       │
+    ///   ┌───┴──┬────┴──┬────┴──┬────┴──┐
+    ///   │ 0|1  │ 2|3   │ 4|5   │ 6|7   │   Folded (N/2 = 4 blocks)
+    ///   └──────┴───────┴───────┴───────┘
+    /// ```
+    ///
+    /// # Why folded == fresh (the two lemmas)
+    ///
+    /// An SBBF insertion does two things with a 64-bit hash `h`:
+    ///
+    ///   1. **Pick a block** — uses the upper 32 bits via `hash_to_block_index`
+    ///   2. **Set 8 bits in that block** — uses the lower 32 bits via `Block::mask`
+    ///
+    /// **Lemma 1 (block index halves):** `hash_to_block_index` uses
+    /// `(upper32 * N) >> 32`. When N halves, the index halves too:
+    /// `index_in(N/2) == index_in(N) / 2`. So the hash lands in the same
+    /// destination block whether you fold or build fresh.
+    ///
+    /// **Lemma 2 (mask is size-independent):** `Block::mask(h as u32)` depends
+    /// only on the lower 32 bits and the fixed SALT constants — the filter
+    /// size N is not involved. So the same 8 bits get set regardless.
+    ///
+    /// Combined: every hash sets the *same bits* in the *same destination
+    /// block* whether you fold or build fresh → filters are bit-identical.
     #[test]
     fn test_sbbf_folded_equals_fresh() {
         let values = (0..5000).map(|i| format!("elem_{i}")).collect::<Vec<_>>();
@@ -940,66 +993,103 @@ mod tests {
         for num_blocks in [64, 256, 1024] {
             let half = num_blocks / 2;
 
-            // original filter
+            // Build a filter with N blocks and insert all values.
             let mut original = Sbbf::new_with_num_of_bytes(num_blocks * 32);
             assert_eq!(original.num_blocks(), num_blocks);
             for &h in &hashes {
                 original.insert_hash(h);
             }
 
+            // --- Per-hash verification of the two lemmas ---
             for &h in hashes.iter() {
+                // mask(h as u32) gives the 8-bit pattern that this hash sets
+                // inside whichever block it lands in. It uses only the lower
+                // 32 bits of h, so it's the same regardless of filter size.
                 let mask = Block::mask(h as u32);
 
-                // step 1: element's block in original
+                // Lemma 1 check: the block index in the original N-block
+                // filter, divided by 2, should equal the block index in a
+                // fresh N/2-block filter.
                 let orig_idx = original.hash_to_block_index(h);
                 assert!(orig_idx < num_blocks);
 
-                // step 2 (lemma 1): destination in N/2 filter
                 let fresh_idx = {
                     let tmp = Sbbf(vec![Block::ZERO; half]);
                     tmp.hash_to_block_index(h)
                 };
-
                 let folded_idx = orig_idx / 2;
-                assert_eq!(fresh_idx, folded_idx,);
+                assert_eq!(
+                    fresh_idx, folded_idx,
+                    "Lemma 1 failed: fresh index {fresh_idx} != folded index {folded_idx}"
+                );
 
-                // step 3 (lemma 2): mask is the same
+                // Lemma 2 check: every bit that mask wants to set is actually
+                // present in the original block.
+                //
+                // mask.0[w] has exactly ONE bit set (see Block::mask: `1 << y`).
+                // The block at orig_idx has many bits set from many inserts, so
+                // we can't test equality — we test that the specific mask bit is
+                // *present*:
+                //
+                //   block_word & mask_word != 0
+                //     ⟺  "the one bit in the mask is set in the block"
+                //
+                // (Since mask_word has exactly 1 bit, `& mask != 0` is the same
+                //  as `& mask == mask` — but `!= 0` reads more naturally.)
                 for w in 0..8 {
-                    assert_ne!(original.0[orig_idx].0[w] & mask.0[w], 0,);
+                    assert_ne!(
+                        original.0[orig_idx].0[w] & mask.0[w],
+                        0,
+                        "Lemma 2 failed: mask bit not set in word {w} of block {orig_idx}"
+                    );
                 }
             }
 
-            // verify the actual blocks match
+            // --- Final bit-identical comparison ---
+            // Fold the original N-block filter down to N/2 blocks.
             let mut folded = original.clone();
             folded.fold_n(1);
             assert_eq!(folded.num_blocks(), half);
 
+            // Build a fresh N/2-block filter with the same values.
             let mut fresh = Sbbf::new_with_num_of_bytes(half * 32);
             for &h in &hashes {
                 fresh.insert_hash(h);
             }
 
+            // By lemmas 1 + 2, every block should be bit-identical.
             for j in 0..half {
                 assert_eq!(
                     folded.0[j].0, fresh.0[j].0,
-                    "Step 4 failed: block {j} differs (N={num_blocks}→{half})"
+                    "Block {j} differs after fold (N={num_blocks} → {half})"
                 );
             }
         }
     }
 
-    /// show multi-step folding.
+    /// Inductive multi-step folding: folding k times from N blocks produces
+    /// a filter bit-identical to a fresh N/2^k-block filter.
     ///
-    /// You can apply the above inductively, folding k times from N blocks produces a filter bit-identical to a fresh N/2^k filter
+    /// `test_sbbf_folded_equals_fresh` proves the base case (one fold).
+    /// This test applies folds *repeatedly*, checking after each step:
+    ///
+    /// ```text
+    ///   512 ─fold→ 256 ─fold→ 128 ─…→ 1  (9 folds total)
+    /// ```
+    ///
+    /// At each intermediate size we build a fresh filter and assert
+    /// bit-equality, confirming the lemma composes across folds.
     #[test]
     fn test_multi_step_fold() {
         let values = (0..3000).map(|i| format!("x_{i}")).collect::<Vec<_>>();
 
+        // Start with a 512-block filter.
         let mut filter = Sbbf::new_with_num_of_bytes(512 * 32);
         for v in &values {
             filter.insert(v.as_str());
         }
 
+        // Fold one level at a time, comparing against a fresh filter each step.
         for expected_blocks in [256, 128, 64, 32, 16, 8, 4, 2, 1] {
             filter.fold_n(1);
             assert_eq!(filter.num_blocks(), expected_blocks);
@@ -1009,7 +1099,7 @@ mod tests {
                 fresh.insert(v.as_str());
             }
             for (fb, rb) in filter.0.iter().zip(fresh.0.iter()) {
-                assert_eq!(fb.0, rb.0,);
+                assert_eq!(fb.0, rb.0);
             }
         }
     }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -897,4 +897,197 @@ mod tests {
             );
         }
     }
+
+    /*
+        Ok, so the following is trying to prove in simple terms that folding an SBBF and
+        building a fresh smaller SBBF from scratch prodcues the exact same bits
+
+        If you insert the same values into a 512-block filter and fold it to 256 blocks,
+        you get a bit-for-bit identical result to just inserting those values into a
+        256-block filter directly. The fold doesn't lose information or scramble anything,
+        it's like you had known the right size all along
+
+        This works because of the 2 lemmas:
+        1. when you half the filter, each hash's block index divides cleanly by 2
+        so the hash that went to block `i` in the big filter goes to block `i/2` in the small one
+        which is exactly where the fold puts it
+        > this is trivial since floor(x/2) == floor(floor(x) / 2) is a basic math fact
+
+        2. the bit pattern set _within_ a block depends only on the lower 32 bits of the hash,
+        which doesn't change with filter size. So the same bits get set regardless!
+        > structually trivial, mask() takes a u32 and uses only the SALT constants..
+
+
+        When you combine it together, every hash sets the same bits in the same destination block
+        whether you fold or build fresh. Therefore the filters are bit-identical
+    */
+    #[test]
+    fn test_sbbf_folded_equals_fresh() {
+        let values = (0..5000).map(|i| format!("elem_{i}")).collect::<Vec<_>>();
+        let hashes = values
+            .iter()
+            .map(|v| hash_as_bytes(v.as_str()))
+            .collect::<Vec<_>>();
+
+        for num_blocks in [64, 256, 1024] {
+            let half = num_blocks / 2;
+
+            // original filter
+            let mut original = Sbbf::new_with_num_of_bytes(num_blocks * 32);
+            assert_eq!(original.num_blocks(), num_blocks);
+            for &h in &hashes {
+                original.insert_hash(h);
+            }
+
+            for &h in hashes.iter() {
+                let mask = Block::mask(h as u32);
+
+                // step 1: element's block in original
+                let orig_idx = original.hash_to_block_index(h);
+                assert!(orig_idx < num_blocks);
+
+                // step 2 (lemma 1): destination in N/2 filter
+                let fresh_idx = {
+                    let tmp = Sbbf(vec![Block::ZERO; half]);
+                    tmp.hash_to_block_index(h)
+                };
+
+                let folded_idx = orig_idx / 2;
+                assert_eq!(fresh_idx, folded_idx,);
+
+                // step 3 (lemma 2): mask is the same
+                for w in 0..8 {
+                    assert_ne!(original.0[orig_idx].0[w] & mask.0[w], 0,);
+                }
+            }
+
+            // verify the actual blocks match
+            let mut folded = original.clone();
+            folded.fold_once();
+            assert_eq!(folded.num_blocks(), half);
+
+            let mut fresh = Sbbf::new_with_num_of_bytes(half * 32);
+            for &h in &hashes {
+                fresh.insert_hash(h);
+            }
+
+            for j in 0..half {
+                assert_eq!(
+                    folded.0[j].0, fresh.0[j].0,
+                    "Step 4 failed: block {j} differs (N={num_blocks}→{half})"
+                );
+            }
+        }
+    }
+
+    /// show multi-step folding.
+    ///
+    /// You can apply the above inductively, folding k times from N blocks prodcues a filter bit-identical to a fresh N/2^k filter
+    #[test]
+    fn test_multi_step_fold() {
+        let values = (0..3000).map(|i| format!("x_{i}")).collect::<Vec<_>>();
+
+        let mut filter = Sbbf::new_with_num_of_bytes(512 * 32);
+        for v in &values {
+            filter.insert(v.as_str());
+        }
+
+        for expected_blocks in [256, 128, 64, 32, 16, 8, 4, 2, 1] {
+            filter.fold_once();
+            assert_eq!(filter.num_blocks(), expected_blocks);
+
+            let mut fresh = Sbbf::new_with_num_of_bytes(expected_blocks * 32);
+            for v in &values {
+                fresh.insert(v.as_str());
+            }
+            for (fb, rb) in filter.0.iter().zip(fresh.0.iter()) {
+                assert_eq!(fb.0, rb.0,);
+            }
+        }
+    }
+
+    /// test that the fpp estimator's overestimation doesn't cause fold_to_target_fpp
+    /// to produce significantly oversized filters
+    ///
+    /// compare the final size after folding agains tthe theoretical optimal size
+    #[test]
+    fn test_fold_size_vs_optimal_fixed_size() {
+        for (ndv, target_fpp) in [
+            (1000, 0.05),
+            (1000, 0.01),
+            (5000, 0.05),
+            (5000, 0.01),
+            (10000, 0.05),
+        ] {
+            let values = (0..ndv).map(|i| format!("d_{i}")).collect::<Vec<_>>();
+
+            let mut folded = Sbbf::new_with_num_of_bytes(128 * 1024); // 128KB
+            for v in &values {
+                folded.insert(v.as_str());
+            }
+            folded.fold_to_target_fpp(target_fpp);
+
+            let folded_bytes = folded.num_blocks() * 32;
+
+            let optimal = Sbbf::new_with_ndv_fpp(ndv as u64, target_fpp).unwrap();
+            let optimal_bytes = optimal.num_blocks() * 32;
+
+            let ratio = folded_bytes as f64 / optimal_bytes as f64;
+
+            assert_eq!(ratio, 1.0);
+        }
+    }
+
+    /// verify that a folded sbbf has the same empirical fpp as a fresh filter of the same size
+    /// this bridges the bit-identity proof above with the FPP guarantee from the folding paper
+    ///     since the bits are identical, the false-positive rate must be too
+    ///
+    /// we measure fpp empirically by probing with values that were never inserted
+    /// and counting how many are incorrectly marked as present
+    #[test]
+    fn test_folded_fpp_matches_fresh_fpp() {
+        let ndv = 2000;
+        let num_probes = 50_000;
+        let inserted = (0..ndv)
+            .map(|i| format!("ins_{i}"))
+            .collect::<Vec<String>>();
+
+        // probe values that were NOT inserted (different prefix guarantees no overlap)
+        let probes = (0..num_probes)
+            .map(|i| format!("probe_{i}"))
+            .collect::<Vec<String>>();
+
+        // build a large filter and fold it down several times
+        let mut folded = Sbbf::new_with_num_of_bytes(512 * 32); // 512 blocks
+        for v in &inserted {
+            folded.insert(v.as_str());
+        }
+
+        // check FPP at each fold level
+        for expected_blocks in [256, 128, 64, 32, 16, 8, 4, 2, 1] {
+            folded.fold_once();
+            assert_eq!(folded.num_blocks(), expected_blocks);
+
+            // build a fresh filter of the same size with the same values
+            let mut fresh = Sbbf::new_with_num_of_bytes(expected_blocks * 32);
+            for v in &inserted {
+                fresh.insert(v.as_str());
+            }
+
+            // measure empirical FPP on both
+            let mut folded_fp = 0u64;
+            let mut fresh_fp = 0u64;
+            for p in &probes {
+                if folded.check(p.as_str()) {
+                    folded_fp += 1;
+                }
+                if fresh.check(p.as_str()) {
+                    fresh_fp += 1;
+                }
+            }
+
+            // bit-identity means these must be exactly equal
+            assert_eq!(folded_fp, fresh_fp);
+        }
+    }
 }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -1009,7 +1009,7 @@ mod tests {
     /// test that the fpp estimator's overestimation doesn't cause fold_to_target_fpp
     /// to produce significantly oversized filters
     ///
-    /// compare the final size after folding agains tthe theoretical optimal size
+    /// compare the final size after folding against the theoretical optimal size
     #[test]
     fn test_fold_size_vs_optimal_fixed_size() {
         for (ndv, target_fpp) in [

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -459,7 +459,7 @@ impl Sbbf {
     /// Fold the bloom filter once, halving its size by merging adjacent block pairs.
     ///
     /// This implements an elementary folding operation for Split Block Bloom
-    /// Filters<sup>[1]</sup>. Each pair of adjacent blocks is combined via bitwise OR:
+    /// Filters. Each pair of adjacent blocks is combined via bitwise OR:
     ///
     /// ```text
     /// folded[i] = blocks[2*i] | blocks[2*i + 1]    for 0 <= i < num_blocks/2
@@ -491,7 +491,10 @@ impl Sbbf {
     /// Panics if the filter has fewer than 2 blocks.
     fn fold_once(&mut self) {
         let len = self.0.len();
-        assert!(len >= 2, "Cannot fold a bloom filter with fewer than 2 blocks");
+        assert!(
+            len >= 2,
+            "Cannot fold a bloom filter with fewer than 2 blocks"
+        );
         let half = len / 2;
         for i in 0..half {
             for j in 0..8 {
@@ -529,7 +532,7 @@ impl Sbbf {
 
     /// Fold the bloom filter down to the smallest size that still meets the target FPP.
     ///
-    /// Repeatedly halves the filter by merging adjacent block pairs (see [`Self::fold_once`]),
+    /// Repeatedly halves the filter by merging adjacent block pairs (see `fold_once`),
     /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or
     /// when the filter reaches the minimum size of 1 block (32 bytes).
     ///
@@ -798,7 +801,10 @@ mod tests {
         // Fold several times
         let original_blocks = sbbf.num_blocks();
         sbbf.fold_to_target_fpp(0.05);
-        assert!(sbbf.num_blocks() < original_blocks, "should have folded at least once");
+        assert!(
+            sbbf.num_blocks() < original_blocks,
+            "should have folded at least once"
+        );
 
         // All inserted values must still be found (no false negatives)
         for v in &values {

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -279,12 +279,14 @@ impl Sbbf {
     /// Create a bloom filter from [`BloomFilterProperties`], returning the filter and an
     /// optional target FPP for folding mode.
     ///
-    /// When `ndv` is set, returns a fixed-size filter sized for that NDV (legacy behavior).
-    /// When `ndv` is `None`, returns a large filter that should be folded down at flush time
-    /// using [`Sbbf::fold_to_target_fpp`] with the returned target FPP.
+    /// | `ndv` | `max_bytes` | Behavior |
+    /// |-------|-------------|----------|
+    /// | Set   | _           | Fixed-size filter sized for that NDV (legacy). Returns `None` for FPP. |
+    /// | None  | Set         | Filter of `max_bytes`, folded at flush via [`Sbbf::fold_to_target_fpp`]. |
+    /// | None  | None        | Filter sized for `max_distinct_items` (default: [`DEFAULT_MAX_ROW_GROUP_ROW_COUNT`]) items at the given FPP, folded at flush. |
     pub fn from_properties(
         props: &BloomFilterProperties,
-        max_row_group_row_count: Option<usize>,
+        max_distinct_items: Option<usize>,
     ) -> Result<(Self, Option<f64>)> {
         match props.ndv {
             Some(ndv) => {
@@ -294,9 +296,8 @@ impl Sbbf {
             None => {
                 // Folding mode: allocate large, fold down at flush
                 let max_bytes = props.max_bytes.unwrap_or_else(|| {
-                    let row_count =
-                        max_row_group_row_count.unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64;
-                    num_of_bits_from_ndv_fpp(row_count, props.fpp) / 8
+                    let ndv = max_distinct_items.unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64;
+                    num_of_bits_from_ndv_fpp(ndv, props.fpp) / 8
                 });
                 Ok((Self::new_with_num_of_bytes(max_bytes), Some(props.fpp)))
             }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -528,8 +528,9 @@ impl Sbbf {
             len >= 2,
             "Cannot fold a bloom filter with fewer than 2 blocks"
         );
-        assert!(
-            len % 2 == 0,
+        assert_eq!(
+            len % 2,
+            0,
             "Cannot fold a bloom filter with an odd number of blocks"
         );
         let half = len / 2;
@@ -555,7 +556,11 @@ impl Sbbf {
     /// Separating the OR from the popcount lets the compiler emit vectorized popcount
     /// instructions (e.g., `cnt.16b` on ARM NEON) instead of per-word scalar popcount.
     fn estimated_fpp_after_fold(&self) -> f64 {
-        let half = self.0.len() as f64 / 2.0;
+        assert_eq!(
+            self.0.len() % 2,
+            0,
+            "Cannot estimate fold FPP for a bloom filter with an odd number of blocks"
+        );
         let mut total_fpp: f64 = 0.0;
         for pair in self.0.chunks_exact(2) {
             let merged = pair[0] | pair[1];
@@ -563,6 +568,7 @@ impl Sbbf {
             let block_fill = f64::from(set_bits) / 256.0;
             total_fpp += block_fill.powi(8);
         }
+        let half = self.0.len() as f64 / 2.0;
         total_fpp / half
     }
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -68,11 +68,45 @@
 //! | 1,000,000 | 0.00001   | 131,072 | 4,096     |
 //! | 1,000,000 | 0.000001  | 262,144 | 8,192     |
 //!
+//! # Structure: Filter → Blocks → Words → Bits
+//!
+//! An SBBF is an array of **blocks**. Each block is 256 bits (32 bytes),
+//! divided into eight 32-bit **words**. A word is just a `u32` — an array of
+//! 32 individual bits that can each be "set" (1) or "not set" (0).
+//!
+//! ```text
+//!   Sbbf (the whole filter)
+//!   ┌──────────┬──────────┬──────────┬─── ─── ──┬──────────┐
+//!   │ Block 0  │ Block 1  │ Block 2  │   ...    │ Block N-1│
+//!   └──────────┴──────────┴──────────┴─── ─── ──┴──────────┘
+//!        │
+//!        ▼
+//!   One Block = 256 bits = 8 words
+//!   ┌────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┐
+//!   │ word 0 │ word 1 │ word 2 │ word 3 │ word 4 │ word 5 │ word 6 │ word 7 │
+//!   │ (u32)  │ (u32)  │ (u32)  │ (u32)  │ (u32)  │ (u32)  │ (u32)  │ (u32)  │
+//!   └────────┴────────┴────────┴────────┴────────┴────────┴────────┴────────┘
+//!        │
+//!        ▼
+//!   One Word = 32 individual bits
+//!   ┌─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┬─┐
+//!   │0│0│1│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│0│  ← bit 29 is set
+//!   └─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┴─┘
+//! ```
+//!
+//! **Inserting** a value hashes it to a 64-bit number, then:
+//!  1. The upper 32 bits pick which **block** (via `Sbbf::hash_to_block_index`).
+//!  2. The lower 32 bits pick one bit position in each of the 8 **words** (via `Block::mask`).
+//!     So each insert sets exactly **8 bits** (one per word) in a single block.
+//!
+//! **Checking** does the same two steps and returns `true` only if all 8 bits
+//! are already set — meaning the value was *probably* inserted (or is a false
+//! positive).
+//!
 //! # Bloom Filter Folding
 //!
-//! When the NDV is not known ahead of time, bloom filters support a **folding mode** that
-//! eliminates the need to guess NDV upfront. See [`Sbbf::fold_to_target_fpp`] for details
-//! on the algorithm and its mathematical basis.
+//! After inserting all values into a bloom filter it can be "folded" to minimize it's size.
+//! See [`Sbbf::fold_to_target_fpp`] for details  on the algorithm and its mathematical basis.
 //!
 //! [parquet-bf-spec]: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
 //! [sbbf-paper]: https://arxiv.org/pdf/2101.01719
@@ -120,8 +154,22 @@ pub struct BloomFilterHeader {
 }
 );
 
-/// Each block is 256 bits, broken up into eight contiguous "words", each consisting of 32 bits.
-/// Each word is thought of as an array of bits; each bit is either "set" or "not set".
+/// A single 256-bit block, the basic unit of the Split Block Bloom Filter.
+///
+/// A block is eight contiguous 32-bit **words** (`[u32; 8]`).
+/// Each word is an independent bit-array of 32 positions:
+///
+/// ```text
+///   Block (256 bits total)
+///   ┌────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┐
+///   │ word 0 │ word 1 │ word 2 │ word 3 │ word 4 │ word 5 │ word 6 │ word 7 │
+///   │ 32 bits│ 32 bits│ 32 bits│ 32 bits│ 32 bits│ 32 bits│ 32 bits│ 32 bits│
+///   └────────┴────────┴────────┴────────┴────────┴────────┴────────┴────────┘
+/// ```
+///
+/// When a value is inserted, [`Block::mask`] picks one bit in each word
+/// (8 bits total), and those bits are OR'd in. When checking, we verify
+/// all 8 bits are set.
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 struct Block([u32; 8]);
@@ -561,11 +609,12 @@ impl Sbbf {
     /// Folding **never introduces false negatives**. Every bit that was set in the original
     /// filter remains set in the folded filter (via bitwise OR). The only effect is a controlled
     /// increase in FPP as set bits from different blocks are merged together.
+    /// This is was originally proven in [Sailhan & Stehr 2012] for standard bloom filters and is empirically
+    /// demonstrated for SBBFs in Lemma 1 and Lemma 2 of the tests.
     ///
     /// ## References
     ///
-    /// - Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
-    ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
+    /// [Sailhan & Stehr 2012]: https://doi.org/10.1109/GreenCom.2012.16
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
         let num_folds = self.num_folds_for_target_fpp(target_fpp);
         if num_folds > 0 {

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -197,6 +197,42 @@ impl std::ops::IndexMut<usize> for Block {
     }
 }
 
+impl std::ops::BitOr for Block {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self {
+        let mut result = [0u32; 8];
+        for i in 0..8 {
+            result[i] = self.0[i] | rhs.0[i];
+        }
+        Self(result)
+    }
+}
+
+impl std::ops::BitOrAssign for Block {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Self) {
+        for i in 0..8 {
+            self.0[i] |= rhs.0[i];
+        }
+    }
+}
+
+impl Block {
+    /// Count the total number of set bits across all 8 words.
+    ///
+    /// Computes popcount on each word separately and sums. Keeping the popcount
+    /// separate from the OR allows the compiler to batch SIMD popcount instructions
+    /// (e.g., `cnt.16b` on ARM NEON) instead of interleaving them with OR operations.
+    #[inline]
+    fn count_ones(self) -> u32 {
+        // Written as a fold over the array so the compiler sees 8 independent
+        // popcount operations it can vectorize into cnt.16b + horizontal sum.
+        self.0.iter().map(|w| w.count_ones()).sum()
+    }
+}
+
 /// A split block Bloom filter (SBBF).
 ///
 /// An SBBF partitions its bit space into fixed-size 256-bit (32-byte) blocks, each fitting in a
@@ -498,13 +534,36 @@ impl Sbbf {
         );
         let half = len / 2;
         for i in 0..half {
-            let a = self.0[2 * i]; // Copy to avoid aliasing with self.0[i]
-            let b = self.0[2 * i + 1];
-            for j in 0..8 {
-                self.0[i].0[j] = a.0[j] | b.0[j];
-            }
+            // Copy both blocks to stack locals before writing. This eliminates
+            // aliasing between self.0[i] and self.0[2*i], allowing the compiler
+            // to vectorize the OR into SIMD instructions.
+            let merged = self.0[2 * i] | self.0[2 * i + 1];
+            self.0[i] = merged;
         }
         self.0.truncate(half);
+    }
+
+    /// Estimate the FPP that would result from folding once, without mutating the filter.
+    ///
+    /// SBBF membership checks are per-block (`k=8` bit checks within one 256-bit block),
+    /// so FPP is the average per-block false positive probability:
+    ///
+    /// ```text
+    /// FPP = (1 / num_blocks) * sum_i (set_bits_in_block_i / 256)^8
+    /// ```
+    ///
+    /// Separating the OR from the popcount lets the compiler emit vectorized popcount
+    /// instructions (e.g., `cnt.16b` on ARM NEON) instead of per-word scalar popcount.
+    fn estimated_fpp_after_fold(&self) -> f64 {
+        let half = self.0.len() / 2;
+        let mut total_fpp: f64 = 0.0;
+        for pair in self.0.chunks_exact(2) {
+            let merged = pair[0] | pair[1];
+            let set_bits = merged.count_ones();
+            let block_fill = f64::from(set_bits) / 256.0;
+            total_fpp += block_fill.powi(8);
+        }
+        total_fpp / half as f64
     }
 
     /// Fold the bloom filter down to the smallest size that still meets the target FPP
@@ -535,8 +594,17 @@ impl Sbbf {
     /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
     /// ```
     ///
-    /// Each iteration computes the folded blocks and their FPP in a single pass. If the
-    /// estimated FPP would exceed the target, the fold is discarded and iteration stops.
+    /// ## Implementation
+    ///
+    /// Each iteration does two passes over the block pairs:
+    /// 1. **Read-only FPP estimate**: OR each pair into a stack-local `Block`, popcount it,
+    ///    and accumulate the per-block FPP. If the estimated FPP exceeds the target, stop.
+    /// 2. **In-place fold**: OR pairs and write results to the first half of the existing Vec,
+    ///    then truncate. This reuses the existing allocation — no heap allocation per fold level.
+    ///
+    /// The data from pass 1 remains hot in CPU cache for pass 2. Separating the OR from the
+    /// popcount (via `Block::count_ones`) allows the compiler to emit batched SIMD popcount
+    /// instructions.
     ///
     /// ## Correctness
     ///
@@ -550,28 +618,14 @@ impl Sbbf {
     ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
         while self.0.len() >= 2 {
-            // Compute the folded blocks and estimate FPP in a single pass.
-            // Using a fresh Vec avoids aliasing, enabling auto-vectorization of the
-            // inner [u32; 8] OR loop. chunks_exact(2) eliminates bounds checks.
-            let half = self.0.len() / 2;
-            let mut folded = Vec::with_capacity(half);
-            let mut total_fpp: f64 = 0.0;
-
-            for pair in self.0.chunks_exact(2) {
-                let mut block = Block::ZERO;
-                let mut set_bits: u32 = 0;
-                for j in 0..8 {
-                    block.0[j] = pair[0].0[j] | pair[1].0[j];
-                    set_bits += block.0[j].count_ones();
-                }
-                total_fpp += (f64::from(set_bits) / 256.0).powi(8);
-                folded.push(block);
-            }
-
-            if total_fpp / half as f64 > target_fpp {
+            // Pass 1: Read-only FPP estimate. If the fold would exceed the
+            // target FPP, stop before mutating the filter.
+            if self.estimated_fpp_after_fold() > target_fpp {
                 break;
             }
-            self.0 = folded;
+            // Pass 2: In-place fold. The block pairs are still hot in cache from
+            // the estimate pass. Reuses the existing Vec allocation.
+            self.fold_once();
         }
     }
 

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -555,7 +555,7 @@ impl Sbbf {
     /// Separating the OR from the popcount lets the compiler emit vectorized popcount
     /// instructions (e.g., `cnt.16b` on ARM NEON) instead of per-word scalar popcount.
     fn estimated_fpp_after_fold(&self) -> f64 {
-        let half = self.0.len() / 2;
+        let half = self.0.len() as f64 / 2.0;
         let mut total_fpp: f64 = 0.0;
         for pair in self.0.chunks_exact(2) {
             let merged = pair[0] | pair[1];
@@ -563,7 +563,7 @@ impl Sbbf {
             let block_fill = f64::from(set_bits) / 256.0;
             total_fpp += block_fill.powi(8);
         }
-        total_fpp / half as f64
+        total_fpp / half
     }
 
     /// Fold the bloom filter down to the smallest size that still meets the target FPP

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -602,15 +602,14 @@ impl Sbbf {
     ///
     /// ## Implementation
     ///
-    /// Each iteration does two passes over the block pairs:
-    /// 1. **Read-only FPP estimate**: OR each pair into a stack-local `Block`, popcount it,
-    ///    and accumulate the per-block FPP. If the estimated FPP exceeds the target, stop.
-    /// 2. **In-place fold**: OR pairs and write results to the first half of the existing Vec,
-    ///    then truncate. This reuses the existing allocation — no heap allocation per fold level.
-    ///
-    /// The data from pass 1 remains hot in CPU cache for pass 2. Separating the OR from the
-    /// popcount (via `Block::count_ones`) allows the compiler to emit batched SIMD popcount
-    /// instructions.
+    /// Uses a two-phase approach:
+    /// 1. **Tree reduction**: Simulate merges in a scratch buffer to determine how many
+    ///    folds are safe. This reads the original data once, then works on progressively
+    ///    smaller scratch — total work O(N). At each level, the FPP is estimated via
+    ///    popcount of the merged blocks.
+    /// 2. **Single in-place fold**: Once the target fold count is known, merge groups of
+    ///    `2^num_folds` adjacent blocks in a single pass over the original data, then
+    ///    truncate. This avoids re-reading the data at each fold level.
     ///
     /// ## Correctness
     ///
@@ -623,16 +622,58 @@ impl Sbbf {
     /// - Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
     ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
-        while self.0.len() >= 2 {
-            // Pass 1: Read-only FPP estimate. If the fold would exceed the
-            // target FPP, stop before mutating the filter.
-            if self.estimated_fpp_after_fold() > target_fpp {
+        let len = self.0.len();
+        if len < 2 {
+            return;
+        }
+
+        // Phase 1: Determine how many folds are safe by simulating merges
+        // in a scratch buffer. This reads the original data once, then works
+        // on progressively smaller scratch — total work O(N).
+        let mut scratch: Vec<Block> = self.0.chunks_exact(2).map(|p| p[0] | p[1]).collect();
+        let mut num_folds = 0u32;
+
+        loop {
+            // Check FPP at this fold level
+            let num_blocks = scratch.len() as f64;
+            let mut total_fpp: f64 = 0.0;
+            for block in &scratch {
+                let set_bits = block.count_ones();
+                let block_fill = f64::from(set_bits) / 256.0;
+                total_fpp += block_fill.powi(8);
+            }
+            if total_fpp / num_blocks > target_fpp {
                 break;
             }
-            // Pass 2: In-place fold. The block pairs are still hot in cache from
-            // the estimate pass. Reuses the existing Vec allocation.
-            self.fold_once();
+            num_folds += 1;
+            if scratch.len() < 2 {
+                break;
+            }
+            // Merge scratch pairwise for next level
+            let new_len = scratch.len() / 2;
+            for i in 0..new_len {
+                scratch[i] = scratch[2 * i] | scratch[2 * i + 1];
+            }
+            scratch.truncate(new_len);
         }
+        drop(scratch);
+
+        if num_folds == 0 {
+            return;
+        }
+
+        // Phase 2: Single in-place fold to the target level.
+        let group_size = 1usize << num_folds;
+        let new_len = len / group_size;
+        for i in 0..new_len {
+            let start = i * group_size;
+            let mut merged = self.0[start];
+            for j in 1..group_size {
+                merged = merged | self.0[start + j];
+            }
+            self.0[i] = merged;
+        }
+        self.0.truncate(new_len);
     }
 
     /// Reads a Sbff from Thrift encoded bytes

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -82,6 +82,7 @@ use crate::basic::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash
 use crate::data_type::AsBytes;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::ColumnChunkMetaData;
+use crate::file::properties::{BloomFilterProperties, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
 use crate::file::reader::ChunkReader;
 use crate::parquet_thrift::{
     ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol, ThriftCompactOutputProtocol,
@@ -275,6 +276,33 @@ pub(crate) fn num_of_bits_from_ndv_fpp(ndv: u64, fpp: f64) -> usize {
 }
 
 impl Sbbf {
+    /// Create a bloom filter from [`BloomFilterProperties`], returning the filter and an
+    /// optional target FPP for folding mode.
+    ///
+    /// When `ndv` is set, returns a fixed-size filter sized for that NDV (legacy behavior).
+    /// When `ndv` is `None`, returns a large filter that should be folded down at flush time
+    /// using [`Sbbf::fold_to_target_fpp`] with the returned target FPP.
+    pub fn from_properties(
+        props: &BloomFilterProperties,
+        max_row_group_row_count: Option<usize>,
+    ) -> Result<(Self, Option<f64>)> {
+        match props.ndv {
+            Some(ndv) => {
+                // Fixed-size mode: size based on explicit NDV (legacy behavior)
+                Ok((Self::new_with_ndv_fpp(ndv, props.fpp)?, None))
+            }
+            None => {
+                // Folding mode: allocate large, fold down at flush
+                let max_bytes = props.max_bytes.unwrap_or_else(|| {
+                    let row_count =
+                        max_row_group_row_count.unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64;
+                    num_of_bits_from_ndv_fpp(row_count, props.fpp) / 8
+                });
+                Ok((Self::new_with_num_of_bytes(max_bytes), Some(props.fpp)))
+            }
+        }
+    }
+
     /// Create a new [Sbbf] with given number of distinct values and false positive probability.
     /// Will return an error if `fpp` is greater than or equal to 1.0 or less than 0.0.
     pub fn new_with_ndv_fpp(ndv: u64, fpp: f64) -> Result<Self, ParquetError> {
@@ -467,10 +495,6 @@ impl Sbbf {
     ///
     /// ## Why adjacent pairs (not halves)?
     ///
-    /// Standard Bloom filter folding merges the two halves (`B[i] | B[i + m/2]`) because
-    /// standard filters use modular hashing: `index = h(x) mod m`, so `h(x) mod (m/2)`
-    /// maps index `i` and index `i + m/2` to the same position.
-    ///
     /// SBBFs use **multiplicative** hashing for block selection:
     ///
     /// ```text
@@ -478,8 +502,11 @@ impl Sbbf {
     /// ```
     ///
     /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`.
-    /// Therefore blocks `2i` and `2i+1` (not `i` and `i + N/2`) map to the same position `i`
-    /// in the folded filter.
+    /// Therefore blocks `2i` and `2i+1` map to the same position `i` in the folded filter.
+    ///
+    /// This differs from standard Bloom filter folding, which merges the two halves
+    /// (`B[i] | B[i + m/2]`) because standard filters use modular hashing where
+    /// `h(x) mod (m/2)` maps indices `i` and `i + m/2` to the same position.
     ///
     /// ## References
     ///
@@ -494,6 +521,10 @@ impl Sbbf {
         assert!(
             len >= 2,
             "Cannot fold a bloom filter with fewer than 2 blocks"
+        );
+        assert!(
+            len % 2 == 0,
+            "Cannot fold a bloom filter with an odd number of blocks"
         );
         let half = len / 2;
         for i in 0..half {
@@ -518,13 +549,13 @@ impl Sbbf {
     /// by computing `(block[2i] | block[2i+1]).count_ones()` without actually mutating the filter.
     fn estimated_fpp_after_fold(&self) -> f64 {
         let half = self.0.len() / 2;
-        let mut total_fpp = 0.0;
+        let mut total_fpp: f64 = 0.0;
         for i in 0..half {
             let mut set_bits: u32 = 0;
             for j in 0..8 {
                 set_bits += (self.0[2 * i].0[j] | self.0[2 * i + 1].0[j]).count_ones();
             }
-            let block_fill = set_bits as f64 / 256.0;
+            let block_fill = f64::from(set_bits) / 256.0;
             total_fpp += block_fill.powi(8);
         }
         total_fpp / half as f64
@@ -982,7 +1013,7 @@ mod tests {
 
     /// show multi-step folding.
     ///
-    /// You can apply the above inductively, folding k times from N blocks prodcues a filter bit-identical to a fresh N/2^k filter
+    /// You can apply the above inductively, folding k times from N blocks produces a filter bit-identical to a fresh N/2^k filter
     #[test]
     fn test_multi_step_fold() {
         let values = (0..3000).map(|i| format!("x_{i}")).collect::<Vec<_>>();

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -203,8 +203,8 @@ impl std::ops::BitOr for Block {
     #[inline]
     fn bitor(self, rhs: Self) -> Self {
         let mut result = [0u32; 8];
-        for i in 0..8 {
-            result[i] = self.0[i] | rhs.0[i];
+        for (i, item) in result.iter_mut().enumerate() {
+            *item = self.0[i] | rhs.0[i];
         }
         Self(result)
     }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -915,7 +915,7 @@ mod tests {
 
         2. the bit pattern set _within_ a block depends only on the lower 32 bits of the hash,
         which doesn't change with filter size. So the same bits get set regardless!
-        > structually trivial, mask() takes a u32 and uses only the SALT constants..
+        > structually trivial, mask() takes a u32 and uses only the SALT constants.
 
 
         When you combine it together, every hash sets the same bits in the same destination block

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -535,45 +535,49 @@ impl Sbbf {
 
     /// Determine how many folds can be applied without exceeding `target_fpp`.
     ///
-    /// Simulates merges via a tree reduction on a scratch buffer: reads the original
-    /// data once (into pairwise-OR'd scratch), then works on progressively smaller
-    /// scratch — total work O(N).
+    /// Computes the average per-block fill rate in a single pass (no allocation),
+    /// then analytically estimates the FPP at each fold level.
     ///
-    /// The FPP after a fold is estimated as the average per-block false positive probability.
-    /// SBBF membership checks perform `k=8` bit checks within one 256-bit block, so:
+    /// When two blocks with independent fill rate `f` are OR'd, the expected fill
+    /// of the merged block is `1 - (1-f)^2`. After `k` folds (merging `2^k` blocks):
     ///
     /// ```text
-    /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
+    /// f_k = 1 - (1 - f)^(2^k)
     /// ```
+    ///
+    /// SBBF membership checks perform `k=8` bit checks within one 256-bit block,
+    /// so the estimated FPP at fold level k is `f_k^8`.
     fn num_folds_for_target_fpp(&self, target_fpp: f64) -> u32 {
         let len = self.0.len();
         if len < 2 {
             return 0;
         }
 
-        let mut scratch: Vec<Block> = self.0.chunks_exact(2).map(|p| p[0] | p[1]).collect();
-        let mut num_folds = 0u32;
+        // Single pass: compute average per-block fill rate.
+        let total_set_bits: u64 = self.0.iter().map(|b| u64::from(b.count_ones())).sum();
+        let avg_fill = total_set_bits as f64 / (len as f64 * 256.0);
 
-        loop {
-            let num_blocks = scratch.len() as f64;
-            let mut total_fpp: f64 = 0.0;
-            for block in &scratch {
-                let set_bits = block.count_ones();
-                let block_fill = f64::from(set_bits) / 256.0;
-                total_fpp += block_fill.powi(8);
-            }
-            if total_fpp / num_blocks > target_fpp {
+        // Empty filter: can fold all the way down.
+        if avg_fill == 0.0 {
+            return len.trailing_zeros();
+        }
+
+        // Find max folds where estimated FPP stays within target.
+        // f_k = 1 - (1 - avg_fill)^(2^k), FPP_k = f_k^8
+        let max_folds = len.trailing_zeros(); // log2(len) since len is power of 2
+        let one_minus_f = 1.0 - avg_fill;
+        let mut num_folds = 0u32;
+        let mut one_minus_fk = one_minus_f; // (1-f)^1 initially
+
+        for _ in 0..max_folds {
+            // After one more fold: (1-f)^(2^(k+1)) = ((1-f)^(2^k))^2
+            one_minus_fk = one_minus_fk * one_minus_fk;
+            let fk = 1.0 - one_minus_fk;
+            let estimated_fpp = fk.powi(8);
+            if estimated_fpp > target_fpp {
                 break;
             }
             num_folds += 1;
-            if scratch.len() < 2 {
-                break;
-            }
-            let new_len = scratch.len() / 2;
-            for i in 0..new_len {
-                scratch[i] = scratch[2 * i] | scratch[2 * i + 1];
-            }
-            scratch.truncate(new_len);
         }
 
         num_folds

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -493,9 +493,10 @@ impl Sbbf {
     /// Fold the bloom filter down to the smallest size that still meets the target FPP
     /// (False Positive Percentage).
     ///
-    /// Repeatedly halves the filter by merging adjacent block pairs via bitwise OR,
-    /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or
-    /// when the filter reaches the minimum size of 1 block (32 bytes).
+    /// Folds the filter by merging groups of adjacent blocks via bitwise OR, where each
+    /// fold level halves the number of blocks. The fold count is chosen as the maximum
+    /// number of folds whose estimated FPP stays within `target_fpp`. The filter stops
+    /// at a minimum size of 1 block (32 bytes).
     ///
     /// ## How it works
     ///
@@ -505,11 +506,13 @@ impl Sbbf {
     /// block_index = ((hash >> 32) * num_blocks) >> 32
     /// ```
     ///
-    /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`, so
-    /// blocks `2i` and `2i+1` map to the same position. Each fold merges **adjacent** pairs:
+    /// A single fold halves the block count: when `num_blocks` is halved, the new index
+    /// becomes `floor(original_index / 2)`, so blocks `2i` and `2i+1` map to the same
+    /// position. More generally, `k` folds reduce the block count by `2^k`, merging
+    /// groups of `2^k` adjacent blocks in a single pass:
     ///
     /// ```text
-    /// folded[i] = blocks[2*i] | blocks[2*i + 1]
+    /// folded[i] = blocks[i*2^k] | blocks[i*2^k + 1] | ... | blocks[i*2^k + 2^k - 1]
     /// ```
     ///
     /// This differs from standard Bloom filter folding, which merges the two halves

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -900,7 +900,7 @@ mod tests {
 
     /*
         Ok, so the following is trying to prove in simple terms that folding an SBBF and
-        building a fresh smaller SBBF from scratch prodcues the exact same bits
+        building a fresh smaller SBBF from scratch produces the exact same bits
 
         If you insert the same values into a 512-block filter and fold it to 256 blocks,
         you get a bit-for-bit identical result to just inserting those values into a

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -604,7 +604,7 @@ impl Sbbf {
             let start = i * group_size;
             let mut merged = self.0[start];
             for j in 1..group_size {
-                merged = merged | self.0[start + j];
+                merged |= self.0[start + j];
             }
             self.0[i] = merged;
         }

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -68,6 +68,12 @@
 //! | 1,000,000 | 0.00001   | 131,072 | 4,096     |
 //! | 1,000,000 | 0.000001  | 262,144 | 8,192     |
 //!
+//! # Bloom Filter Folding
+//!
+//! When the NDV is not known ahead of time, bloom filters support a **folding mode** that
+//! eliminates the need to guess NDV upfront. See [`Sbbf::fold_to_target_fpp`] for details
+//! on the algorithm and its mathematical basis.
+//!
 //! [parquet-bf-spec]: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
 //! [sbbf-paper]: https://arxiv.org/pdf/2101.01719
 //! [bf-formulae]: http://tfk.mit.edu/pdf/bloom.pdf
@@ -191,7 +197,21 @@ impl std::ops::IndexMut<usize> for Block {
     }
 }
 
-/// A split block Bloom filter.
+/// A split block Bloom filter (SBBF).
+///
+/// An SBBF partitions its bit space into fixed-size 256-bit (32-byte) blocks, each fitting in a
+/// single CPU cache line. Each block contains eight 32-bit words, aligned with SIMD lanes for
+/// parallel bit manipulation. When checking membership, only one block is accessed per query,
+/// eliminating the cache-miss penalty of standard Bloom filters.
+///
+/// ## Two sizing modes
+///
+/// - **Fixed-size mode**: Created via [`Sbbf::new_with_ndv_fpp`] when the number of distinct
+///   values (NDV) is known. The filter is sized exactly for the given NDV and FPP.
+///
+/// - **Folding mode**: Created via [`Sbbf::new_with_num_of_bytes`] at a conservatively large
+///   size, then compacted after all values are inserted by calling [`Sbbf::fold_to_target_fpp`].
+///   This eliminates the need to know NDV upfront.
 ///
 /// The creation of this structure is based on the [`crate::file::properties::BloomFilterProperties`]
 /// struct set via [`crate::file::properties::WriterProperties`] and is thus hidden by default.
@@ -436,10 +456,35 @@ impl Sbbf {
         self.0.len()
     }
 
-    /// Fold the bloom filter once by merging adjacent block pairs via bitwise OR,
-    /// halving the filter size. Block[2i] and Block[2i+1] are merged into a single block
-    /// at position [i] in the folded filter. This preserves correctness because
-    /// `hash_to_block_index` maps to `floor(original_index / 2)` when `num_blocks` is halved.
+    /// Fold the bloom filter once, halving its size by merging adjacent block pairs.
+    ///
+    /// This implements an elementary folding operation for Split Block Bloom
+    /// Filters<sup>[1]</sup>. Each pair of adjacent blocks is combined via bitwise OR:
+    ///
+    /// ```text
+    /// folded[i] = blocks[2*i] | blocks[2*i + 1]    for 0 <= i < num_blocks/2
+    /// ```
+    ///
+    /// ## Why adjacent pairs (not halves)?
+    ///
+    /// Standard Bloom filter folding merges the two halves (`B[i] | B[i + m/2]`) because
+    /// standard filters use modular hashing: `index = h(x) mod m`, so `h(x) mod (m/2)`
+    /// maps index `i` and index `i + m/2` to the same position.
+    ///
+    /// SBBFs use **multiplicative** hashing for block selection:
+    ///
+    /// ```text
+    /// block_index = ((hash >> 32) * num_blocks) >> 32
+    /// ```
+    ///
+    /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`.
+    /// Therefore blocks `2i` and `2i+1` (not `i` and `i + N/2`) map to the same position `i`
+    /// in the folded filter.
+    ///
+    /// ## References
+    ///
+    /// 1. Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
+    ///    IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     ///
     /// # Panics
     ///
@@ -458,9 +503,16 @@ impl Sbbf {
 
     /// Estimate the FPP that would result from folding once, without mutating the filter.
     ///
-    /// SBBF checks are per-block: a query hashes to one block, then checks 8 bits within it.
-    /// The FPP is therefore the average of per-block FPPs, not a function of global fill.
-    /// For each merged block pair (2i, 2i+1), we compute `(block_fill)^8` and average.
+    /// Unlike standard Bloom filters where FPP depends on the global fill ratio, SBBF
+    /// membership checks are **per-block**: a query hashes to exactly one block, then checks
+    /// `k=8` bits within that block. The FPP is therefore the **average of per-block FPPs**:
+    ///
+    /// ```text
+    /// FPP = (1 / num_blocks) * sum_i (set_bits_in_block_i / 256)^8
+    /// ```
+    ///
+    /// To project the FPP after a fold, we simulate the merge of each adjacent pair `(2i, 2i+1)`
+    /// by computing `(block[2i] | block[2i+1]).count_ones()` without actually mutating the filter.
     fn estimated_fpp_after_fold(&self) -> f64 {
         let half = self.0.len() / 2;
         let mut total_fpp = 0.0;
@@ -475,15 +527,74 @@ impl Sbbf {
         total_fpp / half as f64
     }
 
-    /// Fold the bloom filter down until reaching the target false positive probability.
+    /// Fold the bloom filter down to the smallest size that still meets the target FPP.
     ///
-    /// Repeatedly halves the filter by OR-ing the upper half into the lower half, stopping
-    /// when the next fold would cause the estimated FPP to exceed `target_fpp`, or when the
-    /// filter reaches the minimum size of 1 block (32 bytes).
+    /// Repeatedly halves the filter by merging adjacent block pairs (see [`Self::fold_once`]),
+    /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or
+    /// when the filter reaches the minimum size of 1 block (32 bytes).
     ///
-    /// This is useful when a bloom filter was allocated conservatively large and needs to be
-    /// compacted after all values have been inserted. Folding preserves all set bits, so there
-    /// are never false negatives — only a controlled increase in false positive probability.
+    /// ## Background
+    ///
+    /// Bloom filter folding is a technique for dynamically resizing filters after
+    /// construction. For a standard Bloom filter of size `m` (a power of two), an element
+    /// hashed to index `i = h(x) mod m` would map to `i' = h(x) mod (m/2)` in a filter
+    /// half the size. Since `m` is a power of two, the fold is a bitwise OR of the upper half
+    /// onto the lower half: `B_folded[j] = B[j] | B[j + m/2]`.
+    ///
+    /// ## Adaptation for SBBF
+    ///
+    /// SBBFs use multiplicative hashing for block selection rather than modular arithmetic:
+    ///
+    /// ```text
+    /// block_index = ((hash >> 32) * num_blocks) >> 32
+    /// ```
+    ///
+    /// When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`, so
+    /// blocks `2i` and `2i+1` (not `i` and `i+N/2`) map to the same position. The fold
+    /// therefore merges **adjacent** pairs:
+    ///
+    /// ```text
+    /// folded[i] = blocks[2*i] | blocks[2*i + 1]
+    /// ```
+    ///
+    /// ## FPP estimation
+    ///
+    /// SBBF membership checks are per-block (`k=8` bit checks within one 256-bit block), so
+    /// the FPP is the average of per-block false positive probabilities:
+    ///
+    /// ```text
+    /// FPP = (1/b) * sum_i (set_bits_in_block_i / 256)^8
+    /// ```
+    ///
+    /// Before each fold, we project the post-fold FPP by simulating the block merges. Folding
+    /// stops when the next fold would exceed the target.
+    ///
+    /// ## Correctness
+    ///
+    /// Folding **never introduces false negatives**. Every bit that was set in the original
+    /// filter remains set in the folded filter (via bitwise OR). The only effect is a controlled
+    /// increase in FPP as set bits from different blocks are merged together.
+    ///
+    /// ## Typical usage
+    ///
+    /// ```text
+    /// // 1. Allocate large (worst-case NDV = max row group rows)
+    /// let mut sbbf = Sbbf::new_with_num_of_bytes(1_048_576); // 1 MiB
+    ///
+    /// // 2. Insert all values during column writing
+    /// for value in column_values {
+    ///     sbbf.insert(&value);
+    /// }
+    ///
+    /// // 3. Fold down to target FPP before serializing
+    /// sbbf.fold_to_target_fpp(0.05);
+    /// // Filter is now optimally sized for the actual data
+    /// ```
+    ///
+    /// ## References
+    ///
+    /// - Sailhan, F. & Stehr, M-O. "Folding and Unfolding Bloom Filters",
+    ///   IEEE iThings 2012. <https://doi.org/10.1109/GreenCom.2012.16>
     pub fn fold_to_target_fpp(&mut self, target_fpp: f64) {
         while self.0.len() >= 2 {
             if self.estimated_fpp_after_fold() > target_fpp {

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -531,7 +531,8 @@ impl Sbbf {
         total_fpp / half as f64
     }
 
-    /// Fold the bloom filter down to the smallest size that still meets the target FPP.
+    /// Fold the bloom filter down to the smallest size that still meets the target FPP 
+    /// (False Positive Percentage)
     ///
     /// Repeatedly halves the filter by merging adjacent block pairs (see `fold_once`),
     /// stopping when the next fold would cause the estimated FPP to exceed `target_fpp`, or

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -564,6 +564,7 @@ impl Sbbf {
 
         // Find max folds where estimated FPP stays within target.
         // f_k = 1 - (1 - avg_fill)^(2^k), FPP_k = f_k^8
+        assert!(len.is_power_of_two(), "Number of blocks must be a power of 2 for folding");
         let max_folds = len.trailing_zeros(); // log2(len) since len is power of 2
         let one_minus_f = 1.0 - avg_fill;
         let mut num_folds = 0u32;

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -27,7 +27,9 @@ use crate::data_type::DataType;
 use crate::data_type::private::ParquetValueType;
 use crate::encodings::encoding::{DictEncoder, Encoder, get_encoder};
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{EnabledStatistics, WriterProperties};
+use crate::file::properties::{
+    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties,
+};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::{ColumnDescPtr, ColumnDescriptor};
@@ -138,7 +140,7 @@ pub struct ColumnValueEncoderImpl<T: DataType> {
     min_value: Option<T::T>,
     max_value: Option<T::T>,
     bloom_filter: Option<Sbbf>,
-    bloom_filter_target_fpp: Option<f64>,
+    bloom_filter_target_fpp: f64,
     variable_length_bytes: Option<i64>,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
 }
@@ -189,9 +191,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn flush_bloom_filter(&mut self) -> Option<Sbbf> {
         let mut sbbf = self.bloom_filter.take()?;
-        if let Some(target_fpp) = self.bloom_filter_target_fpp {
-            sbbf.fold_to_target_fpp(target_fpp);
-        }
+        sbbf.fold_to_target_fpp(self.bloom_filter_target_fpp);
         Some(sbbf)
     }
 
@@ -210,15 +210,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
         let statistics_enabled = props.statistics_enabled(descr.path());
 
-        let (bloom_filter, bloom_filter_target_fpp) =
-            match props.bloom_filter_properties(descr.path()) {
-                Some(bf_props) => {
-                    let (sbbf, target_fpp) =
-                        Sbbf::from_properties(bf_props, props.max_row_group_row_count())?;
-                    (Some(sbbf), target_fpp)
-                }
-                None => (None, None),
-            };
+        let (bloom_filter, bloom_filter_target_fpp) = create_bloom_filter(props, descr)?;
 
         let geo_stats_accumulator = try_new_geo_stats_accumulator(descr);
 
@@ -392,6 +384,28 @@ fn replace_zero<T: ParquetValueType>(val: &T, descr: &ColumnDescriptor, replace:
             T::try_from_le_slice(&f16::to_le_bytes(f16::from_f32(replace))).unwrap()
         }
         _ => val.clone(),
+    }
+}
+
+/// Creates a bloom filter sized for the column's configured NDV (or the row group size
+/// if NDV is not explicitly set), returning the filter and the target FPP for folding.
+pub(crate) fn create_bloom_filter(
+    props: &WriterProperties,
+    descr: &ColumnDescPtr,
+) -> Result<(Option<Sbbf>, f64)> {
+    match props.bloom_filter_properties(descr.path()) {
+        Some(bf_props) => {
+            let ndv = bf_props.ndv.unwrap_or(
+                props
+                    .max_row_group_row_count()
+                    .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64,
+            );
+            Ok((
+                Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?),
+                bf_props.fpp,
+            ))
+        }
+        None => Ok((None, 0.0)),
     }
 }
 

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use half::f16;
 
 use crate::basic::{ConvertedType, Encoding, LogicalType, Type};
-use crate::bloom_filter::{Sbbf, num_of_bits_from_ndv_fpp};
+use crate::bloom_filter::Sbbf;
 use crate::column::writer::{
     compare_greater, fallback_encoding, has_dictionary_support, is_nan, update_max, update_min,
 };
@@ -27,9 +27,7 @@ use crate::data_type::DataType;
 use crate::data_type::private::ParquetValueType;
 use crate::encodings::encoding::{DictEncoder, Encoder, get_encoder};
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{
-    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties,
-};
+use crate::file::properties::{EnabledStatistics, WriterProperties};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::{ColumnDescPtr, ColumnDescriptor};
@@ -214,26 +212,11 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
         let (bloom_filter, bloom_filter_target_fpp) =
             match props.bloom_filter_properties(descr.path()) {
-                Some(bf_props) => match bf_props.ndv {
-                    Some(ndv) => {
-                        // Fixed-size mode: size based on explicit NDV (legacy behavior)
-                        (Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?), None)
-                    }
-                    None => {
-                        // Folding mode: allocate large, fold down at flush
-                        let max_bytes = bf_props.max_bytes.unwrap_or_else(|| {
-                            let row_count = props
-                                .max_row_group_row_count()
-                                .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
-                                as u64;
-                            num_of_bits_from_ndv_fpp(row_count, bf_props.fpp) / 8
-                        });
-                        (
-                            Some(Sbbf::new_with_num_of_bytes(max_bytes)),
-                            Some(bf_props.fpp),
-                        )
-                    }
-                },
+                Some(bf_props) => {
+                    let (sbbf, target_fpp) =
+                        Sbbf::from_properties(bf_props, props.max_row_group_row_count())?;
+                    (Some(sbbf), target_fpp)
+                }
                 None => (None, None),
             };
 

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use half::f16;
 
 use crate::basic::{ConvertedType, Encoding, LogicalType, Type};
-use crate::bloom_filter::Sbbf;
+use crate::bloom_filter::{Sbbf, num_of_bits_from_ndv_fpp};
 use crate::column::writer::{
     compare_greater, fallback_encoding, has_dictionary_support, is_nan, update_max, update_min,
 };
@@ -27,7 +27,7 @@ use crate::data_type::DataType;
 use crate::data_type::private::ParquetValueType;
 use crate::encodings::encoding::{DictEncoder, Encoder, get_encoder};
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{EnabledStatistics, WriterProperties};
+use crate::file::properties::{EnabledStatistics, WriterProperties, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::{ColumnDescPtr, ColumnDescriptor};
@@ -138,6 +138,7 @@ pub struct ColumnValueEncoderImpl<T: DataType> {
     min_value: Option<T::T>,
     max_value: Option<T::T>,
     bloom_filter: Option<Sbbf>,
+    bloom_filter_target_fpp: Option<f64>,
     variable_length_bytes: Option<i64>,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
 }
@@ -187,7 +188,11 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     type Values = [T::T];
 
     fn flush_bloom_filter(&mut self) -> Option<Sbbf> {
-        self.bloom_filter.take()
+        let mut sbbf = self.bloom_filter.take()?;
+        if let Some(target_fpp) = self.bloom_filter_target_fpp {
+            sbbf.fold_to_target_fpp(target_fpp);
+        }
+        Some(sbbf)
     }
 
     fn try_new(descr: &ColumnDescPtr, props: &WriterProperties) -> Result<Self> {
@@ -205,10 +210,30 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
         let statistics_enabled = props.statistics_enabled(descr.path());
 
-        let bloom_filter = props
-            .bloom_filter_properties(descr.path())
-            .map(|props| Sbbf::new_with_ndv_fpp(props.ndv, props.fpp))
-            .transpose()?;
+        let (bloom_filter, bloom_filter_target_fpp) =
+            match props.bloom_filter_properties(descr.path()) {
+                Some(bf_props) => match bf_props.ndv {
+                    Some(ndv) => {
+                        // Fixed-size mode: size based on explicit NDV (legacy behavior)
+                        (Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?), None)
+                    }
+                    None => {
+                        // Folding mode: allocate large, fold down at flush
+                        let max_bytes = bf_props.max_bytes.unwrap_or_else(|| {
+                            let row_count = props
+                                .max_row_group_row_count()
+                                .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
+                                as u64;
+                            num_of_bits_from_ndv_fpp(row_count, bf_props.fpp) / 8
+                        });
+                        (
+                            Some(Sbbf::new_with_num_of_bytes(max_bytes)),
+                            Some(bf_props.fpp),
+                        )
+                    }
+                },
+                None => (None, None),
+            };
 
         let geo_stats_accumulator = try_new_geo_stats_accumulator(descr);
 
@@ -219,6 +244,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
             num_values: 0,
             statistics_enabled,
             bloom_filter,
+            bloom_filter_target_fpp,
             min_value: None,
             max_value: None,
             variable_length_bytes: None,

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -27,9 +27,7 @@ use crate::data_type::DataType;
 use crate::data_type::private::ParquetValueType;
 use crate::encodings::encoding::{DictEncoder, Encoder, get_encoder};
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{
-    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties,
-};
+use crate::file::properties::{EnabledStatistics, WriterProperties};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::{ColumnDescPtr, ColumnDescriptor};
@@ -387,24 +385,17 @@ fn replace_zero<T: ParquetValueType>(val: &T, descr: &ColumnDescriptor, replace:
     }
 }
 
-/// Creates a bloom filter sized for the column's configured NDV (or the row group size
-/// if NDV is not explicitly set), returning the filter and the target FPP for folding.
+/// Creates a bloom filter sized for the column's configured NDV, returning the filter
+/// and the target FPP for folding.
 pub(crate) fn create_bloom_filter(
     props: &WriterProperties,
     descr: &ColumnDescPtr,
 ) -> Result<(Option<Sbbf>, f64)> {
     match props.bloom_filter_properties(descr.path()) {
-        Some(bf_props) => {
-            let ndv = bf_props.ndv.unwrap_or(
-                props
-                    .max_row_group_row_count()
-                    .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64,
-            );
-            Ok((
-                Some(Sbbf::new_with_ndv_fpp(ndv, bf_props.fpp)?),
-                bf_props.fpp,
-            ))
-        }
+        Some(bf_props) => Ok((
+            Some(Sbbf::new_with_ndv_fpp(bf_props.ndv, bf_props.fpp)?),
+            bf_props.fpp,
+        )),
         None => Ok((None, 0.0)),
     }
 }

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -27,7 +27,9 @@ use crate::data_type::DataType;
 use crate::data_type::private::ParquetValueType;
 use crate::encodings::encoding::{DictEncoder, Encoder, get_encoder};
 use crate::errors::{ParquetError, Result};
-use crate::file::properties::{EnabledStatistics, WriterProperties, DEFAULT_MAX_ROW_GROUP_ROW_COUNT};
+use crate::file::properties::{
+    DEFAULT_MAX_ROW_GROUP_ROW_COUNT, EnabledStatistics, WriterProperties,
+};
 use crate::geospatial::accumulator::{GeoStatsAccumulator, try_new_geo_stats_accumulator};
 use crate::geospatial::statistics::GeospatialStatistics;
 use crate::schema::types::{ColumnDescPtr, ColumnDescriptor};

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -53,7 +53,13 @@ pub const DEFAULT_CREATED_BY: &str = concat!("parquet-rs version ", env!("CARGO_
 pub const DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH: Option<usize> = Some(64);
 /// Default value for [`BloomFilterProperties::fpp`]
 pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.05;
-/// Default value for [`BloomFilterProperties::ndv`]
+/// Default value for [`BloomFilterProperties::ndv`].
+///
+/// Note: this is only the fallback default used when constructing [`BloomFilterProperties`]
+/// directly. When using [`WriterPropertiesBuilder`], columns with bloom filters enabled
+/// but without an explicit NDV will have their NDV resolved at build time to
+/// [`WriterProperties::max_row_group_row_count`], which may differ from this constant
+/// if the user configured a custom row group size.
 pub const DEFAULT_BLOOM_FILTER_NDV: u64 = DEFAULT_MAX_ROW_GROUP_ROW_COUNT as u64;
 /// Default values for [`WriterProperties::statistics_truncate_length`]
 pub const DEFAULT_STATISTICS_TRUNCATE_LENGTH: Option<usize> = Some(64);
@@ -587,6 +593,18 @@ impl Default for WriterPropertiesBuilder {
 impl WriterPropertiesBuilder {
     /// Finalizes the configuration and returns immutable writer properties struct.
     pub fn build(self) -> WriterProperties {
+        // Resolve bloom filter NDV for columns where it wasn't explicitly set:
+        // default to max_row_group_row_count so the filter is never undersized.
+        let default_ndv = self
+            .max_row_group_row_count
+            .unwrap_or(DEFAULT_MAX_ROW_GROUP_ROW_COUNT) as u64;
+        let mut default_column_properties = self.default_column_properties;
+        default_column_properties.resolve_bloom_filter_ndv(default_ndv);
+        let mut column_properties = self.column_properties;
+        for props in column_properties.values_mut() {
+            props.resolve_bloom_filter_ndv(default_ndv);
+        }
+
         WriterProperties {
             data_page_row_count_limit: self.data_page_row_count_limit,
             write_batch_size: self.write_batch_size,
@@ -597,8 +615,8 @@ impl WriterPropertiesBuilder {
             created_by: self.created_by,
             offset_index_disabled: self.offset_index_disabled,
             key_value_metadata: self.key_value_metadata,
-            default_column_properties: self.default_column_properties,
-            column_properties: self.column_properties,
+            default_column_properties,
+            column_properties,
             sorting_columns: self.sorting_columns,
             column_index_truncate_length: self.column_index_truncate_length,
             statistics_truncate_length: self.statistics_truncate_length,
@@ -1216,15 +1234,16 @@ pub struct BloomFilterProperties {
     /// This value also serves as the target FPP for bloom filter folding: after all values
     /// are inserted, the filter is folded down to the smallest size that still meets this FPP.
     pub fpp: f64,
-    /// Maximum expected number of distinct values. When `None` (default), the bloom filter
-    /// is sized based on the row group's `max_row_group_row_count` at runtime.
+    /// Maximum expected number of distinct values. Defaults to [`DEFAULT_BLOOM_FILTER_NDV`].
     ///
     /// You should set this value by calling [`WriterPropertiesBuilder::set_bloom_filter_ndv`].
     ///
-    /// The bloom filter is initially sized for this many distinct values at the given `fpp`,
-    /// then folded down after insertion to achieve optimal size. A good heuristic is to set
-    /// this to the expected number of rows in the row group. If fewer distinct values are
-    /// actually written, the filter will be automatically compacted via folding.
+    /// When not explicitly set via the builder, this defaults to
+    /// [`max_row_group_row_count`](WriterProperties::max_row_group_row_count) (resolved at
+    /// build time). The bloom filter is initially sized for this many distinct values at the
+    /// given `fpp`, then folded down after insertion to achieve optimal size. A good heuristic
+    /// is to set this to the expected number of rows in the row group. If fewer distinct values
+    /// are actually written, the filter will be automatically compacted via folding.
     ///
     /// Thus the only negative side of overestimating this value is that the bloom filter
     /// will use more memory during writing than necessary, but it will not affect the final
@@ -1236,14 +1255,14 @@ pub struct BloomFilterProperties {
     /// If you do set this value explicitly it is probably best to set it for each column
     /// individually via [`WriterPropertiesBuilder::set_column_bloom_filter_ndv`] rather than globally,
     /// since different columns may have different numbers of distinct values.
-    pub ndv: Option<u64>,
+    pub ndv: u64,
 }
 
 impl Default for BloomFilterProperties {
     fn default() -> Self {
         BloomFilterProperties {
             fpp: DEFAULT_BLOOM_FILTER_FPP,
-            ndv: None,
+            ndv: DEFAULT_BLOOM_FILTER_NDV,
         }
     }
 }
@@ -1263,6 +1282,8 @@ struct ColumnProperties {
     write_page_header_statistics: Option<bool>,
     /// bloom filter related properties
     bloom_filter_properties: Option<BloomFilterProperties>,
+    /// Whether the bloom filter NDV was explicitly set by the user
+    bloom_filter_ndv_is_set: bool,
 }
 
 impl ColumnProperties {
@@ -1345,7 +1366,8 @@ impl ColumnProperties {
     fn set_bloom_filter_ndv(&mut self, value: u64) {
         self.bloom_filter_properties
             .get_or_insert_with(Default::default)
-            .ndv = Some(value);
+            .ndv = value;
+        self.bloom_filter_ndv_is_set = true;
     }
 
     /// Returns optional encoding for this column.
@@ -1392,6 +1414,16 @@ impl ColumnProperties {
     /// Returns the bloom filter properties, or `None` if not enabled
     fn bloom_filter_properties(&self) -> Option<&BloomFilterProperties> {
         self.bloom_filter_properties.as_ref()
+    }
+
+    /// If bloom filter is enabled and NDV was not explicitly set, resolve it to the
+    /// given `default_ndv` (typically derived from `max_row_group_row_count`).
+    fn resolve_bloom_filter_ndv(&mut self, default_ndv: u64) {
+        if !self.bloom_filter_ndv_is_set {
+            if let Some(ref mut bf) = self.bloom_filter_properties {
+                bf.ndv = default_ndv;
+            }
+        }
     }
 }
 
@@ -1690,7 +1722,7 @@ mod tests {
                 props.bloom_filter_properties(&ColumnPath::from("col")),
                 Some(&BloomFilterProperties {
                     fpp: 0.1,
-                    ndv: Some(100),
+                    ndv: 100,
                 })
             );
         }
@@ -1728,7 +1760,7 @@ mod tests {
             props.bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
                 fpp: DEFAULT_BLOOM_FILTER_FPP,
-                ndv: None,
+                ndv: DEFAULT_BLOOM_FILTER_NDV,
             })
         );
     }
@@ -1771,7 +1803,7 @@ mod tests {
                 .bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
                 fpp: DEFAULT_BLOOM_FILTER_FPP,
-                ndv: Some(100),
+                ndv: 100,
             })
         );
         assert_eq!(
@@ -1781,7 +1813,7 @@ mod tests {
                 .bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
                 fpp: 0.1,
-                ndv: None,
+                ndv: DEFAULT_BLOOM_FILTER_NDV,
             })
         );
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -54,8 +54,7 @@ pub const DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH: Option<usize> = Some(64);
 /// Default value for [`BloomFilterProperties::fpp`]
 pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.05;
 /// Default value for [`BloomFilterProperties::ndv`]
-#[deprecated(note = "NDV is now optional; bloom filters use folding mode by default")]
-pub const DEFAULT_BLOOM_FILTER_NDV: u64 = 1_000_000_u64;
+pub const DEFAULT_BLOOM_FILTER_NDV: u64 = DEFAULT_MAX_ROW_GROUP_ROW_COUNT as u64;
 /// Default values for [`WriterProperties::statistics_truncate_length`]
 pub const DEFAULT_STATISTICS_TRUNCATE_LENGTH: Option<usize> = Some(64);
 /// Default value for [`WriterProperties::offset_index_disabled`]
@@ -997,11 +996,13 @@ impl WriterPropertiesBuilder {
         self
     }
 
-    /// Sets default number of distinct values (ndv) for bloom filter for all columns.
+    /// Sets default maximum expected number of distinct values (ndv) for bloom filter
+    /// for all columns (defaults to [`DEFAULT_BLOOM_FILTER_NDV`]).
     ///
-    /// When set, this activates fixed-size mode: the bloom filter is sized exactly for
-    /// the given NDV at the configured FPP, with no folding. When not set (default),
-    /// the bloom filter uses folding mode instead.
+    /// The bloom filter is initially sized for this many distinct values at the
+    /// configured FPP, then folded down after all values are inserted to achieve
+    /// optimal size. A good heuristic is to set this to the expected number of rows
+    /// in the row group.
     ///
     /// Implicitly enables bloom writing, as if [`set_bloom_filter_enabled`] had
     /// been called.
@@ -1009,26 +1010,6 @@ impl WriterPropertiesBuilder {
     /// [`set_bloom_filter_enabled`]: Self::set_bloom_filter_enabled
     pub fn set_bloom_filter_ndv(mut self, value: u64) -> Self {
         self.default_column_properties.set_bloom_filter_ndv(value);
-        self
-    }
-
-    /// Sets the default maximum initial allocation size in bytes for bloom filter folding mode
-    /// for all columns.
-    ///
-    /// When bloom filters use folding mode (no explicit NDV), this controls the initial
-    /// allocation size. The filter will be folded down at flush time to meet the target FPP.
-    /// If not set, the initial size is derived from `max_row_group_row_count` and `fpp`.
-    ///
-    /// The value will be rounded up to the next power of two, bounded by
-    /// [`BITSET_MIN_LENGTH`](crate::bloom_filter::BITSET_MIN_LENGTH) and
-    /// [`BITSET_MAX_LENGTH`](crate::bloom_filter::BITSET_MAX_LENGTH).
-    ///
-    /// Implicitly enables bloom writing, as if [`set_bloom_filter_enabled`] had been called.
-    ///
-    /// [`set_bloom_filter_enabled`]: Self::set_bloom_filter_enabled
-    pub fn set_bloom_filter_max_bytes(mut self, value: usize) -> Self {
-        self.default_column_properties
-            .set_bloom_filter_max_bytes(value);
         self
     }
 
@@ -1137,15 +1118,6 @@ impl WriterPropertiesBuilder {
         self.get_mut_props(col).set_bloom_filter_ndv(value);
         self
     }
-
-    /// Sets the maximum initial allocation size in bytes for bloom filter folding mode
-    /// for a specific column.
-    ///
-    /// Takes precedence over [`Self::set_bloom_filter_max_bytes`].
-    pub fn set_column_bloom_filter_max_bytes(mut self, col: ColumnPath, value: usize) -> Self {
-        self.get_mut_props(col).set_bloom_filter_max_bytes(value);
-        self
-    }
 }
 
 impl From<WriterProperties> for WriterPropertiesBuilder {
@@ -1225,15 +1197,12 @@ impl Default for EnabledStatistics {
 
 /// Controls the bloom filter to be computed by the writer.
 ///
-/// Two modes are supported:
+/// The bloom filter is initially sized for `ndv` distinct values at the given `fpp`, then
+/// automatically folded down after all values are inserted to achieve optimal size while
+/// maintaining the target `fpp`. See [`Sbbf::fold_to_target_fpp`] for details on the
+/// folding algorithm.
 ///
-/// - **Fixed-size mode**: When `ndv` is set to `Some(n)`, the bloom filter is sized based on `ndv`
-///   and `fpp` at allocation time. This is the legacy behavior.
-///
-/// - **Folding mode** (default): When `ndv` is `None`, a conservatively large bloom filter is
-///   allocated (sized for worst-case NDV = max row group rows, or `max_bytes` if set), then
-///   folded down at flush time to meet the target `fpp`. This eliminates the need to guess NDV
-///   upfront and produces optimally-sized filters automatically.
+/// [`Sbbf::fold_to_target_fpp`]: crate::bloom_filter::Sbbf::fold_to_target_fpp
 #[derive(Debug, Clone, PartialEq)]
 pub struct BloomFilterProperties {
     /// False positive probability. This should be always between 0 and 1 exclusive. Defaults to [`DEFAULT_BLOOM_FILTER_FPP`].
@@ -1242,24 +1211,21 @@ pub struct BloomFilterProperties {
     ///
     /// The bloom filter data structure is a trade of between disk and memory space versus fpp, the
     /// smaller the fpp, the more memory and disk space is required, thus setting it to a reasonable value
-    /// e.g. 0.1, 0.01, or 0.001 is recommended.
+    /// e.g. 0.1, 0.05, or 0.001 is recommended.
+    ///
+    /// This value also serves as the target FPP for bloom filter folding: after all values
+    /// are inserted, the filter is folded down to the smallest size that still meets this FPP.
     pub fpp: f64,
-    /// Number of distinct values. When set to `Some(n)`, the bloom filter is sized exactly for
-    /// `n` distinct values at the given `fpp` (fixed-size mode). When `None` (default), the
-    /// filter uses folding mode instead.
+    /// Maximum expected number of distinct values. When `None` (default), the bloom filter
+    /// is sized based on the row group's `max_row_group_row_count` at runtime.
     ///
     /// You should set this value by calling [`WriterPropertiesBuilder::set_bloom_filter_ndv`].
     ///
-    /// Usage of bloom filter is most beneficial for columns with large cardinality, so a good heuristic
-    /// is to set ndv to the number of rows. However, it can reduce disk size if you know in advance a smaller
-    /// number of distinct values.
+    /// The bloom filter is initially sized for this many distinct values at the given `fpp`,
+    /// then folded down after insertion to achieve optimal size. A good heuristic is to set
+    /// this to the expected number of rows in the row group. If fewer distinct values are
+    /// actually written, the filter will be automatically compacted via folding.
     pub ndv: Option<u64>,
-    /// Maximum initial allocation size in bytes for folding mode. When `None` (default), the
-    /// initial size is derived from `max_row_group_row_count` and `fpp`. Only used when `ndv`
-    /// is `None`.
-    ///
-    /// You should set this value by calling [`WriterPropertiesBuilder::set_bloom_filter_max_bytes`].
-    pub max_bytes: Option<usize>,
 }
 
 impl Default for BloomFilterProperties {
@@ -1267,7 +1233,6 @@ impl Default for BloomFilterProperties {
         BloomFilterProperties {
             fpp: DEFAULT_BLOOM_FILTER_FPP,
             ndv: None,
-            max_bytes: None,
         }
     }
 }
@@ -1364,20 +1329,12 @@ impl ColumnProperties {
             .fpp = value;
     }
 
-    /// Sets the number of distinct (unique) values for bloom filter for this column, and implicitly
-    /// enables bloom filter if not previously enabled. This activates fixed-size mode (no folding).
+    /// Sets the maximum expected number of distinct (unique) values for bloom filter for this
+    /// column, and implicitly enables bloom filter if not previously enabled.
     fn set_bloom_filter_ndv(&mut self, value: u64) {
         self.bloom_filter_properties
             .get_or_insert_with(Default::default)
             .ndv = Some(value);
-    }
-
-    /// Sets the maximum initial allocation size in bytes for bloom filter folding mode, and
-    /// implicitly enables bloom filter if not previously enabled.
-    fn set_bloom_filter_max_bytes(&mut self, value: usize) {
-        self.bloom_filter_properties
-            .get_or_insert_with(Default::default)
-            .max_bytes = Some(value);
     }
 
     /// Returns optional encoding for this column.
@@ -1723,7 +1680,6 @@ mod tests {
                 Some(&BloomFilterProperties {
                     fpp: 0.1,
                     ndv: Some(100),
-                    max_bytes: None,
                 })
             );
         }
@@ -1762,7 +1718,6 @@ mod tests {
             Some(&BloomFilterProperties {
                 fpp: DEFAULT_BLOOM_FILTER_FPP,
                 ndv: None,
-                max_bytes: None,
             })
         );
     }
@@ -1806,7 +1761,6 @@ mod tests {
             Some(&BloomFilterProperties {
                 fpp: DEFAULT_BLOOM_FILTER_FPP,
                 ndv: Some(100),
-                max_bytes: None,
             })
         );
         assert_eq!(
@@ -1817,7 +1771,6 @@ mod tests {
             Some(&BloomFilterProperties {
                 fpp: 0.1,
                 ndv: None,
-                max_bytes: None,
             })
         );
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -52,8 +52,9 @@ pub const DEFAULT_CREATED_BY: &str = concat!("parquet-rs version ", env!("CARGO_
 /// Default value for [`WriterProperties::column_index_truncate_length`]
 pub const DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH: Option<usize> = Some(64);
 /// Default value for [`BloomFilterProperties::fpp`]
-pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.05;
+pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
 /// Default value for [`BloomFilterProperties::ndv`]
+#[deprecated(note = "NDV is now optional; bloom filters use folding mode by default")]
 pub const DEFAULT_BLOOM_FILTER_NDV: u64 = 1_000_000_u64;
 /// Default values for [`WriterProperties::statistics_truncate_length`]
 pub const DEFAULT_STATISTICS_TRUNCATE_LENGTH: Option<usize> = Some(64);
@@ -996,8 +997,11 @@ impl WriterPropertiesBuilder {
         self
     }
 
-    /// Sets default number of distinct values (ndv) for bloom filter for all
-    /// columns (defaults to `1_000_000` via [`DEFAULT_BLOOM_FILTER_NDV`]).
+    /// Sets default number of distinct values (ndv) for bloom filter for all columns.
+    ///
+    /// When set, this activates fixed-size mode: the bloom filter is sized exactly for
+    /// the given NDV at the configured FPP, with no folding. When not set (default),
+    /// the bloom filter uses folding mode instead.
     ///
     /// Implicitly enables bloom writing, as if [`set_bloom_filter_enabled`] had
     /// been called.
@@ -1005,6 +1009,26 @@ impl WriterPropertiesBuilder {
     /// [`set_bloom_filter_enabled`]: Self::set_bloom_filter_enabled
     pub fn set_bloom_filter_ndv(mut self, value: u64) -> Self {
         self.default_column_properties.set_bloom_filter_ndv(value);
+        self
+    }
+
+    /// Sets the default maximum initial allocation size in bytes for bloom filter folding mode
+    /// for all columns.
+    ///
+    /// When bloom filters use folding mode (no explicit NDV), this controls the initial
+    /// allocation size. The filter will be folded down at flush time to meet the target FPP.
+    /// If not set, the initial size is derived from `max_row_group_row_count` and `fpp`.
+    ///
+    /// The value will be rounded up to the next power of two, bounded by
+    /// [`BITSET_MIN_LENGTH`](crate::bloom_filter::BITSET_MIN_LENGTH) and
+    /// [`BITSET_MAX_LENGTH`](crate::bloom_filter::BITSET_MAX_LENGTH).
+    ///
+    /// Implicitly enables bloom writing, as if [`set_bloom_filter_enabled`] had been called.
+    ///
+    /// [`set_bloom_filter_enabled`]: Self::set_bloom_filter_enabled
+    pub fn set_bloom_filter_max_bytes(mut self, value: usize) -> Self {
+        self.default_column_properties
+            .set_bloom_filter_max_bytes(value);
         self
     }
 
@@ -1113,6 +1137,15 @@ impl WriterPropertiesBuilder {
         self.get_mut_props(col).set_bloom_filter_ndv(value);
         self
     }
+
+    /// Sets the maximum initial allocation size in bytes for bloom filter folding mode
+    /// for a specific column.
+    ///
+    /// Takes precedence over [`Self::set_bloom_filter_max_bytes`].
+    pub fn set_column_bloom_filter_max_bytes(mut self, col: ColumnPath, value: usize) -> Self {
+        self.get_mut_props(col).set_bloom_filter_max_bytes(value);
+        self
+    }
 }
 
 impl From<WriterProperties> for WriterPropertiesBuilder {
@@ -1191,6 +1224,16 @@ impl Default for EnabledStatistics {
 }
 
 /// Controls the bloom filter to be computed by the writer.
+///
+/// Two modes are supported:
+///
+/// - **Fixed-size mode**: When `ndv` is set to `Some(n)`, the bloom filter is sized based on `ndv`
+///   and `fpp` at allocation time. This is the legacy behavior.
+///
+/// - **Folding mode** (default): When `ndv` is `None`, a conservatively large bloom filter is
+///   allocated (sized for worst-case NDV = max row group rows, or `max_bytes` if set), then
+///   folded down at flush time to meet the target `fpp`. This eliminates the need to guess NDV
+///   upfront and produces optimally-sized filters automatically.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BloomFilterProperties {
     /// False positive probability. This should be always between 0 and 1 exclusive. Defaults to [`DEFAULT_BLOOM_FILTER_FPP`].
@@ -1199,30 +1242,32 @@ pub struct BloomFilterProperties {
     ///
     /// The bloom filter data structure is a trade of between disk and memory space versus fpp, the
     /// smaller the fpp, the more memory and disk space is required, thus setting it to a reasonable value
-    /// e.g. 0.1, 0.05, or 0.001 is recommended.
-    ///
-    /// Setting to a very small number diminishes the value of the filter itself, as the bitset size is
-    /// even larger than just storing the whole value. You are also expected to set `ndv` if it can
-    /// be known in advance to greatly reduce space usage.
+    /// e.g. 0.1, 0.01, or 0.001 is recommended.
     pub fpp: f64,
-    /// Number of distinct values, should be non-negative to be meaningful. Defaults to [`DEFAULT_BLOOM_FILTER_NDV`].
+    /// Number of distinct values. When set to `Some(n)`, the bloom filter is sized exactly for
+    /// `n` distinct values at the given `fpp` (fixed-size mode). When `None` (default), the
+    /// filter uses folding mode instead.
     ///
     /// You should set this value by calling [`WriterPropertiesBuilder::set_bloom_filter_ndv`].
     ///
     /// Usage of bloom filter is most beneficial for columns with large cardinality, so a good heuristic
     /// is to set ndv to the number of rows. However, it can reduce disk size if you know in advance a smaller
-    /// number of distinct values. For very small ndv value it is probably not worth it to use bloom filter
-    /// anyway.
+    /// number of distinct values.
+    pub ndv: Option<u64>,
+    /// Maximum initial allocation size in bytes for folding mode. When `None` (default), the
+    /// initial size is derived from `max_row_group_row_count` and `fpp`. Only used when `ndv`
+    /// is `None`.
     ///
-    /// Increasing this value (without increasing fpp) will result in an increase in disk or memory size.
-    pub ndv: u64,
+    /// You should set this value by calling [`WriterPropertiesBuilder::set_bloom_filter_max_bytes`].
+    pub max_bytes: Option<usize>,
 }
 
 impl Default for BloomFilterProperties {
     fn default() -> Self {
         BloomFilterProperties {
             fpp: DEFAULT_BLOOM_FILTER_FPP,
-            ndv: DEFAULT_BLOOM_FILTER_NDV,
+            ndv: None,
+            max_bytes: None,
         }
     }
 }
@@ -1320,11 +1365,19 @@ impl ColumnProperties {
     }
 
     /// Sets the number of distinct (unique) values for bloom filter for this column, and implicitly
-    /// enables bloom filter if not previously enabled.
+    /// enables bloom filter if not previously enabled. This activates fixed-size mode (no folding).
     fn set_bloom_filter_ndv(&mut self, value: u64) {
         self.bloom_filter_properties
             .get_or_insert_with(Default::default)
-            .ndv = value;
+            .ndv = Some(value);
+    }
+
+    /// Sets the maximum initial allocation size in bytes for bloom filter folding mode, and
+    /// implicitly enables bloom filter if not previously enabled.
+    fn set_bloom_filter_max_bytes(&mut self, value: usize) {
+        self.bloom_filter_properties
+            .get_or_insert_with(Default::default)
+            .max_bytes = Some(value);
     }
 
     /// Returns optional encoding for this column.
@@ -1667,7 +1720,11 @@ mod tests {
             );
             assert_eq!(
                 props.bloom_filter_properties(&ColumnPath::from("col")),
-                Some(&BloomFilterProperties { fpp: 0.1, ndv: 100 })
+                Some(&BloomFilterProperties {
+                    fpp: 0.1,
+                    ndv: Some(100),
+                    max_bytes: None,
+                })
             );
         }
 
@@ -1703,8 +1760,9 @@ mod tests {
         assert_eq!(
             props.bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
-                fpp: 0.05,
-                ndv: 1_000_000_u64
+                fpp: DEFAULT_BLOOM_FILTER_FPP,
+                ndv: None,
+                max_bytes: None,
             })
         );
     }
@@ -1746,8 +1804,9 @@ mod tests {
                 .build()
                 .bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
-                fpp: 0.05,
-                ndv: 100
+                fpp: DEFAULT_BLOOM_FILTER_FPP,
+                ndv: Some(100),
+                max_bytes: None,
             })
         );
         assert_eq!(
@@ -1757,7 +1816,8 @@ mod tests {
                 .bloom_filter_properties(&ColumnPath::from("col")),
             Some(&BloomFilterProperties {
                 fpp: 0.1,
-                ndv: 1_000_000_u64
+                ndv: None,
+                max_bytes: None,
             })
         );
     }

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -1225,6 +1225,17 @@ pub struct BloomFilterProperties {
     /// then folded down after insertion to achieve optimal size. A good heuristic is to set
     /// this to the expected number of rows in the row group. If fewer distinct values are
     /// actually written, the filter will be automatically compacted via folding.
+    ///
+    /// Thus the only negative side of overestimating this value is that the bloom filter
+    /// will use more memory during writing than necessary, but it will not affect the final
+    /// bloom filter size on disk.
+    ///
+    /// If you wish to reduce memory usage during writing and are able to make a reasonable estimate
+    /// of the number of distinct values in a row group, it is recommended to set this value explicitly
+    /// rather than relying on the default dynamic sizing based on `max_row_group_row_count`.
+    /// If you do set this value explicitly it is probably best to set it for each column
+    /// individually via [`WriterPropertiesBuilder::set_column_bloom_filter_ndv`] rather than globally,
+    /// since different columns may have different numbers of distinct values.
     pub ndv: Option<u64>,
 }
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -52,7 +52,7 @@ pub const DEFAULT_CREATED_BY: &str = concat!("parquet-rs version ", env!("CARGO_
 /// Default value for [`WriterProperties::column_index_truncate_length`]
 pub const DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH: Option<usize> = Some(64);
 /// Default value for [`BloomFilterProperties::fpp`]
-pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
+pub const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.05;
 /// Default value for [`BloomFilterProperties::ndv`]
 #[deprecated(note = "NDV is now optional; bloom filters use folding mode by default")]
 pub const DEFAULT_BLOOM_FILTER_NDV: u64 = 1_000_000_u64;

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -1720,10 +1720,7 @@ mod tests {
             );
             assert_eq!(
                 props.bloom_filter_properties(&ColumnPath::from("col")),
-                Some(&BloomFilterProperties {
-                    fpp: 0.1,
-                    ndv: 100,
-                })
+                Some(&BloomFilterProperties { fpp: 0.1, ndv: 100 })
             );
         }
 


### PR DESCRIPTION
## Summary

Bloom filters now support **folding mode**: allocate a conservatively large filter (sized for worst-case NDV), insert all values during writing, then fold down at flush time to meet a target FPP. This eliminates the need to guess NDV upfront and produces optimally-sized filters automatically.

### Changes

- `BloomFilterProperties.ndv` changed from `u64` to `Option<u64>` — when `None` (new default), the filter is sized based on `max_row_group_row_count`; when `Some(n)`, the explicit NDV is used
- `DEFAULT_BLOOM_FILTER_NDV` redefined to `DEFAULT_MAX_ROW_GROUP_ROW_COUNT as u64` (was hardcoded `1_000_000`)
- Added `Sbbf::fold_to_target_fpp()` and supporting methods (`num_folds_for_target_fpp`, `fold_n`, `num_blocks`) with comprehensive documentation
- `flush_bloom_filter()` in both `ColumnValueEncoderImpl` and `ByteArrayEncoder` now folds the filter before returning it
- New `create_bloom_filter()` helper in `encoder.rs` centralizes bloom filter construction logic

### How folding works

The SBBF fold operation merges adjacent block pairs (`block[2i] | block[2i+1]`) via bitwise OR, halving the filter size. This differs from standard Bloom filter folding (which merges halves at distance `m/2`) because SBBF uses multiplicative hashing for block selection:

```
block_index = ((hash >> 32) * num_blocks) >> 32
```

When `num_blocks` is halved, the new index becomes `floor(original_index / 2)`, so adjacent blocks map to the same position.

The number of safe folds is determined analytically from the average per-block fill rate: after `k` folds, expected fill is `1 - (1-f)^(2^k)`, giving `FPP = fill^8`. This requires only a single popcount scan over the blocks (no scratch allocation), then O(log N) floating-point ops to find the optimal fold count. The actual fold is then performed in a single pass.

### Benchmarks

Filter sized for 1M NDV, varying actual distinct values inserted. Measured on Apple M3 Pro.

**Fold overhead (fold_to_target_fpp only):**

| Actual NDV | Time | Throughput |
|---|---|---|
| 1,000 | 39.1 µs | 838 Melem/s |
| 10,000 | 34.2 µs | 960 Melem/s |
| 100,000 | 32.5 µs | 1.01 Gelem/s |

**End-to-end (insert + fold) vs insert-only:**

| Actual NDV | Insert only | Insert + fold | Fold overhead |
|---|---|---|---|
| 1,000 | 14.7 µs | 49.1 µs | 34.4 µs (70%) |
| 10,000 | 30.7 µs | 58.1 µs | 27.4 µs (47%) |
| 100,000 | 162.5 µs | 189.8 µs | 27.3 µs (14%) |

The fold cost is dominated by the popcount scan over the initial (large) filter. For the common case (100K values into a 1M-NDV filter), folding adds only ~14% overhead to the total insert+fold time.

### References

Sailhan & Stehr, ["Folding and Unfolding Bloom Filters"](https://hal.science/hal-01126174v1/document), IEEE iThings 2012.

Liang, ["Blocked Bloom Filters: Speeding Up Point Lookups in Tiger Postgres' Native Columnstore"](https://www.tigerdata.com/blog/blocked-bloom-filters-speeding-up-point-lookups-in-tiger-postgres-native-columnstore)

### Breaking changes

There are no breaking API changes

However, when bloom filters are enabled without specifying the number of distinct values, the bloom filters are automatically sized. Previously they would be sized using the default value of `DEFAULT_BLOOM_FILTER_NDV`

## Test plan

- [x] All existing bloom filter unit tests pass
- [x] All existing integration tests (sync + async reader roundtrips) pass
- [x] New unit tests: fold correctness, no false negatives after folding, FPP target respected, minimum size guard
- [x] New unit tests: folded filter is bit-identical to a fresh filter of the same size (proves correctness via two lemmas about SBBF hashing)
- [x] New unit tests: multi-step folding, folded FPP matches fresh FPP empirically, fold size matches optimal fixed-size filter
- [x] New integration test: `i32_column_bloom_filter_fixed_ndv` — roundtrip with both overestimated and underestimated NDV
- [x] Full `cargo test -p parquet` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)