### PR TITLE
ci: use ubuntu-slim runner for lightweight CI jobs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,7 +48,7 @@ jobs:
 
   prettier:
     name: Markdown format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   process:
     name: Process
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   issue_assign:
     if: (!github.event.issue.pull_request) && github.event.comment.body == 'take'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v8
         with:


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9536.

# Rationale for this change

`ubuntu-slim` is a cost-efficient, 1-vCPU GitHub Actions runner designed for lightweight jobs that run under a minute. Switching applicable jobs saves ASF infrastructure usage.

# What changes are included in this PR?

Switch `runs-on: ubuntu-latest` to `runs-on: ubuntu-slim` for three lightweight CI jobs:

- `take.yml` → `issue_assign` (assigns issues via `actions/github-script`)
- `dev_pr.yml` → `process` (labels PRs via `actions/labeler`)
- `dev.yml` → `prettier` (Markdown format check via Node.js + prettier)

# Are these changes tested?

CI-only changes. The jobs will be validated when this PR's CI runs.

# Are there any user-facing changes?

No.