### PR TITLE
Disable failing arrow_writer benchmark

### DIFF
--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -34,7 +34,7 @@ use arrow::util::bench_util::{create_f16_array, create_f32_array, create_f64_arr
 use arrow::{record_batch::RecordBatch, util::data_gen::*};
 use arrow_array::RecordBatchOptions;
 use parquet::errors::Result;
-use parquet::file::properties::{CdcOptions, WriterProperties, WriterVersion};
+use parquet::file::properties::{WriterProperties, WriterVersion};
 
 fn create_primitive_bench_batch(
     size: usize,
@@ -421,12 +421,11 @@ fn create_writer_props() -> Vec<(&'static str, WriterProperties)> {
     props.push(("zstd_parquet_2", prop));
 
     // Disabled until https://github.com/apache/arrow-rs/issues/9637 is fixed
-    /*
-    let prop = WriterProperties::builder()
-        .set_content_defined_chunking(Some(CdcOptions::default()))
-        .build();
-    props.push(("cdc", prop));
-     */
+    //
+    // let prop = WriterProperties::builder()
+    //    .set_content_defined_chunking(Some(CdcOptions::default()))
+    //    .build();
+    // props.push(("cdc", prop));
 
     props
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/9637
# Rationale for this change

I can't benchmark the arrow-writer changes in https://github.com/apache/arrow-rs/pull/9447 due to hitting a panic:
- https://github.com/apache/arrow-rs/issues/9637

# What changes are included in this PR?

Temporarily disable the cdc benchmarks until the underlying bug is fixed

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
