### PR TITLE
Support nested REE in arrow-ord partition function

### DIFF
--- a/arrow-ord/src/cmp.rs
+++ b/arrow-ord/src/cmp.rs
@@ -31,7 +31,7 @@ use arrow_array::{
 };
 use arrow_buffer::bit_util::ceil;
 use arrow_buffer::{BooleanBuffer, NullBuffer};
-use arrow_schema::ArrowError;
+use arrow_schema::{ArrowError, DataType};
 use arrow_select::take::take;
 use std::cmp::Ordering;
 use std::ops::Not;
@@ -199,6 +199,20 @@ pub fn distinct(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, ArrowE
 /// For comparisons involving nested types see [`crate::ord::make_comparator`]
 pub fn not_distinct(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, ArrowError> {
     compare_op(Op::NotDistinct, lhs, rhs)
+}
+
+/// Returns true if `distinct` (via `compare_op`) can handle this data type.
+///
+/// `compare_op` unwraps at most one level of dictionary, then dispatches on
+/// the leaf type. Anything else (REE, nested dictionary, nested/complex types)
+/// must go through `make_comparator` instead.
+pub(crate) fn supports_distinct(dt: &DataType) -> bool {
+    use arrow_schema::DataType::*;
+    let leaf = match dt {
+        Dictionary(_, v) => v.as_ref(),
+        dt => dt,
+    };
+    !leaf.is_nested() && !matches!(leaf, Dictionary(_, _) | RunEndEncoded(_, _))
 }
 
 /// Perform `op` on the provided `Datum`
@@ -830,6 +844,38 @@ mod tests {
         let expected = BooleanArray::from(vec![false, false, false, true]);
         assert_eq!(not_distinct(&a, &b).unwrap(), expected);
         assert_eq!(not_distinct(&b, &a).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_supports_distinct() {
+        use arrow_schema::{DataType::*, Field};
+
+        assert!(supports_distinct(&Int32));
+        assert!(supports_distinct(&Float64));
+        assert!(supports_distinct(&Utf8));
+        assert!(supports_distinct(&Boolean));
+
+        // One level of dictionary unwrap is supported.
+        assert!(supports_distinct(&Dictionary(
+            Box::new(Int16),
+            Box::new(Utf8),
+        )));
+
+        // REE, nested dictionary, and complex types are not supported.
+        assert!(!supports_distinct(&RunEndEncoded(
+            Arc::new(Field::new("run_ends", Int32, false)),
+            Arc::new(Field::new("values", Int32, true)),
+        )));
+        assert!(!supports_distinct(&Dictionary(
+            Box::new(Int16),
+            Box::new(Dictionary(Box::new(Int8), Box::new(Utf8))),
+        )));
+        assert!(!supports_distinct(&List(Arc::new(Field::new(
+            "item", Int32, true,
+        )))));
+        assert!(!supports_distinct(&Struct(
+            vec![Field::new("a", Int32, true)].into()
+        )));
     }
 
     #[test]

--- a/arrow-ord/src/partition.rs
+++ b/arrow-ord/src/partition.rs
@@ -21,9 +21,9 @@ use std::ops::Range;
 
 use arrow_array::{Array, ArrayRef};
 use arrow_buffer::BooleanBuffer;
-use arrow_schema::{ArrowError, DataType, SortOptions};
+use arrow_schema::{ArrowError, SortOptions};
 
-use crate::cmp::distinct;
+use crate::cmp::{distinct, supports_distinct};
 use crate::ord::make_comparator;
 
 /// A computed set of partitions, see [`partition`]
@@ -150,23 +150,6 @@ pub fn partition(columns: &[ArrayRef]) -> Result<Partitions, ArrowError> {
         .try_fold(acc, |acc, c| find_boundaries(c.as_ref()).map(|b| &acc | &b))?;
 
     Ok(Partitions(Some(acc)))
-}
-
-/// Returns true if `distinct` (via `compare_op`) can handle this data type.
-///
-/// `compare_op` unwraps at most one level of dictionary, then dispatches on
-/// the leaf type. Anything else (REE, nested dictionary, nested/complex types)
-/// must go through `make_comparator` instead.
-fn supports_distinct(dt: &DataType) -> bool {
-    let leaf = match dt {
-        DataType::Dictionary(_, v) => v.as_ref(),
-        dt => dt,
-    };
-    !leaf.is_nested()
-        && !matches!(
-            leaf,
-            DataType::Dictionary(_, _) | DataType::RunEndEncoded(_, _)
-        )
 }
 
 /// Returns a mask with bits set whenever the value or nullability changes


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9640.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Although rare, it's totally valid to have nested REE and dict encoding and we should handle it correctly.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Process nested REE, nested dict, dict of REE, REE of dict gracefully

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
