### PR TITLE
[Variant] Add `VariantArrayBuilder::append_nulls` API 

### DIFF
--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -58,6 +58,13 @@ pub fn cast_to_variant_with_options(
     input: &dyn Array,
     options: &CastOptions,
 ) -> Result<VariantArray, ArrowError> {
+    // Fast path: any all-null input maps to an all-null VariantArray.
+    if input.null_count() == input.len() {
+        let mut array_builder = VariantArrayBuilder::new(input.len());
+        array_builder.append_nulls(input.len());
+        return Ok(array_builder.build());
+    }
+
     // Create row builder for the input array type
     let mut row_builder = make_arrow_to_variant_row_builder(input.data_type(), input, options)?;
 

--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -29,7 +29,7 @@ macro_rules! string_array_to_variant {
         let len = $input.len();
         let mut i = 0;
         while i < len {
-            if !$input.is_null(i) {
+            if $input.is_valid(i) {
                 $builder.append_json($array.value(i))?;
                 i += 1;
                 continue;

--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -26,12 +26,21 @@ use parquet_variant_json::JsonToVariant;
 /// Macro to convert string array to variant array
 macro_rules! string_array_to_variant {
     ($input:expr, $array:expr, $builder:expr) => {{
-        for i in 0..$input.len() {
-            if $input.is_null(i) {
-                $builder.append_null();
-            } else {
+        let len = $input.len();
+        let mut i = 0;
+        while i < len {
+            if !$input.is_null(i) {
                 $builder.append_json($array.value(i))?;
+                i += 1;
+                continue;
             }
+
+            let start = i;
+            i += 1;
+            while i < len && $input.is_null(i) {
+                i += 1;
+            }
+            $builder.append_nulls(i - start);
         }
     }};
 }

--- a/parquet-variant-compute/src/from_json.rs
+++ b/parquet-variant-compute/src/from_json.rs
@@ -26,21 +26,12 @@ use parquet_variant_json::JsonToVariant;
 /// Macro to convert string array to variant array
 macro_rules! string_array_to_variant {
     ($input:expr, $array:expr, $builder:expr) => {{
-        let len = $input.len();
-        let mut i = 0;
-        while i < len {
-            if $input.is_valid(i) {
+        for i in 0..$input.len() {
+            if $input.is_null(i) {
+                $builder.append_null();
+            } else {
                 $builder.append_json($array.value(i))?;
-                i += 1;
-                continue;
             }
-
-            let start = i;
-            i += 1;
-            while i < len && $input.is_null(i) {
-                i += 1;
-            }
-            $builder.append_nulls(i - start);
         }
     }};
 }

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -156,24 +156,16 @@ impl VariantArrayBuilder {
         self.value_offsets.push(self.value_builder.offset());
     }
 
-    /// Appends `count` null rows to the builder.
-    pub fn append_nulls(&mut self, count: usize) {
-        if count == 0 {
-            return;
-        }
-        if count == 1 {
-            self.append_null();
-            return;
-        }
-
-        self.nulls.append_n_nulls(count);
+    /// Appends `n` null rows to the builder.
+    pub fn append_nulls(&mut self, n: usize) {
+        self.nulls.append_n_nulls(n);
         // The subfields are expected to be non-nullable according to the parquet variant spec.
         let metadata_offset = self.metadata_builder.offset();
         let value_offset = self.value_builder.offset();
         self.metadata_offsets
-            .resize(self.metadata_offsets.len() + count, metadata_offset);
+            .extend(std::iter::repeat_n(metadata_offset, n));
         self.value_offsets
-            .resize(self.value_offsets.len() + count, value_offset);
+            .extend(std::iter::repeat_n(value_offset, n));
     }
 
     /// Append the [`Variant`] to the builder as the next row

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -150,10 +150,23 @@ impl VariantArrayBuilder {
 
     /// Appends a null row to the builder.
     pub fn append_null(&mut self) {
-        self.nulls.append_null();
+        self.append_nulls(1);
+    }
+
+    /// Appends `count` null rows to the builder.
+    pub fn append_nulls(&mut self, count: usize) {
+        if count == 0 {
+            return;
+        }
+
+        self.nulls.append_n_nulls(count);
         // The subfields are expected to be non-nullable according to the parquet variant spec.
-        self.metadata_offsets.push(self.metadata_builder.offset());
-        self.value_offsets.push(self.value_builder.offset());
+        let metadata_offset = self.metadata_builder.offset();
+        let value_offset = self.value_builder.offset();
+        self.metadata_offsets
+            .resize(self.metadata_offsets.len() + count, metadata_offset);
+        self.value_offsets
+            .resize(self.value_offsets.len() + count, value_offset);
     }
 
     /// Append the [`Variant`] to the builder as the next row
@@ -524,6 +537,24 @@ mod test {
         let variant = variant_array.value(3);
         let list = variant.as_list().expect("variant to be a list");
         assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_variant_array_builder_append_nulls() {
+        let mut builder = VariantArrayBuilder::new(6);
+        builder.append_variant(Variant::from(1i32));
+        builder.append_nulls(0); // should be a no-op
+        builder.append_nulls(3);
+        builder.append_variant(Variant::from(2i32));
+
+        let variant_array = builder.build();
+
+        assert_eq!(variant_array.len(), 5);
+        assert_eq!(variant_array.value(0), Variant::from(1i32));
+        assert!(variant_array.is_null(1));
+        assert!(variant_array.is_null(2));
+        assert!(variant_array.is_null(3));
+        assert_eq!(variant_array.value(4), Variant::from(2i32));
     }
 
     #[test]

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -150,12 +150,19 @@ impl VariantArrayBuilder {
 
     /// Appends a null row to the builder.
     pub fn append_null(&mut self) {
-        self.append_nulls(1);
+        self.nulls.append_null();
+        // The subfields are expected to be non-nullable according to the parquet variant spec.
+        self.metadata_offsets.push(self.metadata_builder.offset());
+        self.value_offsets.push(self.value_builder.offset());
     }
 
     /// Appends `count` null rows to the builder.
     pub fn append_nulls(&mut self, count: usize) {
         if count == 0 {
+            return;
+        }
+        if count == 1 {
+            self.append_null();
             return;
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9684.

# Rationale for this change

Check issue
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add `VariantArrayBuilder::append_nulls`
- Add unit test
- add fast paths for `cast_to_variant_with_options` and `string_array_to_variant`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes, added a unit test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
A new public API
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
