### PR TITLE
minor: Re-enable CDC bench

### DIFF
--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -34,7 +34,7 @@ use arrow::util::bench_util::{create_f16_array, create_f32_array, create_f64_arr
 use arrow::{record_batch::RecordBatch, util::data_gen::*};
 use arrow_array::RecordBatchOptions;
 use parquet::errors::Result;
-use parquet::file::properties::{WriterProperties, WriterVersion};
+use parquet::file::properties::{CdcOptions, WriterProperties, WriterVersion};
 
 fn create_primitive_bench_batch(
     size: usize,

--- a/parquet/benches/arrow_writer.rs
+++ b/parquet/benches/arrow_writer.rs
@@ -457,12 +457,10 @@ fn create_writer_props() -> Vec<(&'static str, WriterProperties)> {
         .build();
     props.push(("zstd_parquet_2", prop));
 
-    // Disabled until https://github.com/apache/arrow-rs/issues/9637 is fixed
-    //
-    // let prop = WriterProperties::builder()
-    //    .set_content_defined_chunking(Some(CdcOptions::default()))
-    //    .build();
-    // props.push(("cdc", prop));
+    let prop = WriterProperties::builder()
+        .set_content_defined_chunking(Some(CdcOptions::default()))
+        .build();
+    props.push(("cdc", prop));
 
     props
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

The content defined chunking bench (CDC) was disabled due to a bug (#9637). That has since been fixed (#9644), so the bench can be re-enabled.

# What changes are included in this PR?

Uncomments out the relevant bench in arrow_writer

# Are these changes tested?

N/A

# Are there any user-facing changes?

No
