### PR TITLE
[Variant] Align cast logic for from/to_decimal for variant

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -777,7 +777,7 @@ where
     if cast_options.safe {
         array
             .unary_opt::<_, D>(|v| {
-                single_float_to_decimal::<D>(v.as_(), mul)
+                D::Native::from_f64((mul * v.as_()).round())
                     .filter(|v| D::is_valid_decimal_precision(*v, precision))
             })
             .with_precision_and_scale(precision, scale)
@@ -785,7 +785,7 @@ where
     } else {
         array
             .try_unary::<_, D, _>(|v| {
-                single_float_to_decimal::<D>(v.as_(), mul)
+                D::Native::from_f64((mul * v.as_()).round())
                     .ok_or_else(|| {
                         ArrowError::CastError(format!(
                             "Cannot cast to {}({}, {}). Overflowing on {:?}",
@@ -844,10 +844,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_mul_opt::<D, T::Native>(
-                            array.value(i),
-                            div,
-                        );
+                        let v = array
+                            .value(i)
+                            .mul_checked(div)
+                            .ok()
+                            .and_then(<T::Native as NumCast>::from::<D::Native>);
                         value_builder.append_option(v);
                     }
                 }
@@ -911,19 +912,6 @@ where
         }
     }
     Ok(Arc::new(value_builder.finish()))
-}
-
-/// Casting a given decimal to an integer by multiplying with the given factor.
-/// Returns `None` if checked multiplication overflows or the target cast fails.
-#[inline(always)]
-pub fn cast_single_decimal_to_integer_mul_opt<D, T>(value: D::Native, mul: D::Native) -> Option<T>
-where
-    T: NumCast + ToPrimitive,
-    D: DecimalType + ArrowPrimitiveType,
-    <D as ArrowPrimitiveType>::Native: ToPrimitive,
-{
-    let v = value.mul_checked(mul).ok()?;
-    <T as NumCast>::from::<D::Native>(v)
 }
 
 /// Casting a given decimal to an integer by dividing with the given divisor.

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -777,7 +777,7 @@ where
     if cast_options.safe {
         array
             .unary_opt::<_, D>(|v| {
-                D::Native::from_f64((mul * v.as_()).round())
+                single_float_to_decimal::<D>(v.as_(), mul)
                     .filter(|v| D::is_valid_decimal_precision(*v, precision))
             })
             .with_precision_and_scale(precision, scale)
@@ -785,7 +785,7 @@ where
     } else {
         array
             .try_unary::<_, D, _>(|v| {
-                D::Native::from_f64((mul * v.as_()).round())
+                single_float_to_decimal::<D>(v.as_(), mul)
                     .ok_or_else(|| {
                         ArrowError::CastError(format!(
                             "Cannot cast to {}({}, {}). Overflowing on {:?}",

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -844,13 +844,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer::<D, T::Native>(
+                        let v = cast_single_decimal_to_integer_opt::<D, T::Native>(
                             array.value(i),
                             div,
                             true,
-                            T::DATA_TYPE,
-                        )
-                        .ok();
+                        );
                         value_builder.append_option(v);
                     }
                 }
@@ -860,7 +858,7 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer::<D, T::Native>(
+                        let value = cast_single_decimal_to_integer_result::<D, T::Native>(
                             array.value(i),
                             div,
                             true,
@@ -878,13 +876,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer::<D, T::Native>(
+                        let v = cast_single_decimal_to_integer_opt::<D, T::Native>(
                             array.value(i),
                             div,
                             false,
-                            T::DATA_TYPE,
-                        )
-                        .ok();
+                        );
                         value_builder.append_option(v);
                     }
                 }
@@ -894,7 +890,7 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer::<D, T::Native>(
+                        let value = cast_single_decimal_to_integer_result::<D, T::Native>(
                             array.value(i),
                             div,
                             false,
@@ -912,9 +908,25 @@ where
 
 /// Casting a given decimal to an integer based on given div and scale.
 /// The value is scaled by multiplying or dividing with the div based on the scale sign.
-/// Returns `Err` if the value is overflow or cannot be represented with the requested precision.
+/// Returns `None` if the value is overflow or cannot be represented with the requested precision.
 #[inline]
-pub fn cast_single_decimal_to_integer<D, T>(
+pub fn cast_single_decimal_to_integer_opt<D, T>(
+    value: D::Native,
+    div: D::Native,
+    negative: bool,
+) -> Option<T>
+where
+    T: NumCast + ToPrimitive,
+    D: DecimalType + ArrowPrimitiveType,
+    <D as ArrowPrimitiveType>::Native: ToPrimitive,
+{
+    cast_single_decimal_to_integer::<D, T>(value, div, negative)
+        .ok()
+        .flatten()
+}
+
+#[inline]
+fn cast_single_decimal_to_integer_result<D, T>(
     value: D::Native,
     div: D::Native,
     negative: bool,
@@ -925,15 +937,31 @@ where
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
+    cast_single_decimal_to_integer::<D, T>(value, div, negative)?.ok_or_else(|| {
+        ArrowError::CastError(format!(
+            "value of {:?} is out of range {:?}",
+            value, type_name
+        ))
+    })
+}
+
+#[inline]
+fn cast_single_decimal_to_integer<D, T>(
+    value: D::Native,
+    div: D::Native,
+    negative: bool,
+) -> Result<Option<T>, ArrowError>
+where
+    T: NumCast + ToPrimitive,
+    D: DecimalType + ArrowPrimitiveType,
+    <D as ArrowPrimitiveType>::Native: ToPrimitive,
+{
     let v = if negative {
         value.mul_checked(div)?
     } else {
         value.div_checked(div)?
     };
-
-    T::from::<D::Native>(v).ok_or_else(|| {
-        ArrowError::CastError(format!("value of {:?} is out of range {:?}", v, type_name))
-    })
+    Ok(T::from::<D::Native>(v))
 }
 
 /// Cast a decimal array to a floating point array.

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -844,10 +844,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_opt::<true, D, T::Native>(
-                            array.value(i),
-                            div,
-                        );
+                        let v = array
+                            .value(i)
+                            .mul_checked(div)
+                            .ok()
+                            .and_then(<T::Native as NumCast>::from::<D::Native>);
                         value_builder.append_option(v);
                     }
                 }
@@ -857,11 +858,17 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer_result::<true, D, T::Native>(
-                            array.value(i),
-                            div,
-                            T::DATA_TYPE,
-                        )?;
+                        let v = array.value(i).mul_checked(div)?;
+
+                        let value =
+                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
+                                ArrowError::CastError(format!(
+                                    "value of {:?} is out of range {}",
+                                    v,
+                                    T::DATA_TYPE
+                                ))
+                            })?;
+
                         value_builder.append_value(value);
                     }
                 }
@@ -874,10 +881,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_opt::<false, D, T::Native>(
-                            array.value(i),
-                            div,
-                        );
+                        let v = array
+                            .value(i)
+                            .div_checked(div)
+                            .ok()
+                            .and_then(<T::Native as NumCast>::from::<D::Native>);
                         value_builder.append_option(v);
                     }
                 }
@@ -887,18 +895,23 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer_result::<false, D, T::Native>(
-                            array.value(i),
-                            div,
-                            T::DATA_TYPE,
-                        )?;
+                        let v = array.value(i).div_checked(div)?;
+
+                        let value =
+                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
+                                ArrowError::CastError(format!(
+                                    "value of {:?} is out of range {}",
+                                    v,
+                                    T::DATA_TYPE
+                                ))
+                            })?;
+
                         value_builder.append_value(value);
                     }
                 }
             }
         }
     }
-
     Ok(Arc::new(value_builder.finish()))
 }
 
@@ -921,27 +934,6 @@ where
         value.div_checked(div).ok()?
     };
     <T as NumCast>::from::<D::Native>(v)
-}
-
-#[inline(always)]
-fn cast_single_decimal_to_integer_result<const NEGATIVE_SCALE: bool, D, T>(
-    value: D::Native,
-    div: D::Native,
-    type_name: DataType,
-) -> Result<T, ArrowError>
-where
-    T: NumCast + ToPrimitive,
-    D: DecimalType + ArrowPrimitiveType,
-    <D as ArrowPrimitiveType>::Native: ToPrimitive,
-{
-    let v = if NEGATIVE_SCALE {
-        value.mul_checked(div)?
-    } else {
-        value.div_checked(div)?
-    };
-    T::from::<D::Native>(v).ok_or_else(|| {
-        ArrowError::CastError(format!("value of {:?} is out of range {:?}", v, type_name))
-    })
 }
 
 /// Cast a decimal array to a floating point array.

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -844,10 +844,9 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_opt::<D, T::Native>(
+                        let v = cast_single_decimal_to_integer_opt::<true, D, T::Native>(
                             array.value(i),
                             div,
-                            true,
                         );
                         value_builder.append_option(v);
                     }
@@ -876,10 +875,9 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_opt::<D, T::Native>(
+                        let v = cast_single_decimal_to_integer_opt::<false, D, T::Native>(
                             array.value(i),
                             div,
-                            false,
                         );
                         value_builder.append_option(v);
                     }
@@ -910,22 +908,21 @@ where
 /// The value is scaled by multiplying or dividing with the div based on the scale sign.
 /// Returns `None` if the value is overflow or cannot be represented with the requested precision.
 #[inline]
-pub fn cast_single_decimal_to_integer_opt<D, T>(
+pub fn cast_single_decimal_to_integer_opt<const NEGATIVE_SCALE: bool, D, T>(
     value: D::Native,
     div: D::Native,
-    negative: bool,
 ) -> Option<T>
 where
     T: NumCast + ToPrimitive,
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    let v = if negative {
+    let v = if NEGATIVE_SCALE {
         value.mul_checked(div).ok()?
     } else {
         value.div_checked(div).ok()?
     };
-    T::from::<D::Native>(v)
+    <T as NumCast>::from::<D::Native>(v)
 }
 
 #[inline]

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -804,7 +804,7 @@ where
 
 /// Cast a single floating point value to a decimal native with the given multiple.
 /// Returns `None` if the value cannot be represented with the requested precision.
-#[inline]
+#[inline(always)]
 pub fn single_float_to_decimal<D>(input: f64, mul: f64) -> Option<D::Native>
 where
     D: DecimalType + ArrowPrimitiveType,
@@ -857,10 +857,9 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer_result::<D, T::Native>(
+                        let value = cast_single_decimal_to_integer_result::<true, D, T::Native>(
                             array.value(i),
                             div,
-                            true,
                             T::DATA_TYPE,
                         )?;
                         value_builder.append_value(value);
@@ -888,10 +887,9 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let value = cast_single_decimal_to_integer_result::<D, T::Native>(
+                        let value = cast_single_decimal_to_integer_result::<false, D, T::Native>(
                             array.value(i),
                             div,
-                            false,
                             T::DATA_TYPE,
                         )?;
                         value_builder.append_value(value);
@@ -907,7 +905,7 @@ where
 /// Casting a given decimal to an integer based on given div and scale.
 /// The value is scaled by multiplying or dividing with the div based on the scale sign.
 /// Returns `None` if the value is overflow or cannot be represented with the requested precision.
-#[inline]
+#[inline(always)]
 pub fn cast_single_decimal_to_integer_opt<const NEGATIVE_SCALE: bool, D, T>(
     value: D::Native,
     div: D::Native,
@@ -925,11 +923,10 @@ where
     <T as NumCast>::from::<D::Native>(v)
 }
 
-#[inline]
-fn cast_single_decimal_to_integer_result<D, T>(
+#[inline(always)]
+fn cast_single_decimal_to_integer_result<const NEGATIVE_SCALE: bool, D, T>(
     value: D::Native,
     div: D::Native,
-    negative: bool,
     type_name: DataType,
 ) -> Result<T, ArrowError>
 where
@@ -937,7 +934,7 @@ where
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    let v = if negative {
+    let v = if NEGATIVE_SCALE {
         value.mul_checked(div)?
     } else {
         value.div_checked(div)?

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -837,35 +837,74 @@ where
 
     let mut value_builder = PrimitiveBuilder::<T>::with_capacity(array.len());
 
-    // Helper macro for emitting nearly the same loop every time, so we can hoist branches out
-    // The compiler will specialize the resulting code (inlining and jump threading)
-    macro_rules! cast_loop {
-        (|$v: ident| $body:expr) => {{
-            for i in 0..array.len() {
-                if array.is_null(i) {
-                    value_builder.append_null();
-                } else {
-                    let $v = cast_single_decimal_to_integer::<D, T::Native>(
-                        array.value(i),
-                        div,
-                        <i16 as From<i8>>::from(scale),
-                        T::DATA_TYPE,
-                    );
-                    $body
+    if scale < 0 {
+        match cast_options.safe {
+            true => {
+                for i in 0..array.len() {
+                    if array.is_null(i) {
+                        value_builder.append_null();
+                    } else {
+                        let v = cast_single_decimal_to_integer::<D, T::Native>(
+                            array.value(i),
+                            div,
+                            true,
+                            T::DATA_TYPE,
+                        )
+                        .ok();
+                        value_builder.append_option(v);
+                    }
                 }
             }
-        }};
-    }
-    if scale < 0 {
-        if cast_options.safe {
-            cast_loop!(|v| value_builder.append_option(v.ok()));
-        } else {
-            cast_loop!(|v| value_builder.append_value(v?));
+            false => {
+                for i in 0..array.len() {
+                    if array.is_null(i) {
+                        value_builder.append_null();
+                    } else {
+                        let value = cast_single_decimal_to_integer::<D, T::Native>(
+                            array.value(i),
+                            div,
+                            true,
+                            T::DATA_TYPE,
+                        )?;
+                        value_builder.append_value(value);
+                    }
+                }
+            }
         }
-    } else if cast_options.safe {
-        cast_loop!(|v| value_builder.append_option(v.ok()));
     } else {
-        cast_loop!(|v| value_builder.append_value(v?));
+        match cast_options.safe {
+            true => {
+                for i in 0..array.len() {
+                    if array.is_null(i) {
+                        value_builder.append_null();
+                    } else {
+                        let v = cast_single_decimal_to_integer::<D, T::Native>(
+                            array.value(i),
+                            div,
+                            false,
+                            T::DATA_TYPE,
+                        )
+                        .ok();
+                        value_builder.append_option(v);
+                    }
+                }
+            }
+            false => {
+                for i in 0..array.len() {
+                    if array.is_null(i) {
+                        value_builder.append_null();
+                    } else {
+                        let value = cast_single_decimal_to_integer::<D, T::Native>(
+                            array.value(i),
+                            div,
+                            false,
+                            T::DATA_TYPE,
+                        )?;
+                        value_builder.append_value(value);
+                    }
+                }
+            }
+        }
     }
 
     Ok(Arc::new(value_builder.finish()))
@@ -874,10 +913,11 @@ where
 /// Casting a given decimal to an integer based on given div and scale.
 /// The value is scaled by multiplying or dividing with the div based on the scale sign.
 /// Returns `Err` if the value is overflow or cannot be represented with the requested precision.
+#[inline]
 pub fn cast_single_decimal_to_integer<D, T>(
     value: D::Native,
     div: D::Native,
-    scale: i16,
+    negative: bool,
     type_name: DataType,
 ) -> Result<T, ArrowError>
 where
@@ -885,7 +925,7 @@ where
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    let v = if scale < 0 {
+    let v = if negative {
         value.mul_checked(div)?
     } else {
         value.div_checked(div)?

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -920,9 +920,12 @@ where
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    cast_single_decimal_to_integer::<D, T>(value, div, negative)
-        .ok()
-        .flatten()
+    let v = if negative {
+        value.mul_checked(div).ok()?
+    } else {
+        value.div_checked(div).ok()?
+    };
+    T::from::<D::Native>(v)
 }
 
 #[inline]
@@ -937,31 +940,14 @@ where
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    cast_single_decimal_to_integer::<D, T>(value, div, negative)?.ok_or_else(|| {
-        ArrowError::CastError(format!(
-            "value of {:?} is out of range {:?}",
-            value, type_name
-        ))
-    })
-}
-
-#[inline]
-fn cast_single_decimal_to_integer<D, T>(
-    value: D::Native,
-    div: D::Native,
-    negative: bool,
-) -> Result<Option<T>, ArrowError>
-where
-    T: NumCast + ToPrimitive,
-    D: DecimalType + ArrowPrimitiveType,
-    <D as ArrowPrimitiveType>::Native: ToPrimitive,
-{
     let v = if negative {
         value.mul_checked(div)?
     } else {
         value.div_checked(div)?
     };
-    Ok(T::from::<D::Native>(v))
+    T::from::<D::Native>(v).ok_or_else(|| {
+        ArrowError::CastError(format!("value of {:?} is out of range {:?}", v, type_name))
+    })
 }
 
 /// Cast a decimal array to a floating point array.

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -531,7 +531,7 @@ where
 
 /// Parses given string to specified decimal native (i128/i256) based on given
 /// scale. Returns an `Err` if it cannot parse given string.
-pub(crate) fn parse_string_to_decimal_native<T: DecimalType>(
+pub fn parse_string_to_decimal_native<T: DecimalType>(
     value_str: &str,
     scale: usize,
 ) -> Result<T::Native, ArrowError>
@@ -777,7 +777,7 @@ where
     if cast_options.safe {
         array
             .unary_opt::<_, D>(|v| {
-                D::Native::from_f64((mul * v.as_()).round())
+                single_float_to_decimal::<D>(v.as_(), mul)
                     .filter(|v| D::is_valid_decimal_precision(*v, precision))
             })
             .with_precision_and_scale(precision, scale)
@@ -785,7 +785,7 @@ where
     } else {
         array
             .try_unary::<_, D, _>(|v| {
-                D::Native::from_f64((mul * v.as_()).round())
+                single_float_to_decimal::<D>(v.as_(), mul)
                     .ok_or_else(|| {
                         ArrowError::CastError(format!(
                             "Cannot cast to {}({}, {}). Overflowing on {:?}",
@@ -800,6 +800,17 @@ where
             .with_precision_and_scale(precision, scale)
             .map(|a| Arc::new(a) as ArrayRef)
     }
+}
+
+/// Cast a single floating point value to a decimal native with the given multiple.
+/// Returns `None` if the value cannot be represented with the requested precision.
+#[inline]
+pub fn single_float_to_decimal<D>(input: f64, mul: f64) -> Option<D::Native>
+where
+    D: DecimalType + ArrowPrimitiveType,
+    <D as ArrowPrimitiveType>::Native: DecimalCast,
+{
+    D::Native::from_f64((mul * input).round())
 }
 
 pub(crate) fn cast_decimal_to_integer<D, T>(
@@ -826,82 +837,61 @@ where
 
     let mut value_builder = PrimitiveBuilder::<T>::with_capacity(array.len());
 
-    if scale < 0 {
-        match cast_options.safe {
-            true => {
-                for i in 0..array.len() {
-                    if array.is_null(i) {
-                        value_builder.append_null();
-                    } else {
-                        let v = array
-                            .value(i)
-                            .mul_checked(div)
-                            .ok()
-                            .and_then(<T::Native as NumCast>::from::<D::Native>);
-                        value_builder.append_option(v);
-                    }
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            value_builder.append_null();
+        } else {
+            match cast_options.safe {
+                true => {
+                    let v = cast_single_decimal_to_integer::<D, T::Native>(
+                        array.value(i),
+                        div,
+                        scale as _,
+                        T::DATA_TYPE,
+                    )
+                    .ok();
+                    value_builder.append_option(v);
                 }
-            }
-            false => {
-                for i in 0..array.len() {
-                    if array.is_null(i) {
-                        value_builder.append_null();
-                    } else {
-                        let v = array.value(i).mul_checked(div)?;
+                false => {
+                    let value = cast_single_decimal_to_integer::<D, T::Native>(
+                        array.value(i),
+                        div,
+                        scale as _,
+                        T::DATA_TYPE,
+                    )?;
 
-                        let value =
-                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
-                                ArrowError::CastError(format!(
-                                    "value of {:?} is out of range {}",
-                                    v,
-                                    T::DATA_TYPE
-                                ))
-                            })?;
-
-                        value_builder.append_value(value);
-                    }
-                }
-            }
-        }
-    } else {
-        match cast_options.safe {
-            true => {
-                for i in 0..array.len() {
-                    if array.is_null(i) {
-                        value_builder.append_null();
-                    } else {
-                        let v = array
-                            .value(i)
-                            .div_checked(div)
-                            .ok()
-                            .and_then(<T::Native as NumCast>::from::<D::Native>);
-                        value_builder.append_option(v);
-                    }
-                }
-            }
-            false => {
-                for i in 0..array.len() {
-                    if array.is_null(i) {
-                        value_builder.append_null();
-                    } else {
-                        let v = array.value(i).div_checked(div)?;
-
-                        let value =
-                            <T::Native as NumCast>::from::<D::Native>(v).ok_or_else(|| {
-                                ArrowError::CastError(format!(
-                                    "value of {:?} is out of range {}",
-                                    v,
-                                    T::DATA_TYPE
-                                ))
-                            })?;
-
-                        value_builder.append_value(value);
-                    }
+                    value_builder.append_value(value);
                 }
             }
         }
     }
+
     Ok(Arc::new(value_builder.finish()))
+}
+
+/// Casting a given decimal to an integer based on given div and scale.
+/// The value is scaled by multiplying or dividing with the div based on the scale sign.
+/// Returns `Err` if the value is overflow or cannot be represented with the requested precision.
+pub fn cast_single_decimal_to_integer<D, T>(
+    value: D::Native,
+    div: D::Native,
+    scale: i16,
+    type_name: DataType,
+) -> Result<T, ArrowError>
+where
+    T: NumCast + ToPrimitive,
+    D: DecimalType + ArrowPrimitiveType,
+    <D as ArrowPrimitiveType>::Native: ToPrimitive,
+{
+    let v = if scale < 0 {
+        value.mul_checked(div)?
+    } else {
+        value.div_checked(div)?
+    };
+
+    T::from::<D::Native>(v).ok_or_else(|| {
+        ArrowError::CastError(format!("value of {:?} is out of range {:?}", v, type_name))
+    })
 }
 
 /// Cast a decimal array to a floating point array.

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -837,33 +837,35 @@ where
 
     let mut value_builder = PrimitiveBuilder::<T>::with_capacity(array.len());
 
-    for i in 0..array.len() {
-        if array.is_null(i) {
-            value_builder.append_null();
-        } else {
-            match cast_options.safe {
-                true => {
-                    let v = cast_single_decimal_to_integer::<D, T::Native>(
+    // Helper macro for emitting nearly the same loop every time, so we can hoist branches out
+    // The compiler will specialize the resulting code (inlining and jump threading)
+    macro_rules! cast_loop {
+        (|$v: ident| $body:expr) => {{
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    value_builder.append_null();
+                } else {
+                    let $v = cast_single_decimal_to_integer::<D, T::Native>(
                         array.value(i),
                         div,
-                        scale as _,
+                        <i16 as From<i8>>::from(scale),
                         T::DATA_TYPE,
-                    )
-                    .ok();
-                    value_builder.append_option(v);
-                }
-                false => {
-                    let value = cast_single_decimal_to_integer::<D, T::Native>(
-                        array.value(i),
-                        div,
-                        scale as _,
-                        T::DATA_TYPE,
-                    )?;
-
-                    value_builder.append_value(value);
+                    );
+                    $body
                 }
             }
+        }};
+    }
+    if scale < 0 {
+        if cast_options.safe {
+            cast_loop!(|v| value_builder.append_option(v.ok()));
+        } else {
+            cast_loop!(|v| value_builder.append_value(v?));
         }
+    } else if cast_options.safe {
+        cast_loop!(|v| value_builder.append_option(v.ok()));
+    } else {
+        cast_loop!(|v| value_builder.append_value(v?));
     }
 
     Ok(Arc::new(value_builder.finish()))

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -844,11 +844,10 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = array
-                            .value(i)
-                            .mul_checked(div)
-                            .ok()
-                            .and_then(<T::Native as NumCast>::from::<D::Native>);
+                        let v = cast_single_decimal_to_integer_mul_opt::<D, T::Native>(
+                            array.value(i),
+                            div,
+                        );
                         value_builder.append_option(v);
                     }
                 }
@@ -881,11 +880,10 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = array
-                            .value(i)
-                            .div_checked(div)
-                            .ok()
-                            .and_then(<T::Native as NumCast>::from::<D::Native>);
+                        let v = cast_single_decimal_to_integer_div_opt::<D, T::Native>(
+                            array.value(i),
+                            div,
+                        );
                         value_builder.append_option(v);
                     }
                 }
@@ -915,24 +913,29 @@ where
     Ok(Arc::new(value_builder.finish()))
 }
 
-/// Casting a given decimal to an integer based on given div and scale.
-/// The value is scaled by multiplying or dividing with the div based on the scale sign.
-/// Returns `None` if the value is overflow or cannot be represented with the requested precision.
+/// Casting a given decimal to an integer by multiplying with the given factor.
+/// Returns `None` if checked multiplication overflows or the target cast fails.
 #[inline(always)]
-pub fn cast_single_decimal_to_integer_opt<const NEGATIVE_SCALE: bool, D, T>(
-    value: D::Native,
-    div: D::Native,
-) -> Option<T>
+pub fn cast_single_decimal_to_integer_mul_opt<D, T>(value: D::Native, mul: D::Native) -> Option<T>
 where
     T: NumCast + ToPrimitive,
     D: DecimalType + ArrowPrimitiveType,
     <D as ArrowPrimitiveType>::Native: ToPrimitive,
 {
-    let v = if NEGATIVE_SCALE {
-        value.mul_checked(div).ok()?
-    } else {
-        value.div_checked(div).ok()?
-    };
+    let v = value.mul_checked(mul).ok()?;
+    <T as NumCast>::from::<D::Native>(v)
+}
+
+/// Casting a given decimal to an integer by dividing with the given divisor.
+/// Returns `None` if checked division fails or the target cast fails.
+#[inline(always)]
+pub fn cast_single_decimal_to_integer_div_opt<D, T>(value: D::Native, div: D::Native) -> Option<T>
+where
+    T: NumCast + ToPrimitive,
+    D: DecimalType + ArrowPrimitiveType,
+    <D as ArrowPrimitiveType>::Native: ToPrimitive,
+{
+    let v = value.div_checked(div).ok()?;
     <T as NumCast>::from::<D::Native>(v)
 }
 

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -881,10 +881,11 @@ where
                     if array.is_null(i) {
                         value_builder.append_null();
                     } else {
-                        let v = cast_single_decimal_to_integer_div_opt::<D, T::Native>(
-                            array.value(i),
-                            div,
-                        );
+                        let v = array
+                            .value(i)
+                            .div_checked(div)
+                            .ok()
+                            .and_then(<T::Native as NumCast>::from::<D::Native>);
                         value_builder.append_option(v);
                     }
                 }
@@ -912,19 +913,6 @@ where
         }
     }
     Ok(Arc::new(value_builder.finish()))
-}
-
-/// Casting a given decimal to an integer by dividing with the given divisor.
-/// Returns `None` if checked division fails or the target cast fails.
-#[inline(always)]
-pub fn cast_single_decimal_to_integer_div_opt<D, T>(value: D::Native, div: D::Native) -> Option<T>
-where
-    T: NumCast + ToPrimitive,
-    D: DecimalType + ArrowPrimitiveType,
-    <D as ArrowPrimitiveType>::Native: ToPrimitive,
-{
-    let v = value.div_checked(div).ok()?;
-    <T as NumCast>::from::<D::Native>(v)
 }
 
 /// Cast a decimal array to a floating point array.

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -72,8 +72,25 @@ use arrow_schema::*;
 use arrow_select::take::take;
 use num_traits::{NumCast, ToPrimitive, cast::AsPrimitive};
 
-pub use decimal::{DecimalCast, rescale_decimal};
+pub use decimal::{
+    DecimalCast, cast_single_decimal_to_integer, parse_string_to_decimal_native, rescale_decimal,
+    single_float_to_decimal,
+};
 pub use string::cast_single_string_to_boolean_default;
+
+/// Lossy conversion from decimal to float.
+///
+/// Conversion is lossy and follows standard floating point semantics. Values
+/// that exceed the representable range become `INFINITY` or `-INFINITY` without
+/// returning an error.
+#[inline]
+pub fn single_decimal_to_float_lossy<D, F>(f: &F, x: D::Native, scale: i32) -> f64
+where
+    D: DecimalType,
+    F: Fn(D::Native) -> f64,
+{
+    f(x) / 10_f64.powi(scale)
+}
 
 /// CastOptions provides a way to override the default cast behaviors
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2314,10 +2331,10 @@ where
         Int32 => cast_decimal_to_integer::<D, Int32Type>(array, base, *scale, cast_options),
         Int64 => cast_decimal_to_integer::<D, Int64Type>(array, base, *scale, cast_options),
         Float32 => cast_decimal_to_float::<D, Float32Type, _>(array, |x| {
-            (as_float(x) / 10_f64.powi(*scale as i32)) as f32
+            single_decimal_to_float_lossy::<D, F>(&as_float, x, *scale as _) as f32
         }),
         Float64 => cast_decimal_to_float::<D, Float64Type, _>(array, |x| {
-            as_float(x) / 10_f64.powi(*scale as i32)
+            single_decimal_to_float_lossy::<D, F>(&as_float, x, *scale as _)
         }),
         Utf8View => value_to_string_view(array, cast_options),
         Utf8 => value_to_string::<i32>(array, cast_options),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -73,7 +73,7 @@ use arrow_select::take::take;
 use num_traits::{NumCast, ToPrimitive, cast::AsPrimitive};
 
 pub use decimal::{
-    DecimalCast, cast_single_decimal_to_integer_opt, parse_string_to_decimal_native,
+    DecimalCast, cast_single_decimal_to_integer_div_opt, parse_string_to_decimal_native,
     rescale_decimal, single_float_to_decimal,
 };
 pub use string::cast_single_string_to_boolean_default;

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -89,7 +89,7 @@ where
     D: DecimalType,
     F: Fn(D::Native) -> f64,
 {
-    f(x) * 10_f64.powi(-scale)
+    f(x) / 10_f64.powi(scale)
 }
 
 /// CastOptions provides a way to override the default cast behaviors

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -73,8 +73,8 @@ use arrow_select::take::take;
 use num_traits::{NumCast, ToPrimitive, cast::AsPrimitive};
 
 pub use decimal::{
-    DecimalCast, cast_single_decimal_to_integer, parse_string_to_decimal_native, rescale_decimal,
-    single_float_to_decimal,
+    DecimalCast, cast_single_decimal_to_integer_opt, parse_string_to_decimal_native,
+    rescale_decimal, single_float_to_decimal,
 };
 pub use string::cast_single_string_to_boolean_default;
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -89,7 +89,7 @@ where
     D: DecimalType,
     F: Fn(D::Native) -> f64,
 {
-    f(x) / 10_f64.powi(scale)
+    f(x) * 10_f64.powi(-scale)
 }
 
 /// CastOptions provides a way to override the default cast behaviors
@@ -2331,10 +2331,11 @@ where
         Int32 => cast_decimal_to_integer::<D, Int32Type>(array, base, *scale, cast_options),
         Int64 => cast_decimal_to_integer::<D, Int64Type>(array, base, *scale, cast_options),
         Float32 => cast_decimal_to_float::<D, Float32Type, _>(array, |x| {
-            single_decimal_to_float_lossy::<D, F>(&as_float, x, *scale as _) as f32
+            single_decimal_to_float_lossy::<D, F>(&as_float, x, <i32 as From<i8>>::from(*scale))
+                as f32
         }),
         Float64 => cast_decimal_to_float::<D, Float64Type, _>(array, |x| {
-            single_decimal_to_float_lossy::<D, F>(&as_float, x, *scale as _)
+            single_decimal_to_float_lossy::<D, F>(&as_float, x, <i32 as From<i8>>::from(*scale))
         }),
         Utf8View => value_to_string_view(array, cast_options),
         Utf8 => value_to_string::<i32>(array, cast_options),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -83,7 +83,7 @@ pub use string::cast_single_string_to_boolean_default;
 /// Conversion is lossy and follows standard floating point semantics. Values
 /// that exceed the representable range become `INFINITY` or `-INFINITY` without
 /// returning an error.
-#[inline]
+#[inline(always)]
 pub fn single_decimal_to_float_lossy<D, F>(f: &F, x: D::Native, scale: i32) -> f64
 where
     D: DecimalType,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -73,8 +73,7 @@ use arrow_select::take::take;
 use num_traits::{NumCast, ToPrimitive, cast::AsPrimitive};
 
 pub use decimal::{
-    DecimalCast, cast_single_decimal_to_integer_div_opt, parse_string_to_decimal_native,
-    rescale_decimal, single_float_to_decimal,
+    DecimalCast, parse_string_to_decimal_native, rescale_decimal, single_float_to_decimal,
 };
 pub use string::cast_single_string_to_boolean_default;
 

--- a/parquet-variant-compute/src/type_conversion.rs
+++ b/parquet-variant-compute/src/type_conversion.rs
@@ -254,10 +254,18 @@ where
             precision,
             scale,
         ),
-        Variant::Float(f) => single_float_to_decimal::<O>(*f as _, mul),
+        Variant::Float(f) => single_float_to_decimal::<O>(f64::from(*f), mul),
         Variant::Double(f) => single_float_to_decimal::<O>(*f, mul),
-        Variant::String(v) => parse_string_to_decimal_native::<O>(v, scale as _).ok(),
-        Variant::ShortString(v) => parse_string_to_decimal_native::<O>(v, scale as _).ok(),
+        Variant::String(v) if scale > 0 => parse_string_to_decimal_native::<O>(
+            v,
+            <i8 as TryInto<usize>>::try_into(scale).expect("scale is positive, would never fail"),
+        )
+        .ok(),
+        Variant::ShortString(v) if scale > 0 => parse_string_to_decimal_native::<O>(
+            v,
+            <i8 as TryInto<usize>>::try_into(scale).expect("scale is positive, would never fail"),
+        )
+        .ok(),
         Variant::Decimal4(d) => rescale_decimal::<Decimal32Type, O>(
             d.integer(),
             VariantDecimal4::MAX_PRECISION,

--- a/parquet-variant-compute/src/type_conversion.rs
+++ b/parquet-variant-compute/src/type_conversion.rs
@@ -17,7 +17,10 @@
 
 //! Module for transforming a typed arrow `Array` to `VariantArray`.
 
-use arrow::compute::{CastOptions, DecimalCast, rescale_decimal};
+use arrow::compute::{
+    CastOptions, DecimalCast, parse_string_to_decimal_native, rescale_decimal,
+    single_float_to_decimal,
+};
 use arrow::datatypes::{
     self, ArrowPrimitiveType, ArrowTimestampType, Decimal32Type, Decimal64Type, Decimal128Type,
     DecimalType,
@@ -204,9 +207,12 @@ impl_timestamp_from_variant!(
 ///
 /// - `precision` and `scale` specify the target Arrow decimal parameters
 /// - Integer variants (`Int8/16/32/64`) are treated as decimals with scale 0
+/// - Floating point variants (`Float/Double`) are converted to decimals with the given scale
+/// - String variants (`String/ShortString`) are parsed as decimals with the given scale
 /// - Decimal variants (`Decimal4/8/16`) use their embedded precision and scale
 ///
-/// The value is rescaled to (`precision`, `scale`) using `rescale_decimal` and
+/// The value is rescaled to (`precision`, `scale`) using `rescale_decimal` for integers,
+/// `single_float_to_decimal` for floats, and `parse_string_to_decimal_native` for strings.
 /// returns `None` if it cannot fit the requested precision.
 pub(crate) fn variant_to_unscaled_decimal<O>(
     variant: &Variant<'_, '_>,
@@ -217,6 +223,8 @@ where
     O: DecimalType,
     O::Native: DecimalCast,
 {
+    let mul = 10_f64.powi(scale as i32);
+
     match variant {
         Variant::Int8(i) => rescale_decimal::<Decimal32Type, O>(
             *i as i32,
@@ -246,6 +254,10 @@ where
             precision,
             scale,
         ),
+        Variant::Float(f) => single_float_to_decimal::<O>(*f as _, mul),
+        Variant::Double(f) => single_float_to_decimal::<O>(*f, mul),
+        Variant::String(v) => parse_string_to_decimal_native::<O>(v, scale as _).ok(),
+        Variant::ShortString(v) => parse_string_to_decimal_native::<O>(v, scale as _).ok(),
         Variant::Decimal4(d) => rescale_decimal::<Decimal32Type, O>(
             d.integer(),
             VariantDecimal4::MAX_PRECISION,

--- a/parquet-variant-compute/src/type_conversion.rs
+++ b/parquet-variant-compute/src/type_conversion.rs
@@ -256,16 +256,12 @@ where
         ),
         Variant::Float(f) => single_float_to_decimal::<O>(f64::from(*f), mul),
         Variant::Double(f) => single_float_to_decimal::<O>(*f, mul),
-        Variant::String(v) if scale > 0 => parse_string_to_decimal_native::<O>(
-            v,
-            <i8 as TryInto<usize>>::try_into(scale).expect("scale is positive, would never fail"),
-        )
-        .ok(),
-        Variant::ShortString(v) if scale > 0 => parse_string_to_decimal_native::<O>(
-            v,
-            <i8 as TryInto<usize>>::try_into(scale).expect("scale is positive, would never fail"),
-        )
-        .ok(),
+        // arrow-cast only support cast string to decimal with scale >=0 for now
+        // Please see `cast_string_to_decimal` in arrow-cast/src/cast/decimal.rs for more detail
+        Variant::String(v) if scale >= 0 => parse_string_to_decimal_native::<O>(v, scale as _).ok(),
+        Variant::ShortString(v) if scale >= 0 => {
+            parse_string_to_decimal_native::<O>(v, scale as _).ok()
+        }
         Variant::Decimal4(d) => rescale_decimal::<Decimal32Type, O>(
             d.integer(),
             VariantDecimal4::MAX_PRECISION,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -843,7 +843,7 @@ impl<'m, 'v> Variant<'m, 'v> {
 
         let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
         match T::KIND {
-            NumericKind::Integer => cast_single_decimal_to_integer_opt::<D, T>(raw, div, false),
+            NumericKind::Integer => cast_single_decimal_to_integer_opt::<false, D, T>(raw, div),
             NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
                 &as_float,
                 raw,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -31,15 +31,13 @@ use crate::path::{VariantPath, VariantPathElement};
 use crate::utils::{first_byte_from_slice, slice_from_slice};
 use arrow::array::ArrowNativeTypeOp;
 use arrow::compute::{
-    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer,
+    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer_opt,
     cast_single_string_to_boolean_default, num_cast, parse_string_to_decimal_native,
     single_bool_to_numeric, single_decimal_to_float_lossy, single_float_to_decimal,
 };
 use arrow::datatypes::{Decimal32Type, Decimal64Type, Decimal128Type, DecimalType};
-use arrow_schema::DataType::{
-    Float16, Float32, Float64, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
-};
-use arrow_schema::{ArrowError, DataType};
+
+use arrow_schema::ArrowError;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use num_traits::NumCast;
 use std::ops::Deref;
@@ -309,29 +307,27 @@ enum NumericKind {
 
 trait DecimalCastTarget: NumCast + Default {
     const KIND: NumericKind;
-    const ARROW_TYPE: DataType;
 }
 
 macro_rules! impl_decimal_cast_target {
-    ($raw_type: ident, $target_kind:expr, $arrow_type: expr) => {
+    ($raw_type: ident, $target_kind:expr) => {
         impl DecimalCastTarget for $raw_type {
             const KIND: NumericKind = $target_kind;
-            const ARROW_TYPE: DataType = $arrow_type;
         }
     };
 }
 
-impl_decimal_cast_target!(i8, NumericKind::Integer, Int8);
-impl_decimal_cast_target!(i16, NumericKind::Integer, Int16);
-impl_decimal_cast_target!(i32, NumericKind::Integer, Int32);
-impl_decimal_cast_target!(i64, NumericKind::Integer, Int64);
-impl_decimal_cast_target!(u8, NumericKind::Integer, UInt8);
-impl_decimal_cast_target!(u16, NumericKind::Integer, UInt16);
-impl_decimal_cast_target!(u32, NumericKind::Integer, UInt32);
-impl_decimal_cast_target!(u64, NumericKind::Integer, UInt64);
-impl_decimal_cast_target!(f16, NumericKind::Float, Float16);
-impl_decimal_cast_target!(f32, NumericKind::Float, Float32);
-impl_decimal_cast_target!(f64, NumericKind::Float, Float64);
+impl_decimal_cast_target!(i8, NumericKind::Integer);
+impl_decimal_cast_target!(i16, NumericKind::Integer);
+impl_decimal_cast_target!(i32, NumericKind::Integer);
+impl_decimal_cast_target!(i64, NumericKind::Integer);
+impl_decimal_cast_target!(u8, NumericKind::Integer);
+impl_decimal_cast_target!(u16, NumericKind::Integer);
+impl_decimal_cast_target!(u32, NumericKind::Integer);
+impl_decimal_cast_target!(u64, NumericKind::Integer);
+impl_decimal_cast_target!(f16, NumericKind::Float);
+impl_decimal_cast_target!(f32, NumericKind::Float);
+impl_decimal_cast_target!(f64, NumericKind::Float);
 
 impl<'m, 'v> Variant<'m, 'v> {
     /// Attempts to interpret a metadata and value buffer pair as a new `Variant`.
@@ -847,9 +843,7 @@ impl<'m, 'v> Variant<'m, 'v> {
 
         let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
         match T::KIND {
-            NumericKind::Integer => {
-                cast_single_decimal_to_integer::<D, T>(raw, div, false, T::ARROW_TYPE).ok()
-            }
+            NumericKind::Integer => cast_single_decimal_to_integer_opt::<D, T>(raw, div, false),
             NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
                 &as_float,
                 raw,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -31,7 +31,7 @@ use crate::path::{VariantPath, VariantPathElement};
 use crate::utils::{first_byte_from_slice, slice_from_slice};
 use arrow::array::ArrowNativeTypeOp;
 use arrow::compute::{
-    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer_opt,
+    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer_div_opt,
     cast_single_string_to_boolean_default, num_cast, parse_string_to_decimal_native,
     single_bool_to_numeric, single_decimal_to_float_lossy, single_float_to_decimal,
 };
@@ -843,7 +843,7 @@ impl<'m, 'v> Variant<'m, 'v> {
 
         let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
         match T::KIND {
-            NumericKind::Integer => cast_single_decimal_to_integer_opt::<false, D, T>(raw, div),
+            NumericKind::Integer => cast_single_decimal_to_integer_div_opt::<D, T>(raw, div),
             NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
                 &as_float,
                 raw,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -309,16 +309,14 @@ enum NumericKind {
 
 trait DecimalCastTarget: NumCast + Default {
     const KIND: NumericKind;
-    fn arrow_type() -> DataType;
+    const ARROW_TYPE: DataType;
 }
 
 macro_rules! impl_decimal_cast_target {
     ($raw_type: ident, $target_kind:expr, $arrow_type: expr) => {
         impl DecimalCastTarget for $raw_type {
             const KIND: NumericKind = $target_kind;
-            fn arrow_type() -> DataType {
-                $arrow_type
-            }
+            const ARROW_TYPE: DataType = $arrow_type;
         }
     };
 }
@@ -847,22 +845,21 @@ impl<'m, 'v> Variant<'m, 'v> {
     {
         let base: D::Native = NumCast::from(10)?;
 
-        base.pow_checked(<u32 as From<u8>>::from(scale))
-            .ok()
-            .and_then(|div| match T::KIND {
-                NumericKind::Integer => cast_single_decimal_to_integer::<D, T>(
-                    raw,
-                    div,
-                    <i16 as From<u8>>::from(scale),
-                    T::arrow_type(),
-                )
-                .ok(),
-                NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
-                    &as_float,
-                    raw,
-                    <i32 as From<u8>>::from(scale),
-                )),
-            })
+        let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
+        match T::KIND {
+            NumericKind::Integer => cast_single_decimal_to_integer::<D, T>(
+                raw,
+                div,
+                <i16 as From<u8>>::from(scale),
+                T::ARROW_TYPE,
+            )
+            .ok(),
+            NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
+                &as_float,
+                raw,
+                <i32 as From<u8>>::from(scale),
+            )),
+        }
     }
 
     /// Converts a boolean or numeric variant(integers, floating-point, and decimals)
@@ -1193,9 +1190,7 @@ impl<'m, 'v> Variant<'m, 'v> {
         D::Native: NumCast + DecimalCast,
     {
         // find the last '.'
-        let scale_usize = input
-            .rsplit_once('.')
-            .map_or_else(|| 0, |(_, frac)| frac.len());
+        let scale_usize = input.rsplit_once('.').map_or(0, |(_, frac)| frac.len());
 
         let scale = u8::try_from(scale_usize).ok()?;
 
@@ -1330,14 +1325,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_decimal16(&self) -> Option<VariantDecimal16> {
         match *self {
-            Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => self
-                .as_num::<i64>()
-                .map(|x| <i128 as From<i64>>::from(x).try_into().ok())
-                .unwrap(),
-            Variant::Float(f) => single_float_to_decimal::<Decimal128Type>(f as _, 1f64)
-                .and_then(|x: i128| x.try_into().ok()),
-            Variant::Double(f) => single_float_to_decimal::<Decimal128Type>(f, 1f64)
-                .and_then(|x: i128| x.try_into().ok()),
+            Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
+                let x = self.as_num::<i64>()?;
+                <i128 as From<i64>>::from(x).try_into().ok()
+            }
+            Variant::Float(f) => {
+                single_float_to_decimal::<Decimal128Type>(<f64 as From<f32>>::from(f), 1f64)
+                    .and_then(|x| x.try_into().ok())
+            }
+            Variant::Double(f) => {
+                single_float_to_decimal::<Decimal128Type>(f, 1f64).and_then(|x| x.try_into().ok())
+            }
             Variant::String(v) => Self::convert_string_to_decimal::<Decimal128Type, _>(v),
             Variant::ShortString(v) => {
                 Self::convert_string_to_decimal::<Decimal128Type, _>(v.as_str())

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -31,9 +31,9 @@ use crate::path::{VariantPath, VariantPathElement};
 use crate::utils::{first_byte_from_slice, slice_from_slice};
 use arrow::array::ArrowNativeTypeOp;
 use arrow::compute::{
-    cast_num_to_bool, cast_single_decimal_to_integer, cast_single_string_to_boolean_default,
-    num_cast, parse_string_to_decimal_native, single_bool_to_numeric,
-    single_decimal_to_float_lossy, single_float_to_decimal,
+    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer,
+    cast_single_string_to_boolean_default, num_cast, parse_string_to_decimal_native,
+    single_bool_to_numeric, single_decimal_to_float_lossy, single_float_to_decimal,
 };
 use arrow::datatypes::{Decimal32Type, Decimal64Type, Decimal128Type, DecimalType};
 use arrow_schema::DataType::{
@@ -1037,17 +1037,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     ///  let v2 = Variant::from(d);
     ///  assert_eq!(v2.as_u8(), Some(26u8));
     ///
+    ///  // or a variant that decimal with scale not equal to zero
+    ///  let d = VariantDecimal4::try_new(123, 2).unwrap();
+    ///  let v3 = Variant::from(d);
+    ///  assert_eq!(v3.as_u8(), Some(1));
+    ///
     /// // or from boolean variant
-    /// let v3 = Variant::BooleanFalse;
-    /// assert_eq!(v3.as_u8(), Some(0));
+    /// let v4 = Variant::BooleanFalse;
+    /// assert_eq!(v4.as_u8(), Some(0));
     ///
     ///  // but not a variant that can't fit into the range
-    ///  let v4 = Variant::from(-1);
-    ///  assert_eq!(v4.as_u8(), None);
-    ///
-    ///  // not a variant that decimal with scale not equal to zero
-    ///  let d = VariantDecimal4::try_new(1, 2).unwrap();
-    ///  let v5 = Variant::from(d);
+    ///  let v5 = Variant::from(-1);
     ///  assert_eq!(v5.as_u8(), None);
     ///
     ///  // or not a variant that cannot be cast into an integer
@@ -1078,17 +1078,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     ///  let v2 = Variant::from(d);
     ///  assert_eq!(v2.as_u16(), Some(u16::MAX));
     ///
+    ///  // or a variant that decimal with scale not equal to zero
+    ///  let d = VariantDecimal4::try_new(123, 2).unwrap();
+    ///  let v3 = Variant::from(d);
+    ///  assert_eq!(v3.as_u16(), Some(1));
+    ///
     /// // or from boolean variant
-    /// let v3= Variant::BooleanFalse;
-    /// assert_eq!(v3.as_u16(), Some(0));
+    /// let v4= Variant::BooleanFalse;
+    /// assert_eq!(v4.as_u16(), Some(0));
     ///
     ///  // but not a variant that can't fit into the range
-    ///  let v4 = Variant::from(-1);
-    ///  assert_eq!(v4.as_u16(), None);
-    ///
-    ///  // not a variant that decimal with scale not equal to zero
-    ///  let d = VariantDecimal4::try_new(1, 2).unwrap();
-    ///  let v5 = Variant::from(d);
+    ///  let v5 = Variant::from(-1);
     ///  assert_eq!(v5.as_u16(), None);
     ///
     ///  // or not a variant that cannot be cast into an integer
@@ -1119,17 +1119,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     ///  let v2 = Variant::from(d);
     ///  assert_eq!(v2.as_u32(), Some(u32::MAX));
     ///
+    ///  // or a variant that decimal with scale not equal to zero
+    ///  let d = VariantDecimal8::try_new(123, 2).unwrap();
+    ///  let v3 = Variant::from(d);
+    ///  assert_eq!(v3.as_u32(), Some(1));
+    ///
     /// // or from boolean variant
-    /// let v3 = Variant::BooleanFalse;
-    /// assert_eq!(v3.as_u32(), Some(0));
+    /// let v4 = Variant::BooleanFalse;
+    /// assert_eq!(v4.as_u32(), Some(0));
     ///
     ///  // but not a variant that can't fit into the range
-    ///  let v4 = Variant::from(-1);
-    ///  assert_eq!(v4.as_u32(), None);
-    ///
-    ///  // not a variant that decimal with scale not equal to zero
-    ///  let d = VariantDecimal8::try_new(1, 2).unwrap();
-    ///  let v5 = Variant::from(d);
+    ///  let v5 = Variant::from(-1);
     ///  assert_eq!(v5.as_u32(), None);
     ///
     ///  // or not a variant that cannot be cast into an integer
@@ -1160,17 +1160,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     ///  let v2 = Variant::from(d);
     ///  assert_eq!(v2.as_u64(), Some(u64::MAX));
     ///
+    ///  // or a variant that decimal with scale not equal to zero
+    /// let d = VariantDecimal16::try_new(123, 2).unwrap();
+    ///  let v3 = Variant::from(d);
+    ///  assert_eq!(v3.as_u64(), Some(1));
+    ///
     /// // or from boolean variant
-    /// let v3 = Variant::BooleanFalse;
-    /// assert_eq!(v3.as_u64(), Some(0));
+    /// let v4 = Variant::BooleanFalse;
+    /// assert_eq!(v4.as_u64(), Some(0));
     ///
     ///  // but not a variant that can't fit into the range
-    ///  let v4 = Variant::from(-1);
-    ///  assert_eq!(v4.as_u64(), None);
-    ///
-    ///  // not a variant that decimal with scale not equal to zero
-    /// let d = VariantDecimal16::try_new(1, 2).unwrap();
-    ///  let v5 = Variant::from(d);
+    ///  let v5 = Variant::from(-1);
     ///  assert_eq!(v5.as_u64(), None);
     ///
     ///  // or not a variant that cannot be cast into an integer
@@ -1179,6 +1179,25 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_u64(&self) -> Option<u64> {
         self.as_num()
+    }
+
+    fn convert_string_to_decimal<VD, D>(input: &str) -> Option<VD>
+    where
+        D: DecimalType,
+        VD: VariantDecimalType<Native = D::Native>,
+        D::Native: NumCast + DecimalCast,
+    {
+        // find the last '.'
+        let scale_usize = input
+            .rsplit_once('.')
+            .map(|(_, frac)| frac.len())
+            .unwrap_or(0);
+
+        let scale = u8::try_from(scale_usize).ok()?;
+
+        parse_string_to_decimal_native::<D>(input, scale_usize)
+            .ok()
+            .and_then(|raw| VD::try_new(raw, scale).ok())
     }
 
     /// Converts this variant to tuple with a 4-byte unscaled value if possible.
@@ -1200,13 +1219,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// let v2 = Variant::from(VariantDecimal8::try_new(1234_i64, 2).unwrap());
     /// assert_eq!(v2.as_decimal4(), VariantDecimal4::try_new(1234_i32, 2).ok());
     ///
+    /// // or from string variants if they can be parsed as decimals
+    /// let v3 = Variant::from("123.45");
+    /// assert_eq!(v3.as_decimal4(), VariantDecimal4::try_new(12345, 2).ok());
+    ///
     /// // but not if the value would overflow i32
-    /// let v3 = Variant::from(VariantDecimal8::try_new(12345678901i64, 2).unwrap());
-    /// assert_eq!(v3.as_decimal4(), None);
+    /// let v4 = Variant::from(VariantDecimal8::try_new(12345678901i64, 2).unwrap());
+    /// assert_eq!(v4.as_decimal4(), None);
     ///
     /// // or if the variant is not a decimal
-    /// let v4 = Variant::from("hello!");
-    /// assert_eq!(v4.as_decimal4(), None);
+    /// let v5 = Variant::from("hello!");
+    /// assert_eq!(v5.as_decimal4(), None);
     /// ```
     pub fn as_decimal4(&self) -> Option<VariantDecimal4> {
         match *self {
@@ -1217,13 +1240,9 @@ impl<'m, 'v> Variant<'m, 'v> {
                 .and_then(|x: i32| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal32Type>(f, 1f64)
                 .and_then(|x: i32| x.try_into().ok()),
-            Variant::String(v) => parse_string_to_decimal_native::<Decimal32Type>(v, 0usize)
-                .ok()
-                .and_then(|x: i32| x.try_into().ok()),
+            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal32Type>(v),
             Variant::ShortString(v) => {
-                parse_string_to_decimal_native::<Decimal32Type>(v.as_str(), 0usize)
-                    .ok()
-                    .and_then(|x: i32| x.try_into().ok())
+                Self::convert_string_to_decimal::<_, Decimal32Type>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4),
             Variant::Decimal8(decimal8) => decimal8.try_into().ok(),
@@ -1235,7 +1254,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// Converts this variant to tuple with an 8-byte unscaled value if possible.
     ///
     /// Returns `Some((i64, u8))` for decimal variants where the unscaled value
-    /// fits in `i64` range,
+    /// fits in `i64` range, the scale will be 0 if the input is string variants.
     /// `None` for non-decimal variants or decimal values that would overflow.
     ///
     /// # Examples
@@ -1251,13 +1270,17 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// let v2 = Variant::from(VariantDecimal16::try_new(1234_i128, 2).unwrap());
     /// assert_eq!(v2.as_decimal8(), VariantDecimal8::try_new(1234_i64, 2).ok());
     ///
+    /// // or from string variants if they can be parsed as decimals
+    /// let v3 = Variant::from("123.45");
+    /// assert_eq!(v3.as_decimal8(), VariantDecimal8::try_new(12345, 2).ok());
+    ///
     /// // but not if the value would overflow i64
-    /// let v3 = Variant::from(VariantDecimal16::try_new(2e19 as i128, 2).unwrap());
-    /// assert_eq!(v3.as_decimal8(), None);
+    /// let v4 = Variant::from(VariantDecimal16::try_new(2e19 as i128, 2).unwrap());
+    /// assert_eq!(v4.as_decimal8(), None);
     ///
     /// // or if the variant is not a decimal
-    /// let v4 = Variant::from("hello!");
-    /// assert_eq!(v4.as_decimal8(), None);
+    /// let v5 = Variant::from("hello!");
+    /// assert_eq!(v5.as_decimal8(), None);
     /// ```
     pub fn as_decimal8(&self) -> Option<VariantDecimal8> {
         match *self {
@@ -1268,13 +1291,9 @@ impl<'m, 'v> Variant<'m, 'v> {
                 .and_then(|x: i64| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal64Type>(f, 1f64)
                 .and_then(|x: i64| x.try_into().ok()),
-            Variant::String(v) => parse_string_to_decimal_native::<Decimal64Type>(v, 0usize)
-                .ok()
-                .and_then(|x: i64| x.try_into().ok()),
+            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal64Type>(v),
             Variant::ShortString(v) => {
-                parse_string_to_decimal_native::<Decimal64Type>(v.as_str(), 0usize)
-                    .ok()
-                    .and_then(|x: i64| x.try_into().ok())
+                Self::convert_string_to_decimal::<_, Decimal64Type>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8),
@@ -1286,7 +1305,7 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// Converts this variant to tuple with a 16-byte unscaled value if possible.
     ///
     /// Returns `Some((i128, u8))` for decimal variants where the unscaled value
-    /// fits in `i128` range,
+    /// fits in `i128` range, the scale will be 0 if the input is string variants.
     /// `None` for non-decimal variants or decimal values that would overflow.
     ///
     /// # Examples
@@ -1298,9 +1317,13 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// let v1 = Variant::from(VariantDecimal4::try_new(1234_i32, 2).unwrap());
     /// assert_eq!(v1.as_decimal16(), VariantDecimal16::try_new(1234_i128, 2).ok());
     ///
+    /// // or from a string variant if it can be parsed as decimal
+    /// let v2 = Variant::from("123.45");
+    /// assert_eq!(v2.as_decimal16(), VariantDecimal16::try_new(12345, 2).ok());
+    ///
     /// // but not if the variant is not a decimal
-    /// let v2 = Variant::from("hello!");
-    /// assert_eq!(v2.as_decimal16(), None);
+    /// let v3 = Variant::from("hello!");
+    /// assert_eq!(v3.as_decimal16(), None);
     /// ```
     pub fn as_decimal16(&self) -> Option<VariantDecimal16> {
         match *self {
@@ -1312,13 +1335,9 @@ impl<'m, 'v> Variant<'m, 'v> {
                 .and_then(|x: i128| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal128Type>(f, 1f64)
                 .and_then(|x: i128| x.try_into().ok()),
-            Variant::String(v) => parse_string_to_decimal_native::<Decimal128Type>(v, 0usize)
-                .ok()
-                .and_then(|x: i128| x.try_into().ok()),
+            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal128Type>(v),
             Variant::ShortString(v) => {
-                parse_string_to_decimal_native::<Decimal128Type>(v.as_str(), 0usize)
-                    .ok()
-                    .and_then(|x: i128| x.try_into().ok())
+                Self::convert_string_to_decimal::<_, Decimal128Type>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8.into()),

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -847,15 +847,20 @@ impl<'m, 'v> Variant<'m, 'v> {
     {
         let base: D::Native = NumCast::from(10)?;
 
-        base.pow_checked(scale as _)
+        base.pow_checked(<u32 as From<u8>>::from(scale))
             .ok()
             .and_then(|div| match T::KIND {
-                NumericKind::Integer => {
-                    cast_single_decimal_to_integer::<D, T>(raw, div, scale as _, T::arrow_type())
-                        .ok()
-                }
+                NumericKind::Integer => cast_single_decimal_to_integer::<D, T>(
+                    raw,
+                    div,
+                    <i16 as From<u8>>::from(scale),
+                    T::arrow_type(),
+                )
+                .ok(),
                 NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
-                    &as_float, raw, scale as _,
+                    &as_float,
+                    raw,
+                    <i32 as From<u8>>::from(scale),
                 )),
             })
     }
@@ -878,21 +883,21 @@ impl<'m, 'v> Variant<'m, 'v> {
             Variant::Int64(i) => num_cast(i),
             Variant::Float(f) => num_cast(f),
             Variant::Double(d) => num_cast(d),
-            Variant::Decimal4(d) => Self::cast_decimal_to_num::<Decimal32Type, T, _>(
-                d.integer(),
-                d.scale(),
-                |x: i32| x as f64,
-            ),
-            Variant::Decimal8(d) => Self::cast_decimal_to_num::<Decimal64Type, T, _>(
-                d.integer(),
-                d.scale(),
-                |x: i64| x as f64,
-            ),
-            Variant::Decimal16(d) => Self::cast_decimal_to_num::<Decimal128Type, T, _>(
-                d.integer(),
-                d.scale(),
-                |x: i128| x as f64,
-            ),
+            Variant::Decimal4(d) => {
+                Self::cast_decimal_to_num::<Decimal32Type, T, _>(d.integer(), d.scale(), |x| {
+                    x as f64
+                })
+            }
+            Variant::Decimal8(d) => {
+                Self::cast_decimal_to_num::<Decimal64Type, T, _>(d.integer(), d.scale(), |x| {
+                    x as f64
+                })
+            }
+            Variant::Decimal16(d) => {
+                Self::cast_decimal_to_num::<Decimal128Type, T, _>(d.integer(), d.scale(), |x| {
+                    x as f64
+                })
+            }
             _ => None,
         }
     }
@@ -1181,7 +1186,7 @@ impl<'m, 'v> Variant<'m, 'v> {
         self.as_num()
     }
 
-    fn convert_string_to_decimal<VD, D>(input: &str) -> Option<VD>
+    fn convert_string_to_decimal<D, VD>(input: &str) -> Option<VD>
     where
         D: DecimalType,
         VD: VariantDecimalType<Native = D::Native>,
@@ -1190,14 +1195,12 @@ impl<'m, 'v> Variant<'m, 'v> {
         // find the last '.'
         let scale_usize = input
             .rsplit_once('.')
-            .map(|(_, frac)| frac.len())
-            .unwrap_or(0);
+            .map_or_else(|| 0, |(_, frac)| frac.len());
 
         let scale = u8::try_from(scale_usize).ok()?;
 
-        parse_string_to_decimal_native::<D>(input, scale_usize)
-            .ok()
-            .and_then(|raw| VD::try_new(raw, scale).ok())
+        let raw = parse_string_to_decimal_native::<D>(input, scale_usize).ok()?;
+        VD::try_new(raw, scale).ok()
     }
 
     /// Converts this variant to tuple with a 4-byte unscaled value if possible.
@@ -1240,9 +1243,9 @@ impl<'m, 'v> Variant<'m, 'v> {
                 .and_then(|x: i32| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal32Type>(f, 1f64)
                 .and_then(|x: i32| x.try_into().ok()),
-            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal32Type>(v),
+            Variant::String(v) => Self::convert_string_to_decimal::<Decimal32Type, _>(v),
             Variant::ShortString(v) => {
-                Self::convert_string_to_decimal::<_, Decimal32Type>(v.as_str())
+                Self::convert_string_to_decimal::<Decimal32Type, _>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4),
             Variant::Decimal8(decimal8) => decimal8.try_into().ok(),
@@ -1291,9 +1294,9 @@ impl<'m, 'v> Variant<'m, 'v> {
                 .and_then(|x: i64| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal64Type>(f, 1f64)
                 .and_then(|x: i64| x.try_into().ok()),
-            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal64Type>(v),
+            Variant::String(v) => Self::convert_string_to_decimal::<Decimal64Type, _>(v),
             Variant::ShortString(v) => {
-                Self::convert_string_to_decimal::<_, Decimal64Type>(v.as_str())
+                Self::convert_string_to_decimal::<Decimal64Type, _>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8),
@@ -1329,15 +1332,15 @@ impl<'m, 'v> Variant<'m, 'v> {
         match *self {
             Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => self
                 .as_num::<i64>()
-                .map(|x| (x as i128).try_into().ok())
+                .map(|x| <i128 as From<i64>>::from(x).try_into().ok())
                 .unwrap(),
             Variant::Float(f) => single_float_to_decimal::<Decimal128Type>(f as _, 1f64)
                 .and_then(|x: i128| x.try_into().ok()),
             Variant::Double(f) => single_float_to_decimal::<Decimal128Type>(f, 1f64)
                 .and_then(|x: i128| x.try_into().ok()),
-            Variant::String(v) => Self::convert_string_to_decimal::<_, Decimal128Type>(v),
+            Variant::String(v) => Self::convert_string_to_decimal::<Decimal128Type, _>(v),
             Variant::ShortString(v) => {
-                Self::convert_string_to_decimal::<_, Decimal128Type>(v.as_str())
+                Self::convert_string_to_decimal::<Decimal128Type, _>(v.as_str())
             }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8.into()),

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -847,13 +847,9 @@ impl<'m, 'v> Variant<'m, 'v> {
 
         let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
         match T::KIND {
-            NumericKind::Integer => cast_single_decimal_to_integer::<D, T>(
-                raw,
-                div,
-                <i16 as From<u8>>::from(scale),
-                T::ARROW_TYPE,
-            )
-            .ok(),
+            NumericKind::Integer => {
+                cast_single_decimal_to_integer::<D, T>(raw, div, false, T::ARROW_TYPE).ok()
+            }
             NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
                 &as_float,
                 raw,

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -29,10 +29,17 @@ use crate::decoder::{
 };
 use crate::path::{VariantPath, VariantPathElement};
 use crate::utils::{first_byte_from_slice, slice_from_slice};
+use arrow::array::ArrowNativeTypeOp;
 use arrow::compute::{
-    cast_num_to_bool, cast_single_string_to_boolean_default, num_cast, single_bool_to_numeric,
+    cast_num_to_bool, cast_single_decimal_to_integer, cast_single_string_to_boolean_default,
+    num_cast, parse_string_to_decimal_native, single_bool_to_numeric,
+    single_decimal_to_float_lossy, single_float_to_decimal,
 };
-use arrow_schema::ArrowError;
+use arrow::datatypes::{Decimal32Type, Decimal64Type, Decimal128Type, DecimalType};
+use arrow_schema::DataType::{
+    Float16, Float32, Float64, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+};
+use arrow_schema::{ArrowError, DataType};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use num_traits::NumCast;
 use std::ops::Deref;
@@ -166,10 +173,11 @@ impl Deref for ShortString<'_> {
 ///   Arrow UTF8-to-boolean cast rules.
 /// - Numeric accessors such as [`Self::as_int8`], [`Self::as_int64`], [`Self::as_u8`],
 ///   [`Self::as_u64`], [`Self::as_f16`], [`Self::as_f32`], and [`Self::as_f64`] accept
-///   boolean and numeric variants (integers, floating-point, and decimals with scale `0`).
+///   boolean and numeric variants (integers, floating-point, and decimals).
 ///   They return `None` when conversion is not possible.
 /// - Decimal accessors such as [`Self::as_decimal4`], [`Self::as_decimal8`], and
-///   [`Self::as_decimal16`] accept compatible decimal variants and integer variants.
+///   [`Self::as_decimal16`] accept compatible decimal variants, integer variants,
+///   float variants and string variants.
 ///   They return `None` when conversion is not possible.
 ///
 /// # Examples:
@@ -293,6 +301,39 @@ pub enum Variant<'m, 'v> {
 
 // We don't want this to grow because it could hurt performance of a frequently-created type.
 const _: () = crate::utils::expect_size_of::<Variant>(80);
+
+enum NumericKind {
+    Integer,
+    Float,
+}
+
+trait DecimalCastTarget: NumCast + Default {
+    const KIND: NumericKind;
+    fn arrow_type() -> DataType;
+}
+
+macro_rules! impl_decimal_cast_target {
+    ($raw_type: ident, $target_kind:expr, $arrow_type: expr) => {
+        impl DecimalCastTarget for $raw_type {
+            const KIND: NumericKind = $target_kind;
+            fn arrow_type() -> DataType {
+                $arrow_type
+            }
+        }
+    };
+}
+
+impl_decimal_cast_target!(i8, NumericKind::Integer, Int8);
+impl_decimal_cast_target!(i16, NumericKind::Integer, Int16);
+impl_decimal_cast_target!(i32, NumericKind::Integer, Int32);
+impl_decimal_cast_target!(i64, NumericKind::Integer, Int64);
+impl_decimal_cast_target!(u8, NumericKind::Integer, UInt8);
+impl_decimal_cast_target!(u16, NumericKind::Integer, UInt16);
+impl_decimal_cast_target!(u32, NumericKind::Integer, UInt32);
+impl_decimal_cast_target!(u64, NumericKind::Integer, UInt64);
+impl_decimal_cast_target!(f16, NumericKind::Float, Float16);
+impl_decimal_cast_target!(f32, NumericKind::Float, Float32);
+impl_decimal_cast_target!(f64, NumericKind::Float, Float64);
 
 impl<'m, 'v> Variant<'m, 'v> {
     /// Attempts to interpret a metadata and value buffer pair as a new `Variant`.
@@ -797,14 +838,36 @@ impl<'m, 'v> Variant<'m, 'v> {
         }
     }
 
-    /// Converts a boolean or numeric variant(integers, floating-point, and decimals with scale 0)
+    fn cast_decimal_to_num<D, T, F>(raw: D::Native, scale: u8, as_float: F) -> Option<T>
+    where
+        D: DecimalType,
+        D::Native: NumCast + ArrowNativeTypeOp,
+        T: DecimalCastTarget,
+        F: Fn(D::Native) -> f64,
+    {
+        let base: D::Native = NumCast::from(10)?;
+
+        base.pow_checked(scale as _)
+            .ok()
+            .and_then(|div| match T::KIND {
+                NumericKind::Integer => {
+                    cast_single_decimal_to_integer::<D, T>(raw, div, scale as _, T::arrow_type())
+                        .ok()
+                }
+                NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
+                    &as_float, raw, scale as _,
+                )),
+            })
+    }
+
+    /// Converts a boolean or numeric variant(integers, floating-point, and decimals)
     /// to the specified numeric type `T`.
     ///
     /// Uses Arrow's casting logic to perform the conversion. Returns `Some(T)` if
     /// the conversion succeeds, `None` if the variant can't be casted to type `T`.
     fn as_num<T>(&self) -> Option<T>
     where
-        T: NumCast + Default,
+        T: DecimalCastTarget,
     {
         match *self {
             Variant::BooleanFalse => single_bool_to_numeric(false),
@@ -815,9 +878,21 @@ impl<'m, 'v> Variant<'m, 'v> {
             Variant::Int64(i) => num_cast(i),
             Variant::Float(f) => num_cast(f),
             Variant::Double(d) => num_cast(d),
-            Variant::Decimal4(d) if d.scale() == 0 => num_cast(d.integer()),
-            Variant::Decimal8(d) if d.scale() == 0 => num_cast(d.integer()),
-            Variant::Decimal16(d) if d.scale() == 0 => num_cast(d.integer()),
+            Variant::Decimal4(d) => Self::cast_decimal_to_num::<Decimal32Type, T, _>(
+                d.integer(),
+                d.scale(),
+                |x: i32| x as f64,
+            ),
+            Variant::Decimal8(d) => Self::cast_decimal_to_num::<Decimal64Type, T, _>(
+                d.integer(),
+                d.scale(),
+                |x: i64| x as f64,
+            ),
+            Variant::Decimal16(d) => Self::cast_decimal_to_num::<Decimal128Type, T, _>(
+                d.integer(),
+                d.scale(),
+                |x: i128| x as f64,
+            ),
             _ => None,
         }
     }
@@ -1138,6 +1213,18 @@ impl<'m, 'v> Variant<'m, 'v> {
             Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
                 self.as_num::<i32>().and_then(|x| x.try_into().ok())
             }
+            Variant::Float(f) => single_float_to_decimal::<Decimal32Type>(f as _, 1f64)
+                .and_then(|x: i32| x.try_into().ok()),
+            Variant::Double(f) => single_float_to_decimal::<Decimal32Type>(f, 1f64)
+                .and_then(|x: i32| x.try_into().ok()),
+            Variant::String(v) => parse_string_to_decimal_native::<Decimal32Type>(v, 0usize)
+                .ok()
+                .and_then(|x: i32| x.try_into().ok()),
+            Variant::ShortString(v) => {
+                parse_string_to_decimal_native::<Decimal32Type>(v.as_str(), 0usize)
+                    .ok()
+                    .and_then(|x: i32| x.try_into().ok())
+            }
             Variant::Decimal4(decimal4) => Some(decimal4),
             Variant::Decimal8(decimal8) => decimal8.try_into().ok(),
             Variant::Decimal16(decimal16) => decimal16.try_into().ok(),
@@ -1177,6 +1264,18 @@ impl<'m, 'v> Variant<'m, 'v> {
             Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
                 self.as_num::<i64>().and_then(|x| x.try_into().ok())
             }
+            Variant::Float(f) => single_float_to_decimal::<Decimal64Type>(f as _, 1f64)
+                .and_then(|x: i64| x.try_into().ok()),
+            Variant::Double(f) => single_float_to_decimal::<Decimal64Type>(f, 1f64)
+                .and_then(|x: i64| x.try_into().ok()),
+            Variant::String(v) => parse_string_to_decimal_native::<Decimal64Type>(v, 0usize)
+                .ok()
+                .and_then(|x: i64| x.try_into().ok()),
+            Variant::ShortString(v) => {
+                parse_string_to_decimal_native::<Decimal64Type>(v.as_str(), 0usize)
+                    .ok()
+                    .and_then(|x: i64| x.try_into().ok())
+            }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8),
             Variant::Decimal16(decimal16) => decimal16.try_into().ok(),
@@ -1205,8 +1304,21 @@ impl<'m, 'v> Variant<'m, 'v> {
     /// ```
     pub fn as_decimal16(&self) -> Option<VariantDecimal16> {
         match *self {
-            Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
-                self.as_num::<i128>().and_then(|x| x.try_into().ok())
+            Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => self
+                .as_num::<i64>()
+                .map(|x| (x as i128).try_into().ok())
+                .unwrap(),
+            Variant::Float(f) => single_float_to_decimal::<Decimal128Type>(f as _, 1f64)
+                .and_then(|x: i128| x.try_into().ok()),
+            Variant::Double(f) => single_float_to_decimal::<Decimal128Type>(f, 1f64)
+                .and_then(|x: i128| x.try_into().ok()),
+            Variant::String(v) => parse_string_to_decimal_native::<Decimal128Type>(v, 0usize)
+                .ok()
+                .and_then(|x: i128| x.try_into().ok()),
+            Variant::ShortString(v) => {
+                parse_string_to_decimal_native::<Decimal128Type>(v.as_str(), 0usize)
+                    .ok()
+                    .and_then(|x: i128| x.try_into().ok())
             }
             Variant::Decimal4(decimal4) => Some(decimal4.into()),
             Variant::Decimal8(decimal8) => Some(decimal8.into()),

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -31,9 +31,9 @@ use crate::path::{VariantPath, VariantPathElement};
 use crate::utils::{first_byte_from_slice, slice_from_slice};
 use arrow::array::ArrowNativeTypeOp;
 use arrow::compute::{
-    DecimalCast, cast_num_to_bool, cast_single_decimal_to_integer_div_opt,
-    cast_single_string_to_boolean_default, num_cast, parse_string_to_decimal_native,
-    single_bool_to_numeric, single_decimal_to_float_lossy, single_float_to_decimal,
+    DecimalCast, cast_num_to_bool, cast_single_string_to_boolean_default, num_cast,
+    parse_string_to_decimal_native, single_bool_to_numeric, single_decimal_to_float_lossy,
+    single_float_to_decimal,
 };
 use arrow::datatypes::{Decimal32Type, Decimal64Type, Decimal128Type, DecimalType};
 
@@ -843,7 +843,10 @@ impl<'m, 'v> Variant<'m, 'v> {
 
         let div = base.pow_checked(<u32 as From<u8>>::from(scale)).ok()?;
         match T::KIND {
-            NumericKind::Integer => cast_single_decimal_to_integer_div_opt::<D, T>(raw, div),
+            NumericKind::Integer => raw
+                .div_checked(div)
+                .ok()
+                .and_then(<T as NumCast>::from::<D::Native>),
             NumericKind::Float => T::from(single_decimal_to_float_lossy::<D, _>(
                 &as_float,
                 raw,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9688 .


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Extract some logic in arrow-cast
- Reuse the extracted logic in arrow-cast and parquet-variant

# Are these changes tested?
Reuse the existing tests in arrow-test

# Are there any user-facing changes?

Yes, changed the docs
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
