### PR TITLE
feat(parquet): skip RowFilter evaluation for fully matched row groups

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -139,6 +139,12 @@ pub struct ArrowReaderBuilder<T> {
     pub(crate) metrics: ArrowReaderMetrics,
 
     pub(crate) max_predicate_cache_size: usize,
+
+    /// Row groups where ALL rows are known to match the filter predicate.
+    ///
+    /// For these row groups, the [`RowFilter`] evaluation is skipped entirely
+    /// since the predicate is guaranteed to be true for every row.
+    pub(crate) fully_matched_row_groups: Option<Vec<usize>>,
 }
 
 impl<T: Debug> Debug for ArrowReaderBuilder<T> {
@@ -178,6 +184,7 @@ impl<T> ArrowReaderBuilder<T> {
             offset: None,
             metrics: ArrowReaderMetrics::Disabled,
             max_predicate_cache_size: 100 * 1024 * 1024, // 100MB default cache size
+            fully_matched_row_groups: None,
         }
     }
 
@@ -340,6 +347,28 @@ impl<T> ArrowReaderBuilder<T> {
     pub fn with_row_filter(self, filter: RowFilter) -> Self {
         Self {
             filter: Some(filter),
+            ..self
+        }
+    }
+
+    /// Specify row groups where ALL rows are known to match the filter predicate.
+    ///
+    /// For these row groups, the [`RowFilter`] evaluation (set via
+    /// [`Self::with_row_filter`]) is skipped entirely since the predicate is
+    /// guaranteed to be `true` for every row. This avoids the cost of decoding
+    /// filter columns and evaluating the predicate expression for those row
+    /// groups.
+    ///
+    /// This is typically determined by evaluating row group statistics: if the
+    /// statistics prove that all rows satisfy the predicate, the row group is
+    /// "fully matched."
+    ///
+    /// The provided indices must be a subset of the row groups specified via
+    /// [`Self::with_row_groups`] (or all row groups if none were specified).
+    /// Indices not present in the row group list are ignored.
+    pub fn with_fully_matched_row_groups(self, row_groups: Vec<usize>) -> Self {
+        Self {
+            fully_matched_row_groups: Some(row_groups),
             ..self
         }
     }
@@ -1188,6 +1217,8 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             metrics,
             // Not used for the sync reader, see https://github.com/apache/arrow-rs/issues/8000
             max_predicate_cache_size: _,
+            // Not used for the sync reader (single row group per reader)
+            fully_matched_row_groups: _,
         } = self;
 
         // Try to avoid allocate large buffer

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -497,6 +497,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            fully_matched_row_groups,
         } = self;
 
         // Ensure schema of ParquetRecordBatchStream respects projection, and does
@@ -522,6 +523,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            fully_matched_row_groups,
         }
         .build()?;
 

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -176,6 +176,7 @@ impl ParquetPushDecoderBuilder {
             metrics,
             row_selection_policy,
             max_predicate_cache_size,
+            fully_matched_row_groups,
         } = self;
 
         // If no row groups were specified, read all of them
@@ -197,6 +198,7 @@ impl ParquetPushDecoderBuilder {
             max_predicate_cache_size,
             buffers,
             row_selection_policy,
+            fully_matched_row_groups,
         );
 
         // Initialize the decoder with the configured options

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -38,6 +38,7 @@ use bytes::Bytes;
 use data::DataRequest;
 use filter::AdvanceResult;
 use filter::FilterInfo;
+use std::collections::HashSet;
 use std::ops::Range;
 use std::sync::{Arc, RwLock};
 
@@ -160,6 +161,10 @@ pub(crate) struct RowGroupReaderBuilder {
     /// Strategy for materialising row selections
     row_selection_policy: RowSelectionPolicy,
 
+    /// Row groups where ALL rows are known to match the filter predicate.
+    /// For these row groups, filter evaluation is skipped entirely.
+    fully_matched_row_groups: HashSet<usize>,
+
     /// Current state of the decoder.
     ///
     /// It is taken when processing, and must be put back before returning
@@ -185,6 +190,7 @@ impl RowGroupReaderBuilder {
         max_predicate_cache_size: usize,
         buffers: PushBuffers,
         row_selection_policy: RowSelectionPolicy,
+        fully_matched_row_groups: Option<Vec<usize>>,
     ) -> Self {
         Self {
             batch_size,
@@ -197,6 +203,9 @@ impl RowGroupReaderBuilder {
             metrics,
             max_predicate_cache_size,
             row_selection_policy,
+            fully_matched_row_groups: fully_matched_row_groups
+                .map(|v| v.into_iter().collect())
+                .unwrap_or_default(),
             state: Some(RowGroupDecoderState::Finished),
             buffers,
         }
@@ -327,6 +336,22 @@ impl RowGroupReaderBuilder {
                         cache_info: None,
                     }));
                 };
+
+                // Skip filter for fully matched row groups: all rows are known
+                // to satisfy the predicate based on row group statistics, so
+                // evaluating the filter would be wasted work.
+                if self
+                    .fully_matched_row_groups
+                    .contains(&row_group_info.row_group_idx)
+                {
+                    // Put the filter back for subsequent non-fully-matched row groups
+                    self.filter = Some(filter);
+                    return Ok(NextState::again(RowGroupDecoderState::StartData {
+                        row_group_info,
+                        column_chunks,
+                        cache_info: None,
+                    }));
+                }
 
                 // we have predicates to evaluate
                 let cache_projection =


### PR DESCRIPTION
# Which issue does this PR close?

- Related to https://github.com/apache/datafusion/issues/19028

# Rationale for this change

When DataFusion evaluates a Parquet scan with filter pushdown, it uses row group statistics to determine which row groups to scan. In many real-world queries, the predicate matches **all** rows in some (or all) row groups — for example, a time-range filter where entire row groups fall within the range, or a `WHERE status != 'DELETED'` filter on data that contains no deleted rows.

Today, even when row group statistics **prove** that every row satisfies the predicate, the `RowFilter` is still evaluated row-by-row during decoding. This means the filter columns are decoded and the predicate expression is evaluated for every row — work that produces no useful filtering and can be expensive, especially when filter columns are large (e.g., strings) or the predicate is complex.

This PR adds a mechanism to skip `RowFilter` evaluation entirely for row groups that are known to be "fully matched" based on statistics. The caller (e.g., DataFusion) determines which row groups are fully matched during row group pruning and passes that information to the reader builder. During decoding, fully matched row groups skip straight to data materialization, bypassing filter column decoding and predicate evaluation.


# What changes are included in this PR?

1. **New builder method `with_fully_matched_row_groups(Vec<usize>)`** on `ArrowReaderBuilder` — allows callers to specify which row groups have all rows matching the filter predicate.

2. **Skip filter in `RowGroupReaderBuilder::try_transition()`** — when a row group is in the fully-matched set, the `Start` state transitions directly to `StartData`, bypassing the `Filters` / `WaitingOnFilterData` states entirely. The filter is preserved (put back into `self.filter`) for subsequent non-fully-matched row groups.

3. **Plumbed through all decoder paths** — the field is propagated through `ParquetPushDecoderBuilder`, `ParquetRecordBatchStreamBuilder` (async), and ignored in the sync reader (which processes one row group at a time).

**Design choices:**
- The fully-matched set is stored as a `HashSet<usize>` on `RowGroupReaderBuilder` for O(1) lookup, rather than on `RowGroupDecoderState`, so the state enum size is unchanged (preserving the existing 200-byte size test).
- The API uses `Option<Vec<usize>>` at the builder level and converts to `HashSet` internally.

# Are these changes tested?

The optimization is exercised by an end-to-end benchmark in DataFusion that uses `ParquetPushDecoder` directly (the same code path used by DataFusion's async Parquet opener). The benchmark verifies correctness by asserting the expected row count.

Unit tests can be added if reviewers prefer — happy to add tests that verify:
- Fully matched row groups skip filter evaluation and still return all rows
- Non-fully-matched row groups in the same scan still have filters applied
- The API is a no-op when no fully matched row groups are specified

(I'll open a draft PR in datafusion side tomorrow)

# Are there any user-facing changes?

Yes — a new public method `ArrowReaderBuilder::with_fully_matched_row_groups()` is added. This is a purely additive, non-breaking change. Existing code is unaffected since the default is `None` (no row groups are marked as fully matched).