### PR TITLE
Fix clippy warning in fixed_size_binary_array.rs

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -94,27 +94,31 @@ impl FixedSizeBinaryArray {
             ArrowError::InvalidArgumentError(format!("Size cannot be negative, got {size}"))
         })?;
 
-        let len = if s == 0 {
-            if !values.is_empty() {
-                return Err(ArrowError::InvalidArgumentError(
-                    "Buffer cannot have non-zero length if the item size is zero".to_owned(),
-                ));
-            }
+        let len = match values.len().checked_div(s) {
+            Some(len) => {
+                if let Some(n) = nulls.as_ref() {
+                    if n.len() != len {
+                        return Err(ArrowError::InvalidArgumentError(format!(
+                            "Incorrect length of null buffer for FixedSizeBinaryArray, expected {} got {}",
+                            len,
+                            n.len(),
+                        )));
+                    }
+                }
 
-            // If the item size is zero, try to determine the length from the null buffer
-            nulls.as_ref().map(|n| n.len()).unwrap_or(0)
-        } else {
-            values.len() / s
-        };
-        if let Some(n) = nulls.as_ref() {
-            if n.len() != len {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "Incorrect length of null buffer for FixedSizeBinaryArray, expected {} got {}",
-                    len,
-                    n.len(),
-                )));
+                len
             }
-        }
+            None => {
+                if !values.is_empty() {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "Buffer cannot have non-zero length if the item size is zero".to_owned(),
+                    ));
+                }
+
+                // If the item size is zero, try to determine the length from the null buffer
+                nulls.as_ref().map(|n| n.len()).unwrap_or(0)
+            }
+        };
 
         Ok(Self {
             data_type,
@@ -1032,10 +1036,14 @@ mod tests {
 
         let zero_sized = FixedSizeBinaryArray::new(0, Buffer::default(), None);
         assert_eq!(zero_sized.len(), 0);
+        assert_eq!(zero_sized.null_count(), 0);
+        assert_eq!(zero_sized.values().len(), 0);
 
         let nulls = NullBuffer::new_null(3);
         let zero_sized_with_nulls = FixedSizeBinaryArray::new(0, Buffer::default(), Some(nulls));
         assert_eq!(zero_sized_with_nulls.len(), 3);
+        assert_eq!(zero_sized_with_nulls.null_count(), 3);
+        assert_eq!(zero_sized_with_nulls.values().len(), 0);
 
         let zero_sized_with_non_empty_buffer_err =
             FixedSizeBinaryArray::try_new(0, buffer, None).unwrap_err();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #NNN.

# Rationale for this change

This is a future lint, so I took to the opportunity to make this it clear that the length validation only needs to happen in one case.

# What changes are included in this PR?

Minor changes to validation in `FixedSizeBinaryArray::try_new`.

# Are these changes tested?

Added some assertions to existing tests.

# Are there any user-facing changes?

None
