### PR TITLE
refactor(arrow-avro): use `Decoder::flush_block` in async reader

### DIFF
--- a/arrow-avro/src/reader/async_reader/mod.rs
+++ b/arrow-avro/src/reader/async_reader/mod.rs
@@ -228,7 +228,7 @@ impl<R> AsyncAvroFileReader<R> {
     /// Drain any remaining buffered records from the decoder.
     #[inline]
     fn poll_flush(&mut self) -> Poll<Option<Result<RecordBatch, AvroError>>> {
-        match self.decoder.flush() {
+        match self.decoder.flush_block() {
             Ok(Some(batch)) => {
                 self.reader_state = ReaderState::Flushing;
                 Poll::Ready(Some(Ok(batch)))
@@ -512,7 +512,7 @@ impl<R: AsyncFileReader + Unpin + 'static> AsyncAvroFileReader<R> {
                     // We have a full batch ready, emit it
                     // (This is not mutually exclusive with the block being finished, so the state change is valid)
                     if self.decoder.batch_is_full() {
-                        return match self.decoder.flush() {
+                        return match self.decoder.flush_block() {
                             Ok(Some(batch)) => Poll::Ready(Some(Ok(batch))),
                             Ok(None) => self.finish_with_error(AvroError::General(
                                 "Decoder reported a full batch, but flush returned None".into(),


### PR DESCRIPTION
Since the async reader only reads OCF files and uses `Decoder::decode_block` to decode, use `flush_block` for consistency and to avoid an unnecessary check for mid-content schema changes.

# Are these changes tested?

No new behavior is introduced, the existing tests should pass.

# Are there any user-facing changes?

No