### PR TITLE
arrow-arith: fix 'occured' -> 'occurred' in arity.rs comments

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -456,7 +456,7 @@ mod tests {
             Some(vec![true, true, true, true, true].into()),
         );
 
-        // unwrap here means that no copying occured
+        // unwrap here means that no copying occurred
         let r2 = binary_mut(a, &b, |a, b| a + b).unwrap();
         assert_eq!(r1.unwrap(), r2.unwrap());
     }
@@ -505,7 +505,7 @@ mod tests {
             Some(vec![true, true, true, true, true].into()),
         );
 
-        // unwrap here means that no copying occured
+        // unwrap here means that no copying occurred
         let r2 = try_binary_mut(a, &b, |a, b| Ok(a + b)).unwrap();
         assert_eq!(r1.unwrap(), r2.unwrap());
     }


### PR DESCRIPTION
## Which issue does this PR close?

N/A — typo fix only.

## Rationale

Two comments in `arrow-arith/src/arity.rs` (lines 459, 508) read `no copying occured`. Fixed to `occurred`. Comment-only change.

## Are there any user-facing changes?

No.