### PR TITLE
Remove `len` field from buffer builder

### DIFF
--- a/arrow-buffer/src/builder/mod.rs
+++ b/arrow-buffer/src/builder/mod.rs
@@ -58,7 +58,6 @@ use std::marker::PhantomData;
 #[derive(Debug)]
 pub struct BufferBuilder<T: ArrowNativeType> {
     buffer: MutableBuffer,
-    len: usize,
     _marker: PhantomData<T>,
 }
 
@@ -88,7 +87,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
 
         Self {
             buffer,
-            len: 0,
             _marker: PhantomData,
         }
     }
@@ -99,10 +97,8 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     ///
     /// - `buffer` bytes must be aligned to type `T`
     pub unsafe fn new_from_buffer(buffer: MutableBuffer) -> Self {
-        let buffer_len = buffer.len();
         Self {
             buffer,
-            len: buffer_len / std::mem::size_of::<T>(),
             _marker: PhantomData,
         }
     }
@@ -119,7 +115,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// assert_eq!(builder.len(), 1);
     /// ```
     pub fn len(&self) -> usize {
-        self.len
+        self.buffer.len() / std::mem::size_of::<T>()
     }
 
     /// Returns whether the internal buffer is empty.
@@ -134,7 +130,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// assert_eq!(builder.is_empty(), false);
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.buffer.is_empty()
     }
 
     /// Returns the actual capacity (number of elements) of the internal buffer.
@@ -166,7 +162,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn advance(&mut self, i: usize) {
         self.buffer.extend_zeros(i * std::mem::size_of::<T>());
-        self.len += i;
     }
 
     /// Reserves memory for _at least_ `n` more elements of type `T`.
@@ -201,7 +196,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     pub fn append(&mut self, v: T) {
         self.reserve(1);
         self.buffer.push(v);
-        self.len += 1;
     }
 
     /// Appends a value of type `T` into the builder N times,
@@ -237,7 +231,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn append_n_zeroed(&mut self, n: usize) {
         self.buffer.extend_zeros(n * std::mem::size_of::<T>());
-        self.len += n;
     }
 
     /// Appends a slice of type `T`, growing the internal buffer as needed.
@@ -254,7 +247,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn append_slice(&mut self, slice: &[T]) {
         self.buffer.extend_from_slice(slice);
-        self.len += slice.len();
     }
 
     /// View the contents of this buffer as a slice
@@ -274,7 +266,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
         // - MutableBuffer is aligned and initialized for len elements of T
         // - MutableBuffer corresponds to a single allocation
         // - MutableBuffer does not support modification whilst active immutable borrows
-        unsafe { std::slice::from_raw_parts(self.buffer.as_ptr() as _, self.len) }
+        unsafe { std::slice::from_raw_parts(self.buffer.as_ptr() as _, self.len()) }
     }
 
     /// View the contents of this buffer as a mutable slice
@@ -298,7 +290,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
         // - MutableBuffer is aligned and initialized for len elements of T
         // - MutableBuffer corresponds to a single allocation
         // - MutableBuffer does not support modification whilst active immutable borrows
-        unsafe { std::slice::from_raw_parts_mut(self.buffer.as_mut_ptr() as _, self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.buffer.as_mut_ptr() as _, self.len()) }
     }
 
     /// Shorten this BufferBuilder to `len` items
@@ -323,7 +315,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         self.buffer.truncate(len * std::mem::size_of::<T>());
-        self.len = self.len.min(len);
     }
 
     /// # Safety
@@ -356,7 +347,6 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     #[inline]
     pub fn finish(&mut self) -> Buffer {
         let buf = std::mem::take(&mut self.buffer);
-        self.len = 0;
         buf.into()
     }
 
@@ -387,9 +377,7 @@ impl<T: ArrowNativeType> Default for BufferBuilder<T> {
 
 impl<T: ArrowNativeType> Extend<T> for BufferBuilder<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        self.buffer.extend(iter.into_iter().inspect(|_| {
-            self.len += 1;
-        }))
+        self.buffer.extend(iter)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Split out of https://github.com/apache/arrow-rs/pull/9393

# Rationale for this change

The buffer builder doesn't need to keep its own `len` field, as it can be derived from the inner mutablebuffer

# What changes are included in this PR?

Removes the `len` field from `Bufferbuilder`

# Are these changes tested?

Yes, all tests green

# Are there any user-facing changes?

Nope!
