### PR TITLE
feat(ipc): Remove per-message flush in IPC writer hot path

### DIFF
--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -1467,6 +1467,7 @@ impl<W: Write> StreamWriter<W> {
         }
 
         write_continuation(&mut self.writer, &self.write_options, 0)?;
+        self.writer.flush()?;
 
         self.finished = true;
 
@@ -1618,7 +1619,6 @@ fn write_body_buffers<W: Write>(
         writer.write_all(&PADDING[..pad_len])?;
     }
 
-    writer.flush()?;
     Ok(total_len)
 }
 
@@ -1651,8 +1651,6 @@ fn write_continuation<W: Write>(
         }
         z => panic!("Unsupported crate::MetadataVersion {z:?}"),
     };
-
-    writer.flush()?;
 
     Ok(written)
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9762 .

# Rationale for this change

Currently, `flush()` is called unconditionally in `write_body_buffers` and `write_continuation` - both executed per batch. This forces per-batch syscalls, breaks write coalescing, and adds unnecessary overhead. These flushes are not required for correctness (IPC boundaries are length-prefixed, no durability guarantees).

# What changes are included in this PR?

- Remove `flush()` from `write_body_buffers` and `write_continuation`
- Add `self.writer.flush()?` to `StreamWriter::finish()` (missing; `FileWriter::finish()` already has it)

# Are these changes tested?

Yes the changes were tested successfully by running:
```bash
cargo test -p arrow-ipc
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
```

# Are there any user-facing changes?

No, There are no changes made to any Public APIs
