### PR TITLE
feat(parquet): wire scan_filtered through ArrayReader stack; add with_miniblock_predicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ ehthumbs_vista.db
 
 # Dump file
 *.stackdump
+*.core
 
 # Folder config file
 [Dd]esktop.ini

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -120,6 +120,26 @@ pub trait ArrayReader: Send {
     /// a filter to the resulting array.
     fn skip_records(&mut self, num_records: usize) -> Result<usize>;
 
+    /// Reads at most `batch_size` records, using `predicate` to skip miniblock regions
+    /// whose value range `[lo, hi]` does not satisfy `predicate(lo, hi)`.
+    ///
+    /// Returns the number of records consumed (rows advanced in the page).  The
+    /// number of values written into the internal buffer may be less — callers can
+    /// retrieve it via [`consume_batch`].
+    ///
+    /// The default implementation ignores the predicate and falls back to
+    /// [`read_records`], which is correct for all encodings.  Only
+    /// [`crate::basic::Encoding::DELTA_BINARY_PACKED`] on mandatory columns
+    /// gains the miniblock-skip benefit.
+    fn scan_records(
+        &mut self,
+        batch_size: usize,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<usize> {
+        let _ = predicate;
+        self.read_records(batch_size)
+    }
+
     /// If this array has a non-zero definition level, i.e. has a nullable parent
     /// array, returns the definition levels of data from the last call of `next_batch`
     ///
@@ -242,4 +262,40 @@ where
         }
     }
     Ok(records_skipped)
+}
+
+/// Uses `record_reader` to scan up to `batch_size` records from `pages`, emitting to
+/// the internal buffer only values from miniblock regions matching `predicate`.
+///
+/// Returns `(records_consumed, values_emitted)`.
+///
+/// For optional/repeated columns the predicate is ignored and all values are decoded
+/// (see [`GenericRecordReader::scan_filtered_records`]).
+pub(crate) fn scan_filtered_records<V, CV>(
+    record_reader: &mut GenericRecordReader<V, CV>,
+    pages: &mut dyn PageIterator,
+    batch_size: usize,
+    predicate: &dyn Fn(i64, i64) -> bool,
+) -> Result<(usize, usize)>
+where
+    V: ValuesBuffer,
+    CV: ColumnValueDecoder<Buffer = V>,
+{
+    let mut total_consumed = 0usize;
+    let mut total_emitted = 0usize;
+    while total_consumed < batch_size {
+        let to_scan = batch_size - total_consumed;
+        let (consumed, emitted) = record_reader.scan_filtered_records(to_scan, predicate)?;
+        total_consumed += consumed;
+        total_emitted += emitted;
+
+        if consumed < to_scan {
+            if let Some(page_reader) = pages.next() {
+                record_reader.set_page_reader(page_reader?)?;
+            } else {
+                break;
+            }
+        }
+    }
+    Ok((total_consumed, total_emitted))
 }

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::arrow::array_reader::{ArrayReader, read_records, skip_records};
+use crate::arrow::array_reader::{ArrayReader, read_records, scan_filtered_records, skip_records};
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
 use crate::basic::Type as PhysicalType;
@@ -210,6 +210,20 @@ where
 
     fn skip_records(&mut self, num_records: usize) -> Result<usize> {
         skip_records(&mut self.record_reader, self.pages.as_mut(), num_records)
+    }
+
+    fn scan_records(
+        &mut self,
+        batch_size: usize,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<usize> {
+        let (consumed, _emitted) = scan_filtered_records(
+            &mut self.record_reader,
+            self.pages.as_mut(),
+            batch_size,
+            predicate,
+        )?;
+        Ok(consumed)
     }
 
     fn get_def_levels(&self) -> Option<&[i16]> {
@@ -942,6 +956,70 @@ mod tests {
                 .with_precision_and_scale(34, 0)
                 .unwrap();
             assert_ne!(array, &data_decimal_array)
+        }
+    }
+
+    #[test]
+    fn test_scan_records_delta_binary_packed_mandatory() {
+        use crate::util::test_common::page_util::{DataPageBuilder, DataPageBuilderImpl};
+
+        // Build a mandatory INT64 column schema.
+        let message_type = "
+            message test_schema {
+                REQUIRED INT64 col;
+            }
+        ";
+        let schema = parse_message_type(message_type)
+            .map(|t| Arc::new(SchemaDescriptor::new(Arc::new(t))))
+            .unwrap();
+        let column_desc = schema.column(0);
+
+        // 512 monotone values: 0, 1, 2, …, 511 (step=1, constant within each miniblock).
+        // DELTA_BINARY_PACKED uses miniblocks of 64 values for INT64.
+        // 512 values = 8 miniblocks.  The predicate selects lo >= 256, i.e. the upper 4.
+        let n: i64 = 512;
+        let values: Vec<i64> = (0..n).collect();
+
+        let mut pb = DataPageBuilderImpl::new(column_desc.clone(), n as u32, true);
+        pb.add_values::<Int64Type>(Encoding::DELTA_BINARY_PACKED, &values);
+        let page = pb.consume();
+
+        let page_lists = vec![vec![page]];
+        let page_iterator = InMemoryPageIterator::new(page_lists);
+
+        let mut array_reader = PrimitiveArrayReader::<Int64Type>::new(
+            Box::new(page_iterator),
+            column_desc,
+            None,
+            DEFAULT_BATCH_SIZE,
+        )
+        .unwrap();
+
+        // Predicate: keep miniblocks whose value range overlaps [257, ∞).
+        // INT64 miniblock_size=64, block_size=256.  Block 0 has 4 miniblocks:
+        //   mb0: lv=0,  hi=0+64=64   → 64  < 257 → skip
+        //   mb1: lv=64, hi=64+64=128  → 128 < 257 → skip
+        //   mb2: lv=128,hi=192        → skip
+        //   mb3: lv=192,hi=256        → 256 < 257 → skip (no false-positive here)
+        // Block 1 miniblocks all have hi ≥ 320 ≥ 257 → emit (values 257..511).
+        let predicate = |_lo: i64, hi: i64| hi >= 257;
+
+        let consumed = array_reader.scan_records(n as usize, &predicate).unwrap();
+        // scan_records returns number of rows *consumed* from the page (all 512).
+        assert_eq!(consumed, n as usize);
+
+        let array = array_reader.consume_batch().unwrap();
+        let array = array
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap();
+
+        // Block 0 (0..256) all skipped; block 1 emits values 257..511 = 255 values.
+        // (First value 0 is skipped as a point [0,0]; 256 is the last value of block 0.)
+        let expected: Vec<i64> = (257..512).collect();
+        assert_eq!(array.len(), expected.len(), "emitted count mismatch");
+        for (i, &v) in expected.iter().enumerate() {
+            assert_eq!(array.value(i), v, "mismatch at index {i}");
         }
     }
 

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -187,6 +187,25 @@ impl ArrayReader for StructArrayReader {
         }
     }
 
+    fn scan_records(
+        &mut self,
+        batch_size: usize,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<usize> {
+        // Miniblock-level predicate skipping requires all children to produce the same
+        // number of values.  For a single-child struct (a single-column projection) we
+        // can safely delegate — the predicate is applied to the one leaf and the struct
+        // assembles from whatever count that leaf emits.
+        //
+        // For multi-column structs the columns have independent value ranges so a shared
+        // predicate would cause mismatched output lengths; fall back to full decoding.
+        if self.children.len() == 1 {
+            self.children[0].scan_records(batch_size, predicate)
+        } else {
+            self.read_records(batch_size)
+        }
+    }
+
     fn skip_records(&mut self, num_records: usize) -> Result<usize> {
         let mut skipped = None;
         for child in self.children.iter_mut() {

--- a/parquet/src/arrow/arrow_reader/filter.rs
+++ b/parquet/src/arrow/arrow_reader/filter.rs
@@ -19,6 +19,37 @@ use crate::arrow::ProjectionMask;
 use arrow_array::{BooleanArray, RecordBatch};
 use arrow_schema::ArrowError;
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+/// A miniblock-level predicate for DELTA_BINARY_PACKED columns.
+///
+/// The predicate receives the conservative value range `[lo, hi]` for an entire
+/// miniblock (64 values for INT64, 32 for INT32) and returns `true` if ANY row
+/// in that miniblock could satisfy the caller's actual filter.  Returning `false`
+/// means the entire miniblock is skipped without decoding individual values.
+///
+/// **Conservatism**: the `[lo, hi]` bounds may be wider than the actual value
+/// range in the miniblock (they are never narrower), so the predicate must be
+/// monotone: if `predicate(lo, hi)` is `false` then every value `v ∈ [lo, hi]`
+/// must also fail the caller's real filter.  False positives (returning `true`
+/// when no row would pass) are safe — they cause unnecessary decoding but never
+/// omit rows that should be returned.
+///
+/// # Example — keep rows where `value >= 1_000_000`:
+/// ```rust
+/// use parquet::arrow::arrow_reader::MiniblockPredicate;
+/// use std::sync::Arc;
+/// let pred: MiniblockPredicate = Arc::new(|_lo, hi| hi >= 1_000_000);
+/// ```
+///
+/// # Limitations
+///
+/// * Only [`crate::basic::Encoding::DELTA_BINARY_PACKED`] mandatory (non-nullable,
+///   non-repeated) columns gain the miniblock-skip benefit.  All other encodings
+///   and column types fall back to decoding every value.
+/// * For multi-column projections the predicate is applied only when a single
+///   column is projected.  Multi-column reads fall back to full decoding.
+pub type MiniblockPredicate = Arc<dyn Fn(i64, i64) -> bool + Send + Sync>;
 
 /// A predicate operating on [`RecordBatch`]
 ///

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -21,7 +21,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, RecordBatch, RecordBatchReader};
 use arrow_schema::{ArrowError, DataType as ArrowType, FieldRef, Schema, SchemaRef};
 use arrow_select::filter::filter_record_batch;
-pub use filter::{ArrowPredicate, ArrowPredicateFn, RowFilter};
+pub use filter::{ArrowPredicate, ArrowPredicateFn, MiniblockPredicate, RowFilter};
 pub use selection::{RowSelection, RowSelectionCursor, RowSelectionPolicy, RowSelector};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
@@ -142,6 +142,8 @@ pub struct ArrowReaderBuilder<T> {
     pub(crate) metrics: ArrowReaderMetrics,
 
     pub(crate) max_predicate_cache_size: usize,
+
+    pub(crate) miniblock_predicate: Option<MiniblockPredicate>,
 }
 
 impl<T: Debug> Debug for ArrowReaderBuilder<T> {
@@ -160,6 +162,10 @@ impl<T: Debug> Debug for ArrowReaderBuilder<T> {
             .field("limit", &self.limit)
             .field("offset", &self.offset)
             .field("metrics", &self.metrics)
+            .field(
+                "miniblock_predicate",
+                &self.miniblock_predicate.as_ref().map(|_| "<predicate>"),
+            )
             .finish()
     }
 }
@@ -181,6 +187,7 @@ impl<T> ArrowReaderBuilder<T> {
             offset: None,
             metrics: ArrowReaderMetrics::Disabled,
             max_predicate_cache_size: 100 * 1024 * 1024, // 100MB default cache size
+            miniblock_predicate: None,
         }
     }
 
@@ -430,6 +437,38 @@ impl<T> ArrowReaderBuilder<T> {
     pub fn with_max_predicate_cache_size(self, max_predicate_cache_size: usize) -> Self {
         Self {
             max_predicate_cache_size,
+            ..self
+        }
+    }
+
+    /// Apply a miniblock-level predicate to enable sub-page predicate pushdown
+    /// on [`DELTA_BINARY_PACKED`] encoded mandatory columns.
+    ///
+    /// When set, the reader will call [`ArrayReader::scan_records`] instead of
+    /// [`ArrayReader::read_records`] in the inner read loop.  For mandatory INT32
+    /// or INT64 columns encoded with `DELTA_BINARY_PACKED`, entire miniblocks
+    /// (32 / 64 values respectively) are skipped without decoding if
+    /// `predicate(lo, hi)` returns `false` for that miniblock's conservative
+    /// value range.
+    ///
+    /// All other encodings and optional/repeated columns automatically fall back
+    /// to full decoding — no correctness risk, only a potential speedup is
+    /// foregone.
+    ///
+    /// # Single-column projections
+    ///
+    /// The benefit is greatest when a single column is projected (via
+    /// [`Self::with_projection`]).  For multi-column projections the predicate
+    /// is currently forwarded only when the top-level struct has exactly one
+    /// child (i.e. the projection mask selects a single leaf column); otherwise
+    /// it is silently ignored.
+    ///
+    /// See [`MiniblockPredicate`] for the exact predicate contract.
+    ///
+    /// [`DELTA_BINARY_PACKED`]: crate::basic::Encoding::DELTA_BINARY_PACKED
+    pub fn with_miniblock_predicate(self, predicate: MiniblockPredicate) -> Self {
+        Self {
+            miniblock_predicate: Some(predicate),
             ..self
         }
     }
@@ -1191,6 +1230,7 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             metrics,
             // Not used for the sync reader, see https://github.com/apache/arrow-rs/issues/8000
             max_predicate_cache_size: _,
+            miniblock_predicate,
         } = self;
 
         // Try to avoid allocate large buffer
@@ -1240,7 +1280,11 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             .build_limited()
             .build();
 
-        Ok(ParquetRecordBatchReader::new(array_reader, read_plan))
+        Ok(ParquetRecordBatchReader::new(
+            array_reader,
+            read_plan,
+            miniblock_predicate,
+        ))
     }
 }
 
@@ -1342,6 +1386,7 @@ pub struct ParquetRecordBatchReader {
     array_reader: Box<dyn ArrayReader>,
     schema: SchemaRef,
     read_plan: ReadPlan,
+    miniblock_predicate: Option<MiniblockPredicate>,
 }
 
 impl Debug for ParquetRecordBatchReader {
@@ -1486,9 +1531,15 @@ impl ParquetRecordBatchReader {
                     };
                 }
             }
-            RowSelectionCursor::All => {
-                self.array_reader.read_records(batch_size)?;
-            }
+            RowSelectionCursor::All => match &self.miniblock_predicate {
+                Some(pred) => {
+                    let pred = pred.clone();
+                    self.array_reader.scan_records(batch_size, pred.as_ref())?;
+                }
+                None => {
+                    self.array_reader.read_records(batch_size)?;
+                }
+            },
         };
 
         let array = self.array_reader.consume_batch()?;
@@ -1549,13 +1600,18 @@ impl ParquetRecordBatchReader {
             array_reader,
             schema: Arc::new(Schema::new(levels.fields.clone())),
             read_plan,
+            miniblock_predicate: None,
         })
     }
 
     /// Create a new [`ParquetRecordBatchReader`] that will read at most `batch_size` rows at
     /// a time from [`ArrayReader`] based on the configured `selection`. If `selection` is `None`
     /// all rows will be returned
-    pub(crate) fn new(array_reader: Box<dyn ArrayReader>, read_plan: ReadPlan) -> Self {
+    pub(crate) fn new(
+        array_reader: Box<dyn ArrayReader>,
+        read_plan: ReadPlan,
+        miniblock_predicate: Option<MiniblockPredicate>,
+    ) -> Self {
         let schema = match array_reader.get_data_type() {
             ArrowType::Struct(fields) => Schema::new(fields.clone()),
             _ => unreachable!("Struct array reader's data type is not struct!"),
@@ -1565,6 +1621,7 @@ impl ParquetRecordBatchReader {
             array_reader,
             schema: Arc::new(schema),
             read_plan,
+            miniblock_predicate,
         }
     }
 
@@ -1589,8 +1646,9 @@ pub(crate) mod tests {
     use tempfile::tempfile;
 
     use crate::arrow::arrow_reader::{
-        ArrowPredicateFn, ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReader,
-        ParquetRecordBatchReaderBuilder, RowFilter, RowSelection, RowSelector,
+        ArrowPredicateFn, ArrowReaderMetadata, ArrowReaderOptions, MiniblockPredicate,
+        ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder, RowFilter, RowSelection,
+        RowSelector,
     };
     use crate::arrow::schema::{
         add_encoded_arrow_schema_to_metadata,
@@ -5804,6 +5862,101 @@ pub(crate) mod tests {
                 .map(|number| number.map(|number| number + 1))
                 .collect::<Vec<_>>(),
             values
+        );
+    }
+
+    /// Verify that `with_miniblock_predicate` skips miniblocks in a single-column
+    /// DELTA_BINARY_PACKED mandatory INT64 file and that no false negatives occur.
+    #[test]
+    fn test_with_miniblock_predicate_single_column() {
+        // Write 2 batches of monotone INT64 values with DELTA_BINARY_PACKED encoding.
+        // Batch 0: 0..512  (block 0: values 0..255, block 1: values 256..511)
+        // Batch 1: 512..1024
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "v",
+            ArrowDataType::Int64,
+            false,
+        )]));
+        let props = WriterProperties::builder()
+            .set_dictionary_enabled(false)
+            .set_encoding(crate::basic::Encoding::DELTA_BINARY_PACKED)
+            .build();
+        let mut buf = Vec::<u8>::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buf, schema.clone(), Some(props)).expect("writer");
+
+        for chunk_start in [0i64, 512] {
+            let vals: Vec<i64> = (chunk_start..chunk_start + 512).collect();
+            let batch =
+                RecordBatch::try_from_iter([("v", Arc::new(Int64Array::from(vals)) as _)]).unwrap();
+            writer.write(&batch).unwrap();
+        }
+        writer.close().unwrap();
+
+        let file = Bytes::from(buf);
+
+        // Read back with a miniblock predicate that keeps only values >= 768.
+        // With INT64 miniblock_size=64 and block_size=256:
+        // The threshold 768 = 512 + 256 = batch-1 + 1 block, so it aligns cleanly.
+        let pred: MiniblockPredicate = Arc::new(|_lo, hi| hi >= 768);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file.clone())
+            .unwrap()
+            .with_miniblock_predicate(pred)
+            .build()
+            .unwrap();
+
+        let batches: Vec<RecordBatch> = reader.map(|b| b.unwrap()).collect();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+        // All 1024 rows decoded without predicate for reference.
+        let reader_all = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let all_batches: Vec<RecordBatch> = reader_all.map(|b| b.unwrap()).collect();
+        let all_vals: Vec<i64> = all_batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+
+        // No false negatives: every value >= 768 must appear in the filtered output.
+        let filtered_vals: Vec<i64> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+
+        let expected_vals: Vec<i64> = all_vals.iter().copied().filter(|&v| v >= 768).collect();
+        for &expected in &expected_vals {
+            assert!(
+                filtered_vals.contains(&expected),
+                "false negative: value {expected} missing from miniblock-filtered output"
+            );
+        }
+
+        // The filtered output should be strictly smaller than the full read.
+        assert!(
+            total_rows < 1024,
+            "expected fewer rows with predicate, got {total_rows}"
+        );
+        assert!(
+            total_rows > 0,
+            "expected some rows to pass predicate, got 0"
         );
     }
 

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -148,7 +148,7 @@ impl ReadPlanBuilder {
         array_reader: Box<dyn ArrayReader>,
         predicate: &mut dyn ArrowPredicate,
     ) -> Result<Self> {
-        let reader = ParquetRecordBatchReader::new(array_reader, self.clone().build());
+        let reader = ParquetRecordBatchReader::new(array_reader, self.clone().build(), None);
         let mut filters = vec![];
         for maybe_batch in reader {
             let maybe_batch = maybe_batch?;

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -497,6 +497,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            miniblock_predicate,
         } = self;
 
         // Ensure schema of ParquetRecordBatchStream respects projection, and does
@@ -522,6 +523,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            miniblock_predicate,
         }
         .build()?;
 

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -176,6 +176,7 @@ impl ParquetPushDecoderBuilder {
             metrics,
             row_selection_policy,
             max_predicate_cache_size,
+            miniblock_predicate,
         } = self;
 
         // If no row groups were specified, read all of them
@@ -197,6 +198,7 @@ impl ParquetPushDecoderBuilder {
             max_predicate_cache_size,
             buffers,
             row_selection_policy,
+            miniblock_predicate,
         );
 
         // Initialize the decoder with the configured options

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -24,7 +24,8 @@ use crate::arrow::array_reader::{ArrayReaderBuilder, CacheOptions, RowGroupCache
 use crate::arrow::arrow_reader::metrics::ArrowReaderMetrics;
 use crate::arrow::arrow_reader::selection::RowSelectionStrategy;
 use crate::arrow::arrow_reader::{
-    ParquetRecordBatchReader, ReadPlanBuilder, RowFilter, RowSelection, RowSelectionPolicy,
+    MiniblockPredicate, ParquetRecordBatchReader, ReadPlanBuilder, RowFilter, RowSelection,
+    RowSelectionPolicy,
 };
 use crate::arrow::in_memory_row_group::ColumnChunkData;
 use crate::arrow::push_decoder::reader_builder::data::DataRequestBuilder;
@@ -126,7 +127,6 @@ impl NextState {
 /// This struct drives the main state machine for decoding each row group -- it
 /// determines what data is needed, and then assembles the
 /// `ParquetRecordBatchReader` when all data is available.
-#[derive(Debug)]
 pub(crate) struct RowGroupReaderBuilder {
     /// The output batch size
     batch_size: usize,
@@ -142,6 +142,9 @@ pub(crate) struct RowGroupReaderBuilder {
 
     /// Optional filter
     filter: Option<RowFilter>,
+
+    /// Optional miniblock predicate for sub-page predicate pushdown
+    miniblock_predicate: Option<MiniblockPredicate>,
 
     /// Limit to apply to remaining row groups (decremented as rows are read)
     limit: Option<usize>,
@@ -170,6 +173,29 @@ pub(crate) struct RowGroupReaderBuilder {
     buffers: PushBuffers,
 }
 
+impl std::fmt::Debug for RowGroupReaderBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RowGroupReaderBuilder")
+            .field("batch_size", &self.batch_size)
+            .field("projection", &self.projection)
+            .field("metadata", &self.metadata)
+            .field("fields", &self.fields)
+            .field("filter", &self.filter)
+            .field("limit", &self.limit)
+            .field("offset", &self.offset)
+            .field("metrics", &self.metrics)
+            .field("max_predicate_cache_size", &self.max_predicate_cache_size)
+            .field("row_selection_policy", &self.row_selection_policy)
+            .field(
+                "miniblock_predicate",
+                &self.miniblock_predicate.as_ref().map(|_| "<predicate>"),
+            )
+            .field("state", &self.state)
+            .field("buffers", &self.buffers)
+            .finish()
+    }
+}
+
 impl RowGroupReaderBuilder {
     /// Create a new RowGroupReaderBuilder
     #[expect(clippy::too_many_arguments)]
@@ -185,6 +211,7 @@ impl RowGroupReaderBuilder {
         max_predicate_cache_size: usize,
         buffers: PushBuffers,
         row_selection_policy: RowSelectionPolicy,
+        miniblock_predicate: Option<MiniblockPredicate>,
     ) -> Self {
         Self {
             batch_size,
@@ -197,6 +224,7 @@ impl RowGroupReaderBuilder {
             metrics,
             max_predicate_cache_size,
             row_selection_policy,
+            miniblock_predicate,
             state: Some(RowGroupDecoderState::Finished),
             buffers,
         }
@@ -627,7 +655,11 @@ impl RowGroupReaderBuilder {
                         .build_array_reader(self.fields.as_deref(), &self.projection)
                 }?;
 
-                let reader = ParquetRecordBatchReader::new(array_reader, plan);
+                let reader = ParquetRecordBatchReader::new(
+                    array_reader,
+                    plan,
+                    self.miniblock_predicate.clone(),
+                );
                 NextState::result(RowGroupDecoderState::Finished, DecodeResult::Data(reader))
             }
             RowGroupDecoderState::Finished => {

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -148,6 +148,44 @@ where
         }
     }
 
+    /// Scan up to `num_records` records, writing to the internal buffer only those
+    /// values from miniblock regions where `predicate(lo, hi)` returns `true`.
+    ///
+    /// Only supported for mandatory (non-nullable, non-repeated) columns.  For
+    /// optional/repeated columns this falls back to [`Self::read_records`], which
+    /// decodes everything and ignores the predicate.
+    ///
+    /// Returns `(records_consumed, values_emitted)`.
+    pub fn scan_filtered_records(
+        &mut self,
+        num_records: usize,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)> {
+        let Some(reader) = self.column_reader.as_mut() else {
+            return Ok((0, 0));
+        };
+
+        // Optional/repeated columns: def/rep levels are separate from values.
+        // Skipping miniblock values would desync them from the null bitmap.
+        // Fall back to full decode; predicate is handled by the caller.
+        if self.def_levels.is_some() || self.rep_levels.is_some() {
+            let read = self.read_records(num_records)?;
+            return Ok((read, read));
+        }
+
+        let capacity_hint = self.capacity_hint;
+        let values = self
+            .values
+            .get_or_insert_with(|| V::with_capacity(capacity_hint));
+
+        let (consumed, emitted) = reader.scan_filtered_records(num_records, values, predicate)?;
+
+        self.num_records += consumed;
+        self.num_values += emitted;
+
+        Ok((consumed, emitted))
+    }
+
     /// Returns number of records stored in buffer.
     #[allow(unused)]
     pub fn num_records(&self) -> usize {

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -381,6 +381,52 @@ where
         Ok(num_records - remaining_records)
     }
 
+    /// Scan up to `max_records` records, emitting to `values` only those from miniblock
+    /// regions where `predicate(lo, hi)` returns `true`.
+    ///
+    /// This is only supported for **mandatory** (non-nullable, non-repeated) columns.
+    /// Returns an error if the column has definition or repetition levels — the caller
+    /// should fall back to [`Self::read_records`] for optional/repeated columns.
+    ///
+    /// Returns `(records_consumed, values_emitted)`.  `records_consumed` equals the
+    /// number of rows advanced in the page; `values_emitted` is the subset written to
+    /// `values` (≤ `records_consumed`).
+    pub fn scan_filtered_records(
+        &mut self,
+        max_records: usize,
+        values: &mut V::Buffer,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)>
+    where
+        V: ColumnValueDecoder,
+    {
+        if self.def_level_decoder.is_some() || self.rep_level_decoder.is_some() {
+            return Err(general_err!(
+                "scan_filtered_records is only supported for mandatory (non-nullable, \
+                 non-repeated) columns; use read_records for optional/repeated columns"
+            ));
+        }
+
+        let mut total_consumed = 0;
+        let mut total_emitted = 0;
+
+        while total_consumed < max_records && self.has_next()? {
+            let remaining = max_records - total_consumed;
+            let available = self.num_buffered_values - self.num_decoded_values;
+            let to_scan = remaining.min(available);
+
+            let (emitted, consumed) = self
+                .values_decoder
+                .scan_filtered_values(to_scan, values, predicate)?;
+
+            self.num_decoded_values += consumed;
+            total_consumed += consumed;
+            total_emitted += emitted;
+        }
+
+        Ok((total_consumed, total_emitted))
+    }
+
     /// Read the next page as a dictionary page. If the next page is not a dictionary page,
     /// this will return an error.
     fn read_dictionary_page(&mut self) -> Result<()> {

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -132,6 +132,31 @@ pub trait ColumnValueDecoder {
     ///
     /// Returns the number of values skipped
     fn skip_values(&mut self, num_values: usize) -> Result<usize>;
+
+    /// Scan up to `num_values` values, appending to `out` only those from
+    /// miniblock regions where `predicate(lo, hi)` returns `true`.
+    ///
+    /// `predicate` receives the inclusive value range `[lo, hi]` for a region
+    /// and returns `true` if it could contain a matching value.  Returning
+    /// `true` for a non-matching region is safe (produces false positives that
+    /// the caller filters); returning `false` for a matching region would drop
+    /// values, so implementations must be conservative.
+    ///
+    /// Returns `(values_emitted, values_consumed)`.
+    ///
+    /// The default implementation ignores the predicate and decodes everything,
+    /// which is safe for all encodings.  [`crate::basic::Encoding::DELTA_BINARY_PACKED`]
+    /// overrides this to skip non-matching miniblocks in O(1).
+    fn scan_filtered_values(
+        &mut self,
+        num_values: usize,
+        out: &mut Self::Buffer,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)> {
+        let _ = predicate;
+        let read = self.read(out, num_values)?;
+        Ok((read, read))
+    }
 }
 
 /// Bucket-based storage for decoder instances keyed by `Encoding`.
@@ -255,6 +280,23 @@ impl<T: DataType> ColumnValueDecoder for ColumnValueDecoderImpl<T> {
             .unwrap_or_else(|| panic!("decoder for encoding {encoding} should be set"));
 
         current_decoder.skip(num_values)
+    }
+
+    fn scan_filtered_values(
+        &mut self,
+        num_values: usize,
+        out: &mut Self::Buffer,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)> {
+        let encoding = self
+            .current_encoding
+            .expect("current_encoding should be set");
+
+        let current_decoder = self.decoders[encoding as usize]
+            .as_mut()
+            .unwrap_or_else(|| panic!("decoder for encoding {encoding} should be set"));
+
+        current_decoder.scan_filtered(num_values, out, predicate)
     }
 }
 

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -882,9 +882,9 @@ where
             self.values_left -= 1;
         }
 
-        // Terminal skip: caller is discarding all remaining values on this page.
-        // last_value will never be read again, so we can use O(1) arithmetic
-        // skips (BitReader::skip) instead of decoding through get_batch.
+        // Terminal skip: caller discards all remaining values on this page.
+        // last_value is not needed again, so we can use O(1) arithmetic skips
+        // (BitReader::skip) instead of decoding through get_batch.
         let terminal = to_skip >= self.values_left + skip;
 
         if terminal {
@@ -895,7 +895,7 @@ where
                 let bit_width = self.mini_block_bit_widths[self.mini_block_idx] as usize;
                 self.check_bit_width(bit_width)?;
                 let n = self.mini_block_remaining.min(to_skip - skip);
-                // bit_width=0 produces a no-op here (correct: 0-byte payloads)
+                // bit_width=0 is a no-op here (correct: 0-byte payloads).
                 self.bit_reader.skip(n, bit_width);
                 skip += n;
                 self.mini_block_remaining -= n;
@@ -904,8 +904,7 @@ where
             return Ok(to_skip);
         }
 
-        // Non-terminal skip: last_value must be exact so subsequent get() calls
-        // produce correct absolute values.
+        // Non-terminal: last_value must be exact for subsequent get() calls.
         let mini_block_batch_size = match T::T::PHYSICAL_TYPE {
             Type::INT32 => 32,
             Type::INT64 => 64,
@@ -922,13 +921,12 @@ where
             self.check_bit_width(bit_width)?;
             let mini_block_to_skip = self.mini_block_remaining.min(to_skip - skip);
 
-            let min_delta = self.min_delta.as_i64()?;
             if bit_width == 0 {
                 // All remainders are zero: every delta equals min_delta exactly.
                 // Advance last_value by n * min_delta with no bit reads.
+                let min_delta = self.min_delta.as_i64()?;
                 if min_delta != 0 {
-                    let total =
-                        min_delta.wrapping_mul(mini_block_to_skip as i64);
+                    let total = min_delta.wrapping_mul(mini_block_to_skip as i64);
                     let step = T::T::from_i64(total)
                         .ok_or_else(|| general_err!("delta*n overflow in skip"))?;
                     self.last_value = self.last_value.wrapping_add(&step);
@@ -948,6 +946,7 @@ where
                     ));
                 }
 
+                let min_delta = self.min_delta.as_i64()?;
                 if min_delta == 0 {
                     for v in &mut skip_buffer[0..skip_count] {
                         *v = v.wrapping_add(&self.last_value);
@@ -1027,9 +1026,7 @@ where
             let ni = n as i64;
             let lv = self.last_value.as_i64()?;
             let lo = lv.saturating_add(ni.saturating_mul(min_delta.min(0)));
-            let hi = lv.saturating_add(
-                ni.saturating_mul(min_delta.saturating_add(max_rem).max(0)),
-            );
+            let hi = lv.saturating_add(ni.saturating_mul(min_delta.saturating_add(max_rem).max(0)));
 
             if !predicate(lo, hi) {
                 // This miniblock cannot satisfy the predicate — skip it.
@@ -2530,9 +2527,7 @@ mod tests {
         let bytes = encoder.flush_buffer().expect("ok to flush");
 
         let mut decoder = get_decoder::<T>(col_descr, encoding).expect("get decoder");
-        decoder
-            .set_data(bytes, data.len())
-            .expect("ok to set data");
+        decoder.set_data(bytes, data.len()).expect("ok to set data");
 
         let mut out = Vec::new();
         let (emitted, consumed) = decoder
@@ -2596,11 +2591,10 @@ mod tests {
     #[test]
     fn test_scan_filtered_delta_conservative_overlap() {
         let data: Vec<i32> = (0..64).collect();
-        let (out, emitted, consumed) = test_scan_filtered::<Int32Type>(
-            &data,
-            Encoding::DELTA_BINARY_PACKED,
-            &|_lo, hi| hi >= 32,
-        );
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::DELTA_BINARY_PACKED, &|_lo, hi| {
+                hi >= 32
+            });
         assert_eq!(consumed, 64);
         assert_eq!(emitted, 63); // value 0 rejected at first_value point check
         assert_eq!(out, data[1..].to_vec());

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -236,6 +236,41 @@ pub trait Decoder<T: DataType>: Send {
 
     /// Skip the specified number of values in this decoder stream.
     fn skip(&mut self, num_values: usize) -> Result<usize>;
+
+    /// Scan up to `num_values`, appending to `out` only values from regions
+    /// where `predicate(lo, hi)` returns `true`.
+    ///
+    /// `predicate` receives the inclusive value range `[lo, hi]` for a
+    /// region (e.g. a miniblock) and returns `true` if that region could
+    /// contain a matching value.  Returning `true` for a region that does
+    /// not actually match is safe — it produces false positives that the
+    /// caller filters row-by-row.  Returning `false` for a region that
+    /// does match would silently drop values, so implementations must be
+    /// conservative.
+    ///
+    /// Returns `(values_emitted, values_consumed)`.  `values_consumed` is
+    /// the number of logical positions advanced in the stream (always <=
+    /// `num_values`); `values_emitted` is how many were appended to `out`
+    /// (always <= `values_consumed`).
+    ///
+    /// The default implementation cannot inspect region ranges, so it
+    /// decodes everything (predicate is effectively ignored, all values
+    /// are emitted).  Encodings that carry per-region metadata — such as
+    /// `DELTA_BINARY_PACKED` with its per-miniblock bit-width headers —
+    /// should override this to skip non-matching regions in O(1).
+    fn scan_filtered(
+        &mut self,
+        num_values: usize,
+        out: &mut Vec<T::T>,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)> {
+        let _ = predicate; // conservative default: can't check ranges
+        let start = out.len();
+        out.resize(start + num_values, T::T::default());
+        let emitted = self.get(&mut out[start..])?;
+        out.truncate(start + emitted);
+        Ok((emitted, emitted))
+    }
 }
 
 /// Gets a decoder for the column descriptor `descr` and encoding type `encoding`.
@@ -847,6 +882,30 @@ where
             self.values_left -= 1;
         }
 
+        // Terminal skip: caller is discarding all remaining values on this page.
+        // last_value will never be read again, so we can use O(1) arithmetic
+        // skips (BitReader::skip) instead of decoding through get_batch.
+        let terminal = to_skip >= self.values_left + skip;
+
+        if terminal {
+            while skip < to_skip {
+                if self.mini_block_remaining == 0 {
+                    self.next_mini_block()?;
+                }
+                let bit_width = self.mini_block_bit_widths[self.mini_block_idx] as usize;
+                self.check_bit_width(bit_width)?;
+                let n = self.mini_block_remaining.min(to_skip - skip);
+                // bit_width=0 produces a no-op here (correct: 0-byte payloads)
+                self.bit_reader.skip(n, bit_width);
+                skip += n;
+                self.mini_block_remaining -= n;
+                self.values_left -= n;
+            }
+            return Ok(to_skip);
+        }
+
+        // Non-terminal skip: last_value must be exact so subsequent get() calls
+        // produce correct absolute values.
         let mini_block_batch_size = match T::T::PHYSICAL_TYPE {
             Type::INT32 => 32,
             Type::INT64 => 64,
@@ -862,55 +921,191 @@ where
             let bit_width = self.mini_block_bit_widths[self.mini_block_idx] as usize;
             self.check_bit_width(bit_width)?;
             let mini_block_to_skip = self.mini_block_remaining.min(to_skip - skip);
-            let mini_block_should_skip = mini_block_to_skip;
 
-            let skip_count = self
-                .bit_reader
-                .get_batch(&mut skip_buffer[0..mini_block_to_skip], bit_width);
-
-            if skip_count != mini_block_to_skip {
-                return Err(general_err!(
-                    "Expected to skip {} values from mini block got {}.",
-                    mini_block_batch_size,
-                    skip_count
-                ));
-            }
-
-            // see commentary in self.get() above regarding optimizations
             let min_delta = self.min_delta.as_i64()?;
             if bit_width == 0 {
-                // if min_delta == 0, there's nothing to do. self.last_value is unchanged
+                // All remainders are zero: every delta equals min_delta exactly.
+                // Advance last_value by n * min_delta with no bit reads.
                 if min_delta != 0 {
-                    let mut delta = self.min_delta;
-                    for v in &mut skip_buffer[0..skip_count] {
-                        *v = self.last_value.wrapping_add(&delta);
-                        delta = delta.wrapping_add(&self.min_delta);
-                    }
-
-                    self.last_value = skip_buffer[skip_count - 1];
+                    let total =
+                        min_delta.wrapping_mul(mini_block_to_skip as i64);
+                    let step = T::T::from_i64(total)
+                        .ok_or_else(|| general_err!("delta*n overflow in skip"))?;
+                    self.last_value = self.last_value.wrapping_add(&step);
                 }
-            } else if min_delta == 0 {
-                for v in &mut skip_buffer[0..skip_count] {
-                    *v = v.wrapping_add(&self.last_value);
-
-                    self.last_value = *v;
-                }
+                // bit_width=0 payloads occupy zero bytes; no bit_reader advancement needed.
             } else {
-                for v in &mut skip_buffer[0..skip_count] {
-                    *v = v
-                        .wrapping_add(&self.min_delta)
-                        .wrapping_add(&self.last_value);
+                // bw>0: must decode to track last_value for subsequent get() calls.
+                let skip_count = self
+                    .bit_reader
+                    .get_batch(&mut skip_buffer[0..mini_block_to_skip], bit_width);
 
-                    self.last_value = *v;
+                if skip_count != mini_block_to_skip {
+                    return Err(general_err!(
+                        "Expected to skip {} values from mini block got {}.",
+                        mini_block_to_skip,
+                        skip_count
+                    ));
+                }
+
+                if min_delta == 0 {
+                    for v in &mut skip_buffer[0..skip_count] {
+                        *v = v.wrapping_add(&self.last_value);
+                        self.last_value = *v;
+                    }
+                } else {
+                    for v in &mut skip_buffer[0..skip_count] {
+                        *v = v
+                            .wrapping_add(&self.min_delta)
+                            .wrapping_add(&self.last_value);
+                        self.last_value = *v;
+                    }
                 }
             }
 
-            skip += mini_block_should_skip;
-            self.mini_block_remaining -= mini_block_should_skip;
-            self.values_left -= mini_block_should_skip;
+            skip += mini_block_to_skip;
+            self.mini_block_remaining -= mini_block_to_skip;
+            self.values_left -= mini_block_to_skip;
         }
 
         Ok(to_skip)
+    }
+
+    fn scan_filtered(
+        &mut self,
+        num_values: usize,
+        out: &mut Vec<T::T>,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> Result<(usize, usize)> {
+        assert!(self.initialized, "Bit reader is not initialized");
+
+        let mut emitted = 0usize;
+        let mut consumed = 0usize;
+        let to_scan = num_values.min(self.values_left);
+
+        if to_scan == 0 {
+            return Ok((0, 0));
+        }
+
+        // The first value is stored as an absolute in the page header (not delta-encoded).
+        // Check it as a single-point range [v, v].
+        if let Some(value) = self.first_value.take() {
+            self.last_value = value;
+            let lv = self.last_value.as_i64()?;
+            if predicate(lv, lv) {
+                out.push(value);
+                emitted += 1;
+            }
+            consumed += 1;
+            self.values_left -= 1;
+        }
+
+        // Scratch buffer for non-emitting decodes (bw>0 predicate misses mid-stream).
+        let mut scratch = Vec::<T::T>::new();
+
+        while consumed < to_scan {
+            if self.mini_block_remaining == 0 {
+                self.next_mini_block()?;
+            }
+
+            let bw = self.mini_block_bit_widths[self.mini_block_idx] as usize;
+            self.check_bit_width(bw)?;
+            let n = self.mini_block_remaining.min(to_scan - consumed);
+            let min_delta = self.min_delta.as_i64()?;
+
+            // Conservative range for the n values that follow last_value:
+            //   each step adds (min_delta + remainder), remainder ∈ [0, max_rem]
+            //   worst-case lo: n steps at min_delta, remainder=0
+            //   worst-case hi: n steps at min_delta+max_rem
+            let max_rem: i64 = if bw == 0 {
+                0
+            } else if bw >= 63 {
+                i64::MAX
+            } else {
+                (1i64 << bw) - 1
+            };
+            let ni = n as i64;
+            let lv = self.last_value.as_i64()?;
+            let lo = lv.saturating_add(ni.saturating_mul(min_delta.min(0)));
+            let hi = lv.saturating_add(
+                ni.saturating_mul(min_delta.saturating_add(max_rem).max(0)),
+            );
+
+            if !predicate(lo, hi) {
+                // This miniblock cannot satisfy the predicate — skip it.
+                if bw == 0 {
+                    // Zero-byte payload: advance last_value arithmetically, no reads.
+                    if min_delta != 0 {
+                        let total = min_delta.wrapping_mul(ni);
+                        let step = T::T::from_i64(total)
+                            .ok_or_else(|| general_err!("delta*n overflow in scan_filtered"))?;
+                        self.last_value = self.last_value.wrapping_add(&step);
+                    }
+                } else if consumed + n >= to_scan {
+                    // Last miniblock of this scan call — last_value won't be used again
+                    // within this call, so skip bits without decoding.
+                    self.bit_reader.skip(n, bw);
+                } else {
+                    // Mid-stream bw>0 miss: must decode to keep last_value exact for
+                    // the subsequent predicate range checks in this same scan call.
+                    scratch.resize(n, T::T::default());
+                    let got = self.bit_reader.get_batch(&mut scratch[..n], bw);
+                    if min_delta == 0 {
+                        for v in &scratch[..got] {
+                            self.last_value = v.wrapping_add(&self.last_value);
+                        }
+                    } else {
+                        for v in &scratch[..got] {
+                            self.last_value = v
+                                .wrapping_add(&self.min_delta)
+                                .wrapping_add(&self.last_value);
+                        }
+                    }
+                }
+            } else {
+                // Predicate may match — decode and emit all values in this miniblock.
+                // (Caller filters individual values if a finer predicate is needed.)
+                let start = out.len();
+                out.resize(start + n, T::T::default());
+                let got = self.bit_reader.get_batch(&mut out[start..start + n], bw);
+                out.truncate(start + got);
+
+                if bw == 0 {
+                    if min_delta == 0 {
+                        out[start..start + got].fill(self.last_value);
+                    } else {
+                        let mut delta = self.min_delta;
+                        for v in &mut out[start..start + got] {
+                            *v = self.last_value.wrapping_add(&delta);
+                            delta = delta.wrapping_add(&self.min_delta);
+                        }
+                        if got > 0 {
+                            self.last_value = out[start + got - 1];
+                        }
+                    }
+                } else if min_delta == 0 {
+                    for v in &mut out[start..start + got] {
+                        *v = v.wrapping_add(&self.last_value);
+                        self.last_value = *v;
+                    }
+                } else {
+                    for v in &mut out[start..start + got] {
+                        *v = v
+                            .wrapping_add(&self.min_delta)
+                            .wrapping_add(&self.last_value);
+                        self.last_value = *v;
+                    }
+                }
+
+                emitted += got;
+            }
+
+            consumed += n;
+            self.mini_block_remaining -= n;
+            self.values_left -= n;
+        }
+
+        Ok((emitted, consumed))
     }
 }
 
@@ -2316,5 +2511,124 @@ mod tests {
             "{}",
             err
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // scan_filtered tests
+    // -----------------------------------------------------------------------
+
+    /// Encode `data` with `encoding`, then call `scan_filtered` with `predicate`.
+    /// Returns `(out, emitted, consumed)`.
+    fn test_scan_filtered<T: DataType>(
+        data: &[T::T],
+        encoding: Encoding,
+        predicate: &dyn Fn(i64, i64) -> bool,
+    ) -> (Vec<T::T>, usize, usize) {
+        let col_descr = create_test_col_desc_ptr(-1, T::get_physical_type());
+        let mut encoder = get_encoder::<T>(encoding, &col_descr).expect("get encoder");
+        encoder.put(data).expect("ok to encode");
+        let bytes = encoder.flush_buffer().expect("ok to flush");
+
+        let mut decoder = get_decoder::<T>(col_descr, encoding).expect("get decoder");
+        decoder
+            .set_data(bytes, data.len())
+            .expect("ok to set data");
+
+        let mut out = Vec::new();
+        let (emitted, consumed) = decoder
+            .scan_filtered(data.len(), &mut out, predicate)
+            .expect("ok to scan_filtered");
+        (out, emitted, consumed)
+    }
+
+    /// Default provided impl (PLAIN encoding): predicate is ignored — all values emitted.
+    #[test]
+    fn test_scan_filtered_plain_default_always_true() {
+        let data: Vec<i32> = (1..=10).collect();
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::PLAIN, &|_, _| true);
+        assert_eq!(emitted, 10);
+        assert_eq!(consumed, 10);
+        assert_eq!(out, data);
+    }
+
+    /// Default provided impl: even with a reject-all predicate, all values are emitted
+    /// because the default cannot inspect region ranges.
+    #[test]
+    fn test_scan_filtered_plain_default_always_false() {
+        let data: Vec<i32> = (1..=10).collect();
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::PLAIN, &|_, _| false);
+        // Default implementation: predicate ignored, everything decoded
+        assert_eq!(emitted, 10);
+        assert_eq!(consumed, 10);
+        assert_eq!(out, data);
+    }
+
+    /// DeltaBitPackDecoder override: reject-all predicate emits nothing.
+    #[test]
+    fn test_scan_filtered_delta_reject_all() {
+        let data: Vec<i32> = (0..64).collect();
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::DELTA_BINARY_PACKED, &|_, _| false);
+        assert_eq!(emitted, 0);
+        assert_eq!(consumed, 64);
+        assert!(out.is_empty());
+    }
+
+    /// DeltaBitPackDecoder override: accept-all predicate emits everything (same as get).
+    #[test]
+    fn test_scan_filtered_delta_accept_all() {
+        let data: Vec<i32> = (0..64).collect();
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::DELTA_BINARY_PACKED, &|_, _| true);
+        assert_eq!(emitted, 64);
+        assert_eq!(consumed, 64);
+        assert_eq!(out, data);
+    }
+
+    /// DeltaBitPackDecoder override: predicate hi >= 32 on ascending 0..64.
+    ///
+    /// The first_value (0) is checked as a point [0,0] → rejected (0 < 32).
+    /// Miniblock 1 covers [1..=32], range check [0,32]: hi=32 >= 32 → accepted.
+    /// Miniblock 2 covers [33..=63], range [32,63]: hi=63 >= 32 → accepted.
+    /// Result: values 1..=63 emitted (63 values); 0 was correctly rejected at point check.
+    #[test]
+    fn test_scan_filtered_delta_conservative_overlap() {
+        let data: Vec<i32> = (0..64).collect();
+        let (out, emitted, consumed) = test_scan_filtered::<Int32Type>(
+            &data,
+            Encoding::DELTA_BINARY_PACKED,
+            &|_lo, hi| hi >= 32,
+        );
+        assert_eq!(consumed, 64);
+        assert_eq!(emitted, 63); // value 0 rejected at first_value point check
+        assert_eq!(out, data[1..].to_vec());
+    }
+
+    /// DeltaBitPackDecoder override: constant column (bw=0) — reject predicate skips O(1).
+    #[test]
+    fn test_scan_filtered_delta_bw0_reject() {
+        let data = vec![42i32; 64]; // constant → bw=0 miniblocks
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::DELTA_BINARY_PACKED, &|lo, hi| {
+                lo <= 99 && hi >= 100 // requires value >= 100; 42 is outside
+            });
+        assert_eq!(consumed, 64);
+        assert_eq!(emitted, 0);
+        assert!(out.is_empty());
+    }
+
+    /// DeltaBitPackDecoder override: constant column (bw=0) — accept predicate emits all.
+    #[test]
+    fn test_scan_filtered_delta_bw0_accept() {
+        let data = vec![42i32; 64];
+        let (out, emitted, consumed) =
+            test_scan_filtered::<Int32Type>(&data, Encoding::DELTA_BINARY_PACKED, &|lo, _hi| {
+                lo <= 42 // range includes 42
+            });
+        assert_eq!(consumed, 64);
+        assert_eq!(emitted, 64);
+        assert_eq!(out, data);
     }
 }


### PR DESCRIPTION
  Which issue does this PR close?

  Depends on #9788 (the decoder PR, currently open — diff includes those changes while that PR is pending). Note: original parent #9769 was closed and split; #9788 is the carry-forward replacement that adds Decoder::scan_filtered.
Please review after #9788 merges; this PR's diff includes those decoder changes while that PR is pending.

  Rationale for this change

  Exposes the scan_filtered miniblock-level predicate pushdown added in #9788 through the full column reader stack and as a public API. For mandatory DELTA_BINARY_PACKED
  INT32/INT64 columns, entire miniblocks (32/64 values) can be skipped without decoding when a caller-supplied range predicate rules them out. This is especially effective
  for monotone columns (timestamps, sequence numbers, auto-increment IDs) where bw=0 blocks allow O(1) skipping.

  What changes are included in this PR?

  Wiring chain (bottom to top):
  - ColumnValueDecoderImpl::scan_filtered_values() — dispatches to decoder
  - GenericColumnReader::scan_filtered_records() — mandatory columns only; optional/repeated fall back to full decode to keep def/rep levels in sync
  - GenericRecordReader::scan_filtered_records() — page-switching loop with same fallback
  - ArrayReader::scan_records() — new provided trait method (default = read_records, safe for all encodings/types)
  - PrimitiveArrayReader::scan_records() — override that calls the above chain
  - StructArrayReader::scan_records() — delegates to its single child for single-column projections; multi-column projections fall back to read_records
  - ParquetRecordBatchReader::next_inner — uses scan_records in the All selection branch when a predicate is set
  - ArrowReaderBuilder::with_miniblock_predicate() — fluent setter; works for both ParquetRecordBatchReaderBuilder (sync) and ParquetRecordBatchStreamBuilder (async)

  New public API:
  pub type MiniblockPredicate = Arc<dyn Fn(i64, i64) -> bool + Send + Sync>;

  // on ArrowReaderBuilder<T>:
  pub fn with_miniblock_predicate(self, predicate: MiniblockPredicate) -> Self;

  Example:
  let pred: MiniblockPredicate = Arc::new(|_lo, hi| hi >= 1_000_000);
  let reader = ParquetRecordBatchReaderBuilder::try_new(file)?
      .with_projection(mask)
      .with_miniblock_predicate(pred)
      .build()?;

  Limitations (documented in MiniblockPredicate rustdoc):
  - Multi-column projections fall back to full decode (each column has independent value ranges)
  - Optional/repeated columns fall back (def/rep level synchronization required)
  - No file format changes; miniblock ranges are computed on-the-fly from data already present in DELTA_BINARY_PACKED block headers

  Are these changes tested?

  - test_scan_records_delta_binary_packed_mandatory in primitive_array.rs: unit test exercising the full wiring chain on a mandatory INT64 DELTA column, verifying correct
  miniblock-level skipping and no false negatives
  - test_with_miniblock_predicate_single_column in arrow_reader/mod.rs: end-to-end test through ParquetRecordBatchReaderBuilder verifying the public API, correct output,
  and that fewer rows are returned than a full read

  Are there any user-facing changes?

  Yes — two additive public API items:
  - MiniblockPredicate type alias
  - ArrowReaderBuilder::with_miniblock_predicate() method

  No breaking changes. The new scan_records method on the ArrayReader trait has a provided default (read_records) so no existing implementations are affected.

