### PR TITLE
feat(ipc): Reduce redundant zero-initialization in IPC reader

### DIFF
--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -869,25 +869,11 @@ fn get_dictionary_values(
 }
 
 /// Reads the full data block (metadata + body) from the underlying reader.
-///
-/// Uses a zero-initialized buffer for small blocks. For larger blocks, reads
-/// into a temporary `Vec<u8>` and reuses the allocation when it is 64-byte
-/// aligned, matching Arrow's `ALIGNMENT` for `MutableBuffer`. Otherwise, it
-/// falls back to copying into an Arrow-aligned buffer.
-///
-/// This reduces redundant zero-initialization on large reads while preserving
-/// the alignment expected by Arrow buffers.
 fn read_block<R: Read + Seek>(mut reader: R, block: &Block) -> Result<Buffer, ArrowError> {
     reader.seek(SeekFrom::Start(block.offset() as u64))?;
     let body_len = block.bodyLength().to_usize().unwrap();
     let metadata_len = block.metaDataLength().to_usize().unwrap();
     let total_len = body_len.checked_add(metadata_len).unwrap();
-
-    if total_len < 8 * 1024 {
-        let mut buf = MutableBuffer::from_len_zeroed(total_len);
-        reader.read_exact(&mut buf)?;
-        return Ok(buf.into());
-    }
 
     let mut vec = Vec::with_capacity(total_len);
     reader
@@ -902,13 +888,7 @@ fn read_block<R: Read + Seek>(mut reader: R, block: &Block) -> Result<Buffer, Ar
         )));
     }
 
-    if ((vec.as_ptr() as usize) & 63) == 0 {
-        Ok(Buffer::from_vec(vec))
-    } else {
-        let mut buf = MutableBuffer::from_len_zeroed(total_len);
-        buf.copy_from_slice(&vec);
-        Ok(buf.into())
-    }
+    Ok(Buffer::from_vec(vec))
 }
 
 /// Parse an encapsulated message
@@ -1806,17 +1786,6 @@ impl<R: Read> MessageReader<R> {
         }
     }
 
-    /// Reads the entire next message from the underlying reader which includes
-    /// the metadata length, the metadata, and the body.
-    ///
-    /// Small message bodies use the zero-initialized buffer path. Larger bodies are
-    /// read into a temporary `Vec<u8>` and reused directly when the allocation is
-    /// 64-byte aligned, matching Arrow's `ALIGNMENT` for `MutableBuffer`. Otherwise,
-    /// the body is copied into an Arrow-aligned buffer.
-    ///
-    /// This avoids an extra initialization pass on large reads while preserving the
-    /// alignment expected by Arrow buffers.
-    ///
     /// # Returns
     /// - `Ok(None)` if the reader signals end-of-stream on the initial read
     /// - `Err(_)` if an error occurs or metadata is invalid
@@ -1826,44 +1795,30 @@ impl<R: Read> MessageReader<R> {
         let Some(meta_len) = meta_len else {
             return Ok(None);
         };
-
+    
         self.buf.resize(meta_len, 0);
         self.reader.read_exact(&mut self.buf)?;
-
+    
         let message = crate::root_as_message(self.buf.as_slice()).map_err(|err| {
             ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
         })?;
-
+    
         let body_len = message.bodyLength() as usize;
-
-        if body_len < 8 * 1024 {
-            let mut buf = MutableBuffer::from_len_zeroed(body_len);
-            self.reader.read_exact(&mut buf)?;
-            return Ok(Some((message, buf)));
-        }
-
+    
         let mut vec = Vec::with_capacity(body_len);
         self.reader
             .by_ref()
             .take(body_len as u64)
             .read_to_end(&mut vec)?;
-
+    
         if vec.len() != body_len {
             return Err(ArrowError::IpcError(format!(
                 "Expected IPC message body of length {body_len}, got {}",
                 vec.len()
             )));
         }
-
-        let buf = if ((vec.as_ptr() as usize) & 63) == 0 {
-            MutableBuffer::from(vec)
-        } else {
-            let mut buf = MutableBuffer::from_len_zeroed(body_len);
-            buf.copy_from_slice(&vec);
-            buf
-        };
-
-        Ok(Some((message, buf)))
+    
+        Ok(Some((message, MutableBuffer::from(vec))))
     }
 
     /// Get a mutable reference to the underlying reader.

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1795,29 +1795,29 @@ impl<R: Read> MessageReader<R> {
         let Some(meta_len) = meta_len else {
             return Ok(None);
         };
-    
+
         self.buf.resize(meta_len, 0);
         self.reader.read_exact(&mut self.buf)?;
-    
+
         let message = crate::root_as_message(self.buf.as_slice()).map_err(|err| {
             ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
         })?;
-    
+
         let body_len = message.bodyLength() as usize;
-    
+
         let mut vec = Vec::with_capacity(body_len);
         self.reader
             .by_ref()
             .take(body_len as u64)
             .read_to_end(&mut vec)?;
-    
+
         if vec.len() != body_len {
             return Err(ArrowError::IpcError(format!(
                 "Expected IPC message body of length {body_len}, got {}",
                 vec.len()
             )));
         }
-    
+
         Ok(Some((message, MutableBuffer::from(vec))))
     }
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -72,6 +72,21 @@ fn read_buffer(
         }
     }
 }
+
+/// Ensure the buffer is aligned for the element type `T`; otherwise copy into an aligned buffer.
+/// Needed for paths (e.g. Union) that convert directly to `ScalarBuffer<T>`.
+#[inline]
+fn ensure_aligned_for<T: ArrowNativeType>(buffer: Buffer) -> Buffer {
+    let align = std::mem::align_of::<T>();
+    if (buffer.as_ptr() as usize) & (align - 1) == 0 {
+        buffer
+    } else {
+        let mut aligned = MutableBuffer::from_len_zeroed(buffer.len());
+        aligned.copy_from_slice(buffer.as_slice());
+        aligned.into()
+    }
+}
+
 impl RecordBatchDecoder<'_> {
     /// Coordinates reading arrays based on data types.
     ///
@@ -211,8 +226,10 @@ impl RecordBatchDecoder<'_> {
 
                 let value_offsets = match mode {
                     UnionMode::Dense => {
-                        let offsets: ScalarBuffer<i32> =
-                            self.next_buffer()?.slice_with_length(0, len * 4).into();
+                        let offsets_buffer = ensure_aligned_for::<i32>(
+                            self.next_buffer()?.slice_with_length(0, len * 4),
+                        );
+                        let offsets: ScalarBuffer<i32> = offsets_buffer.into();
                         Some(offsets)
                     }
                     UnionMode::Sparse => None,

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -868,20 +868,47 @@ fn get_dictionary_values(
     Ok(dictionary_values)
 }
 
-/// Read the data for a given block
+/// Reads the full data block (metadata + body) from the underlying reader.
+///
+/// Uses a zero-initialized buffer for small blocks. For larger blocks, reads
+/// into a temporary `Vec<u8>` and reuses the allocation when it is 64-byte
+/// aligned, matching Arrow's `ALIGNMENT` for `MutableBuffer`. Otherwise, it
+/// falls back to copying into an Arrow-aligned buffer.
+///
+/// This reduces redundant zero-initialization on large reads while preserving
+/// the alignment expected by Arrow buffers.
 fn read_block<R: Read + Seek>(mut reader: R, block: &Block) -> Result<Buffer, ArrowError> {
     reader.seek(SeekFrom::Start(block.offset() as u64))?;
     let body_len = block.bodyLength().to_usize().unwrap();
     let metadata_len = block.metaDataLength().to_usize().unwrap();
     let total_len = body_len.checked_add(metadata_len).unwrap();
 
-    let mut buf = MutableBuffer::with_capacity(total_len);
-    // Buffer is immediately fully initialized by `read_exact` before any read occurs
-    // SAFETY: no future code must directly access the buffer contents between
-    // `set_len` and the successful completion of `read_exact`.
-    unsafe { buf.set_len(total_len) };
-    reader.read_exact(buf.as_slice_mut())?;
-    Ok(buf.into())
+    if total_len < 8 * 1024 {
+        let mut buf = MutableBuffer::from_len_zeroed(total_len);
+        reader.read_exact(&mut buf)?;
+        return Ok(buf.into());
+    }
+
+    let mut vec = Vec::with_capacity(total_len);
+    reader
+        .by_ref()
+        .take(total_len as u64)
+        .read_to_end(&mut vec)?;
+
+    if vec.len() != total_len {
+        return Err(ArrowError::IpcError(format!(
+            "Expected IPC block of length {total_len}, got {}",
+            vec.len()
+        )));
+    }
+
+    if ((vec.as_ptr() as usize) & 63) == 0 {
+        Ok(Buffer::from_vec(vec))
+    } else {
+        let mut buf = MutableBuffer::from_len_zeroed(total_len);
+        buf.copy_from_slice(&vec);
+        Ok(buf.into())
+    }
 }
 
 /// Parse an encapsulated message
@@ -1782,13 +1809,18 @@ impl<R: Read> MessageReader<R> {
     /// Reads the entire next message from the underlying reader which includes
     /// the metadata length, the metadata, and the body.
     ///
+    /// Small message bodies use the zero-initialized buffer path. Larger bodies are
+    /// read into a temporary `Vec<u8>` and reused directly when the allocation is
+    /// 64-byte aligned, matching Arrow's `ALIGNMENT` for `MutableBuffer`. Otherwise,
+    /// the body is copied into an Arrow-aligned buffer.
+    ///
+    /// This avoids an extra initialization pass on large reads while preserving the
+    /// alignment expected by Arrow buffers.
+    ///
     /// # Returns
-    /// - `Ok(None)` if the the reader signals the end of stream with EOF on
-    ///   the first read
-    /// - `Err(_)` if the reader returns an error other than on the first
-    ///   read, or if the metadata length is invalid
-    /// - `Ok(Some(_))` with the Message and buffer containiner the
-    ///   body bytes otherwise.
+    /// - `Ok(None)` if the reader signals end-of-stream on the initial read
+    /// - `Err(_)` if an error occurs or metadata is invalid
+    /// - `Ok(Some(_))` containing the parsed message and its body buffer
     fn maybe_next(&mut self) -> Result<Option<(Message::Message<'_>, MutableBuffer)>, ArrowError> {
         let meta_len = self.read_meta_len()?;
         let Some(meta_len) = meta_len else {
@@ -1803,12 +1835,34 @@ impl<R: Read> MessageReader<R> {
         })?;
 
         let body_len = message.bodyLength() as usize;
-        let mut buf = MutableBuffer::with_capacity(body_len);
-        // SAFETY: `set_len` exposes uninitialized bytes, but they are not read or observed.
-        // The buffer is immediately and fully initialized by `read_exact` before any access.
-        // No furture code must access `buf` between `set_len` and the successful return of `read_exact`.
-        unsafe { buf.set_len(body_len) };
-        self.reader.read_exact(buf.as_slice_mut())?;
+
+        if body_len < 8 * 1024 {
+            let mut buf = MutableBuffer::from_len_zeroed(body_len);
+            self.reader.read_exact(&mut buf)?;
+            return Ok(Some((message, buf)));
+        }
+
+        let mut vec = Vec::with_capacity(body_len);
+        self.reader
+            .by_ref()
+            .take(body_len as u64)
+            .read_to_end(&mut vec)?;
+
+        if vec.len() != body_len {
+            return Err(ArrowError::IpcError(format!(
+                "Expected IPC message body of length {body_len}, got {}",
+                vec.len()
+            )));
+        }
+
+        let buf = if ((vec.as_ptr() as usize) & 63) == 0 {
+            MutableBuffer::from(vec)
+        } else {
+            let mut buf = MutableBuffer::from_len_zeroed(body_len);
+            buf.copy_from_slice(&vec);
+            buf
+        };
+
         Ok(Some((message, buf)))
     }
 

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -875,8 +875,12 @@ fn read_block<R: Read + Seek>(mut reader: R, block: &Block) -> Result<Buffer, Ar
     let metadata_len = block.metaDataLength().to_usize().unwrap();
     let total_len = body_len.checked_add(metadata_len).unwrap();
 
-    let mut buf = MutableBuffer::from_len_zeroed(total_len);
-    reader.read_exact(&mut buf)?;
+    let mut buf = MutableBuffer::with_capacity(total_len);
+    // Buffer is immediately fully initialized by `read_exact` before any read occurs
+    // SAFETY: no future code must directly access the buffer contents between
+    // `set_len` and the successful completion of `read_exact`.
+    unsafe { buf.set_len(total_len) };
+    reader.read_exact(buf.as_slice_mut())?;
     Ok(buf.into())
 }
 
@@ -1798,9 +1802,13 @@ impl<R: Read> MessageReader<R> {
             ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
         })?;
 
-        let mut buf = MutableBuffer::from_len_zeroed(message.bodyLength() as usize);
-        self.reader.read_exact(&mut buf)?;
-
+        let body_len = message.bodyLength() as usize;
+        let mut buf = MutableBuffer::with_capacity(body_len);
+        // SAFETY: `set_len` exposes uninitialized bytes, but they are not read or observed.
+        // The buffer is immediately and fully initialized by `read_exact` before any access.
+        // No furture code must access `buf` between `set_len` and the successful return of `read_exact`.
+        unsafe { buf.set_len(body_len) };
+        self.reader.read_exact(buf.as_slice_mut())?;
         Ok(Some((message, buf)))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9777 .

# Rationale for this change

In `arrow-ipc/src/reader.rs`, buffers are currently allocated with `MutableBuffer::from_len_zeroed(len)` and then passed to `read_exact`, which fully overwrites the entire buffer contents.

This results in an unnecessary full memory pass for all data bytes:

* first zero-initialization
* then complete overwrite by the incoming data

Since `read_exact` guarantees that the provided slice is fully written on success, the initial zeroing step is redundant and can be safely avoided by allocating with capacity and setting the length before the read.


# What changes are included in this PR?
Use `Vec` and `read_exact` rather than `MutableBuffer` to avoid zerioning

### Rationale

# Are these changes tested?

Yes the changes were tested by CI and performance

# Are there any user-facing changes?

No, there are no changes made to any public api code.