### PR TITLE
docs(variant): link VariantArray doc to official Parquet Variant extension type

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -134,12 +134,11 @@ impl ExtensionType for VariantType {
 ///
 /// # Documentation
 ///
-/// At the time of this writing, Variant has been accepted as an official
-/// extension type but not been published to the [official list of extension
-/// types] on the Apache Arrow website. See the [Extension Type for Parquet
-/// Variant arrow] ticket for more details.
+/// Variant is documented as a canonical Arrow extension type in the
+/// [Parquet Variant] section of the [official list of extension types] on
+/// the Apache Arrow website.
 ///
-/// [Extension Type for Parquet Variant arrow]: https://github.com/apache/arrow/issues/46908
+/// [Parquet Variant]: https://arrow.apache.org/docs/format/CanonicalExtensions.html#parquet-variant
 /// [official list of extension types]: https://arrow.apache.org/docs/format/CanonicalExtensions.html
 ///
 /// # Example: Check if a [`StructArray`] has the [`VariantType`] extension


### PR DESCRIPTION
# Which issue does this PR close?

Closes none (doc-only follow-up to [apache/arrow#46908](https://github.com/apache/arrow/issues/46908), which was closed 2025-09-17 when the canonical extension type was published).

# Rationale for this change

The `VariantArray` struct-level doc comment currently states:

> At the time of this writing, Variant has been accepted as an official extension type but not been published to the official list of extension types on the Apache Arrow website.

That is no longer true: Parquet Variant is now documented as a canonical Arrow extension type under the [Parquet Variant](https://arrow.apache.org/docs/format/CanonicalExtensions.html#parquet-variant) section of [`CanonicalExtensions`](https://arrow.apache.org/docs/format/CanonicalExtensions.html). The rendered [rustdoc for `VariantArray`](https://arrow.apache.org/rust/parquet/variant/struct.VariantArray.html#documentation) is therefore stale.

# What changes are included in this PR?

Update the `# Documentation` section of the `VariantArray` rustdoc to link directly to the `#parquet-variant` anchor of the canonical extensions page, and drop the reference to the now-closed tracking issue.

# Are there any user-facing changes?

Documentation only — no API or behavior changes.