### PR TITLE
parquet: fix panic in DeltaByteArrayDecoder on invalid prefix lengths

### DIFF
--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1134,14 +1134,13 @@ impl<T: DataType> Decoder<T> for DeltaByteArrayDecoder<T> {
                     let suffix = v[0].data();
 
                     // Extract current prefix length, can be 0
-                    let prefix_len_i32 = self.prefix_lengths[self.current_idx];
-                    if prefix_len_i32 < 0 {
-                        return Err(general_err!(
-                            "Invalid DELTA_BYTE_ARRAY prefix length {}",
-                            prefix_len_i32
-                        ));
-                    }
-                    let prefix_len = prefix_len_i32 as usize;
+                    let prefix_len = usize::try_from(self.prefix_lengths[self.current_idx])
+                        .map_err(|_| {
+                            general_err!(
+                                "Invalid DELTA_BYTE_ARRAY prefix length {}",
+                                self.prefix_lengths[self.current_idx]
+                            )
+                        })?;
 
                     if prefix_len > self.previous_value.len() {
                         return Err(general_err!(
@@ -1241,6 +1240,32 @@ mod tests {
             .set_data(Bytes::from(corrupted), input.len())
             .unwrap();
 
+        let mut out = vec![ByteArray::new(); input.len()];
+
+        let err = decoder.get(&mut out).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Invalid DELTA_BYTE_ARRAY prefix length"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_delta_byte_array_negative_prefix_len_returns_error() {
+        let col_descr = create_test_col_desc_ptr(-1, Type::BYTE_ARRAY);
+
+        let mut encoder =
+            get_encoder::<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY, &col_descr).unwrap();
+        let input = vec![ByteArray::from("a"), ByteArray::from("ab")];
+        encoder.put(&input).unwrap();
+        let encoded = encoder.flush_buffer().unwrap();
+
+        let mut decoder = DeltaByteArrayDecoder::<ByteArrayType>::new();
+        decoder.set_data(encoded, input.len()).unwrap();
+
+        // Force a negative prefix length after decoder initialization
+        decoder.prefix_lengths[0] = -1;
         let mut out = vec![ByteArray::new(); input.len()];
 
         let err = decoder.get(&mut out).unwrap_err();

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1134,7 +1134,15 @@ impl<T: DataType> Decoder<T> for DeltaByteArrayDecoder<T> {
                     let suffix = v[0].data();
 
                     // Extract current prefix length, can be 0
-                    let prefix_len = self.prefix_lengths[self.current_idx] as usize;
+                    let prefix_len_i32 = self.prefix_lengths[self.current_idx];
+                    if prefix_len_i32 < 0 {
+                        return Err(general_err!("Invalid DELTA_BYTE_ARRAY prefix length {}", prefix_len_i32));
+                    }
+                    let prefix_len = prefix_len_i32 as usize;
+
+                    if prefix_len > self.previous_value.len() {
+                        return Err(general_err!("Invalid DELTA_BYTE_ARRAY prefix length {} exceeds previous value length {}", prefix_len, self.previous_value.len()));
+                    }
 
                     // Concatenate prefix with suffix
                     let mut result = Vec::with_capacity(prefix_len + suffix.len());
@@ -1181,6 +1189,47 @@ mod tests {
 
     use crate::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type as SchemaType};
     use crate::util::test_common::rand_gen::RandGen;
+
+    #[test]
+    fn test_delta_byte_array_invalid_prefix_len_returns_error() {
+        let col_descr = create_test_col_desc_ptr(-1, Type::BYTE_ARRAY);
+
+        let mut encoder = get_encoder::<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY, &col_descr).unwrap();
+        let input = vec![ByteArray::from("a"), ByteArray::from("ab")];
+        encoder.put(&input).unwrap();
+        let encoded = encoder.flush_buffer().unwrap();
+
+        // First, decode just the prefix-length stream so we know where the suffix stream starts.
+        let mut prefix_len_decoder = DeltaBitPackDecoder::<Int32Type>::new();
+        prefix_len_decoder.set_data(encoded.clone(), input.len()).unwrap();
+        let num_prefixes = prefix_len_decoder.values_left();
+        let mut prefix_lengths = vec![0; num_prefixes];
+        prefix_len_decoder.get(&mut prefix_lengths).unwrap();
+
+        // check: valid encoding should produce prefix lengths [0, 1]
+        assert_eq!(prefix_lengths, vec![0, 1]);
+
+        let prefix_stream_end = prefix_len_decoder.get_offset();
+
+        // Corrupt the prefix-length stream itself:
+        // replace it with a valid DELTA_BINARY_PACKED stream for [1, 1],
+        // so the first decoded prefix length becomes impossible because previous_value is empty.
+        let mut prefix_encoder = get_encoder::<Int32Type>(Encoding::DELTA_BINARY_PACKED, &create_test_col_desc_ptr(-1, Type::INT32)).unwrap();
+        prefix_encoder.put(&[1i32, 1i32]).unwrap();
+        let corrupted_prefix = prefix_encoder.flush_buffer().unwrap();
+
+        let mut corrupted = Vec::new();
+        corrupted.extend_from_slice(corrupted_prefix.as_ref());
+        corrupted.extend_from_slice(&encoded[prefix_stream_end..]);
+
+        let mut decoder = DeltaByteArrayDecoder::<ByteArrayType>::new();
+        decoder.set_data(Bytes::from(corrupted), input.len()).unwrap();
+
+        let mut out = vec![ByteArray::new(); input.len()];
+
+        let err = decoder.get(&mut out).unwrap_err();
+        assert!(err.to_string().contains("Invalid DELTA_BYTE_ARRAY prefix length"), "{}", err);
+    }
 
     #[test]
     fn test_get_decoders() {

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1136,12 +1136,19 @@ impl<T: DataType> Decoder<T> for DeltaByteArrayDecoder<T> {
                     // Extract current prefix length, can be 0
                     let prefix_len_i32 = self.prefix_lengths[self.current_idx];
                     if prefix_len_i32 < 0 {
-                        return Err(general_err!("Invalid DELTA_BYTE_ARRAY prefix length {}", prefix_len_i32));
+                        return Err(general_err!(
+                            "Invalid DELTA_BYTE_ARRAY prefix length {}",
+                            prefix_len_i32
+                        ));
                     }
                     let prefix_len = prefix_len_i32 as usize;
 
                     if prefix_len > self.previous_value.len() {
-                        return Err(general_err!("Invalid DELTA_BYTE_ARRAY prefix length {} exceeds previous value length {}", prefix_len, self.previous_value.len()));
+                        return Err(general_err!(
+                            "Invalid DELTA_BYTE_ARRAY prefix length {} exceeds previous value length {}",
+                            prefix_len,
+                            self.previous_value.len()
+                        ));
                     }
 
                     // Concatenate prefix with suffix
@@ -1194,14 +1201,17 @@ mod tests {
     fn test_delta_byte_array_invalid_prefix_len_returns_error() {
         let col_descr = create_test_col_desc_ptr(-1, Type::BYTE_ARRAY);
 
-        let mut encoder = get_encoder::<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY, &col_descr).unwrap();
+        let mut encoder =
+            get_encoder::<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY, &col_descr).unwrap();
         let input = vec![ByteArray::from("a"), ByteArray::from("ab")];
         encoder.put(&input).unwrap();
         let encoded = encoder.flush_buffer().unwrap();
 
         // First, decode just the prefix-length stream so we know where the suffix stream starts.
         let mut prefix_len_decoder = DeltaBitPackDecoder::<Int32Type>::new();
-        prefix_len_decoder.set_data(encoded.clone(), input.len()).unwrap();
+        prefix_len_decoder
+            .set_data(encoded.clone(), input.len())
+            .unwrap();
         let num_prefixes = prefix_len_decoder.values_left();
         let mut prefix_lengths = vec![0; num_prefixes];
         prefix_len_decoder.get(&mut prefix_lengths).unwrap();
@@ -1214,7 +1224,11 @@ mod tests {
         // Corrupt the prefix-length stream itself:
         // replace it with a valid DELTA_BINARY_PACKED stream for [1, 1],
         // so the first decoded prefix length becomes impossible because previous_value is empty.
-        let mut prefix_encoder = get_encoder::<Int32Type>(Encoding::DELTA_BINARY_PACKED, &create_test_col_desc_ptr(-1, Type::INT32)).unwrap();
+        let mut prefix_encoder = get_encoder::<Int32Type>(
+            Encoding::DELTA_BINARY_PACKED,
+            &create_test_col_desc_ptr(-1, Type::INT32),
+        )
+        .unwrap();
         prefix_encoder.put(&[1i32, 1i32]).unwrap();
         let corrupted_prefix = prefix_encoder.flush_buffer().unwrap();
 
@@ -1223,12 +1237,19 @@ mod tests {
         corrupted.extend_from_slice(&encoded[prefix_stream_end..]);
 
         let mut decoder = DeltaByteArrayDecoder::<ByteArrayType>::new();
-        decoder.set_data(Bytes::from(corrupted), input.len()).unwrap();
+        decoder
+            .set_data(Bytes::from(corrupted), input.len())
+            .unwrap();
 
         let mut out = vec![ByteArray::new(); input.len()];
 
         let err = decoder.get(&mut out).unwrap_err();
-        assert!(err.to_string().contains("Invalid DELTA_BYTE_ARRAY prefix length"), "{}", err);
+        assert!(
+            err.to_string()
+                .contains("Invalid DELTA_BYTE_ARRAY prefix length"),
+            "{}",
+            err
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #9796 .

# Rationale for this change

Currently, `DeltaByteArrayDecoder::get` assumes prefix lengths are always valid and directly slices `previous_value`. Invalid prefix lengths (negative or exceeding previous value length) can cause a panic instead of returning an error.

# What changes are included in this PR?

* Add validation for decoded prefix lengths:

  * reject negative values
  * reject values exceeding `previous_value.len()`
* Return `Err` instead of panicking on invalid input
* Add a regression test using corrupted encoded data

# Are these changes tested?

Yes.

* Added `test_delta_byte_array_invalid_prefix_len_returns_error`
* Test:

  * encodes valid data
  * corrupts prefix-length stream
  * verifies decoder returns `Err` (previously panicked)
* All the other existing tests pass

# Are there any user-facing changes?

No.

* No API changes
* Only improves error handling for invalid input