### PR TITLE
refactor(ipc): derive Default for CompressionContext

### DIFF
--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -27,19 +27,10 @@ const LENGTH_OF_PREFIX_DATA: i64 = 8;
 /// In the case of zstd, this will contain the zstd context, which can be reused between subsequent
 /// compression calls to avoid the performance overhead of initialising a new context for every
 /// compression.
+#[derive(Default)]
 pub struct CompressionContext {
     #[cfg(feature = "zstd")]
     compressor: Option<zstd::bulk::Compressor<'static>>,
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for CompressionContext {
-    fn default() -> Self {
-        CompressionContext {
-            #[cfg(feature = "zstd")]
-            compressor: None,
-        }
-    }
 }
 
 impl CompressionContext {


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #9808.

# Rationale for this change

After #9808 changed the zstd `Compressor` field to `Option`, the manual `impl Default` for `CompressionContext` just sets it to `None`, which is identical to the derived `Default`. The `#[allow(clippy::derivable_impls)]` annotation confirms this was already a known issue.

# What changes are included in this PR?

Replace the manual `impl Default for CompressionContext` with `#[derive(Default)]` and remove the `clippy::derivable_impls` allow.

# Are these changes tested?

Existing tests cover this. The struct's default behavior is unchanged.

# Are there any user-facing changes?

No.
