### PR TITLE
Fix JSON reader panic for non-nullable zero-size FixedSizeList

### DIFF
--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -215,7 +215,13 @@ impl ArrayDecoder for FixedSizeListArrayDecoder {
         let values = self.decoder.decode(tape, &child_pos)?;
         let nulls = nulls.as_mut().map(|x| NullBuffer::new(x.finish()));
 
-        let array = FixedSizeListArray::try_new(self.field.clone(), self.size, values, nulls)?;
+        let array = FixedSizeListArray::try_new_with_length(
+            self.field.clone(),
+            self.size,
+            values,
+            nulls,
+            pos.len(),
+        )?;
         Ok(Arc::new(array))
     }
 }

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -2369,6 +2369,32 @@ mod tests {
     }
 
     #[test]
+    fn test_fixed_size_list_zero_size_non_nullable() {
+        let buf = r#"
+        {"a": []}
+        {"a": []}
+        {"a": []}
+        "#;
+
+        let field = Field::new_list_field(DataType::Int32, true);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            DataType::FixedSizeList(Arc::new(field), 0),
+            false,
+        )]));
+
+        let batches = do_read(buf, 1024, false, false, schema);
+        assert_eq!(batches.len(), 1);
+
+        let col = batches[0].column(0).as_fixed_size_list();
+        assert_eq!(col.len(), 3);
+        assert_eq!(col.value_length(), 0);
+
+        let values = col.values().as_primitive::<Int32Type>();
+        assert!(values.values().is_empty());
+    }
+
+    #[test]
     fn test_fixed_size_list_wrong_size() {
         let buf = r#"{"a": [1, 2, 3]}"#;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9780.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use `FixedSizeListArray::try_new_with_length` to avoid panic when decoding degenerate non-nullable `FixedSizeList`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
Bug fixed