### PR TITLE
Minor: document why FixedSizeBinary offset is always 0

### DIFF
--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -643,8 +643,8 @@ unsafe impl Array for FixedSizeBinaryArray {
     }
 
     fn offset(&self) -> usize {
-        // Slices are normalized by rebasing `value_data`/`nulls`, so this type
-        // does not retain a separate logical element offset.
+        // Slices are normalized by slicing `value_data`/`nulls` directly;
+        // FSB does not retain a separate logical element offset.
         0
     }
 

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -643,6 +643,8 @@ unsafe impl Array for FixedSizeBinaryArray {
     }
 
     fn offset(&self) -> usize {
+        // Slices are normalized by rebasing `value_data`/`nulls`, so this type
+        // does not retain a separate logical element offset.
         0
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- related to https://github.com/apache/arrow-rs/pull/9850

# Rationale for this change

While working on https://github.com/apache/arrow-rs/pull/9850 I noticed that FixedSizeBinaryArray::offset always returns zero. 

This was confusing to me and so I wanted to document it for future readrs

# What changes are included in this PR?

Add some comments

# Are these changes tested?

By CI

# Are there any user-facing changes?
No, this is internal comments
