### PR TITLE
[arrow-string]: add `like::eq_ascii_ignore_case` kernel

### DIFF
--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -15,7 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Provide SQL's LIKE operators for Arrow's string arrays
+//! String predicate kernels for Arrow arrays.
+//!
+//! Provides SQL `LIKE`/`ILIKE` kernels as well as related
+//! string predicates such as `contains`, `starts_with`, `ends_with`, and
+//! ASCII case-insensitive equality.
 
 use crate::predicate::Predicate;
 
@@ -189,7 +193,7 @@ pub fn contains(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, Arr
     like_op(Op::Contains, left, right)
 }
 
-/// Perform equality check on two byte arrays using an ASCII case-insensitive match.
+/// Perform equality check on two arrays using an ASCII case-insensitive match.
 ///
 /// `left` and `right` must be the same type, and one of
 /// - Utf8
@@ -1427,18 +1431,18 @@ mod tests {
 
     test_utf8!(
         test_utf8_array_eq_ignore_ascii_case,
-        vec!["arrow", "arrow", "arrow", "parquet", "parquet"],
-        vec!["arrow", "ARROW", "aRrOw", "arrow", "ARROW"],
+        vec!["arrow", "arrow", "arrow", "arrow", "parquet", "parquet"],
+        vec!["arrow", "ARROW", "arro", "aRrOw", "arrow", "ARROW"],
         eq_ignore_ascii_case,
-        vec![true, true, true, false, false]
+        vec![true, true, false, true, false, false]
     );
 
     test_utf8_scalar!(
         test_utf8_array_eq_ignore_ascii_case_scalar,
-        vec!["arrow", "aRrOW", "ARROW", "parquet", "PARQUET"],
+        vec!["arrow", "aRrOW", "arro", "ARROW", "parquet", "PARQUET"],
         "arrow",
         eq_ignore_ascii_case,
-        vec![true, true, true, false, false]
+        vec![true, true, false, true, false, false]
     );
 
     #[test]

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -34,6 +34,7 @@ pub(crate) enum Op {
     Like(bool),
     ILike(bool),
     Contains,
+    EqIgnoreAsciiCase,
     StartsWith,
     EndsWith,
 }
@@ -46,6 +47,7 @@ impl std::fmt::Display for Op {
             Op::ILike(false) => write!(f, "ILIKE"),
             Op::ILike(true) => write!(f, "NILIKE"),
             Op::Contains => write!(f, "CONTAINS"),
+            Op::EqIgnoreAsciiCase => write!(f, "EQ_IGNORE_ASCII_CASE"),
             Op::StartsWith => write!(f, "STARTS_WITH"),
             Op::EndsWith => write!(f, "ENDS_WITH"),
         }
@@ -124,7 +126,7 @@ pub fn nilike(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, Arrow
 /// # Example
 /// ```
 /// # use arrow_array::{StringArray, BooleanArray};
-/// # use arrow_string::like::{like, starts_with};
+/// # use arrow_string::like::starts_with;
 /// let strings = StringArray::from(vec!["arrow-rs", "arrow-rs", "arrow-rs", "Parquet"]);
 /// let patterns = StringArray::from(vec!["arr", "arrow", "arrow-cpp", "p"]);
 ///
@@ -150,7 +152,7 @@ pub fn starts_with(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, 
 /// # Example
 /// ```
 /// # use arrow_array::{StringArray, BooleanArray};
-/// # use arrow_string::like::{ends_with, like, starts_with};
+/// # use arrow_string::like::ends_with;
 /// let strings = StringArray::from(vec!["arrow-rs", "arrow-rs",  "Parquet"]);
 /// let patterns = StringArray::from(vec!["arr", "-rs", "t"]);
 ///
@@ -176,7 +178,7 @@ pub fn ends_with(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, Ar
 /// # Example
 /// ```
 /// # use arrow_array::{StringArray, BooleanArray};
-/// # use arrow_string::like::{contains, like, starts_with};
+/// # use arrow_string::like::contains;
 /// let strings = StringArray::from(vec!["arrow-rs", "arrow-rs", "arrow-rs", "Parquet"]);
 /// let patterns = StringArray::from(vec!["arr", "-rs", "arrow-cpp", "X"]);
 ///
@@ -185,6 +187,30 @@ pub fn ends_with(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, Ar
 /// ```
 pub fn contains(left: &dyn Datum, right: &dyn Datum) -> Result<BooleanArray, ArrowError> {
     like_op(Op::Contains, left, right)
+}
+
+/// Perform equality check on two byte arrays using an ASCII case-insensitive match.
+///
+/// `left` and `right` must be the same type, and one of
+/// - Utf8
+/// - LargeUtf8
+/// - Utf8View
+///
+/// # Example
+/// ```
+/// # use arrow_array::{StringArray, BooleanArray};
+/// # use arrow_string::like::eq_ignore_ascii_case;
+/// let strings = StringArray::from(vec!["arrow", "rs", "arrow-rS", "Parquet"]);
+/// let patterns = StringArray::from(vec!["ARROW", "rS", "ARROW-rs", "arrow"]);
+///
+/// let result = eq_ignore_ascii_case(&strings, &patterns).unwrap();
+/// assert_eq!(result, BooleanArray::from(vec![true, true, true, false]));
+/// ```
+pub fn eq_ignore_ascii_case(
+    left: &dyn Datum,
+    right: &dyn Datum,
+) -> Result<BooleanArray, ArrowError> {
+    like_op(Op::EqIgnoreAsciiCase, left, right)
 }
 
 fn like_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, ArrowError> {
@@ -328,6 +354,7 @@ fn op_scalar<'a, T: StringArrayType<'a>>(
         Op::Like(neg) => Predicate::like(r)?.evaluate_array(l, neg),
         Op::ILike(neg) => Predicate::ilike(r, l.is_ascii())?.evaluate_array(l, neg),
         Op::Contains => Predicate::contains(r).evaluate_array(l, false),
+        Op::EqIgnoreAsciiCase => Predicate::IEqAscii(r).evaluate_array(l, false),
         Op::StartsWith => Predicate::StartsWith(r).evaluate_array(l, false),
         Op::EndsWith => Predicate::EndsWith(r).evaluate_array(l, false),
     };
@@ -362,6 +389,10 @@ fn op_binary<'a>(
         Op::Like(neg) => binary_predicate(l, r, neg, Predicate::like),
         Op::ILike(neg) => binary_predicate(l, r, neg, |s| Predicate::ilike(s, false)),
         Op::Contains => Ok(l.zip(r).map(|(l, r)| Some(str_contains(l?, r?))).collect()),
+        Op::EqIgnoreAsciiCase => Ok(l
+            .zip(r)
+            .map(|(l, r)| Some(Predicate::IEqAscii(l?).evaluate(r?)))
+            .collect()),
         Op::StartsWith => Ok(l
             .zip(r)
             .map(|(l, r)| Some(Predicate::StartsWith(r?).evaluate(l?)))
@@ -1392,6 +1423,22 @@ mod tests {
         "arrow_",
         nilike,
         vec![true, false, true, true, true]
+    );
+
+    test_utf8!(
+        test_utf8_array_eq_ignore_ascii_case,
+        vec!["arrow", "arrow", "arrow", "parquet", "parquet"],
+        vec!["arrow", "ARROW", "aRrOw", "arrow", "ARROW"],
+        eq_ignore_ascii_case,
+        vec![true, true, true, false, false]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_eq_ignore_ascii_case_scalar,
+        vec!["arrow", "aRrOW", "ARROW", "parquet", "PARQUET"],
+        "arrow",
+        eq_ignore_ascii_case,
+        vec![true, true, true, false, false]
     );
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes https://github.com/apache/arrow-rs/issues/9870

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Users might wish to have a mechanism to do check if two strings are equal in a case-insensitive way. We already have some machinery to do this in the arrow-string crate (in the `predicate` module). This PR exposes a function so it can be invoked easily.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a function `like::eq_ascii_ignore_case` to the arrow-string crate that performs a case-insensitive equals check on two string arrays.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

yes unit tests


# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

Yes this function is public