### PR TITLE
parquet: drop the leaf scan in parquet_column; add reusable ArrowReaderMetadata primitives

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -33,7 +33,8 @@ use std::sync::Arc;
 pub use crate::arrow::array_reader::RowGroups;
 use crate::arrow::array_reader::{ArrayReader, ArrayReaderBuilder};
 use crate::arrow::schema::{
-    ParquetField, parquet_to_arrow_schema_and_fields, virtual_type::is_virtual_column,
+    ParquetField, parquet_to_arrow_schema_and_field_levels_with_virtual,
+    virtual_type::is_virtual_column,
 };
 use crate::arrow::{FieldLevels, ProjectionMask, parquet_to_arrow_field_levels_with_virtual};
 use crate::basic::{BloomFilterAlgorithm, BloomFilterCompression, BloomFilterHash};
@@ -783,6 +784,24 @@ impl ArrowReaderOptions {
         })
     }
 
+    /// Returns the configured virtual columns, if any.
+    pub fn virtual_columns(&self) -> &[FieldRef] {
+        &self.virtual_columns
+    }
+
+    /// Returns the supplied arrow [`Schema`], if one was provided via
+    /// [`Self::with_schema`].
+    pub fn supplied_schema(&self) -> Option<&SchemaRef> {
+        self.supplied_schema.as_ref()
+    }
+
+    /// Returns whether the reader will skip the embedded arrow schema
+    /// metadata stored in the parquet file (set via
+    /// [`Self::with_skip_arrow_metadata`]).
+    pub fn skip_arrow_metadata(&self) -> bool {
+        self.skip_arrow_metadata
+    }
+
     /// Retrieve the currently set [`PageIndexPolicy`] for the offset index.
     ///
     /// This can be set via [`with_offset_index_policy`][Self::with_offset_index_policy]
@@ -903,6 +922,43 @@ impl ArrowReaderMetadata {
         Self::try_new(Arc::new(metadata), options)
     }
 
+    /// Construct an [`ArrowReaderMetadata`] from precomputed
+    /// [`FieldLevels`].
+    ///
+    /// Use this when the caller has already computed the arrow [`Schema`]
+    /// and [`FieldLevels`] for `metadata` (e.g. by calling
+    /// [`parquet_to_arrow_field_levels`]) and wants to avoid recomputing
+    /// them. For wide schemas the field-levels conversion walks every leaf
+    /// in the parquet schema, so reusing it across reader builds for the
+    /// same metadata is significantly cheaper than calling [`Self::try_new`]
+    /// repeatedly.
+    ///
+    /// `arrow_schema` and `field_levels` must describe the same columns:
+    /// they are normally produced together by
+    /// [`parquet_to_arrow_schema_and_field_levels`]. `arrow_schema` is taken
+    /// separately only because it additionally carries the file's key/value
+    /// metadata, which [`FieldLevels`] does not.
+    ///
+    /// [`parquet_to_arrow_field_levels`]: crate::arrow::schema::parquet_to_arrow_field_levels
+    /// [`parquet_to_arrow_schema_and_field_levels`]: crate::arrow::schema::parquet_to_arrow_schema_and_field_levels
+    pub fn from_field_levels(
+        metadata: Arc<ParquetMetaData>,
+        arrow_schema: SchemaRef,
+        field_levels: FieldLevels,
+    ) -> Self {
+        let FieldLevels { fields, levels } = field_levels;
+        debug_assert_eq!(
+            arrow_schema.fields(),
+            &fields,
+            "arrow_schema fields must match field_levels fields"
+        );
+        Self {
+            metadata,
+            schema: arrow_schema,
+            fields: levels.map(Arc::new),
+        }
+    }
+
     /// Create a new [`ArrowReaderMetadata`] from a pre-existing
     /// [`ParquetMetaData`] and [`ArrowReaderOptions`].
     ///
@@ -923,18 +979,18 @@ impl ArrowReaderMetadata {
                     false => metadata.file_metadata().key_value_metadata(),
                 };
 
-                let (schema, fields) = parquet_to_arrow_schema_and_fields(
+                let (schema, field_levels) = parquet_to_arrow_schema_and_field_levels_with_virtual(
                     metadata.file_metadata().schema_descr(),
                     ProjectionMask::all(),
                     kv_metadata,
                     &options.virtual_columns,
                 )?;
 
-                Ok(Self {
+                Ok(Self::from_field_levels(
                     metadata,
-                    schema: Arc::new(schema),
-                    fields: fields.map(Arc::new),
-                })
+                    Arc::new(schema),
+                    field_levels,
+                ))
             }
         }
     }

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -1595,12 +1595,36 @@ impl<'a> StatisticsConverter<'a> {
             None => None,
         };
 
-        Ok(Self {
-            parquet_column_index: parquet_index,
+        Ok(Self::from_arrow_field(
+            arrow_field,
+            parquet_schema,
+            parquet_index,
+        ))
+    }
+
+    /// Construct a [`StatisticsConverter`] from a precomputed
+    /// `(arrow_field, parquet_leaf_index)` pair.
+    ///
+    /// This is a low-overhead alternative to [`Self::try_new`] for callers
+    /// that need to build many converters against the same schemas — for
+    /// example when extracting per-column statistics for a wide schema.
+    /// [`Self::try_new`] performs O(N) name lookups against both the arrow
+    /// and parquet schemas; this constructor avoids those lookups by taking
+    /// the resolved field and column index directly.
+    ///
+    /// `parquet_leaf_index` should be `None` if the column does not exist in
+    /// the parquet file (schema evolution case).
+    pub fn from_arrow_field(
+        arrow_field: &'a Field,
+        parquet_schema: &'a SchemaDescriptor,
+        parquet_leaf_index: Option<usize>,
+    ) -> Self {
+        Self {
+            parquet_column_index: parquet_leaf_index,
             arrow_field,
             missing_null_counts_as_zero: true,
-            physical_type: parquet_index.map(|idx| parquet_schema.column(idx).physical_type()),
-        })
+            physical_type: parquet_leaf_index.map(|idx| parquet_schema.column(idx).physical_type()),
+        }
     }
 
     /// Create a new `StatisticsConverter` from a Parquet leaf column index directly.

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -198,6 +198,31 @@ pub trait AsyncFileReader: Send {
         &'a mut self,
         options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>>;
+
+    /// Return a future resolving to a fully-built [`ArrowReaderMetadata`].
+    ///
+    /// The default implementation calls [`Self::get_metadata`] and then
+    /// constructs the [`ArrowReaderMetadata`] via
+    /// [`ArrowReaderMetadata::try_new`], which walks every leaf in the
+    /// parquet schema to derive the matching arrow [`Schema`] and field
+    /// levels.
+    ///
+    /// Implementations that already cache the per-file metadata (e.g.
+    /// because the same file is opened many times across queries) can
+    /// override this method to also cache the derived arrow schema view.
+    /// For wide schemas this can dominate per-file CPU overhead, since the
+    /// per-leaf walk is `O(N_columns)` and is otherwise repeated on every
+    /// reader build for the same file.
+    fn get_arrow_reader_metadata<'a>(
+        &'a mut self,
+        options: ArrowReaderOptions,
+    ) -> BoxFuture<'a, Result<ArrowReaderMetadata>> {
+        async move {
+            let metadata = self.get_metadata(Some(&options)).await?;
+            ArrowReaderMetadata::try_new(metadata, options)
+        }
+        .boxed()
+    }
 }
 
 /// This allows Box<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,
@@ -215,6 +240,13 @@ impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
         options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
         self.as_mut().get_metadata(options)
+    }
+
+    fn get_arrow_reader_metadata<'a>(
+        &'a mut self,
+        options: ArrowReaderOptions,
+    ) -> BoxFuture<'a, Result<ArrowReaderMetadata>> {
+        self.as_mut().get_arrow_reader_metadata(options)
     }
 }
 
@@ -268,8 +300,11 @@ impl ArrowReaderMetadata {
         input: &mut T,
         options: ArrowReaderOptions,
     ) -> Result<Self> {
-        let metadata = input.get_metadata(Some(&options)).await?;
-        Self::try_new(metadata, options)
+        // Delegate to AsyncFileReader::get_arrow_reader_metadata so
+        // implementations that cache derived state (e.g. an arrow Schema
+        // and field-levels view) can short-circuit the per-leaf walk
+        // performed by Self::try_new.
+        input.get_arrow_reader_metadata(options).await
     }
 }
 

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -210,7 +210,8 @@ use arrow_schema::{FieldRef, Schema};
 pub use self::schema::{
     ArrowSchemaConverter, FieldLevels, add_encoded_arrow_schema_to_metadata, encode_arrow_schema,
     parquet_to_arrow_field_levels, parquet_to_arrow_field_levels_with_virtual,
-    parquet_to_arrow_schema, parquet_to_arrow_schema_by_columns, virtual_type::*,
+    parquet_to_arrow_schema, parquet_to_arrow_schema_and_field_levels,
+    parquet_to_arrow_schema_by_columns, virtual_type::*,
 };
 
 /// Schema metadata key used to store serialized Arrow schema

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -475,9 +475,11 @@ pub fn parquet_column<'a>(
         return None;
     }
 
-    // This could be made more efficient (#TBD)
-    let parquet_idx = (0..parquet_schema.columns().len())
-        .find(|x| parquet_schema.get_column_root_idx(*x) == root_idx)?;
+    // For non-nested fields the parquet column ordering matches the arrow
+    // root field ordering, so the first leaf descended from `root_idx` is
+    // exactly the parquet column we want. SchemaDescriptor caches this
+    // mapping for O(1) lookup.
+    let parquet_idx = parquet_schema.root_first_leaf_index(root_idx)?;
     Some((parquet_idx, field))
 }
 

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -67,17 +67,40 @@ pub fn parquet_to_arrow_schema_by_columns(
     Ok(parquet_to_arrow_schema_and_fields(parquet_schema, mask, key_value_metadata, &[])?.0)
 }
 
-/// Determines the Arrow Schema from a Parquet schema
+/// Convert a parquet [`SchemaDescriptor`] into both the arrow [`Schema`]
+/// and matching [`FieldLevels`] in a single walk.
 ///
-/// Looks for an Arrow schema metadata "hint" (see
-/// [`parquet_to_arrow_field_levels`]), and uses it if present to ensure
-/// lossless round trips.
-pub(crate) fn parquet_to_arrow_schema_and_fields(
+/// This is a convenience around [`parquet_to_arrow_field_levels`] that
+/// also produces a [`Schema`] (with the parquet file's key/value metadata
+/// attached). Useful for callers that want to pre-compute and reuse both
+/// for [`ArrowReaderMetadata::from_field_levels`].
+///
+/// [`ArrowReaderMetadata::from_field_levels`]: crate::arrow::arrow_reader::ArrowReaderMetadata::from_field_levels
+pub fn parquet_to_arrow_schema_and_field_levels(
+    parquet_schema: &SchemaDescriptor,
+    mask: ProjectionMask,
+    key_value_metadata: Option<&Vec<KeyValue>>,
+) -> Result<(Schema, FieldLevels)> {
+    parquet_to_arrow_schema_and_field_levels_with_virtual(
+        parquet_schema,
+        mask,
+        key_value_metadata,
+        &[],
+    )
+}
+
+/// As [`parquet_to_arrow_schema_and_field_levels`] but also appends the
+/// given `virtual_columns` to the resulting schema and field levels.
+///
+/// This is the single schema-walk used by [`parquet_to_arrow_schema_and_fields`]
+/// (which discards the [`FieldLevels`] wrapper) and by
+/// [`parquet_to_arrow_schema_and_field_levels`] (which keeps it).
+pub(crate) fn parquet_to_arrow_schema_and_field_levels_with_virtual(
     parquet_schema: &SchemaDescriptor,
     mask: ProjectionMask,
     key_value_metadata: Option<&Vec<KeyValue>>,
     virtual_columns: &[FieldRef],
-) -> Result<(Schema, Option<ParquetField>)> {
+) -> Result<(Schema, FieldLevels)> {
     let mut metadata = parse_key_value_metadata(key_value_metadata).unwrap_or_default();
     let maybe_schema = metadata
         .remove(super::ARROW_SCHEMA_META_KEY)
@@ -94,7 +117,27 @@ pub(crate) fn parquet_to_arrow_schema_and_fields(
     let hint = maybe_schema.as_ref().map(|s| s.fields());
     let field_levels =
         parquet_to_arrow_field_levels_with_virtual(parquet_schema, mask, hint, virtual_columns)?;
-    let schema = Schema::new_with_metadata(field_levels.fields, metadata);
+    let schema = Schema::new_with_metadata(field_levels.fields.clone(), metadata);
+    Ok((schema, field_levels))
+}
+
+/// Determines the Arrow Schema from a Parquet schema
+///
+/// Looks for an Arrow schema metadata "hint" (see
+/// [`parquet_to_arrow_field_levels`]), and uses it if present to ensure
+/// lossless round trips.
+pub(crate) fn parquet_to_arrow_schema_and_fields(
+    parquet_schema: &SchemaDescriptor,
+    mask: ProjectionMask,
+    key_value_metadata: Option<&Vec<KeyValue>>,
+    virtual_columns: &[FieldRef],
+) -> Result<(Schema, Option<ParquetField>)> {
+    let (schema, field_levels) = parquet_to_arrow_schema_and_field_levels_with_virtual(
+        parquet_schema,
+        mask,
+        key_value_metadata,
+        virtual_columns,
+    )?;
     Ok((schema, field_levels.levels))
 }
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -2094,10 +2094,12 @@ mod tests {
             .set_row_groups(row_group_meta_with_stats)
             .build();
 
+        // Sizes include the `root_to_first_leaf: Vec<usize>` cache that
+        // SchemaDescriptor adds to make `parquet_column` lookups O(1).
         #[cfg(not(feature = "encryption"))]
-        let base_expected_size = 2798;
+        let base_expected_size = 2838;
         #[cfg(feature = "encryption")]
-        let base_expected_size = 2966;
+        let base_expected_size = 3006;
 
         assert_eq!(parquet_meta.memory_size(), base_expected_size);
 
@@ -2126,9 +2128,9 @@ mod tests {
             .build();
 
         #[cfg(not(feature = "encryption"))]
-        let bigger_expected_size = 3248;
+        let bigger_expected_size = 3288;
         #[cfg(feature = "encryption")]
-        let bigger_expected_size = 3416;
+        let bigger_expected_size = 3456;
 
         // more set fields means more memory usage
         assert!(bigger_expected_size > base_expected_size);
@@ -2175,7 +2177,7 @@ mod tests {
             .set_row_groups(row_group_meta.clone())
             .build();
 
-        let base_expected_size = 2074;
+        let base_expected_size = 2114;
         assert_eq!(parquet_meta_data.memory_size(), base_expected_size);
 
         let footer_key = "0123456789012345".as_bytes();
@@ -2201,7 +2203,7 @@ mod tests {
             .set_file_decryptor(Some(decryptor))
             .build();
 
-        let expected_size_with_decryptor = 3088;
+        let expected_size_with_decryptor = 3128;
         assert!(expected_size_with_decryptor > base_expected_size);
 
         assert_eq!(

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -1048,6 +1048,12 @@ pub struct SchemaDescriptor {
     /// -- -- -- -- d
     /// ```
     leaf_to_base: Vec<usize>,
+
+    /// For each root field index, the index of its first leaf column in
+    /// [`Self::leaves`]. This is the inverse of (the first occurrence in)
+    /// [`Self::leaf_to_base`] and is used to look up a leaf column from a
+    /// root field index in O(1) time.
+    root_to_first_leaf: Vec<usize>,
 }
 
 impl fmt::Debug for SchemaDescriptor {
@@ -1062,7 +1068,10 @@ impl fmt::Debug for SchemaDescriptor {
 // Need to implement HeapSize in this module as the fields are private
 impl HeapSize for SchemaDescriptor {
     fn heap_size(&self) -> usize {
-        self.schema.heap_size() + self.leaves.heap_size() + self.leaf_to_base.heap_size()
+        self.schema.heap_size()
+            + self.leaves.heap_size()
+            + self.leaf_to_base.heap_size()
+            + self.root_to_first_leaf.heap_size()
     }
 }
 
@@ -1090,11 +1099,34 @@ impl SchemaDescriptor {
             );
         }
 
+        // Build root_to_first_leaf inverse map: for each root field index,
+        // record the index of its first leaf column. Leaves are emitted in
+        // root order by build_tree, so the first occurrence of each root_idx
+        // in leaf_to_base is the first leaf for that root.
+        let n_roots = tp.get_fields().len();
+        let mut root_to_first_leaf = vec![usize::MAX; n_roots];
+        for (leaf_idx, &root_idx) in leaf_to_base.iter().enumerate() {
+            if root_to_first_leaf[root_idx] == usize::MAX {
+                root_to_first_leaf[root_idx] = leaf_idx;
+            }
+        }
+
         Self {
             schema: tp,
             leaves,
             leaf_to_base,
+            root_to_first_leaf,
         }
+    }
+
+    /// Returns the leaf column index of the first leaf descended from the
+    /// given root field. Returns `None` if `root_idx` is out of range or the
+    /// root has no leaves.
+    pub fn root_first_leaf_index(&self, root_idx: usize) -> Option<usize> {
+        self.root_to_first_leaf
+            .get(root_idx)
+            .copied()
+            .filter(|&i| i != usize::MAX)
     }
 
     /// Returns [`ColumnDescriptor`] for a field position.


### PR DESCRIPTION
# Which issue does this PR close?

Part of #9722 and apache/datafusion#21968.

# Rationale for this change

Two per-file costs in `parquet` scale with schema width even when a reader touches only a few columns.

**1. `parquet_column` resolves a name with two linear scans.** First `Fields::find` over the arrow schema, then a scan over the parquet leaves to find the first one descended from the matched root. The second scan is pure waste: the root→first-leaf mapping is fixed for a given `SchemaDescriptor` and can be computed once when it is built.

**2. Every file open re-walks every parquet leaf** to build the arrow `Schema` and dremel field levels (`ArrowReaderMetadata::try_new`). A reader that already caches per-file metadata has no way to cache the derived arrow view alongside it, so the walk repeats on every open of the same file.

### Scope — what this PR does not do

**It does not make `parquet_column` O(1), and it does not remove the O(N²) that callers hit when resolving every column of a file.** `Fields::find` lives in `arrow-schema` and is still a linear scan with string comparisons; `StatisticsConverter::try_new` calls it twice (once directly, once inside `parquet_column`). Those two scans dominate, and eliminating them needs name indexing on `Fields`, which is not attempted here.

This PR removes the third scan — the cheapest of the three, being a sweep over a flat `Vec<usize>` — and the repeated schema walks. Callers that want the quadratic term gone must hoist the name lookup themselves; apache/datafusion#21987 does exactly that, and **no longer depends on this PR** (it builds on `StatisticsConverter::from_column_index`, released in 59.1.0). So this PR should be judged on its own merits, not as the fix for that workload.

# What changes are included in this PR?

Four commits, each green on its own:

1. **Drop the leaf scan in `parquet_column`** — `SchemaDescriptor` precomputes a `root_to_first_leaf` map, exposed as `root_first_leaf_index`. Costs 8 bytes per root field, reflected in the updated `memory_size` expectations (+40 bytes for the 5-root test schema).
2. **Reusable arrow-reader-metadata primitives** — `parquet_to_arrow_schema_and_field_levels` (one schema walk → `(Schema, FieldLevels)`), `ArrowReaderMetadata::from_field_levels`, and public `ArrowReaderOptions` accessors.
3. **`StatisticsConverter::from_arrow_field`** — constructor taking an already-resolved `(field, Option<leaf index>)`. Overlaps with `from_column_index` (#9540, merged since this PR was opened) but is strictly more expressive: `from_column_index` takes a bare `usize` and so cannot represent a column with no parquet leaf — nested types, or schema evolution — which is precisely the case that forces callers back onto the O(N) `try_new`.
4. **`AsyncFileReader::get_arrow_reader_metadata`** — new trait method, default delegating to `try_new`, with `load_async` routed through it, so a cache-aware reader can return a fully-built `ArrowReaderMetadata` and skip the per-leaf walk.

# Are these changes tested?

Existing parquet tests pass with `--all-features`, including the `memory_size` expectations updated for the new `SchemaDescriptor` field. `parquet_column`'s behaviour is unchanged and is covered by the existing suite — the new map reproduces its tie-break (lowest leaf index for a root wins).

# Are there any user-facing changes?

New public API only, no breaking changes. `SchemaDescriptor` grows by 8 bytes per root field, which is visible through `ParquetMetaData::memory_size` — about 0.65% for a 1024-column schema.
