### PR TITLE
fix(parquet): bound thrift list capacity by remaining input bytes

### DIFF
--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -286,6 +286,24 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
     /// Skip the next `n` bytes of input.
     fn skip_bytes(&mut self, n: usize) -> ThriftProtocolResult<()>;
 
+    /// Upper bound on the number of bytes still available to read from this
+    /// input. Implementations backed by an in-memory slice can return the
+    /// exact remaining length; implementations wrapping a streaming reader
+    /// that doesn't know its bound should fall back to `usize::MAX`, which
+    /// is what the default impl returns.
+    ///
+    /// Used by [`read_thrift_vec`] to cap up-front list allocations: a Thrift
+    /// list element occupies at least one byte on the wire, so the list size
+    /// declared in the header is always at most `bytes_remaining()`. Without
+    /// this cap an attacker-controlled varint of `~i32::MAX` in the list
+    /// header drives a multi-GiB up-front allocation; `try_reserve_exact`
+    /// alone is not sufficient because on Linux with default overcommit the
+    /// allocator returns success and the OOM only surfaces under tools like
+    /// libFuzzer / ASan that observe the malloc size.
+    fn bytes_remaining(&self) -> usize {
+        usize::MAX
+    }
+
     /// Read a ULEB128 encoded unsigned varint from the input.
     fn read_vlq(&mut self) -> ThriftProtocolResult<u64> {
         // try the happy path first
@@ -551,6 +569,11 @@ impl<'a> ThriftSliceInputProtocol<'a> {
 
 impl<'b, 'a: 'b> ThriftCompactInputProtocol<'b> for ThriftSliceInputProtocol<'a> {
     #[inline]
+    fn bytes_remaining(&self) -> usize {
+        self.buf.len()
+    }
+
+    #[inline]
     fn read_byte(&mut self) -> ThriftProtocolResult<u8> {
         let ret = *self.buf.first().ok_or(ThriftProtocolError::Eof)?;
         self.buf = &self.buf[1..];
@@ -704,18 +727,27 @@ where
     R: ThriftCompactInputProtocol<'a>,
     T: ReadThrift<'a, R>,
 {
-    // `read_list_begin` rejects sizes above `i32::MAX`; `try_reserve_exact`
-    // catches the remaining attacker-controlled allocation case so a
-    // malformed `size` cannot trigger a `Vec::with_capacity` panic.
+    // `read_list_begin` rejects sizes above `i32::MAX`, but on a 64-bit
+    // target that is still ~2 GiB of `T`s — easily a multi-GB up-front
+    // allocation when `T` is a struct like `SchemaElement`. Cap the
+    // up-front capacity by the bytes still in the input: each Thrift list
+    // element occupies at least one byte on the wire, so a declared size
+    // larger than what the reader has left is always invalid input. The
+    // subsequent `try_reserve_exact` then serves as belt-and-suspenders
+    // for protocol implementations that can't compute a tight bound.
     let list_ident = prot.read_list_begin()?;
-    let len = list_ident.size as usize;
+    let declared = list_ident.size as usize;
+    let bound = declared.min(prot.bytes_remaining());
     let mut res: Vec<T> = Vec::new();
-    if res.try_reserve_exact(len).is_err() {
+    if res.try_reserve_exact(bound).is_err() {
         return Err(general_err!(
             "cannot allocate Thrift list of {} elements",
-            len
+            declared
         ));
     }
+    // Iterate up to the declared length: `T::read_thrift` will surface a
+    // protocol-level EOF the moment the input is exhausted, which is the
+    // correct user-visible error for a header that overstates its list size.
     for _ in 0..list_ident.size {
         let val = T::read_thrift(prot)?;
         res.push(val);
@@ -1162,6 +1194,35 @@ pub(crate) mod tests {
         data.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x08]);
         let mut prot = ThriftSliceInputProtocol::new(&data);
         let result = prot.read_list_begin();
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    /// Regression test for a 7-byte cargo-fuzz repro found by the
+    /// `parquet/fuzz` `thrift_decode` harness on `parquet/main` after the
+    /// `try_reserve_exact` change: the fix above clamps `i32::MAX`-class
+    /// sizes, but on a 64-bit target the allocator is still asked for
+    /// ~6.6 GiB (`i32::MAX * size_of::<SchemaElement>()`) before the
+    /// `try_reserve_exact` Err path can fire, which is enough to OOM the
+    /// process under libFuzzer / ASan. Bounding by `bytes_remaining` keeps
+    /// the up-front allocation proportional to the input size, so on the
+    /// 7-byte input below the allocator is asked for at most a few bytes.
+    #[test]
+    fn test_decode_metadata_oom_repro_7byte_does_not_oom() {
+        let bytes: [u8; 7] = [0x26, 0xf6, 0xf6, 0xf6, 0xd4, 0x6b, 0x6c];
+        let result = crate::file::metadata::ParquetMetaDataReader::decode_metadata(&bytes);
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    /// Regression test for the larger 42-byte fuzz repro produced by the
+    /// `parquet/fuzz` `arrow_reader` harness with the seed corpus from
+    /// `apache/arrow-testing`. The header padding is the literal byte 0x20
+    /// (ASCII space) — those bytes drove the `Vec<SchemaElement>` allocation
+    /// past 6 GiB before this fix.
+    #[test]
+    fn test_decode_metadata_oom_repro_padded_does_not_oom() {
+        let mut bytes: Vec<u8> = vec![0x15, 0x20, 0x19, 0xf3, 0xff, 0xff, 0xff];
+        bytes.extend(std::iter::repeat(0x20u8).take(42 - bytes.len()));
+        let result = crate::file::metadata::ParquetMetaDataReader::decode_metadata(&bytes);
         assert!(result.is_err(), "expected error, got {result:?}");
     }
 }

--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -36,6 +36,7 @@ use crate::{
     write_thrift_field,
 };
 use std::io::Error;
+use std::num::TryFromIntError;
 use std::str::Utf8Error;
 
 #[derive(Debug)]
@@ -46,6 +47,7 @@ pub(crate) enum ThriftProtocolError {
     InvalidElementType(u8),
     FieldDeltaOverflow { field_delta: u8, last_field_id: i16 },
     InvalidBoolean(u8),
+    IntegerOverflow,
     Utf8Error,
     SkipDepth(FieldType),
     SkipUnsupportedType(FieldType),
@@ -70,6 +72,9 @@ impl From<ThriftProtocolError> for ParquetError {
             ThriftProtocolError::InvalidBoolean(value) => {
                 general_err!("cannot convert {} into bool", value)
             }
+            ThriftProtocolError::IntegerOverflow => {
+                general_err!("integer overflow decoding thrift value")
+            }
             ThriftProtocolError::Utf8Error => general_err!("invalid utf8"),
             ThriftProtocolError::SkipDepth(field_type) => {
                 general_err!("cannot parse past {:?}", field_type)
@@ -91,6 +96,13 @@ impl From<Utf8Error> for ThriftProtocolError {
 impl From<Error> for ThriftProtocolError {
     fn from(e: Error) -> Self {
         Self::IO(e)
+    }
+}
+
+impl From<TryFromIntError> for ThriftProtocolError {
+    fn from(_: TryFromIntError) -> Self {
+        // ignore error payload to reduce the size of ThriftProtocolError
+        Self::IntegerOverflow
     }
 }
 
@@ -317,7 +329,13 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
             // high bits set high if count and type encoded separately
             possible_element_count as i32
         } else {
-            self.read_vlq()? as _
+            // The list size on the wire is an unsigned varint, but we represent
+            // it as `i32` (matching Java's `int` and the Parquet Thrift schema).
+            // A varint that decodes above `i32::MAX` is malformed input — reject
+            // it here at the protocol layer rather than letting the cast wrap
+            // into a negative size that downstream allocation code has to
+            // re-validate.
+            i32::try_from(self.read_vlq()?)?
         };
 
         Ok(ListIdentifier {
@@ -686,8 +704,18 @@ where
     R: ThriftCompactInputProtocol<'a>,
     T: ReadThrift<'a, R>,
 {
+    // `read_list_begin` rejects sizes above `i32::MAX`; `try_reserve_exact`
+    // catches the remaining attacker-controlled allocation case so a
+    // malformed `size` cannot trigger a `Vec::with_capacity` panic.
     let list_ident = prot.read_list_begin()?;
-    let mut res = Vec::with_capacity(list_ident.size as usize);
+    let len = list_ident.size as usize;
+    let mut res: Vec<T> = Vec::new();
+    if res.try_reserve_exact(len).is_err() {
+        return Err(general_err!(
+            "cannot allocate Thrift list of {} elements",
+            len
+        ));
+    }
     for _ in 0..list_ident.size {
         let val = T::read_thrift(prot)?;
         res.push(val);
@@ -1105,5 +1133,35 @@ pub(crate) mod tests {
         let header = prot.read_list_begin().expect("error reading list header");
         assert_eq!(header.size, 0);
         assert_eq!(header.element_type, ElementType::Byte);
+    }
+
+    /// Regression test for the 10-byte fuzzer repro that panicked inside
+    /// `alloc::raw_vec::handle_error` with "capacity overflow" before this
+    /// fix: the list header for `SchemaElement` decodes to a multi-billion
+    /// `size`, and `Vec::with_capacity(size)` then tripped the
+    /// `size_of::<SchemaElement>() * size` isize-overflow check. After the
+    /// fix the allocation goes through `try_reserve_exact` and returns a
+    /// clean `ParquetError`.
+    #[test]
+    fn test_decode_metadata_huge_thrift_list_does_not_panic() {
+        let bytes: [u8; 10] = [0x28, 0xfc, 0xfc, 0xfc, 0xfc, 0xfc, 0xfc, 0xfc, 0xfc, 0x51];
+        let result = crate::file::metadata::ParquetMetaDataReader::decode_metadata(&bytes);
+        // The bytes are not valid Parquet metadata — we only require that
+        // `decode_metadata` returns an error rather than panicking.
+        assert!(result.is_err(), "expected error, got {result:?}");
+    }
+
+    /// A Thrift list header whose `size` varint decodes above `i32::MAX`
+    /// must be rejected at the protocol layer rather than wrapping into a
+    /// negative `i32` and being smuggled into downstream allocation code.
+    #[test]
+    fn test_read_list_begin_size_above_i32_max_returns_err() {
+        // List header: element_type=8 (Binary), 0xF=follow-up varint.
+        // Varint 80 80 80 80 08 decodes to 0x8000_0000 = i32::MAX + 1.
+        let mut data: Vec<u8> = vec![0xF8];
+        data.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x08]);
+        let mut prot = ThriftSliceInputProtocol::new(&data);
+        let result = prot.read_list_begin();
+        assert!(result.is_err(), "expected error, got {result:?}");
     }
 }


### PR DESCRIPTION
**Builds on #9868.** When that PR is merged this rebases to a single commit; until then the diff includes its commit as ancestor.

## What

Cap the up-front list-allocation in `parquet::parquet_thrift::read_thrift_vec` by the bytes still available to the input protocol. Adds a `bytes_remaining()` method to `ThriftCompactInputProtocol` (default `usize::MAX`; overridden in `ThriftSliceInputProtocol` to return `self.buf.len()`).

```rust
let declared = list_ident.size as usize;
let bound = declared.min(prot.bytes_remaining());
let mut res: Vec<T> = Vec::new();
if res.try_reserve_exact(bound).is_err() { … }
for _ in 0..list_ident.size {                      // EOF surfaces if header overstated size
    let val = T::read_thrift(prot)?;
    res.push(val);
}
```

## Why `try_reserve_exact` alone isn't enough

#9868's `try_reserve_exact` is the right defense in principle, but on **Linux with default overcommit** the allocator returns success for the requested size and the OOM only surfaces under tools that observe the malloc size (libFuzzer, ASan). In practice that means production processes will still OOM-kill on these inputs.

A 7-byte cargo-fuzz repro produced by the new `parquet/fuzz/thrift_decode` harness (#5332) demonstrates this:

```
==…== ERROR: libFuzzer: out-of-memory (malloc(6643777440))
…
#11 0x…  RawVec<…SchemaElement>::try_reserve_exact   alloc/src/raw_vec/mod.rs:384
#12 0x…  parquet_thrift::read_thrift_vec::<SchemaElement, ThriftSliceInputProtocol>
              parquet_thrift.rs:713
#13 0x…  parquet_metadata_from_bytes                 metadata/thrift/mod.rs:790
```

Input bytes: `[0x26, 0xf6, 0xf6, 0xf6, 0xd4, 0x6b, 0x6c]` — `i32::MAX`-class list size, then `i32::MAX * sizeof(SchemaElement) ≈ 6.6 GiB`.

After this PR the same 7 bytes return `ParquetError::General("cannot allocate Thrift list of … elements")` immediately, peak RSS stays in single-digit MiB.

## Tests

Two new regression tests in `parquet::parquet_thrift::tests`:

- `test_decode_metadata_oom_repro_7byte_does_not_oom` — the 7-byte cargo-fuzz repro
- `test_decode_metadata_oom_repro_padded_does_not_oom` — a 42-byte variant with `0x20` padding (matches the larger `arrow_reader`-harness repro)

The existing `test_decode_metadata_huge_thrift_list_does_not_panic` and `test_read_list_begin_size_above_i32_max_returns_err` from #9868 continue to pass.

## Out-of-scope (follow-ups)

I'll send these as separate PRs once this lands and #5332's fuzz harness is set up to keep them honest:

1. **`parquet/src/schema/types.rs:1404`** — `Vec::with_capacity(n as usize)` over an attacker-controlled `num_children`. Reachable downstream of thrift decoding; produces a separate `capacity overflow` panic on the same input class. A 22-byte fuzz repro is already in hand.
2. **`parquet/src/format.rs`** — ~22 hand-rolled `Vec::with_capacity(list_ident.size as usize)` sites in the legacy thrift codegen path. Identical mitigation pattern (bound by `bytes_remaining()`), but the file is large and noisy enough to deserve its own PR.

---

xref #5332 #9868 #9869 #9874
