### PR TITLE
[57_maintenance] Prevent BitChunks length overflow (#9818)

### DIFF
--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -220,10 +220,8 @@ pub struct BitChunks<'a> {
 impl<'a> BitChunks<'a> {
     /// Create a new [`BitChunks`] from a byte array, and an offset and length in bits
     pub fn new(buffer: &'a [u8], offset: usize, len: usize) -> Self {
-        assert!(
-            ceil(offset + len, 8) <= buffer.len(),
-            "offset + len out of bounds"
-        );
+        let end = offset.checked_add(len).expect("offset + len out of bounds");
+        assert!(ceil(end, 8) <= buffer.len(), "offset + len out of bounds");
 
         let byte_offset = offset / 8;
         let bit_offset = offset % 8;
@@ -548,6 +546,13 @@ mod tests {
 
         // We are reading more than exists in the buffer
         buffer.bit_chunks(1, ALLOC_SIZE * 8);
+    }
+
+    #[test]
+    #[should_panic(expected = "offset + len out of bounds")]
+    fn test_out_of_bound_should_panic_when_offset_and_length_overflow() {
+        let buffer = Buffer::from(vec![0xFF_u8; 8]);
+        buffer.bit_chunks(1, usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
- Part of https://github.com/apache/arrow-rs/issues/9858
- Fixes https://github.com/apache/arrow-rs/issues/9903 in 57.x releases

This PR:
- Backports https://github.com/apache/arrow-rs/pull/9818 from @alamb to the `57_maintenance` line
