### PR TITLE
[57_maintenance] Prevent repeat slice length overflow (#9819)

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -284,9 +284,15 @@ impl MutableBuffer {
         }
 
         let bytes_to_repeat = size_of_val(slice_to_repeat);
+        let repeated_bytes = repeat_count
+            .checked_mul(bytes_to_repeat)
+            .expect("repeated slice byte length overflow");
+        self.len
+            .checked_add(repeated_bytes)
+            .expect("mutable buffer length overflow");
 
         // Ensure capacity
-        self.reserve(repeat_count * bytes_to_repeat);
+        self.reserve(repeated_bytes);
 
         // Save the length before we do all the copies to know where to start from
         let length_before = self.len;
@@ -1338,6 +1344,21 @@ mod tests {
 
         // Zero repeats
         test_repeat_count(0, &[1i32, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "repeated slice byte length overflow")]
+    fn test_repeat_slice_count_multiply_overflow() {
+        let mut buffer = MutableBuffer::new(0);
+        buffer.repeat_slice_n_times(&[0_u64], usize::MAX / mem::size_of::<u64>() + 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "mutable buffer length overflow")]
+    fn test_repeat_slice_count_len_overflow() {
+        let mut buffer = MutableBuffer::new(0);
+        buffer.push(0_u8);
+        buffer.repeat_slice_n_times(&[0_u8], usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
- Part of https://github.com/apache/arrow-rs/issues/9858
- Fixes https://github.com/apache/arrow-rs/issues/9904 in 57.x releases

This PR:
- Backports https://github.com/apache/arrow-rs/pull/9819 from @alamb to the `57_maintenance` line
