### PR TITLE
Validate encoded Thrift lists match the schema

### DIFF
--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -315,6 +315,8 @@ pub enum LogicalType {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for LogicalType {
+    const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let field_ident = prot.read_field_begin(0)?;
         if field_ident.field_type == FieldType::Stop {
@@ -766,6 +768,8 @@ impl HeapSize for EncodingMask {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EncodingMask {
+    const ELEMENT_TYPE: ElementType = ElementType::I32;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let mut mask = 0;
 
@@ -835,6 +839,8 @@ pub enum Compression {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for Compression {
+    const ELEMENT_TYPE: ElementType = ElementType::I32;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let val = prot.read_i32()?;
         Ok(match val {
@@ -1076,6 +1082,8 @@ impl FromStr for EdgeInterpolationAlgorithm {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EdgeInterpolationAlgorithm {
+    const ELEMENT_TYPE: ElementType = ElementType::I32;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let val = prot.read_i32()?;
         match val {
@@ -1304,6 +1312,8 @@ impl ColumnOrder {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for ColumnOrder {
+    const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let field_ident = prot.read_field_begin(0)?;
         if field_ident.field_type == FieldType::Stop {

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -315,8 +315,6 @@ pub enum LogicalType {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for LogicalType {
-    const ELEMENT_TYPE: ElementType = ElementType::Struct;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let field_ident = prot.read_field_begin(0)?;
         if field_ident.field_type == FieldType::Stop {
@@ -768,8 +766,6 @@ impl HeapSize for EncodingMask {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EncodingMask {
-    const ELEMENT_TYPE: ElementType = ElementType::I32;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let mut mask = 0;
 
@@ -841,8 +837,6 @@ pub enum Compression {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for Compression {
-    const ELEMENT_TYPE: ElementType = ElementType::I32;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let val = prot.read_i32()?;
         Ok(match val {
@@ -1084,8 +1078,6 @@ impl FromStr for EdgeInterpolationAlgorithm {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EdgeInterpolationAlgorithm {
-    const ELEMENT_TYPE: ElementType = ElementType::I32;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let val = prot.read_i32()?;
         match val {
@@ -1314,8 +1306,6 @@ impl ColumnOrder {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for ColumnOrder {
-    const ELEMENT_TYPE: ElementType = ElementType::Struct;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         let field_ident = prot.read_field_begin(0)?;
         if field_ident.field_type == FieldType::Stop {

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -775,6 +775,13 @@ impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EncodingMask {
 
         // This reads a Thrift `list<Encoding>` and turns it into a bitmask
         let list_ident = prot.read_list_begin()?;
+        // check for enum (encoded as I32)
+        if list_ident.element_type != ElementType::I32 {
+            return Err(general_err!(
+                "Expected list element type of Encoding but got {:?}",
+                list_ident.element_type
+            ));
+        }
         for _ in 0..list_ident.size {
             let val = Encoding::read_thrift(prot)?;
             mask |= 1 << val as i32;

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -28,7 +28,7 @@ pub use crate::compression::{BrotliLevel, GzipLevel, ZstdLevel};
 use crate::file::metadata::HeapSize;
 use crate::parquet_thrift::{
     ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol, ThriftCompactOutputProtocol,
-    WriteThrift, WriteThriftField,
+    WriteThrift, WriteThriftField, validate_list_type,
 };
 use crate::{thrift_enum, thrift_struct, thrift_union_all_empty, write_thrift_field};
 
@@ -776,12 +776,7 @@ impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EncodingMask {
         // This reads a Thrift `list<Encoding>` and turns it into a bitmask
         let list_ident = prot.read_list_begin()?;
         // check for enum (encoded as I32)
-        if list_ident.element_type != ElementType::I32 {
-            return Err(general_err!(
-                "Expected list element type of Encoding but got {:?}",
-                list_ident.element_type
-            ));
-        }
+        validate_list_type(ElementType::I32, &list_ident)?;
         for _ in 0..list_ident.size {
             let val = Encoding::read_thrift(prot)?;
             mask |= 1 << val as i32;

--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -387,6 +387,13 @@ fn read_encoding_stats_as_mask<'a>(
     // read the vector of stats, setting mask bits for data pages
     let mut mask = 0i32;
     let list_ident = prot.read_list_begin()?;
+    // check for enum (encoded as I32)
+    if list_ident.element_type != ElementType::I32 {
+        return Err(general_err!(
+            "Expected list element type of Encoding but got {:?}",
+            list_ident.element_type
+        ));
+    }
     for _ in 0..list_ident.size {
         let pes = PageEncodingStats::read_thrift(prot)?;
         match pes.page_type {
@@ -652,6 +659,13 @@ fn read_row_group(
         match field_ident.id {
             1 => {
                 let list_ident = prot.read_list_begin()?;
+                // check for list of struct
+                if list_ident.element_type != ElementType::Struct {
+                    return Err(general_err!(
+                        "Expected list element type of Struct but got {:?}",
+                        list_ident.element_type
+                    ));
+                }
                 if schema_descr.num_columns() != list_ident.size as usize {
                     return Err(general_err!(
                         "Column count mismatch. Schema has {} columns while Row Group has {}",
@@ -801,6 +815,13 @@ pub(crate) fn parquet_metadata_from_bytes(
                 }
                 let schema_descr = schema_descr.as_ref().unwrap();
                 let list_ident = prot.read_list_begin()?;
+                // check for list of struct
+                if list_ident.element_type != ElementType::Struct {
+                    return Err(general_err!(
+                        "Expected list element type of Struct but got {:?}",
+                        list_ident.element_type
+                    ));
+                }
                 let mut rg_vec = Vec::with_capacity(list_ident.size as usize);
 
                 // Read row groups and handle ordinal assignment

--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     parquet_thrift::{
         ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol,
         ThriftCompactOutputProtocol, ThriftSliceInputProtocol, WriteThrift, WriteThriftField,
-        read_thrift_vec,
+        read_thrift_vec, validate_list_type,
     },
     schema::types::{
         ColumnDescriptor, SchemaDescriptor, TypePtr, num_nodes, parquet_schema_from_array,
@@ -387,13 +387,9 @@ fn read_encoding_stats_as_mask<'a>(
     // read the vector of stats, setting mask bits for data pages
     let mut mask = 0i32;
     let list_ident = prot.read_list_begin()?;
-    // check for enum (encoded as I32)
-    if list_ident.element_type != ElementType::I32 {
-        return Err(general_err!(
-            "Expected list element type of Encoding but got {:?}",
-            list_ident.element_type
-        ));
-    }
+    // check for PageEncodingStats struct
+    validate_list_type(ElementType::Struct, &list_ident)?;
+
     for _ in 0..list_ident.size {
         let pes = PageEncodingStats::read_thrift(prot)?;
         match pes.page_type {
@@ -660,12 +656,7 @@ fn read_row_group(
             1 => {
                 let list_ident = prot.read_list_begin()?;
                 // check for list of struct
-                if list_ident.element_type != ElementType::Struct {
-                    return Err(general_err!(
-                        "Expected list element type of Struct but got {:?}",
-                        list_ident.element_type
-                    ));
-                }
+                validate_list_type(ElementType::Struct, &list_ident)?;
                 if schema_descr.num_columns() != list_ident.size as usize {
                     return Err(general_err!(
                         "Column count mismatch. Schema has {} columns while Row Group has {}",
@@ -816,12 +807,7 @@ pub(crate) fn parquet_metadata_from_bytes(
                 let schema_descr = schema_descr.as_ref().unwrap();
                 let list_ident = prot.read_list_begin()?;
                 // check for list of struct
-                if list_ident.element_type != ElementType::Struct {
-                    return Err(general_err!(
-                        "Expected list element type of Struct but got {:?}",
-                        list_ident.element_type
-                    ));
-                }
+                validate_list_type(ElementType::Struct, &list_ident)?;
                 let mut rg_vec = Vec::with_capacity(list_ident.size as usize);
 
                 // Read row groups and handle ordinal assignment

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -23,7 +23,7 @@ use std::io::Write;
 
 use crate::parquet_thrift::{
     ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol, ThriftCompactOutputProtocol,
-    WriteThrift, WriteThriftField, read_thrift_vec,
+    WriteThrift, WriteThriftField, read_thrift_vec, validate_list_type,
 };
 use crate::{
     errors::{ParquetError, Result},
@@ -90,12 +90,7 @@ impl OffsetIndexMetaData {
 
         // we have to do this manually because we want to use the fast PageLocation decoder
         let list_ident = prot.read_list_begin()?;
-        if list_ident.element_type != ElementType::Struct {
-            return Err(general_err!(
-                "Expected list element type of Struct but got {:?}",
-                list_ident.element_type
-            ));
-        }
+        validate_list_type(ElementType::Struct, &list_ident)?;
         let mut page_locations = Vec::with_capacity(list_ident.size as usize);
         for _ in 0..list_ident.size {
             page_locations.push(read_page_location(prot)?);

--- a/parquet/src/file/page_index/offset_index.rs
+++ b/parquet/src/file/page_index/offset_index.rs
@@ -90,6 +90,12 @@ impl OffsetIndexMetaData {
 
         // we have to do this manually because we want to use the fast PageLocation decoder
         let list_ident = prot.read_list_begin()?;
+        if list_ident.element_type != ElementType::Struct {
+            return Err(general_err!(
+                "Expected list element type of Struct but got {:?}",
+                list_ident.element_type
+            ));
+        }
         let mut page_locations = Vec::with_capacity(list_ident.size as usize);
         for _ in 0..list_ident.size {
             page_locations.push(read_page_location(prot)?);

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -2117,7 +2117,7 @@ mod tests {
         let ret = SerializedFileReader::new(Bytes::copy_from_slice(&data));
         assert_eq!(
             ret.err().unwrap().to_string(),
-            "Parquet error: Received empty union from remote ColumnOrder"
+            "Parquet error: Expected list element type of Struct but got List"
         );
     }
 

--- a/parquet/src/parquet_macros.rs
+++ b/parquet/src/parquet_macros.rs
@@ -50,6 +50,8 @@ macro_rules! thrift_enum {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
+            const ELEMENT_TYPE: ElementType = ElementType::I32;
+
             #[allow(deprecated)]
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let val = prot.read_i32()?;
@@ -140,6 +142,8 @@ macro_rules! thrift_union_all_empty {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let field_ident = prot.read_field_begin(0)?;
                 if field_ident.field_type == FieldType::Stop {
@@ -214,6 +218,8 @@ macro_rules! thrift_union {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let field_ident = prot.read_field_begin(0)?;
                 if field_ident.field_type == FieldType::Stop {
@@ -281,6 +287,8 @@ macro_rules! thrift_struct {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 $(let mut $field_name: Option<$crate::__thrift_field_type!($field_type $($field_lt)? $($element_type)?)> = None;)*
                 let mut last_field_id = 0i16;

--- a/parquet/src/parquet_macros.rs
+++ b/parquet/src/parquet_macros.rs
@@ -50,8 +50,6 @@ macro_rules! thrift_enum {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
-            const ELEMENT_TYPE: ElementType = ElementType::I32;
-
             #[allow(deprecated)]
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let val = prot.read_i32()?;
@@ -142,8 +140,6 @@ macro_rules! thrift_union_all_empty {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
-            const ELEMENT_TYPE: ElementType = ElementType::Struct;
-
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let field_ident = prot.read_field_begin(0)?;
                 if field_ident.field_type == FieldType::Stop {
@@ -218,8 +214,6 @@ macro_rules! thrift_union {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
-            const ELEMENT_TYPE: ElementType = ElementType::Struct;
-
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let field_ident = prot.read_field_begin(0)?;
                 if field_ident.field_type == FieldType::Stop {
@@ -287,8 +281,6 @@ macro_rules! thrift_struct {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
-            const ELEMENT_TYPE: ElementType = ElementType::Struct;
-
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 $(let mut $field_name: Option<$crate::__thrift_field_type!($field_type $($field_lt)? $($element_type)?)> = None;)*
                 let mut last_field_id = 0i16;

--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -726,19 +726,24 @@ where
     T: ReadThrift<'a, R>,
 {
     let list_ident = prot.read_list_begin()?;
-    if list_ident.element_type != T::ELEMENT_TYPE {
-        return Err(general_err!(
-            "Expected list element type of {:?} but got {:?}",
-            T::ELEMENT_TYPE,
-            list_ident.element_type
-        ));
-    }
+    validate_list_type(T::ELEMENT_TYPE, &list_ident)?;
     let mut res = Vec::with_capacity(list_ident.size as usize);
     for _ in 0..list_ident.size {
         let val = T::read_thrift(prot)?;
         res.push(val);
     }
     Ok(res)
+}
+
+pub(crate) fn validate_list_type(expected: ElementType, got: &ListIdentifier) -> Result<()> {
+    if got.element_type != expected {
+        return Err(general_err!(
+            "Expected list element type of {:?} but got {:?}",
+            expected,
+            got.element_type
+        ));
+    }
+    Ok(())
 }
 
 /////////////////////////

--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -1166,4 +1166,20 @@ pub(crate) mod tests {
         let result = prot.read_list_begin();
         assert!(result.is_err(), "expected error, got {result:?}");
     }
+
+    #[test]
+    fn test_read_list_wrong_type() {
+        // list header: 4 elements of `Boolean`
+        let data = [0x42, 0x01];
+        let mut prot = ThriftSliceInputProtocol::new(&data);
+        // try to read as list<i32>
+        let result = read_thrift_vec::<i32, ThriftSliceInputProtocol>(&mut prot);
+        println!("{result:?}");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Expected list element type of I32 but got Bool")
+        );
+    }
 }

--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -636,9 +636,6 @@ impl<'a, R: Read> ThriftCompactInputProtocol<'a> for ThriftReadInputProtocol<R> 
 /// Trait implemented for objects that can be deserialized from a Thrift input stream.
 /// Implementations are provided for Thrift primitive types.
 pub(crate) trait ReadThrift<'a, R: ThriftCompactInputProtocol<'a>> {
-    /// The [`ElementType`] to use when a list of this object is read.
-    const ELEMENT_TYPE: ElementType;
-
     /// Read an object of type `Self` from the input protocol object.
     fn read_thrift(prot: &mut R) -> Result<Self>
     where
@@ -646,72 +643,54 @@ pub(crate) trait ReadThrift<'a, R: ThriftCompactInputProtocol<'a>> {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for bool {
-    const ELEMENT_TYPE: ElementType = ElementType::Bool;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_bool()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i8 {
-    const ELEMENT_TYPE: ElementType = ElementType::Byte;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i8()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i16 {
-    const ELEMENT_TYPE: ElementType = ElementType::I16;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i16()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i32 {
-    const ELEMENT_TYPE: ElementType = ElementType::I32;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i32()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i64 {
-    const ELEMENT_TYPE: ElementType = ElementType::I64;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i64()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for OrderedF64 {
-    const ELEMENT_TYPE: ElementType = ElementType::Double;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(OrderedF64(prot.read_double()?))
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a str {
-    const ELEMENT_TYPE: ElementType = ElementType::Binary;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_string()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for String {
-    const ELEMENT_TYPE: ElementType = ElementType::Binary;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(String::from_utf8(prot.read_bytes_owned()?)?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a [u8] {
-    const ELEMENT_TYPE: ElementType = ElementType::Binary;
-
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_bytes()?)
     }
@@ -723,7 +702,7 @@ impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a [u8] {
 pub(crate) fn read_thrift_vec<'a, T, R>(prot: &mut R) -> Result<Vec<T>>
 where
     R: ThriftCompactInputProtocol<'a>,
-    T: ReadThrift<'a, R>,
+    T: ReadThrift<'a, R> + WriteThrift,
 {
     let list_ident = prot.read_list_begin()?;
     validate_list_type(T::ELEMENT_TYPE, &list_ident)?;

--- a/parquet/src/parquet_thrift.rs
+++ b/parquet/src/parquet_thrift.rs
@@ -636,6 +636,9 @@ impl<'a, R: Read> ThriftCompactInputProtocol<'a> for ThriftReadInputProtocol<R> 
 /// Trait implemented for objects that can be deserialized from a Thrift input stream.
 /// Implementations are provided for Thrift primitive types.
 pub(crate) trait ReadThrift<'a, R: ThriftCompactInputProtocol<'a>> {
+    /// The [`ElementType`] to use when a list of this object is read.
+    const ELEMENT_TYPE: ElementType;
+
     /// Read an object of type `Self` from the input protocol object.
     fn read_thrift(prot: &mut R) -> Result<Self>
     where
@@ -643,54 +646,72 @@ pub(crate) trait ReadThrift<'a, R: ThriftCompactInputProtocol<'a>> {
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for bool {
+    const ELEMENT_TYPE: ElementType = ElementType::Bool;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_bool()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i8 {
+    const ELEMENT_TYPE: ElementType = ElementType::Byte;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i8()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i16 {
+    const ELEMENT_TYPE: ElementType = ElementType::I16;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i16()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i32 {
+    const ELEMENT_TYPE: ElementType = ElementType::I32;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i32()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i64 {
+    const ELEMENT_TYPE: ElementType = ElementType::I64;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_i64()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for OrderedF64 {
+    const ELEMENT_TYPE: ElementType = ElementType::Double;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(OrderedF64(prot.read_double()?))
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a str {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_string()?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for String {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(String::from_utf8(prot.read_bytes_owned()?)?)
     }
 }
 
 impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a [u8] {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
     fn read_thrift(prot: &mut R) -> Result<Self> {
         Ok(prot.read_bytes()?)
     }
@@ -705,6 +726,13 @@ where
     T: ReadThrift<'a, R>,
 {
     let list_ident = prot.read_list_begin()?;
+    if list_ident.element_type != T::ELEMENT_TYPE {
+        return Err(general_err!(
+            "Expected list element type of {:?} but got {:?}",
+            T::ELEMENT_TYPE,
+            list_ident.element_type
+        ));
+    }
     let mut res = Vec::with_capacity(list_ident.size as usize);
     for _ in 0..list_ident.size {
         let val = T::read_thrift(prot)?;

--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -98,7 +98,7 @@ fn test_arrow_gh_41317() {
     let err = read_file("ARROW-GH-41317.parquet").unwrap_err();
     assert_eq!(
         err.to_string(),
-        "External: Parquet argument error: Parquet error: StructArrayReader out of sync in read_records, expected 5 read, got 2"
+        "Parquet error: Expected list element type of I32 but got I16"
     );
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #9923.

# Rationale for this change

A first attempt at adding some validation. This will check that the encoded list element type matches what is expected from the Parquet schema.

# What changes are included in this PR?
Adds an `ELEMENT_TYPE` to the `ReadThrift` trait for use in validating data types in `read_thrift_vec`.

# Are these changes tested?

Should be covered by existing. These changes also cause an earlier error detection in an existing test of malformed data. 

# Are there any user-facing changes?

No, just improves error handling
