### PR TITLE
Prepare 57.3.1 release

### DIFF
--- a/CHANGELOG-old.md
+++ b/CHANGELOG-old.md
@@ -20,6 +20,22 @@
 # Historical Changelog
 
 
+## [57.3.0](https://github.com/apache/arrow-rs/tree/57.3.0) (2026-02-02)
+
+[Full Changelog](https://github.com/apache/arrow-rs/compare/57.2.0...57.3.0)
+
+**Breaking changes:**
+
+- Revert "Seal Array trait", mark `Array` as `unsafe` [#9313](https://github.com/apache/arrow-rs/pull/9313) ([alamb](https://github.com/alamb), [gabotechs](https://github.com/gabotechs))
+- Mark `BufferBuilder::new_from_buffer` as unsafe [#9312](https://github.com/apache/arrow-rs/pull/9312) ([alamb](https://github.com/alamb), [Jefffrey](https://github.com/Jefffrey))
+
+**Fixed bugs:**
+
+- Fix string array equality when the values buffer is the same and only the offsets to access it differ [#9330](https://github.com/apache/arrow-rs/pull/9330) ([alamb](https://github.com/alamb), [jhorstmann](https://github.com/jhorstmann))
+- Ensure `BufferBuilder::truncate` doesn't overset length [#9311](https://github.com/apache/arrow-rs/pull/9311) ([alamb](https://github.com/alamb), [Jefffrey](https://github.com/Jefffrey))
+- [parquet] Provide only encrypted column stats in plaintext footer [#9310](https://github.com/apache/arrow-rs/pull/9310) ([alamb](https://github.com/alamb), [rok](https://github.com/rok), [adamreeve](https://github.com/adamreeve))
+- [regression] Error with adaptive predicate pushdown: "Invalid offset …" [#9309](https://github.com/apache/arrow-rs/pull/9309) ([alamb](https://github.com/alamb), [erratic-pattern](https://github.com/erratic-pattern), [sdf-jkl](https://github.com/sdf-jkl))
+
 ## [57.2.0](https://github.com/apache/arrow-rs/tree/57.2.0) (2026-01-07)
 
 [Full Changelog](https://github.com/apache/arrow-rs/compare/57.1.0...57.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,26 @@
 
 # Changelog
 
-## [57.3.0](https://github.com/apache/arrow-rs/tree/57.3.0) (2026-02-02)
+## [57.3.1](https://github.com/apache/arrow-rs/tree/57.3.1) (2026-05-07)
 
-[Full Changelog](https://github.com/apache/arrow-rs/compare/57.2.0...57.3.0)
-
-**Breaking changes:**
-
-- Revert "Seal Array trait", mark `Array` as `unsafe` [#9313](https://github.com/apache/arrow-rs/pull/9313) ([alamb](https://github.com/alamb), [gabotechs](https://github.com/gabotechs))
-- Mark `BufferBuilder::new_from_buffer` as unsafe [#9312](https://github.com/apache/arrow-rs/pull/9312) ([alamb](https://github.com/alamb), [Jefffrey](https://github.com/Jefffrey))
+[Full Changelog](https://github.com/apache/arrow-rs/compare/57.3.0...57.3.1)
 
 **Fixed bugs:**
 
-- Fix string array equality when the values buffer is the same and only the offsets to access it differ [#9330](https://github.com/apache/arrow-rs/pull/9330) ([alamb](https://github.com/alamb), [jhorstmann](https://github.com/jhorstmann))
-- Ensure `BufferBuilder::truncate` doesn't overset length [#9311](https://github.com/apache/arrow-rs/pull/9311) ([alamb](https://github.com/alamb), [Jefffrey](https://github.com/Jefffrey))
-- [parquet] Provide only encrypted column stats in plaintext footer [#9310](https://github.com/apache/arrow-rs/pull/9310) ([alamb](https://github.com/alamb), [rok](https://github.com/rok), [adamreeve](https://github.com/adamreeve))
-- [regression] Error with adaptive predicate pushdown: "Invalid offset …" [#9309](https://github.com/apache/arrow-rs/pull/9309) ([alamb](https://github.com/alamb), [erratic-pattern](https://github.com/erratic-pattern), [sdf-jkl](https://github.com/sdf-jkl))
+- \[arrow-buffer\] Integer overflow in BufferBuilder::reserve leads to undefined behavior [\#9897](https://github.com/apache/arrow-rs/issues/9897) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-array\] Integer overflow in FixedSizeBinaryArray::value leads to undefined behavior [\#9898](https://github.com/apache/arrow-rs/issues/9898) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-data\] Integer overflow in ArrayData::slice leads to undefined behavior [\#9899](https://github.com/apache/arrow-rs/issues/9899) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-data\] Integer overflow in ArrayData validation leads to undefined behavior [\#9900](https://github.com/apache/arrow-rs/issues/9900) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-row\] Integer overflow in Rows::row index handling leads to undefined behavior [\#9901](https://github.com/apache/arrow-rs/issues/9901) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-buffer\] Integer overflow in BitChunks::new leads to undefined behavior [\#9903](https://github.com/apache/arrow-rs/issues/9903) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+- \[arrow-buffer\] Integer overflow in repeat_slice_n_times leads to undefined behavior [\#9904](https://github.com/apache/arrow-rs/issues/9904) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)]
+
+**Merged pull requests:**
+
+- \[57_maintenance\] Prevent ArrayData::slice length overflow \(\#9813\) [\#9927](https://github.com/apache/arrow-rs/pull/9927) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent repeat slice length overflow \(\#9819\) [\#9920](https://github.com/apache/arrow-rs/pull/9920) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent buffer builder length overflow in MutableBuffer::extend_zeros \(\#9820\) [\#9926](https://github.com/apache/arrow-rs/pull/9926) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent FixedSizeBinaryArray i32 offset overflows \(\#9872\) [\#9928](https://github.com/apache/arrow-rs/pull/9928) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent ArrayData validation length overflow \(\#9816\) [\#9925](https://github.com/apache/arrow-rs/pull/9925) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent Rows row index overflow \(\#9817\) [\#9922](https://github.com/apache/arrow-rs/pull/9922) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))
+- \[57_maintenance\] Prevent BitChunks length overflow \(\#9818\) [\#9918](https://github.com/apache/arrow-rs/pull/9918) [[arrow](https://github.com/apache/arrow-rs/labels/arrow)] ([alamb](https://github.com/alamb))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "57.3.0"
+version = "57.3.1"
 homepage = "https://github.com/apache/arrow-rs"
 repository = "https://github.com/apache/arrow-rs"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
@@ -85,26 +85,26 @@ edition = "2024"
 rust-version = "1.85"
 
 [workspace.dependencies]
-arrow = { version = "57.3.0", path = "./arrow", default-features = false }
-arrow-arith = { version = "57.3.0", path = "./arrow-arith" }
-arrow-array = { version = "57.3.0", path = "./arrow-array" }
-arrow-buffer = { version = "57.3.0", path = "./arrow-buffer" }
-arrow-cast = { version = "57.3.0", path = "./arrow-cast" }
-arrow-csv = { version = "57.3.0", path = "./arrow-csv" }
-arrow-data = { version = "57.3.0", path = "./arrow-data" }
-arrow-ipc = { version = "57.3.0", path = "./arrow-ipc" }
-arrow-json = { version = "57.3.0", path = "./arrow-json" }
-arrow-ord = { version = "57.3.0", path = "./arrow-ord" }
-arrow-pyarrow = { version = "57.3.0", path = "./arrow-pyarrow" }
-arrow-row = { version = "57.3.0", path = "./arrow-row" }
-arrow-schema = { version = "57.3.0", path = "./arrow-schema" }
-arrow-select = { version = "57.3.0", path = "./arrow-select" }
-arrow-string = { version = "57.3.0", path = "./arrow-string" }
-parquet = { version = "57.3.0", path = "./parquet", default-features = false }
-parquet-geospatial = { version = "57.3.0", path = "./parquet-geospatial" }
-parquet-variant = { version = "57.3.0", path = "./parquet-variant" }
-parquet-variant-json = { version = "57.3.0", path = "./parquet-variant-json" }
-parquet-variant-compute = { version = "57.3.0", path = "./parquet-variant-compute" }
+arrow = { version = "57.3.1", path = "./arrow", default-features = false }
+arrow-arith = { version = "57.3.1", path = "./arrow-arith" }
+arrow-array = { version = "57.3.1", path = "./arrow-array" }
+arrow-buffer = { version = "57.3.1", path = "./arrow-buffer" }
+arrow-cast = { version = "57.3.1", path = "./arrow-cast" }
+arrow-csv = { version = "57.3.1", path = "./arrow-csv" }
+arrow-data = { version = "57.3.1", path = "./arrow-data" }
+arrow-ipc = { version = "57.3.1", path = "./arrow-ipc" }
+arrow-json = { version = "57.3.1", path = "./arrow-json" }
+arrow-ord = { version = "57.3.1", path = "./arrow-ord" }
+arrow-pyarrow = { version = "57.3.1", path = "./arrow-pyarrow" }
+arrow-row = { version = "57.3.1", path = "./arrow-row" }
+arrow-schema = { version = "57.3.1", path = "./arrow-schema" }
+arrow-select = { version = "57.3.1", path = "./arrow-select" }
+arrow-string = { version = "57.3.1", path = "./arrow-string" }
+parquet = { version = "57.3.1", path = "./parquet", default-features = false }
+parquet-geospatial = { version = "57.3.1", path = "./parquet-geospatial" }
+parquet-variant = { version = "57.3.1", path = "./parquet-variant" }
+parquet-variant-json = { version = "57.3.1", path = "./parquet-variant-json" }
+parquet-variant-compute = { version = "57.3.1", path = "./parquet-variant-compute" }
 
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 

--- a/dev/release/update_change_log.sh
+++ b/dev/release/update_change_log.sh
@@ -29,8 +29,8 @@
 
 set -e
 
-SINCE_TAG="57.1.0"
-FUTURE_RELEASE="57.2.0"
+SINCE_TAG="57.3.0"
+FUTURE_RELEASE="57.3.1"
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_TOP_DIR="$(cd "${SOURCE_DIR}/../../" && pwd)"


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/9858

# Rationale for this change

Prepare the 57 maintenance line for the 57.3.1 patch release with the overflow fixes tracked in the release issue.

# What changes are included in this PR?

1. Update workspace version references to 57.3.1
2. Update CHANGELOG.md for 57.3.1 and move 57.3.0 notes to CHANGELOG-old.md
3. Update dev/release/update_change_log.sh for the 57.3.1 release range

Rendered preview: https://github.com/alamb/arrow-rs/blob/alamb/prepare_57.3.1/CHANGELOG.md

# Are these changes tested?

By CI
# Are there any user-facing changes?

yes