### PR TITLE
Improve email created by create_tarball.sh script

### DIFF
--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -97,6 +97,8 @@ The proposed release tarball and signatures are hosted at [2].
 
 The changelog is located at [3].
 
+The release tracking issue is: [4]
+
 Please download, verify checksums and signatures, run the unit tests,
 and vote on the release. There is a script [4] that automates some of
 the verification.
@@ -111,6 +113,7 @@ The vote will be open for at least 72 hours.
 [2]: ${url}
 [3]: https://github.com/apache/arrow-rs/blob/${commit_sha}/CHANGELOG.md
 [4]: https://github.com/apache/arrow-rs/blob/master/dev/release/verify-release-candidate.sh
+[5]: RELEASE_ISSUE
 MAIL
 echo "---------------------------------------------------------"
 

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -80,6 +80,26 @@ url="https://dist.apache.org/repos/dist/dev/arrow/${release}-rc${rc}"
 echo "Attempting to create ${tarball} from tag ${tag}"
 
 
+# create <tarball> containing the files in git at $tag
+# the files in the tarball are prefixed with {release}
+# (e.g. apache-arrow-rs-4.0.1)
+mkdir -p ${distdir}
+(cd "${SOURCE_TOP_DIR}" && \
+     git archive ${tag} --prefix ${release}/ \
+         | gzip > ${tarball})
+
+echo "Running rat license checker on ${tarball}"
+${SOURCE_DIR}/run-rat.sh ${tarball}
+
+echo "Signing tarball and creating checksums"
+gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
+# create signing with relative path of tarball
+# so that they can be verified with a command such as
+#  shasum --check apache-arrow-rs-4.1.0-rc2.tar.gz.sha512
+(cd ${distdir} && shasum -a 256 ${tarname}) > ${tarball}.sha256
+(cd ${distdir} && shasum -a 512 ${tarname}) > ${tarball}.sha512
+sha256=$(cut -d ' ' -f 1 "${tarball}.sha256")
+
 echo "Draft email for dev@arrow.apache.org mailing list"
 echo ""
 echo "---------------------------------------------------------"
@@ -91,7 +111,8 @@ Hi,
 
 I would like to propose a release of Apache Arrow Rust Implementation, version ${tag}.
 
-This release candidate is based on commit: ${commit_sha} [1]
+This release candidate is based on commit: ${commit_sha} [1].
+The SHA256 of the release candidate is: ${sha256}
 
 The proposed release tarball and signatures are hosted at [2].
 
@@ -116,27 +137,6 @@ The vote will be open for at least 72 hours.
 [5]: RELEASE_ISSUE
 MAIL
 echo "---------------------------------------------------------"
-
-
-
-# create <tarball> containing the files in git at $tag
-# the files in the tarball are prefixed with {release}
-# (e.g. apache-arrow-rs-4.0.1)
-mkdir -p ${distdir}
-(cd "${SOURCE_TOP_DIR}" && \
-     git archive ${tag} --prefix ${release}/ \
-         | gzip > ${tarball})
-
-echo "Running rat license checker on ${tarball}"
-${SOURCE_DIR}/run-rat.sh ${tarball}
-
-echo "Signing tarball and creating checksums"
-gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
-# create signing with relative path of tarball
-# so that they can be verified with a command such as
-#  shasum --check apache-arrow-rs-4.1.0-rc2.tar.gz.sha512
-(cd ${distdir} && shasum -a 256 ${tarname}) > ${tarball}.sha256
-(cd ${distdir} && shasum -a 512 ${tarname}) > ${tarball}.sha512
 
 echo "Uploading to apache dist/dev to ${url}"
 svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow ${SOURCE_TOP_DIR}/dev/dist

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -65,8 +65,9 @@ else
     tar=tar
 fi
 
-if ! git -C "${SOURCE_TOP_DIR}" rev-list --max-count=1 ${tag}; then
+if ! commit_sha=$(git -C "${SOURCE_TOP_DIR}" rev-list --max-count=1 "${tag}"); then
     echo "Cannot continue: unknown git tag: $tag"
+    exit 1
 fi
 
 
@@ -90,7 +91,7 @@ Hi,
 
 I would like to propose a release of Apache Arrow Rust Implementation, version ${tag}.
 
-This release candidate is based on commit: ${tag} [1]
+This release candidate is based on commit: ${commit_sha} [1]
 
 The proposed release tarball and signatures are hosted at [2].
 
@@ -106,9 +107,9 @@ The vote will be open for at least 72 hours.
 [ ] +0
 [ ] -1 Do not release this as Apache Arrow Rust ${version} because...
 
-[1]: https://github.com/apache/arrow-rs/tree/${tag}
+[1]: https://github.com/apache/arrow-rs/tree/${commit_sha}
 [2]: ${url}
-[3]: https://github.com/apache/arrow-rs/blob/${tag}/CHANGELOG.md
+[3]: https://github.com/apache/arrow-rs/blob/${commit_sha}/CHANGELOG.md
 [4]: https://github.com/apache/arrow-rs/blob/master/dev/release/verify-release-candidate.sh
 MAIL
 echo "---------------------------------------------------------"

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -109,7 +109,7 @@ Subject: [VOTE][RUST] Release Apache Arrow Rust ${version} RC${rc}
 
 Hi,
 
-I would like to propose a release of Apache Arrow Rust Implementation, version ${tag}.
+I would like to propose a release of Apache Arrow Rust Implementation, version ${version}.
 
 This release candidate is based on commit: ${commit_sha} [1].
 The SHA256 of the release candidate is: ${sha256}


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change

There are several issues I found with the email template created by the current template:
1. It uses links to tags (rather than git shas) which can potentially be changed
2. It does not include the actual SHA values (only a link to a place to download the sha values) which means in theory it is not clear what exact artifact is being voted on
3. It does not include a link to the issue used to do release coordiation

# What changes are included in this PR?

Fix the above issues 

Example new output:
```
---------------------------------------------------------
To: dev@arrow.apache.org
Subject: [VOTE][RUST] Release Apache Arrow Rust 57.3.1 RC1

Hi,

I would like to propose a release of Apache Arrow Rust Implementation, version 57.3.1.

This release candidate is based on commit: da8975cfacdf8623892a7937dc5c5e6515a05483 [1].
The SHA256 of the release candidate is: 067a4c47c515d57b283f431d426c46c0f48601a2017202a490d2a234e0cd2fb4

The proposed release tarball and signatures are hosted at [2].

The changelog is located at [3].

The release tracking issue is: [4]

Please download, verify checksums and signatures, run the unit tests,
and vote on the release. There is a script [4] that automates some of
the verification.

The vote will be open for at least 72 hours.

[ ] +1 Release this as Apache Arrow Rust 57.3.1
[ ] +0
[ ] -1 Do not release this as Apache Arrow Rust 57.3.1 because...

[1]: https://github.com/apache/arrow-rs/tree/da8975cfacdf8623892a7937dc5c5e6515a05483
[2]: https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-rs-57.3.1-rc1
[3]: https://github.com/apache/arrow-rs/blob/da8975cfacdf8623892a7937dc5c5e6515a05483/CHANGELOG.md
[4]: https://github.com/apache/arrow-rs/blob/master/dev/release/verify-release-candidate.sh
[5]: RELEASE_ISSUE
```
# Are these changes tested?

I tested this script while creating release candidates for 57.3.1 and 56.2.1 and it worked well
- https://github.com/apache/arrow-rs/issues/9858
- https://github.com/apache/arrow-rs/issues/9857 

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
